### PR TITLE
fix: add missing filesystem dependency for link script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require-dev": {
         "php": ">=8.2",
         "php-cs-fixer/shim": "^3.75",
-        "symfony/finder": "^6.4|^7.0",
-        "symfony/process": "^6.4|^7.0"
+        "symfony/finder": "^6.4 || ^7.0",
+        "symfony/filesystem": "^6.4 || ^7.0"
     },
     "config": {
         "sort-packages": true

--- a/link
+++ b/link
@@ -15,7 +15,7 @@ require __DIR__.'/vendor/autoload.php';
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * Links dependencies of a project to a local clone of the main symfony/symfony GitHub repository.
+ * Links dependencies of a project to a local clone of the main symfony/ai GitHub repository.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

should work now