### PR TITLE
refactor: rename `Embedder` to `Indexer` and open input to iterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,22 +396,22 @@ $response = $agent->call($messages);
 Symfony AI supports document embedding and similarity search using vector stores like ChromaDB, Azure AI Search, MongoDB
 Atlas Search, or Pinecone.
 
-For populating a vector store, Symfony AI provides the service `Embedder`, which requires an instance of an
+For populating a vector store, Symfony AI provides the service `Indexer`, which requires an instance of an
 `EmbeddingsModel` and one of `StoreInterface`, and works with a collection of `Document` objects as input:
 
 ```php
 use Symfony\AI\Platform\Bridge\OpenAI\Embeddings;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Store\Bridge\Pinecone\Store;
-use Symfony\AI\Store\Embedder;
+use Symfony\AI\Store\Indexer;
 use Probots\Pinecone\Pinecone;
 
-$embedder = new Embedder(
+$indexer = new Indexer(
     PlatformFactory::create($_ENV['OPENAI_API_KEY']),
     new Embeddings(),
     new Store(Pinecone::client($_ENV['PINECONE_API_KEY'], $_ENV['PINECONE_HOST']),
 );
-$embedder->embed($documents);
+$indexer->index($documents);
 ```
 
 The collection of `Document` instances is usually created by text input of your domain entities:

--- a/examples/store/mongodb-similarity-search.php
+++ b/examples/store/mongodb-similarity-search.php
@@ -22,7 +22,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Store\Bridge\MongoDB\Store;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\TextDocument;
-use Symfony\AI\Store\Embedder;
+use Symfony\AI\Store\Indexer;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Uid\Uuid;
 
