### PR TITLE
[Platform] Add tooling support for ollama to allow agent and toolbox usage

### DIFF
--- a/examples/ollama/toolcall.php
+++ b/examples/ollama/toolcall.php
@@ -10,6 +10,9 @@
  */
 
 use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Tool\Clock;
+use Symfony\AI\Agent\Toolbox\Toolbox;
 use Symfony\AI\Platform\Bridge\Ollama\Ollama;
 use Symfony\AI\Platform\Bridge\Ollama\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,11 +23,11 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
 $model = new Ollama();
 
-$agent = new Agent($platform, $model, logger: logger());
-$messages = new MessageBag(
-    Message::forSystem('You are a helpful assistant.'),
-    Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
-);
+$toolbox = new Toolbox([new Clock()], logger: logger());
+$processor = new AgentProcessor($toolbox);
+$agent = new Agent($platform, $model, [$processor], [$processor], logger());
+
+$messages = new MessageBag(Message::ofUser('What time is it?'));
 $result = $agent->call($messages);
 
 echo $result->getContent().\PHP_EOL;

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -57,5 +57,6 @@ CHANGELOG
  * Add support for embeddings generation across multiple providers
  * Add response promises for async operations
  * Add InMemoryPlatform and InMemoryRawResult for testing Platform without external Providers calls
+ * Add tool calling support for Ollama platform
 
 

