### PR TITLE
[Agent] Keep the rawResponse and metadata when parsing structured output

### DIFF
--- a/src/agent/src/StructuredOutput/AgentProcessor.php
+++ b/src/agent/src/StructuredOutput/AgentProcessor.php
@@ -91,8 +91,17 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
             return;
         }
 
+        $originalResult = $output->result;
         $output->result = new ObjectResult(
             $this->serializer->deserialize($output->result->getContent(), $this->outputStructure, 'json')
         );
+
+        if ($originalResult->getMetadata()->count() > 0) {
+            $output->result->getMetadata()->set($originalResult->getMetadata()->all());
+        }
+
+        if (!empty($originalResult->getRawResult())) {
+            $output->result->setRawResult($originalResult->getRawResult());
+        }
     }
 }

--- a/src/agent/tests/StructuredOutput/AgentProcessorTest.php
+++ b/src/agent/tests/StructuredOutput/AgentProcessorTest.php
@@ -26,6 +26,7 @@ use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\Choice;
+use Symfony\AI\Platform\Result\Metadata\Metadata;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -98,6 +99,8 @@ final class AgentProcessorTest extends TestCase
 
         $this->assertInstanceOf(ObjectResult::class, $output->result);
         $this->assertInstanceOf(SomeStructure::class, $output->result->getContent());
+        $this->assertInstanceOf(Metadata::class, $output->result->getMetadata());
+        $this->assertNull($output->result->getRawResult());
         $this->assertSame('data', $output->result->getContent()->some);
     }
 
@@ -145,6 +148,8 @@ final class AgentProcessorTest extends TestCase
 
         $this->assertInstanceOf(ObjectResult::class, $output->result);
         $this->assertInstanceOf(MathReasoning::class, $structure = $output->result->getContent());
+        $this->assertInstanceOf(Metadata::class, $output->result->getMetadata());
+        $this->assertNull($output->result->getRawResult());
         $this->assertCount(5, $structure->steps);
         $this->assertInstanceOf(Step::class, $structure->steps[0]);
         $this->assertInstanceOf(Step::class, $structure->steps[1]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #206
| License       | MIT

Keep the rawResponse and metadata when parsing structured output