### PR TITLE
refactor: replace composer suggests with runtime checks

### DIFF
--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -43,14 +43,6 @@
         "symfony/event-dispatcher": "^6.4 || ^7.1",
         "symfony/http-foundation": "^6.4 || ^7.1"
     },
-    "suggest": {
-        "mrmysql/youtube-transcript": "For using the YouTube transcription tool.",
-        "symfony/ai-store": "For using Similarity Search with a vector store.",
-        "symfony/css-selector": "For using the YouTube transcription tool.",
-        "symfony/dom-crawler": "For using the Crawler tool.",
-        "symfony/http-foundation": "For using the SessionStore as message store.",
-        "psr/cache": "For using the CacheStore as message store."
-    },
     "config": {
         "sort-packages": true
     },

--- a/src/agent/src/Chat/MessageStore/CacheStore.php
+++ b/src/agent/src/Chat/MessageStore/CacheStore.php
@@ -23,6 +23,9 @@ final readonly class CacheStore implements MessageStoreInterface
         private string $cacheKey,
         private int $ttl = 86400,
     ) {
+        if (!interface_exists(CacheItemPoolInterface::class)) {
+            throw new \RuntimeException('For using the CacheStore as message store, a PSR-6 cache implementation is required. Try running "composer require symfony/cache" or another PSR-6 compatible cache.');
+        }
     }
 
     public function save(MessageBagInterface $messages): void

--- a/src/agent/src/Chat/MessageStore/SessionStore.php
+++ b/src/agent/src/Chat/MessageStore/SessionStore.php
@@ -25,6 +25,9 @@ final readonly class SessionStore implements MessageStoreInterface
         RequestStack $requestStack,
         private string $sessionKey = 'messages',
     ) {
+        if (!class_exists(RequestStack::class)) {
+            throw new \RuntimeException('For using the SessionStore as message store, the symfony/http-foundation package is required. Try running "composer require symfony/http-foundation".');
+        }
         $this->session = $requestStack->getSession();
     }
 

--- a/src/agent/src/Toolbox/Tool/Crawler.php
+++ b/src/agent/src/Toolbox/Tool/Crawler.php
@@ -26,7 +26,7 @@ final readonly class Crawler
         private HttpClientInterface $httpClient,
     ) {
         if (!class_exists(DomCrawler::class)) {
-            throw new RuntimeException('The DomCrawler component is not installed. Please install it using "composer require symfony/dom-crawler".');
+            throw new RuntimeException('For using the Crawler tool, the symfony/dom-crawler package is required. Try running "composer require symfony/dom-crawler".');
         }
     }
 

--- a/src/agent/src/Toolbox/Tool/YouTubeTranscriber.php
+++ b/src/agent/src/Toolbox/Tool/YouTubeTranscriber.php
@@ -27,7 +27,7 @@ final readonly class YouTubeTranscriber
         private HttpClientInterface $client,
     ) {
         if (!class_exists(TranscriptListFetcher::class)) {
-            throw new LogicException('The package `mrmysql/youtube-transcript` is required to use this tool. Try running "composer require mrmysql/youtube-transcript".');
+            throw new LogicException('For using the YouTube transcription tool, the mrmysql/youtube-transcript package is required. Try running "composer require mrmysql/youtube-transcript".');
         }
     }
 

--- a/src/platform/composer.json
+++ b/src/platform/composer.json
@@ -50,10 +50,6 @@
         "symfony/process": "^6.4 || ^7.1",
         "symfony/var-dumper": "^6.4 || ^7.1"
     },
