### PR TITLE
[Demo] Remove --strict to composer validate (using @dev for now on deps)

### DIFF
--- a/demo/composer.json
+++ b/demo/composer.json
@@ -103,16 +103,6 @@
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd",
             "importmap:install": "symfony-cmd"
-        },
-        "pipeline": [
-            "composer validate --strict",
-            "php -l src/**/*.php tests/**/*.php",
-            "bin/console lint:twig templates",
-            "bin/console lint:yaml config",
-            "bin/console lint:container",
-            "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix",
-            "phpstan analyse",
-            "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html=coverage"
-        ]
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

As we're using unbounded deps for now (`@dev`), we cannot use `--strict` on `composer validate`.
