### PR TITLE
[Agent] Use PHPStan error identifier instead of regex pattern

### DIFF
--- a/src/agent/phpstan.dist.neon
+++ b/src/agent/phpstan.dist.neon
@@ -5,6 +5,6 @@ parameters:
         - tests/
     ignoreErrors:
         -
-            message: '#no value type specified in iterable type array#'
+            identifier: missingType.iterableValue
             path: tests/*
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Cherry picking https://github.com/php-llm/llm-chain/pull/389