### PR TITLE
[Agent] Add basic setup for memory injections to system prompt

### DIFF
--- a/examples/misc/chat-with-memory.php
+++ b/examples/misc/chat-with-memory.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\InputProcessor\SystemPromptInputProcessor;
+use Symfony\AI\Agent\Memory\MemoryInputProcessor;
+use Symfony\AI\Agent\Memory\StaticMemoryProvider;
+use Symfony\AI\Platform\Bridge\OpenAI\GPT;
+use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+
+if (!$_ENV['OPENAI_API_KEY']) {
+    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
+    exit(1);
+}
+
+$platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
+$model = new GPT(GPT::GPT_4O_MINI);
+
+$systemPromptProcessor = new SystemPromptInputProcessor('You are a professional trainer with short, personalized advices and a motivating claim.');
+
+$personalFacts = new StaticMemoryProvider(
+    'My name is Wilhelm Tell',
+    'I wish to be a swiss national hero',
+    'I am struggling with hitting apples but want to be professional with the bow and arrow',
+);
+$memoryProcessor = new MemoryInputProcessor($personalFacts);
+
+$chain = new Agent($platform, $model, [$systemPromptProcessor, $memoryProcessor]);
+$messages = new MessageBag(Message::ofUser('What do we do today?'));
+$response = $chain->call($messages);
+
+echo $response->getContent().\PHP_EOL;

--- a/examples/store/mariadb-chat-memory.php
+++ b/examples/store/mariadb-chat-memory.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Tools\DsnParser;
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Memory\EmbeddingProvider;
+use Symfony\AI\Agent\Memory\MemoryInputProcessor;
+use Symfony\AI\Platform\Bridge\OpenAI\Embeddings;
+use Symfony\AI\Platform\Bridge\OpenAI\GPT;
+use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Store\Bridge\MariaDB\Store;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Indexer;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\Uid\Uuid;
+
+require_once dirname(__DIR__).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+
+if (!$_ENV['OPENAI_API_KEY'] || !$_ENV['MARIADB_URI']) {
+    echo 'Please set OPENAI_API_KEY and MARIADB_URI environment variables.'.\PHP_EOL;
+    exit(1);
+}
+
+// initialize the store
+$store = Store::fromDbal(
+    connection: DriverManager::getConnection((new DsnParser())->parse($_ENV['MARIADB_URI'])),
+    tableName: 'my_table',
+    indexName: 'my_index',
+    vectorFieldName: 'embedding',
+);
+
+// our data
+$pastConversationPieces = [
+    ['role' => 'user', 'timestamp' => '2024-12-14 12:00:00', 'content' => 'My friends John and Emma are friends, too, are there hints why?'],
+    ['role' => 'assistant', 'timestamp' => '2024-12-14 12:00:01', 'content' => 'Based on the found documents i would expect they are friends since childhood, this can give a deep bound!'],
+    ['role' => 'user', 'timestamp' => '2024-12-14 12:02:02', 'content' => 'Yeah but how does this bound? I know John was once there with a wound dressing as Emma fell, could this be a hint?'],
+    ['role' => 'assistant', 'timestamp' => '2024-12-14 12:02:03', 'content' => 'Yes, this could be a hint that they have been through difficult times together, which can strengthen their bond.'],
+];
+
+// create embeddings and documents
+foreach ($pastConversationPieces as $i => $message) {
+    $documents[] = new TextDocument(
+        id: Uuid::v4(),
+        content: 'Role: '.$message['role'].\PHP_EOL.'Timestamp: '.$message['timestamp'].\PHP_EOL.'Message: '.$message['content'],
+        metadata: new Metadata($message),
+    );
+}
+
+// initialize the table
+$store->initialize();
+
+// create embeddings for documents as preparation of the chain memory
+$platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$indexer = new Indexer($vectorizer, $store);
+$indexer->index($documents);
+
+// Execute a chat call that is utilizing the memory
+$embeddingsMemory = new EmbeddingProvider($platform, $embeddings, $store);
+$memoryProcessor = new MemoryInputProcessor($embeddingsMemory);
+
+$chain = new Agent($platform, new GPT(GPT::GPT_4O_MINI), [$memoryProcessor]);
+$messages = new MessageBag(Message::ofUser('Have we discussed about my friend John in the past? If yes, what did we talk about?'));
+$response = $chain->call($messages);
+
+echo $response->getContent().\PHP_EOL;

