### PR TITLE
[Platform] Do not throw exception if tools are not used

### DIFF
--- a/src/agent/src/Toolbox/AgentProcessor.php
+++ b/src/agent/src/Toolbox/AgentProcessor.php
@@ -46,6 +46,11 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
 
     public function processInput(Input $input): void
     {
+        $options = $input->getOptions();
+        if (!isset($options['tools'])) {
+            return;
+        }
+
         if (!$input->model->supports(Capability::TOOL_CALLING)) {
             throw MissingModelSupportException::forToolCalling($input->model::class);
         }

--- a/src/agent/src/Toolbox/AgentProcessor.php
+++ b/src/agent/src/Toolbox/AgentProcessor.php
@@ -46,13 +46,8 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
 
     public function processInput(Input $input): void
     {
-        $options = $input->getOptions();
-        if (!isset($options['tools'])) {
-            return;
-        }
-
         if (!$input->model->supports(Capability::TOOL_CALLING)) {
-            throw MissingModelSupportException::forToolCalling($input->model::class);
+            return;
         }
 
         $toolMap = $this->toolbox->getTools();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT

When using a model which does not supports tools, an exception is thrown even when I don't intend to use any.
