### PR TITLE
[Store][Meilisearch] Remove id, score and vectors from metadata

### DIFF
--- a/examples/store/memory-similarity-search.php
+++ b/examples/store/memory-similarity-search.php
@@ -13,6 +13,7 @@ use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\Toolbox\AgentProcessor;
 use Symfony\AI\Agent\Toolbox\Tool\SimilaritySearch;
 use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Fixtures\Movies;
 use Symfony\AI\Platform\Bridge\OpenAI\Embeddings;
 use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
@@ -37,15 +38,8 @@ if (!isset($_SERVER['OPENAI_API_KEY'])) {
 // initialize the store
 $store = new InMemoryStore();
 
-// our data
-$movies = [
-    ['title' => 'Inception', 'description' => 'A skilled thief is given a chance at redemption if he can successfully perform inception, the act of planting an idea in someone\'s subconscious.', 'director' => 'Christopher Nolan'],
-    ['title' => 'The Matrix', 'description' => 'A hacker discovers the world he lives in is a simulated reality and joins a rebellion to overthrow its controllers.', 'director' => 'The Wachowskis'],
-    ['title' => 'The Godfather', 'description' => 'The aging patriarch of an organized crime dynasty transfers control of his empire to his reluctant son.', 'director' => 'Francis Ford Coppola'],
-];
-
 // create embeddings and documents
-foreach ($movies as $i => $movie) {
+foreach (Movies::all() as $i => $movie) {
     $documents[] = new TextDocument(
         id: Uuid::v4(),
         content: 'Title: '.$movie['title'].\PHP_EOL.'Director: '.$movie['director'].\PHP_EOL.'Description: '.$movie['description'],

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -123,12 +123,13 @@ final readonly class Store implements InitializableStoreInterface, VectorStoreIn
      */
     private function convertToVectorDocument(array $data): VectorDocument
     {
-        return new VectorDocument(
-            id: Uuid::fromString($data['id']),
-            vector: !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
-                ? new NullVector()
-                : new Vector($data[$this->vectorFieldName][$this->embedder]['embeddings']),
-            metadata: new Metadata($data),
-        );
+        $id = $data['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data');
+        $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
+            ? new NullVector() : new Vector($data[$this->vectorFieldName][$this->embedder]['embeddings']);
+        $score = $data['_rankingScore'] ?? null;
+
+        unset($data['id'], $data[$this->vectorFieldName], $data['_rankingScore']);
+
+        return new VectorDocument(Uuid::fromString($id), $vector, new Metadata($data), $score);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Metadata should only include additional but relevant information. It is handed over by the SimilaritySearch to the LLM and too much unnecessary information hurt the context size and token consumption.

On top, score was not set.