--- a/src/agent/src/Memory/EmbeddingProvider.php
+++ b/src/agent/src/Memory/EmbeddingProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Memory;
+
+use Symfony\AI\Agent\Input;
+use Symfony\AI\Platform\Message\Content\ContentInterface;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\MessageInterface;
+use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Store\VectorStoreInterface;
+
+/**
+ * @author Denis Zunke <denis.zunke@gmail.com>
+ */
+final readonly class EmbeddingProvider implements MemoryProviderInterface
+{
+    public function __construct(
+        private PlatformInterface $platform,
+        private Model $model,
+        private VectorStoreInterface $vectorStore,
+    ) {
+    }
+
+    public function loadMemory(Input $input): array
+    {
+        $messages = $input->messages->getMessages();
+        /** @var MessageInterface|null $userMessage */
+        $userMessage = $messages[array_key_last($messages)] ?? null;
+
+        if (!$userMessage instanceof UserMessage) {
+            return [];
+        }
+
+        $userMessageTextContent = array_filter(
+            $userMessage->content,
+            static fn (ContentInterface $content): bool => $content instanceof Text,
+        );
+
+        if (0 === \count($userMessageTextContent)) {
+            return [];
+        }
+
+        $userMessageTextContent = array_shift($userMessageTextContent);
+
+        $vectors = $this->platform->request($this->model, $userMessageTextContent->text)->asVectors();
+        $foundEmbeddingContent = $this->vectorStore->query($vectors[0]);
+        if (0 === \count($foundEmbeddingContent)) {
+            return [];
+        }
+
+        $content = '## Dynamic memories fitting user message'.\PHP_EOL.\PHP_EOL;
+        foreach ($foundEmbeddingContent as $document) {
+            $content .= json_encode($document->metadata);
+        }
+
+        return [new Memory($content)];
+    }
+}

--- a/src/agent/src/Memory/Memory.php
+++ b/src/agent/src/Memory/Memory.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Memory;
+
+/**
+ * @author Denis Zunke <denis.zunke@gmail.com>
+ */
+final readonly class Memory
+{
+    public function __construct(public string $content)
+    {
+    }
+}

--- a/src/agent/src/Memory/MemoryInputProcessor.php
+++ b/src/agent/src/Memory/MemoryInputProcessor.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Memory;
+
+use Symfony\AI\Agent\Input;
+use Symfony\AI\Agent\InputProcessorInterface;
+use Symfony\AI\Platform\Message\Message;
+
+/**
+ * @author Denis Zunke <denis.zunke@gmail.com>
+ */
+final readonly class MemoryInputProcessor implements InputProcessorInterface
+{
+    private const MEMORY_PROMPT_MESSAGE = <<<MARKDOWN
+        # Conversation Memory
+        This is the memory I have found for this conversation. The memory has more weight to answer user input,
+        so try to answer utilizing the memory as much as possible. Your answer must be changed to fit the given
+        memory. If the memory is irrelevant, ignore it. Do not reply to the this section of the prompt and do not
+        reference it as this is just for your reference.
+        MARKDOWN;
+
+    /**
+     * @var MemoryProviderInterface[]
+     */
+    private array $memoryProviders;
+
+    public function __construct(
+        MemoryProviderInterface ...$memoryProviders,
+    ) {
+        $this->memoryProviders = $memoryProviders;
+    }
+
+    public function processInput(Input $input): void
+    {
+        $options = $input->getOptions();
+        $useMemory = $options['use_memory'] ?? true;
+        unset($options['use_memory']);
+        $input->setOptions($options);
+
+        if (false === $useMemory || 0 === \count($this->memoryProviders)) {
+            return;
+        }
+
+        $memory = '';
+        foreach ($this->memoryProviders as $provider) {
+            $memoryMessages = $provider->loadMemory($input);
+
+            if (0 === \count($memoryMessages)) {
+                continue;
+            }
+
+            $memory .= \PHP_EOL.\PHP_EOL;
+            $memory .= implode(
+                \PHP_EOL,
+                array_map(static fn (Memory $memory): string => $memory->content, $memoryMessages),
+            );
+        }
+
+        if ('' === $memory) {
+            return;
+        }
+
+        $systemMessage = $input->messages->getSystemMessage()->content ?? '';
+        if ('' !== $systemMessage) {
+            $systemMessage .= \PHP_EOL.\PHP_EOL;
+        }
+
+        $messages = $input->messages
+            ->withoutSystemMessage()
+            ->prepend(Message::forSystem($systemMessage.self::MEMORY_PROMPT_MESSAGE.$memory));
+
+        $input->messages = $messages;
+    }
+}

