### PR TITLE
[Platform] Add Albert API to platform CHANGELOG

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.1
 ---
 
+ * Add support for Albert API for French/EU data sovereignty
  * Add unified abstraction layer for interacting with various AI models and providers
  * Add support for 13+ AI providers:
    - OpenAI (GPT-4, GPT-3.5, DALL·E, Whisper)


### PR DESCRIPTION
## Summary
- Added Albert API to the platform CHANGELOG as it was missing from PR #140

This PR adds the changelog entry for the Albert API support that was merged in #140. The Albert API is a French sovereign AI gateway that provides OpenAI-compatible endpoints while ensuring data remains within French/EU jurisdiction.

## References
- Original PR: #140