--- a/src/platform/src/Bridge/Ollama/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Ollama/Contract/AssistantMessageNormalizer.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Ollama\Contract;
+
+use Symfony\AI\Platform\Bridge\Ollama\Ollama;
+use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Role;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+
+/**
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+final class AssistantMessageNormalizer extends ModelContractNormalizer implements NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    protected function supportedDataClass(): string
+    {
+        return AssistantMessage::class;
+    }
+
+    protected function supportsModel(Model $model): bool
+    {
+        return $model instanceof Ollama;
+    }
+
+    /**
+     * @param AssistantMessage $data
+     *
+     * @return array{
+     *     role: Role::Assistant,
+     *     tool_calls: list<array{
+     *         type: 'function',
+     *         function: array{
+     *             name: string,
+     *             arguments: array<string, mixed>
+     *         }
+     *     }>
+     * }
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        return [
+            'role' => Role::Assistant,
+            'tool_calls' => array_values(array_map(function (ToolCall $message): array {
+                return [
+                    'type' => 'function',
+                    'function' => [
+                        'name' => $message->name,
+                        // stdClass forces empty object
+                        'arguments' => [] === $message->arguments ? new \stdClass() : $message->arguments,
+                    ],
+                ];
+            }, $data->toolCalls ?? [])),
+        ];
+    }
+}

--- a/src/platform/src/Bridge/Ollama/Contract/OllamaContract.php
+++ b/src/platform/src/Bridge/Ollama/Contract/OllamaContract.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Ollama\Contract;
+
+use Symfony\AI\Platform\Contract;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+final readonly class OllamaContract extends Contract
+{
+    public static function create(NormalizerInterface ...$normalizer): Contract
+    {
+        return parent::create(
+            new AssistantMessageNormalizer(),
+            ...$normalizer,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Ollama/Ollama.php
+++ b/src/platform/src/Bridge/Ollama/Ollama.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Ollama;
+
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+class Ollama extends Model
+{
+    public const DEEPSEEK_R_1 = 'deepseek-r1';
+    public const GEMMA_3_N = 'gemma3n';
+    public const GEMMA_3 = 'gemma3';
+    public const QWEN_3 = 'qwen3';
+    public const QWEN_2_5_VL = 'qwen2.5vl';
+    public const LLAMA_3_1 = 'llama3.1';
+    public const LLAMA_3_2 = 'llama3.2';
+    public const MISTRAL = 'mistral';
+    public const QWEN_2_5 = 'qwen2.5';
+    public const LLAMA_3 = 'llama3';
+    public const LLAVA = 'llava';
+    public const PHI_3 = 'phi3';
+    public const GEMMA_2 = 'gemma2';
+    public const QWEN_2_5_CODER = 'qwen2.5-coder';
+    public const GEMMA = 'gemma';
+    public const QWEN = 'qwen';
+    public const QWEN_2 = 'qwen2';
+    public const LLAMA_2 = 'llama2';
+
+    private const TOOL_PATTERNS = [
+        '/./' => [
+            Capability::INPUT_MESSAGES,
+            Capability::OUTPUT_TEXT,
+        ],
+        '/^llama\D*3(\D*\d+)/' => [
+            Capability::TOOL_CALLING,
+        ],
+        '/^qwen\d(\.\d)?(-coder)?$/' => [
+            Capability::TOOL_CALLING,
+        ],
+        '/^(deepseek|mistral)/' => [
+            Capability::TOOL_CALLING,
+        ],
+    ];
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(string $name = self::LLAMA_3_2, array $options = [])
+    {
+        $capabilities = [];
+
+        foreach (self::TOOL_PATTERNS as $pattern => $possibleCapabilities) {
+            if (1 === preg_match($pattern, $name)) {
+                foreach ($possibleCapabilities as $capability) {
+                    $capabilities[] = $capability;
+                }
+            }
+        }
+
+        parent::__construct($name, $capabilities, $options);
+    }
+}

--- a/src/platform/src/Bridge/Ollama/OllamaModelClient.php
+++ b/src/platform/src/Bridge/Ollama/OllamaModelClient.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Platform\Bridge\Ollama;
 
-use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -20,7 +19,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final readonly class LlamaModelClient implements ModelClientInterface
+final readonly class OllamaModelClient implements ModelClientInterface
 {
     public function __construct(
         private HttpClientInterface $httpClient,
@@ -30,7 +29,7 @@ final readonly class LlamaModelClient implements ModelClientInterface
 
     public function supports(Model $model): bool
     {
-        return $model instanceof Llama;
+        return $model instanceof Ollama;
     }
 
     public function request(Model $model, array|string $payload, array $options = []): RawHttpResult

--- a/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
+++ b/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
@@ -11,22 +11,23 @@
 
 namespace Symfony\AI\Platform\Bridge\Ollama;
 
-use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final readonly class LlamaResultConverter implements ResultConverterInterface
+final readonly class OllamaResultConverter implements ResultConverterInterface
 {
     public function supports(Model $model): bool
     {
-        return $model instanceof Llama;
+        return $model instanceof Ollama;
     }
 
     public function convert(RawResultInterface $result, array $options = []): ResultInterface
@@ -39,6 +40,16 @@ final readonly class LlamaResultConverter implements ResultConverterInterface
 
         if (!isset($data['message']['content'])) {
             throw new RuntimeException('Message does not contain content.');
+        }
+
+        $toolCalls = [];
+
+        foreach ($data['message']['tool_calls'] ?? [] as $id => $toolCall) {
+            $toolCalls[] = new ToolCall($id, $toolCall['function']['name'], $toolCall['function']['arguments']);
+        }
+
+        if ([] !== $toolCalls) {
+            return new ToolCallResult(...$toolCalls);
         }
 
         return new TextResult($data['message']['content']);

--- a/src/platform/src/Bridge/Ollama/PlatformFactory.php
+++ b/src/platform/src/Bridge/Ollama/PlatformFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Ollama;
 
+use Symfony\AI\Platform\Bridge\Ollama\Contract\OllamaContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
@@ -28,6 +29,6 @@ final class PlatformFactory
     ): Platform {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
-        return new Platform([new LlamaModelClient($httpClient, $hostUrl)], [new LlamaResultConverter()], $contract);
+        return new Platform([new OllamaModelClient($httpClient, $hostUrl)], [new OllamaResultConverter()], $contract ?? OllamaContract::create());
     }
 }

--- a/src/platform/tests/Bridge/Ollama/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Ollama/Contract/AssistantMessageNormalizerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\Ollama\Contract;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Ollama\Contract\AssistantMessageNormalizer;
+use Symfony\AI\Platform\Bridge\Ollama\Ollama;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Role;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ToolCall;
+
+#[Small]
+#[CoversClass(AssistantMessageNormalizer::class)]
+#[UsesClass(Ollama::class)]
+#[UsesClass(AssistantMessage::class)]
+#[UsesClass(Model::class)]
+#[UsesClass(ToolCall::class)]
+final class AssistantMessageNormalizerTest extends TestCase
+{
+    private AssistantMessageNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new AssistantMessageNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
+            Contract::CONTEXT_MODEL => new Ollama(),
+        ]));
+        $this->assertFalse($this->normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
+            Contract::CONTEXT_MODEL => new Model('any-model'),
+        ]));
+        $this->assertFalse($this->normalizer->supportsNormalization('not an assistant message'));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame([AssistantMessage::class => true], $this->normalizer->getSupportedTypes(null));
+    }
+
+    #[DataProvider('normalizeDataProvider')]
+    public function testNormalize(AssistantMessage $message, array $expectedOutput)
+    {
+        $normalized = $this->normalizer->normalize($message);
+
+        $this->assertEquals($expectedOutput, $normalized);
+    }
+
+    /**
+     * @return iterable<string, array{AssistantMessage, array{role: Role::Assistant, tool_calls: list<array{type: string, function: array{name: string, arguments: mixed}}>}}>
+     */
+    public static function normalizeDataProvider(): iterable
+    {
+        yield 'assistant message without tool calls' => [
+            new AssistantMessage('Hello'),
+            [
+                'role' => Role::Assistant,
+                'tool_calls' => [],
+            ],
+        ];
+
+        yield 'assistant message with tool calls' => [
+            new AssistantMessage(toolCalls: [new ToolCall('id1', 'function1', ['param' => 'value'])]),
+            [
+                'role' => Role::Assistant,
+                'tool_calls' => [
+                    [
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'function1',
+                            'arguments' => ['param' => 'value'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'assistant message with empty arguments' => [
+            new AssistantMessage(toolCalls: [new ToolCall('id1', 'function1', [])]),
+            [
+                'role' => Role::Assistant,
+                'tool_calls' => [
+                    [
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'function1',
+                            'arguments' => new \stdClass(),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'assistant message with multiple tool calls' => [
+            new AssistantMessage(toolCalls: [
+                new ToolCall('id1', 'function1', ['param1' => 'value1']),
+                new ToolCall('id2', 'function2', ['param2' => 'value2']),
+            ]),
+            [
+                'role' => Role::Assistant,
+                'tool_calls' => [
+                    [
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'function1',
+                            'arguments' => ['param1' => 'value1'],
+                        ],
+                    ],
+                    [
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'function2',
+                            'arguments' => ['param2' => 'value2'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/platform/tests/Bridge/Ollama/OllamaResultConverterTest.php
+++ b/src/platform/tests/Bridge/Ollama/OllamaResultConverterTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\Ollama;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Ollama\Ollama;
+use Symfony\AI\Platform\Bridge\Ollama\OllamaResultConverter;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+
+#[CoversClass(OllamaResultConverter::class)]
+#[Small]
+#[UsesClass(Ollama::class)]
+#[UsesClass(TextResult::class)]
+#[UsesClass(ToolCall::class)]
+#[UsesClass(ToolCallResult::class)]
+final class OllamaResultConverterTest extends TestCase
+{
+    public function testSupportsLlamaModel()
+    {
+        $converter = new OllamaResultConverter();
+
+        $this->assertTrue($converter->supports(new Ollama()));
+        $this->assertFalse($converter->supports(new Model('any-model')));
+    }
+
+    public function testConvertTextResponse()
+    {
+        $converter = new OllamaResultConverter();
+        $rawResult = new InMemoryRawResult([
+            'message' => [
+                'content' => 'Hello world',
+            ],
+        ]);
+
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello world', $result->getContent());
+    }
+
+    public function testConvertToolCallResponse()
+    {
+        $converter = new OllamaResultConverter();
+        $rawResult = new InMemoryRawResult([
+            'message' => [
+                'content' => 'This content will be ignored because tool_calls are present',
+                'tool_calls' => [
+                    [
+                        'function' => [
+                            'name' => 'test_function',
+                            'arguments' => ['arg1' => 'value1'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('0', $toolCalls[0]->id); // ID is the array index as a string
+        $this->assertSame('test_function', $toolCalls[0]->name);
+        $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->arguments);
+    }
+
+    public function testConvertMultipleToolCallsResponse()
+    {
+        $converter = new OllamaResultConverter();
+        $rawResult = new InMemoryRawResult([
+            'message' => [
+                'content' => 'This content will be ignored because tool_calls are present',
+                'tool_calls' => [
+                    [
+                        'function' => [
+                            'name' => 'function1',
+                            'arguments' => ['param1' => 'value1'],
+                        ],
+                    ],
+                    [
+                        'function' => [
+                            'name' => 'function2',
+                            'arguments' => ['param2' => 'value2'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(2, $toolCalls);
+
+        $this->assertSame('0', $toolCalls[0]->id);
+        $this->assertSame('function1', $toolCalls[0]->name);
+        $this->assertSame(['param1' => 'value1'], $toolCalls[0]->arguments);
+
+        $this->assertSame('1', $toolCalls[1]->id);
+        $this->assertSame('function2', $toolCalls[1]->name);
+        $this->assertSame(['param2' => 'value2'], $toolCalls[1]->arguments);
+    }
+
+    public function testThrowsExceptionWhenNoMessage()
+    {
+        $converter = new OllamaResultConverter();
+        $rawResult = new InMemoryRawResult([]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Response does not contain message');
+
+        $converter->convert($rawResult);
+    }
+
+    public function testThrowsExceptionWhenNoContent()
+    {
+        $converter = new OllamaResultConverter();
+        $rawResult = new InMemoryRawResult([
+            'message' => [],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Message does not contain content');
+
+        $converter->convert($rawResult);
+    }
+}

--- a/src/platform/tests/Bridge/Ollama/OllamaTest.php
+++ b/src/platform/tests/Bridge/Ollama/OllamaTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\Ollama;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Ollama\Ollama;
+use Symfony\AI\Platform\Capability;
+
+#[CoversClass(Ollama::class)]
+#[Small]
+final class OllamaTest extends TestCase
+{
+    #[DataProvider('provideModelsWithToolCallingCapability')]
+    public function testModelsWithToolCallingCapability(string $modelName)
+    {
+        $model = new Ollama($modelName);
+
+        $this->assertTrue(
+            $model->supports(Capability::TOOL_CALLING),
+            \sprintf('Model "%s" should support tool calling capability', $modelName)
+        );
+    }
+
+    #[DataProvider('provideModelsWithoutToolCallingCapability')]
+    public function testModelsWithoutToolCallingCapability(string $modelName)
+    {
+        $model = new Ollama($modelName);
+
+        $this->assertFalse(
+            $model->supports(Capability::TOOL_CALLING),
+            \sprintf('Model "%s" should not support tool calling capability', $modelName)
+        );
+    }
+
+    /**
+     * @return iterable<array{string}>
+     */
+    public static function provideModelsWithToolCallingCapability(): iterable
+    {
+        // Models that match the llama3.x pattern
+        yield 'llama3.1' => [Ollama::LLAMA_3_1];
+        yield 'llama3.2' => [Ollama::LLAMA_3_2];
+
+        // Models that match the qwen pattern
+        yield 'qwen2' => [Ollama::QWEN_2];
+        yield 'qwen2.5' => [Ollama::QWEN_2_5];
+        yield 'qwen2.5-coder' => [Ollama::QWEN_2_5_CODER];
+        yield 'qwen3' => [Ollama::QWEN_3];
+
+        // Models that match the deepseek pattern
+        yield 'deepseek-r1' => [Ollama::DEEPSEEK_R_1];
+
+        // Models that match the mistral pattern
+        yield 'mistral' => [Ollama::MISTRAL];
+    }
+
+    /**
+     * @return iterable<array{string}>
+     */
+    public static function provideModelsWithoutToolCallingCapability(): iterable
+    {
+        // Models that don't match any of the tool calling patterns
+        yield 'llama3' => [Ollama::LLAMA_3]; // No version number
+        yield 'llama2' => [Ollama::LLAMA_2];
+        yield 'gemma' => [Ollama::GEMMA];
+        yield 'gemma2' => [Ollama::GEMMA_2];
+        yield 'gemma3' => [Ollama::GEMMA_3];
+        yield 'gemma3n' => [Ollama::GEMMA_3_N];
+        yield 'phi3' => [Ollama::PHI_3];
+        yield 'llava' => [Ollama::LLAVA];
+        yield 'qwen2.5vl' => [Ollama::QWEN_2_5_VL]; // This has 'vl' suffix which doesn't match the pattern
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes?
| Docs?         | no
| License       | MIT

Running a toolbox agent with ollama was not yet supported. This ensures, that tool messages and responses work with a locally hosted ollama instance. It seems not to be a fix as it was not meant to work and it is not really a mentionable feature as one could expect it to work like the others so I am not really sure to work where to add more content for humans. I tested it with the given new example in `examples/ollama/toolcall.php`.

A current design decision had me struggling a bit. I was not yet able to solve in a good way the fact, that ollama itself cannot claim every model to have tool support. So someone who uses a model needs to know before its usage whether it has model support. This can be queried easily but the capabilities are part of the model, that you need to create before using the platform to query in the name of the model. So this is like hen-egg. If the model itself would not know its capabilities but there is a service, that has model and platform at hand, could evaluate it (and cache it). Is this something we want to establish?

Possible query:
```shell
curl http://localhost:11434/api/chat -d '{
  "model": "llama3:8b-instruct-q6_K",
  "tools": [{}],
  "stream": false
}'
{"error":"llama3:8b-instruct-q6_K does not support tools"}
```

