### PR TITLE
fix(store): Change pgvector Docker image to the official up to date one

### DIFF
--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -8,7 +8,7 @@ services:
       - "3309:3306"
 
   postgres:
-    image: ankane/pgvector
+    image: pgvector/pgvector:0.8.0-pg17
     environment:
         POSTGRES_DB: my_database
         POSTGRES_USER: postgres


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Officiel PGVector Docker image is https://hub.docker.com/r/pgvector/pgvector/tags

The previous one is marked as abandoned https://hub.docker.com/r/ankane/pgvector