### PR TITLE
fix: recursively remove `additionalProperties` from Gemini requests

### DIFF
--- a/src/platform/src/Bridge/Google/Contract/ToolNormalizer.php
+++ b/src/platform/src/Bridge/Google/Contract/ToolNormalizer.php
@@ -47,17 +47,34 @@ final class ToolNormalizer extends ModelContractNormalizer
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        $parameters = $data->parameters;
-        unset($parameters['additionalProperties']);
-
         return [
             'functionDeclarations' => [
                 [
                     'description' => $data->description,
                     'name' => $data->name,
-                    'parameters' => $parameters,
+                    'parameters' => $data->parameters ? $this->removeAdditionalProperties($data->parameters) : null,
                 ],
             ],
         ];
+    }
+
+    /**
+     * @template T of array
+     *
+     * @phpstan-param T $data
+     *
+     * @phpstan-return T
+     */
+    private function removeAdditionalProperties(array $data): array
+    {
+        unset($data['additionalProperties']); // not supported by Gemini
+
+        foreach ($data as &$value) {
+            if (\is_array($value)) {
+                $value = $this->removeAdditionalProperties($value);
+            }
+        }
+
+        return $data;
     }
 }

--- a/src/platform/tests/Bridge/Google/Contract/ToolNormalizerTest.php
+++ b/src/platform/tests/Bridge/Google/Contract/ToolNormalizerTest.php
@@ -88,6 +88,11 @@ final class ToolNormalizerTest extends TestCase
                             'type' => 'integer',
                             'description' => 'Number parameter',
                         ],
+                        'nestedObject' => [
+                            'type' => 'object',
+                            'description' => 'bar',
+                            'additionalProperties' => false,
+                        ],
                     ],
                     'required' => ['text', 'number'],
                     'additionalProperties' => false,
@@ -108,6 +113,10 @@ final class ToolNormalizerTest extends TestCase
                                 'number' => [
                                     'type' => 'integer',
                                     'description' => 'Number parameter',
+                                ],
+                                'nestedObject' => [
+                                    'type' => 'object',
+                                    'description' => 'bar',
                                 ],
                             ],
                             'required' => ['text', 'number'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Cherry picking https://github.com/php-llm/llm-chain/pull/351

> Tool parameters with nested objects cause 400 bad request from Gemini due to only removing the unsupported `additionalProperties` on top-level.

```
Invalid JSON payload received. Unknown name "additionalProperties" at 'tools[0].function_declarations[0].parameters.properties[0].value': Cannot find field.
```