### PR TITLE
[MCPSDK] Make content an array to match the MCP spec

### DIFF
--- a/src/mcp-sdk/src/Server/RequestHandler/ToolCallHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/ToolCallHandler.php
@@ -60,7 +60,7 @@ final class ToolCallHandler extends BaseRequestHandler
         };
 
         return new Response($message->id, [
-            'content' => $content,
+            'content' => [$content], // TODO: allow multiple `ToolCallResult`s in the future
             'isError' => $result->isError,
         ]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #123
| License       | MIT

Force `content` in `\Symfony\AI\McpSdk\Server\RequestHandler\ToolCallHandler` to be an array to match the [spec](https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolresult-content)
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
