### PR TITLE
fix: Async response not instanceof ImageResponse in example

### DIFF
--- a/examples/openai/image-output-dall-e-3.php
+++ b/examples/openai/image-output-dall-e-3.php
@@ -12,6 +12,7 @@
 use Symfony\AI\Platform\Bridge\OpenAI\DallE;
 use Symfony\AI\Platform\Bridge\OpenAI\DallE\ImageResponse;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
+use Symfony\AI\Platform\Response\AsyncResponse;
 use Symfony\Component\Dotenv\Dotenv;
 
 require_once dirname(__DIR__).'/vendor/autoload.php';
@@ -32,9 +33,14 @@ $response = $platform->request(
     ],
 );
 
-assert($response instanceof ImageResponse);
+if ($response instanceof AsyncResponse) {
+    echo 'This is an async response. Please wait for the completion...'.\PHP_EOL;
 
-echo 'Revised Prompt: '.$response->revisedPrompt.\PHP_EOL.\PHP_EOL;
+    $innerResponse = $response->unwrap();
+    assert($innerResponse instanceof ImageResponse);
+}
+
+echo 'Revised Prompt: '.$innerResponse->revisedPrompt.\PHP_EOL.\PHP_EOL;
 
 foreach ($response->getContent() as $index => $image) {
     echo 'Image '.$index.': '.$image->url.\PHP_EOL;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... 
| License       | MIT

In [examples/openai/image-output-dall-e-3.php](https://github.com/smnandre/ai/blob/96c9a47e3e912b4f495d45ee7b6e4a01dd43ec34/examples/openai/image-output-dall-e-3.php#L35)

```php
assert($response instanceof ImageResponse);   //  ❌
```

The response is an `AsyncResponse` that wraps a `ImageResponse` (and forwards methods and properties via __call and __get) but the assertion fails.

Not sure how to explain this simply in the example code.
