### PR TITLE
[AIBundle] Fix profiler with non-string tool results

### DIFF
--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -239,7 +239,7 @@
                     </tr>
                     <tr>
                         <th>Result</th>
-                        <td>{{ call.result|nl2br }}</td>
+                        <td>{{ dump(call.result) }}</td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT

Fix the following issue in Symfony AI profiler view which appears when using `blog` demo which has a `clock` tool returning a `DatePoint` instance:

```
An exception has been thrown during the rendering of a template ("nl2br(): Argument #1 ($string) must be of type string, Symfony\Component\Clock\DatePoint given") in @AI/data_collector.html.twig at line 242
```