### PR TITLE
[Platform] Use intersection type `AbstractUid&TimeBasedUidInterface` for flexible message IDs

### DIFF
--- a/src/platform/src/Message/AssistantMessage.php
+++ b/src/platform/src/Message/AssistantMessage.php
@@ -12,6 +12,8 @@
 namespace Symfony\AI\Platform\Message;
 
 use Symfony\AI\Platform\Response\ToolCall;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -19,7 +21,7 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class AssistantMessage implements MessageInterface
 {
-    public Uuid $id;
+    public AbstractUid&TimeBasedUidInterface $id;
 
     /**
      * @param ?ToolCall[] $toolCalls
@@ -36,7 +38,7 @@ final readonly class AssistantMessage implements MessageInterface
         return Role::Assistant;
     }
 
-    public function getId(): Uuid
+    public function getId(): AbstractUid&TimeBasedUidInterface
     {
         return $this->id;
     }

--- a/src/platform/src/Message/MessageInterface.php
+++ b/src/platform/src/Message/MessageInterface.php
@@ -11,7 +11,8 @@
 
 namespace Symfony\AI\Platform\Message;
 
-use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 
 /**
  * @author Denis Zunke <denis.zunke@gmail.com>
@@ -20,5 +21,5 @@ interface MessageInterface
 {
     public function getRole(): Role;
 
-    public function getId(): Uuid;
+    public function getId(): AbstractUid&TimeBasedUidInterface;
 }

--- a/src/platform/src/Message/SystemMessage.php
+++ b/src/platform/src/Message/SystemMessage.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Platform\Message;
 
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -18,7 +20,7 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class SystemMessage implements MessageInterface
 {
-    public Uuid $id;
+    public AbstractUid&TimeBasedUidInterface $id;
 
     public function __construct(public string $content)
     {
@@ -30,7 +32,7 @@ final readonly class SystemMessage implements MessageInterface
         return Role::System;
     }
 
-    public function getId(): Uuid
+    public function getId(): AbstractUid&TimeBasedUidInterface
     {
         return $this->id;
     }

--- a/src/platform/src/Message/ToolCallMessage.php
+++ b/src/platform/src/Message/ToolCallMessage.php
@@ -12,6 +12,8 @@
 namespace Symfony\AI\Platform\Message;
 
 use Symfony\AI\Platform\Response\ToolCall;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -19,7 +21,7 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class ToolCallMessage implements MessageInterface
 {
-    public Uuid $id;
+    public AbstractUid&TimeBasedUidInterface $id;
 
     public function __construct(
         public ToolCall $toolCall,
@@ -33,7 +35,7 @@ final readonly class ToolCallMessage implements MessageInterface
         return Role::ToolCall;
     }
 
-    public function getId(): Uuid
+    public function getId(): AbstractUid&TimeBasedUidInterface
     {
         return $this->id;
     }

--- a/src/platform/src/Message/UserMessage.php
+++ b/src/platform/src/Message/UserMessage.php
@@ -15,6 +15,8 @@ use Symfony\AI\Platform\Message\Content\Audio;
 use Symfony\AI\Platform\Message\Content\ContentInterface;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -27,7 +29,7 @@ final readonly class UserMessage implements MessageInterface
      */
     public array $content;
 
-    public Uuid $id;
+    public AbstractUid&TimeBasedUidInterface $id;
 
     public function __construct(
         ContentInterface ...$content,
@@ -41,7 +43,7 @@ final readonly class UserMessage implements MessageInterface
         return Role::User;
     }
 
-    public function getId(): Uuid
+    public function getId(): AbstractUid&TimeBasedUidInterface
     {
         return $this->id;
     }

--- a/src/platform/tests/ContractTest.php
+++ b/src/platform/tests/ContractTest.php
@@ -42,6 +42,8 @@ use Symfony\AI\Platform\Message\Role;
 use Symfony\AI\Platform\Message\SystemMessage;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Model;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Uuid;
 
 #[Large]
@@ -208,7 +210,7 @@ final class ContractTest extends TestCase
                 return Role::User;
             }
 
-            public function getId(): Uuid
+            public function getId(): AbstractUid&TimeBasedUidInterface
             {
                 return Uuid::v7();
             }

