### PR TITLE
Remove ext-pdo from store's dev dependencies

### DIFF
--- a/src/store/composer.json
+++ b/src/store/composer.json
@@ -29,7 +29,6 @@
         "symfony/uid": "^6.4 || ^7.1"
     },
     "require-dev": {
-        "ext-pdo": "*",
         "codewithkyrian/chromadb-php": "^0.2.1 || ^0.3 || ^0.4",
         "doctrine/dbal": "^3.3 || ^4.0",
         "mongodb/mongodb": "^1.21 || ^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix #87 
| License       | MIT

Removing `ext-pdo` as dev dependency from store to ease contributor's life, see #87