### PR TITLE
feat: allow `\Stringable` for `Message::ofUser()` and `Message:forSystem()`

### DIFF
--- a/src/platform/src/Message/Message.php
+++ b/src/platform/src/Message/Message.php
@@ -26,9 +26,9 @@ final readonly class Message
     {
     }
 
-    public static function forSystem(string $content): SystemMessage
+    public static function forSystem(\Stringable|string $content): SystemMessage
     {
-        return new SystemMessage($content);
+        return new SystemMessage($content instanceof \Stringable ? (string) $content : $content);
     }
 
     /**
@@ -39,10 +39,10 @@ final readonly class Message
         return new AssistantMessage($content, $toolCalls);
     }
 
-    public static function ofUser(string|ContentInterface ...$content): UserMessage
+    public static function ofUser(\Stringable|string|ContentInterface ...$content): UserMessage
     {
         $content = array_map(
-            static fn (string|ContentInterface $entry) => \is_string($entry) ? new Text($entry) : $entry,
+            static fn (\Stringable|string|ContentInterface $entry) => $entry instanceof ContentInterface ? $entry : (\is_string($entry) ? new Text($entry) : new Text((string) $entry)),
             $content,
         );
 

--- a/src/platform/tests/Message/MessageTest.php
+++ b/src/platform/tests/Message/MessageTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\ContentInterface;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
@@ -39,9 +40,22 @@ use Symfony\AI\Platform\Response\ToolCall;
 final class MessageTest extends TestCase
 {
     #[Test]
-    public function createSystemMessage(): void
+    public function createSystemMessageWithString(): void
     {
         $message = Message::forSystem('My amazing system prompt.');
+
+        self::assertSame('My amazing system prompt.', $message->content);
+    }
+
+    #[Test]
+    public function createSystemMessageWithStringable(): void
+    {
+        $message = Message::forSystem(new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'My amazing system prompt.';
+            }
+        });
 
         self::assertSame('My amazing system prompt.', $message->content);
     }
@@ -68,13 +82,42 @@ final class MessageTest extends TestCase
     }
 
     #[Test]
-    public function createUserMessage(): void
+    public function createUserMessageWithString(): void
     {
         $message = Message::ofUser('Hi, my name is John.');
 
         self::assertCount(1, $message->content);
         self::assertInstanceOf(Text::class, $message->content[0]);
         self::assertSame('Hi, my name is John.', $message->content[0]->text);
+    }
+
+    #[Test]
+    public function createUserMessageWithStringable(): void
+    {
+        $message = Message::ofUser(new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'Hi, my name is John.';
+            }
+        });
+
+        self::assertCount(1, $message->content);
+        self::assertInstanceOf(Text::class, $message->content[0]);
+        self::assertSame('Hi, my name is John.', $message->content[0]->text);
+    }
+
+    #[Test]
+    public function createUserMessageContentInterfaceImplementingStringable(): void
+    {
+        $message = Message::ofUser(new class implements ContentInterface, \Stringable {
+            public function __toString(): string
+            {
+                return 'I am a ContentInterface!';
+            }
+        });
+
+        self::assertCount(1, $message->content);
+        self::assertInstanceOf(ContentInterface::class, $message->content[0]);
     }
 
     #[Test]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

Cherry picking https://github.com/php-llm/llm-chain/pull/340
