### PR TITLE
Fix MariaDB Store query with minScore argument

### DIFF
--- a/src/store/src/Bridge/MariaDB/Store.php
+++ b/src/store/src/Bridge/MariaDB/Store.php
@@ -113,7 +113,7 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
                     SQL,
                 $this->vectorFieldName,
                 $this->tableName,
-                null !== $minScore ? 'WHERE VEC_DISTANCE_EUCLIDEAN(%1$s, VEC_FromText(:embedding)) >= :minScore' : '',
+                null !== $minScore ? \sprintf('WHERE VEC_DISTANCE_EUCLIDEAN(%1$s, VEC_FromText(:embedding)) >= :minScore', $this->vectorFieldName) : '',
                 $options['limit'] ?? 5,
             ),
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Fix SQL query generation with dynamic field name in WHERE clause

Previously, the WHERE clause used a raw format string with a `%1$s` placeholder, but it was not processed by `sprintf`, resulting in the literal `%1$s` being inserted into the SQL. This caused the prepared SQL statement to be incorrect and fail at runtime.