--- a/src/agent/src/Memory/MemoryProviderInterface.php
+++ b/src/agent/src/Memory/MemoryProviderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Memory;
+
+use Symfony\AI\Agent\Input;
+
+/**
+ * @author Denis Zunke <denis.zunke@gmail.com>
+ */
+interface MemoryProviderInterface
+{
+    /**
+     * @return list<Memory>
+     */
+    public function loadMemory(Input $input): array;
+}

--- a/src/agent/src/Memory/StaticMemoryProvider.php
+++ b/src/agent/src/Memory/StaticMemoryProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Memory;
+
+use Symfony\AI\Agent\Input;
+
+/**
+ * @author Denis Zunke <denis.zunke@gmail.com>
+ */
+final readonly class StaticMemoryProvider implements MemoryProviderInterface
+{
+    /**
+     * @var array<string>
+     */
+    private array $memory;
+
+    public function __construct(string ...$memory)
+    {
+        $this->memory = $memory;
+    }
+
+    public function loadMemory(Input $input): array
+    {
+        if (0 === \count($this->memory)) {
+            return [];
+        }
+
+        $content = '## Static Memory'.\PHP_EOL;
+
+        foreach ($this->memory as $memory) {
+            $content .= \PHP_EOL.'- '.$memory;
+        }
+
+        return [new Memory($content)];
+    }
+}

