### PR TITLE
[Platform] Add `InMemoryPlatform` and `InMemoryRawResult` for testing

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -56,3 +56,6 @@ CHANGELOG
  * Add exception handling with specific error types
  * Add support for embeddings generation across multiple providers
  * Add response promises for async operations
+ * Add InMemoryPlatform and InMemoryRawResult for testing Platform without external Providers calls
+
+

--- a/src/platform/doc/index.rst
+++ b/src/platform/doc/index.rst
@@ -281,6 +281,30 @@ which can be useful to speed up the processing::
         echo $result->asText().PHP_EOL;
     }
 
+Testing Tools
+-------------
+
+For unit or integration testing, you can use the `InMemoryPlatform`, which implements `PlatformInterface` without calling external APIs.
+
+It supports returning either:
+
+- A fixed string result
+- A callable that dynamically returns a response based on the model, input, and options::
+
+    use Symfony\AI\Platform\InMemoryPlatform;
+    use Symfony\AI\Platform\Model;
+
+    $platform = new InMemoryPlatform('Fake result');
+
+    $result = $platform->invoke(new Model('test'), 'What is the capital of France?');
+
+    echo $result->asText(); // "Fake result"
+
+
+Internally, it uses `InMemoryRawResult` to simulate the behavior of real API responses and support `ResultPromise`.
+
+This allows fast and isolated testing of AI-powered features without relying on live providers or HTTP requests.
+
 .. note::
 
     This requires `cURL` and the `ext-curl` extension to be installed.

--- a/src/platform/src/InMemoryPlatform.php
+++ b/src/platform/src/InMemoryPlatform.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform;
+
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\ResultPromise;
+use Symfony\AI\Platform\Result\TextResult;
+
+/**
+ * A fake implementation of PlatformInterface that returns fixed or callable responses.
+ *
+ * Useful for unit or integration testing without real API calls.
+ *
+ * @author Ramy Hakam <pencilsoft1@gmail.com>
+ */
+class InMemoryPlatform implements PlatformInterface
+{
+    /**
+     * The mock result can be a string or a callable that returns a string.
+     * If it's a closure, it receives the model, input, and  optionally options as parameters like a real platform call.
+     */
+    public function __construct(private readonly \Closure|string $mockResult)
+    {
+    }
+
+    public function invoke(Model $model, array|string|object $input, array $options = []): ResultPromise
+    {
+        $resultText = $this->mockResult instanceof \Closure
+            ? ($this->mockResult)($model, $input, $options)
+            : $this->mockResult;
+
+        $textResult = new TextResult($resultText);
+
+        return new ResultPromise(
+            static fn () => $textResult,
+            rawResult: new InMemoryRawResult(
+                ['text' => $resultText],
+                (object) ['text' => $resultText],
+            ),
+            options: $options
+        );
+    }
+}

--- a/src/platform/src/Result/InMemoryRawResult.php
+++ b/src/platform/src/Result/InMemoryRawResult.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * A fake implementation of RawResultInterface that returns fixed data.
+ *
+ * @author Ramy Hakam <pencilsoft1@gmail.com>
+ */
+final readonly class InMemoryRawResult implements RawResultInterface
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(
+        private array $data = [],
+        private object $object = new \stdClass(),
+    ) {
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getObject(): object
+    {
+        return $this->object;
+    }
+}

--- a/src/platform/tests/InMemoryPlatformTest.php
+++ b/src/platform/tests/InMemoryPlatformTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\InMemoryPlatform;
+use Symfony\AI\Platform\Model;
+
+#[CoversClass(InMemoryPlatform::class)]
+class InMemoryPlatformTest extends TestCase
+{
+    #[Test]
+    public function platformInvokeWithFixedResponse(): void
+    {
+        $platform = new InMemoryPlatform('Mocked result');
+        $result = $platform->invoke(new Model('test'), 'input');
+
+        $this->assertSame('Mocked result', $result->asText());
+        $this->assertSame('Mocked result', $result->getResult()->getContent());
+        $this->assertSame(['text' => 'Mocked result'], $result->getRawResult()->getData());
+    }
+
+    #[Test]
+    public function platformInvokeWithCallableResponse(): void
+    {
+        $platform = new InMemoryPlatform(function (Model $model, $input) {
+            return strtoupper((string) $input);
+        });
+
+        $result = $platform->invoke(new Model('test'), 'dynamic text');
+
+        $this->assertSame('DYNAMIC TEXT', $result->asText());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | none <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PR adds two test-friendly classes to the Symfony AI Platform component:

###  InMemoryPlatform

The `InMemoryPlatform` is a test-specific implementation of `PlatformInterface` that returns a `TextResult` wrapped in a `ResultPromise`.
 It supports:
- A fixed string response (e.g. `'Fake reply'`)
- A callable response based on the `Model`, `input`, and `options`

This makes it ideal for unit or integration tests, or even functional tests where a full AI stack is not needed.

###  InMemoryRawResult

The `InMemoryRawResult` implements `RawResultInterface` and is used internally by `InMemoryPlatform`. It wraps:

- A structured array (`getData()`)
- A generic object (`getObject()`)

to simulate what real raw results look like in production usage.

### The Problem

While testing new code that uses the AI platform, developers often need to manually create `PlatformInterface` instances. The existing `Platform` and `PlatformFactory` classes are tightly coupled to real AI providers.
 This in-memory implementation simplifies unit and integration testing by allowing developers to inject a dummy platform and return mock results without any external API calls.

### Example

```php
$platform = new InMemoryPlatform('Test reply');
$response = $platform->invoke(new Model('test'), 'Hello');
echo $response->asText(); // "Test reply"


