### PR TITLE
[Agent] Add `@throws` tag

### DIFF
--- a/src/agent/src/AgentInterface.php
+++ b/src/agent/src/AgentInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Exception\ExceptionInterface;
 use Symfony\AI\Platform\Message\MessageBagInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 
@@ -21,6 +22,8 @@ interface AgentInterface
 {
     /**
      * @param array<string, mixed> $options
+     *
+     * @throws ExceptionInterface
      */
     public function call(MessageBagInterface $messages, array $options = []): ResultInterface;
 }

--- a/src/agent/src/ChatInterface.php
+++ b/src/agent/src/ChatInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Exception\ExceptionInterface;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\MessageBagInterface;
 use Symfony\AI\Platform\Message\UserMessage;
@@ -19,5 +20,8 @@ interface ChatInterface
 {
     public function initiate(MessageBagInterface $messages): void;
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function submit(UserMessage $message): AssistantMessage;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | Fix #...
| License       | MIT

Hi @chr-hertel, this lib seems to lack of `@throws` phpdoc.

For static analysis usage (and developer experience) it seems better to tell which methods are throwing exceptions.
I didn't look for every methods but started with two important methods imho.