--- a/src/agent/tests/Memory/EmbeddingProviderTest.php
+++ b/src/agent/tests/Memory/EmbeddingProviderTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Memory;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Input;
+use Symfony\AI\Agent\Memory\EmbeddingProvider;
+use Symfony\AI\Platform\Message\Content\ImageUrl;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Response\RawResponseInterface;
+use Symfony\AI\Platform\Response\ResponsePromise;
+use Symfony\AI\Platform\Response\VectorResponse;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\VectorStoreInterface;
+
+#[UsesClass(Text::class)]
+#[UsesClass(ImageUrl::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(Input::class)]
+#[UsesClass(MessageBag::class)]
+#[UsesClass(VectorStoreInterface::class)]
+#[UsesClass(Model::class)]
+#[UsesClass(PlatformInterface::class)]
+#[CoversClass(EmbeddingProvider::class)]
+#[Small]
+final class EmbeddingProviderTest extends TestCase
+{
+    #[Test]
+    public function itIsDoingNothingWithEmptyMessageBag(): void
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->never())->method('request');
+
+        $vectorStore = $this->createMock(VectorStoreInterface::class);
+        $vectorStore->expects($this->never())->method('query');
+
+        $embeddingProvider = new EmbeddingProvider(
+            $platform,
+            self::createStub(Model::class),
+            $vectorStore,
+        );
+
+        $embeddingProvider->loadMemory(new Input(
+            self::createStub(Model::class),
+            new MessageBag(),
+            [],
+        ));
+    }
+
+    #[Test]
+    public function itIsDoingNothingWithoutUserMessageInBag(): void
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->never())->method('request');
+
+        $vectorStore = $this->createMock(VectorStoreInterface::class);
+        $vectorStore->expects($this->never())->method('query');
+
+        $embeddingProvider = new EmbeddingProvider(
+            $platform,
+            self::createStub(Model::class),
+            $vectorStore,
+        );
+
+        $embeddingProvider->loadMemory(new Input(
+            self::createStub(Model::class),
+            new MessageBag(Message::forSystem('This is a system message')),
+            [],
+        ));
+    }
+
+    #[Test]
+    public function itIsDoingNothingWhenUserMessageHasNoTextContent(): void
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->never())->method('request');
+
+        $vectorStore = $this->createMock(VectorStoreInterface::class);
+        $vectorStore->expects($this->never())->method('query');
+
+        $embeddingProvider = new EmbeddingProvider(
+            $platform,
+            self::createStub(Model::class),
+            $vectorStore,
+        );
+
+        $embeddingProvider->loadMemory(new Input(
+            self::createStub(Model::class),
+            new MessageBag(Message::ofUser(new ImageUrl('foo.jpg'))),
+            [],
+        ));
+    }
+
+    #[Test]
+    public function itIsNotCreatingMemoryWhenNoVectorsFound(): void
+    {
+        $vectorResponse = new VectorResponse($vector = new Vector([0.1, 0.2], 2));
+        $responsePromise = new ResponsePromise(
+            static fn () => $vectorResponse,
+            self::createStub(RawResponseInterface::class),
+        );
+
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())
+            ->method('request')
+            ->willReturn($responsePromise);
+
+        $vectorStore = $this->createMock(VectorStoreInterface::class);
+        $vectorStore->expects($this->once())
+            ->method('query')
+            ->with($vector)
+            ->willReturn([]);
+
+        $embeddingProvider = new EmbeddingProvider(
+            $platform,
+            self::createStub(Model::class),
+            $vectorStore,
+        );
+
+        $memory = $embeddingProvider->loadMemory(new Input(
+            self::createStub(Model::class),
+            new MessageBag(Message::ofUser(new Text('Have we talked about the weather?'))),
+            [],
+        ));
+
+        self::assertCount(0, $memory);
+    }
+
+    #[Test]
+    public function itIsCreatingMemoryWithFoundVectors(): void
+    {
+        $vectorResponse = new VectorResponse($vector = new Vector([0.1, 0.2], 2));
+        $responsePromise = new ResponsePromise(
+            static fn () => $vectorResponse,
+            self::createStub(RawResponseInterface::class),
+        );
+
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())
+            ->method('request')
+            ->willReturn($responsePromise);
+
+        $vectorStore = $this->createMock(VectorStoreInterface::class);
+        $vectorStore->expects($this->once())
+            ->method('query')
+            ->with($vector)
+            ->willReturn([
+                (object) ['metadata' => ['fact' => 'The sky is blue']],
+                (object) ['metadata' => ['fact' => 'Water is wet']],
+            ]);
+
+        $embeddingProvider = new EmbeddingProvider(
+            $platform,
+            self::createStub(Model::class),
+            $vectorStore,
+        );
+
+        $memory = $embeddingProvider->loadMemory(new Input(
+            self::createStub(Model::class),
+            new MessageBag(Message::ofUser(new Text('Have we talked about the weather?'))),
+            [],
+        ));
+
+        self::assertCount(1, $memory);
+        self::assertSame(
+            <<<MARKDOWN
+                ## Dynamic memories fitting user message
+
+                {"fact":"The sky is blue"}{"fact":"Water is wet"}
+                MARKDOWN,
+            $memory[0]->content,
+        );
+    }
+}

