### PR TITLE
Add PHP-CS-Fixer rules for PHPUnit attributes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -38,6 +38,10 @@ return (new PhpCsFixer\Config())
         'header_comment' => [
             'header' => implode('', $fileHeaderParts),
         ],
+        'php_unit_test_annotation' => [
+            'style' => 'annotation',
+        ],
+        'php_unit_attributes' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/agent/tests/Toolbox/MetadataFactory/ChainFactoryTest.php
+++ b/src/agent/tests/Toolbox/MetadataFactory/ChainFactoryTest.php
@@ -47,7 +47,7 @@ final class ChainFactoryTest extends TestCase
     }
 
     #[Test]
-    public function testGetMetadataNotExistingClass(): void
+    public function getMetadataNotExistingClass(): void
     {
         self::expectException(ToolException::class);
         self::expectExceptionMessage('The reference "NoClass" is not a valid tool.');
@@ -56,7 +56,7 @@ final class ChainFactoryTest extends TestCase
     }
 
     #[Test]
-    public function testGetMetadataNotConfiguredClass(): void
+    public function getMetadataNotConfiguredClass(): void
     {
         self::expectException(ToolConfigurationException::class);
         self::expectExceptionMessage(\sprintf('Method "foo" not found in tool "%s".', ToolMisconfigured::class));
@@ -65,7 +65,7 @@ final class ChainFactoryTest extends TestCase
     }
 
     #[Test]
-    public function testGetMetadataWithAttributeSingleHit(): void
+    public function getMetadataWithAttributeSingleHit(): void
     {
         $metadata = iterator_to_array($this->factory->getTool(ToolRequiredParams::class));
 
@@ -73,7 +73,7 @@ final class ChainFactoryTest extends TestCase
     }
 
     #[Test]
-    public function testGetMetadataOverwrite(): void
+    public function getMetadataOverwrite(): void
     {
         $metadata = iterator_to_array($this->factory->getTool(ToolOptionalParam::class));
 
@@ -84,7 +84,7 @@ final class ChainFactoryTest extends TestCase
     }
 
     #[Test]
-    public function testGetMetadataWithAttributeDoubleHit(): void
+    public function getMetadataWithAttributeDoubleHit(): void
     {
         $metadata = iterator_to_array($this->factory->getTool(ToolMultiple::class));
 
@@ -92,7 +92,7 @@ final class ChainFactoryTest extends TestCase
     }
 
     #[Test]
-    public function testGetMetadataWithMemorySingleHit(): void
+    public function getMetadataWithMemorySingleHit(): void
     {
         $metadata = iterator_to_array($this->factory->getTool(ToolNoAttribute1::class));
 

--- a/src/agent/tests/Toolbox/ToolResultConverterTest.php
+++ b/src/agent/tests/Toolbox/ToolResultConverterTest.php
@@ -23,7 +23,7 @@ final class ToolResultConverterTest extends TestCase
 {
     #[Test]
     #[DataProvider('provideResults')]
-    public function testConvert(mixed $result, ?string $expected): void
+    public function convert(mixed $result, ?string $expected): void
     {
         $converter = new ToolResultConverter();
 

--- a/src/platform/tests/Bridge/Bedrock/Nova/ContractTest.php
+++ b/src/platform/tests/Bridge/Bedrock/Nova/ContractTest.php
@@ -47,7 +47,7 @@ final class ContractTest extends TestCase
 {
     #[Test]
     #[DataProvider('provideMessageBag')]
-    public function testConvert(MessageBag $bag, array $expected): void
+    public function convert(MessageBag $bag, array $expected): void
     {
         $contract = Contract::create(
             new AssistantMessageNormalizer(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Configure php_unit_test_annotation and php_unit_attributes rules to enforce modern PHPUnit attribute syntax and remove test prefixes from methods that use the #[Test] attribute.

cc @valtzu