### PR TITLE
[Plateform][HuggingFaces] Fix: throw exceptions directly instead of using 'return throw'

### DIFF
--- a/src/platform/src/Bridge/HuggingFace/ResultConverter.php
+++ b/src/platform/src/Bridge/HuggingFace/ResultConverter.php
@@ -47,11 +47,11 @@ final readonly class ResultConverter implements PlatformResponseConverter
     {
         $httpResponse = $result->getObject();
         if (503 === $httpResponse->getStatusCode()) {
-            return throw new RuntimeException('Service unavailable.');
+            throw new RuntimeException('Service unavailable.');
         }
 
         if (404 === $httpResponse->getStatusCode()) {
-            return throw new InvalidArgumentException('Model, provider or task not found (404).');
+            throw new InvalidArgumentException('Model, provider or task not found (404).');
         }
 
         $headers = $httpResponse->getHeaders(false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #181
| License       | MIT

Replace `return throw` with direct throw statements for all exception cases in ResultConverter
