### PR TITLE
[AIBundle] Fix dependency injection

### DIFF
--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -68,15 +68,15 @@ return static function (ContainerConfigurator $container): void {
         ->set('ai.toolbox.abstract', Toolbox::class)
             ->abstract()
             ->args([
-                service('ai.tool_factory'),
                 abstract_arg('Collection of tools'),
+                service('ai.tool_factory'),
                 service('ai.tool_call_argument_resolver'),
                 service('logger')->ignoreOnInvalid(),
                 service('event_dispatcher')->nullOnInvalid(),
             ])
         ->set('ai.toolbox', Toolbox::class)
             ->parent('ai.toolbox.abstract')
-            ->arg('index_1', tagged_iterator('ai.tool'))
+            ->arg('index_0', tagged_iterator('ai.tool'))
         ->alias(ToolboxInterface::class, 'ai.toolbox')
         ->set('ai.tool_factory.abstract', AbstractToolFactory::class)
             ->abstract()

--- a/src/ai-bundle/src/AIBundle.php
+++ b/src/ai-bundle/src/AIBundle.php
@@ -347,8 +347,8 @@ final class AIBundle extends AbstractBundle
                 }
 
                 $toolboxDefinition = (new ChildDefinition('ai.toolbox.abstract'))
-                    ->replaceArgument(0, new Reference('ai.toolbox.'.$name.'.chain_factory'))
-                    ->replaceArgument(1, $tools);
+                    ->replaceArgument(0, $tools)
+                    ->replaceArgument(1, new Reference('ai.toolbox.'.$name.'.chain_factory'));
                 $container->setDefinition('ai.toolbox.'.$name, $toolboxDefinition);
 
                 if ($config['fault_tolerant_toolbox']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT

Fix DI config after #163 / #154. Should've rebased before merge – now we're getting a bunch of errors on `main`:

```
Symfony\AI\Agent\Toolbox\Toolbox::__construct(): Argument #1 ($tools) must be of type Traversable|array, Symfony\AI\Agent\Toolbox\ToolFactory\ReflectionToolFactory given
```

etc