--- a/src/platform/tests/Message/AssistantMessageTest.php
+++ b/src/platform/tests/Message/AssistantMessageTest.php
@@ -20,6 +20,8 @@ use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Role;
 use Symfony\AI\Platform\Response\ToolCall;
 use Symfony\AI\Platform\Tests\Helper\UuidAssertionTrait;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\UuidV7;
 
 #[CoversClass(AssistantMessage::class)]
@@ -85,5 +87,15 @@ final class AssistantMessageTest extends TestCase
         self::assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
         self::assertIsUuidV7($message1->getId()->toRfc4122());
         self::assertIsUuidV7($message2->getId()->toRfc4122());
+    }
+
+    #[Test]
+    public function messageIdImplementsRequiredInterfaces(): void
+    {
+        $message = new AssistantMessage('test');
+
+        self::assertInstanceOf(AbstractUid::class, $message->getId());
+        self::assertInstanceOf(TimeBasedUidInterface::class, $message->getId());
+        self::assertInstanceOf(UuidV7::class, $message->getId());
     }
 }

--- a/src/platform/tests/Message/SystemMessageTest.php
+++ b/src/platform/tests/Message/SystemMessageTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Message\Role;
 use Symfony\AI\Platform\Message\SystemMessage;
 use Symfony\AI\Platform\Tests\Helper\UuidAssertionTrait;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\UuidV7;
 
 #[CoversClass(SystemMessage::class)]
@@ -65,5 +67,15 @@ final class SystemMessageTest extends TestCase
         self::assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
         self::assertIsUuidV7($message1->getId()->toRfc4122());
         self::assertIsUuidV7($message2->getId()->toRfc4122());
+    }
+
+    #[Test]
+    public function messageIdImplementsRequiredInterfaces(): void
+    {
+        $message = new SystemMessage('test');
+
+        self::assertInstanceOf(AbstractUid::class, $message->getId());
+        self::assertInstanceOf(TimeBasedUidInterface::class, $message->getId());
+        self::assertInstanceOf(UuidV7::class, $message->getId());
     }
 }

--- a/src/platform/tests/Message/ToolCallMessageTest.php
+++ b/src/platform/tests/Message/ToolCallMessageTest.php
@@ -19,6 +19,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Message\ToolCallMessage;
 use Symfony\AI\Platform\Response\ToolCall;
 use Symfony\AI\Platform\Tests\Helper\UuidAssertionTrait;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\UuidV7;
 
 #[CoversClass(ToolCallMessage::class)]
@@ -71,5 +73,16 @@ final class ToolCallMessageTest extends TestCase
         self::assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
         self::assertIsUuidV7($message1->getId()->toRfc4122());
         self::assertIsUuidV7($message2->getId()->toRfc4122());
+    }
+
+    #[Test]
+    public function messageIdImplementsRequiredInterfaces(): void
+    {
+        $toolCall = new ToolCall('foo', 'bar');
+        $message = new ToolCallMessage($toolCall, 'test');
+
+        self::assertInstanceOf(AbstractUid::class, $message->getId());
+        self::assertInstanceOf(TimeBasedUidInterface::class, $message->getId());
+        self::assertInstanceOf(UuidV7::class, $message->getId());
     }
 }

--- a/src/platform/tests/Message/UserMessageTest.php
+++ b/src/platform/tests/Message/UserMessageTest.php
@@ -22,6 +22,8 @@ use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Role;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Tests\Helper\UuidAssertionTrait;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\UuidV7;
 
 #[CoversClass(UserMessage::class)]
@@ -115,5 +117,15 @@ final class UserMessageTest extends TestCase
         self::assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
         self::assertIsUuidV7($message1->getId()->toRfc4122());
         self::assertIsUuidV7($message2->getId()->toRfc4122());
+    }
+
+    #[Test]
+    public function messageIdImplementsRequiredInterfaces(): void
+    {
+        $message = new UserMessage(new Text('test'));
+
+        self::assertInstanceOf(AbstractUid::class, $message->getId());
+        self::assertInstanceOf(TimeBasedUidInterface::class, $message->getId());
+        self::assertInstanceOf(UuidV7::class, $message->getId());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

Cherry picking https://github.com/php-llm/llm-chain/pull/384