### PR TITLE
[Platform] Improve error reporting in platform layer

### DIFF
--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -13,6 +13,7 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\Exception\ExceptionInterface as AgentException;
 use Symfony\AI\Platform\Exception\ExceptionInterface as PlatformException;
+use Symfony\AI\Platform\Exception\ResultException;
 use Symfony\AI\Platform\Metadata\Metadata;
 use Symfony\AI\Platform\Metadata\TokenUsage;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -190,7 +191,11 @@ set_exception_handler(function ($exception) {
     if ($exception instanceof AgentException || $exception instanceof PlatformException || $exception instanceof StoreException) {
         output()->writeln(sprintf('<error>%s</error>', $exception->getMessage()));
 
-        if (output()->isVerbose()) {
+        if ($exception instanceof ResultException && output()->isVerbose()) {
+            dump($exception->getDetails());
+        }
+
+        if (output()->isVeryVerbose()) {
             output()->writeln($exception->getTraceAsString());
         }
 

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Anthropic;
 
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Exception\ResultException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -51,6 +52,10 @@ class ResultConverter implements ResultConverterInterface
         }
 
         $data = $result->getData();
+
+        if (isset($data['error'])) {
+            throw new ResultException($data['error']['message'], $data['error']);
+        }
 
         if (!isset($data['content']) || [] === $data['content']) {
             throw new RuntimeException('Response does not contain any content.');

--- a/src/platform/src/Bridge/Replicate/Client.php
+++ b/src/platform/src/Bridge/Replicate/Client.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Replicate;
 
+use Symfony\AI\Platform\Exception\ResultException;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -40,7 +41,11 @@ final readonly class Client
             'auth_bearer' => $this->apiKey,
             'json' => ['input' => $body],
         ]);
-        $data = $response->toArray();
+        $data = $response->toArray(false);
+
+        if (isset($data['detail'])) {
+            throw new ResultException($data['detail'], $data);
+        }
 
         while (!\in_array($data['status'], ['succeeded', 'failed', 'canceled'], true)) {
             $this->clock->sleep(1); // we need to wait until the prediction is ready

--- a/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Scaleway\Llm;
 
 use Symfony\AI\Platform\Bridge\Scaleway\Scaleway;
-use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ResultException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -45,8 +45,8 @@ final class ResultConverter implements ResultConverterInterface
         }
         $data = $result->getData();
 
-        if (isset($data['error']['code']) && 'content_filter' === $data['error']['code']) {
-            throw new ContentFilterException($data['error']['message']);
+        if (isset($data['error'])) {
+            throw new ResultException($data['error']['message'], $data['error']);
         }
 
         if (!isset($data['choices'])) {

--- a/src/platform/src/Bridge/Voyage/ResultConverter.php
+++ b/src/platform/src/Bridge/Voyage/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Voyage;
 
+use Symfony\AI\Platform\Exception\ResultException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -32,6 +33,10 @@ final readonly class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface $result, array $options = []): ResultInterface
     {
         $result = $result->getData();
+
+        if (isset($result['detail'])) {
+            throw new ResultException($result['detail']);
+        }
 
         if (!isset($result['data'])) {
             throw new RuntimeException('Response does not contain embedding data.');

--- a/src/platform/src/Exception/AuthenticationException.php
+++ b/src/platform/src/Exception/AuthenticationException.php
@@ -17,6 +17,6 @@ namespace Symfony\AI\Platform\Exception;
  * @author Vitalii Kyktov <vitalii.kyktov@gmail.com>
  * @author Dmytro Liashko <dmlyashko@gmail.com>
  */
-class AuthenticationException extends RuntimeException
+class AuthenticationException extends ResultException
 {
 }

--- a/src/platform/src/Exception/RateLimitExceededException.php
+++ b/src/platform/src/Exception/RateLimitExceededException.php
@@ -14,7 +14,7 @@ namespace Symfony\AI\Platform\Exception;
 /**
  * @author Floran Pagliai <floran.pagliai@gmail.com>
  */
-final class RateLimitExceededException extends RuntimeException
+final class RateLimitExceededException extends ResultException
 {
     public function __construct(
         private readonly ?int $retryAfter = null,

--- a/src/platform/src/Exception/ResultException.php
+++ b/src/platform/src/Exception/ResultException.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Exception;
+
+class ResultException extends \Exception implements ExceptionInterface
+{
+    /**
+     * @param array<string, string> $details
+     */
+    public function __construct(
+        string $message,
+        private array $details = [],
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, previous: $previous);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getDetails(): array
+    {
+        return $this->details;
+    }
+}

--- a/src/platform/src/Result/RawHttpResult.php
+++ b/src/platform/src/Result/RawHttpResult.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\AI\Platform\Result;
 
+use Symfony\AI\Platform\Exception\ResultException;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -25,7 +28,13 @@ final readonly class RawHttpResult implements RawResultInterface
 
     public function getData(): array
     {
-        return $this->response->toArray(false);
+        try {
+            return $this->response->toArray();
+        } catch (ClientExceptionInterface $e) {
+            throw new ResultException(message: \sprintf('API responded with an error: "%s"', $e->getMessage()), details: $this->response->toArray(false), previous: $e);
+        } catch (ExceptionInterface $e) {
+            throw new ResultException(\sprintf('Error while calling the API: "%s"', $e->getMessage()), previous: $e);
+        }
     }
 
     public function getObject(): ResponseInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

With #142 I accidentally changed the error reporting/handling of the platform layer, since I used `toArray(false)` instead of `toArray()` on the http client's response.

However, maybe it's better to go ahead with that and implement better error handling, since this was annoying to me anyways :speak_no_evil: 

- [ ] Tests
- [ ] Roll out to all bridges