### PR TITLE
refactor: switch to Symfony AI namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require-dev": {
         "php": ">=8.1",
         "symfony/filesystem": "^6.4|^7.0",
-        "symfony/finder": "^6.4|^7.0"
+        "symfony/finder": "^6.4|^7.0",
+        "php-cs-fixer/shim": "^3.75"
     }
 }

--- a/src/mcp-sdk/composer.json
+++ b/src/mcp-sdk/composer.json
@@ -31,12 +31,12 @@
     },
     "autoload": {
         "psr-4": {
-            "PhpLlm\\McpSdk\\": "src/"
+            "Symfony\\AI\\McpSdk\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "PhpLlm\\McpSdk\\Tests\\": "tests/"
+            "Symfony\\AI\\McpSdk\\Tests\\": "tests/"
         }
     }
 }

--- a/src/mcp-sdk/examples/cli/index.php
+++ b/src/mcp-sdk/examples/cli/index.php
@@ -24,18 +24,18 @@ $output = new SymfonyConsole\Output\ConsoleOutput($debug ? OutputInterface::VERB
 $logger = new SymfonyConsole\Logger\ConsoleLogger($output);
 
 // Configure the JsonRpcHandler and build the functionality
-$jsonRpcHandler = new PhpLlm\McpSdk\Server\JsonRpcHandler(
-    new PhpLlm\McpSdk\Message\Factory(),
+$jsonRpcHandler = new Symfony\AI\McpSdk\Server\JsonRpcHandler(
+    new Symfony\AI\McpSdk\Message\Factory(),
     App\Builder::buildRequestHandlers(),
     App\Builder::buildNotificationHandlers(),
     $logger
 );
 
 // Set up the server
-$sever = new PhpLlm\McpSdk\Server($jsonRpcHandler, $logger);
+$sever = new Symfony\AI\McpSdk\Server($jsonRpcHandler, $logger);
 
 // Create the transport layer using Symfony Console
-$transport = new PhpLlm\McpSdk\Server\Transport\Stdio\SymfonyConsoleTransport($input, $output);
+$transport = new Symfony\AI\McpSdk\Server\Transport\Stdio\SymfonyConsoleTransport($input, $output);
 
 // Start our application
 $sever->connect($transport);

--- a/src/mcp-sdk/examples/cli/src/Builder.php
+++ b/src/mcp-sdk/examples/cli/src/Builder.php
@@ -13,20 +13,20 @@ declare(strict_types=1);
 
 namespace App;
 
-use PhpLlm\McpSdk\Capability\PromptChain;
-use PhpLlm\McpSdk\Capability\ResourceChain;
-use PhpLlm\McpSdk\Capability\ToolChain;
-use PhpLlm\McpSdk\Server\NotificationHandler\InitializedHandler;
-use PhpLlm\McpSdk\Server\NotificationHandlerInterface;
-use PhpLlm\McpSdk\Server\RequestHandler\InitializeHandler;
-use PhpLlm\McpSdk\Server\RequestHandler\PingHandler;
-use PhpLlm\McpSdk\Server\RequestHandler\PromptGetHandler;
-use PhpLlm\McpSdk\Server\RequestHandler\PromptListHandler;
-use PhpLlm\McpSdk\Server\RequestHandler\ResourceListHandler;
-use PhpLlm\McpSdk\Server\RequestHandler\ResourceReadHandler;
-use PhpLlm\McpSdk\Server\RequestHandler\ToolCallHandler;
-use PhpLlm\McpSdk\Server\RequestHandler\ToolListHandler;
-use PhpLlm\McpSdk\Server\RequestHandlerInterface;
+use Symfony\AI\McpSdk\Capability\PromptChain;
+use Symfony\AI\McpSdk\Capability\ResourceChain;
+use Symfony\AI\McpSdk\Capability\ToolChain;
+use Symfony\AI\McpSdk\Server\NotificationHandler\InitializedHandler;
+use Symfony\AI\McpSdk\Server\NotificationHandlerInterface;
+use Symfony\AI\McpSdk\Server\RequestHandler\InitializeHandler;
+use Symfony\AI\McpSdk\Server\RequestHandler\PingHandler;
+use Symfony\AI\McpSdk\Server\RequestHandler\PromptGetHandler;
+use Symfony\AI\McpSdk\Server\RequestHandler\PromptListHandler;
+use Symfony\AI\McpSdk\Server\RequestHandler\ResourceListHandler;
+use Symfony\AI\McpSdk\Server\RequestHandler\ResourceReadHandler;
+use Symfony\AI\McpSdk\Server\RequestHandler\ToolCallHandler;
+use Symfony\AI\McpSdk\Server\RequestHandler\ToolListHandler;
+use Symfony\AI\McpSdk\Server\RequestHandlerInterface;
 
 class Builder
 {

--- a/src/mcp-sdk/examples/cli/src/ExamplePrompt.php
+++ b/src/mcp-sdk/examples/cli/src/ExamplePrompt.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace App;
 
-use PhpLlm\McpSdk\Capability\Prompt\MetadataInterface;
-use PhpLlm\McpSdk\Capability\Prompt\PromptGet;
-use PhpLlm\McpSdk\Capability\Prompt\PromptGetResult;
-use PhpLlm\McpSdk\Capability\Prompt\PromptGetResultMessages;
-use PhpLlm\McpSdk\Capability\Prompt\PromptGetterInterface;
+use Symfony\AI\McpSdk\Capability\Prompt\MetadataInterface;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGet;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGetResult;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGetResultMessages;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGetterInterface;
 
 class ExamplePrompt implements MetadataInterface, PromptGetterInterface
 {

--- a/src/mcp-sdk/examples/cli/src/ExampleResource.php
+++ b/src/mcp-sdk/examples/cli/src/ExampleResource.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace App;
 
-use PhpLlm\McpSdk\Capability\Resource\MetadataInterface;
-use PhpLlm\McpSdk\Capability\Resource\ResourceRead;
-use PhpLlm\McpSdk\Capability\Resource\ResourceReaderInterface;
-use PhpLlm\McpSdk\Capability\Resource\ResourceReadResult;
+use Symfony\AI\McpSdk\Capability\Resource\MetadataInterface;
+use Symfony\AI\McpSdk\Capability\Resource\ResourceRead;
+use Symfony\AI\McpSdk\Capability\Resource\ResourceReaderInterface;
+use Symfony\AI\McpSdk\Capability\Resource\ResourceReadResult;
 
 class ExampleResource implements MetadataInterface, ResourceReaderInterface
 {

--- a/src/mcp-sdk/examples/cli/src/ExampleTool.php
+++ b/src/mcp-sdk/examples/cli/src/ExampleTool.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace App;
 
-use PhpLlm\McpSdk\Capability\Tool\MetadataInterface;
-use PhpLlm\McpSdk\Capability\Tool\ToolCall;
-use PhpLlm\McpSdk\Capability\Tool\ToolCallResult;
-use PhpLlm\McpSdk\Capability\Tool\ToolExecutorInterface;
+use Symfony\AI\McpSdk\Capability\Tool\MetadataInterface;
+use Symfony\AI\McpSdk\Capability\Tool\ToolCall;
+use Symfony\AI\McpSdk\Capability\Tool\ToolCallResult;
+use Symfony\AI\McpSdk\Capability\Tool\ToolExecutorInterface;
 
 class ExampleTool implements MetadataInterface, ToolExecutorInterface
 {

--- a/src/mcp-sdk/src/Capability/Prompt/CollectionInterface.php
+++ b/src/mcp-sdk/src/Capability/Prompt/CollectionInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Prompt;
+namespace Symfony\AI\McpSdk\Capability\Prompt;
 
 interface CollectionInterface
 {

--- a/src/mcp-sdk/src/Capability/Prompt/IdentifierInterface.php
+++ b/src/mcp-sdk/src/Capability/Prompt/IdentifierInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Prompt;
+namespace Symfony\AI\McpSdk\Capability\Prompt;
 
 interface IdentifierInterface
 {

--- a/src/mcp-sdk/src/Capability/Prompt/MetadataInterface.php
+++ b/src/mcp-sdk/src/Capability/Prompt/MetadataInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Prompt;
+namespace Symfony\AI\McpSdk\Capability\Prompt;
 
 interface MetadataInterface extends IdentifierInterface
 {

--- a/src/mcp-sdk/src/Capability/Prompt/PromptGet.php
+++ b/src/mcp-sdk/src/Capability/Prompt/PromptGet.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Prompt;
+namespace Symfony\AI\McpSdk\Capability\Prompt;
 
 final readonly class PromptGet
 {

--- a/src/mcp-sdk/src/Capability/Prompt/PromptGetResult.php
+++ b/src/mcp-sdk/src/Capability/Prompt/PromptGetResult.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Prompt;
+namespace Symfony\AI\McpSdk\Capability\Prompt;
 
 final readonly class PromptGetResult
 {

--- a/src/mcp-sdk/src/Capability/Prompt/PromptGetResultMessages.php
+++ b/src/mcp-sdk/src/Capability/Prompt/PromptGetResultMessages.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Prompt;
+namespace Symfony\AI\McpSdk\Capability\Prompt;
 
 final readonly class PromptGetResultMessages
 {

--- a/src/mcp-sdk/src/Capability/Prompt/PromptGetterInterface.php
+++ b/src/mcp-sdk/src/Capability/Prompt/PromptGetterInterface.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Prompt;
+namespace Symfony\AI\McpSdk\Capability\Prompt;
 
-use PhpLlm\McpSdk\Exception\PromptGetException;
-use PhpLlm\McpSdk\Exception\PromptNotFoundException;
+use Symfony\AI\McpSdk\Exception\PromptGetException;
+use Symfony\AI\McpSdk\Exception\PromptNotFoundException;
 
 interface PromptGetterInterface
 {

--- a/src/mcp-sdk/src/Capability/PromptChain.php
+++ b/src/mcp-sdk/src/Capability/PromptChain.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability;
+namespace Symfony\AI\McpSdk\Capability;
 
-use PhpLlm\McpSdk\Capability\Prompt\CollectionInterface;
-use PhpLlm\McpSdk\Capability\Prompt\IdentifierInterface;
-use PhpLlm\McpSdk\Capability\Prompt\MetadataInterface;
-use PhpLlm\McpSdk\Capability\Prompt\PromptGet;
-use PhpLlm\McpSdk\Capability\Prompt\PromptGetResult;
-use PhpLlm\McpSdk\Capability\Prompt\PromptGetterInterface;
-use PhpLlm\McpSdk\Exception\PromptGetException;
-use PhpLlm\McpSdk\Exception\PromptNotFoundException;
+use Symfony\AI\McpSdk\Capability\Prompt\CollectionInterface;
+use Symfony\AI\McpSdk\Capability\Prompt\IdentifierInterface;
+use Symfony\AI\McpSdk\Capability\Prompt\MetadataInterface;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGet;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGetResult;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGetterInterface;
+use Symfony\AI\McpSdk\Exception\PromptGetException;
+use Symfony\AI\McpSdk\Exception\PromptNotFoundException;
 
 /**
  * A collection of prompts. All prompts need to implement IdentifierInterface.

--- a/src/mcp-sdk/src/Capability/Resource/CollectionInterface.php
+++ b/src/mcp-sdk/src/Capability/Resource/CollectionInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Resource;
+namespace Symfony\AI\McpSdk\Capability\Resource;
 
 interface CollectionInterface
 {

--- a/src/mcp-sdk/src/Capability/Resource/IdentifierInterface.php
+++ b/src/mcp-sdk/src/Capability/Resource/IdentifierInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Resource;
+namespace Symfony\AI\McpSdk\Capability\Resource;
 
 interface IdentifierInterface
 {

--- a/src/mcp-sdk/src/Capability/Resource/MetadataInterface.php
+++ b/src/mcp-sdk/src/Capability/Resource/MetadataInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Resource;
+namespace Symfony\AI\McpSdk\Capability\Resource;
 
 interface MetadataInterface extends IdentifierInterface
 {

--- a/src/mcp-sdk/src/Capability/Resource/ResourceRead.php
+++ b/src/mcp-sdk/src/Capability/Resource/ResourceRead.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Resource;
+namespace Symfony\AI\McpSdk\Capability\Resource;
 
 final readonly class ResourceRead
 {

--- a/src/mcp-sdk/src/Capability/Resource/ResourceReadResult.php
+++ b/src/mcp-sdk/src/Capability/Resource/ResourceReadResult.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Resource;
+namespace Symfony\AI\McpSdk\Capability\Resource;
 
 final readonly class ResourceReadResult
 {

--- a/src/mcp-sdk/src/Capability/Resource/ResourceReaderInterface.php
+++ b/src/mcp-sdk/src/Capability/Resource/ResourceReaderInterface.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Resource;
+namespace Symfony\AI\McpSdk\Capability\Resource;
 
-use PhpLlm\McpSdk\Exception\ResourceNotFoundException;
-use PhpLlm\McpSdk\Exception\ResourceReadException;
+use Symfony\AI\McpSdk\Exception\ResourceNotFoundException;
+use Symfony\AI\McpSdk\Exception\ResourceReadException;
 
 interface ResourceReaderInterface
 {

--- a/src/mcp-sdk/src/Capability/ResourceChain.php
+++ b/src/mcp-sdk/src/Capability/ResourceChain.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability;
+namespace Symfony\AI\McpSdk\Capability;
 
-use PhpLlm\McpSdk\Capability\Resource\CollectionInterface;
-use PhpLlm\McpSdk\Capability\Resource\IdentifierInterface;
-use PhpLlm\McpSdk\Capability\Resource\MetadataInterface;
-use PhpLlm\McpSdk\Capability\Resource\ResourceRead;
-use PhpLlm\McpSdk\Capability\Resource\ResourceReaderInterface;
-use PhpLlm\McpSdk\Capability\Resource\ResourceReadResult;
-use PhpLlm\McpSdk\Exception\ResourceNotFoundException;
-use PhpLlm\McpSdk\Exception\ResourceReadException;
+use Symfony\AI\McpSdk\Capability\Resource\CollectionInterface;
+use Symfony\AI\McpSdk\Capability\Resource\IdentifierInterface;
+use Symfony\AI\McpSdk\Capability\Resource\MetadataInterface;
+use Symfony\AI\McpSdk\Capability\Resource\ResourceRead;
+use Symfony\AI\McpSdk\Capability\Resource\ResourceReaderInterface;
+use Symfony\AI\McpSdk\Capability\Resource\ResourceReadResult;
+use Symfony\AI\McpSdk\Exception\ResourceNotFoundException;
+use Symfony\AI\McpSdk\Exception\ResourceReadException;
 
 /**
  * A collection of resources. All resources need to implement IdentifierInterface.

--- a/src/mcp-sdk/src/Capability/Tool/CollectionInterface.php
+++ b/src/mcp-sdk/src/Capability/Tool/CollectionInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Tool;
+namespace Symfony\AI\McpSdk\Capability\Tool;
 
 interface CollectionInterface
 {

--- a/src/mcp-sdk/src/Capability/Tool/IdentifierInterface.php
+++ b/src/mcp-sdk/src/Capability/Tool/IdentifierInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Tool;
+namespace Symfony\AI\McpSdk\Capability\Tool;
 
 interface IdentifierInterface
 {

--- a/src/mcp-sdk/src/Capability/Tool/MetadataInterface.php
+++ b/src/mcp-sdk/src/Capability/Tool/MetadataInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Tool;
+namespace Symfony\AI\McpSdk\Capability\Tool;
 
 interface MetadataInterface extends IdentifierInterface
 {

--- a/src/mcp-sdk/src/Capability/Tool/ToolCall.php
+++ b/src/mcp-sdk/src/Capability/Tool/ToolCall.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Tool;
+namespace Symfony\AI\McpSdk\Capability\Tool;
 
 final readonly class ToolCall
 {

--- a/src/mcp-sdk/src/Capability/Tool/ToolCallResult.php
+++ b/src/mcp-sdk/src/Capability/Tool/ToolCallResult.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Tool;
+namespace Symfony\AI\McpSdk\Capability\Tool;
 
 final readonly class ToolCallResult
 {

--- a/src/mcp-sdk/src/Capability/Tool/ToolCollectionInterface.php
+++ b/src/mcp-sdk/src/Capability/Tool/ToolCollectionInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Tool;
+namespace Symfony\AI\McpSdk\Capability\Tool;
 
 interface ToolCollectionInterface
 {

--- a/src/mcp-sdk/src/Capability/Tool/ToolExecutorInterface.php
+++ b/src/mcp-sdk/src/Capability/Tool/ToolExecutorInterface.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability\Tool;
+namespace Symfony\AI\McpSdk\Capability\Tool;
 
-use PhpLlm\McpSdk\Exception\ToolExecutionException;
-use PhpLlm\McpSdk\Exception\ToolNotFoundException;
+use Symfony\AI\McpSdk\Exception\ToolExecutionException;
+use Symfony\AI\McpSdk\Exception\ToolNotFoundException;
 
 interface ToolExecutorInterface
 {

--- a/src/mcp-sdk/src/Capability/ToolChain.php
+++ b/src/mcp-sdk/src/Capability/ToolChain.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Capability;
+namespace Symfony\AI\McpSdk\Capability;
 
-use PhpLlm\McpSdk\Capability\Tool\CollectionInterface;
-use PhpLlm\McpSdk\Capability\Tool\IdentifierInterface;
-use PhpLlm\McpSdk\Capability\Tool\MetadataInterface;
-use PhpLlm\McpSdk\Capability\Tool\ToolCall;
-use PhpLlm\McpSdk\Capability\Tool\ToolCallResult;
-use PhpLlm\McpSdk\Capability\Tool\ToolExecutorInterface;
-use PhpLlm\McpSdk\Exception\ToolExecutionException;
-use PhpLlm\McpSdk\Exception\ToolNotFoundException;
+use Symfony\AI\McpSdk\Capability\Tool\CollectionInterface;
+use Symfony\AI\McpSdk\Capability\Tool\IdentifierInterface;
+use Symfony\AI\McpSdk\Capability\Tool\MetadataInterface;
+use Symfony\AI\McpSdk\Capability\Tool\ToolCall;
+use Symfony\AI\McpSdk\Capability\Tool\ToolCallResult;
+use Symfony\AI\McpSdk\Capability\Tool\ToolExecutorInterface;
+use Symfony\AI\McpSdk\Exception\ToolExecutionException;
+use Symfony\AI\McpSdk\Exception\ToolNotFoundException;
 
 /**
  * A collection of tools. All tools need to implement IdentifierInterface.

--- a/src/mcp-sdk/src/Exception/ExceptionInterface.php
+++ b/src/mcp-sdk/src/Exception/ExceptionInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Exception;
+namespace Symfony\AI\McpSdk\Exception;
 
 interface ExceptionInterface
 {

--- a/src/mcp-sdk/src/Exception/NotFoundExceptionInterface.php
+++ b/src/mcp-sdk/src/Exception/NotFoundExceptionInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Exception;
+namespace Symfony\AI\McpSdk\Exception;
 
 interface NotFoundExceptionInterface extends ExceptionInterface
 {

--- a/src/mcp-sdk/src/Exception/PromptGetException.php
+++ b/src/mcp-sdk/src/Exception/PromptGetException.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Exception;
+namespace Symfony\AI\McpSdk\Exception;
 
-use PhpLlm\McpSdk\Capability\Prompt\PromptGet;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGet;
 
 final class PromptGetException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/mcp-sdk/src/Exception/PromptNotFoundException.php
+++ b/src/mcp-sdk/src/Exception/PromptNotFoundException.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Exception;
+namespace Symfony\AI\McpSdk\Exception;
 
-use PhpLlm\McpSdk\Capability\Prompt\PromptGet;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGet;
 
 final class PromptNotFoundException extends \RuntimeException implements NotFoundExceptionInterface
 {

--- a/src/mcp-sdk/src/Exception/ResourceNotFoundException.php
+++ b/src/mcp-sdk/src/Exception/ResourceNotFoundException.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Exception;
+namespace Symfony\AI\McpSdk\Exception;
 
-use PhpLlm\McpSdk\Capability\Resource\ResourceRead;
+use Symfony\AI\McpSdk\Capability\Resource\ResourceRead;
 
 final class ResourceNotFoundException extends \RuntimeException implements NotFoundExceptionInterface
 {

--- a/src/mcp-sdk/src/Exception/ResourceReadException.php
+++ b/src/mcp-sdk/src/Exception/ResourceReadException.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Exception;
+namespace Symfony\AI\McpSdk\Exception;
 
-use PhpLlm\McpSdk\Capability\Resource\ResourceRead;
+use Symfony\AI\McpSdk\Capability\Resource\ResourceRead;
 
 final class ResourceReadException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/mcp-sdk/src/Exception/ToolExecutionException.php
+++ b/src/mcp-sdk/src/Exception/ToolExecutionException.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Exception;
+namespace Symfony\AI\McpSdk\Exception;
 
-use PhpLlm\McpSdk\Capability\Tool\ToolCall;
+use Symfony\AI\McpSdk\Capability\Tool\ToolCall;
 
 final class ToolExecutionException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/mcp-sdk/src/Exception/ToolNotFoundException.php
+++ b/src/mcp-sdk/src/Exception/ToolNotFoundException.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Exception;
+namespace Symfony\AI\McpSdk\Exception;
 
-use PhpLlm\McpSdk\Capability\Tool\ToolCall;
+use Symfony\AI\McpSdk\Capability\Tool\ToolCall;
 
 final class ToolNotFoundException extends \RuntimeException implements NotFoundExceptionInterface
 {

--- a/src/mcp-sdk/src/Message/Error.php
+++ b/src/mcp-sdk/src/Message/Error.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Message;
+namespace Symfony\AI\McpSdk\Message;
 
 final readonly class Error implements \JsonSerializable
 {

--- a/src/mcp-sdk/src/Message/Factory.php
+++ b/src/mcp-sdk/src/Message/Factory.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Message;
+namespace Symfony\AI\McpSdk\Message;
 
 final class Factory
 {

--- a/src/mcp-sdk/src/Message/Notification.php
+++ b/src/mcp-sdk/src/Message/Notification.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Message;
+namespace Symfony\AI\McpSdk\Message;
 
 final readonly class Notification implements \JsonSerializable, \Stringable
 {

--- a/src/mcp-sdk/src/Message/Request.php
+++ b/src/mcp-sdk/src/Message/Request.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Message;
+namespace Symfony\AI\McpSdk\Message;
 
 final class Request implements \JsonSerializable, \Stringable
 {

--- a/src/mcp-sdk/src/Message/Response.php
+++ b/src/mcp-sdk/src/Message/Response.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Message;
+namespace Symfony\AI\McpSdk\Message;
 
 final readonly class Response implements \JsonSerializable
 {

--- a/src/mcp-sdk/src/Server.php
+++ b/src/mcp-sdk/src/Server.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk;
+namespace Symfony\AI\McpSdk;
 
-use PhpLlm\McpSdk\Server\JsonRpcHandler;
-use PhpLlm\McpSdk\Server\TransportInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\AI\McpSdk\Server\JsonRpcHandler;
+use Symfony\AI\McpSdk\Server\TransportInterface;
 
 final readonly class Server
 {

--- a/src/mcp-sdk/src/Server/JsonRpcHandler.php
+++ b/src/mcp-sdk/src/Server/JsonRpcHandler.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server;
+namespace Symfony\AI\McpSdk\Server;
 
-use PhpLlm\McpSdk\Message\Error;
-use PhpLlm\McpSdk\Message\Factory;
-use PhpLlm\McpSdk\Message\Notification;
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Message\Response;
 use Psr\Log\LoggerInterface;
+use Symfony\AI\McpSdk\Message\Error;
+use Symfony\AI\McpSdk\Message\Factory;
+use Symfony\AI\McpSdk\Message\Notification;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Message\Response;
 
 /**
  * @final

--- a/src/mcp-sdk/src/Server/NotificationHandler/BaseNotificationHandler.php
+++ b/src/mcp-sdk/src/Server/NotificationHandler/BaseNotificationHandler.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\NotificationHandler;
+namespace Symfony\AI\McpSdk\Server\NotificationHandler;
 
-use PhpLlm\McpSdk\Message\Notification;
-use PhpLlm\McpSdk\Server\NotificationHandlerInterface;
+use Symfony\AI\McpSdk\Message\Notification;
+use Symfony\AI\McpSdk\Server\NotificationHandlerInterface;
 
 abstract class BaseNotificationHandler implements NotificationHandlerInterface
 {

--- a/src/mcp-sdk/src/Server/NotificationHandler/InitializedHandler.php
+++ b/src/mcp-sdk/src/Server/NotificationHandler/InitializedHandler.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\NotificationHandler;
+namespace Symfony\AI\McpSdk\Server\NotificationHandler;
 
-use PhpLlm\McpSdk\Message\Notification;
+use Symfony\AI\McpSdk\Message\Notification;
 
 final class InitializedHandler extends BaseNotificationHandler
 {

--- a/src/mcp-sdk/src/Server/NotificationHandlerInterface.php
+++ b/src/mcp-sdk/src/Server/NotificationHandlerInterface.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server;
+namespace Symfony\AI\McpSdk\Server;
 
-use PhpLlm\McpSdk\Message\Notification;
+use Symfony\AI\McpSdk\Message\Notification;
 
 interface NotificationHandlerInterface
 {

--- a/src/mcp-sdk/src/Server/RequestHandler/BaseRequestHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/BaseRequestHandler.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\RequestHandler;
+namespace Symfony\AI\McpSdk\Server\RequestHandler;
 
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Server\RequestHandlerInterface;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Server\RequestHandlerInterface;
 
 abstract class BaseRequestHandler implements RequestHandlerInterface
 {

--- a/src/mcp-sdk/src/Server/RequestHandler/InitializeHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/InitializeHandler.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\RequestHandler;
+namespace Symfony\AI\McpSdk\Server\RequestHandler;
 
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Message\Response;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Message\Response;
 
 final class InitializeHandler extends BaseRequestHandler
 {

--- a/src/mcp-sdk/src/Server/RequestHandler/PingHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/PingHandler.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\RequestHandler;
+namespace Symfony\AI\McpSdk\Server\RequestHandler;
 
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Message\Response;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Message\Response;
 
 final class PingHandler extends BaseRequestHandler
 {

--- a/src/mcp-sdk/src/Server/RequestHandler/PromptGetHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/PromptGetHandler.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\RequestHandler;
+namespace Symfony\AI\McpSdk\Server\RequestHandler;
 
-use PhpLlm\McpSdk\Capability\Prompt\PromptGet;
-use PhpLlm\McpSdk\Capability\Prompt\PromptGetterInterface;
-use PhpLlm\McpSdk\Exception\ExceptionInterface;
-use PhpLlm\McpSdk\Message\Error;
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Message\Response;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGet;
+use Symfony\AI\McpSdk\Capability\Prompt\PromptGetterInterface;
+use Symfony\AI\McpSdk\Exception\ExceptionInterface;
+use Symfony\AI\McpSdk\Message\Error;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Message\Response;
 
 final class PromptGetHandler extends BaseRequestHandler
 {

--- a/src/mcp-sdk/src/Server/RequestHandler/PromptListHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/PromptListHandler.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\RequestHandler;
+namespace Symfony\AI\McpSdk\Server\RequestHandler;
 
-use PhpLlm\McpSdk\Capability\Prompt\CollectionInterface;
-use PhpLlm\McpSdk\Capability\Prompt\MetadataInterface;
-use PhpLlm\McpSdk\Message\Notification;
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Message\Response;
+use Symfony\AI\McpSdk\Capability\Prompt\CollectionInterface;
+use Symfony\AI\McpSdk\Capability\Prompt\MetadataInterface;
+use Symfony\AI\McpSdk\Message\Notification;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Message\Response;
 
 final class PromptListHandler extends BaseRequestHandler
 {

--- a/src/mcp-sdk/src/Server/RequestHandler/ResourceListHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/ResourceListHandler.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\RequestHandler;
+namespace Symfony\AI\McpSdk\Server\RequestHandler;
 
-use PhpLlm\McpSdk\Capability\Resource\CollectionInterface;
-use PhpLlm\McpSdk\Capability\Resource\MetadataInterface;
-use PhpLlm\McpSdk\Message\Notification;
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Message\Response;
+use Symfony\AI\McpSdk\Capability\Resource\CollectionInterface;
+use Symfony\AI\McpSdk\Capability\Resource\MetadataInterface;
+use Symfony\AI\McpSdk\Message\Notification;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Message\Response;
 
 final class ResourceListHandler extends BaseRequestHandler
 {

--- a/src/mcp-sdk/src/Server/RequestHandler/ResourceReadHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/ResourceReadHandler.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\RequestHandler;
+namespace Symfony\AI\McpSdk\Server\RequestHandler;
 
-use PhpLlm\McpSdk\Capability\Resource\ResourceRead;
-use PhpLlm\McpSdk\Capability\Resource\ResourceReaderInterface;
-use PhpLlm\McpSdk\Exception\ExceptionInterface;
-use PhpLlm\McpSdk\Message\Error;
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Message\Response;
+use Symfony\AI\McpSdk\Capability\Resource\ResourceRead;
+use Symfony\AI\McpSdk\Capability\Resource\ResourceReaderInterface;
+use Symfony\AI\McpSdk\Exception\ExceptionInterface;
+use Symfony\AI\McpSdk\Message\Error;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Message\Response;
 
 final class ResourceReadHandler extends BaseRequestHandler
 {

--- a/src/mcp-sdk/src/Server/RequestHandler/ToolCallHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/ToolCallHandler.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\RequestHandler;
+namespace Symfony\AI\McpSdk\Server\RequestHandler;
 
-use PhpLlm\McpSdk\Capability\Tool\ToolCall;
-use PhpLlm\McpSdk\Capability\Tool\ToolExecutorInterface;
-use PhpLlm\McpSdk\Exception\ExceptionInterface;
-use PhpLlm\McpSdk\Message\Error;
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Message\Response;
+use Symfony\AI\McpSdk\Capability\Tool\ToolCall;
+use Symfony\AI\McpSdk\Capability\Tool\ToolExecutorInterface;
+use Symfony\AI\McpSdk\Exception\ExceptionInterface;
+use Symfony\AI\McpSdk\Message\Error;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Message\Response;
 
 final class ToolCallHandler extends BaseRequestHandler
 {

--- a/src/mcp-sdk/src/Server/RequestHandler/ToolListHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/ToolListHandler.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\RequestHandler;
+namespace Symfony\AI\McpSdk\Server\RequestHandler;
 
-use PhpLlm\McpSdk\Capability\Tool\CollectionInterface;
-use PhpLlm\McpSdk\Capability\Tool\MetadataInterface;
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Message\Response;
+use Symfony\AI\McpSdk\Capability\Tool\CollectionInterface;
+use Symfony\AI\McpSdk\Capability\Tool\MetadataInterface;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Message\Response;
 
 final class ToolListHandler extends BaseRequestHandler
 {

--- a/src/mcp-sdk/src/Server/RequestHandlerInterface.php
+++ b/src/mcp-sdk/src/Server/RequestHandlerInterface.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server;
+namespace Symfony\AI\McpSdk\Server;
 
-use PhpLlm\McpSdk\Message\Error;
-use PhpLlm\McpSdk\Message\Request;
-use PhpLlm\McpSdk\Message\Response;
+use Symfony\AI\McpSdk\Message\Error;
+use Symfony\AI\McpSdk\Message\Request;
+use Symfony\AI\McpSdk\Message\Response;
 
 interface RequestHandlerInterface
 {

--- a/src/mcp-sdk/src/Server/Transport/Sse/Store/CachePoolStore.php
+++ b/src/mcp-sdk/src/Server/Transport/Sse/Store/CachePoolStore.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\Transport\Sse\Store;
+namespace Symfony\AI\McpSdk\Server\Transport\Sse\Store;
 
-use PhpLlm\McpSdk\Server\Transport\Sse\StoreInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\AI\McpSdk\Server\Transport\Sse\StoreInterface;
 use Symfony\Component\Uid\Uuid;
 
 final readonly class CachePoolStore implements StoreInterface

--- a/src/mcp-sdk/src/Server/Transport/Sse/StoreInterface.php
+++ b/src/mcp-sdk/src/Server/Transport/Sse/StoreInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\Transport\Sse;
+namespace Symfony\AI\McpSdk\Server\Transport\Sse;
 
 use Symfony\Component\Uid\Uuid;
 

--- a/src/mcp-sdk/src/Server/Transport/Sse/StreamTransport.php
+++ b/src/mcp-sdk/src/Server/Transport/Sse/StreamTransport.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\Transport\Sse;
+namespace Symfony\AI\McpSdk\Server\Transport\Sse;
 
-use PhpLlm\McpSdk\Server\TransportInterface;
+use Symfony\AI\McpSdk\Server\TransportInterface;
 use Symfony\Component\Uid\Uuid;
 
 final readonly class StreamTransport implements TransportInterface

--- a/src/mcp-sdk/src/Server/Transport/Stdio/SymfonyConsoleTransport.php
+++ b/src/mcp-sdk/src/Server/Transport/Stdio/SymfonyConsoleTransport.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server\Transport\Stdio;
+namespace Symfony\AI\McpSdk\Server\Transport\Stdio;
 
-use PhpLlm\McpSdk\Server\TransportInterface;
+use Symfony\AI\McpSdk\Server\TransportInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StreamableInputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/mcp-sdk/src/Server/TransportInterface.php
+++ b/src/mcp-sdk/src/Server/TransportInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Server;
+namespace Symfony\AI\McpSdk\Server;
 
 interface TransportInterface
 {

--- a/src/mcp-sdk/tests/Fixtures/InMemoryTransport.php
+++ b/src/mcp-sdk/tests/Fixtures/InMemoryTransport.php
@@ -1,8 +1,19 @@
 <?php
 
-namespace PhpLlm\McpSdk\Tests\Fixtures;
+declare(strict_types=1);
 
-use PhpLlm\McpSdk\Server\TransportInterface;
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpSdk\Tests\Fixtures;
+
+use Symfony\AI\McpSdk\Server\TransportInterface;
 
 class InMemoryTransport implements TransportInterface
 {

--- a/src/mcp-sdk/tests/Message/ErrorTest.php
+++ b/src/mcp-sdk/tests/Message/ErrorTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Tests\Message;
+namespace Symfony\AI\McpSdk\Tests\Message;
 
-use PhpLlm\McpSdk\Message\Error;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpSdk\Message\Error;
 
 final class ErrorTest extends TestCase
 {

--- a/src/mcp-sdk/tests/Message/FactoryTest.php
+++ b/src/mcp-sdk/tests/Message/FactoryTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Tests\Message;
+namespace Symfony\AI\McpSdk\Tests\Message;
 
-use PhpLlm\McpSdk\Message\Factory;
-use PhpLlm\McpSdk\Message\Notification;
-use PhpLlm\McpSdk\Message\Request;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpSdk\Message\Factory;
+use Symfony\AI\McpSdk\Message\Notification;
+use Symfony\AI\McpSdk\Message\Request;
 
 final class FactoryTest extends TestCase
 {

--- a/src/mcp-sdk/tests/Message/ResponseTest.php
+++ b/src/mcp-sdk/tests/Message/ResponseTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Tests\Message;
+namespace Symfony\AI\McpSdk\Tests\Message;
 
-use PhpLlm\McpSdk\Message\Response;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpSdk\Message\Response;
 
 final class ResponseTest extends TestCase
 {

--- a/src/mcp-sdk/tests/ServerTest.php
+++ b/src/mcp-sdk/tests/ServerTest.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace PhpLlm\McpSdk\Tests;
+namespace Symfony\AI\McpSdk\Tests;
 
-use PhpLlm\McpSdk\Server;
-use PhpLlm\McpSdk\Server\JsonRpcHandler;
-use PhpLlm\McpSdk\Tests\Fixtures\InMemoryTransport;
 use PHPUnit\Framework\MockObject\Stub\Exception;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\AI\McpSdk\Server;
+use Symfony\AI\McpSdk\Server\JsonRpcHandler;
+use Symfony\AI\McpSdk\Tests\Fixtures\InMemoryTransport;
 
 class ServerTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Switches from `PHPLlm\McpSdk`  to `Symfony\AI\McpSdk` 