--- a/src/agent/tests/Memory/MemoryInputProcessorTest.php
+++ b/src/agent/tests/Memory/MemoryInputProcessorTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Memory;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Input;
+use Symfony\AI\Agent\Memory\Memory;
+use Symfony\AI\Agent\Memory\MemoryInputProcessor;
+use Symfony\AI\Agent\Memory\MemoryProviderInterface;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Model;
+
+#[CoversClass(MemoryInputProcessor::class)]
+#[UsesClass(MemoryProviderInterface::class)]
+#[UsesClass(Input::class)]
+#[UsesClass(MessageBag::class)]
+#[UsesClass(Model::class)]
+#[UsesClass(Memory::class)]
+#[UsesClass(Message::class)]
+#[Small]
+final class MemoryInputProcessorTest extends TestCase
+{
+    #[Test]
+    public function itIsDoingNothingOnInactiveMemory(): void
+    {
+        $memoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $memoryProvider->expects($this->never())->method(self::anything());
+
+        $memoryInputProcessor = new MemoryInputProcessor($memoryProvider);
+        $memoryInputProcessor->processInput($input = new Input(
+            self::createStub(Model::class),
+            new MessageBag(),
+            ['use_memory' => false]
+        ));
+
+        self::assertArrayNotHasKey('use_memory', $input->getOptions());
+    }
+
+    #[Test]
+    public function itIsDoingNothingWhenThereAreNoProviders(): void
+    {
+        $memoryInputProcessor = new MemoryInputProcessor();
+        $memoryInputProcessor->processInput($input = new Input(
+            self::createStub(Model::class),
+            new MessageBag(),
+            ['use_memory' => true]
+        ));
+
+        self::assertArrayNotHasKey('use_memory', $input->getOptions());
+    }
+
+    #[Test]
+    public function itIsAddingMemoryToSystemPrompt(): void
+    {
+        $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $firstMemoryProvider->expects($this->once())
+            ->method('loadMemory')
+            ->willReturn([new Memory('First memory content')]);
+
+        $secondMemoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $secondMemoryProvider->expects($this->once())
+            ->method('loadMemory')
+            ->willReturn([]);
+
+        $memoryInputProcessor = new MemoryInputProcessor(
+            $firstMemoryProvider,
+            $secondMemoryProvider,
+        );
+
+        $memoryInputProcessor->processInput($input = new Input(
+            self::createStub(Model::class),
+            new MessageBag(Message::forSystem('You are a helpful and kind assistant.')),
+            []
+        ));
+
+        self::assertArrayNotHasKey('use_memory', $input->getOptions());
+        self::assertSame(
+            <<<MARKDOWN
+                You are a helpful and kind assistant.
+
+                # Conversation Memory
+                This is the memory I have found for this conversation. The memory has more weight to answer user input,
+                so try to answer utilizing the memory as much as possible. Your answer must be changed to fit the given
+                memory. If the memory is irrelevant, ignore it. Do not reply to the this section of the prompt and do not
+                reference it as this is just for your reference.
+
+                First memory content
+                MARKDOWN,
+            $input->messages->getSystemMessage()->content,
+        );
+    }
+
+    #[Test]
+    public function itIsAddingMemoryToSystemPromptEvenItIsEmpty(): void
+    {
+        $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $firstMemoryProvider->expects($this->once())
+            ->method('loadMemory')
+            ->willReturn([new Memory('First memory content')]);
+
+        $memoryInputProcessor = new MemoryInputProcessor($firstMemoryProvider);
+
+        $memoryInputProcessor->processInput($input = new Input(
+            self::createStub(Model::class),
+            new MessageBag(),
+            []
+        ));
+
+        self::assertArrayNotHasKey('use_memory', $input->getOptions());
+        self::assertSame(
+            <<<MARKDOWN
+                # Conversation Memory
+                This is the memory I have found for this conversation. The memory has more weight to answer user input,
+                so try to answer utilizing the memory as much as possible. Your answer must be changed to fit the given
+                memory. If the memory is irrelevant, ignore it. Do not reply to the this section of the prompt and do not
+                reference it as this is just for your reference.
+
+                First memory content
+                MARKDOWN,
+            $input->messages->getSystemMessage()->content,
+        );
+    }
+
+    #[Test]
+    public function itIsAddingMultipleMemoryFromSingleProviderToSystemPrompt(): void
+    {
+        $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $firstMemoryProvider->expects($this->once())
+            ->method('loadMemory')
+            ->willReturn([new Memory('First memory content'), new Memory('Second memory content')]);
+
+        $memoryInputProcessor = new MemoryInputProcessor($firstMemoryProvider);
+
+        $memoryInputProcessor->processInput($input = new Input(
+            self::createStub(Model::class),
+            new MessageBag(),
+            []
+        ));
+
+        self::assertArrayNotHasKey('use_memory', $input->getOptions());
+        self::assertSame(
+            <<<MARKDOWN
+                # Conversation Memory
+                This is the memory I have found for this conversation. The memory has more weight to answer user input,
+                so try to answer utilizing the memory as much as possible. Your answer must be changed to fit the given
+                memory. If the memory is irrelevant, ignore it. Do not reply to the this section of the prompt and do not
+                reference it as this is just for your reference.
+
+                First memory content
+                Second memory content
+                MARKDOWN,
+            $input->messages->getSystemMessage()->content,
+        );
+    }
+
+    #[Test]
+    public function itIsNotAddingAnythingIfMemoryWasEmpty(): void
+    {
+        $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $firstMemoryProvider->expects($this->once())
+            ->method('loadMemory')
+            ->willReturn([]);
+
+        $memoryInputProcessor = new MemoryInputProcessor($firstMemoryProvider);
+
+        $memoryInputProcessor->processInput($input = new Input(
+            self::createStub(Model::class),
+            new MessageBag(),
+            []
+        ));
+
+        self::assertArrayNotHasKey('use_memory', $input->getOptions());
+        self::assertNull($input->messages->getSystemMessage()?->content);
+    }
+}

