### PR TITLE
[Examples] Improve bootstrapping and logging in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -55,7 +55,13 @@ Every example script is a standalone PHP script that can be run from the command
 You can run an example by executing the following command:
 
 ```bash
-php openai/openai/chat.php
+php openai/chat.php
+```
+
+To get more insights into what is happening at runtime, e.g. HTTP and tool calls, you can add `-vv` or `-vvv`:
+
+```bash
+php openai/toolcall-stream.php -vvv
 ```
 
 ### Running examples via the example runner
@@ -70,8 +76,14 @@ You can run the example runner by executing the following command:
 ./runner
 ```
 
-If you want to run only examples of a specific subdirectory, you can pass the subdirectory name as an argument:
+If you only want to run examples of one or multiple specific subdirectories, you can pass the name as an argument:
 
 ```bash
-./runner openai
+./runner openai mistral
+```
+
+If you only want to run a specific subset of examples, you can use a filter option:
+
+```bash
+./runner --filter=toolcall
 ```

--- a/examples/albert/chat.php
+++ b/examples/albert/chat.php
@@ -15,17 +15,12 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 
-require_once dirname(__DIR__).'/../vendor/autoload.php';
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['ALBERT_API_KEY'], $_SERVER['ALBERT_API_URL'])) {
-    echo 'Please set the ALBERT_API_KEY and ALBERT_API_URL environment variable (e.g., https://your-albert-instance.com/v1).'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['ALBERT_API_KEY'], $_SERVER['ALBERT_API_URL']);
+$platform = PlatformFactory::create(env('ALBERT_API_KEY'), env('ALBERT_API_URL'), http_client());
 
 $model = new GPT('gpt-4o');
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 
 $documentContext = <<<'CONTEXT'
     Document: AI Strategy of France

--- a/examples/anthropic/chat.php
+++ b/examples/anthropic/chat.php
@@ -14,20 +14,13 @@ use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['ANTHROPIC_API_KEY'])) {
-    echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['ANTHROPIC_API_KEY']);
+$platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude(Claude::SONNET_37);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/anthropic/image-input-binary.php
+++ b/examples/anthropic/image-input-binary.php
@@ -15,20 +15,13 @@ use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['ANTHROPIC_API_KEY'])) {
-    echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['ANTHROPIC_API_KEY']);
+$platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude(Claude::SONNET_37);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(

--- a/examples/anthropic/image-input-url.php
+++ b/examples/anthropic/image-input-url.php
@@ -15,20 +15,13 @@ use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['ANTHROPIC_API_KEY'])) {
-    echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['ANTHROPIC_API_KEY']);
+$platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude(Claude::SONNET_37);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(

--- a/examples/anthropic/pdf-input-binary.php
+++ b/examples/anthropic/pdf-input-binary.php
@@ -15,20 +15,13 @@ use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Document;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['ANTHROPIC_API_KEY'])) {
-    echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['ANTHROPIC_API_KEY']);
+$platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude(Claude::SONNET_37);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         Document::fromFile(dirname(__DIR__, 2).'/fixtures/document.pdf'),

--- a/examples/anthropic/pdf-input-url.php
+++ b/examples/anthropic/pdf-input-url.php
@@ -15,20 +15,13 @@ use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\DocumentUrl;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['ANTHROPIC_API_KEY'])) {
-    echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['ANTHROPIC_API_KEY']);
+$platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude(Claude::SONNET_37);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         new DocumentUrl('https://upload.wikimedia.org/wikipedia/commons/2/20/Re_example.pdf'),

--- a/examples/anthropic/stream.php
+++ b/examples/anthropic/stream.php
@@ -14,20 +14,13 @@ use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['ANTHROPIC_API_KEY'])) {
-    echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['ANTHROPIC_API_KEY']);
+$platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude();
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a thoughtful philosopher.'),
     Message::ofUser('What is the purpose of an ant?'),

--- a/examples/anthropic/toolcall.php
+++ b/examples/anthropic/toolcall.php
@@ -17,24 +17,16 @@ use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpClient\HttpClient;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['ANTHROPIC_API_KEY'])) {
-    echo 'Please set the ANTHROPIC_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['ANTHROPIC_API_KEY']);
+$platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude();
 
-$wikipedia = new Wikipedia(HttpClient::create());
-$toolbox = new Toolbox([$wikipedia]);
+$wikipedia = new Wikipedia(http_client());
+$toolbox = new Toolbox([$wikipedia], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(Message::ofUser('Who is the current chancellor of Germany?'));
 $response = $agent->call($messages);

--- a/examples/azure/audio-transcript.php
+++ b/examples/azure/audio-transcript.php
@@ -12,21 +12,15 @@
 use Symfony\AI\Platform\Bridge\Azure\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Bridge\OpenAI\Whisper;
 use Symfony\AI\Platform\Message\Content\Audio;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
-
-if (!isset($_SERVER['AZURE_OPENAI_BASEURL'], $_SERVER['AZURE_OPENAI_WHISPER_DEPLOYMENT'], $_SERVER['AZURE_OPENAI_WHISPER_API_VERSION'], $_SERVER['AZURE_OPENAI_KEY'])) {
-    echo 'Please set the AZURE_OPENAI_BASEURL, AZURE_OPENAI_WHISPER_DEPLOYMENT, AZURE_OPENAI_WHISPER_API_VERSION, and AZURE_OPENAI_KEY environment variables.'.\PHP_EOL;
-    exit(1);
-}
+require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(
-    $_SERVER['AZURE_OPENAI_BASEURL'],
-    $_SERVER['AZURE_OPENAI_WHISPER_DEPLOYMENT'],
-    $_SERVER['AZURE_OPENAI_WHISPER_API_VERSION'],
-    $_SERVER['AZURE_OPENAI_KEY'],
+    env('AZURE_OPENAI_BASEURL'),
+    env('AZURE_OPENAI_WHISPER_DEPLOYMENT'),
+    env('AZURE_OPENAI_WHISPER_API_VERSION'),
+    env('AZURE_OPENAI_KEY'),
+    http_client(),
 );
 $model = new Whisper();
 $file = Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3');

--- a/examples/azure/chat-gpt.php
+++ b/examples/azure/chat-gpt.php
@@ -14,25 +14,19 @@ use Symfony\AI\Platform\Bridge\Azure\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
-
-if (!isset($_SERVER['AZURE_OPENAI_BASEURL'], $_SERVER['AZURE_OPENAI_GPT_DEPLOYMENT'], $_SERVER['AZURE_OPENAI_GPT_API_VERSION'], $_SERVER['AZURE_OPENAI_KEY'])) {
-    echo 'Please set the AZURE_OPENAI_BASEURL, AZURE_OPENAI_GPT_DEPLOYMENT, AZURE_OPENAI_GPT_API_VERSION, and AZURE_OPENAI_KEY environment variables.'.\PHP_EOL;
-    exit(1);
-}
+require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(
-    $_SERVER['AZURE_OPENAI_BASEURL'],
-    $_SERVER['AZURE_OPENAI_GPT_DEPLOYMENT'],
-    $_SERVER['AZURE_OPENAI_GPT_API_VERSION'],
-    $_SERVER['AZURE_OPENAI_KEY'],
+    env('AZURE_OPENAI_BASEURL'),
+    env('AZURE_OPENAI_GPT_DEPLOYMENT'),
+    env('AZURE_OPENAI_GPT_API_VERSION'),
+    env('AZURE_OPENAI_KEY'),
+    http_client(),
 );
 $model = new GPT(GPT::GPT_4O_MINI);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/azure/chat-llama.php
+++ b/examples/azure/chat-llama.php
@@ -14,20 +14,13 @@ use Symfony\AI\Platform\Bridge\Azure\Meta\PlatformFactory;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['AZURE_LLAMA_BASEURL'], $_SERVER['AZURE_LLAMA_KEY'])) {
-    echo 'Please set the AZURE_LLAMA_BASEURL and AZURE_LLAMA_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['AZURE_LLAMA_BASEURL'], $_SERVER['AZURE_LLAMA_KEY']);
+$platform = PlatformFactory::create(env('AZURE_LLAMA_BASEURL'), env('AZURE_LLAMA_KEY'), http_client());
 $model = new Llama(Llama::V3_3_70B_INSTRUCT);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(Message::ofUser('I am going to Paris, what should I see?'));
 $response = $agent->call($messages, [
     'max_tokens' => 2048,

--- a/examples/azure/embeddings.php
+++ b/examples/azure/embeddings.php
@@ -11,21 +11,15 @@
 
 use Symfony\AI\Platform\Bridge\Azure\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Bridge\OpenAI\Embeddings;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
-
-if (!isset($_SERVER['AZURE_OPENAI_BASEURL'], $_SERVER['AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT'], $_SERVER['AZURE_OPENAI_EMBEDDINGS_API_VERSION'], $_SERVER['AZURE_OPENAI_KEY'])) {
-    echo 'Please set the AZURE_OPENAI_BASEURL, AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT, AZURE_OPENAI_EMBEDDINGS_API_VERSION, and AZURE_OPENAI_KEY environment variables.'.\PHP_EOL;
-    exit(1);
-}
+require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(
-    $_SERVER['AZURE_OPENAI_BASEURL'],
-    $_SERVER['AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT'],
-    $_SERVER['AZURE_OPENAI_EMBEDDINGS_API_VERSION'],
-    $_SERVER['AZURE_OPENAI_KEY'],
+    env('AZURE_OPENAI_BASEURL'),
+    env('AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT'),
+    env('AZURE_OPENAI_EMBEDDINGS_API_VERSION'),
+    env('AZURE_OPENAI_KEY'),
+    http_client(),
 );
 $embeddings = new Embeddings();
 

--- a/examples/bedrock/chat-claude.php
+++ b/examples/bedrock/chat-claude.php
@@ -14,10 +14,8 @@ use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
 if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_SERVER['AWS_DEFAULT_REGION'])
 ) {
@@ -28,7 +26,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Claude('claude-3-7-sonnet-20250219');
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You answer questions in short and concise manner.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/bedrock/chat-llama.php
+++ b/examples/bedrock/chat-llama.php
@@ -14,10 +14,8 @@ use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
 if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_SERVER['AWS_DEFAULT_REGION'])
 ) {
@@ -28,7 +26,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Llama(Llama::V3_2_3B_INSTRUCT);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/bedrock/chat-nova.php
+++ b/examples/bedrock/chat-nova.php
@@ -14,10 +14,8 @@ use Symfony\AI\Platform\Bridge\Bedrock\Nova\Nova;
 use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
 if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_SERVER['AWS_DEFAULT_REGION'])
 ) {
@@ -28,7 +26,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Nova(Nova::PRO);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/bedrock/image-claude-binary.php
+++ b/examples/bedrock/image-claude-binary.php
@@ -15,10 +15,8 @@ use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
 if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_SERVER['AWS_DEFAULT_REGION'])
 ) {
@@ -29,7 +27,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Claude('claude-3-7-sonnet-20250219');
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(

--- a/examples/bedrock/image-nova.php
+++ b/examples/bedrock/image-nova.php
@@ -15,10 +15,8 @@ use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
 if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_SERVER['AWS_DEFAULT_REGION'])
 ) {
@@ -29,7 +27,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Nova(Nova::PRO);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(

--- a/examples/bedrock/toolcall-claude.php
+++ b/examples/bedrock/toolcall-claude.php
@@ -17,11 +17,8 @@ use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpClient\HttpClient;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
 if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_SERVER['AWS_DEFAULT_REGION'])
 ) {
@@ -32,10 +29,10 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Claude('claude-3-7-sonnet-20250219');
 
-$wikipedia = new Wikipedia(HttpClient::create());
+$wikipedia = new Wikipedia(http_client());
 $toolbox = new Toolbox([$wikipedia]);
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(Message::ofUser('Who is the current chancellor of Germany?'));
 $response = $agent->call($messages);

--- a/examples/bedrock/toolcall-nova.php
+++ b/examples/bedrock/toolcall-nova.php
@@ -17,11 +17,8 @@ use Symfony\AI\Platform\Bridge\Bedrock\Nova\Nova;
 use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpClient\HttpClient;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
 if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_SERVER['AWS_DEFAULT_REGION'])
 ) {
@@ -32,10 +29,10 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Nova();
 
-$wikipedia = new Wikipedia(HttpClient::create());
+$wikipedia = new Wikipedia(http_client());
 $toolbox = new Toolbox([$wikipedia]);
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(
     Message::ofUser('Who is the current chancellor of Germany? Use Wikipedia to find the answer.')

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+require_once __DIR__.'/vendor/autoload.php';
+(new Dotenv())->loadEnv(__DIR__.'/.env');
+
+function env(string $var)
+{
+    if (!isset($_SERVER[$var])) {
+        printf('Please set the "%s" environment variable to run this example.', $var);
+        exit(1);
+    }
+
+    return $_SERVER[$var];
+}
+
+function http_client(): HttpClientInterface
+{
+    $httpClient = HttpClient::create();
+
+    if ($httpClient instanceof LoggerAwareInterface) {
+        $httpClient->setLogger(logger());
+    }
+
+    return $httpClient;
+}
+
+function logger(): LoggerInterface
+{
+    $verbosity = match ($_SERVER['argv'][1] ?? null) {
+        '-v', '--verbose' => ConsoleOutput::VERBOSITY_VERBOSE,
+        '-vv', '--very-verbose' => ConsoleOutput::VERBOSITY_VERY_VERBOSE,
+        '-vvv', '--debug' => ConsoleOutput::VERBOSITY_DEBUG,
+        default => ConsoleOutput::VERBOSITY_NORMAL,
+    };
+
+    return new ConsoleLogger(new ConsoleOutput($verbosity));
+}

--- a/examples/google/audio-input.php
+++ b/examples/google/audio-input.php
@@ -15,20 +15,13 @@ use Symfony\AI\Platform\Bridge\Google\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Audio;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['GEMINI_API_KEY'])) {
-    echo 'Please set the GEMINI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['GEMINI_API_KEY']);
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_1_5_FLASH);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         'What is this recording about?',

--- a/examples/google/chat.php
+++ b/examples/google/chat.php
@@ -14,20 +14,13 @@ use Symfony\AI\Platform\Bridge\Google\Gemini;
 use Symfony\AI\Platform\Bridge\Google\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['GEMINI_API_KEY'])) {
-    echo 'Please set the GEMINI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['GEMINI_API_KEY']);
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_2_FLASH);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/google/embeddings.php
+++ b/examples/google/embeddings.php
@@ -11,17 +11,10 @@
 
 use Symfony\AI\Platform\Bridge\Google\Embeddings;
 use Symfony\AI\Platform\Bridge\Google\PlatformFactory;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['GEMINI_API_KEY'])) {
-    echo 'Please set the GEMINI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['GEMINI_API_KEY']);
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $embeddings = new Embeddings();
 
 $response = $platform->request($embeddings, <<<TEXT

--- a/examples/google/image-input.php
+++ b/examples/google/image-input.php
@@ -15,20 +15,13 @@ use Symfony\AI\Platform\Bridge\Google\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['GEMINI_API_KEY'])) {
-    echo 'Please set the GEMINI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['GEMINI_API_KEY']);
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_1_5_FLASH);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(

--- a/examples/google/pdf-input-binary.php
+++ b/examples/google/pdf-input-binary.php
@@ -15,20 +15,13 @@ use Symfony\AI\Platform\Bridge\Google\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Document;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['GEMINI_API_KEY'])) {
-    echo 'Please set the GEMINI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['GEMINI_API_KEY']);
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_1_5_FLASH);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         Document::fromFile(dirname(__DIR__, 2).'/fixtures/document.pdf'),

--- a/examples/google/server-tools.php
+++ b/examples/google/server-tools.php
@@ -17,24 +17,17 @@ use Symfony\AI\Platform\Bridge\Google\Gemini;
 use Symfony\AI\Platform\Bridge\Google\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['GEMINI_API_KEY'])) {
-    echo 'Please set the GEMINI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['GEMINI_API_KEY']);
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 
 // Available server-side tools as of 2025-06-28: url_context, google_search, code_execution
 $llm = new Gemini('gemini-2.5-pro-preview-03-25', ['server_tools' => ['url_context' => true], 'temperature' => 1.0]);
 
-$toolbox = new Toolbox([new Clock()]);
+$toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $llm);
+$agent = new Agent($platform, $llm, logger: logger());
 
 $messages = new MessageBag(
     Message::ofUser(

--- a/examples/google/stream.php
+++ b/examples/google/stream.php
@@ -14,20 +14,13 @@ use Symfony\AI\Platform\Bridge\Google\Gemini;
 use Symfony\AI\Platform\Bridge\Google\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['GEMINI_API_KEY'])) {
-    echo 'Please set the GEMINI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['GEMINI_API_KEY']);
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_2_FLASH);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a funny clown that entertains people.'),
     Message::ofUser('What is the purpose of an ant?'),

--- a/examples/google/structured-output-clock.php
+++ b/examples/google/structured-output-clock.php
@@ -19,24 +19,17 @@ use Symfony\AI\Platform\Bridge\Google\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\Component\Clock\Clock as SymfonyClock;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['GEMINI_API_KEY'])) {
-    echo 'Please set the GEMINI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['GEMINI_API_KEY']);
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_1_5_FLASH);
 
 $clock = new Clock(new SymfonyClock());
 $toolbox = new Toolbox([$clock]);
 $toolProcessor = new ToolProcessor($toolbox);
 $structuredOutputProcessor = new StructuredOutputProcessor();
-$agent = new Agent($platform, $model, [$toolProcessor, $structuredOutputProcessor], [$toolProcessor, $structuredOutputProcessor]);
+$agent = new Agent($platform, $model, [$toolProcessor, $structuredOutputProcessor], [$toolProcessor, $structuredOutputProcessor], logger());
 
 $messages = new MessageBag(Message::ofUser('What date and time is it?'));
 $response = $agent->call($messages, ['response_format' => [

--- a/examples/google/structured-output-math.php
+++ b/examples/google/structured-output-math.php
@@ -16,21 +16,14 @@ use Symfony\AI\Platform\Bridge\Google\Gemini;
 use Symfony\AI\Platform\Bridge\Google\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['GEMINI_API_KEY'])) {
-    echo 'Please set the GEMINI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['GEMINI_API_KEY']);
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_1_5_FLASH);
 
 $processor = new AgentProcessor();
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful math tutor. Guide the user through the solution step by step.'),
     Message::ofUser('how can I solve 8x + 7 = -23'),

--- a/examples/google/toolcall.php
+++ b/examples/google/toolcall.php
@@ -17,22 +17,15 @@ use Symfony\AI\Platform\Bridge\Google\Gemini;
 use Symfony\AI\Platform\Bridge\Google\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['GEMINI_API_KEY'])) {
-    echo 'Please set the GEMINI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['GEMINI_API_KEY']);
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $llm = new Gemini(Gemini::GEMINI_2_FLASH);
 
-$toolbox = new Toolbox([new Clock()]);
+$toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $llm, [$processor], [$processor]);
+$agent = new Agent($platform, $llm, [$processor], [$processor], logger());
 
 $messages = new MessageBag(Message::ofUser('What time is it?'));
 $response = $agent->call($messages);

--- a/examples/huggingface/_model-listing.php
+++ b/examples/huggingface/_model-listing.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\SingleCommandApplication;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
+require_once dirname(__DIR__).'/bootstrap.php';
 
 $app = (new SingleCommandApplication('HuggingFace Model Listing'))
     ->setDescription('Lists all available models on HuggingFace')

--- a/examples/huggingface/audio-classification.php
+++ b/examples/huggingface/audio-classification.php
@@ -13,17 +13,10 @@ use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Message\Content\Audio;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('MIT/ast-finetuned-audioset-10-10-0.4593');
 $audio = Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3');
 

--- a/examples/huggingface/automatic-speech-recognition.php
+++ b/examples/huggingface/automatic-speech-recognition.php
@@ -13,17 +13,10 @@ use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Message\Content\Audio;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('openai/whisper-large-v3');
 $audio = Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3');
 

--- a/examples/huggingface/chat-completion.php
+++ b/examples/huggingface/chat-completion.php
@@ -14,17 +14,10 @@ use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('HuggingFaceH4/zephyr-7b-beta');
 
 $messages = new MessageBag(Message::ofUser('Hello, how are you doing today?'));

--- a/examples/huggingface/feature-extraction.php
+++ b/examples/huggingface/feature-extraction.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('thenlper/gte-large');
 
 $response = $platform->request($model, 'Today is a sunny day and I will get some ice cream.', [

--- a/examples/huggingface/fill-mask.php
+++ b/examples/huggingface/fill-mask.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('FacebookAI/xlm-roberta-base');
 
 $response = $platform->request($model, 'Hello I\'m a <mask> model.', [

--- a/examples/huggingface/image-classification.php
+++ b/examples/huggingface/image-classification.php
@@ -13,17 +13,10 @@ use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('google/vit-base-patch16-224');
 
 $image = Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg');

--- a/examples/huggingface/image-segmentation.php
+++ b/examples/huggingface/image-segmentation.php
@@ -13,17 +13,10 @@ use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('nvidia/segformer-b0-finetuned-ade-512-512');
 
 $image = Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg');

--- a/examples/huggingface/image-to-text.php
+++ b/examples/huggingface/image-to-text.php
@@ -13,17 +13,10 @@ use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('Salesforce/blip-image-captioning-base');
 
 $image = Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg');

--- a/examples/huggingface/object-detection.php
+++ b/examples/huggingface/object-detection.php
@@ -13,17 +13,10 @@ use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('facebook/detr-resnet-50');
 
 $image = Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg');

--- a/examples/huggingface/question-answering.php
+++ b/examples/huggingface/question-answering.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('deepset/roberta-base-squad2');
 
 $input = [

--- a/examples/huggingface/sentence-similarity.php
+++ b/examples/huggingface/sentence-similarity.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('sentence-transformers/all-MiniLM-L6-v2');
 
 $input = [

--- a/examples/huggingface/summarization.php
+++ b/examples/huggingface/summarization.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('facebook/bart-large-cnn');
 
 $longText = <<<TEXT

--- a/examples/huggingface/table-question-answering.php
+++ b/examples/huggingface/table-question-answering.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('microsoft/tapex-base');
 
 $input = [

--- a/examples/huggingface/text-classification.php
+++ b/examples/huggingface/text-classification.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('ProsusAI/finbert');
 
 $response = $platform->request($model, 'I like you. I love you.', [

--- a/examples/huggingface/text-generation.php
+++ b/examples/huggingface/text-generation.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('gpt2');
 
 $response = $platform->request($model, 'The quick brown fox jumps over the lazy', [

--- a/examples/huggingface/text-to-image.php
+++ b/examples/huggingface/text-to-image.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('black-forest-labs/FLUX.1-dev');
 
 $response = $platform->request($model, 'Astronaut riding a horse', [

--- a/examples/huggingface/token-classification.php
+++ b/examples/huggingface/token-classification.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('dbmdz/bert-large-cased-finetuned-conll03-english');
 
 $response = $platform->request($model, 'John Smith works at Microsoft in London.', [

--- a/examples/huggingface/translation.php
+++ b/examples/huggingface/translation.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('facebook/mbart-large-50-many-to-many-mmt');
 
 $response = $platform->request($model, 'Меня зовут Вольфганг и я живу в Берлине', [

--- a/examples/huggingface/zero-shot-classification.php
+++ b/examples/huggingface/zero-shot-classification.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['HUGGINGFACE_KEY'])) {
-    echo 'Please set the HUGGINGFACE_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['HUGGINGFACE_KEY']);
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 $model = new Model('facebook/bart-large-mnli');
 
 $text = 'Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!';

--- a/examples/lmstudio/chat.php
+++ b/examples/lmstudio/chat.php
@@ -14,20 +14,13 @@ use Symfony\AI\Platform\Bridge\LMStudio\Completions;
 use Symfony\AI\Platform\Bridge\LMStudio\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['LMSTUDIO_HOST_URL'])) {
-    echo 'Please set the LMSTUDIO_HOST_URL environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['LMSTUDIO_HOST_URL']);
+$platform = PlatformFactory::create(env('LMSTUDIO_HOST_URL'), http_client());
 $model = new Completions('gemma-3-4b-it-qat');
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/lmstudio/image-input-binary.php
+++ b/examples/lmstudio/image-input-binary.php
@@ -16,23 +16,16 @@ use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['LMSTUDIO_HOST_URL'])) {
-    echo 'Please set the LMSTUDIO_HOST_URL environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['LMSTUDIO_HOST_URL']);
+$platform = PlatformFactory::create(env('LMSTUDIO_HOST_URL'), http_client());
 $model = new Completions(
     name: 'gemma-3-4b-it-qat',
     capabilities: [...Completions::DEFAULT_CAPABILITIES, Capability::INPUT_IMAGE]
 );
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(

--- a/examples/misc/chat-system-prompt.php
+++ b/examples/misc/chat-system-prompt.php
@@ -15,22 +15,15 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
 $processor = new SystemPromptInputProcessor('You are Yoda and write like he speaks. But short.');
 
-$agent = new Agent($platform, $model, [$processor]);
+$agent = new Agent($platform, $model, [$processor], logger: logger());
 $messages = new MessageBag(Message::ofUser('What is the meaning of life?'));
 $response = $agent->call($messages);
 

--- a/examples/misc/chat-with-memory.php
+++ b/examples/misc/chat-with-memory.php
@@ -17,17 +17,10 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!$_ENV['OPENAI_API_KEY']) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
+$platform = PlatformFactory::create($_ENV['OPENAI_API_KEY'], http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
 $systemPromptProcessor = new SystemPromptInputProcessor('You are a professional trainer with short, personalized advices and a motivating claim.');
@@ -39,7 +32,7 @@ $personalFacts = new StaticMemoryProvider(
 );
 $memoryProcessor = new MemoryInputProcessor($personalFacts);
 
-$chain = new Agent($platform, $model, [$systemPromptProcessor, $memoryProcessor]);
+$chain = new Agent($platform, $model, [$systemPromptProcessor, $memoryProcessor], logger: logger());
 $messages = new MessageBag(Message::ofUser('What do we do today?'));
 $response = $chain->call($messages);
 

--- a/examples/misc/parallel-chat-gpt.php
+++ b/examples/misc/parallel-chat-gpt.php
@@ -13,17 +13,10 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI, [
     'temperature' => 0.5, // default options for the model
 ]);

--- a/examples/misc/parallel-embeddings.php
+++ b/examples/misc/parallel-embeddings.php
@@ -11,17 +11,10 @@
 
 use Symfony\AI\Platform\Bridge\OpenAI\Embeddings;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $ada = new Embeddings(Embeddings::TEXT_ADA_002);
 $small = new Embeddings(Embeddings::TEXT_3_SMALL);
 $large = new Embeddings(Embeddings::TEXT_3_LARGE);

--- a/examples/misc/persistent-chat.php
+++ b/examples/misc/persistent-chat.php
@@ -16,20 +16,13 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $llm = new GPT(GPT::GPT_4O_MINI);
 
-$agent = new Agent($platform, $llm);
+$agent = new Agent($platform, $llm, logger: logger());
 $chat = new Chat($agent, new InMemoryStore());
 
 $messages = new MessageBag(

--- a/examples/mistral/chat.php
+++ b/examples/mistral/chat.php
@@ -14,19 +14,12 @@ use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['MISTRAL_API_KEY'])) {
-    echo 'Please set the REPLICATE_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['MISTRAL_API_KEY']);
+$platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
 $model = new Mistral();
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(Message::ofUser('What is the best French cheese?'));
 $response = $agent->call($messages, [

--- a/examples/mistral/embeddings.php
+++ b/examples/mistral/embeddings.php
@@ -11,17 +11,10 @@
 
 use Symfony\AI\Platform\Bridge\Mistral\Embeddings;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['MISTRAL_API_KEY'])) {
-    echo 'Please set the MISTRAL_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['MISTRAL_API_KEY']);
+$platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
 $model = new Embeddings();
 
 $response = $platform->request($model, <<<TEXT

--- a/examples/mistral/image.php
+++ b/examples/mistral/image.php
@@ -15,19 +15,12 @@ use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['MISTRAL_API_KEY']);
+$platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
 $model = new Mistral(Mistral::MISTRAL_SMALL);
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),

--- a/examples/mistral/stream.php
+++ b/examples/mistral/stream.php
@@ -14,19 +14,12 @@ use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['MISTRAL_API_KEY'])) {
-    echo 'Please set the REPLICATE_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['MISTRAL_API_KEY']);
+$platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
 $model = new Mistral();
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(Message::ofUser('What is the eighth prime number?'));
 $response = $agent->call($messages, [

--- a/examples/mistral/structured-output-math.php
+++ b/examples/mistral/structured-output-math.php
@@ -17,25 +17,18 @@ use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['MISTRAL_API_KEY'])) {
-    echo 'Please set the MISTRAL_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['MISTRAL_API_KEY']);
+$platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
 $model = new Mistral(Mistral::MISTRAL_SMALL);
 $serializer = new Serializer([new ObjectNormalizer()], [new JsonEncoder()]);
 
 $processor = new AgentProcessor(new ResponseFormatFactory(), $serializer);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful math tutor. Guide the user through the solution step by step.'),
     Message::ofUser('how can I solve 8x + 7 = -23'),

--- a/examples/mistral/toolcall-stream.php
+++ b/examples/mistral/toolcall-stream.php
@@ -17,24 +17,16 @@ use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpClient\HttpClient;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['MISTRAL_API_KEY'])) {
-    echo 'Please set the REPLICATE_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['MISTRAL_API_KEY']);
+$platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
 $model = new Mistral();
 
-$transcriber = new YouTubeTranscriber(HttpClient::create());
-$toolbox = new Toolbox([$transcriber]);
+$transcriber = new YouTubeTranscriber(http_client());
+$toolbox = new Toolbox([$transcriber], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(Message::ofUser('Please summarize this video for me: https://www.youtube.com/watch?v=6uXW-ulpj0s'));
 $response = $agent->call($messages, [

--- a/examples/mistral/toolcall.php
+++ b/examples/mistral/toolcall.php
@@ -17,22 +17,15 @@ use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['MISTRAL_API_KEY'])) {
-    echo 'Please set the REPLICATE_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['MISTRAL_API_KEY']);
+$platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
 $model = new Mistral();
 
-$toolbox = new Toolbox([new Clock()]);
+$toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(Message::ofUser('What time is it?'));
 $response = $agent->call($messages);

--- a/examples/ollama/chat-llama.php
+++ b/examples/ollama/chat-llama.php
@@ -14,20 +14,13 @@ use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Bridge\Ollama\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OLLAMA_HOST_URL'])) {
-    echo 'Please set the OLLAMA_HOST_URL environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OLLAMA_HOST_URL']);
+$platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
 $model = new Llama('llama3.2');
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),

--- a/examples/openai/audio-input.php
+++ b/examples/openai/audio-input.php
@@ -15,20 +15,13 @@ use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Audio;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_AUDIO);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         'What is this recording about?',

--- a/examples/openai/audio-transcript.php
+++ b/examples/openai/audio-transcript.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Bridge\OpenAI\Whisper;
 use Symfony\AI\Platform\Message\Content\Audio;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new Whisper();
 $file = Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3');
 

--- a/examples/openai/chat.php
+++ b/examples/openai/chat.php
@@ -14,22 +14,15 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI, [
     'temperature' => 0.5, // default options for the model
 ]);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/openai/embeddings.php
+++ b/examples/openai/embeddings.php
@@ -11,17 +11,10 @@
 
 use Symfony\AI\Platform\Bridge\OpenAI\Embeddings;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $embeddings = new Embeddings();
 
 $response = $platform->request($embeddings, <<<TEXT

--- a/examples/openai/image-input-binary.php
+++ b/examples/openai/image-input-binary.php
@@ -15,20 +15,13 @@ use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(

--- a/examples/openai/image-input-url.php
+++ b/examples/openai/image-input-url.php
@@ -15,20 +15,13 @@ use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(

--- a/examples/openai/image-output-dall-e-2.php
+++ b/examples/openai/image-output-dall-e-2.php
@@ -11,17 +11,10 @@
 
 use Symfony\AI\Platform\Bridge\OpenAI\DallE;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
 $response = $platform->request(
     model: new DallE(), // Utilize Dall-E 2 version in default

--- a/examples/openai/image-output-dall-e-3.php
+++ b/examples/openai/image-output-dall-e-3.php
@@ -12,17 +12,10 @@
 use Symfony\AI\Platform\Bridge\OpenAI\DallE;
 use Symfony\AI\Platform\Bridge\OpenAI\DallE\ImageResponse;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
 $response = $platform->request(
     model: new DallE(name: DallE::DALL_E_3),

--- a/examples/openai/stream.php
+++ b/examples/openai/stream.php
@@ -14,20 +14,13 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a thoughtful philosopher.'),
     Message::ofUser('What is the purpose of an ant?'),

--- a/examples/openai/structured-output-clock.php
+++ b/examples/openai/structured-output-clock.php
@@ -19,21 +19,14 @@ use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\Component\Clock\Clock as SymfonyClock;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
 $clock = new Clock(new SymfonyClock());
-$toolbox = new Toolbox([$clock]);
+$toolbox = new Toolbox([$clock], logger: logger());
 $toolProcessor = new ToolProcessor($toolbox);
 $structuredOutputProcessor = new StructuredOutputProcessor();
 $agent = new Agent($platform, $model, [$toolProcessor, $structuredOutputProcessor], [$toolProcessor, $structuredOutputProcessor]);

--- a/examples/openai/structured-output-math.php
+++ b/examples/openai/structured-output-math.php
@@ -16,21 +16,14 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
 $processor = new AgentProcessor();
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful math tutor. Guide the user through the solution step by step.'),
     Message::ofUser('how can I solve 8x + 7 = -23'),

--- a/examples/openai/token-metadata.php
+++ b/examples/openai/token-metadata.php
@@ -15,22 +15,15 @@ use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Bridge\OpenAI\TokenOutputProcessor;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI, [
     'temperature' => 0.5, // default options for the model
 ]);
 
-$agent = new Agent($platform, $model, outputProcessors: [new TokenOutputProcessor()]);
+$agent = new Agent($platform, $model, outputProcessors: [new TokenOutputProcessor()], logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/openai/toolcall-stream.php
+++ b/examples/openai/toolcall-stream.php
@@ -17,24 +17,16 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpClient\HttpClient;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
-$wikipedia = new Wikipedia(HttpClient::create());
-$toolbox = new Toolbox([$wikipedia]);
+$wikipedia = new Wikipedia(http_client());
+$toolbox = new Toolbox([$wikipedia], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 $messages = new MessageBag(Message::ofUser(<<<TXT
         First, define unicorn in 30 words.
         Then lookup at Wikipedia what the irish history looks like in 2 sentences.

--- a/examples/openai/toolcall.php
+++ b/examples/openai/toolcall.php
@@ -17,24 +17,16 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpClient\HttpClient;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
-$transcriber = new YouTubeTranscriber(HttpClient::create());
-$toolbox = new Toolbox([$transcriber]);
+$transcriber = new YouTubeTranscriber(http_client());
+$toolbox = new Toolbox([$transcriber], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(Message::ofUser('Please summarize this video for me: https://www.youtube.com/watch?v=6uXW-ulpj0s'));
 $response = $agent->call($messages);

--- a/examples/openrouter/chat-gemini.php
+++ b/examples/openrouter/chat-gemini.php
@@ -14,22 +14,15 @@ use Symfony\AI\Platform\Bridge\OpenRouter\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENROUTER_KEY'])) {
-    echo 'Please set the OPENROUTER_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENROUTER_KEY']);
+$platform = PlatformFactory::create(env('OPENROUTER_KEY'), http_client());
 // In case free is running into 429 rate limit errors, you can use the paid model:
 // $model = new Model('google/gemini-2.0-flash-lite-001');
 $model = new Model('google/gemini-2.0-flash-exp:free');
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),

--- a/examples/replicate/chat-llama.php
+++ b/examples/replicate/chat-llama.php
@@ -14,20 +14,13 @@ use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Bridge\Replicate\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['REPLICATE_API_KEY'])) {
-    echo 'Please set the REPLICATE_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['REPLICATE_API_KEY']);
+$platform = PlatformFactory::create(env('REPLICATE_API_KEY'), http_client());
 $model = new Llama();
 
-$agent = new Agent($platform, $model);
+$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),

--- a/examples/store/document-splitting.php
+++ b/examples/store/document-splitting.php
@@ -12,7 +12,7 @@
 use Symfony\AI\Store\Document\Loader\TextFileLoader;
 use Symfony\AI\Store\Document\Transformer\TextSplitTransformer;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
+require_once dirname(__DIR__).'/bootstrap.php';
 
 $loader = new TextFileLoader();
 $splitter = new TextSplitTransformer();

--- a/examples/store/document-vectorizing.php
+++ b/examples/store/document-vectorizing.php
@@ -14,18 +14,11 @@ use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Document\Vectorizer;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Uid\Uuid;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $embeddings = new Embeddings(Embeddings::TEXT_3_LARGE);
 
 $textDocuments = [

--- a/examples/store/mariadb-similarity-search.php
+++ b/examples/store/mariadb-similarity-search.php
@@ -26,20 +26,13 @@ use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Uid\Uuid;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
-
-if (!isset($_SERVER['OPENAI_API_KEY'], $_SERVER['MARIADB_URI'])) {
-    echo 'Please set OPENAI_API_KEY and MARIADB_URI environment variables.'.\PHP_EOL;
-    exit(1);
-}
+require_once dirname(__DIR__).'/bootstrap.php';
 
 // initialize the store
 $store = Store::fromDbal(
-    connection: DriverManager::getConnection((new DsnParser())->parse($_SERVER['MARIADB_URI'])),
+    connection: DriverManager::getConnection((new DsnParser())->parse(env('MARIADB_URI'))),
     tableName: 'my_table',
     indexName: 'my_index',
 );
@@ -57,17 +50,17 @@ foreach (Movies::all() as $i => $movie) {
 $store->initialize();
 
 // create embeddings for documents
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
-$indexer = new Indexer($vectorizer, $store);
+$indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
 $model = new GPT(GPT::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
-$toolbox = new Toolbox([$similaritySearch]);
+$toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/store/memory-similarity-search.php
+++ b/examples/store/memory-similarity-search.php
@@ -24,16 +24,9 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer;
 use Symfony\AI\Store\InMemoryStore;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Uid\Uuid;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
-
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
+require_once dirname(__DIR__).'/bootstrap.php';
 
 // initialize the store
 $store = new InMemoryStore();
@@ -48,17 +41,17 @@ foreach (Movies::all() as $i => $movie) {
 }
 
 // create embeddings for documents
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
-$indexer = new Indexer($vectorizer, $store);
+$indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
 $model = new GPT(GPT::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
-$toolbox = new Toolbox([$similaritySearch]);
+$toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/store/pinecone-similarity-search.php
+++ b/examples/store/pinecone-similarity-search.php
@@ -25,19 +25,12 @@ use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Uid\Uuid;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
-
-if (!isset($_SERVER['OPENAI_API_KEY'], $_SERVER['PINECONE_API_KEY'], $_SERVER['PINECONE_HOST'])) {
-    echo 'Please set OPENAI_API_KEY, PINECONE_API_KEY and PINECONE_HOST environment variables.'.\PHP_EOL;
-    exit(1);
-}
+require_once dirname(__DIR__).'/bootstrap.php';
 
 // initialize the store
-$store = new Store(Pinecone::client($_SERVER['PINECONE_API_KEY'], $_SERVER['PINECONE_HOST']));
+$store = new Store(Pinecone::client(env('PINECONE_API_KEY'), env('PINECONE_HOST')));
 
 // create embeddings and documents
 foreach (Movies::all() as $movie) {
@@ -49,17 +42,17 @@ foreach (Movies::all() as $movie) {
 }
 
 // create embeddings for documents
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
-$indexer = new Indexer($vectorizer, $store);
+$indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
 $model = new GPT(GPT::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
-$toolbox = new Toolbox([$similaritySearch]);
+$toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/store/qdrant-similarity-search.php
+++ b/examples/store/qdrant-similarity-search.php
@@ -24,23 +24,16 @@ use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Uid\Uuid;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
-
-if (!isset($_SERVER['OPENAI_API_KEY'], $_SERVER['QDRANT_HOST'], $_SERVER['QDRANT_SERVICE_API_KEY'])) {
-    echo 'Please set OPENAI_API_KEY, QDRANT_HOST and QDRANT_SERVICE_API_KEY environment variables.'.\PHP_EOL;
-    exit(1);
-}
+require_once dirname(__DIR__).'/bootstrap.php';
 
 // initialize the store
 $store = new Store(
     HttpClient::create(),
-    $_SERVER['QDRANT_HOST'],
-    $_SERVER['QDRANT_SERVICE_API_KEY'],
+    env('QDRANT_HOST'),
+    env('QDRANT_SERVICE_API_KEY'),
     'movies',
 );
 
@@ -57,17 +50,17 @@ foreach (Movies::all() as $movie) {
 }
 
 // create embeddings for documents
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
-$indexer = new Indexer($vectorizer, $store);
+$indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
 $model = new GPT(GPT::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
-$toolbox = new Toolbox([$similaritySearch]);
+$toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/toolbox/brave.php
+++ b/examples/toolbox/brave.php
@@ -18,25 +18,17 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpClient\HttpClient;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'], $_SERVER['BRAVE_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY and BRAVE_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
-$httpClient = HttpClient::create();
-$brave = new Brave($httpClient, $_SERVER['BRAVE_API_KEY']);
-$crawler = new Crawler($httpClient);
-$toolbox = new Toolbox([$brave, $crawler]);
+$brave = new Brave(http_client(), env('BRAVE_API_KEY'));
+$crawler = new Crawler(http_client());
+$toolbox = new Toolbox([$brave, $crawler], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(Message::ofUser('What was the latest game result of Dallas Cowboys?'));
 $response = $agent->call($messages);

--- a/examples/toolbox/clock.php
+++ b/examples/toolbox/clock.php
@@ -18,24 +18,17 @@ use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\Component\Clock\Clock;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
 $metadataFactory = (new MemoryToolFactory())
     ->addTool(Clock::class, 'clock', 'Get the current date and time', 'now');
-$toolbox = new Toolbox($metadataFactory, [new Clock()]);
+$toolbox = new Toolbox([new Clock()], $metadataFactory, logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(Message::ofUser('What date and time is it?'));
 $response = $agent->call($messages);

--- a/examples/toolbox/serpapi.php
+++ b/examples/toolbox/serpapi.php
@@ -17,23 +17,16 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpClient\HttpClient;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'], $_SERVER['SERP_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY and SERP_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
-$serpApi = new SerpApi(HttpClient::create(), $_SERVER['SERP_API_KEY']);
-$toolbox = new Toolbox([$serpApi]);
+$serpApi = new SerpApi(http_client(), env('SERP_API_KEY'));
+$toolbox = new Toolbox([$serpApi], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(Message::ofUser('Who is the current chancellor of Germany?'));
 $response = $agent->call($messages);

--- a/examples/toolbox/tavily.php
+++ b/examples/toolbox/tavily.php
@@ -17,23 +17,16 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT;
 use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpClient\HttpClient;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'], $_SERVER['TAVILY_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY and TAVILY_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
-$tavily = new Tavily(HttpClient::create(), $_SERVER['TAVILY_API_KEY']);
-$toolbox = new Toolbox([$tavily]);
+$tavily = new Tavily(http_client(), env('TAVILY_API_KEY'));
+$toolbox = new Toolbox([$tavily], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 $messages = new MessageBag(Message::ofUser('What was the latest game result of Dallas Cowboys?'));
 $response = $agent->call($messages);

--- a/examples/toolbox/weather-event.php
+++ b/examples/toolbox/weather-event.php
@@ -19,26 +19,18 @@ use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Response\ObjectResponse;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\HttpClient\HttpClient;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['OPENAI_API_KEY'])) {
-    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new GPT(GPT::GPT_4O_MINI);
 
-$openMeteo = new OpenMeteo(HttpClient::create());
-$toolbox = new Toolbox([$openMeteo]);
+$openMeteo = new OpenMeteo(http_client());
+$toolbox = new Toolbox([$openMeteo], logger: logger());
 $eventDispatcher = new EventDispatcher();
 $processor = new AgentProcessor($toolbox, eventDispatcher: $eventDispatcher);
-$agent = new Agent($platform, $model, [$processor], [$processor]);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
 
 // Add tool call result listener to enforce chain exits direct with structured response for weather tools
 $eventDispatcher->addListener(ToolCallsExecuted::class, function (ToolCallsExecuted $event): void {

--- a/examples/transformers/text-generation.php
+++ b/examples/transformers/text-generation.php
@@ -13,7 +13,7 @@ use Codewithkyrian\Transformers\Pipelines\Task;
 use Symfony\AI\Platform\Bridge\TransformersPHP\PlatformFactory;
 use Symfony\AI\Platform\Model;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
+require_once dirname(__DIR__).'/bootstrap.php';
 
 if (!extension_loaded('ffi') || '1' !== ini_get('ffi.enable')) {
     echo 'FFI extension is not loaded or enabled. Please enable it in your php.ini file.'.\PHP_EOL;

--- a/examples/voyage/embeddings.php
+++ b/examples/voyage/embeddings.php
@@ -11,17 +11,10 @@
 
 use Symfony\AI\Platform\Bridge\Voyage\PlatformFactory;
 use Symfony\AI\Platform\Bridge\Voyage\Voyage;
-use Symfony\Component\Dotenv\Dotenv;
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
-(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+require_once dirname(__DIR__).'/bootstrap.php';
 
-if (!isset($_SERVER['VOYAGE_API_KEY'])) {
-    echo 'Please set the VOYAGE_API_KEY environment variable.'.\PHP_EOL;
-    exit(1);
-}
-
-$platform = PlatformFactory::create($_SERVER['VOYAGE_API_KEY']);
+$platform = PlatformFactory::create(env('VOYAGE_API_KEY'), http_client());
 $embeddings = new Voyage();
 
 $response = $platform->request($embeddings, <<<TEXT

--- a/src/platform/doc/index.rst
+++ b/src/platform/doc/index.rst
@@ -33,7 +33,7 @@ For example, to use the OpenAI provider, you would typically do something like t
     use Symfony\AI\Platform\Bridge\OpenAI\PlatformFactory;
 
     // Platform
-    $platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
+    $platform = PlatformFactory::create(env('OPENAI_API_KEY'));
 
     // Embeddings Model
     $embeddings = new Embeddings();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

Brings to things:
* Easier bootstrapping and env var checks
* Enables logging of HTTP calls with `-vv` or tool calls with `-vvv`

Sometimes I'd like to see more details of the execution of an example. This would be possible now:
<img width="1915" height="594" alt="image" src="https://github.com/user-attachments/assets/25de4bfe-69bb-459b-8331-dd01482040e6" />

What do you think? does it make the examples too complex to read & write - or helpful?

(only a draft, would roll that out to all examples if feedback is positive)