@@ -61,8 +61,8 @@ foreach ($movies as $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
-$embedder = new Embedder($platform, $embeddings = new Embeddings(), $store);
-$embedder->embed($documents);
+$indexer = new Indexer($platform, $embeddings = new Embeddings(), $store);
+$indexer->index($documents);
 
 // initialize the index
 $store->initialize();

--- a/examples/store/pinecone-similarity-search.php
+++ b/examples/store/pinecone-similarity-search.php
@@ -22,7 +22,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Store\Bridge\Pinecone\Store;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\TextDocument;
-use Symfony\AI\Store\Embedder;
+use Symfony\AI\Store\Indexer;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Uid\Uuid;
 
@@ -55,8 +55,8 @@ foreach ($movies as $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
-$embedder = new Embedder($platform, $embeddings = new Embeddings(), $store);
-$embedder->embed($documents);
+$indexer = new Indexer($platform, $embeddings = new Embeddings(), $store);
+$indexer->index($documents);
 
 $model = new GPT(GPT::GPT_4O_MINI);
 

--- a/src/ai-bundle/README.md
+++ b/src/ai-bundle/README.md
@@ -77,7 +77,7 @@ ai:
             # multiple collections possible per type
             default:
                 collection: 'my_collection'
-    embedder:
+    indexer:
         default:
             # platform: 'symfony_ai.platform.anthropic'
             # store: 'symfony_ai.store.chroma_db.default'

--- a/src/ai-bundle/src/DependencyInjection/Configuration.php
+++ b/src/ai-bundle/src/DependencyInjection/Configuration.php
@@ -192,7 +192,7 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
-                ->arrayNode('embedder')
+                ->arrayNode('indexer')
                     ->normalizeKeys(false)
                     ->useAttributeAsKey('name')
                     ->arrayPrototype()

--- a/src/store/src/Indexer.php
+++ b/src/store/src/Indexer.php
@@ -24,7 +24,7 @@ use Symfony\Component\Clock\ClockInterface;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final readonly class Embedder
+final readonly class Indexer
 {
     private ClockInterface $clock;
 
@@ -39,16 +39,16 @@ final readonly class Embedder
     }
 
     /**
-     * @param TextDocument|TextDocument[] $documents
+     * @param TextDocument|iterable<TextDocument> $documents
      */
-    public function embed(TextDocument|array $documents, int $chunkSize = 0, int $sleep = 0): void
+    public function index(TextDocument|iterable $documents, int $chunkSize = 0, int $sleep = 0): void
     {
         if ($documents instanceof TextDocument) {
             $documents = [$documents];
         }
 
         if ([] === $documents) {
-            $this->logger->debug('No documents to embed');
+            $this->logger->debug('No documents to index');
 
             return;
         }

--- a/src/store/tests/IndexerTest.php
+++ b/src/store/tests/IndexerTest.php
@@ -27,13 +27,13 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\VectorDocument;
-use Symfony\AI\Store\Embedder;
+use Symfony\AI\Store\Indexer;
 use Symfony\AI\Store\Tests\Double\PlatformTestHandler;
 use Symfony\AI\Store\Tests\Double\TestStore;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Uid\Uuid;
 
-#[CoversClass(Embedder::class)]
+#[CoversClass(Indexer::class)]
 #[Medium]
 #[UsesClass(TextDocument::class)]
 #[UsesClass(Vector::class)]
@@ -44,7 +44,7 @@ use Symfony\Component\Uid\Uuid;
 #[UsesClass(Platform::class)]
 #[UsesClass(AsyncResponse::class)]
 #[UsesClass(VectorResponse::class)]
-final class EmbedderTest extends TestCase
+final class IndexerTest extends TestCase
 {
     #[Test]
     public function embedSingleDocument(): void
@@ -52,14 +52,14 @@ final class EmbedderTest extends TestCase
         $document = new TextDocument($id = Uuid::v4(), 'Test content');
         $vector = new Vector([0.1, 0.2, 0.3]);
 
-        $embedder = new Embedder(
+        $indexer = new Indexer(
             PlatformTestHandler::createPlatform(new VectorResponse($vector)),
             new Embeddings(),
             $store = new TestStore(),
             new MockClock(),
         );
 
-        $embedder->embed($document);
+        $indexer->index($document);
 
         self::assertCount(1, $store->documents);
         self::assertInstanceOf(VectorDocument::class, $store->documents[0]);
@@ -71,9 +71,9 @@ final class EmbedderTest extends TestCase
     public function embedEmptyDocumentList(): void
     {
         $logger = self::createMock(LoggerInterface::class);
-        $logger->expects(self::once())->method('debug')->with('No documents to embed');
+        $logger->expects(self::once())->method('debug')->with('No documents to index');
 
-        $embedder = new Embedder(
+        $indexer = new Indexer(
             PlatformTestHandler::createPlatform(),
             new Embeddings(),
             $store = new TestStore(),
@@ -81,7 +81,7 @@ final class EmbedderTest extends TestCase
             $logger,
         );
 
-        $embedder->embed([]);
+        $indexer->index([]);
 
         self::assertSame([], $store->documents);
     }
@@ -93,14 +93,14 @@ final class EmbedderTest extends TestCase
         $document = new TextDocument($id = Uuid::v4(), 'Test content', $metadata);
         $vector = new Vector([0.1, 0.2, 0.3]);
 
-        $embedder = new Embedder(
+        $indexer = new Indexer(
             PlatformTestHandler::createPlatform(new VectorResponse($vector)),
             new Embeddings(),
             $store = new TestStore(),
             new MockClock(),
         );
 
-        $embedder->embed($document);
+        $indexer->index($document);
 
         self::assertSame(1, $store->addCalls);
         self::assertCount(1, $store->documents);
@@ -119,14 +119,14 @@ final class EmbedderTest extends TestCase
         $document1 = new TextDocument(Uuid::v4(), 'Test content 1');
         $document2 = new TextDocument(Uuid::v4(), 'Test content 2');
 
-        $embedder = new Embedder(
+        $indexer = new Indexer(
             PlatformTestHandler::createPlatform(new VectorResponse($vector1, $vector2)),
             new Embeddings(),
             $store = new TestStore(),
             $clock = new MockClock('2024-01-01 00:00:00'),
         );
 
-        $embedder->embed(
+        $indexer->index(
             documents: [$document1, $document2],
             sleep: 3
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Cherry picking https://github.com/php-llm/llm-chain/pull/336