### PR TITLE
Fixed Typo Error on Platform documentation

### DIFF
--- a/src/platform/doc/index.rst
+++ b/src/platform/doc/index.rst
@@ -122,7 +122,7 @@ have different content types, like ``Text``, ``Image`` or ``Audio``, and can be 
 
     // Create a message bag with a user message
     $messageBag = new MessageBag(
-        Message::ofSystem('You are a helpful assistant.')
+        Message::forSystem('You are a helpful assistant.')
         Message::ofUser('Please describe this picture?', Image::fromFile('/path/to/image.jpg')),
     );
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | Fix
| License       | MIT

This is not a bug fix or feature, I noticed the error while trying to work with the package. I fixed a typographical error in the documentation. The static method "ofSystem" does not exist on the Symfony\AI\Platform\Message class, it should be "forSystem".