-    "suggest": {
-        "async-aws/bedrock-runtime": "For using the Bedrock platform.",
-        "codewithkyrian/transformers": "For using the TransformersPHP with FFI to run models in PHP."
-    },
     "config": {
         "allow-plugins": {
             "codewithkyrian/transformers-libsloader": true

--- a/src/platform/src/Bridge/Bedrock/PlatformFactory.php
+++ b/src/platform/src/Bridge/Bedrock/PlatformFactory.php
@@ -26,6 +26,10 @@ final readonly class PlatformFactory
         BedrockRuntimeClient $bedrockRuntimeClient = new BedrockRuntimeClient(),
         ?Contract $contract = null,
     ): Platform {
+        if (!class_exists(BedrockRuntimeClient::class)) {
+            throw new \RuntimeException('For using the Bedrock platform, the async-aws/bedrock-runtime package is required. Try running "composer require async-aws/bedrock-runtime".');
+        }
+
         $modelClient[] = new ClaudeHandler($bedrockRuntimeClient);
         $modelClient[] = new NovaHandler($bedrockRuntimeClient);
         $modelClient[] = new LlamaModelClient($bedrockRuntimeClient);

--- a/src/platform/src/Bridge/TransformersPHP/PlatformFactory.php
+++ b/src/platform/src/Bridge/TransformersPHP/PlatformFactory.php
@@ -22,7 +22,7 @@ final readonly class PlatformFactory
     public static function create(): Platform
     {
         if (!class_exists(Transformers::class)) {
-            throw new RuntimeException('TransformersPHP is not installed. Please install it using "composer require codewithkyrian/transformers".');
+            throw new RuntimeException('For using the TransformersPHP with FFI to run models in PHP, the codewithkyrian/transformers package is required. Try running "composer require codewithkyrian/transformers".');
         }
 
         return new Platform();

--- a/src/store/composer.json
+++ b/src/store/composer.json
@@ -39,13 +39,6 @@
         "phpunit/phpunit": "^11.5",
         "probots-io/pinecone-php": "^1.0"
     },
-    "suggest": {
-        "ext-pdo": "For using MariaDB as retrieval vector store.",
-        "codewithkyrian/chromadb-php": "For using the ChromaDB as retrieval vector store.",
-        "doctrine/dbal": "For using MariaDB via Doctrine as retrieval vector store",
-        "mongodb/mongodb": "For using MongoDB Atlas as retrieval vector store.",
-        "probots-io/pinecone-php": "For using the Pinecone as retrieval vector store."
-    },
     "config": {
         "sort-packages": true
     },

--- a/src/store/src/Bridge/ChromaDB/Store.php
+++ b/src/store/src/Bridge/ChromaDB/Store.php
@@ -27,6 +27,9 @@ final readonly class Store implements VectorStoreInterface
         private Client $client,
         private string $collectionName,
     ) {
+        if (!class_exists(Client::class)) {
+            throw new \RuntimeException('For using the ChromaDB as retrieval vector store, the codewithkyrian/chromadb-php package is required. Try running "composer require codewithkyrian/chromadb-php".');
+        }
     }
 
     public function add(VectorDocument ...$documents): void

--- a/src/store/src/Bridge/MariaDB/Store.php
+++ b/src/store/src/Bridge/MariaDB/Store.php
@@ -41,6 +41,9 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
         private string $indexName,
         private string $vectorFieldName,
     ) {
+        if (!\extension_loaded('pdo')) {
+            throw new \RuntimeException('For using MariaDB as retrieval vector store, the PDO extension needs to be enabled.');
+        }
     }
 
     public static function fromPdo(\PDO $connection, string $tableName, string $indexName = 'embedding', string $vectorFieldName = 'embedding'): self
@@ -53,6 +56,10 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
      */
     public static function fromDbal(Connection $connection, string $tableName, string $indexName = 'embedding', string $vectorFieldName = 'embedding'): self
     {
+        if (!class_exists(Connection::class)) {
+            throw new \RuntimeException('For using MariaDB as retrieval vector store, the PDO extension needs to be enabled.');
+        }
+
         $pdo = $connection->getNativeConnection();
 
         if (!$pdo instanceof \PDO) {

--- a/src/store/src/Bridge/MongoDB/Store.php
+++ b/src/store/src/Bridge/MongoDB/Store.php
@@ -66,6 +66,9 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
         private bool $bulkWrite = false,
         private LoggerInterface $logger = new NullLogger(),
     ) {
+        if (!class_exists(Client::class)) {
+            throw new \RuntimeException('For using MongoDB Atlas as retrieval vector store, the mongodb/mongodb package is required. Try running "composer require mongodb/mongodb".');
+        }
     }
 
     public function add(VectorDocument ...$documents): void

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -33,6 +33,9 @@ final readonly class Store implements VectorStoreInterface
         private array $filter = [],
         private int $topK = 3,
     ) {
+        if (!class_exists(Client::class)) {
+            throw new \RuntimeException('For using the Pinecone as retrieval vector store, the probots-io/pinecone-php package is required. Try running "composer require probots-io/pinecone-php".');
+        }
     }
 
     public function add(VectorDocument ...$documents): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no
| Docs?         | no
| Issues        | Fix #76 
| License       | MIT

Cherry picking https://github.com/php-llm/llm-chain/pull/385

> Remove the `suggest` section from composer.json and add explicit runtime checks
that throw exceptions with helpful composer require commands when optional
dependencies are missing.
> 
> This provides better developer experience by:
> - Giving clear error messages when optional dependencies are needed
> - Providing the exact composer command to install missing packages
> - Following Symfony's pattern for handling optional dependencies
> 
> Optional dependencies now throw exceptions instead of silently failing when the required packages are not installed.