--- a/src/agent/tests/Memory/StaticMemoryProviderTest.php
+++ b/src/agent/tests/Memory/StaticMemoryProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Memory;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Input;
+use Symfony\AI\Agent\Memory\Memory;
+use Symfony\AI\Agent\Memory\StaticMemoryProvider;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Model;
+
+#[CoversClass(StaticMemoryProvider::class)]
+#[UsesClass(Input::class)]
+#[UsesClass(Memory::class)]
+#[UsesClass(MessageBag::class)]
+#[UsesClass(Model::class)]
+#[Small]
+final class StaticMemoryProviderTest extends TestCase
+{
+    #[Test]
+    public function itsReturnsNullWhenNoFactsAreProvided(): void
+    {
+        $provider = new StaticMemoryProvider();
+
+        $memory = $provider->loadMemory(new Input(
+            self::createStub(Model::class),
+            new MessageBag(),
+            []
+        ));
+
+        self::assertCount(0, $memory);
+    }
+
+    #[Test]
+    public function itDeliversFormattedFacts(): void
+    {
+        $provider = new StaticMemoryProvider(
+            $fact1 = 'The sky is blue',
+            $fact2 = 'Water is wet',
+        );
+
+        $memory = $provider->loadMemory(new Input(
+            self::createStub(Model::class),
+            new MessageBag(),
+            []
+        ));
+
+        self::assertCount(1, $memory);
+        self::assertInstanceOf(Memory::class, $memory[0]);
+        $expectedContent = "## Static Memory\n\n- {$fact1}\n- {$fact2}";
+        self::assertSame($expectedContent, $memory[0]->content);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        |  
| License       | MIT

See original contribution at https://github.com/php-llm/llm-chain/pull/387

> This PR introduces a flexible memory system that allows the LLM to recall contextual information that are permantent for the conversation. In difference to tools it can be always utilized, when use_memory option is not disabled. It would be possible to fetch memory by a tool with a system instruction like always call the tool foo_bar but, for me, this feels like a bad design to always force the model to do a tool call without further need.
>
> Currently i have added just two memory providers to show what my idea is. I could also think about a write layer to fill a memory, together with a read layer, this could, for example, be working good with a graph database and tools for memory handling. But these are ideas for the future.
>
> So for this first throw i hope you get what i was thinking about to reach. I decided to inject the memory to the system prompt, when it is available, instead of adding a second system prompt to the message bag. But this was just a 50/50 thinking. I tried both seem to be working equally, at least for open ai. I am open to change it back again.
>
> What do you think?
