### PR TITLE
chore: Allow arbitrary vector dimensions for MariaDB store

### DIFF
--- a/src/store/src/Bridge/MariaDB/Store.php
+++ b/src/store/src/Bridge/MariaDB/Store.php
@@ -133,12 +133,12 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
     }
 
     /**
-     * @param array{} $options
+     * @param array{dimensions?: positive-int} $options
      */
     public function initialize(array $options = []): void
     {
-        if ([] !== $options) {
-            throw new InvalidArgumentException('No supported options');
+        if ([] !== $options && !\array_key_exists('dimensions', $options)) {
+            throw new InvalidArgumentException('The only supported option is "dimensions"');
         }
 
         $serverVersion = $this->connection->getAttribute(\PDO::ATTR_SERVER_VERSION);
@@ -153,13 +153,14 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
                     CREATE TABLE IF NOT EXISTS %1$s (
                         id BINARY(16) NOT NULL PRIMARY KEY,
                         metadata JSON,
-                        %2$s VECTOR(1536) NOT NULL,
+                        %2$s VECTOR(%4$d) NOT NULL,
                         VECTOR INDEX %3$s (%2$s)
                     )
                     SQL,
                 $this->tableName,
                 $this->vectorFieldName,
                 $this->indexName,
+                $options['dimensions'] ?? 1536,
             ),
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | 
| Issues        | 
| License       | MIT

Cherry picking https://github.com/php-llm/llm-chain/pull/348

> MariaDB insists the dimensions of the vector being inserted match exactly the dimensions of the vector defined in the schema.

Since the store knows nothing about the Model & it's expected vector dimensions, let's allow passing vector dimensions as a parameter to `initialize()` leave the problem to the user.