### PR TITLE
Replace test method prefix with `#[Test]` attribute

### DIFF
--- a/demo/tests/Blog/LoaderTest.php
+++ b/demo/tests/Blog/LoaderTest.php
@@ -14,6 +14,7 @@ namespace App\Tests\Blog;
 use App\Blog\FeedLoader;
 use App\Blog\Post;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -23,7 +24,8 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 #[UsesClass(Post::class)]
 final class LoaderTest extends TestCase
 {
-    public function testLoad(): void
+    #[Test]
+    public function load(): void
     {
         $response = MockResponse::fromFile(__DIR__.'/fixtures/blog.rss');
         $client = new MockHttpClient($response);

--- a/demo/tests/Blog/PostTest.php
+++ b/demo/tests/Blog/PostTest.php
@@ -13,13 +13,15 @@ namespace App\Tests\Blog;
 
 use App\Blog\Post;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;
 
 #[CoversClass(Post::class)]
 final class PostTest extends TestCase
 {
-    public function testPostToString(): void
+    #[Test]
+    public function postToString(): void
     {
         $post = new Post(
             Uuid::v4(),
@@ -41,7 +43,8 @@ final class PostTest extends TestCase
         self::assertSame($expected, $post->toString());
     }
 
-    public function testPostToArray(): void
+    #[Test]
+    public function postToArray(): void
     {
         $id = Uuid::v4();
         $post = new Post(

--- a/demo/tests/SmokeTest.php
+++ b/demo/tests/SmokeTest.php
@@ -13,6 +13,7 @@ namespace App\Tests;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
 
@@ -21,7 +22,8 @@ final class SmokeTest extends WebTestCase
 {
     use InteractsWithLiveComponents;
 
-    public function testIndex(): void
+    #[Test]
+    public function index(): void
     {
         $client = static::createClient();
         $client->request('GET', '/');
@@ -31,8 +33,9 @@ final class SmokeTest extends WebTestCase
         self::assertSelectorCount(5, '.card');
     }
 
+    #[Test]
     #[DataProvider('provideChats')]
-    public function testChats(string $path, string $expectedHeadline): void
+    public function chats(string $path, string $expectedHeadline): void
     {
         $client = static::createClient();
         $client->request('GET', $path);

--- a/src/ai-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/ai-bundle/tests/Profiler/DataCollectorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\AIBundle\Tests\Profiler;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
@@ -32,7 +33,8 @@ use Symfony\AI\Platform\Result\TextResult;
 #[UsesClass(ResultPromise::class)]
 class DataCollectorTest extends TestCase
 {
-    public function testCollectsDataForNonStreamingResponse()
+    #[Test]
+    public function collectsDataForNonStreamingResponse()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $traceablePlatform = new TraceablePlatform($platform);
@@ -51,7 +53,8 @@ class DataCollectorTest extends TestCase
         $this->assertSame('Assistant response', $dataCollector->getPlatformCalls()[0]['result']);
     }
 
-    public function testCollectsDataForStreamingResponse()
+    #[Test]
+    public function collectsDataForStreamingResponse()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $traceablePlatform = new TraceablePlatform($platform);

--- a/src/mcp-sdk/tests/Message/ErrorTest.php
+++ b/src/mcp-sdk/tests/Message/ErrorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\McpSdk\Tests\Message;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpSdk\Message\Error;
 
@@ -20,7 +21,8 @@ use Symfony\AI\McpSdk\Message\Error;
 #[CoversClass(Error::class)]
 final class ErrorTest extends TestCase
 {
-    public function testWithIntegerId(): void
+    #[Test]
+    public function withIntegerId(): void
     {
         $error = new Error(1, -32602, 'Another error occurred');
         $expected = [
@@ -35,7 +37,8 @@ final class ErrorTest extends TestCase
         self::assertSame($expected, $error->jsonSerialize());
     }
 
-    public function testWithStringId(): void
+    #[Test]
+    public function withStringId(): void
     {
         $error = new Error('abc', -32602, 'Another error occurred');
         $expected = [

--- a/src/mcp-sdk/tests/Message/FactoryTest.php
+++ b/src/mcp-sdk/tests/Message/FactoryTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\McpSdk\Tests\Message;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpSdk\Exception\InvalidInputMessageException;
 use Symfony\AI\McpSdk\Message\Factory;
@@ -42,7 +43,8 @@ final class FactoryTest extends TestCase
         return null;
     }
 
-    public function testCreateRequest(): void
+    #[Test]
+    public function createRequest(): void
     {
         $json = '{"jsonrpc": "2.0", "method": "test_method", "params": {"foo": "bar"}, "id": 123}';
 
@@ -54,7 +56,8 @@ final class FactoryTest extends TestCase
         self::assertSame(123, $result->id);
     }
 
-    public function testCreateNotification(): void
+    #[Test]
+    public function createNotification(): void
     {
         $json = '{"jsonrpc": "2.0", "method": "notifications/test_event", "params": {"foo": "bar"}}';
 
@@ -65,21 +68,24 @@ final class FactoryTest extends TestCase
         self::assertSame(['foo' => 'bar'], $result->params);
     }
 
-    public function testInvalidJson(): void
+    #[Test]
+    public function invalidJson(): void
     {
         $this->expectException(\JsonException::class);
 
         $this->first($this->factory->create('invalid json'));
     }
 
-    public function testMissingMethod(): void
+    #[Test]
+    public function missingMethod(): void
     {
         $result = $this->first($this->factory->create('{"jsonrpc": "2.0", "params": {}, "id": 1}'));
         self::assertInstanceOf(InvalidInputMessageException::class, $result);
         $this->assertEquals('Invalid JSON-RPC request, missing "method".', $result->getMessage());
     }
 
-    public function testBatchMissingMethod(): void
+    #[Test]
+    public function batchMissingMethod(): void
     {
         $results = $this->factory->create('[{"jsonrpc": "2.0", "params": {}, "id": 1}, {"jsonrpc": "2.0", "method": "notifications/test_event", "params": {}, "id": 2}]');
 

--- a/src/mcp-sdk/tests/Message/ResponseTest.php
+++ b/src/mcp-sdk/tests/Message/ResponseTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\McpSdk\Tests\Message;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpSdk\Message\Response;
 
@@ -20,7 +21,8 @@ use Symfony\AI\McpSdk\Message\Response;
 #[CoversClass(Response::class)]
 final class ResponseTest extends TestCase
 {
-    public function testWithIntegerId(): void
+    #[Test]
+    public function withIntegerId(): void
     {
         $response = new Response(1, ['foo' => 'bar']);
         $expected = [
@@ -32,7 +34,8 @@ final class ResponseTest extends TestCase
         self::assertSame($expected, $response->jsonSerialize());
     }
 
-    public function testWithStringId(): void
+    #[Test]
+    public function withStringId(): void
     {
         $response = new Response('abc', ['foo' => 'bar']);
         $expected = [

--- a/src/mcp-sdk/tests/Server/JsonRpcHandlerTest.php
+++ b/src/mcp-sdk/tests/Server/JsonRpcHandlerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\McpSdk\Tests\Server;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -26,8 +27,9 @@ use Symfony\AI\McpSdk\Server\RequestHandlerInterface;
 #[CoversClass(JsonRpcHandler::class)]
 class JsonRpcHandlerTest extends TestCase
 {
+    #[Test]
     #[TestDox('Make sure a single notification can be handled by multiple handlers.')]
-    public function testHandleMultipleNotifications(): void
+    public function handleMultipleNotifications(): void
     {
         $handlerA = $this->getMockBuilder(NotificationHandlerInterface::class)
             ->disableOriginalConstructor()
@@ -57,8 +59,9 @@ class JsonRpcHandlerTest extends TestCase
         iterator_to_array($result);
     }
 
+    #[Test]
     #[TestDox('Make sure a single request can NOT be handled by multiple handlers.')]
-    public function testHandleMultipleRequests(): void
+    public function handleMultipleRequests(): void
     {
         $handlerA = $this->getMockBuilder(RequestHandlerInterface::class)
             ->disableOriginalConstructor()

--- a/src/mcp-sdk/tests/Server/RequestHandler/PromptListHandlerTest.php
+++ b/src/mcp-sdk/tests/Server/RequestHandler/PromptListHandlerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\McpSdk\Tests\Server\RequestHandler;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpSdk\Capability\Prompt\MetadataInterface;
 use Symfony\AI\McpSdk\Capability\PromptChain;
@@ -23,7 +24,8 @@ use Symfony\AI\McpSdk\Server\RequestHandler\PromptListHandler;
 #[CoversClass(PromptListHandler::class)]
 class PromptListHandlerTest extends TestCase
 {
-    public function testHandleEmpty(): void
+    #[Test]
+    public function handleEmpty(): void
     {
         $handler = new PromptListHandler(new PromptChain([]));
         $message = new Request(1, 'prompts/list', []);
@@ -32,7 +34,8 @@ class PromptListHandlerTest extends TestCase
         $this->assertEquals(['prompts' => []], $response->result);
     }
 
-    public function testHandleReturnAll(): void
+    #[Test]
+    public function handleReturnAll(): void
     {
         $item = self::createMetadataItem();
         $handler = new PromptListHandler(new PromptChain([$item]));
@@ -42,7 +45,8 @@ class PromptListHandlerTest extends TestCase
         $this->assertArrayNotHasKey('nextCursor', $response->result);
     }
 
-    public function testHandlePagination(): void
+    #[Test]
+    public function handlePagination(): void
     {
         $item = self::createMetadataItem();
         $handler = new PromptListHandler(new PromptChain([$item, $item]), 2);

--- a/src/mcp-sdk/tests/Server/RequestHandler/ResourceListHandlerTest.php
+++ b/src/mcp-sdk/tests/Server/RequestHandler/ResourceListHandlerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\McpSdk\Tests\Server\RequestHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpSdk\Capability\Resource\CollectionInterface;
 use Symfony\AI\McpSdk\Capability\Resource\MetadataInterface;
@@ -24,7 +25,8 @@ use Symfony\AI\McpSdk\Server\RequestHandler\ResourceListHandler;
 #[CoversClass(ResourceListHandler::class)]
 class ResourceListHandlerTest extends TestCase
 {
-    public function testHandleEmpty(): void
+    #[Test]
+    public function handleEmpty(): void
     {
         $collection = $this->getMockBuilder(CollectionInterface::class)
             ->disableOriginalConstructor()
@@ -42,8 +44,9 @@ class ResourceListHandlerTest extends TestCase
     /**
      * @param iterable<MetadataInterface> $metadataList
      */
+    #[Test]
     #[DataProvider('metadataProvider')]
-    public function testHandleReturnAll(iterable $metadataList): void
+    public function handleReturnAll(iterable $metadataList): void
     {
         $collection = $this->getMockBuilder(CollectionInterface::class)
             ->disableOriginalConstructor()
@@ -70,7 +73,8 @@ class ResourceListHandlerTest extends TestCase
         ];
     }
 
-    public function testHandlePagination(): void
+    #[Test]
+    public function handlePagination(): void
     {
         $item = self::createMetadataItem();
         $collection = $this->getMockBuilder(CollectionInterface::class)

--- a/src/mcp-sdk/tests/Server/RequestHandler/ToolListHandlerTest.php
+++ b/src/mcp-sdk/tests/Server/RequestHandler/ToolListHandlerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\McpSdk\Tests\Server\RequestHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpSdk\Capability\Tool\CollectionInterface;
 use Symfony\AI\McpSdk\Capability\Tool\MetadataInterface;
@@ -24,7 +25,8 @@ use Symfony\AI\McpSdk\Server\RequestHandler\ToolListHandler;
 #[CoversClass(ToolListHandler::class)]
 class ToolListHandlerTest extends TestCase
 {
-    public function testHandleEmpty(): void
+    #[Test]
+    public function handleEmpty(): void
     {
         $collection = $this->getMockBuilder(CollectionInterface::class)
             ->disableOriginalConstructor()
@@ -42,8 +44,9 @@ class ToolListHandlerTest extends TestCase
     /**
      * @param iterable<MetadataInterface> $metadataList
      */
+    #[Test]
     #[DataProvider('metadataProvider')]
-    public function testHandleReturnAll(iterable $metadataList): void
+    public function handleReturnAll(iterable $metadataList): void
     {
         $collection = $this->getMockBuilder(CollectionInterface::class)
             ->disableOriginalConstructor()
@@ -70,7 +73,8 @@ class ToolListHandlerTest extends TestCase
         ];
     }
 
-    public function testHandlePagination(): void
+    #[Test]
+    public function handlePagination(): void
     {
         $item = self::createMetadataItem();
         $collection = $this->getMockBuilder(CollectionInterface::class)

--- a/src/mcp-sdk/tests/ServerTest.php
+++ b/src/mcp-sdk/tests/ServerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\McpSdk\Tests;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub\Exception;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -24,7 +25,8 @@ use Symfony\AI\McpSdk\Tests\Fixtures\InMemoryTransport;
 #[CoversClass(Server::class)]
 class ServerTest extends TestCase
 {
-    public function testJsonExceptions(): void
+    #[Test]
+    public function jsonExceptions(): void
     {
         $logger = $this->getMockBuilder(NullLogger::class)
             ->disableOriginalConstructor()

--- a/src/platform/tests/Bridge/Anthropic/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/Anthropic/ResultConverterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Tests\Bridge\Anthropic;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Anthropic\ResultConverter;
@@ -28,7 +29,8 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 #[UsesClass(ToolCallResult::class)]
 final class ResultConverterTest extends TestCase
 {
-    public function testConvertThrowsExceptionWhenContentIsToolUseAndLacksText(): void
+    #[Test]
+    public function convertThrowsExceptionWhenContentIsToolUseAndLacksText(): void
     {
         $httpClient = new MockHttpClient(new JsonMockResponse([
             'content' => [

--- a/src/platform/tests/Bridge/HuggingFace/ModelClientTest.php
+++ b/src/platform/tests/Bridge/HuggingFace/ModelClientTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Tests\Bridge\HuggingFace;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\HuggingFace\Contract\FileNormalizer;
@@ -32,8 +33,9 @@ use Symfony\Component\HttpClient\MockHttpClient;
 #[UsesClass(Model::class)]
 final class ModelClientTest extends TestCase
 {
+    #[Test]
     #[DataProvider('urlTestCases')]
-    public function testGetUrlForDifferentInputsAndTasks(?string $task, string $expectedUrl): void
+    public function getUrlForDifferentInputsAndTasks(?string $task, string $expectedUrl): void
     {
         $reflection = new \ReflectionClass(ModelClient::class);
         $getUrlMethod = $reflection->getMethod('getUrl');
@@ -74,8 +76,9 @@ final class ModelClientTest extends TestCase
         ];
     }
 
+    #[Test]
     #[DataProvider('payloadTestCases')]
-    public function testGetPayloadForDifferentInputsAndTasks(object|array|string $input, array $options, array $expectedKeys, array $expectedValues = []): void
+    public function getPayloadForDifferentInputsAndTasks(object|array|string $input, array $options, array $expectedKeys, array $expectedValues = []): void
     {
         // Contract handling first
         $contract = Contract::create(

--- a/src/platform/tests/Bridge/OpenAI/GPT/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/OpenAI/GPT/ResultConverterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Tests\Bridge\OpenAI\GPT;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\OpenAI\GPT\ResultConverter;
@@ -36,7 +37,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[UsesClass(ToolCallResult::class)]
 class ResultConverterTest extends TestCase
 {
-    public function testConvertTextResponse(): void
+    #[Test]
+    public function convertTextResponse(): void
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -58,7 +60,8 @@ class ResultConverterTest extends TestCase
         self::assertSame('Hello world', $result->getContent());
     }
 
-    public function testConvertToolCallResponse(): void
+    #[Test]
+    public function convertToolCallResponse(): void
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -94,7 +97,8 @@ class ResultConverterTest extends TestCase
         self::assertSame(['arg1' => 'value1'], $toolCalls[0]->arguments);
     }
 
-    public function testConvertMultipleChoices(): void
+    #[Test]
+    public function convertMultipleChoices(): void
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -126,7 +130,8 @@ class ResultConverterTest extends TestCase
         self::assertSame('Choice 2', $choices[1]->getContent());
     }
 
-    public function testContentFilterException(): void
+    #[Test]
+    public function contentFilterException(): void
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -157,7 +162,8 @@ class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
-    public function testThrowsExceptionWhenNoChoices(): void
+    #[Test]
+    public function throwsExceptionWhenNoChoices(): void
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -169,7 +175,8 @@ class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
-    public function testThrowsExceptionForUnsupportedFinishReason(): void
+    #[Test]
+    public function throwsExceptionForUnsupportedFinishReason(): void
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);

--- a/src/store/tests/Bridge/MariaDB/StoreTest.php
+++ b/src/store/tests/Bridge/MariaDB/StoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Store\Tests\Bridge\MariaDB;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\MariaDB\Store;
@@ -21,7 +22,8 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testQueryWithMinScore(): void
+    #[Test]
+    public function queryWithMinScore(): void
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -73,7 +75,8 @@ final class StoreTest extends TestCase
         $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
     }
 
-    public function testQueryWithoutMinScore(): void
+    #[Test]
+    public function queryWithoutMinScore(): void
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -120,7 +123,8 @@ final class StoreTest extends TestCase
         $this->assertSame(0.95, $results[0]->score);
     }
 
-    public function testQueryWithCustomLimit(): void
+    #[Test]
+    public function queryWithCustomLimit(): void
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);

--- a/src/store/tests/Bridge/Meilisearch/StoreTest.php
+++ b/src/store/tests/Bridge/Meilisearch/StoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Store\Tests\Bridge\Meilisearch;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Meilisearch\Store;
@@ -24,7 +25,8 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testStoreCannotInitializeOnInvalidResponse(): void
+    #[Test]
+    public function storeCannotInitializeOnInvalidResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -50,7 +52,8 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testStoreCanInitialize(): void
+    #[Test]
+    public function storeCanInitialize(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -85,7 +88,8 @@ final class StoreTest extends TestCase
         self::assertSame(2, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotAddOnInvalidResponse(): void
+    #[Test]
+    public function storeCannotAddOnInvalidResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -111,7 +115,8 @@ final class StoreTest extends TestCase
         $store->add(new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2, 0.3])));
     }
 
-    public function testStoreCanAdd(): void
+    #[Test]
+    public function storeCanAdd(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -137,7 +142,8 @@ final class StoreTest extends TestCase
         self::assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotQueryOnInvalidResponse(): void
+    #[Test]
+    public function storeCannotQueryOnInvalidResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -163,7 +169,8 @@ final class StoreTest extends TestCase
         $store->query(new Vector([0.1, 0.2, 0.3]));
     }
 
-    public function testStoreCanQuery(): void
+    #[Test]
+    public function storeCanQuery(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -212,7 +219,8 @@ final class StoreTest extends TestCase
         self::assertSame(0.85, $vectors[1]->score);
     }
 
-    public function testMetadataWithoutIDRankingandVector(): void
+    #[Test]
+    public function metadataWithoutIDRankingandVector(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([

--- a/src/store/tests/Bridge/Qdrant/StoreTest.php
+++ b/src/store/tests/Bridge/Qdrant/StoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Store\Tests\Bridge\Qdrant;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Qdrant\Store;
@@ -24,7 +25,8 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testStoreCannotInitializeOnInvalidResponse(): void
+    #[Test]
+    public function storeCannotInitializeOnInvalidResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -48,7 +50,8 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testStoreCannotInitializeOnExistingCollection(): void
+    #[Test]
+    public function storeCannotInitializeOnExistingCollection(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -74,7 +77,8 @@ final class StoreTest extends TestCase
         self::assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCanInitialize(): void
+    #[Test]
+    public function storeCanInitialize(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -100,7 +104,8 @@ final class StoreTest extends TestCase
         self::assertSame(2, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotAddOnInvalidResponse(): void
+    #[Test]
+    public function storeCannotAddOnInvalidResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([], [
@@ -116,7 +121,8 @@ final class StoreTest extends TestCase
         $store->add(new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2, 0.3])));
     }
 
-    public function testStoreCanAdd(): void
+    #[Test]
+    public function storeCanAdd(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -138,7 +144,8 @@ final class StoreTest extends TestCase
         self::assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotQueryOnInvalidResponse(): void
+    #[Test]
+    public function storeCannotQueryOnInvalidResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([], [
@@ -159,7 +166,8 @@ final class StoreTest extends TestCase
         $store->query(new Vector([0.1, 0.2, 0.3]));
     }
 
-    public function testStoreCanQuery(): void
+    #[Test]
+    public function storeCanQuery(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([

--- a/src/store/tests/Bridge/SurrealDB/StoreTest.php
+++ b/src/store/tests/Bridge/SurrealDB/StoreTest.php
@@ -12,6 +12,7 @@
 namespace Bridge\SurrealDB;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\SurrealDB\Store;
@@ -24,7 +25,8 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testStoreCannotInitializeOnInvalidResponse(): void
+    #[Test]
+    public function storeCannotInitializeOnInvalidResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([], [
@@ -40,7 +42,8 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testStoreCannotInitializeOnValidAuthenticationResponse(): void
+    #[Test]
+    public function storeCannotInitializeOnValidAuthenticationResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -63,7 +66,8 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testStoreCannotInitializeOnValidAuthenticationAndIndexResponse(): void
+    #[Test]
+    public function storeCannotInitializeOnValidAuthenticationAndIndexResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -91,7 +95,8 @@ final class StoreTest extends TestCase
         self::assertSame(2, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotAddOnInvalidResponse(): void
+    #[Test]
+    public function storeCannotAddOnInvalidResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -124,7 +129,8 @@ final class StoreTest extends TestCase
         $store->add(new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2, 0.3])));
     }
 
-    public function testStoreCannotAddOnInvalidAddResponse(): void
+    #[Test]
+    public function storeCannotAddOnInvalidAddResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -157,7 +163,8 @@ final class StoreTest extends TestCase
         $store->add(new VectorDocument(Uuid::v4(), new Vector(array_fill(0, 1275, 0.1))));
     }
 
-    public function testStoreCanAdd(): void
+    #[Test]
+    public function storeCanAdd(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -210,7 +217,8 @@ final class StoreTest extends TestCase
         self::assertSame(3, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotQueryOnInvalidResponse(): void
+    #[Test]
+    public function storeCannotQueryOnInvalidResponse(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -269,7 +277,8 @@ final class StoreTest extends TestCase
         $store->query(new Vector(array_fill(0, 1275, 0.1)));
     }
 
-    public function testStoreCanQueryOnValidEmbeddings(): void
+    #[Test]
+    public function storeCanQueryOnValidEmbeddings(): void
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([

--- a/src/store/tests/Document/Transformer/ChainTransformerTest.php
+++ b/src/store/tests/Document/Transformer/ChainTransformerTest.php
@@ -55,7 +55,8 @@ final class ChainTransformerTest extends TestCase
         self::assertSame('bar-A-B', $result[1]->content);
     }
 
-    public function testChainTransformerWithNoTransformersReturnsInput(): void
+    #[Test]
+    public function chainTransformerWithNoTransformersReturnsInput(): void
     {
         $chain = new ChainTransformer([]);
         $documents = [new TextDocument(Uuid::v4(), 'baz')];

--- a/src/store/tests/InMemoryStoreTest.php
+++ b/src/store/tests/InMemoryStoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Store\Tests;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\VectorDocument;
@@ -21,7 +22,8 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(InMemoryStore::class)]
 final class InMemoryStoreTest extends TestCase
 {
-    public function testStoreCanSearchUsingCosineSimilarity(): void
+    #[Test]
+    public function storeCanSearchUsingCosineSimilarity(): void
     {
         $store = new InMemoryStore();
         $store->add(
@@ -41,7 +43,8 @@ final class InMemoryStoreTest extends TestCase
         self::assertCount(6, $store->query(new Vector([0.0, 0.1, 0.6])));
     }
 
-    public function testStoreCanSearchUsingCosineSimilarityWithMaxItems(): void
+    #[Test]
+    public function storeCanSearchUsingCosineSimilarityWithMaxItems(): void
     {
         $store = new InMemoryStore();
         $store->add(
@@ -55,7 +58,8 @@ final class InMemoryStoreTest extends TestCase
         ]));
     }
 
-    public function testStoreCanSearchUsingAngularDistance(): void
+    #[Test]
+    public function storeCanSearchUsingAngularDistance(): void
     {
         $store = new InMemoryStore(InMemoryStore::ANGULAR_DISTANCE);
         $store->add(
@@ -69,7 +73,8 @@ final class InMemoryStoreTest extends TestCase
         self::assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
     }
 
-    public function testStoreCanSearchUsingEuclideanDistance(): void
+    #[Test]
+    public function storeCanSearchUsingEuclideanDistance(): void
     {
         $store = new InMemoryStore(InMemoryStore::EUCLIDEAN_DISTANCE);
         $store->add(
@@ -83,7 +88,8 @@ final class InMemoryStoreTest extends TestCase
         self::assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
     }
 
-    public function testStoreCanSearchUsingManhattanDistance(): void
+    #[Test]
+    public function storeCanSearchUsingManhattanDistance(): void
     {
         $store = new InMemoryStore(InMemoryStore::MANHATTAN_DISTANCE);
         $store->add(
@@ -97,7 +103,8 @@ final class InMemoryStoreTest extends TestCase
         self::assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
     }
 
-    public function testStoreCanSearchUsingChebyshevDistance(): void
+    #[Test]
+    public function storeCanSearchUsingChebyshevDistance(): void
     {
         $store = new InMemoryStore(InMemoryStore::CHEBYSHEV_DISTANCE);
         $store->add(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Updated all test files that were using the 'test' prefix convention to use the modern PHPUnit #[Test] attribute instead. This brings consistency across the codebase as the majority of tests were already using the attribute syntax.