### PR TITLE
chore: remove occurrences of `empty()`

### DIFF
--- a/examples/anthropic/chat.php
+++ b/examples/anthropic/chat.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['ANTHROPIC_API_KEY'])) {
+if (!$_ENV['ANTHROPIC_API_KEY']) {
     echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/anthropic/image-input-binary.php
+++ b/examples/anthropic/image-input-binary.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['ANTHROPIC_API_KEY'])) {
+if (!$_ENV['ANTHROPIC_API_KEY']) {
     echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/anthropic/image-input-url.php
+++ b/examples/anthropic/image-input-url.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['ANTHROPIC_API_KEY'])) {
+if (!$_ENV['ANTHROPIC_API_KEY']) {
     echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/anthropic/pdf-input-binary.php
+++ b/examples/anthropic/pdf-input-binary.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['ANTHROPIC_API_KEY'])) {
+if (!$_ENV['ANTHROPIC_API_KEY']) {
     echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/anthropic/pdf-input-url.php
+++ b/examples/anthropic/pdf-input-url.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['ANTHROPIC_API_KEY'])) {
+if (!$_ENV['ANTHROPIC_API_KEY']) {
     echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/anthropic/stream.php
+++ b/examples/anthropic/stream.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['ANTHROPIC_API_KEY'])) {
+if (!$_ENV['ANTHROPIC_API_KEY']) {
     echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/anthropic/toolcall.php
+++ b/examples/anthropic/toolcall.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpClient\HttpClient;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['ANTHROPIC_API_KEY'])) {
+if (!$_ENV['ANTHROPIC_API_KEY']) {
     echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/azure/audio-transcript.php
+++ b/examples/azure/audio-transcript.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AZURE_OPENAI_BASEURL']) || empty($_ENV['AZURE_OPENAI_WHISPER_DEPLOYMENT']) || empty($_ENV['AZURE_OPENAI_WHISPER_API_VERSION']) || empty($_ENV['AZURE_OPENAI_KEY'])
+if (!$_ENV['AZURE_OPENAI_BASEURL'] || !$_ENV['AZURE_OPENAI_WHISPER_DEPLOYMENT'] || !$_ENV['AZURE_OPENAI_WHISPER_API_VERSION'] || !$_ENV['AZURE_OPENAI_KEY']
 ) {
     echo 'Please set the AZURE_OPENAI_BASEURL, AZURE_OPENAI_WHISPER_DEPLOYMENT, AZURE_OPENAI_WHISPER_API_VERSION, and AZURE_OPENAI_KEY environment variables.'.\PHP_EOL;
     exit(1);

--- a/examples/azure/chat-gpt.php
+++ b/examples/azure/chat-gpt.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AZURE_OPENAI_BASEURL']) || empty($_ENV['AZURE_OPENAI_GPT_DEPLOYMENT']) || empty($_ENV['AZURE_OPENAI_GPT_API_VERSION']) || empty($_ENV['AZURE_OPENAI_KEY'])
+if (!$_ENV['AZURE_OPENAI_BASEURL'] || !$_ENV['AZURE_OPENAI_GPT_DEPLOYMENT'] || !$_ENV['AZURE_OPENAI_GPT_API_VERSION'] || !$_ENV['AZURE_OPENAI_KEY']
 ) {
     echo 'Please set the AZURE_OPENAI_BASEURL, AZURE_OPENAI_GPT_DEPLOYMENT, AZURE_OPENAI_GPT_API_VERSION, and AZURE_OPENAI_KEY environment variables.'.\PHP_EOL;
     exit(1);

--- a/examples/azure/chat-llama.php
+++ b/examples/azure/chat-llama.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AZURE_LLAMA_BASEURL']) || empty($_ENV['AZURE_LLAMA_KEY'])) {
+if (!$_ENV['AZURE_LLAMA_BASEURL'] || !$_ENV['AZURE_LLAMA_KEY']) {
     echo 'Please set the AZURE_LLAMA_BASEURL and AZURE_LLAMA_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/azure/embeddings.php
+++ b/examples/azure/embeddings.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AZURE_OPENAI_BASEURL']) || empty($_ENV['AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT']) || empty($_ENV['AZURE_OPENAI_EMBEDDINGS_API_VERSION']) || empty($_ENV['AZURE_OPENAI_KEY'])
+if (!$_ENV['AZURE_OPENAI_BASEURL'] || !$_ENV['AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT'] || !$_ENV['AZURE_OPENAI_EMBEDDINGS_API_VERSION'] || !$_ENV['AZURE_OPENAI_KEY']
 ) {
     echo 'Please set the AZURE_OPENAI_BASEURL, AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT, AZURE_OPENAI_EMBEDDINGS_API_VERSION, and AZURE_OPENAI_KEY environment variables.'.\PHP_EOL;
     exit(1);

--- a/examples/bedrock/chat-claude.php
+++ b/examples/bedrock/chat-claude.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AWS_ACCESS_KEY_ID']) || empty($_ENV['AWS_SECRET_ACCESS_KEY']) || empty($_ENV['AWS_DEFAULT_REGION'])
+if (!$_ENV['AWS_ACCESS_KEY_ID'] || !$_ENV['AWS_SECRET_ACCESS_KEY'] || !$_ENV['AWS_DEFAULT_REGION']
 ) {
     echo 'Please set the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION environment variables.'.\PHP_EOL;
     exit(1);

--- a/examples/bedrock/chat-llama.php
+++ b/examples/bedrock/chat-llama.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AWS_ACCESS_KEY_ID']) || empty($_ENV['AWS_SECRET_ACCESS_KEY']) || empty($_ENV['AWS_DEFAULT_REGION'])
+if (!$_ENV['AWS_ACCESS_KEY_ID'] || !$_ENV['AWS_SECRET_ACCESS_KEY'] || !$_ENV['AWS_DEFAULT_REGION']
 ) {
     echo 'Please set the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION environment variables.'.\PHP_EOL;
     exit(1);

--- a/examples/bedrock/chat-nova.php
+++ b/examples/bedrock/chat-nova.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AWS_ACCESS_KEY_ID']) || empty($_ENV['AWS_SECRET_ACCESS_KEY']) || empty($_ENV['AWS_DEFAULT_REGION'])
+if (!$_ENV['AWS_ACCESS_KEY_ID'] || !$_ENV['AWS_SECRET_ACCESS_KEY'] || !$_ENV['AWS_DEFAULT_REGION']
 ) {
     echo 'Please set the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION environment variables.'.\PHP_EOL;
     exit(1);

--- a/examples/bedrock/image-claude-binary.php
+++ b/examples/bedrock/image-claude-binary.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AWS_ACCESS_KEY_ID']) || empty($_ENV['AWS_SECRET_ACCESS_KEY']) || empty($_ENV['AWS_DEFAULT_REGION'])
+if (!$_ENV['AWS_ACCESS_KEY_ID'] || !$_ENV['AWS_SECRET_ACCESS_KEY'] || !$_ENV['AWS_DEFAULT_REGION']
 ) {
     echo 'Please set the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION environment variables.'.\PHP_EOL;
     exit(1);

--- a/examples/bedrock/image-nova.php
+++ b/examples/bedrock/image-nova.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AWS_ACCESS_KEY_ID']) || empty($_ENV['AWS_SECRET_ACCESS_KEY']) || empty($_ENV['AWS_DEFAULT_REGION'])
+if (!$_ENV['AWS_ACCESS_KEY_ID'] || !$_ENV['AWS_SECRET_ACCESS_KEY'] || !$_ENV['AWS_DEFAULT_REGION']
 ) {
     echo 'Please set the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION environment variables.'.\PHP_EOL;
     exit(1);

--- a/examples/bedrock/toolcall-claude.php
+++ b/examples/bedrock/toolcall-claude.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpClient\HttpClient;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AWS_ACCESS_KEY_ID']) || empty($_ENV['AWS_SECRET_ACCESS_KEY']) || empty($_ENV['AWS_DEFAULT_REGION'])
+if (!$_ENV['AWS_ACCESS_KEY_ID'] || !$_ENV['AWS_SECRET_ACCESS_KEY'] || !$_ENV['AWS_DEFAULT_REGION']
 ) {
     echo 'Please set the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION environment variables.'.\PHP_EOL;
     exit(1);

--- a/examples/bedrock/toolcall-nova.php
+++ b/examples/bedrock/toolcall-nova.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpClient\HttpClient;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['AWS_ACCESS_KEY_ID']) || empty($_ENV['AWS_SECRET_ACCESS_KEY']) || empty($_ENV['AWS_DEFAULT_REGION'])
+if (!$_ENV['AWS_ACCESS_KEY_ID'] || !$_ENV['AWS_SECRET_ACCESS_KEY'] || !$_ENV['AWS_DEFAULT_REGION']
 ) {
     echo 'Please set the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION environment variables.'.\PHP_EOL;
     exit(1);

--- a/examples/google/audio-input.php
+++ b/examples/google/audio-input.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY'])) {
+if (!$_ENV['GOOGLE_API_KEY']) {
     echo 'Please set the GOOGLE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/google/chat.php
+++ b/examples/google/chat.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY'])) {
+if (!$_ENV['GOOGLE_API_KEY']) {
     echo 'Please set the GOOGLE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/google/embeddings.php
+++ b/examples/google/embeddings.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY'])) {
+if (!$_ENV['GOOGLE_API_KEY']) {
     echo 'Please set the GOOGLE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/google/image-input.php
+++ b/examples/google/image-input.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY'])) {
+if (!$_ENV['GOOGLE_API_KEY']) {
     echo 'Please set the GOOGLE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/google/pdf-input-binary.php
+++ b/examples/google/pdf-input-binary.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY'])) {
+if (!$_ENV['GOOGLE_API_KEY']) {
     echo 'Please set the GOOGLE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/google/server-tools.php
+++ b/examples/google/server-tools.php
@@ -22,7 +22,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__, 2).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY'])) {
+if (!$_ENV['GOOGLE_API_KEY']) {
     echo 'Please set the GOOGLE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/google/stream.php
+++ b/examples/google/stream.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY'])) {
+if (!$_ENV['GOOGLE_API_KEY']) {
     echo 'Please set the GOOGLE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/google/structured-output-clock.php
+++ b/examples/google/structured-output-clock.php
@@ -24,7 +24,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__, 2).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY'])) {
+if (!$_ENV['GOOGLE_API_KEY']) {
     echo 'Please set the GOOGLE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/google/structured-output-math.php
+++ b/examples/google/structured-output-math.php
@@ -21,7 +21,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__, 2).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY'])) {
+if (!$_ENV['GOOGLE_API_KEY']) {
     echo 'Please set the GOOGLE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/google/toolcall.php
+++ b/examples/google/toolcall.php
@@ -22,7 +22,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY'])) {
+if (!$_ENV['GOOGLE_API_KEY']) {
     echo 'Please set the GOOGLE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/audio-classification.php
+++ b/examples/huggingface/audio-classification.php
@@ -18,7 +18,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/automatic-speech-recognition.php
+++ b/examples/huggingface/automatic-speech-recognition.php
@@ -18,7 +18,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/chat-completion.php
+++ b/examples/huggingface/chat-completion.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/feature-extraction.php
+++ b/examples/huggingface/feature-extraction.php
@@ -18,7 +18,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/fill-mask.php
+++ b/examples/huggingface/fill-mask.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/image-classification.php
+++ b/examples/huggingface/image-classification.php
@@ -18,7 +18,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/image-segmentation.php
+++ b/examples/huggingface/image-segmentation.php
@@ -18,7 +18,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/image-to-text.php
+++ b/examples/huggingface/image-to-text.php
@@ -18,7 +18,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/object-detection.php
+++ b/examples/huggingface/object-detection.php
@@ -18,7 +18,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/question-answering.php
+++ b/examples/huggingface/question-answering.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/sentence-similarity.php
+++ b/examples/huggingface/sentence-similarity.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/summarization.php
+++ b/examples/huggingface/summarization.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/table-question-answering.php
+++ b/examples/huggingface/table-question-answering.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/text-classification.php
+++ b/examples/huggingface/text-classification.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/text-generation.php
+++ b/examples/huggingface/text-generation.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/text-to-image.php
+++ b/examples/huggingface/text-to-image.php
@@ -18,7 +18,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/token-classification.php
+++ b/examples/huggingface/token-classification.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/translation.php
+++ b/examples/huggingface/translation.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/huggingface/zero-shot-classification.php
+++ b/examples/huggingface/zero-shot-classification.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['HUGGINGFACE_KEY'])) {
+if (!$_ENV['HUGGINGFACE_KEY']) {
     echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/misc/chat-system-prompt.php
+++ b/examples/misc/chat-system-prompt.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/misc/parallel-chat-gpt.php
+++ b/examples/misc/parallel-chat-gpt.php
@@ -18,7 +18,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/misc/parallel-embeddings.php
+++ b/examples/misc/parallel-embeddings.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/mistral/chat.php
+++ b/examples/mistral/chat.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['MISTRAL_API_KEY'])) {
+if (!$_ENV['MISTRAL_API_KEY']) {
     echo 'Please set the REPLICATE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/mistral/embeddings.php
+++ b/examples/mistral/embeddings.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['MISTRAL_API_KEY'])) {
+if (!$_ENV['MISTRAL_API_KEY']) {
     echo 'Please set the MISTRAL_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/mistral/image.php
+++ b/examples/mistral/image.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/mistral/stream.php
+++ b/examples/mistral/stream.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['MISTRAL_API_KEY'])) {
+if (!$_ENV['MISTRAL_API_KEY']) {
     echo 'Please set the REPLICATE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/mistral/structured-output-math.php
+++ b/examples/mistral/structured-output-math.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Serializer;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['MISTRAL_API_KEY'])) {
+if (!$_ENV['MISTRAL_API_KEY']) {
     echo 'Please set the MISTRAL_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/mistral/toolcall-stream.php
+++ b/examples/mistral/toolcall-stream.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpClient\HttpClient;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['MISTRAL_API_KEY'])) {
+if (!$_ENV['MISTRAL_API_KEY']) {
     echo 'Please set the REPLICATE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/mistral/toolcall.php
+++ b/examples/mistral/toolcall.php
@@ -22,7 +22,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['MISTRAL_API_KEY'])) {
+if (!$_ENV['MISTRAL_API_KEY']) {
     echo 'Please set the REPLICATE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/ollama/chat-llama.php
+++ b/examples/ollama/chat-llama.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OLLAMA_HOST_URL'])) {
+if (!$_ENV['OLLAMA_HOST_URL']) {
     echo 'Please set the OLLAMA_HOST_URL environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/audio-input.php
+++ b/examples/openai/audio-input.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/audio-transcript.php
+++ b/examples/openai/audio-transcript.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/chat-o1.php
+++ b/examples/openai/chat-o1.php
@@ -19,12 +19,12 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }
 
-if (empty($_ENV['RUN_EXPENSIVE_EXAMPLES']) || false === filter_var($_ENV['RUN_EXPENSIVE_EXAMPLES'], \FILTER_VALIDATE_BOOLEAN)) {
+if (!$_ENV['RUN_EXPENSIVE_EXAMPLES'] || false === filter_var($_ENV['RUN_EXPENSIVE_EXAMPLES'], \FILTER_VALIDATE_BOOLEAN)) {
     echo 'This example is marked as expensive and will not run unless RUN_EXPENSIVE_EXAMPLES is set to true.'.\PHP_EOL;
     exit(134);
 }

--- a/examples/openai/chat.php
+++ b/examples/openai/chat.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/embeddings.php
+++ b/examples/openai/embeddings.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/image-input-binary.php
+++ b/examples/openai/image-input-binary.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/image-input-url.php
+++ b/examples/openai/image-input-url.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/image-output-dall-e-2.php
+++ b/examples/openai/image-output-dall-e-2.php
@@ -16,7 +16,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/image-output-dall-e-3.php
+++ b/examples/openai/image-output-dall-e-3.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/stream.php
+++ b/examples/openai/stream.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/structured-output-clock.php
+++ b/examples/openai/structured-output-clock.php
@@ -24,7 +24,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/structured-output-math.php
+++ b/examples/openai/structured-output-math.php
@@ -21,7 +21,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/token-metadata.php
+++ b/examples/openai/token-metadata.php
@@ -20,7 +20,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/toolcall-stream.php
+++ b/examples/openai/toolcall-stream.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpClient\HttpClient;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openai/toolcall.php
+++ b/examples/openai/toolcall.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpClient\HttpClient;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/openrouter/chat-gemini.php
+++ b/examples/openrouter/chat-gemini.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENROUTER_KEY'])) {
+if (!$_ENV['OPENROUTER_KEY']) {
     echo 'Please set the OPENROUTER_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/replicate/chat-llama.php
+++ b/examples/replicate/chat-llama.php
@@ -19,7 +19,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['REPLICATE_API_KEY'])) {
+if (!$_ENV['REPLICATE_API_KEY']) {
     echo 'Please set the REPLICATE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/store/mariadb-similarity-search-gemini.php
+++ b/examples/store/mariadb-similarity-search-gemini.php
@@ -31,7 +31,7 @@ use Symfony\Component\Uid\Uuid;
 require_once dirname(__DIR__, 2).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
 
-if (empty($_ENV['GOOGLE_API_KEY']) || empty($_ENV['MARIADB_URI'])) {
+if (!$_ENV['GOOGLE_API_KEY'] || !$_ENV['MARIADB_URI']) {
     echo 'Please set GOOGLE_API_KEY and MARIADB_URI environment variables.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/store/mariadb-similarity-search.php
+++ b/examples/store/mariadb-similarity-search.php
@@ -28,7 +28,7 @@ use Symfony\Component\Uid\Uuid;
 require_once dirname(__DIR__, 2).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__, 2).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY']) || empty($_ENV['MARIADB_URI'])) {
+if (!$_ENV['OPENAI_API_KEY'] || !$_ENV['MARIADB_URI']) {
     echo 'Please set OPENAI_API_KEY and MARIADB_URI environment variables.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/store/mongodb-similarity-search.php
+++ b/examples/store/mongodb-similarity-search.php
@@ -29,7 +29,7 @@ use Symfony\Component\Uid\Uuid;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY']) || empty($_ENV['MONGODB_URI'])) {
+if (!$_ENV['OPENAI_API_KEY'] || !$_ENV['MONGODB_URI']) {
     echo 'Please set OPENAI_API_KEY and MONGODB_URI environment variables.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/store/pinecone-similarity-search.php
+++ b/examples/store/pinecone-similarity-search.php
@@ -29,7 +29,7 @@ use Symfony\Component\Uid\Uuid;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY']) || empty($_ENV['PINECONE_API_KEY']) || empty($_ENV['PINECONE_HOST'])) {
+if (!$_ENV['OPENAI_API_KEY'] || !$_ENV['PINECONE_API_KEY'] || !$_ENV['PINECONE_HOST']) {
     echo 'Please set OPENAI_API_KEY, PINECONE_API_KEY and PINECONE_HOST environment variables.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/toolbox/brave.php
+++ b/examples/toolbox/brave.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpClient\HttpClient;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY']) || empty($_ENV['BRAVE_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY'] || !$_ENV['BRAVE_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY and BRAVE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/toolbox/clock.php
+++ b/examples/toolbox/clock.php
@@ -23,7 +23,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/toolbox/serpapi.php
+++ b/examples/toolbox/serpapi.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpClient\HttpClient;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY']) || empty($_ENV['SERP_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY'] || !$_ENV['SERP_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY and SERP_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/toolbox/tavily.php
+++ b/examples/toolbox/tavily.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpClient\HttpClient;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY']) || empty($_ENV['TAVILY_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY'] || !$_ENV['TAVILY_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY and TAVILY_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/toolbox/weather-event.php
+++ b/examples/toolbox/weather-event.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpClient\HttpClient;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['OPENAI_API_KEY'])) {
+if (!$_ENV['OPENAI_API_KEY']) {
     echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/examples/voyage/embeddings.php
+++ b/examples/voyage/embeddings.php
@@ -17,7 +17,7 @@ use Symfony\Component\Dotenv\Dotenv;
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 
-if (empty($_ENV['VOYAGE_API_KEY'])) {
+if (!$_ENV['VOYAGE_API_KEY']) {
     echo 'Please set the VOYAGE_API_KEY environment variable.'.\PHP_EOL;
     exit(1);
 }

--- a/src/agent/src/Toolbox/Tool/Wikipedia.php
+++ b/src/agent/src/Toolbox/Tool/Wikipedia.php
@@ -41,7 +41,7 @@ final readonly class Wikipedia
 
         $titles = array_map(fn (array $item) => $item['title'], $result['query']['search']);
 
-        if (empty($titles)) {
+        if (!$titles) {
             return 'No articles were found on Wikipedia.';
         }
 

--- a/src/platform/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
@@ -58,7 +58,7 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
                     'type' => 'tool_use',
                     'id' => $toolCall->id,
                     'name' => $toolCall->name,
-                    'input' => empty($toolCall->arguments) ? new \stdClass() : $toolCall->arguments,
+                    'input' => $toolCall->arguments ?: new \stdClass(),
                 ];
             }, $data->toolCalls),
         ];

--- a/src/platform/src/Bridge/Anthropic/ResponseConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResponseConverter.php
@@ -57,7 +57,7 @@ class ResponseConverter implements ResponseConverterInterface
             throw new RuntimeException('Response content does not contain any text nor tool calls.');
         }
 
-        if (!empty($toolCalls)) {
+        if ($toolCalls) {
             return new ToolCallResponse(...$toolCalls);
         }
 

--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeHandler.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeHandler.php
@@ -80,7 +80,7 @@ final readonly class ClaudeHandler implements BedrockModelClient
                 $toolCalls[] = new ToolCall($content['id'], $content['name'], $content['input']);
             }
         }
-        if (!empty($toolCalls)) {
+        if ($toolCalls) {
             return new ToolCallResponse(...$toolCalls);
         }
 

--- a/src/platform/src/Bridge/Bedrock/Nova/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/Contract/AssistantMessageNormalizer.php
@@ -57,7 +57,7 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
                         'toolUse' => [
                             'toolUseId' => $toolCall->id,
                             'name' => $toolCall->name,
-                            'input' => empty($toolCall->arguments) ? new \stdClass() : $toolCall->arguments,
+                            'input' => $toolCall->arguments ?: new \stdClass(),
                         ],
                     ];
                 }, $data->toolCalls),

--- a/src/platform/src/Bridge/Bedrock/Nova/NovaHandler.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/NovaHandler.php
@@ -81,7 +81,7 @@ class NovaHandler implements BedrockModelClient
                 $toolCalls[] = new ToolCall($content['toolUse']['toolUseId'], $content['toolUse']['name'], $content['toolUse']['input']);
             }
         }
-        if (!empty($toolCalls)) {
+        if ($toolCalls) {
             return new ToolCallResponse(...$toolCalls);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

`empty()` is banned from Symfony codebase, I suggest we don't use it in this repo neither so we have a consistent code style.