### PR TITLE
Remove `void` return type from tests

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -43,7 +43,7 @@ return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setFinder(
         (new PhpCsFixer\Finder())
-            ->in([__DIR__.'/demo', __DIR__.'/examples', __DIR__.'/fixtures', __DIR__.'/src'])
+            ->in(__DIR__.'/{demo,examples,fixtures,src}')
             ->append([__FILE__])
             ->exclude('var')
     )

--- a/demo/phpstan.dist.neon
+++ b/demo/phpstan.dist.neon
@@ -6,3 +6,6 @@ parameters:
         - public/
         - src/
         - tests/
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"

--- a/demo/tests/Blog/LoaderTest.php
+++ b/demo/tests/Blog/LoaderTest.php
@@ -14,7 +14,6 @@ namespace App\Tests\Blog;
 use App\Blog\FeedLoader;
 use App\Blog\Post;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -24,8 +23,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 #[UsesClass(Post::class)]
 final class LoaderTest extends TestCase
 {
-    #[Test]
-    public function load(): void
+    public function testLoad()
     {
         $response = MockResponse::fromFile(__DIR__.'/fixtures/blog.rss');
         $client = new MockHttpClient($response);

--- a/demo/tests/Blog/PostTest.php
+++ b/demo/tests/Blog/PostTest.php
@@ -13,15 +13,13 @@ namespace App\Tests\Blog;
 
 use App\Blog\Post;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;
 
 #[CoversClass(Post::class)]
 final class PostTest extends TestCase
 {
-    #[Test]
-    public function postToString(): void
+    public function testPostToString()
     {
         $post = new Post(
             Uuid::v4(),
@@ -43,8 +41,7 @@ final class PostTest extends TestCase
         $this->assertSame($expected, $post->toString());
     }
 
-    #[Test]
-    public function postToArray(): void
+    public function testPostToArray()
     {
         $id = Uuid::v4();
         $post = new Post(

--- a/demo/tests/SmokeTest.php
+++ b/demo/tests/SmokeTest.php
@@ -13,7 +13,6 @@ namespace App\Tests;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
 
@@ -22,8 +21,7 @@ final class SmokeTest extends WebTestCase
 {
     use InteractsWithLiveComponents;
 
-    #[Test]
-    public function index(): void
+    public function testIndex()
     {
         $client = static::createClient();
         $client->request('GET', '/');
@@ -33,9 +31,8 @@ final class SmokeTest extends WebTestCase
         self::assertSelectorCount(5, '.card');
     }
 
-    #[Test]
     #[DataProvider('provideChats')]
-    public function chats(string $path, string $expectedHeadline): void
+    public function testChats(string $path, string $expectedHeadline)
     {
         $client = static::createClient();
         $client->request('GET', $path);

--- a/src/agent/phpstan.dist.neon
+++ b/src/agent/phpstan.dist.neon
@@ -8,6 +8,8 @@ parameters:
         - tests/
     ignoreErrors:
         -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+        -
             identifier: missingType.iterableValue
             path: tests/*
         -

--- a/src/agent/tests/AgentTest.php
+++ b/src/agent/tests/AgentTest.php
@@ -52,7 +52,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponseInterface;
 #[Small]
 final class AgentTest extends TestCase
 {
-    public function testConstructorInitializesWithDefaults(): void
+    public function testConstructorInitializesWithDefaults()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -62,7 +62,7 @@ final class AgentTest extends TestCase
         $this->assertInstanceOf(AgentInterface::class, $agent);
     }
 
-    public function testConstructorInitializesWithProcessors(): void
+    public function testConstructorInitializesWithProcessors()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -74,7 +74,7 @@ final class AgentTest extends TestCase
         $this->assertInstanceOf(AgentInterface::class, $agent);
     }
 
-    public function testConstructorSetsAgentOnAgentAwareProcessors(): void
+    public function testConstructorSetsAgentOnAgentAwareProcessors()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -97,7 +97,7 @@ final class AgentTest extends TestCase
         $this->assertSame($agent, $agentAwareProcessor->agent);
     }
 
-    public function testConstructorThrowsExceptionForInvalidInputProcessor(): void
+    public function testConstructorThrowsExceptionForInvalidInputProcessor()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -110,7 +110,7 @@ final class AgentTest extends TestCase
         new Agent($platform, $model, [$invalidProcessor]);
     }
 
-    public function testConstructorThrowsExceptionForInvalidOutputProcessor(): void
+    public function testConstructorThrowsExceptionForInvalidOutputProcessor()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -123,7 +123,7 @@ final class AgentTest extends TestCase
         new Agent($platform, $model, [], [$invalidProcessor]);
     }
 
-    public function testCallProcessesInputThroughProcessors(): void
+    public function testCallProcessesInputThroughProcessors()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -149,7 +149,7 @@ final class AgentTest extends TestCase
         $this->assertSame($result, $actualResult);
     }
 
-    public function testCallProcessesOutputThroughProcessors(): void
+    public function testCallProcessesOutputThroughProcessors()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -175,7 +175,7 @@ final class AgentTest extends TestCase
         $this->assertSame($result, $actualResult);
     }
 
-    public function testCallThrowsExceptionForAudioInputWithoutSupport(): void
+    public function testCallThrowsExceptionForAudioInputWithoutSupport()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -192,7 +192,7 @@ final class AgentTest extends TestCase
         $agent->call($messages);
     }
 
-    public function testCallThrowsExceptionForImageInputWithoutSupport(): void
+    public function testCallThrowsExceptionForImageInputWithoutSupport()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -209,7 +209,7 @@ final class AgentTest extends TestCase
         $agent->call($messages);
     }
 
-    public function testCallAllowsAudioInputWithSupport(): void
+    public function testCallAllowsAudioInputWithSupport()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -234,7 +234,7 @@ final class AgentTest extends TestCase
         $this->assertSame($result, $actualResult);
     }
 
-    public function testCallAllowsImageInputWithSupport(): void
+    public function testCallAllowsImageInputWithSupport()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -258,7 +258,7 @@ final class AgentTest extends TestCase
         $this->assertSame($result, $actualResult);
     }
 
-    public function testCallHandlesClientException(): void
+    public function testCallHandlesClientException()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -301,7 +301,7 @@ final class AgentTest extends TestCase
         $agent->call($messages);
     }
 
-    public function testCallHandlesClientExceptionWithEmptyMessage(): void
+    public function testCallHandlesClientExceptionWithEmptyMessage()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -339,7 +339,7 @@ final class AgentTest extends TestCase
         $agent->call($messages);
     }
 
-    public function testCallHandlesHttpException(): void
+    public function testCallHandlesHttpException()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -358,7 +358,7 @@ final class AgentTest extends TestCase
         $agent->call($messages);
     }
 
-    public function testCallPassesOptionsToInvoke(): void
+    public function testCallPassesOptionsToInvoke()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);
@@ -380,7 +380,7 @@ final class AgentTest extends TestCase
         $this->assertSame($result, $actualResult);
     }
 
-    public function testConstructorAcceptsTraversableProcessors(): void
+    public function testConstructorAcceptsTraversableProcessors()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $model = $this->createMock(Model::class);

--- a/src/agent/tests/ChatTest.php
+++ b/src/agent/tests/ChatTest.php
@@ -42,7 +42,7 @@ final class ChatTest extends TestCase
         $this->chat = new Chat($this->agent, $this->store);
     }
 
-    public function testItInitiatesChatByClearingAndSavingMessages(): void
+    public function testItInitiatesChatByClearingAndSavingMessages()
     {
         $messages = $this->createMock(MessageBagInterface::class);
 
@@ -56,7 +56,7 @@ final class ChatTest extends TestCase
         $this->chat->initiate($messages);
     }
 
-    public function testItSubmitsUserMessageAndReturnsAssistantMessage(): void
+    public function testItSubmitsUserMessageAndReturnsAssistantMessage()
     {
         $userMessage = Message::ofUser('Hello, how are you?');
         $existingMessages = new MessageBag();
@@ -95,7 +95,7 @@ final class ChatTest extends TestCase
         $this->assertSame($assistantContent, $result->content);
     }
 
-    public function testItAppendsMessagesToExistingConversation(): void
+    public function testItAppendsMessagesToExistingConversation()
     {
         $existingUserMessage = Message::ofUser('What is the weather?');
         $existingAssistantMessage = Message::ofAssistant('I cannot provide weather information.');
@@ -136,7 +136,7 @@ final class ChatTest extends TestCase
         $this->assertSame($newAssistantContent, $result->content);
     }
 
-    public function testItHandlesEmptyMessageStore(): void
+    public function testItHandlesEmptyMessageStore()
     {
         $userMessage = Message::ofUser('First message');
         $emptyMessages = new MessageBag();

--- a/src/agent/tests/InputProcessor/ModelOverrideInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/ModelOverrideInputProcessorTest.php
@@ -32,7 +32,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 #[Small]
 final class ModelOverrideInputProcessorTest extends TestCase
 {
-    public function testProcessInputWithValidModelOption(): void
+    public function testProcessInputWithValidModelOption()
     {
         $gpt = new GPT();
         $claude = new Claude();
@@ -44,7 +44,7 @@ final class ModelOverrideInputProcessorTest extends TestCase
         $this->assertSame($claude, $input->model);
     }
 
-    public function testProcessInputWithoutModelOption(): void
+    public function testProcessInputWithoutModelOption()
     {
         $gpt = new GPT();
         $input = new Input($gpt, new MessageBag(), []);
@@ -55,7 +55,7 @@ final class ModelOverrideInputProcessorTest extends TestCase
         $this->assertSame($gpt, $input->model);
     }
 
-    public function testProcessInputWithInvalidModelOption(): void
+    public function testProcessInputWithInvalidModelOption()
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('Option "model" must be an instance of Symfony\AI\Platform\Model.');

--- a/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
@@ -43,7 +43,7 @@ use Symfony\AI\Platform\Tool\Tool;
 #[Small]
 final class SystemPromptInputProcessorTest extends TestCase
 {
-    public function testProcessInputAddsSystemMessageWhenNoneExists(): void
+    public function testProcessInputAddsSystemMessageWhenNoneExists()
     {
         $processor = new SystemPromptInputProcessor('This is a system prompt');
 
@@ -57,7 +57,7 @@ final class SystemPromptInputProcessorTest extends TestCase
         $this->assertSame('This is a system prompt', $messages[0]->content);
     }
 
-    public function testProcessInputDoesNotAddSystemMessageWhenOneExists(): void
+    public function testProcessInputDoesNotAddSystemMessageWhenOneExists()
     {
         $processor = new SystemPromptInputProcessor('This is a system prompt');
 
@@ -75,7 +75,7 @@ final class SystemPromptInputProcessorTest extends TestCase
         $this->assertSame('This is already a system prompt', $messages[0]->content);
     }
 
-    public function testDoesNotIncludeToolsIfToolboxIsEmpty(): void
+    public function testDoesNotIncludeToolsIfToolboxIsEmpty()
     {
         $processor = new SystemPromptInputProcessor(
             'This is a system prompt',
@@ -102,7 +102,7 @@ final class SystemPromptInputProcessorTest extends TestCase
         $this->assertSame('This is a system prompt', $messages[0]->content);
     }
 
-    public function testIncludeToolDefinitions(): void
+    public function testIncludeToolDefinitions()
     {
         $processor = new SystemPromptInputProcessor(
             'This is a system prompt',
@@ -151,7 +151,7 @@ final class SystemPromptInputProcessorTest extends TestCase
             PROMPT, $messages[0]->content);
     }
 
-    public function testWithStringableSystemPrompt(): void
+    public function testWithStringableSystemPrompt()
     {
         $processor = new SystemPromptInputProcessor(
             new SystemPromptService(),

--- a/src/agent/tests/Memory/EmbeddingProviderTest.php
+++ b/src/agent/tests/Memory/EmbeddingProviderTest.php
@@ -41,7 +41,7 @@ use Symfony\AI\Store\VectorStoreInterface;
 #[Small]
 final class EmbeddingProviderTest extends TestCase
 {
-    public function testItIsDoingNothingWithEmptyMessageBag(): void
+    public function testItIsDoingNothingWithEmptyMessageBag()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $platform->expects($this->never())->method('invoke');
@@ -62,7 +62,7 @@ final class EmbeddingProviderTest extends TestCase
         ));
     }
 
-    public function testItIsDoingNothingWithoutUserMessageInBag(): void
+    public function testItIsDoingNothingWithoutUserMessageInBag()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $platform->expects($this->never())->method('invoke');
@@ -83,7 +83,7 @@ final class EmbeddingProviderTest extends TestCase
         ));
     }
 
-    public function testItIsDoingNothingWhenUserMessageHasNoTextContent(): void
+    public function testItIsDoingNothingWhenUserMessageHasNoTextContent()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $platform->expects($this->never())->method('invoke');
@@ -104,7 +104,7 @@ final class EmbeddingProviderTest extends TestCase
         ));
     }
 
-    public function testItIsNotCreatingMemoryWhenNoVectorsFound(): void
+    public function testItIsNotCreatingMemoryWhenNoVectorsFound()
     {
         $vectorResult = new VectorResult($vector = new Vector([0.1, 0.2], 2));
         $resultPromise = new ResultPromise(
@@ -138,7 +138,7 @@ final class EmbeddingProviderTest extends TestCase
         $this->assertCount(0, $memory);
     }
 
-    public function testItIsCreatingMemoryWithFoundVectors(): void
+    public function testItIsCreatingMemoryWithFoundVectors()
     {
         $vectorResult = new VectorResult($vector = new Vector([0.1, 0.2], 2));
         $resultPromise = new ResultPromise(

--- a/src/agent/tests/Memory/MemoryInputProcessorTest.php
+++ b/src/agent/tests/Memory/MemoryInputProcessorTest.php
@@ -33,7 +33,7 @@ use Symfony\AI\Platform\Model;
 #[Small]
 final class MemoryInputProcessorTest extends TestCase
 {
-    public function testItIsDoingNothingOnInactiveMemory(): void
+    public function testItIsDoingNothingOnInactiveMemory()
     {
         $memoryProvider = $this->createMock(MemoryProviderInterface::class);
         $memoryProvider->expects($this->never())->method($this->anything());
@@ -48,7 +48,7 @@ final class MemoryInputProcessorTest extends TestCase
         $this->assertArrayNotHasKey('use_memory', $input->getOptions());
     }
 
-    public function testItIsDoingNothingWhenThereAreNoProviders(): void
+    public function testItIsDoingNothingWhenThereAreNoProviders()
     {
         $memoryInputProcessor = new MemoryInputProcessor();
         $memoryInputProcessor->processInput($input = new Input(
@@ -60,7 +60,7 @@ final class MemoryInputProcessorTest extends TestCase
         $this->assertArrayNotHasKey('use_memory', $input->getOptions());
     }
 
-    public function testItIsAddingMemoryToSystemPrompt(): void
+    public function testItIsAddingMemoryToSystemPrompt()
     {
         $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
         $firstMemoryProvider->expects($this->once())
@@ -100,7 +100,7 @@ final class MemoryInputProcessorTest extends TestCase
         );
     }
 
-    public function testItIsAddingMemoryToSystemPromptEvenItIsEmpty(): void
+    public function testItIsAddingMemoryToSystemPromptEvenItIsEmpty()
     {
         $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
         $firstMemoryProvider->expects($this->once())
@@ -130,7 +130,7 @@ final class MemoryInputProcessorTest extends TestCase
         );
     }
 
-    public function testItIsAddingMultipleMemoryFromSingleProviderToSystemPrompt(): void
+    public function testItIsAddingMultipleMemoryFromSingleProviderToSystemPrompt()
     {
         $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
         $firstMemoryProvider->expects($this->once())
@@ -161,7 +161,7 @@ final class MemoryInputProcessorTest extends TestCase
         );
     }
 
-    public function testItIsNotAddingAnythingIfMemoryWasEmpty(): void
+    public function testItIsNotAddingAnythingIfMemoryWasEmpty()
     {
         $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
         $firstMemoryProvider->expects($this->once())

--- a/src/agent/tests/Memory/StaticMemoryProviderTest.php
+++ b/src/agent/tests/Memory/StaticMemoryProviderTest.php
@@ -29,7 +29,7 @@ use Symfony\AI\Platform\Model;
 #[Small]
 final class StaticMemoryProviderTest extends TestCase
 {
-    public function testItsReturnsNullWhenNoFactsAreProvided(): void
+    public function testItsReturnsNullWhenNoFactsAreProvided()
     {
         $provider = new StaticMemoryProvider();
 
@@ -42,7 +42,7 @@ final class StaticMemoryProviderTest extends TestCase
         $this->assertCount(0, $memory);
     }
 
-    public function testItDeliversFormattedFacts(): void
+    public function testItDeliversFormattedFacts()
     {
         $provider = new StaticMemoryProvider(
             $fact1 = 'The sky is blue',

--- a/src/agent/tests/StructuredOutput/AgentProcessorTest.php
+++ b/src/agent/tests/StructuredOutput/AgentProcessorTest.php
@@ -41,7 +41,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[UsesClass(Model::class)]
 final class AgentProcessorTest extends TestCase
 {
-    public function testProcessInputWithOutputStructure(): void
+    public function testProcessInputWithOutputStructure()
     {
         $processor = new AgentProcessor(new ConfigurableResponseFormatFactory(['some' => 'format']));
 
@@ -53,7 +53,7 @@ final class AgentProcessorTest extends TestCase
         $this->assertSame(['response_format' => ['some' => 'format']], $input->getOptions());
     }
 
-    public function testProcessInputWithoutOutputStructure(): void
+    public function testProcessInputWithoutOutputStructure()
     {
         $processor = new AgentProcessor(new ConfigurableResponseFormatFactory());
 
@@ -65,7 +65,7 @@ final class AgentProcessorTest extends TestCase
         $this->assertSame([], $input->getOptions());
     }
 
-    public function testProcessInputThrowsExceptionWhenLlmDoesNotSupportStructuredOutput(): void
+    public function testProcessInputThrowsExceptionWhenLlmDoesNotSupportStructuredOutput()
     {
         self::expectException(MissingModelSupportException::class);
 
@@ -77,7 +77,7 @@ final class AgentProcessorTest extends TestCase
         $processor->processInput($input);
     }
 
-    public function testProcessOutputWithResponseFormat(): void
+    public function testProcessOutputWithResponseFormat()
     {
         $processor = new AgentProcessor(new ConfigurableResponseFormatFactory(['some' => 'format']));
 
@@ -99,7 +99,7 @@ final class AgentProcessorTest extends TestCase
         $this->assertSame('data', $output->result->getContent()->some);
     }
 
-    public function testProcessOutputWithComplexResponseFormat(): void
+    public function testProcessOutputWithComplexResponseFormat()
     {
         $processor = new AgentProcessor(new ConfigurableResponseFormatFactory(['some' => 'format']));
 
@@ -153,7 +153,7 @@ final class AgentProcessorTest extends TestCase
         $this->assertSame('x = -3.75', $structure->finalAnswer);
     }
 
-    public function testProcessOutputWithoutResponseFormat(): void
+    public function testProcessOutputWithoutResponseFormat()
     {
         $resultFormatFactory = new ConfigurableResponseFormatFactory();
         $serializer = self::createMock(SerializerInterface::class);

--- a/src/agent/tests/StructuredOutput/ResponseFormatFactoryTest.php
+++ b/src/agent/tests/StructuredOutput/ResponseFormatFactoryTest.php
@@ -24,7 +24,7 @@ use Symfony\AI\Platform\Contract\JsonSchema\Factory;
 #[UsesClass(Factory::class)]
 final class ResponseFormatFactoryTest extends TestCase
 {
-    public function testCreate(): void
+    public function testCreate()
     {
         $this->assertSame([
             'type' => 'json_schema',

--- a/src/agent/tests/Toolbox/AgentProcessorTest.php
+++ b/src/agent/tests/Toolbox/AgentProcessorTest.php
@@ -42,7 +42,7 @@ use Symfony\AI\Platform\Tool\Tool;
 #[UsesClass(Model::class)]
 class AgentProcessorTest extends TestCase
 {
-    public function testProcessInputWithoutRegisteredToolsWillResultInNoOptionChange(): void
+    public function testProcessInputWithoutRegisteredToolsWillResultInNoOptionChange()
     {
         $toolbox = $this->createStub(ToolboxInterface::class);
         $toolbox->method('getTools')->willReturn([]);
@@ -56,7 +56,7 @@ class AgentProcessorTest extends TestCase
         $this->assertSame([], $input->getOptions());
     }
 
-    public function testProcessInputWithRegisteredToolsWillResultInOptionChange(): void
+    public function testProcessInputWithRegisteredToolsWillResultInOptionChange()
     {
         $toolbox = $this->createStub(ToolboxInterface::class);
         $tool1 = new Tool(new ExecutionReference('ClassTool1', 'method1'), 'tool1', 'description1', null);
@@ -72,7 +72,7 @@ class AgentProcessorTest extends TestCase
         $this->assertSame(['tools' => [$tool1, $tool2]], $input->getOptions());
     }
 
-    public function testProcessInputWithRegisteredToolsButToolOverride(): void
+    public function testProcessInputWithRegisteredToolsButToolOverride()
     {
         $toolbox = $this->createStub(ToolboxInterface::class);
         $tool1 = new Tool(new ExecutionReference('ClassTool1', 'method1'), 'tool1', 'description1', null);
@@ -88,7 +88,7 @@ class AgentProcessorTest extends TestCase
         $this->assertSame(['tools' => [$tool2]], $input->getOptions());
     }
 
-    public function testProcessInputWithUnsupportedToolCallingWillThrowException(): void
+    public function testProcessInputWithUnsupportedToolCallingWillThrowException()
     {
         self::expectException(MissingModelSupportException::class);
 
@@ -99,7 +99,7 @@ class AgentProcessorTest extends TestCase
         $processor->processInput($input);
     }
 
-    public function testProcessOutputWithToolCallResponseKeepingMessages(): void
+    public function testProcessOutputWithToolCallResponseKeepingMessages()
     {
         $toolbox = $this->createMock(ToolboxInterface::class);
         $toolbox->expects($this->once())->method('execute')->willReturn('Test response');
@@ -124,7 +124,7 @@ class AgentProcessorTest extends TestCase
         $this->assertInstanceOf(ToolCallMessage::class, $messageBag->getMessages()[1]);
     }
 
-    public function testProcessOutputWithToolCallResponseForgettingMessages(): void
+    public function testProcessOutputWithToolCallResponseForgettingMessages()
     {
         $toolbox = $this->createMock(ToolboxInterface::class);
         $toolbox->expects($this->once())->method('execute')->willReturn('Test response');

--- a/src/agent/tests/Toolbox/Attribute/AsToolTest.php
+++ b/src/agent/tests/Toolbox/Attribute/AsToolTest.php
@@ -18,7 +18,7 @@ use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 #[CoversClass(AsTool::class)]
 final class AsToolTest extends TestCase
 {
-    public function testCanBeConstructed(): void
+    public function testCanBeConstructed()
     {
         $attribute = new AsTool(
             name: 'name',

--- a/src/agent/tests/Toolbox/FaultTolerantToolboxTest.php
+++ b/src/agent/tests/Toolbox/FaultTolerantToolboxTest.php
@@ -32,7 +32,7 @@ use Symfony\AI\Platform\Tool\Tool;
 #[UsesClass(ToolExecutionException::class)]
 final class FaultTolerantToolboxTest extends TestCase
 {
-    public function testFaultyToolExecution(): void
+    public function testFaultyToolExecution()
     {
         $faultyToolbox = $this->createFaultyToolbox(
             fn (ToolCall $toolCall) => ToolExecutionException::executionFailed($toolCall, new \Exception('error'))
@@ -47,7 +47,7 @@ final class FaultTolerantToolboxTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testFaultyToolCall(): void
+    public function testFaultyToolCall()
     {
         $faultyToolbox = $this->createFaultyToolbox(
             fn (ToolCall $toolCall) => ToolNotFoundException::notFoundForToolCall($toolCall)

--- a/src/agent/tests/Toolbox/MetadataFactory/ChainFactoryTest.php
+++ b/src/agent/tests/Toolbox/MetadataFactory/ChainFactoryTest.php
@@ -45,7 +45,7 @@ final class ChainFactoryTest extends TestCase
         $this->factory = new ChainFactory([$factory1, $factory2]);
     }
 
-    public function testTestGetMetadataNotExistingClass(): void
+    public function testTestGetMetadataNotExistingClass()
     {
         self::expectException(ToolException::class);
         self::expectExceptionMessage('The reference "NoClass" is not a valid tool.');
@@ -53,7 +53,7 @@ final class ChainFactoryTest extends TestCase
         iterator_to_array($this->factory->getTool('NoClass'));
     }
 
-    public function testTestGetMetadataNotConfiguredClass(): void
+    public function testTestGetMetadataNotConfiguredClass()
     {
         self::expectException(ToolConfigurationException::class);
         self::expectExceptionMessage(\sprintf('Method "foo" not found in tool "%s".', ToolMisconfigured::class));
@@ -61,14 +61,14 @@ final class ChainFactoryTest extends TestCase
         iterator_to_array($this->factory->getTool(ToolMisconfigured::class));
     }
 
-    public function testTestGetMetadataWithAttributeSingleHit(): void
+    public function testTestGetMetadataWithAttributeSingleHit()
     {
         $metadata = iterator_to_array($this->factory->getTool(ToolRequiredParams::class));
 
         $this->assertCount(1, $metadata);
     }
 
-    public function testTestGetMetadataOverwrite(): void
+    public function testTestGetMetadataOverwrite()
     {
         $metadata = iterator_to_array($this->factory->getTool(ToolOptionalParam::class));
 
@@ -78,14 +78,14 @@ final class ChainFactoryTest extends TestCase
         $this->assertSame('bar', $metadata[0]->reference->method);
     }
 
-    public function testTestGetMetadataWithAttributeDoubleHit(): void
+    public function testTestGetMetadataWithAttributeDoubleHit()
     {
         $metadata = iterator_to_array($this->factory->getTool(ToolMultiple::class));
 
         $this->assertCount(2, $metadata);
     }
 
-    public function testTestGetMetadataWithMemorySingleHit(): void
+    public function testTestGetMetadataWithMemorySingleHit()
     {
         $metadata = iterator_to_array($this->factory->getTool(ToolNoAttribute1::class));
 

--- a/src/agent/tests/Toolbox/MetadataFactory/MemoryFactoryTest.php
+++ b/src/agent/tests/Toolbox/MetadataFactory/MemoryFactoryTest.php
@@ -33,7 +33,7 @@ use Symfony\AI\Platform\Tool\Tool;
 #[UsesClass(DescriptionParser::class)]
 final class MemoryFactoryTest extends TestCase
 {
-    public function testGetMetadataWithoutTools(): void
+    public function testGetMetadataWithoutTools()
     {
         self::expectException(ToolException::class);
         self::expectExceptionMessage('The reference "SomeClass" is not a valid tool.');
@@ -42,7 +42,7 @@ final class MemoryFactoryTest extends TestCase
         iterator_to_array($factory->getTool('SomeClass')); // @phpstan-ignore-line Yes, this class does not exist
     }
 
-    public function testGetMetadataWithDistinctToolPerClass(): void
+    public function testGetMetadataWithDistinctToolPerClass()
     {
         $factory = (new MemoryToolFactory())
             ->addTool(ToolNoAttribute1::class, 'happy_birthday', 'Generates birthday message')
@@ -69,7 +69,7 @@ final class MemoryFactoryTest extends TestCase
         $this->assertSame($expectedParams, $metadata[0]->parameters);
     }
 
-    public function testGetMetadataWithMultipleToolsInClass(): void
+    public function testGetMetadataWithMultipleToolsInClass()
     {
         $factory = (new MemoryToolFactory())
             ->addTool(ToolNoAttribute2::class, 'checkout', 'Buys a number of items per product', 'buy')

--- a/src/agent/tests/Toolbox/MetadataFactory/ReflectionFactoryTest.php
+++ b/src/agent/tests/Toolbox/MetadataFactory/ReflectionFactoryTest.php
@@ -43,7 +43,7 @@ final class ReflectionFactoryTest extends TestCase
         $this->factory = new ReflectionToolFactory();
     }
 
-    public function testInvalidReferenceNonExistingClass(): void
+    public function testInvalidReferenceNonExistingClass()
     {
         self::expectException(ToolException::class);
         self::expectExceptionMessage('The reference "invalid" is not a valid tool.');
@@ -51,7 +51,7 @@ final class ReflectionFactoryTest extends TestCase
         iterator_to_array($this->factory->getTool('invalid')); // @phpstan-ignore-line Yes, this class does not exist
     }
 
-    public function testWithoutAttribute(): void
+    public function testWithoutAttribute()
     {
         self::expectException(ToolException::class);
         self::expectExceptionMessage(\sprintf('The class "%s" is not a tool, please add %s attribute.', ToolWrong::class, AsTool::class));
@@ -59,7 +59,7 @@ final class ReflectionFactoryTest extends TestCase
         iterator_to_array($this->factory->getTool(ToolWrong::class));
     }
 
-    public function testGetDefinition(): void
+    public function testGetDefinition()
     {
         /** @var Tool[] $metadatas */
         $metadatas = iterator_to_array($this->factory->getTool(ToolRequiredParams::class));
@@ -88,7 +88,7 @@ final class ReflectionFactoryTest extends TestCase
         );
     }
 
-    public function testGetDefinitionWithMultiple(): void
+    public function testGetDefinitionWithMultiple()
     {
         $metadatas = iterator_to_array($this->factory->getTool(ToolMultiple::class));
 

--- a/src/agent/tests/Toolbox/Tool/BraveTest.php
+++ b/src/agent/tests/Toolbox/Tool/BraveTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 #[CoversClass(Brave::class)]
 final class BraveTest extends TestCase
 {
-    public function testReturnsSearchResults(): void
+    public function testReturnsSearchResults()
     {
         $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/brave.json');
         $httpClient = new MockHttpClient($result);
@@ -38,7 +38,7 @@ final class BraveTest extends TestCase
         $this->assertSame('https://www.espn.com/nfl/team/_/name/dal/dallas-cowboys', $results[0]['url']);
     }
 
-    public function testPassesCorrectParametersToApi(): void
+    public function testPassesCorrectParametersToApi()
     {
         $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/brave.json');
         $httpClient = new MockHttpClient($result);
@@ -57,7 +57,7 @@ final class BraveTest extends TestCase
         $this->assertContains('X-Subscription-Token: test-api-key', $requestOptions['headers']);
     }
 
-    public function testHandlesEmptyResults(): void
+    public function testHandlesEmptyResults()
     {
         $result = new MockResponse(json_encode(['web' => ['results' => []]]));
         $httpClient = new MockHttpClient($result);

--- a/src/agent/tests/Toolbox/Tool/OpenMeteoTest.php
+++ b/src/agent/tests/Toolbox/Tool/OpenMeteoTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 #[CoversClass(OpenMeteo::class)]
 final class OpenMeteoTest extends TestCase
 {
-    public function testCurrent(): void
+    public function testCurrent()
     {
         $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/openmeteo-current.json');
         $httpClient = new MockHttpClient($result);
@@ -38,7 +38,7 @@ final class OpenMeteoTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testForecast(): void
+    public function testForecast()
     {
         $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/openmeteo-forecast.json');
         $httpClient = new MockHttpClient($result);

--- a/src/agent/tests/Toolbox/Tool/SimilaritySearchTest.php
+++ b/src/agent/tests/Toolbox/Tool/SimilaritySearchTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(SimilaritySearch::class)]
 final class SimilaritySearchTest extends TestCase
 {
-    public function testSearchWithResults(): void
+    public function testSearchWithResults()
     {
         $searchTerm = 'find similar documents';
         $vector = new Vector([0.1, 0.2, 0.3]);
@@ -72,7 +72,7 @@ final class SimilaritySearchTest extends TestCase
         $this->assertSame([$document1, $document2], $similaritySearch->usedDocuments);
     }
 
-    public function testSearchWithoutResults(): void
+    public function testSearchWithoutResults()
     {
         $searchTerm = 'find nothing';
         $vector = new Vector([0.1, 0.2, 0.3]);
@@ -105,7 +105,7 @@ final class SimilaritySearchTest extends TestCase
         $this->assertSame([], $similaritySearch->usedDocuments);
     }
 
-    public function testSearchWithSingleResult(): void
+    public function testSearchWithSingleResult()
     {
         $searchTerm = 'specific query';
         $vector = new Vector([0.5, 0.6, 0.7]);

--- a/src/agent/tests/Toolbox/Tool/WikipediaTest.php
+++ b/src/agent/tests/Toolbox/Tool/WikipediaTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 #[CoversClass(Wikipedia::class)]
 final class WikipediaTest extends TestCase
 {
-    public function testSearchWithResults(): void
+    public function testSearchWithResults()
     {
         $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/wikipedia-search-result.json');
         $httpClient = new MockHttpClient($result);
@@ -47,7 +47,7 @@ final class WikipediaTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testSearchWithoutResults(): void
+    public function testSearchWithoutResults()
     {
         $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/wikipedia-search-empty.json');
         $httpClient = new MockHttpClient($result);
@@ -60,7 +60,7 @@ final class WikipediaTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testArticleWithResult(): void
+    public function testArticleWithResult()
     {
         $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/wikipedia-article.json');
         $httpClient = new MockHttpClient($result);
@@ -76,7 +76,7 @@ final class WikipediaTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testArticleWithRedirect(): void
+    public function testArticleWithRedirect()
     {
         $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/wikipedia-article-redirect.json');
         $httpClient = new MockHttpClient($result);
@@ -94,7 +94,7 @@ final class WikipediaTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testArticleMissing(): void
+    public function testArticleMissing()
     {
         $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/wikipedia-article-missing.json');
         $httpClient = new MockHttpClient($result);

--- a/src/agent/tests/Toolbox/ToolCallArgumentResolverTest.php
+++ b/src/agent/tests/Toolbox/ToolCallArgumentResolverTest.php
@@ -30,7 +30,7 @@ use Symfony\AI\Platform\Tool\Tool;
 #[UsesClass(ToolCall::class)]
 class ToolCallArgumentResolverTest extends TestCase
 {
-    public function testResolveArguments(): void
+    public function testResolveArguments()
     {
         $resolver = new ToolCallArgumentResolver();
 
@@ -40,7 +40,7 @@ class ToolCallArgumentResolverTest extends TestCase
         $this->assertEquals(['date' => new \DateTimeImmutable('2025-06-29')], $resolver->resolveArguments($metadata, $toolCall));
     }
 
-    public function testResolveScalarArrayArguments(): void
+    public function testResolveScalarArrayArguments()
     {
         $resolver = new ToolCallArgumentResolver();
 
@@ -58,7 +58,7 @@ class ToolCallArgumentResolverTest extends TestCase
         $this->assertSame($expected, $resolver->resolveArguments($metadata, $toolCall));
     }
 
-    public function testResolveMultidimensionalArrayArguments(): void
+    public function testResolveMultidimensionalArrayArguments()
     {
         $resolver = new ToolCallArgumentResolver();
 
@@ -78,7 +78,7 @@ class ToolCallArgumentResolverTest extends TestCase
         $this->assertEquals($expected, $resolver->resolveArguments($metadata, $toolCall));
     }
 
-    public function testIgnoreExtraArguments(): void
+    public function testIgnoreExtraArguments()
     {
         $resolver = new ToolCallArgumentResolver();
 

--- a/src/agent/tests/Toolbox/ToolResultConverterTest.php
+++ b/src/agent/tests/Toolbox/ToolResultConverterTest.php
@@ -21,7 +21,7 @@ use Symfony\AI\Fixtures\StructuredOutput\UserWithConstructor;
 final class ToolResultConverterTest extends TestCase
 {
     #[DataProvider('provideResults')]
-    public function testConvert(mixed $result, ?string $expected): void
+    public function testConvert(mixed $result, ?string $expected)
     {
         $converter = new ToolResultConverter();
 

--- a/src/agent/tests/Toolbox/ToolboxTest.php
+++ b/src/agent/tests/Toolbox/ToolboxTest.php
@@ -64,7 +64,7 @@ final class ToolboxTest extends TestCase
         ], new ReflectionToolFactory());
     }
 
-    public function testGetTools(): void
+    public function testGetTools()
     {
         $actual = $this->toolbox->getTools();
 
@@ -151,7 +151,7 @@ final class ToolboxTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testExecuteWithUnknownTool(): void
+    public function testExecuteWithUnknownTool()
     {
         self::expectException(ToolNotFoundException::class);
         self::expectExceptionMessage('Tool not found for call: foo_bar_baz');
@@ -159,7 +159,7 @@ final class ToolboxTest extends TestCase
         $this->toolbox->execute(new ToolCall('call_1234', 'foo_bar_baz'));
     }
 
-    public function testExecuteWithMisconfiguredTool(): void
+    public function testExecuteWithMisconfiguredTool()
     {
         self::expectException(ToolConfigurationException::class);
         self::expectExceptionMessage('Method "foo" not found in tool "Symfony\AI\Fixtures\Tool\ToolMisconfigured".');
@@ -169,7 +169,7 @@ final class ToolboxTest extends TestCase
         $toolbox->execute(new ToolCall('call_1234', 'tool_misconfigured'));
     }
 
-    public function testExecuteWithException(): void
+    public function testExecuteWithException()
     {
         self::expectException(ToolExecutionException::class);
         self::expectExceptionMessage('Execution of tool "tool_exception" failed with error: Tool error.');
@@ -178,7 +178,7 @@ final class ToolboxTest extends TestCase
     }
 
     #[DataProvider('executeProvider')]
-    public function testExecute(string $expected, string $toolName, array $toolPayload = []): void
+    public function testExecute(string $expected, string $toolName, array $toolPayload = [])
     {
         $this->assertSame(
             $expected,
@@ -204,7 +204,7 @@ final class ToolboxTest extends TestCase
         ];
     }
 
-    public function testToolboxMapWithMemoryFactory(): void
+    public function testToolboxMapWithMemoryFactory()
     {
         $memoryFactory = (new MemoryToolFactory())
             ->addTool(ToolNoAttribute1::class, 'happy_birthday', 'Generates birthday message');
@@ -236,7 +236,7 @@ final class ToolboxTest extends TestCase
         $this->assertEquals($expected, $toolbox->getTools());
     }
 
-    public function testToolboxExecutionWithMemoryFactory(): void
+    public function testToolboxExecutionWithMemoryFactory()
     {
         $memoryFactory = (new MemoryToolFactory())
             ->addTool(ToolNoAttribute1::class, 'happy_birthday', 'Generates birthday message');
@@ -247,7 +247,7 @@ final class ToolboxTest extends TestCase
         $this->assertSame('Happy Birthday, John! You are 30 years old.', $result);
     }
 
-    public function testToolboxMapWithOverrideViaChain(): void
+    public function testToolboxMapWithOverrideViaChain()
     {
         $factory1 = (new MemoryToolFactory())
             ->addTool(ToolOptionalParam::class, 'optional_param', 'Tool with optional param', 'bar');

--- a/src/ai-bundle/phpstan.dist.neon
+++ b/src/ai-bundle/phpstan.dist.neon
@@ -5,7 +5,13 @@ parameters:
     level: 6
     paths:
         - src/
+        - tests/
     ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+        -
+            identifier: missingType.iterableValue
+            path: tests/*
         -
             message: '#\\AuthorizationCheckerInterface::isGranted\(\) invoked with 3 parameters, 1-2 required#'
             path: src/*

--- a/src/ai-bundle/tests/DependencyInjection/AIBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AIBundleTest.php
@@ -24,12 +24,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class AIBundleTest extends TestCase
 {
     #[DoesNotPerformAssertions]
-    public function testExtensionLoadDoesNotThrow(): void
+    public function testExtensionLoadDoesNotThrow()
     {
         $this->buildContainer($this->getFullConfig());
     }
 
-    public function testAgentsCanBeRegisteredAsTools(): void
+    public function testAgentsCanBeRegisteredAsTools()
     {
         $container = $this->buildContainer([
             'ai' => [
@@ -49,7 +49,7 @@ class AIBundleTest extends TestCase
         $this->assertTrue($container->hasDefinition('ai.toolbox.main_agent.agent_wrapper.another_agent_instance'));
     }
 
-    public function testAgentsAsToolsCannotDefineService(): void
+    public function testAgentsAsToolsCannotDefineService()
     {
         $this->expectException(InvalidConfigurationException::class);
         $this->buildContainer([

--- a/src/ai-bundle/tests/Profiler/TraceableToolboxTest.php
+++ b/src/ai-bundle/tests/Profiler/TraceableToolboxTest.php
@@ -24,7 +24,7 @@ use Symfony\AI\Platform\Tool\Tool;
 #[Small]
 final class TraceableToolboxTest extends TestCase
 {
-    public function testGetMap(): void
+    public function testGetMap()
     {
         $metadata = new Tool(new ExecutionReference('Foo\Bar'), 'bar', 'description', null);
         $toolbox = $this->createToolbox(['tool' => $metadata]);
@@ -35,7 +35,7 @@ final class TraceableToolboxTest extends TestCase
         $this->assertSame(['tool' => $metadata], $map);
     }
 
-    public function testExecute(): void
+    public function testExecute()
     {
         $metadata = new Tool(new ExecutionReference('Foo\Bar'), 'bar', 'description', null);
         $toolbox = $this->createToolbox(['tool' => $metadata]);

--- a/src/ai-bundle/tests/Security/IsGrantedToolAttributeListenerTest.php
+++ b/src/ai-bundle/tests/Security/IsGrantedToolAttributeListenerTest.php
@@ -52,7 +52,7 @@ class IsGrantedToolAttributeListenerTest extends TestCase
     #[TestWith([new ToolWithIsGrantedOnMethod(), new Tool(new ExecutionReference(ToolWithIsGrantedOnMethod::class, 'simple'), 'simple', '')])]
     #[TestWith([new ToolWithIsGrantedOnMethod(), new Tool(new ExecutionReference(ToolWithIsGrantedOnMethod::class, 'expressionAsSubject'), 'expressionAsSubject', '')])]
     #[TestWith([new ToolWithIsGrantedOnClass(), new Tool(new ExecutionReference(ToolWithIsGrantedOnClass::class, '__invoke'), 'ToolWithIsGrantedOnClass', '')])]
-    public function testItWillThrowWhenNotGranted(object $tool, Tool $metadata): void
+    public function testItWillThrowWhenNotGranted(object $tool, Tool $metadata)
     {
         $this->authChecker->expects($this->once())->method('isGranted')->willReturn(false);
 
@@ -62,7 +62,7 @@ class IsGrantedToolAttributeListenerTest extends TestCase
     }
 
     #[TestWith([new ToolWithIsGrantedOnMethod(), new Tool(new ExecutionReference(ToolWithIsGrantedOnMethod::class, 'simple'), '', '')], 'method')]
-    public function testItWillNotThrowWhenGranted(object $tool, Tool $metadata): void
+    public function testItWillNotThrowWhenGranted(object $tool, Tool $metadata)
     {
         $this->authChecker->expects($this->once())->method('isGranted')->with('ROLE_USER')->willReturn(true);
         $this->dispatcher->dispatch(new ToolCallArgumentsResolved($tool, $metadata, []));
@@ -70,14 +70,14 @@ class IsGrantedToolAttributeListenerTest extends TestCase
 
     #[TestWith([new ToolWithIsGrantedOnMethod(), new Tool(new ExecutionReference(ToolWithIsGrantedOnMethod::class, 'argumentAsSubject'), '', '')], 'method')]
     #[TestWith([new ToolWithIsGrantedOnClass(), new Tool(new ExecutionReference(ToolWithIsGrantedOnClass::class, '__invoke'), '', '')], 'class')]
-    public function testItWillProvideArgumentAsSubject(object $tool, Tool $metadata): void
+    public function testItWillProvideArgumentAsSubject(object $tool, Tool $metadata)
     {
         $this->authChecker->expects($this->once())->method('isGranted')->with('test:permission', 44)->willReturn(true);
         $this->dispatcher->dispatch(new ToolCallArgumentsResolved($tool, $metadata, ['itemId' => 44]));
     }
 
     #[TestWith([new ToolWithIsGrantedOnMethod(), new Tool(new ExecutionReference(ToolWithIsGrantedOnMethod::class, 'expressionAsSubject'), '', '')], 'method')]
-    public function testItWillEvaluateSubjectExpression(object $tool, Tool $metadata): void
+    public function testItWillEvaluateSubjectExpression(object $tool, Tool $metadata)
     {
         $this->authChecker->expects($this->once())->method('isGranted')->with('test:permission', 44)->willReturn(true);
         $this->dispatcher->dispatch(new ToolCallArgumentsResolved($tool, $metadata, ['itemId' => 44]));

--- a/src/mcp-bundle/phpstan.dist.neon
+++ b/src/mcp-bundle/phpstan.dist.neon
@@ -5,3 +5,8 @@ parameters:
     level: 6
     paths:
         - src/
+        - tests/
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+            reportUnmatched: false # we don't have tests yet

--- a/src/mcp-sdk/phpstan.dist.neon
+++ b/src/mcp-sdk/phpstan.dist.neon
@@ -9,3 +9,6 @@ parameters:
         - tests/
     excludePaths:
         - examples/cli/vendor (?)
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"

--- a/src/mcp-sdk/tests/Message/ErrorTest.php
+++ b/src/mcp-sdk/tests/Message/ErrorTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\McpSdk\Message\Error;
 #[CoversClass(Error::class)]
 final class ErrorTest extends TestCase
 {
-    public function testWithIntegerId(): void
+    public function testWithIntegerId()
     {
         $error = new Error(1, -32602, 'Another error occurred');
         $expected = [
@@ -35,7 +35,7 @@ final class ErrorTest extends TestCase
         $this->assertSame($expected, $error->jsonSerialize());
     }
 
-    public function testWithStringId(): void
+    public function testWithStringId()
     {
         $error = new Error('abc', -32602, 'Another error occurred');
         $expected = [

--- a/src/mcp-sdk/tests/Message/FactoryTest.php
+++ b/src/mcp-sdk/tests/Message/FactoryTest.php
@@ -42,7 +42,7 @@ final class FactoryTest extends TestCase
         return null;
     }
 
-    public function testCreateRequest(): void
+    public function testCreateRequest()
     {
         $json = '{"jsonrpc": "2.0", "method": "test_method", "params": {"foo": "bar"}, "id": 123}';
 
@@ -54,7 +54,7 @@ final class FactoryTest extends TestCase
         $this->assertSame(123, $result->id);
     }
 
-    public function testCreateNotification(): void
+    public function testCreateNotification()
     {
         $json = '{"jsonrpc": "2.0", "method": "notifications/test_event", "params": {"foo": "bar"}}';
 
@@ -65,21 +65,21 @@ final class FactoryTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $result->params);
     }
 
-    public function testInvalidJson(): void
+    public function testInvalidJson()
     {
         $this->expectException(\JsonException::class);
 
         $this->first($this->factory->create('invalid json'));
     }
 
-    public function testMissingMethod(): void
+    public function testMissingMethod()
     {
         $result = $this->first($this->factory->create('{"jsonrpc": "2.0", "params": {}, "id": 1}'));
         $this->assertInstanceOf(InvalidInputMessageException::class, $result);
         $this->assertEquals('Invalid JSON-RPC request, missing "method".', $result->getMessage());
     }
 
-    public function testBatchMissingMethod(): void
+    public function testBatchMissingMethod()
     {
         $results = $this->factory->create('[{"jsonrpc": "2.0", "params": {}, "id": 1}, {"jsonrpc": "2.0", "method": "notifications/test_event", "params": {}, "id": 2}]');
 

--- a/src/mcp-sdk/tests/Message/ResponseTest.php
+++ b/src/mcp-sdk/tests/Message/ResponseTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\McpSdk\Message\Response;
 #[CoversClass(Response::class)]
 final class ResponseTest extends TestCase
 {
-    public function testWithIntegerId(): void
+    public function testWithIntegerId()
     {
         $response = new Response(1, ['foo' => 'bar']);
         $expected = [
@@ -32,7 +32,7 @@ final class ResponseTest extends TestCase
         $this->assertSame($expected, $response->jsonSerialize());
     }
 
-    public function testWithStringId(): void
+    public function testWithStringId()
     {
         $response = new Response('abc', ['foo' => 'bar']);
         $expected = [

--- a/src/mcp-sdk/tests/Server/JsonRpcHandlerTest.php
+++ b/src/mcp-sdk/tests/Server/JsonRpcHandlerTest.php
@@ -27,7 +27,7 @@ use Symfony\AI\McpSdk\Server\RequestHandlerInterface;
 class JsonRpcHandlerTest extends TestCase
 {
     #[TestDox('Make sure a single notification can be handled by multiple handlers.')]
-    public function testHandleMultipleNotifications(): void
+    public function testHandleMultipleNotifications()
     {
         $handlerA = $this->getMockBuilder(NotificationHandlerInterface::class)
             ->disableOriginalConstructor()
@@ -58,7 +58,7 @@ class JsonRpcHandlerTest extends TestCase
     }
 
     #[TestDox('Make sure a single request can NOT be handled by multiple handlers.')]
-    public function testHandleMultipleRequests(): void
+    public function testHandleMultipleRequests()
     {
         $handlerA = $this->getMockBuilder(RequestHandlerInterface::class)
             ->disableOriginalConstructor()

--- a/src/mcp-sdk/tests/Server/RequestHandler/PromptListHandlerTest.php
+++ b/src/mcp-sdk/tests/Server/RequestHandler/PromptListHandlerTest.php
@@ -23,7 +23,7 @@ use Symfony\AI\McpSdk\Server\RequestHandler\PromptListHandler;
 #[CoversClass(PromptListHandler::class)]
 class PromptListHandlerTest extends TestCase
 {
-    public function testHandleEmpty(): void
+    public function testHandleEmpty()
     {
         $handler = new PromptListHandler(new PromptChain([]));
         $message = new Request(1, 'prompts/list', []);
@@ -32,7 +32,7 @@ class PromptListHandlerTest extends TestCase
         $this->assertEquals(['prompts' => []], $response->result);
     }
 
-    public function testHandleReturnAll(): void
+    public function testHandleReturnAll()
     {
         $item = self::createMetadataItem();
         $handler = new PromptListHandler(new PromptChain([$item]));
@@ -42,7 +42,7 @@ class PromptListHandlerTest extends TestCase
         $this->assertArrayNotHasKey('nextCursor', $response->result);
     }
 
-    public function testHandlePagination(): void
+    public function testHandlePagination()
     {
         $item = self::createMetadataItem();
         $handler = new PromptListHandler(new PromptChain([$item, $item]), 2);

--- a/src/mcp-sdk/tests/Server/RequestHandler/ResourceListHandlerTest.php
+++ b/src/mcp-sdk/tests/Server/RequestHandler/ResourceListHandlerTest.php
@@ -24,7 +24,7 @@ use Symfony\AI\McpSdk\Server\RequestHandler\ResourceListHandler;
 #[CoversClass(ResourceListHandler::class)]
 class ResourceListHandlerTest extends TestCase
 {
-    public function testHandleEmpty(): void
+    public function testHandleEmpty()
     {
         $collection = $this->getMockBuilder(CollectionInterface::class)
             ->disableOriginalConstructor()
@@ -43,7 +43,7 @@ class ResourceListHandlerTest extends TestCase
      * @param iterable<MetadataInterface> $metadataList
      */
     #[DataProvider('metadataProvider')]
-    public function testHandleReturnAll(iterable $metadataList): void
+    public function testHandleReturnAll(iterable $metadataList)
     {
         $collection = $this->getMockBuilder(CollectionInterface::class)
             ->disableOriginalConstructor()
@@ -70,7 +70,7 @@ class ResourceListHandlerTest extends TestCase
         ];
     }
 
-    public function testHandlePagination(): void
+    public function testHandlePagination()
     {
         $item = self::createMetadataItem();
         $collection = $this->getMockBuilder(CollectionInterface::class)

--- a/src/mcp-sdk/tests/Server/RequestHandler/ToolListHandlerTest.php
+++ b/src/mcp-sdk/tests/Server/RequestHandler/ToolListHandlerTest.php
@@ -24,7 +24,7 @@ use Symfony\AI\McpSdk\Server\RequestHandler\ToolListHandler;
 #[CoversClass(ToolListHandler::class)]
 class ToolListHandlerTest extends TestCase
 {
-    public function testHandleEmpty(): void
+    public function testHandleEmpty()
     {
         $collection = $this->getMockBuilder(CollectionInterface::class)
             ->disableOriginalConstructor()
@@ -43,7 +43,7 @@ class ToolListHandlerTest extends TestCase
      * @param iterable<MetadataInterface> $metadataList
      */
     #[DataProvider('metadataProvider')]
-    public function testHandleReturnAll(iterable $metadataList): void
+    public function testHandleReturnAll(iterable $metadataList)
     {
         $collection = $this->getMockBuilder(CollectionInterface::class)
             ->disableOriginalConstructor()
@@ -70,7 +70,7 @@ class ToolListHandlerTest extends TestCase
         ];
     }
 
-    public function testHandlePagination(): void
+    public function testHandlePagination()
     {
         $item = self::createMetadataItem();
         $collection = $this->getMockBuilder(CollectionInterface::class)

--- a/src/mcp-sdk/tests/ServerTest.php
+++ b/src/mcp-sdk/tests/ServerTest.php
@@ -24,7 +24,7 @@ use Symfony\AI\McpSdk\Tests\Fixtures\InMemoryTransport;
 #[CoversClass(Server::class)]
 class ServerTest extends TestCase
 {
-    public function testJsonExceptions(): void
+    public function testJsonExceptions()
     {
         $logger = $this->getMockBuilder(NullLogger::class)
             ->disableOriginalConstructor()

--- a/src/platform/phpstan.dist.neon
+++ b/src/platform/phpstan.dist.neon
@@ -9,6 +9,8 @@ parameters:
         - tests/
     ignoreErrors:
         -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+        -
             message: '#supportsNormalization\(\) has parameter \$context with no value type specified in iterable type array#'
             path: src/*
             reportUnmatched: false # only needed for older Symfony versions

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -152,7 +152,7 @@ final readonly class ResultConverter implements ResultConverterInterface
 
     /**
      * @param array{
-     *     index: integer,
+     *     index: int,
      *     message: array{
      *         role: 'assistant',
      *         content: ?string,

--- a/src/platform/src/Bridge/OpenAI/GPT/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAI/GPT/ResultConverter.php
@@ -149,7 +149,7 @@ final class ResultConverter implements PlatformResponseConverter
 
     /**
      * @param array{
-     *     index: integer,
+     *     index: int,
      *     message: array{
      *         role: 'assistant',
      *         content: ?string,

--- a/src/platform/tests/Bridge/Albert/EmbeddingsModelClientTest.php
+++ b/src/platform/tests/Bridge/Albert/EmbeddingsModelClientTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 #[Small]
 final class EmbeddingsModelClientTest extends TestCase
 {
-    public function testConstructorThrowsExceptionForEmptyApiKey(): void
+    public function testConstructorThrowsExceptionForEmptyApiKey()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API key must not be empty.');
@@ -38,7 +38,7 @@ final class EmbeddingsModelClientTest extends TestCase
         );
     }
 
-    public function testConstructorThrowsExceptionForEmptyBaseUrl(): void
+    public function testConstructorThrowsExceptionForEmptyBaseUrl()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The base URL must not be empty.');
@@ -50,7 +50,7 @@ final class EmbeddingsModelClientTest extends TestCase
         );
     }
 
-    public function testSupportsEmbeddingsModel(): void
+    public function testSupportsEmbeddingsModel()
     {
         $client = new EmbeddingsModelClient(
             new MockHttpClient(),
@@ -62,7 +62,7 @@ final class EmbeddingsModelClientTest extends TestCase
         $this->assertTrue($client->supports($embeddingsModel));
     }
 
-    public function testDoesNotSupportNonEmbeddingsModel(): void
+    public function testDoesNotSupportNonEmbeddingsModel()
     {
         $client = new EmbeddingsModelClient(
             new MockHttpClient(),
@@ -75,7 +75,7 @@ final class EmbeddingsModelClientTest extends TestCase
     }
 
     #[DataProvider('providePayloadToJson')]
-    public function testRequestSendsCorrectHttpRequest(array|string $payload, array $options, array|string $expectedJson): void
+    public function testRequestSendsCorrectHttpRequest(array|string $payload, array $options, array|string $expectedJson)
     {
         $capturedRequest = null;
         $httpClient = new MockHttpClient(function ($method, $url, $options) use (&$capturedRequest) {
@@ -136,7 +136,7 @@ final class EmbeddingsModelClientTest extends TestCase
         ];
     }
 
-    public function testRequestHandlesBaseUrlWithoutTrailingSlash(): void
+    public function testRequestHandlesBaseUrlWithoutTrailingSlash()
     {
         $capturedUrl = null;
         $httpClient = new MockHttpClient(function ($method, $url) use (&$capturedUrl) {
@@ -157,7 +157,7 @@ final class EmbeddingsModelClientTest extends TestCase
         $this->assertSame('https://albert.example.com/v1/embeddings', $capturedUrl);
     }
 
-    public function testRequestHandlesBaseUrlWithTrailingSlash(): void
+    public function testRequestHandlesBaseUrlWithTrailingSlash()
     {
         $capturedUrl = null;
         $httpClient = new MockHttpClient(function ($method, $url) use (&$capturedUrl) {

--- a/src/platform/tests/Bridge/Albert/GPTModelClientTest.php
+++ b/src/platform/tests/Bridge/Albert/GPTModelClientTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 #[Small]
 final class GPTModelClientTest extends TestCase
 {
-    public function testConstructorThrowsExceptionForEmptyApiKey(): void
+    public function testConstructorThrowsExceptionForEmptyApiKey()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API key must not be empty.');
@@ -40,7 +40,7 @@ final class GPTModelClientTest extends TestCase
         );
     }
 
-    public function testConstructorThrowsExceptionForEmptyBaseUrl(): void
+    public function testConstructorThrowsExceptionForEmptyBaseUrl()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The base URL must not be empty.');
@@ -52,7 +52,7 @@ final class GPTModelClientTest extends TestCase
         );
     }
 
-    public function testConstructorWrapsHttpClientInEventSourceHttpClient(): void
+    public function testConstructorWrapsHttpClientInEventSourceHttpClient()
     {
         self::expectNotToPerformAssertions();
 
@@ -73,7 +73,7 @@ final class GPTModelClientTest extends TestCase
         $client->request($model, ['messages' => []]);
     }
 
-    public function testConstructorAcceptsEventSourceHttpClient(): void
+    public function testConstructorAcceptsEventSourceHttpClient()
     {
         self::expectNotToPerformAssertions();
 
@@ -94,7 +94,7 @@ final class GPTModelClientTest extends TestCase
         $client->request($model, ['messages' => []]);
     }
 
-    public function testSupportsGPTModel(): void
+    public function testSupportsGPTModel()
     {
         $client = new GPTModelClient(
             new MockHttpClient(),
@@ -106,7 +106,7 @@ final class GPTModelClientTest extends TestCase
         $this->assertTrue($client->supports($gptModel));
     }
 
-    public function testDoesNotSupportNonGPTModel(): void
+    public function testDoesNotSupportNonGPTModel()
     {
         $client = new GPTModelClient(
             new MockHttpClient(),
@@ -119,7 +119,7 @@ final class GPTModelClientTest extends TestCase
     }
 
     #[DataProvider('providePayloadToJson')]
-    public function testRequestSendsCorrectHttpRequest(array|string $payload, array $options, array|string $expectedJson): void
+    public function testRequestSendsCorrectHttpRequest(array|string $payload, array $options, array|string $expectedJson)
     {
         $capturedRequest = null;
         $httpClient = new MockHttpClient(function ($method, $url, $options) use (&$capturedRequest) {
@@ -186,7 +186,7 @@ final class GPTModelClientTest extends TestCase
         ];
     }
 
-    public function testRequestHandlesBaseUrlWithoutTrailingSlash(): void
+    public function testRequestHandlesBaseUrlWithoutTrailingSlash()
     {
         $capturedUrl = null;
         $httpClient = new MockHttpClient(function ($method, $url) use (&$capturedUrl) {
@@ -207,7 +207,7 @@ final class GPTModelClientTest extends TestCase
         $this->assertSame('https://albert.example.com/v1/chat/completions', $capturedUrl);
     }
 
-    public function testRequestHandlesBaseUrlWithTrailingSlash(): void
+    public function testRequestHandlesBaseUrlWithTrailingSlash()
     {
         $capturedUrl = null;
         $httpClient = new MockHttpClient(function ($method, $url) use (&$capturedUrl) {

--- a/src/platform/tests/Bridge/Albert/PlatformFactoryTest.php
+++ b/src/platform/tests/Bridge/Albert/PlatformFactoryTest.php
@@ -23,7 +23,7 @@ use Symfony\AI\Platform\Platform;
 #[Small]
 final class PlatformFactoryTest extends TestCase
 {
-    public function testCreatesPlatformWithCorrectBaseUrl(): void
+    public function testCreatesPlatformWithCorrectBaseUrl()
     {
         $platform = PlatformFactory::create('test-key', 'https://albert.example.com/v1');
 
@@ -31,7 +31,7 @@ final class PlatformFactoryTest extends TestCase
     }
 
     #[DataProvider('provideValidUrls')]
-    public function testHandlesUrlsCorrectly(string $url): void
+    public function testHandlesUrlsCorrectly(string $url)
     {
         $platform = PlatformFactory::create('test-key', $url);
 
@@ -47,7 +47,7 @@ final class PlatformFactoryTest extends TestCase
         yield 'with v99 path' => ['https://albert.example.com/v99'];
     }
 
-    public function testThrowsExceptionForNonHttpsUrl(): void
+    public function testThrowsExceptionForNonHttpsUrl()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The Albert URL must start with "https://".');
@@ -56,7 +56,7 @@ final class PlatformFactoryTest extends TestCase
     }
 
     #[DataProvider('provideUrlsWithTrailingSlash')]
-    public function testThrowsExceptionForUrlsWithTrailingSlash(string $url): void
+    public function testThrowsExceptionForUrlsWithTrailingSlash(string $url)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The Albert URL must not end with a trailing slash.');
@@ -72,7 +72,7 @@ final class PlatformFactoryTest extends TestCase
     }
 
     #[DataProvider('provideUrlsWithoutVersion')]
-    public function testThrowsExceptionForUrlsWithoutVersion(string $url): void
+    public function testThrowsExceptionForUrlsWithoutVersion(string $url)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The Albert URL must include an API version (e.g., /v1, /v2).');

--- a/src/platform/tests/Bridge/Anthropic/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/Anthropic/ResultConverterTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 #[UsesClass(ToolCallResult::class)]
 final class ResultConverterTest extends TestCase
 {
-    public function testConvertThrowsExceptionWhenContentIsToolUseAndLacksText(): void
+    public function testConvertThrowsExceptionWhenContentIsToolUseAndLacksText()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse([
             'content' => [

--- a/src/platform/tests/Bridge/Azure/OpenAI/EmbeddingsModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAI/EmbeddingsModelClientTest.php
@@ -34,7 +34,7 @@ final class EmbeddingsModelClientTest extends TestCase
     #[TestWith(['https://test.azure.com', 'The base URL must not contain the protocol.'])]
     #[TestWith(['http://test.azure.com/path', 'The base URL must not contain the protocol.'])]
     #[TestWith(['https://test.azure.com:443', 'The base URL must not contain the protocol.'])]
-    public function testItThrowsExceptionWhenBaseUrlContainsProtocol(string $invalidUrl, string $expectedMessage): void
+    public function testItThrowsExceptionWhenBaseUrlContainsProtocol(string $invalidUrl, string $expectedMessage)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedMessage);
@@ -42,7 +42,7 @@ final class EmbeddingsModelClientTest extends TestCase
         new EmbeddingsModelClient(new MockHttpClient(), $invalidUrl, 'deployment', 'api-version', 'api-key');
     }
 
-    public function testItThrowsExceptionWhenDeploymentIsEmpty(): void
+    public function testItThrowsExceptionWhenDeploymentIsEmpty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The deployment must not be empty.');
@@ -50,7 +50,7 @@ final class EmbeddingsModelClientTest extends TestCase
         new EmbeddingsModelClient(new MockHttpClient(), 'test.azure.com', '', 'api-version', 'api-key');
     }
 
-    public function testItThrowsExceptionWhenApiVersionIsEmpty(): void
+    public function testItThrowsExceptionWhenApiVersionIsEmpty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API version must not be empty.');
@@ -58,7 +58,7 @@ final class EmbeddingsModelClientTest extends TestCase
         new EmbeddingsModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '', 'api-key');
     }
 
-    public function testItThrowsExceptionWhenApiKeyIsEmpty(): void
+    public function testItThrowsExceptionWhenApiKeyIsEmpty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API key must not be empty.');
@@ -66,21 +66,21 @@ final class EmbeddingsModelClientTest extends TestCase
         new EmbeddingsModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', 'api-version', '');
     }
 
-    public function testItAcceptsValidParameters(): void
+    public function testItAcceptsValidParameters()
     {
         $client = new EmbeddingsModelClient(new MockHttpClient(), 'test.azure.com', 'text-embedding-ada-002', '2023-12-01-preview', 'valid-api-key');
 
         $this->assertInstanceOf(EmbeddingsModelClient::class, $client);
     }
 
-    public function testItIsSupportingTheCorrectModel(): void
+    public function testItIsSupportingTheCorrectModel()
     {
         $client = new EmbeddingsModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '2023-12-01', 'api-key');
 
         $this->assertTrue($client->supports(new Embeddings()));
     }
 
-    public function testItIsExecutingTheCorrectRequest(): void
+    public function testItIsExecutingTheCorrectRequest()
     {
         $resultCallback = static function (string $method, string $url, array $options): MockResponse {
             self::assertSame('POST', $method);

--- a/src/platform/tests/Bridge/Azure/OpenAI/GPTModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAI/GPTModelClientTest.php
@@ -34,7 +34,7 @@ final class GPTModelClientTest extends TestCase
     #[TestWith(['https://test.azure.com', 'The base URL must not contain the protocol.'])]
     #[TestWith(['http://test.azure.com/openai', 'The base URL must not contain the protocol.'])]
     #[TestWith(['https://test.azure.com:443', 'The base URL must not contain the protocol.'])]
-    public function testItThrowsExceptionWhenBaseUrlContainsProtocol(string $invalidUrl, string $expectedMessage): void
+    public function testItThrowsExceptionWhenBaseUrlContainsProtocol(string $invalidUrl, string $expectedMessage)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedMessage);
@@ -42,7 +42,7 @@ final class GPTModelClientTest extends TestCase
         new GPTModelClient(new MockHttpClient(), $invalidUrl, 'deployment', 'api-version', 'api-key');
     }
 
-    public function testItThrowsExceptionWhenDeploymentIsEmpty(): void
+    public function testItThrowsExceptionWhenDeploymentIsEmpty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The deployment must not be empty.');
@@ -50,7 +50,7 @@ final class GPTModelClientTest extends TestCase
         new GPTModelClient(new MockHttpClient(), 'test.azure.com', '', 'api-version', 'api-key');
     }
 
-    public function testItThrowsExceptionWhenApiVersionIsEmpty(): void
+    public function testItThrowsExceptionWhenApiVersionIsEmpty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API version must not be empty.');
@@ -58,7 +58,7 @@ final class GPTModelClientTest extends TestCase
         new GPTModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '', 'api-key');
     }
 
-    public function testItThrowsExceptionWhenApiKeyIsEmpty(): void
+    public function testItThrowsExceptionWhenApiKeyIsEmpty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API key must not be empty.');
@@ -66,21 +66,21 @@ final class GPTModelClientTest extends TestCase
         new GPTModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', 'api-version', '');
     }
 
-    public function testItAcceptsValidParameters(): void
+    public function testItAcceptsValidParameters()
     {
         $client = new GPTModelClient(new MockHttpClient(), 'test.azure.com', 'gpt-35-turbo', '2023-12-01-preview', 'valid-api-key');
 
         $this->assertInstanceOf(GPTModelClient::class, $client);
     }
 
-    public function testItIsSupportingTheCorrectModel(): void
+    public function testItIsSupportingTheCorrectModel()
     {
         $client = new GPTModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '2023-12-01', 'api-key');
 
         $this->assertTrue($client->supports(new GPT()));
     }
 
-    public function testItIsExecutingTheCorrectRequest(): void
+    public function testItIsExecutingTheCorrectRequest()
     {
         $resultCallback = static function (string $method, string $url, array $options): MockResponse {
             self::assertSame('POST', $method);

--- a/src/platform/tests/Bridge/Azure/OpenAI/WhisperModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAI/WhisperModelClientTest.php
@@ -30,7 +30,7 @@ final class WhisperModelClientTest extends TestCase
     #[TestWith(['https://test.azure.com', 'The base URL must not contain the protocol.'])]
     #[TestWith(['http://test.azure.com:8080', 'The base URL must not contain the protocol.'])]
     #[TestWith(['https://test.azure.com:443', 'The base URL must not contain the protocol.'])]
-    public function testItThrowsExceptionWhenBaseUrlContainsProtocol(string $invalidUrl, string $expectedMessage): void
+    public function testItThrowsExceptionWhenBaseUrlContainsProtocol(string $invalidUrl, string $expectedMessage)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedMessage);
@@ -38,7 +38,7 @@ final class WhisperModelClientTest extends TestCase
         new WhisperModelClient(new MockHttpClient(), $invalidUrl, 'deployment', 'api-version', 'api-key');
     }
 
-    public function testItThrowsExceptionWhenDeploymentIsEmpty(): void
+    public function testItThrowsExceptionWhenDeploymentIsEmpty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The deployment must not be empty.');
@@ -46,7 +46,7 @@ final class WhisperModelClientTest extends TestCase
         new WhisperModelClient(new MockHttpClient(), 'test.azure.com', '', 'api-version', 'api-key');
     }
 
-    public function testItThrowsExceptionWhenApiVersionIsEmpty(): void
+    public function testItThrowsExceptionWhenApiVersionIsEmpty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API version must not be empty.');
@@ -54,7 +54,7 @@ final class WhisperModelClientTest extends TestCase
         new WhisperModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '', 'api-key');
     }
 
-    public function testItThrowsExceptionWhenApiKeyIsEmpty(): void
+    public function testItThrowsExceptionWhenApiKeyIsEmpty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API key must not be empty.');
@@ -62,14 +62,14 @@ final class WhisperModelClientTest extends TestCase
         new WhisperModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', 'api-version', '');
     }
 
-    public function testItAcceptsValidParameters(): void
+    public function testItAcceptsValidParameters()
     {
         $client = new WhisperModelClient(new MockHttpClient(), 'test.azure.com', 'valid-deployment', '2023-12-01', 'valid-api-key');
 
         $this->assertInstanceOf(WhisperModelClient::class, $client);
     }
 
-    public function testItSupportsWhisperModel(): void
+    public function testItSupportsWhisperModel()
     {
         $client = new WhisperModelClient(
             new MockHttpClient(),
@@ -83,7 +83,7 @@ final class WhisperModelClientTest extends TestCase
         $this->assertTrue($client->supports($model));
     }
 
-    public function testItUsesTranscriptionEndpointByDefault(): void
+    public function testItUsesTranscriptionEndpointByDefault()
     {
         $httpClient = new MockHttpClient([
             function ($method, $url): MockResponse {
@@ -103,7 +103,7 @@ final class WhisperModelClientTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testItUsesTranscriptionEndpointWhenTaskIsSpecified(): void
+    public function testItUsesTranscriptionEndpointWhenTaskIsSpecified()
     {
         $httpClient = new MockHttpClient([
             function ($method, $url): MockResponse {
@@ -124,7 +124,7 @@ final class WhisperModelClientTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testItUsesTranslationEndpointWhenTaskIsSpecified(): void
+    public function testItUsesTranslationEndpointWhenTaskIsSpecified()
     {
         $httpClient = new MockHttpClient([
             function ($method, $url): MockResponse {

--- a/src/platform/tests/Bridge/Bedrock/Nova/ContractTest.php
+++ b/src/platform/tests/Bridge/Bedrock/Nova/ContractTest.php
@@ -45,7 +45,7 @@ use Symfony\AI\Platform\Result\ToolCall;
 final class ContractTest extends TestCase
 {
     #[DataProvider('provideMessageBag')]
-    public function testConvert(MessageBag $bag, array $expected): void
+    public function testConvert(MessageBag $bag, array $expected)
     {
         $contract = Contract::create(
             new AssistantMessageNormalizer(),

--- a/src/platform/tests/Bridge/Gemini/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/AssistantMessageNormalizerTest.php
@@ -31,7 +31,7 @@ use Symfony\AI\Platform\Result\ToolCall;
 #[UsesClass(ToolCall::class)]
 final class AssistantMessageNormalizerTest extends TestCase
 {
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $normalizer = new AssistantMessageNormalizer();
 
@@ -41,7 +41,7 @@ final class AssistantMessageNormalizerTest extends TestCase
         $this->assertFalse($normalizer->supportsNormalization('not an assistant message'));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $normalizer = new AssistantMessageNormalizer();
 
@@ -49,7 +49,7 @@ final class AssistantMessageNormalizerTest extends TestCase
     }
 
     #[DataProvider('normalizeDataProvider')]
-    public function testNormalize(AssistantMessage $message, array $expectedOutput): void
+    public function testNormalize(AssistantMessage $message, array $expectedOutput)
     {
         $normalizer = new AssistantMessageNormalizer();
 

--- a/src/platform/tests/Bridge/Gemini/Contract/MessageBagNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/MessageBagNormalizerTest.php
@@ -41,7 +41,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 #[UsesClass(AssistantMessage::class)]
 final class MessageBagNormalizerTest extends TestCase
 {
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $normalizer = new MessageBagNormalizer();
 
@@ -51,7 +51,7 @@ final class MessageBagNormalizerTest extends TestCase
         $this->assertFalse($normalizer->supportsNormalization('not a message bag'));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $normalizer = new MessageBagNormalizer();
 
@@ -63,7 +63,7 @@ final class MessageBagNormalizerTest extends TestCase
     }
 
     #[DataProvider('provideMessageBagData')]
-    public function testNormalize(MessageBag $bag, array $expected): void
+    public function testNormalize(MessageBag $bag, array $expected)
     {
         $normalizer = new MessageBagNormalizer();
 

--- a/src/platform/tests/Bridge/Gemini/Contract/ToolCallMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/ToolCallMessageNormalizerTest.php
@@ -31,7 +31,7 @@ use Symfony\AI\Platform\Result\ToolCall;
 #[UsesClass(ToolCall::class)]
 final class ToolCallMessageNormalizerTest extends TestCase
 {
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $normalizer = new ToolCallMessageNormalizer();
 
@@ -41,7 +41,7 @@ final class ToolCallMessageNormalizerTest extends TestCase
         $this->assertFalse($normalizer->supportsNormalization('not a tool call'));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $normalizer = new ToolCallMessageNormalizer();
 
@@ -53,7 +53,7 @@ final class ToolCallMessageNormalizerTest extends TestCase
     }
 
     #[DataProvider('normalizeDataProvider')]
-    public function testNormalize(ToolCallMessage $message, array $expected): void
+    public function testNormalize(ToolCallMessage $message, array $expected)
     {
         $normalizer = new ToolCallMessageNormalizer();
 

--- a/src/platform/tests/Bridge/Gemini/Contract/ToolNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/ToolNormalizerTest.php
@@ -32,7 +32,7 @@ use Symfony\AI\Platform\Tool\Tool;
 #[UsesClass(Tool::class)]
 final class ToolNormalizerTest extends TestCase
 {
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $normalizer = new ToolNormalizer();
 
@@ -42,7 +42,7 @@ final class ToolNormalizerTest extends TestCase
         $this->assertFalse($normalizer->supportsNormalization('not a tool'));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $normalizer = new ToolNormalizer();
 
@@ -54,7 +54,7 @@ final class ToolNormalizerTest extends TestCase
     }
 
     #[DataProvider('normalizeDataProvider')]
-    public function testNormalize(Tool $tool, array $expected): void
+    public function testNormalize(Tool $tool, array $expected)
     {
         $normalizer = new ToolNormalizer();
 

--- a/src/platform/tests/Bridge/Gemini/Contract/UserMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/UserMessageNormalizerTest.php
@@ -37,7 +37,7 @@ use Symfony\AI\Platform\Message\UserMessage;
 #[UsesClass(Audio::class)]
 final class UserMessageNormalizerTest extends TestCase
 {
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $normalizer = new UserMessageNormalizer();
 
@@ -47,14 +47,14 @@ final class UserMessageNormalizerTest extends TestCase
         $this->assertFalse($normalizer->supportsNormalization('not a user message'));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $normalizer = new UserMessageNormalizer();
 
         $this->assertSame([UserMessage::class => true], $normalizer->getSupportedTypes(null));
     }
 
-    public function testNormalizeTextContent(): void
+    public function testNormalizeTextContent()
     {
         $normalizer = new UserMessageNormalizer();
         $message = new UserMessage(new Text('Write a story about a magic backpack.'));
@@ -65,7 +65,7 @@ final class UserMessageNormalizerTest extends TestCase
     }
 
     #[DataProvider('binaryContentProvider')]
-    public function testNormalizeBinaryContent(File $content, string $expectedMimeType, string $expectedPrefix): void
+    public function testNormalizeBinaryContent(File $content, string $expectedMimeType, string $expectedPrefix)
     {
         $normalizer = new UserMessageNormalizer();
         $message = new UserMessage(new Text('Tell me about this instrument'), $content);

--- a/src/platform/tests/Bridge/Gemini/Embeddings/ModelClientTest.php
+++ b/src/platform/tests/Bridge/Gemini/Embeddings/ModelClientTest.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[UsesClass(Embeddings::class)]
 final class ModelClientTest extends TestCase
 {
-    public function testItMakesARequestWithCorrectPayload(): void
+    public function testItMakesARequestWithCorrectPayload()
     {
         $result = $this->createStub(ResponseInterface::class);
         $result

--- a/src/platform/tests/Bridge/Gemini/Embeddings/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/Gemini/Embeddings/ResultConverterTest.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[UsesClass(Embeddings::class)]
 final class ResultConverterTest extends TestCase
 {
-    public function testItConvertsAResponseToAVectorResult(): void
+    public function testItConvertsAResponseToAVectorResult()
     {
         $result = $this->createStub(ResponseInterface::class);
         $result

--- a/src/platform/tests/Bridge/HuggingFace/ModelClientTest.php
+++ b/src/platform/tests/Bridge/HuggingFace/ModelClientTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpClient\MockHttpClient;
 final class ModelClientTest extends TestCase
 {
     #[DataProvider('urlTestCases')]
-    public function testGetUrlForDifferentInputsAndTasks(?string $task, string $expectedUrl): void
+    public function testGetUrlForDifferentInputsAndTasks(?string $task, string $expectedUrl)
     {
         $reflection = new \ReflectionClass(ModelClient::class);
         $getUrlMethod = $reflection->getMethod('getUrl');
@@ -75,7 +75,7 @@ final class ModelClientTest extends TestCase
     }
 
     #[DataProvider('payloadTestCases')]
-    public function testGetPayloadForDifferentInputsAndTasks(object|array|string $input, array $options, array $expectedKeys, array $expectedValues = []): void
+    public function testGetPayloadForDifferentInputsAndTasks(object|array|string $input, array $options, array $expectedKeys, array $expectedValues = [])
     {
         // Contract handling first
         $contract = Contract::create(

--- a/src/platform/tests/Bridge/LMStudio/Completions/ModelClientTest.php
+++ b/src/platform/tests/Bridge/LMStudio/Completions/ModelClientTest.php
@@ -27,14 +27,14 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 #[Small]
 class ModelClientTest extends TestCase
 {
-    public function testItIsSupportingTheCorrectModel(): void
+    public function testItIsSupportingTheCorrectModel()
     {
         $client = new ModelClient(new MockHttpClient(), 'http://localhost:1234');
 
         $this->assertTrue($client->supports(new Completions('test-model')));
     }
 
-    public function testItIsExecutingTheCorrectRequest(): void
+    public function testItIsExecutingTheCorrectRequest()
     {
         $resultCallback = static function (string $method, string $url, array $options): MockResponse {
             self::assertSame('POST', $method);
@@ -60,7 +60,7 @@ class ModelClientTest extends TestCase
         $client->request(new Completions('test-model'), $payload);
     }
 
-    public function testItMergesOptionsWithPayload(): void
+    public function testItMergesOptionsWithPayload()
     {
         $resultCallback = static function (string $method, string $url, array $options): MockResponse {
             self::assertSame('POST', $method);
@@ -86,7 +86,7 @@ class ModelClientTest extends TestCase
         $client->request(new Completions('test-model'), $payload, ['temperature' => 0.7]);
     }
 
-    public function testItUsesEventSourceHttpClient(): void
+    public function testItUsesEventSourceHttpClient()
     {
         $httpClient = new MockHttpClient();
         $client = new ModelClient($httpClient, 'http://localhost:1234');
@@ -97,7 +97,7 @@ class ModelClientTest extends TestCase
         $this->assertInstanceOf(EventSourceHttpClient::class, $reflection->getValue($client));
     }
 
-    public function testItKeepsExistingEventSourceHttpClient(): void
+    public function testItKeepsExistingEventSourceHttpClient()
     {
         $eventSourceHttpClient = new EventSourceHttpClient(new MockHttpClient());
         $client = new ModelClient($eventSourceHttpClient, 'http://localhost:1234');

--- a/src/platform/tests/Bridge/LMStudio/Completions/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/LMStudio/Completions/ResultConverterTest.php
@@ -25,7 +25,7 @@ use Symfony\AI\Platform\Bridge\OpenAI\GPT\ResultConverter as OpenAIResultConvert
 #[Small]
 class ResultConverterTest extends TestCase
 {
-    public function testItSupportsCompletionsModel(): void
+    public function testItSupportsCompletionsModel()
     {
         $converter = new ResultConverter();
 

--- a/src/platform/tests/Bridge/LMStudio/Embeddings/ModelClientTest.php
+++ b/src/platform/tests/Bridge/LMStudio/Embeddings/ModelClientTest.php
@@ -25,14 +25,14 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 #[Small]
 class ModelClientTest extends TestCase
 {
-    public function testItIsSupportingTheCorrectModel(): void
+    public function testItIsSupportingTheCorrectModel()
     {
         $client = new ModelClient(new MockHttpClient(), 'http://localhost:1234');
 
         $this->assertTrue($client->supports(new Embeddings('test-model')));
     }
 
-    public function testItIsExecutingTheCorrectRequest(): void
+    public function testItIsExecutingTheCorrectRequest()
     {
         $resultCallback = static function (string $method, string $url, array $options): MockResponse {
             self::assertSame('POST', $method);
@@ -50,7 +50,7 @@ class ModelClientTest extends TestCase
         $client->request($model, 'Hello, world!');
     }
 
-    public function testItMergesOptionsWithPayload(): void
+    public function testItMergesOptionsWithPayload()
     {
         $resultCallback = static function (string $method, string $url, array $options): MockResponse {
             self::assertSame('POST', $method);
@@ -71,7 +71,7 @@ class ModelClientTest extends TestCase
         $client->request($model, 'Hello, world!', ['custom_option' => 'value']);
     }
 
-    public function testItHandlesArrayInput(): void
+    public function testItHandlesArrayInput()
     {
         $resultCallback = static function (string $method, string $url, array $options): MockResponse {
             self::assertSame('POST', $method);

--- a/src/platform/tests/Bridge/LMStudio/Embeddings/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/LMStudio/Embeddings/ResultConverterTest.php
@@ -30,7 +30,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[UsesClass(Embeddings::class)]
 class ResultConverterTest extends TestCase
 {
-    public function testItConvertsAResponseToAVectorResult(): void
+    public function testItConvertsAResponseToAVectorResult()
     {
         $result = $this->createStub(ResponseInterface::class);
         $result
@@ -67,7 +67,7 @@ class ResultConverterTest extends TestCase
         $this->assertSame([0.0, 0.0, 0.2], $convertedContent[1]->getData());
     }
 
-    public function testItThrowsExceptionWhenResponseDoesNotContainData(): void
+    public function testItThrowsExceptionWhenResponseDoesNotContainData()
     {
         $result = $this->createStub(ResponseInterface::class);
         $result
@@ -80,7 +80,7 @@ class ResultConverterTest extends TestCase
         (new ResultConverter())->convert(new RawHttpResult($result));
     }
 
-    public function testItSupportsEmbeddingsModel(): void
+    public function testItSupportsEmbeddingsModel()
     {
         $converter = new ResultConverter();
 

--- a/src/platform/tests/Bridge/Meta/LlamaPromptConverterTest.php
+++ b/src/platform/tests/Bridge/Meta/LlamaPromptConverterTest.php
@@ -36,7 +36,7 @@ use Symfony\AI\Platform\Message\UserMessage;
 #[UsesClass(UserMessage::class)]
 final class LlamaPromptConverterTest extends TestCase
 {
-    public function testConvertMessages(): void
+    public function testConvertMessages()
     {
         $messageBag = new MessageBag();
         foreach (self::provideMessages() as $message) {
@@ -74,7 +74,7 @@ final class LlamaPromptConverterTest extends TestCase
     }
 
     #[DataProvider('provideMessages')]
-    public function testConvertMessage(string $expected, UserMessage|SystemMessage|AssistantMessage $message): void
+    public function testConvertMessage(string $expected, UserMessage|SystemMessage|AssistantMessage $message)
     {
         $this->assertSame(
             $expected,

--- a/src/platform/tests/Bridge/Mistral/TokenOutputProcessorTest.php
+++ b/src/platform/tests/Bridge/Mistral/TokenOutputProcessorTest.php
@@ -34,7 +34,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[Small]
 final class TokenOutputProcessorTest extends TestCase
 {
-    public function testItHandlesStreamResponsesWithoutProcessing(): void
+    public function testItHandlesStreamResponsesWithoutProcessing()
     {
         $processor = new TokenOutputProcessor();
         $streamResult = new StreamResult((static function () { yield 'test'; })());
@@ -46,7 +46,7 @@ final class TokenOutputProcessorTest extends TestCase
         $this->assertCount(0, $metadata);
     }
 
-    public function testItDoesNothingWithoutRawResponse(): void
+    public function testItDoesNothingWithoutRawResponse()
     {
         $processor = new TokenOutputProcessor();
         $textResult = new TextResult('test');
@@ -58,7 +58,7 @@ final class TokenOutputProcessorTest extends TestCase
         $this->assertCount(0, $metadata);
     }
 
-    public function testItAddsRemainingTokensToMetadata(): void
+    public function testItAddsRemainingTokensToMetadata()
     {
         $processor = new TokenOutputProcessor();
         $textResult = new TextResult('test');
@@ -75,7 +75,7 @@ final class TokenOutputProcessorTest extends TestCase
         $this->assertSame(1000000, $metadata->get('remaining_tokens_month'));
     }
 
-    public function testItAddsUsageTokensToMetadata(): void
+    public function testItAddsUsageTokensToMetadata()
     {
         $processor = new TokenOutputProcessor();
         $textResult = new TextResult('test');
@@ -103,7 +103,7 @@ final class TokenOutputProcessorTest extends TestCase
         $this->assertSame(30, $metadata->get('total_tokens'));
     }
 
-    public function testItHandlesMissingUsageFields(): void
+    public function testItHandlesMissingUsageFields()
     {
         $processor = new TokenOutputProcessor();
         $textResult = new TextResult('test');

--- a/src/platform/tests/Bridge/OpenAI/DallE/Base64ImageTest.php
+++ b/src/platform/tests/Bridge/OpenAI/DallE/Base64ImageTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Bridge\OpenAI\DallE\Base64Image;
 #[Small]
 final class Base64ImageTest extends TestCase
 {
-    public function testItCreatesBase64Image(): void
+    public function testItCreatesBase64Image()
     {
         $emptyPixel = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
         $base64Image = new Base64Image($emptyPixel);
@@ -28,7 +28,7 @@ final class Base64ImageTest extends TestCase
         $this->assertSame($emptyPixel, $base64Image->encodedImage);
     }
 
-    public function testItThrowsExceptionWhenBase64ImageIsEmpty(): void
+    public function testItThrowsExceptionWhenBase64ImageIsEmpty()
     {
         self::expectException(\InvalidArgumentException::class);
         self::expectExceptionMessage('The base64 encoded image generated must be given.');

--- a/src/platform/tests/Bridge/OpenAI/DallE/ImageResultTest.php
+++ b/src/platform/tests/Bridge/OpenAI/DallE/ImageResultTest.php
@@ -25,7 +25,7 @@ use Symfony\AI\Platform\Bridge\OpenAI\DallE\UrlImage;
 #[Small]
 final class ImageResultTest extends TestCase
 {
-    public function testItCreatesImagesResult(): void
+    public function testItCreatesImagesResult()
     {
         $base64Image = new Base64Image('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==');
         $generatedImagesResult = new ImageResult(null, $base64Image);
@@ -35,7 +35,7 @@ final class ImageResultTest extends TestCase
         $this->assertSame($base64Image, $generatedImagesResult->getContent()[0]);
     }
 
-    public function testItCreatesImagesResultWithRevisedPrompt(): void
+    public function testItCreatesImagesResultWithRevisedPrompt()
     {
         $base64Image = new Base64Image('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==');
         $generatedImagesResult = new ImageResult('revised prompt', $base64Image);
@@ -45,7 +45,7 @@ final class ImageResultTest extends TestCase
         $this->assertSame($base64Image, $generatedImagesResult->getContent()[0]);
     }
 
-    public function testItIsCreatableWithMultipleImages(): void
+    public function testItIsCreatableWithMultipleImages()
     {
         $image1 = new UrlImage('https://example');
         $image2 = new UrlImage('https://example2');

--- a/src/platform/tests/Bridge/OpenAI/DallE/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAI/DallE/ModelClientTest.php
@@ -28,7 +28,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
 #[Small]
 final class ModelClientTest extends TestCase
 {
-    public function testItThrowsExceptionWhenApiKeyIsEmpty(): void
+    public function testItThrowsExceptionWhenApiKeyIsEmpty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API key must not be empty.');
@@ -42,7 +42,7 @@ final class ModelClientTest extends TestCase
     #[TestWith(['skapikey'])]
     #[TestWith(['sk api-key'])]
     #[TestWith(['sk'])]
-    public function testItThrowsExceptionWhenApiKeyDoesNotStartWithSk(string $invalidApiKey): void
+    public function testItThrowsExceptionWhenApiKeyDoesNotStartWithSk(string $invalidApiKey)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API key must start with "sk-".');
@@ -50,21 +50,21 @@ final class ModelClientTest extends TestCase
         new ModelClient(new MockHttpClient(), $invalidApiKey);
     }
 
-    public function testItAcceptsValidApiKey(): void
+    public function testItAcceptsValidApiKey()
     {
         $modelClient = new ModelClient(new MockHttpClient(), 'sk-valid-api-key');
 
         $this->assertInstanceOf(ModelClient::class, $modelClient);
     }
 
-    public function testItIsSupportingTheCorrectModel(): void
+    public function testItIsSupportingTheCorrectModel()
     {
         $modelClient = new ModelClient(new MockHttpClient(), 'sk-api-key');
 
         $this->assertTrue($modelClient->supports(new DallE()));
     }
 
-    public function testItIsExecutingTheCorrectRequest(): void
+    public function testItIsExecutingTheCorrectRequest()
     {
         $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
             self::assertSame('POST', $method);

--- a/src/platform/tests/Bridge/OpenAI/DallE/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/OpenAI/DallE/ResultConverterTest.php
@@ -29,7 +29,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
 #[Small]
 final class ResultConverterTest extends TestCase
 {
-    public function testItIsConvertingTheResponse(): void
+    public function testItIsConvertingTheResponse()
     {
         $httpResponse = $this->createStub(HttpResponse::class);
         $httpResponse->method('toArray')->willReturn([
@@ -46,7 +46,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('https://example.com/image.jpg', $result->getContent()[0]->url);
     }
 
-    public function testItIsConvertingTheResponseWithRevisedPrompt(): void
+    public function testItIsConvertingTheResponseWithRevisedPrompt()
     {
         $emptyPixel = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 

--- a/src/platform/tests/Bridge/OpenAI/DallE/UrlImageTest.php
+++ b/src/platform/tests/Bridge/OpenAI/DallE/UrlImageTest.php
@@ -20,14 +20,14 @@ use Symfony\AI\Platform\Bridge\OpenAI\DallE\UrlImage;
 #[Small]
 final class UrlImageTest extends TestCase
 {
-    public function testItCreatesUrlImage(): void
+    public function testItCreatesUrlImage()
     {
         $urlImage = new UrlImage('https://example.com/image.jpg');
 
         $this->assertSame('https://example.com/image.jpg', $urlImage->url);
     }
 
-    public function testItThrowsExceptionWhenUrlIsEmpty(): void
+    public function testItThrowsExceptionWhenUrlIsEmpty()
     {
         self::expectException(\InvalidArgumentException::class);
         self::expectExceptionMessage('The image url must be given.');

--- a/src/platform/tests/Bridge/OpenAI/DallETest.php
+++ b/src/platform/tests/Bridge/OpenAI/DallETest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Bridge\OpenAI\DallE;
 #[Small]
 final class DallETest extends TestCase
 {
-    public function testItCreatesDallEWithDefaultSettings(): void
+    public function testItCreatesDallEWithDefaultSettings()
     {
         $dallE = new DallE();
 
@@ -28,7 +28,7 @@ final class DallETest extends TestCase
         $this->assertSame([], $dallE->getOptions());
     }
 
-    public function testItCreatesDallEWithCustomSettings(): void
+    public function testItCreatesDallEWithCustomSettings()
     {
         $dallE = new DallE(DallE::DALL_E_3, ['response_format' => 'base64', 'n' => 2]);
 

--- a/src/platform/tests/Bridge/OpenAI/Embeddings/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/OpenAI/Embeddings/ResultConverterTest.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[UsesClass(VectorResult::class)]
 class ResultConverterTest extends TestCase
 {
-    public function testItConvertsAResponseToAVectorResult(): void
+    public function testItConvertsAResponseToAVectorResult()
     {
         $result = $this->createStub(ResponseInterface::class);
         $result

--- a/src/platform/tests/Bridge/OpenAI/GPT/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/OpenAI/GPT/ResultConverterTest.php
@@ -36,7 +36,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[UsesClass(ToolCallResult::class)]
 class ResultConverterTest extends TestCase
 {
-    public function testConvertTextResult(): void
+    public function testConvertTextResult()
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -58,7 +58,7 @@ class ResultConverterTest extends TestCase
         $this->assertSame('Hello world', $result->getContent());
     }
 
-    public function testConvertToolCallResult(): void
+    public function testConvertToolCallResult()
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -94,7 +94,7 @@ class ResultConverterTest extends TestCase
         $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->arguments);
     }
 
-    public function testConvertMultipleChoices(): void
+    public function testConvertMultipleChoices()
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -126,7 +126,7 @@ class ResultConverterTest extends TestCase
         $this->assertSame('Choice 2', $choices[1]->getContent());
     }
 
-    public function testContentFilterException(): void
+    public function testContentFilterException()
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -157,7 +157,7 @@ class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
-    public function testThrowsExceptionWhenNoChoices(): void
+    public function testThrowsExceptionWhenNoChoices()
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -169,7 +169,7 @@ class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
-    public function testThrowsExceptionForUnsupportedFinishReason(): void
+    public function testThrowsExceptionForUnsupportedFinishReason()
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);

--- a/src/platform/tests/Bridge/OpenAI/TokenOutputProcessorTest.php
+++ b/src/platform/tests/Bridge/OpenAI/TokenOutputProcessorTest.php
@@ -34,7 +34,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[Small]
 final class TokenOutputProcessorTest extends TestCase
 {
-    public function testItHandlesStreamResponsesWithoutProcessing(): void
+    public function testItHandlesStreamResponsesWithoutProcessing()
     {
         $processor = new TokenOutputProcessor();
         $streamResult = new StreamResult((static function () { yield 'test'; })());
@@ -46,7 +46,7 @@ final class TokenOutputProcessorTest extends TestCase
         $this->assertCount(0, $metadata);
     }
 
-    public function testItDoesNothingWithoutRawResponse(): void
+    public function testItDoesNothingWithoutRawResponse()
     {
         $processor = new TokenOutputProcessor();
         $textResult = new TextResult('test');
@@ -58,7 +58,7 @@ final class TokenOutputProcessorTest extends TestCase
         $this->assertCount(0, $metadata);
     }
 
-    public function testItAddsRemainingTokensToMetadata(): void
+    public function testItAddsRemainingTokensToMetadata()
     {
         $processor = new TokenOutputProcessor();
         $textResult = new TextResult('test');
@@ -74,7 +74,7 @@ final class TokenOutputProcessorTest extends TestCase
         $this->assertSame(1000, $metadata->get('remaining_tokens'));
     }
 
-    public function testItAddsUsageTokensToMetadata(): void
+    public function testItAddsUsageTokensToMetadata()
     {
         $processor = new TokenOutputProcessor();
         $textResult = new TextResult('test');
@@ -101,7 +101,7 @@ final class TokenOutputProcessorTest extends TestCase
         $this->assertSame(30, $metadata->get('total_tokens'));
     }
 
-    public function testItHandlesMissingUsageFields(): void
+    public function testItHandlesMissingUsageFields()
     {
         $processor = new TokenOutputProcessor();
         $textResult = new TextResult('test');

--- a/src/platform/tests/Bridge/OpenAI/Whisper/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAI/Whisper/ModelClientTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 #[Small]
 final class ModelClientTest extends TestCase
 {
-    public function testItSupportsWhisperModel(): void
+    public function testItSupportsWhisperModel()
     {
         $client = new ModelClient(new MockHttpClient(), 'test-key');
         $model = new Whisper();
@@ -32,7 +32,7 @@ final class ModelClientTest extends TestCase
         $this->assertTrue($client->supports($model));
     }
 
-    public function testItUsesTranscriptionEndpointByDefault(): void
+    public function testItUsesTranscriptionEndpointByDefault()
     {
         $httpClient = new MockHttpClient([
             function ($method, $url): MockResponse {
@@ -52,7 +52,7 @@ final class ModelClientTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testItUsesTranscriptionEndpointWhenTaskIsSpecified(): void
+    public function testItUsesTranscriptionEndpointWhenTaskIsSpecified()
     {
         $httpClient = new MockHttpClient([
             function ($method, $url): MockResponse {
@@ -73,7 +73,7 @@ final class ModelClientTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testItUsesTranslationEndpointWhenTaskIsSpecified(): void
+    public function testItUsesTranslationEndpointWhenTaskIsSpecified()
     {
         $httpClient = new MockHttpClient([
             function ($method, $url): MockResponse {

--- a/src/platform/tests/Contract/JsonSchema/Attribute/ToolParameterTest.php
+++ b/src/platform/tests/Contract/JsonSchema/Attribute/ToolParameterTest.php
@@ -19,62 +19,62 @@ use Symfony\AI\Platform\Exception\InvalidArgumentException;
 #[CoversClass(With::class)]
 final class ToolParameterTest extends TestCase
 {
-    public function testValidEnum(): void
+    public function testValidEnum()
     {
         $enum = ['value1', 'value2'];
         $toolParameter = new With(enum: $enum);
         $this->assertSame($enum, $toolParameter->enum);
     }
 
-    public function testInvalidEnumContainsNonString(): void
+    public function testInvalidEnumContainsNonString()
     {
         self::expectException(InvalidArgumentException::class);
         $enum = ['value1', 2];
         new With(enum: $enum);
     }
 
-    public function testValidConstString(): void
+    public function testValidConstString()
     {
         $const = 'constant value';
         $toolParameter = new With(const: $const);
         $this->assertSame($const, $toolParameter->const);
     }
 
-    public function testInvalidConstEmptyString(): void
+    public function testInvalidConstEmptyString()
     {
         self::expectException(InvalidArgumentException::class);
         $const = '   ';
         new With(const: $const);
     }
 
-    public function testValidPattern(): void
+    public function testValidPattern()
     {
         $pattern = '/^[a-z]+$/';
         $toolParameter = new With(pattern: $pattern);
         $this->assertSame($pattern, $toolParameter->pattern);
     }
 
-    public function testInvalidPatternEmptyString(): void
+    public function testInvalidPatternEmptyString()
     {
         self::expectException(InvalidArgumentException::class);
         $pattern = '   ';
         new With(pattern: $pattern);
     }
 
-    public function testValidMinLength(): void
+    public function testValidMinLength()
     {
         $minLength = 5;
         $toolParameter = new With(minLength: $minLength);
         $this->assertSame($minLength, $toolParameter->minLength);
     }
 
-    public function testInvalidMinLengthNegative(): void
+    public function testInvalidMinLengthNegative()
     {
         self::expectException(InvalidArgumentException::class);
         new With(minLength: -1);
     }
 
-    public function testValidMinLengthAndMaxLength(): void
+    public function testValidMinLengthAndMaxLength()
     {
         $minLength = 5;
         $maxLength = 10;
@@ -83,39 +83,39 @@ final class ToolParameterTest extends TestCase
         $this->assertSame($maxLength, $toolParameter->maxLength);
     }
 
-    public function testInvalidMaxLengthLessThanMinLength(): void
+    public function testInvalidMaxLengthLessThanMinLength()
     {
         self::expectException(InvalidArgumentException::class);
         new With(minLength: 10, maxLength: 5);
     }
 
-    public function testValidMinimum(): void
+    public function testValidMinimum()
     {
         $minimum = 0;
         $toolParameter = new With(minimum: $minimum);
         $this->assertSame($minimum, $toolParameter->minimum);
     }
 
-    public function testInvalidMinimumNegative(): void
+    public function testInvalidMinimumNegative()
     {
         self::expectException(InvalidArgumentException::class);
         new With(minimum: -1);
     }
 
-    public function testValidMultipleOf(): void
+    public function testValidMultipleOf()
     {
         $multipleOf = 5;
         $toolParameter = new With(multipleOf: $multipleOf);
         $this->assertSame($multipleOf, $toolParameter->multipleOf);
     }
 
-    public function testInvalidMultipleOfNegative(): void
+    public function testInvalidMultipleOfNegative()
     {
         self::expectException(InvalidArgumentException::class);
         new With(multipleOf: -5);
     }
 
-    public function testValidExclusiveMinimumAndMaximum(): void
+    public function testValidExclusiveMinimumAndMaximum()
     {
         $exclusiveMinimum = 1;
         $exclusiveMaximum = 10;
@@ -124,13 +124,13 @@ final class ToolParameterTest extends TestCase
         $this->assertSame($exclusiveMaximum, $toolParameter->exclusiveMaximum);
     }
 
-    public function testInvalidExclusiveMaximumLessThanExclusiveMinimum(): void
+    public function testInvalidExclusiveMaximumLessThanExclusiveMinimum()
     {
         self::expectException(InvalidArgumentException::class);
         new With(exclusiveMinimum: 10, exclusiveMaximum: 5);
     }
 
-    public function testValidMinItemsAndMaxItems(): void
+    public function testValidMinItemsAndMaxItems()
     {
         $minItems = 1;
         $maxItems = 5;
@@ -139,25 +139,25 @@ final class ToolParameterTest extends TestCase
         $this->assertSame($maxItems, $toolParameter->maxItems);
     }
 
-    public function testInvalidMaxItemsLessThanMinItems(): void
+    public function testInvalidMaxItemsLessThanMinItems()
     {
         self::expectException(InvalidArgumentException::class);
         new With(minItems: 5, maxItems: 1);
     }
 
-    public function testValidUniqueItemsTrue(): void
+    public function testValidUniqueItemsTrue()
     {
         $toolParameter = new With(uniqueItems: true);
         $this->assertTrue($toolParameter->uniqueItems);
     }
 
-    public function testInvalidUniqueItemsFalse(): void
+    public function testInvalidUniqueItemsFalse()
     {
         self::expectException(InvalidArgumentException::class);
         new With(uniqueItems: false);
     }
 
-    public function testValidMinContainsAndMaxContains(): void
+    public function testValidMinContainsAndMaxContains()
     {
         $minContains = 1;
         $maxContains = 3;
@@ -166,19 +166,19 @@ final class ToolParameterTest extends TestCase
         $this->assertSame($maxContains, $toolParameter->maxContains);
     }
 
-    public function testInvalidMaxContainsLessThanMinContains(): void
+    public function testInvalidMaxContainsLessThanMinContains()
     {
         self::expectException(InvalidArgumentException::class);
         new With(minContains: 3, maxContains: 1);
     }
 
-    public function testValidRequired(): void
+    public function testValidRequired()
     {
         $toolParameter = new With(required: true);
         $this->assertTrue($toolParameter->required);
     }
 
-    public function testValidMinPropertiesAndMaxProperties(): void
+    public function testValidMinPropertiesAndMaxProperties()
     {
         $minProperties = 1;
         $maxProperties = 5;
@@ -187,19 +187,19 @@ final class ToolParameterTest extends TestCase
         $this->assertSame($maxProperties, $toolParameter->maxProperties);
     }
 
-    public function testInvalidMaxPropertiesLessThanMinProperties(): void
+    public function testInvalidMaxPropertiesLessThanMinProperties()
     {
         self::expectException(InvalidArgumentException::class);
         new With(minProperties: 5, maxProperties: 1);
     }
 
-    public function testValidDependentRequired(): void
+    public function testValidDependentRequired()
     {
         $toolParameter = new With(dependentRequired: true);
         $this->assertTrue($toolParameter->dependentRequired);
     }
 
-    public function testValidCombination(): void
+    public function testValidCombination()
     {
         $toolParameter = new With(
             enum: ['value1', 'value2'],
@@ -226,7 +226,7 @@ final class ToolParameterTest extends TestCase
         $this->assertInstanceOf(With::class, $toolParameter);
     }
 
-    public function testInvalidCombination(): void
+    public function testInvalidCombination()
     {
         self::expectException(InvalidArgumentException::class);
         new With(minLength: -1, maxLength: -2);

--- a/src/platform/tests/Contract/JsonSchema/DescriptionParserTest.php
+++ b/src/platform/tests/Contract/JsonSchema/DescriptionParserTest.php
@@ -23,7 +23,7 @@ use Symfony\AI\Platform\Contract\JsonSchema\DescriptionParser;
 #[CoversClass(DescriptionParser::class)]
 final class DescriptionParserTest extends TestCase
 {
-    public function testFromPropertyWithoutDocBlock(): void
+    public function testFromPropertyWithoutDocBlock()
     {
         $property = new \ReflectionProperty(User::class, 'id');
 
@@ -32,7 +32,7 @@ final class DescriptionParserTest extends TestCase
         $this->assertSame('', $actual);
     }
 
-    public function testFromPropertyWithDocBlock(): void
+    public function testFromPropertyWithDocBlock()
     {
         $property = new \ReflectionProperty(User::class, 'name');
 
@@ -41,7 +41,7 @@ final class DescriptionParserTest extends TestCase
         $this->assertSame('The name of the user in lowercase', $actual);
     }
 
-    public function testFromPropertyWithConstructorDocBlock(): void
+    public function testFromPropertyWithConstructorDocBlock()
     {
         $property = new \ReflectionProperty(UserWithConstructor::class, 'name');
 
@@ -50,7 +50,7 @@ final class DescriptionParserTest extends TestCase
         $this->assertSame('The name of the user in lowercase', $actual);
     }
 
-    public function testFromParameterWithoutDocBlock(): void
+    public function testFromParameterWithoutDocBlock()
     {
         $parameter = new \ReflectionParameter([ToolWithoutDocs::class, 'bar'], 'text');
 
@@ -59,7 +59,7 @@ final class DescriptionParserTest extends TestCase
         $this->assertSame('', $actual);
     }
 
-    public function testFromParameterWithDocBlock(): void
+    public function testFromParameterWithDocBlock()
     {
         $parameter = new \ReflectionParameter([ToolRequiredParams::class, 'bar'], 'text');
 
@@ -69,7 +69,7 @@ final class DescriptionParserTest extends TestCase
     }
 
     #[DataProvider('provideMethodDescriptionCases')]
-    public function testFromParameterWithDocs(string $comment, string $expected): void
+    public function testFromParameterWithDocs(string $comment, string $expected)
     {
         $method = self::createMock(\ReflectionMethod::class);
         $method->method('getDocComment')->willReturn($comment);

--- a/src/platform/tests/Contract/JsonSchema/FactoryTest.php
+++ b/src/platform/tests/Contract/JsonSchema/FactoryTest.php
@@ -42,7 +42,7 @@ final class FactoryTest extends TestCase
         unset($this->factory);
     }
 
-    public function testBuildParametersDefinitionRequired(): void
+    public function testBuildParametersDefinitionRequired()
     {
         $actual = $this->factory->buildParameters(ToolRequiredParams::class, 'bar');
         $expected = [
@@ -64,7 +64,7 @@ final class FactoryTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testBuildParametersDefinitionRequiredWithAdditionalToolParameterAttribute(): void
+    public function testBuildParametersDefinitionRequiredWithAdditionalToolParameterAttribute()
     {
         $actual = $this->factory->buildParameters(ToolWithToolParameterAttribute::class, '__invoke');
         $expected = [
@@ -141,7 +141,7 @@ final class FactoryTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testBuildParametersDefinitionOptional(): void
+    public function testBuildParametersDefinitionOptional()
     {
         $actual = $this->factory->buildParameters(ToolOptionalParam::class, 'bar');
         $expected = [
@@ -163,14 +163,14 @@ final class FactoryTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testBuildParametersDefinitionNone(): void
+    public function testBuildParametersDefinitionNone()
     {
         $actual = $this->factory->buildParameters(ToolNoParams::class, '__invoke');
 
         $this->assertNull($actual);
     }
 
-    public function testBuildPropertiesForUserClass(): void
+    public function testBuildPropertiesForUserClass()
     {
         $expected = [
             'type' => 'object',
@@ -196,7 +196,7 @@ final class FactoryTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testBuildPropertiesForMathReasoningClass(): void
+    public function testBuildPropertiesForMathReasoningClass()
     {
         $expected = [
             'type' => 'object',
@@ -224,7 +224,7 @@ final class FactoryTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testBuildPropertiesForStepClass(): void
+    public function testBuildPropertiesForStepClass()
     {
         $expected = [
             'type' => 'object',

--- a/src/platform/tests/Contract/Normalizer/Message/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/AssistantMessageNormalizerTest.php
@@ -31,18 +31,18 @@ final class AssistantMessageNormalizerTest extends TestCase
         $this->normalizer = new AssistantMessageNormalizer();
     }
 
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $this->assertTrue($this->normalizer->supportsNormalization(new AssistantMessage('content')));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $this->assertSame([AssistantMessage::class => true], $this->normalizer->getSupportedTypes(null));
     }
 
-    public function testNormalizeWithContent(): void
+    public function testNormalizeWithContent()
     {
         $message = new AssistantMessage('I am an assistant');
 
@@ -54,7 +54,7 @@ final class AssistantMessageNormalizerTest extends TestCase
         $this->assertSame($expected, $this->normalizer->normalize($message));
     }
 
-    public function testNormalizeWithToolCalls(): void
+    public function testNormalizeWithToolCalls()
     {
         $toolCalls = [
             new ToolCall('id1', 'function1', ['param' => 'value']),
@@ -84,7 +84,7 @@ final class AssistantMessageNormalizerTest extends TestCase
         $this->assertSame($expected, $this->normalizer->normalize($message));
     }
 
-    public function testNormalizeWithNullContent(): void
+    public function testNormalizeWithNullContent()
     {
         $toolCalls = [new ToolCall('id1', 'function1', ['param' => 'value'])];
         $message = new AssistantMessage(null, $toolCalls);

--- a/src/platform/tests/Contract/Normalizer/Message/Content/AudioNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/AudioNormalizerTest.php
@@ -31,19 +31,19 @@ final class AudioNormalizerTest extends TestCase
         $this->normalizer = new AudioNormalizer();
     }
 
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $this->assertTrue($this->normalizer->supportsNormalization(Audio::fromFile(\dirname(__DIR__, 7).'/fixtures/audio.mp3')));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $this->assertSame([Audio::class => true], $this->normalizer->getSupportedTypes(null));
     }
 
     #[DataProvider('provideAudioData')]
-    public function testNormalize(string $data, string $format, array $expected): void
+    public function testNormalize(string $data, string $format, array $expected)
     {
         $audio = new Audio(base64_decode($data), $format);
 

--- a/src/platform/tests/Contract/Normalizer/Message/Content/ImageNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/ImageNormalizerTest.php
@@ -30,18 +30,18 @@ final class ImageNormalizerTest extends TestCase
         $this->normalizer = new ImageNormalizer();
     }
 
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $this->assertTrue($this->normalizer->supportsNormalization(Image::fromFile(\dirname(__DIR__, 7).'/fixtures/image.jpg')));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $this->assertSame([Image::class => true], $this->normalizer->getSupportedTypes(null));
     }
 
-    public function testNormalize(): void
+    public function testNormalize()
     {
         $image = Image::fromDataUrl('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABKklEQVR42mNk+A8AAwMhIv9n+Q==');
 

--- a/src/platform/tests/Contract/Normalizer/Message/Content/ImageUrlNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/ImageUrlNormalizerTest.php
@@ -28,18 +28,18 @@ final class ImageUrlNormalizerTest extends TestCase
         $this->normalizer = new ImageUrlNormalizer();
     }
 
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $this->assertTrue($this->normalizer->supportsNormalization(new ImageUrl('https://example.com/image.jpg')));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $this->assertSame([ImageUrl::class => true], $this->normalizer->getSupportedTypes(null));
     }
 
-    public function testNormalize(): void
+    public function testNormalize()
     {
         $imageUrl = new ImageUrl('https://example.com/image.jpg');
 

--- a/src/platform/tests/Contract/Normalizer/Message/Content/TextNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/TextNormalizerTest.php
@@ -28,18 +28,18 @@ final class TextNormalizerTest extends TestCase
         $this->normalizer = new TextNormalizer();
     }
 
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $this->assertTrue($this->normalizer->supportsNormalization(new Text('Hello, world!')));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $this->assertSame([Text::class => true], $this->normalizer->getSupportedTypes(null));
     }
 
-    public function testNormalize(): void
+    public function testNormalize()
     {
         $text = new Text('Hello, world!');
 

--- a/src/platform/tests/Contract/Normalizer/Message/MessageBagNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/MessageBagNormalizerTest.php
@@ -41,7 +41,7 @@ final class MessageBagNormalizerTest extends TestCase
         $this->normalizer = new MessageBagNormalizer();
     }
 
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $messageBag = $this->createMock(MessageBagInterface::class);
 
@@ -49,12 +49,12 @@ final class MessageBagNormalizerTest extends TestCase
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $this->assertSame([MessageBagInterface::class => true], $this->normalizer->getSupportedTypes(null));
     }
 
-    public function testNormalizeWithoutModel(): void
+    public function testNormalizeWithoutModel()
     {
         $messages = [
             new SystemMessage('You are a helpful assistant'),
@@ -84,7 +84,7 @@ final class MessageBagNormalizerTest extends TestCase
         $this->assertSame($expected, $this->normalizer->normalize($messageBag));
     }
 
-    public function testNormalizeWithModel(): void
+    public function testNormalizeWithModel()
     {
         $messages = [
             new SystemMessage('You are a helpful assistant'),

--- a/src/platform/tests/Contract/Normalizer/Message/SystemMessageNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/SystemMessageNormalizerTest.php
@@ -28,18 +28,18 @@ final class SystemMessageNormalizerTest extends TestCase
         $this->normalizer = new SystemMessageNormalizer();
     }
 
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $this->assertTrue($this->normalizer->supportsNormalization(new SystemMessage('content')));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $this->assertSame([SystemMessage::class => true], $this->normalizer->getSupportedTypes(null));
     }
 
-    public function testNormalize(): void
+    public function testNormalize()
     {
         $message = new SystemMessage('You are a helpful assistant');
 

--- a/src/platform/tests/Contract/Normalizer/Message/ToolCallMessageNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/ToolCallMessageNormalizerTest.php
@@ -31,7 +31,7 @@ final class ToolCallMessageNormalizerTest extends TestCase
         $this->normalizer = new ToolCallMessageNormalizer();
     }
 
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $toolCallMessage = new ToolCallMessage(new ToolCall('id', 'function'), 'content');
 
@@ -39,12 +39,12 @@ final class ToolCallMessageNormalizerTest extends TestCase
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $this->assertSame([ToolCallMessage::class => true], $this->normalizer->getSupportedTypes(null));
     }
 
-    public function testNormalize(): void
+    public function testNormalize()
     {
         $toolCall = new ToolCall('tool_call_123', 'get_weather', ['location' => 'Paris']);
         $message = new ToolCallMessage($toolCall, 'Weather data for Paris');

--- a/src/platform/tests/Contract/Normalizer/Message/UserMessageNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/UserMessageNormalizerTest.php
@@ -33,18 +33,18 @@ final class UserMessageNormalizerTest extends TestCase
         $this->normalizer = new UserMessageNormalizer();
     }
 
-    public function testSupportsNormalization(): void
+    public function testSupportsNormalization()
     {
         $this->assertTrue($this->normalizer->supportsNormalization(new UserMessage(new Text('content'))));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 
-    public function testGetSupportedTypes(): void
+    public function testGetSupportedTypes()
     {
         $this->assertSame([UserMessage::class => true], $this->normalizer->getSupportedTypes(null));
     }
 
-    public function testNormalizeWithSingleTextContent(): void
+    public function testNormalizeWithSingleTextContent()
     {
         $textContent = new Text('Hello, how can you help me?');
         $message = new UserMessage($textContent);
@@ -57,7 +57,7 @@ final class UserMessageNormalizerTest extends TestCase
         $this->assertSame($expected, $this->normalizer->normalize($message));
     }
 
-    public function testNormalizeWithMixedContent(): void
+    public function testNormalizeWithMixedContent()
     {
         $textContent = new Text('Please describe this image:');
         $imageContent = new ImageUrl('https://example.com/image.jpg');

--- a/src/platform/tests/Contract/Normalizer/ToolNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/ToolNormalizerTest.php
@@ -28,7 +28,7 @@ use Symfony\AI\Platform\Tool\Tool;
 class ToolNormalizerTest extends TestCase
 {
     #[DataProvider('provideTools')]
-    public function testNormalize(Tool $tool, array $expected): void
+    public function testNormalize(Tool $tool, array $expected)
     {
         $this->assertSame($expected, (new ToolNormalizer())->normalize($tool));
     }

--- a/src/platform/tests/ContractTest.php
+++ b/src/platform/tests/ContractTest.php
@@ -65,7 +65,7 @@ use Symfony\Component\Uid\Uuid;
 final class ContractTest extends TestCase
 {
     #[DataProvider('providePayloadTestCases')]
-    public function testCreateRequestPayload(Model $model, array|string|object $input, array|string $expected): void
+    public function testCreateRequestPayload(Model $model, array|string|object $input, array|string $expected)
     {
         $contract = Contract::create();
 
@@ -234,7 +234,7 @@ final class ContractTest extends TestCase
         ];
     }
 
-    public function testExtendedContractHandlesWhisper(): void
+    public function testExtendedContractHandlesWhisper()
     {
         $contract = Contract::create(new AudioNormalizer());
 

--- a/src/platform/tests/InMemoryPlatformTest.php
+++ b/src/platform/tests/InMemoryPlatformTest.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Model;
 #[CoversClass(InMemoryPlatform::class)]
 class InMemoryPlatformTest extends TestCase
 {
-    public function testPlatformInvokeWithFixedResult(): void
+    public function testPlatformInvokeWithFixedResult()
     {
         $platform = new InMemoryPlatform('Mocked result');
         $result = $platform->invoke(new Model('test'), 'input');
@@ -27,7 +27,7 @@ class InMemoryPlatformTest extends TestCase
         $this->assertSame(['text' => 'Mocked result'], $result->getRawResult()->getData());
     }
 
-    public function testPlatformInvokeWithCallableResult(): void
+    public function testPlatformInvokeWithCallableResult()
     {
         $platform = new InMemoryPlatform(function (Model $model, $input) {
             return strtoupper((string) $input);

--- a/src/platform/tests/Message/AssistantMessageTest.php
+++ b/src/platform/tests/Message/AssistantMessageTest.php
@@ -30,12 +30,12 @@ final class AssistantMessageTest extends TestCase
 {
     use UuidAssertionTrait;
 
-    public function testTheRoleOfTheMessageIsAsExpected(): void
+    public function testTheRoleOfTheMessageIsAsExpected()
     {
         $this->assertSame(Role::Assistant, (new AssistantMessage())->getRole());
     }
 
-    public function testConstructionWithoutToolCallIsPossible(): void
+    public function testConstructionWithoutToolCallIsPossible()
     {
         $message = new AssistantMessage('foo');
 
@@ -43,7 +43,7 @@ final class AssistantMessageTest extends TestCase
         $this->assertNull($message->toolCalls);
     }
 
-    public function testConstructionWithoutContentIsPossible(): void
+    public function testConstructionWithoutContentIsPossible()
     {
         $toolCall = new ToolCall('foo', 'foo');
         $message = new AssistantMessage(toolCalls: [$toolCall]);
@@ -53,7 +53,7 @@ final class AssistantMessageTest extends TestCase
         $this->assertTrue($message->hasToolCalls());
     }
 
-    public function testMessageHasUid(): void
+    public function testMessageHasUid()
     {
         $message = new AssistantMessage('foo');
 
@@ -62,7 +62,7 @@ final class AssistantMessageTest extends TestCase
         $this->assertSame($message->id, $message->getId());
     }
 
-    public function testDifferentMessagesHaveDifferentUids(): void
+    public function testDifferentMessagesHaveDifferentUids()
     {
         $message1 = new AssistantMessage('foo');
         $message2 = new AssistantMessage('bar');
@@ -72,7 +72,7 @@ final class AssistantMessageTest extends TestCase
         self::assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
-    public function testSameMessagesHaveDifferentUids(): void
+    public function testSameMessagesHaveDifferentUids()
     {
         $message1 = new AssistantMessage('foo');
         $message2 = new AssistantMessage('foo');
@@ -82,7 +82,7 @@ final class AssistantMessageTest extends TestCase
         self::assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
-    public function testMessageIdImplementsRequiredInterfaces(): void
+    public function testMessageIdImplementsRequiredInterfaces()
     {
         $message = new AssistantMessage('test');
 

--- a/src/platform/tests/Message/Content/AudioTest.php
+++ b/src/platform/tests/Message/Content/AudioTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Message\Content\Audio;
 #[Small]
 final class AudioTest extends TestCase
 {
-    public function testConstructWithValidData(): void
+    public function testConstructWithValidData()
     {
         $audio = new Audio('somedata', 'audio/mpeg');
 
@@ -28,7 +28,7 @@ final class AudioTest extends TestCase
         $this->assertSame('audio/mpeg', $audio->getFormat());
     }
 
-    public function testFromDataUrlWithValidUrl(): void
+    public function testFromDataUrlWithValidUrl()
     {
         $dataUrl = 'data:audio/mpeg;base64,SUQzBAAAAAAAfVREUkMAAAAMAAADMg==';
         $audio = Audio::fromDataUrl($dataUrl);
@@ -37,7 +37,7 @@ final class AudioTest extends TestCase
         $this->assertSame('audio/mpeg', $audio->getFormat());
     }
 
-    public function testFromDataUrlWithInvalidUrl(): void
+    public function testFromDataUrlWithInvalidUrl()
     {
         self::expectException(\InvalidArgumentException::class);
         self::expectExceptionMessage('Invalid audio data URL format.');
@@ -45,7 +45,7 @@ final class AudioTest extends TestCase
         Audio::fromDataUrl('invalid-url');
     }
 
-    public function testFromFileWithValidPath(): void
+    public function testFromFileWithValidPath()
     {
         $audio = Audio::fromFile(\dirname(__DIR__, 5).'/fixtures/audio.mp3');
 
@@ -53,7 +53,7 @@ final class AudioTest extends TestCase
         $this->assertNotEmpty($audio->asBinary());
     }
 
-    public function testFromFileWithInvalidPath(): void
+    public function testFromFileWithInvalidPath()
     {
         self::expectException(\InvalidArgumentException::class);
         self::expectExceptionMessage('The file "foo.mp3" does not exist or is not readable.');

--- a/src/platform/tests/Message/Content/BinaryTest.php
+++ b/src/platform/tests/Message/Content/BinaryTest.php
@@ -22,7 +22,7 @@ use Symfony\AI\Platform\Message\Content\File;
 #[Small]
 final class BinaryTest extends TestCase
 {
-    public function testCreateFromDataUrl(): void
+    public function testCreateFromDataUrl()
     {
         $dataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
 
@@ -33,7 +33,7 @@ final class BinaryTest extends TestCase
         $this->assertSame('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', $binary->asBase64());
     }
 
-    public function testThrowsExceptionForInvalidDataUrl(): void
+    public function testThrowsExceptionForInvalidDataUrl()
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('Invalid audio data URL format.');
@@ -41,7 +41,7 @@ final class BinaryTest extends TestCase
         File::fromDataUrl('invalid-data-url');
     }
 
-    public function testCreateFromFile(): void
+    public function testCreateFromFile()
     {
         $content = 'test file content';
         $filename = sys_get_temp_dir().'/binary-test-file.txt';
@@ -58,7 +58,7 @@ final class BinaryTest extends TestCase
     }
 
     #[DataProvider('provideExistingFiles')]
-    public function testCreateFromExistingFiles(string $filePath, string $expectedFormat): void
+    public function testCreateFromExistingFiles(string $filePath, string $expectedFormat)
     {
         $binary = File::fromFile($filePath);
 
@@ -75,14 +75,14 @@ final class BinaryTest extends TestCase
         yield 'jpg' => [\dirname(__DIR__, 5).'/fixtures/image.jpg', 'image/jpeg'];
     }
 
-    public function testThrowsExceptionForNonExistentFile(): void
+    public function testThrowsExceptionForNonExistentFile()
     {
         self::expectException(\InvalidArgumentException::class);
 
         File::fromFile('/non/existent/file.jpg');
     }
 
-    public function testConvertToDataUrl(): void
+    public function testConvertToDataUrl()
     {
         $data = 'Hello World';
         $format = 'text/plain';
@@ -93,7 +93,7 @@ final class BinaryTest extends TestCase
         $this->assertSame('data:text/plain;base64,'.base64_encode($data), $dataUrl);
     }
 
-    public function testRoundTripConversion(): void
+    public function testRoundTripConversion()
     {
         $originalDataUrl = 'data:application/pdf;base64,JVBERi0xLjQKJcfsj6IKNSAwIG9iago8PC9MZW5ndGggNiAwIFIvRmls';
 

--- a/src/platform/tests/Message/Content/ImageTest.php
+++ b/src/platform/tests/Message/Content/ImageTest.php
@@ -18,21 +18,21 @@ use Symfony\AI\Platform\Message\Content\Image;
 #[CoversClass(Image::class)]
 final class ImageTest extends TestCase
 {
-    public function testConstructWithValidDataUrl(): void
+    public function testConstructWithValidDataUrl()
     {
         $image = Image::fromDataUrl('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABKklEQVR42mNk+A8AAwMhIv9n+X');
 
         $this->assertStringStartsWith('data:image/png;base64', $image->asDataUrl());
     }
 
-    public function testWithValidFile(): void
+    public function testWithValidFile()
     {
         $image = Image::fromFile(\dirname(__DIR__, 5).'/fixtures/image.jpg');
 
         $this->assertStringStartsWith('data:image/jpeg;base64,', $image->asDataUrl());
     }
 
-    public function testFromBinaryWithInvalidFile(): void
+    public function testFromBinaryWithInvalidFile()
     {
         self::expectExceptionMessage('The file "foo.jpg" does not exist or is not readable.');
 

--- a/src/platform/tests/Message/Content/ImageUrlTest.php
+++ b/src/platform/tests/Message/Content/ImageUrlTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Message\Content\ImageUrl;
 #[Small]
 final class ImageUrlTest extends TestCase
 {
-    public function testConstructWithValidUrl(): void
+    public function testConstructWithValidUrl()
     {
         $image = new ImageUrl('https://foo.com/test.png');
 

--- a/src/platform/tests/Message/Content/TextTest.php
+++ b/src/platform/tests/Message/Content/TextTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Message\Content\Text;
 #[Small]
 final class TextTest extends TestCase
 {
-    public function testConstructionIsPossible(): void
+    public function testConstructionIsPossible()
     {
         $obj = new Text('foo');
 

--- a/src/platform/tests/Message/MessageBagTest.php
+++ b/src/platform/tests/Message/MessageBagTest.php
@@ -37,7 +37,7 @@ use Symfony\AI\Platform\Result\ToolCall;
 #[Small]
 final class MessageBagTest extends TestCase
 {
-    public function testGetSystemMessage(): void
+    public function testGetSystemMessage()
     {
         $messageBag = new MessageBag(
             Message::forSystem('My amazing system prompt.'),
@@ -51,7 +51,7 @@ final class MessageBagTest extends TestCase
         $this->assertSame('My amazing system prompt.', $systemMessage->content);
     }
 
-    public function testGetSystemMessageWithoutSystemMessage(): void
+    public function testGetSystemMessageWithoutSystemMessage()
     {
         $messageBag = new MessageBag(
             Message::ofAssistant('It is time to sleep.'),
@@ -62,7 +62,7 @@ final class MessageBagTest extends TestCase
         $this->assertNull($messageBag->getSystemMessage());
     }
 
-    public function testWith(): void
+    public function testWith()
     {
         $messageBag = new MessageBag(
             Message::forSystem('My amazing system prompt.'),
@@ -82,7 +82,7 @@ final class MessageBagTest extends TestCase
         $this->assertSame('It is time to wake up.', $newMessageFromBag->content);
     }
 
-    public function testMerge(): void
+    public function testMerge()
     {
         $messageBag = new MessageBag(
             Message::forSystem('My amazing system prompt.'),
@@ -102,7 +102,7 @@ final class MessageBagTest extends TestCase
         $this->assertSame('It is time to wake up.', $messageFromBag->content);
     }
 
-    public function testWithoutSystemMessage(): void
+    public function testWithoutSystemMessage()
     {
         $messageBag = new MessageBag(
             Message::forSystem('My amazing system prompt.'),
@@ -127,7 +127,7 @@ final class MessageBagTest extends TestCase
         $this->assertSame('Hello, world!', $userMessage->content[0]->text);
     }
 
-    public function testPrepend(): void
+    public function testPrepend()
     {
         $messageBag = new MessageBag(
             Message::ofAssistant('It is time to sleep.'),
@@ -146,7 +146,7 @@ final class MessageBagTest extends TestCase
         $this->assertSame('My amazing system prompt.', $newMessageBagMessage->content);
     }
 
-    public function testContainsImageReturnsFalseWithoutImage(): void
+    public function testContainsImageReturnsFalseWithoutImage()
     {
         $messageBag = new MessageBag(
             Message::ofAssistant('It is time to sleep.'),
@@ -156,7 +156,7 @@ final class MessageBagTest extends TestCase
         $this->assertFalse($messageBag->containsImage());
     }
 
-    public function testContainsImageReturnsTrueWithImage(): void
+    public function testContainsImageReturnsTrueWithImage()
     {
         $messageBag = new MessageBag(
             Message::ofAssistant('It is time to sleep.'),

--- a/src/platform/tests/Message/MessageTest.php
+++ b/src/platform/tests/Message/MessageTest.php
@@ -38,14 +38,14 @@ use Symfony\AI\Platform\Result\ToolCall;
 #[Small]
 final class MessageTest extends TestCase
 {
-    public function testCreateSystemMessageWithString(): void
+    public function testCreateSystemMessageWithString()
     {
         $message = Message::forSystem('My amazing system prompt.');
 
         $this->assertSame('My amazing system prompt.', $message->content);
     }
 
-    public function testCreateSystemMessageWithStringable(): void
+    public function testCreateSystemMessageWithStringable()
     {
         $message = Message::forSystem(new class implements \Stringable {
             public function __toString(): string
@@ -57,14 +57,14 @@ final class MessageTest extends TestCase
         $this->assertSame('My amazing system prompt.', $message->content);
     }
 
-    public function testCreateAssistantMessage(): void
+    public function testCreateAssistantMessage()
     {
         $message = Message::ofAssistant('It is time to sleep.');
 
         $this->assertSame('It is time to sleep.', $message->content);
     }
 
-    public function testCreateAssistantMessageWithToolCalls(): void
+    public function testCreateAssistantMessageWithToolCalls()
     {
         $toolCalls = [
             new ToolCall('call_123456', 'my_tool', ['foo' => 'bar']),
@@ -76,7 +76,7 @@ final class MessageTest extends TestCase
         $this->assertTrue($message->hasToolCalls());
     }
 
-    public function testCreateUserMessageWithString(): void
+    public function testCreateUserMessageWithString()
     {
         $message = Message::ofUser('Hi, my name is John.');
 
@@ -85,7 +85,7 @@ final class MessageTest extends TestCase
         $this->assertSame('Hi, my name is John.', $message->content[0]->text);
     }
 
-    public function testCreateUserMessageWithStringable(): void
+    public function testCreateUserMessageWithStringable()
     {
         $message = Message::ofUser(new class implements \Stringable {
             public function __toString(): string
@@ -99,7 +99,7 @@ final class MessageTest extends TestCase
         $this->assertSame('Hi, my name is John.', $message->content[0]->text);
     }
 
-    public function testCreateUserMessageContentInterfaceImplementingStringable(): void
+    public function testCreateUserMessageContentInterfaceImplementingStringable()
     {
         $message = Message::ofUser(new class implements ContentInterface, \Stringable {
             public function __toString(): string
@@ -112,7 +112,7 @@ final class MessageTest extends TestCase
         $this->assertInstanceOf(ContentInterface::class, $message->content[0]);
     }
 
-    public function testCreateUserMessageWithTextContent(): void
+    public function testCreateUserMessageWithTextContent()
     {
         $text = new Text('Hi, my name is John.');
         $message = Message::ofUser($text);
@@ -120,7 +120,7 @@ final class MessageTest extends TestCase
         $this->assertSame([$text], $message->content);
     }
 
-    public function testCreateUserMessageWithImages(): void
+    public function testCreateUserMessageWithImages()
     {
         $message = Message::ofUser(
             new Text('Hi, my name is John.'),
@@ -132,7 +132,7 @@ final class MessageTest extends TestCase
         $this->assertCount(4, $message->content);
     }
 
-    public function testCreateToolCallMessage(): void
+    public function testCreateToolCallMessage()
     {
         $toolCall = new ToolCall('call_123456', 'my_tool', ['foo' => 'bar']);
         $message = Message::ofToolCall($toolCall, 'Foo bar.');

--- a/src/platform/tests/Message/RoleTest.php
+++ b/src/platform/tests/Message/RoleTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Message\Role;
 #[Small]
 final class RoleTest extends TestCase
 {
-    public function testValues(): void
+    public function testValues()
     {
         $this->assertSame('system', Role::System->value);
         $this->assertSame('assistant', Role::Assistant->value);
@@ -28,22 +28,22 @@ final class RoleTest extends TestCase
         $this->assertSame('tool', Role::ToolCall->value);
     }
 
-    public function testEquals(): void
+    public function testEquals()
     {
         $this->assertTrue(Role::System->equals(Role::System));
     }
 
-    public function testNotEquals(): void
+    public function testNotEquals()
     {
         $this->assertTrue(Role::System->notEquals(Role::Assistant));
     }
 
-    public function testNotEqualsOneOf(): void
+    public function testNotEqualsOneOf()
     {
         $this->assertTrue(Role::System->notEqualsOneOf([Role::Assistant, Role::User]));
     }
 
-    public function testEqualsOneOf(): void
+    public function testEqualsOneOf()
     {
         $this->assertTrue(Role::System->equalsOneOf([Role::System, Role::User]));
     }

--- a/src/platform/tests/Message/SystemMessageTest.php
+++ b/src/platform/tests/Message/SystemMessageTest.php
@@ -27,7 +27,7 @@ final class SystemMessageTest extends TestCase
 {
     use UuidAssertionTrait;
 
-    public function testConstructionIsPossible(): void
+    public function testConstructionIsPossible()
     {
         $message = new SystemMessage('foo');
 
@@ -35,7 +35,7 @@ final class SystemMessageTest extends TestCase
         $this->assertSame('foo', $message->content);
     }
 
-    public function testMessageHasUid(): void
+    public function testMessageHasUid()
     {
         $message = new SystemMessage('foo');
 
@@ -44,7 +44,7 @@ final class SystemMessageTest extends TestCase
         $this->assertSame($message->id, $message->getId());
     }
 
-    public function testDifferentMessagesHaveDifferentUids(): void
+    public function testDifferentMessagesHaveDifferentUids()
     {
         $message1 = new SystemMessage('foo');
         $message2 = new SystemMessage('bar');
@@ -54,7 +54,7 @@ final class SystemMessageTest extends TestCase
         self::assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
-    public function testSameMessagesHaveDifferentUids(): void
+    public function testSameMessagesHaveDifferentUids()
     {
         $message1 = new SystemMessage('foo');
         $message2 = new SystemMessage('foo');
@@ -64,7 +64,7 @@ final class SystemMessageTest extends TestCase
         self::assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
-    public function testMessageIdImplementsRequiredInterfaces(): void
+    public function testMessageIdImplementsRequiredInterfaces()
     {
         $message = new SystemMessage('test');
 

--- a/src/platform/tests/Message/ToolCallMessageTest.php
+++ b/src/platform/tests/Message/ToolCallMessageTest.php
@@ -29,7 +29,7 @@ final class ToolCallMessageTest extends TestCase
 {
     use UuidAssertionTrait;
 
-    public function testConstructionIsPossible(): void
+    public function testConstructionIsPossible()
     {
         $toolCall = new ToolCall('foo', 'bar');
         $obj = new ToolCallMessage($toolCall, 'bar');
@@ -38,7 +38,7 @@ final class ToolCallMessageTest extends TestCase
         $this->assertSame('bar', $obj->content);
     }
 
-    public function testMessageHasUid(): void
+    public function testMessageHasUid()
     {
         $toolCall = new ToolCall('foo', 'bar');
         $message = new ToolCallMessage($toolCall, 'bar');
@@ -48,7 +48,7 @@ final class ToolCallMessageTest extends TestCase
         $this->assertSame($message->id, $message->getId());
     }
 
-    public function testDifferentMessagesHaveDifferentUids(): void
+    public function testDifferentMessagesHaveDifferentUids()
     {
         $toolCall = new ToolCall('foo', 'bar');
         $message1 = new ToolCallMessage($toolCall, 'bar');
@@ -59,7 +59,7 @@ final class ToolCallMessageTest extends TestCase
         self::assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
-    public function testSameMessagesHaveDifferentUids(): void
+    public function testSameMessagesHaveDifferentUids()
     {
         $toolCall = new ToolCall('foo', 'bar');
         $message1 = new ToolCallMessage($toolCall, 'bar');
@@ -70,7 +70,7 @@ final class ToolCallMessageTest extends TestCase
         self::assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
-    public function testMessageIdImplementsRequiredInterfaces(): void
+    public function testMessageIdImplementsRequiredInterfaces()
     {
         $toolCall = new ToolCall('foo', 'bar');
         $message = new ToolCallMessage($toolCall, 'test');

--- a/src/platform/tests/Message/UserMessageTest.php
+++ b/src/platform/tests/Message/UserMessageTest.php
@@ -35,7 +35,7 @@ final class UserMessageTest extends TestCase
 {
     use UuidAssertionTrait;
 
-    public function testConstructionIsPossible(): void
+    public function testConstructionIsPossible()
     {
         $obj = new UserMessage(new Text('foo'));
 
@@ -45,42 +45,42 @@ final class UserMessageTest extends TestCase
         $this->assertSame('foo', $obj->content[0]->text);
     }
 
-    public function testConstructionIsPossibleWithMultipleContent(): void
+    public function testConstructionIsPossibleWithMultipleContent()
     {
         $message = new UserMessage(new Text('foo'), new ImageUrl('https://foo.com/bar.jpg'));
 
         $this->assertCount(2, $message->content);
     }
 
-    public function testHasAudioContentWithoutAudio(): void
+    public function testHasAudioContentWithoutAudio()
     {
         $message = new UserMessage(new Text('foo'), new Text('bar'));
 
         $this->assertFalse($message->hasAudioContent());
     }
 
-    public function testHasAudioContentWithAudio(): void
+    public function testHasAudioContentWithAudio()
     {
         $message = new UserMessage(new Text('foo'), Audio::fromFile(\dirname(__DIR__, 4).'/fixtures/audio.mp3'));
 
         $this->assertTrue($message->hasAudioContent());
     }
 
-    public function testHasImageContentWithoutImage(): void
+    public function testHasImageContentWithoutImage()
     {
         $message = new UserMessage(new Text('foo'), new Text('bar'));
 
         $this->assertFalse($message->hasImageContent());
     }
 
-    public function testHasImageContentWithImage(): void
+    public function testHasImageContentWithImage()
     {
         $message = new UserMessage(new Text('foo'), new ImageUrl('https://foo.com/bar.jpg'));
 
         $this->assertTrue($message->hasImageContent());
     }
 
-    public function testMessageHasUid(): void
+    public function testMessageHasUid()
     {
         $message = new UserMessage(new Text('foo'));
 
@@ -89,7 +89,7 @@ final class UserMessageTest extends TestCase
         $this->assertSame($message->id, $message->getId());
     }
 
-    public function testDifferentMessagesHaveDifferentUids(): void
+    public function testDifferentMessagesHaveDifferentUids()
     {
         $message1 = new UserMessage(new Text('foo'));
         $message2 = new UserMessage(new Text('bar'));
@@ -99,7 +99,7 @@ final class UserMessageTest extends TestCase
         self::assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
-    public function testSameMessagesHaveDifferentUids(): void
+    public function testSameMessagesHaveDifferentUids()
     {
         $message1 = new UserMessage(new Text('foo'));
         $message2 = new UserMessage(new Text('foo'));
@@ -109,7 +109,7 @@ final class UserMessageTest extends TestCase
         self::assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
-    public function testMessageIdImplementsRequiredInterfaces(): void
+    public function testMessageIdImplementsRequiredInterfaces()
     {
         $message = new UserMessage(new Text('test'));
 

--- a/src/platform/tests/ModelTest.php
+++ b/src/platform/tests/ModelTest.php
@@ -23,21 +23,21 @@ use Symfony\AI\Platform\Model;
 #[UsesClass(Capability::class)]
 final class ModelTest extends TestCase
 {
-    public function testReturnsName(): void
+    public function testReturnsName()
     {
         $model = new Model('gpt-4');
 
         $this->assertSame('gpt-4', $model->getName());
     }
 
-    public function testReturnsCapabilities(): void
+    public function testReturnsCapabilities()
     {
         $model = new Model('gpt-4', [Capability::INPUT_TEXT, Capability::OUTPUT_TEXT]);
 
         $this->assertSame([Capability::INPUT_TEXT, Capability::OUTPUT_TEXT], $model->getCapabilities());
     }
 
-    public function testChecksSupportForCapability(): void
+    public function testChecksSupportForCapability()
     {
         $model = new Model('gpt-4', [Capability::INPUT_TEXT, Capability::OUTPUT_TEXT]);
 
@@ -46,14 +46,14 @@ final class ModelTest extends TestCase
         $this->assertFalse($model->supports(Capability::INPUT_IMAGE));
     }
 
-    public function testReturnsEmptyCapabilitiesByDefault(): void
+    public function testReturnsEmptyCapabilitiesByDefault()
     {
         $model = new Model('gpt-4');
 
         $this->assertSame([], $model->getCapabilities());
     }
 
-    public function testReturnsOptions(): void
+    public function testReturnsOptions()
     {
         $options = [
             'temperature' => 0.7,
@@ -64,7 +64,7 @@ final class ModelTest extends TestCase
         $this->assertSame($options, $model->getOptions());
     }
 
-    public function testReturnsEmptyOptionsByDefault(): void
+    public function testReturnsEmptyOptionsByDefault()
     {
         $model = new Model('gpt-4');
 

--- a/src/platform/tests/Result/BaseResultTest.php
+++ b/src/platform/tests/Result/BaseResultTest.php
@@ -31,7 +31,7 @@ use Symfony\AI\Platform\Result\RawResultInterface;
 #[Small]
 final class BaseResultTest extends TestCase
 {
-    public function testItCanHandleMetadata(): void
+    public function testItCanHandleMetadata()
     {
         $result = $this->createResult();
         $metadata = $result->getMetadata();
@@ -44,7 +44,7 @@ final class BaseResultTest extends TestCase
         $this->assertCount(1, $metadata);
     }
 
-    public function testItCanBeEnrichedWithARawResponse(): void
+    public function testItCanBeEnrichedWithARawResponse()
     {
         $result = $this->createResult();
         $rawResult = $this->createRawResult();
@@ -53,7 +53,7 @@ final class BaseResultTest extends TestCase
         $this->assertSame($rawResult, $result->getRawResult());
     }
 
-    public function testItThrowsAnExceptionWhenSettingARawResponseTwice(): void
+    public function testItThrowsAnExceptionWhenSettingARawResponseTwice()
     {
         self::expectException(RawResultAlreadySetException::class);
 

--- a/src/platform/tests/Result/ChoiceResultTest.php
+++ b/src/platform/tests/Result/ChoiceResultTest.php
@@ -24,7 +24,7 @@ use Symfony\AI\Platform\Result\ChoiceResult;
 #[Small]
 final class ChoiceResultTest extends TestCase
 {
-    public function testChoiceResultCreation(): void
+    public function testChoiceResultCreation()
     {
         $choice1 = new Choice('choice1');
         $choice2 = new Choice(null);
@@ -37,7 +37,7 @@ final class ChoiceResultTest extends TestCase
         $this->assertSame('choice3', $result->getContent()[2]->getContent());
     }
 
-    public function testChoiceResultWithNoChoices(): void
+    public function testChoiceResultWithNoChoices()
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('Result must have at least one choice.');

--- a/src/platform/tests/Result/ChoiceTest.php
+++ b/src/platform/tests/Result/ChoiceTest.php
@@ -23,7 +23,7 @@ use Symfony\AI\Platform\Result\ToolCall;
 #[Small]
 final class ChoiceTest extends TestCase
 {
-    public function testChoiceEmpty(): void
+    public function testChoiceEmpty()
     {
         $choice = new Choice();
         $this->assertFalse($choice->hasContent());
@@ -32,7 +32,7 @@ final class ChoiceTest extends TestCase
         $this->assertCount(0, $choice->getToolCalls());
     }
 
-    public function testChoiceWithContent(): void
+    public function testChoiceWithContent()
     {
         $choice = new Choice('content');
         $this->assertTrue($choice->hasContent());
@@ -41,7 +41,7 @@ final class ChoiceTest extends TestCase
         $this->assertCount(0, $choice->getToolCalls());
     }
 
-    public function testChoiceWithToolCall(): void
+    public function testChoiceWithToolCall()
     {
         $choice = new Choice(null, [new ToolCall('name', 'arguments')]);
         $this->assertFalse($choice->hasContent());
@@ -50,7 +50,7 @@ final class ChoiceTest extends TestCase
         $this->assertCount(1, $choice->getToolCalls());
     }
 
-    public function testChoiceWithContentAndToolCall(): void
+    public function testChoiceWithContentAndToolCall()
     {
         $choice = new Choice('content', [new ToolCall('name', 'arguments')]);
         $this->assertTrue($choice->hasContent());

--- a/src/platform/tests/Result/Exception/RawResultAlreadySetTest.php
+++ b/src/platform/tests/Result/Exception/RawResultAlreadySetTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Result\Exception\RawResultAlreadySetException;
 #[Small]
 final class RawResultAlreadySetTest extends TestCase
 {
-    public function testItHasCorrectExceptionMessage(): void
+    public function testItHasCorrectExceptionMessage()
     {
         $exception = new RawResultAlreadySetException();
 

--- a/src/platform/tests/Result/Metadata/MetadataAwareTraitTest.php
+++ b/src/platform/tests/Result/Metadata/MetadataAwareTraitTest.php
@@ -23,7 +23,7 @@ use Symfony\AI\Platform\Result\Metadata\MetadataAwareTrait;
 #[UsesClass(Metadata::class)]
 final class MetadataAwareTraitTest extends TestCase
 {
-    public function testItCanHandleMetadata(): void
+    public function testItCanHandleMetadata()
     {
         $result = $this->createTestClass();
         $metadata = $result->getMetadata();

--- a/src/platform/tests/Result/Metadata/MetadataTest.php
+++ b/src/platform/tests/Result/Metadata/MetadataTest.php
@@ -20,21 +20,21 @@ use Symfony\AI\Platform\Result\Metadata\Metadata;
 #[Small]
 final class MetadataTest extends TestCase
 {
-    public function testItCanBeCreatedEmpty(): void
+    public function testItCanBeCreatedEmpty()
     {
         $metadata = new Metadata();
         $this->assertCount(0, $metadata);
         $this->assertSame([], $metadata->all());
     }
 
-    public function testItCanBeCreatedWithInitialData(): void
+    public function testItCanBeCreatedWithInitialData()
     {
         $metadata = new Metadata(['key' => 'value']);
         $this->assertCount(1, $metadata);
         $this->assertSame(['key' => 'value'], $metadata->all());
     }
 
-    public function testItCanAddNewMetadata(): void
+    public function testItCanAddNewMetadata()
     {
         $metadata = new Metadata();
         $metadata->add('key', 'value');
@@ -43,7 +43,7 @@ final class MetadataTest extends TestCase
         $this->assertSame('value', $metadata->get('key'));
     }
 
-    public function testItCanCheckIfMetadataExists(): void
+    public function testItCanCheckIfMetadataExists()
     {
         $metadata = new Metadata(['key' => 'value']);
 
@@ -51,7 +51,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->has('nonexistent'));
     }
 
-    public function testItCanGetMetadataWithDefault(): void
+    public function testItCanGetMetadataWithDefault()
     {
         $metadata = new Metadata(['key' => 'value']);
 
@@ -60,7 +60,7 @@ final class MetadataTest extends TestCase
         $this->assertNull($metadata->get('nonexistent'));
     }
 
-    public function testItCanRemoveMetadata(): void
+    public function testItCanRemoveMetadata()
     {
         $metadata = new Metadata(['key' => 'value']);
         $this->assertTrue($metadata->has('key'));
@@ -69,7 +69,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->has('key'));
     }
 
-    public function testItCanSetEntireMetadataArray(): void
+    public function testItCanSetEntireMetadataArray()
     {
         $metadata = new Metadata(['key1' => 'value1']);
         $metadata->set(['key2' => 'value2', 'key3' => 'value3']);
@@ -80,13 +80,13 @@ final class MetadataTest extends TestCase
         $this->assertSame(['key2' => 'value2', 'key3' => 'value3'], $metadata->all());
     }
 
-    public function testItImplementsJsonSerializable(): void
+    public function testItImplementsJsonSerializable()
     {
         $metadata = new Metadata(['key' => 'value']);
         $this->assertSame(['key' => 'value'], $metadata->jsonSerialize());
     }
 
-    public function testItImplementsArrayAccess(): void
+    public function testItImplementsArrayAccess()
     {
         $metadata = new Metadata(['key' => 'value']);
 
@@ -100,7 +100,7 @@ final class MetadataTest extends TestCase
         $this->assertArrayNotHasKey('key', $metadata);
     }
 
-    public function testItImplementsIteratorAggregate(): void
+    public function testItImplementsIteratorAggregate()
     {
         $metadata = new Metadata(['key1' => 'value1', 'key2' => 'value2']);
         $result = iterator_to_array($metadata);
@@ -108,7 +108,7 @@ final class MetadataTest extends TestCase
         $this->assertSame(['key1' => 'value1', 'key2' => 'value2'], $result);
     }
 
-    public function testItImplementsCountable(): void
+    public function testItImplementsCountable()
     {
         $metadata = new Metadata();
         $this->assertCount(0, $metadata);

--- a/src/platform/tests/Result/ObjectResultTest.php
+++ b/src/platform/tests/Result/ObjectResultTest.php
@@ -20,13 +20,13 @@ use Symfony\AI\Platform\Result\ObjectResult;
 #[Small]
 final class ObjectResultTest extends TestCase
 {
-    public function testGetContentWithArray(): void
+    public function testGetContentWithArray()
     {
         $result = new ObjectResult($expected = ['foo' => 'bar', 'baz' => ['qux']]);
         $this->assertSame($expected, $result->getContent());
     }
 
-    public function testGetContentWithObject(): void
+    public function testGetContentWithObject()
     {
         $result = new ObjectResult($expected = (object) ['foo' => 'bar', 'baz' => ['qux']]);
         $this->assertSame($expected, $result->getContent());

--- a/src/platform/tests/Result/RawResultAwareTraitTest.php
+++ b/src/platform/tests/Result/RawResultAwareTraitTest.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpResponse;
 #[UsesClass(RawResultAlreadySetException::class)]
 final class RawResultAwareTraitTest extends TestCase
 {
-    public function testItCanBeEnrichedWithARawResponse(): void
+    public function testItCanBeEnrichedWithARawResponse()
     {
         $result = $this->createTestClass();
         $rawResponse = self::createMock(SymfonyHttpResponse::class);
@@ -34,7 +34,7 @@ final class RawResultAwareTraitTest extends TestCase
         $this->assertSame($rawResponse, $result->getRawResult()?->getObject());
     }
 
-    public function testItThrowsAnExceptionWhenSettingARawResponseTwice(): void
+    public function testItThrowsAnExceptionWhenSettingARawResponseTwice()
     {
         self::expectException(RawResultAlreadySetException::class);
 

--- a/src/platform/tests/Result/ResultPromiseTest.php
+++ b/src/platform/tests/Result/ResultPromiseTest.php
@@ -33,7 +33,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpResponse;
 #[Small]
 final class ResultPromiseTest extends TestCase
 {
-    public function testItUnwrapsTheResultWhenGettingContent(): void
+    public function testItUnwrapsTheResultWhenGettingContent()
     {
         $httpResponse = $this->createStub(SymfonyHttpResponse::class);
         $rawHttpResult = new RawHttpResult($httpResponse);
@@ -50,7 +50,7 @@ final class ResultPromiseTest extends TestCase
         $this->assertSame('test content', $resultPromise->getResult()->getContent());
     }
 
-    public function testItConvertsTheResponseOnlyOnce(): void
+    public function testItConvertsTheResponseOnlyOnce()
     {
         $httpResponse = $this->createStub(SymfonyHttpResponse::class);
         $rawHttpResult = new RawHttpResult($httpResponse);
@@ -70,7 +70,7 @@ final class ResultPromiseTest extends TestCase
         $resultPromise->getResult();
     }
 
-    public function testItGetsRawResponseDirectly(): void
+    public function testItGetsRawResponseDirectly()
     {
         $httpResponse = $this->createStub(SymfonyHttpResponse::class);
         $resultConverter = $this->createStub(ResultConverterInterface::class);
@@ -80,7 +80,7 @@ final class ResultPromiseTest extends TestCase
         $this->assertSame($httpResponse, $resultPromise->getRawResult()->getObject());
     }
 
-    public function testItSetsRawResponseOnUnwrappedResponseWhenNeeded(): void
+    public function testItSetsRawResponseOnUnwrappedResponseWhenNeeded()
     {
         $httpResponse = $this->createStub(SymfonyHttpResponse::class);
 
@@ -96,7 +96,7 @@ final class ResultPromiseTest extends TestCase
         $this->assertSame($httpResponse, $unwrappedResponse->getRawResult()->getObject());
     }
 
-    public function testItDoesNotSetRawResponseOnUnwrappedResponseWhenAlreadySet(): void
+    public function testItDoesNotSetRawResponseOnUnwrappedResponseWhenAlreadySet()
     {
         $originHttpResponse = $this->createStub(SymfonyHttpResponse::class);
         $anotherHttpResponse = $this->createStub(SymfonyHttpResponse::class);
@@ -113,7 +113,7 @@ final class ResultPromiseTest extends TestCase
         $this->assertSame($anotherHttpResponse, $unwrappedResult->getRawResult()->getObject());
     }
 
-    public function testItPassesOptionsToConverter(): void
+    public function testItPassesOptionsToConverter()
     {
         $httpResponse = $this->createStub(SymfonyHttpResponse::class);
         $rawHttpResponse = new RawHttpResult($httpResponse);

--- a/src/platform/tests/Result/StreamResultTest.php
+++ b/src/platform/tests/Result/StreamResultTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Result\StreamResult;
 #[Small]
 final class StreamResultTest extends TestCase
 {
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $generator = (function () {
             yield 'data1';

--- a/src/platform/tests/Result/TextResultTest.php
+++ b/src/platform/tests/Result/TextResultTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Result\TextResult;
 #[Small]
 final class TextResultTest extends TestCase
 {
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $result = new TextResult($expected = 'foo');
         $this->assertSame($expected, $result->getContent());

--- a/src/platform/tests/Result/TollCallResultTest.php
+++ b/src/platform/tests/Result/TollCallResultTest.php
@@ -24,7 +24,7 @@ use Symfony\AI\Platform\Result\ToolCallResult;
 #[Small]
 final class TollCallResultTest extends TestCase
 {
-    public function testThrowsIfNoToolCall(): void
+    public function testThrowsIfNoToolCall()
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('Response must have at least one tool call.');
@@ -32,7 +32,7 @@ final class TollCallResultTest extends TestCase
         new ToolCallResult();
     }
 
-    public function testGetContent(): void
+    public function testGetContent()
     {
         $result = new ToolCallResult($toolCall = new ToolCall('ID', 'name', ['foo' => 'bar']));
         $this->assertSame([$toolCall], $result->getContent());

--- a/src/platform/tests/Result/ToolCallTest.php
+++ b/src/platform/tests/Result/ToolCallTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Result\ToolCall;
 #[Small]
 final class ToolCallTest extends TestCase
 {
-    public function testToolCall(): void
+    public function testToolCall()
     {
         $toolCall = new ToolCall('id', 'name', ['foo' => 'bar']);
         $this->assertSame('id', $toolCall->id);
@@ -28,7 +28,7 @@ final class ToolCallTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $toolCall->arguments);
     }
 
-    public function testToolCallJsonSerialize(): void
+    public function testToolCallJsonSerialize()
     {
         $toolCall = new ToolCall('id', 'name', ['foo' => 'bar']);
         $this->assertSame([

--- a/src/platform/tests/Vector/NullVectorTest.php
+++ b/src/platform/tests/Vector/NullVectorTest.php
@@ -20,19 +20,19 @@ use Symfony\AI\Platform\Vector\VectorInterface;
 #[CoversClass(NullVector::class)]
 final class NullVectorTest extends TestCase
 {
-    public function testImplementsInterface(): void
+    public function testImplementsInterface()
     {
         $this->assertInstanceOf(VectorInterface::class, new NullVector());
     }
 
-    public function testGetDataThrowsOnAccess(): void
+    public function testGetDataThrowsOnAccess()
     {
         self::expectException(RuntimeException::class);
 
         (new NullVector())->getData();
     }
 
-    public function testGetDimensionsThrowsOnAccess(): void
+    public function testGetDimensionsThrowsOnAccess()
     {
         self::expectException(RuntimeException::class);
 

--- a/src/platform/tests/Vector/VectorTest.php
+++ b/src/platform/tests/Vector/VectorTest.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Vector\VectorInterface;
 #[CoversClass(Vector::class)]
 final class VectorTest extends TestCase
 {
-    public function testImplementsInterface(): void
+    public function testImplementsInterface()
     {
         $this->assertInstanceOf(
             VectorInterface::class,
@@ -27,7 +27,7 @@ final class VectorTest extends TestCase
         );
     }
 
-    public function testWithDimensionNull(): void
+    public function testWithDimensionNull()
     {
         $vector = new Vector($vectors = [1.0, 2.0, 3.0], null);
 

--- a/src/store/phpstan.dist.neon
+++ b/src/store/phpstan.dist.neon
@@ -7,3 +7,6 @@ parameters:
         - src/
         - tests/
     treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"

--- a/src/store/tests/Bridge/Azure/SearchStoreTest.php
+++ b/src/store/tests/Bridge/Azure/SearchStoreTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(SearchStore::class)]
 final class SearchStoreTest extends TestCase
 {
-    public function testAddDocumentsSuccessfully(): void
+    public function testAddDocumentsSuccessfully()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -54,7 +54,7 @@ final class SearchStoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testAddDocumentsWithMetadata(): void
+    public function testAddDocumentsWithMetadata()
     {
         $httpClient = new MockHttpClient([
             function (string $method, string $url, array $options): JsonMockResponse {
@@ -104,7 +104,7 @@ final class SearchStoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testAddDocumentsFailure(): void
+    public function testAddDocumentsFailure()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -135,7 +135,7 @@ final class SearchStoreTest extends TestCase
         $store->add($document);
     }
 
-    public function testQueryReturnsDocuments(): void
+    public function testQueryReturnsDocuments()
     {
         $uuid1 = Uuid::v4();
         $uuid2 = Uuid::v4();
@@ -180,7 +180,7 @@ final class SearchStoreTest extends TestCase
         $this->assertSame('Second Document', $results[1]->metadata['title']);
     }
 
-    public function testQueryWithCustomVectorFieldName(): void
+    public function testQueryWithCustomVectorFieldName()
     {
         $httpClient = new MockHttpClient([
             function (string $method, string $url, array $options): JsonMockResponse {
@@ -224,7 +224,7 @@ final class SearchStoreTest extends TestCase
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
     }
 
-    public function testQueryFailure(): void
+    public function testQueryFailure()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -252,7 +252,7 @@ final class SearchStoreTest extends TestCase
         $store->query(new Vector([0.1, 0.2, 0.3]));
     }
 
-    public function testQueryWithNullVector(): void
+    public function testQueryWithNullVector()
     {
         $uuid = Uuid::v4();
 

--- a/src/store/tests/Bridge/ChromaDB/StoreTest.php
+++ b/src/store/tests/Bridge/ChromaDB/StoreTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testAddDocumentsSuccessfully(): void
+    public function testAddDocumentsSuccessfully()
     {
         $collection = $this->createMock(CollectionResource::class);
         $client = $this->createMock(Client::class);
@@ -53,7 +53,7 @@ final class StoreTest extends TestCase
         $store->add($document1, $document2);
     }
 
-    public function testAddSingleDocument(): void
+    public function testAddSingleDocument()
     {
         $collection = $this->createMock(CollectionResource::class);
         $client = $this->createMock(Client::class);

--- a/src/store/tests/Bridge/MariaDB/StoreTest.php
+++ b/src/store/tests/Bridge/MariaDB/StoreTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testQueryWithMinScore(): void
+    public function testQueryWithMinScore()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -73,7 +73,7 @@ final class StoreTest extends TestCase
         $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
     }
 
-    public function testQueryWithoutMinScore(): void
+    public function testQueryWithoutMinScore()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -120,7 +120,7 @@ final class StoreTest extends TestCase
         $this->assertSame(0.95, $results[0]->score);
     }
 
-    public function testQueryWithCustomLimit(): void
+    public function testQueryWithCustomLimit()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);

--- a/src/store/tests/Bridge/Meilisearch/StoreTest.php
+++ b/src/store/tests/Bridge/Meilisearch/StoreTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testStoreCannotInitializeOnInvalidResponse(): void
+    public function testStoreCannotInitializeOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -50,7 +50,7 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testStoreCanInitialize(): void
+    public function testStoreCanInitialize()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -85,7 +85,7 @@ final class StoreTest extends TestCase
         $this->assertSame(2, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotAddOnInvalidResponse(): void
+    public function testStoreCannotAddOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -111,7 +111,7 @@ final class StoreTest extends TestCase
         $store->add(new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2, 0.3])));
     }
 
-    public function testStoreCanAdd(): void
+    public function testStoreCanAdd()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -137,7 +137,7 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotQueryOnInvalidResponse(): void
+    public function testStoreCannotQueryOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -163,7 +163,7 @@ final class StoreTest extends TestCase
         $store->query(new Vector([0.1, 0.2, 0.3]));
     }
 
-    public function testStoreCanQuery(): void
+    public function testStoreCanQuery()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -212,7 +212,7 @@ final class StoreTest extends TestCase
         $this->assertSame(0.85, $vectors[1]->score);
     }
 
-    public function testMetadataWithoutIDRankingandVector(): void
+    public function testMetadataWithoutIDRankingandVector()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([

--- a/src/store/tests/Bridge/MongoDB/StoreTest.php
+++ b/src/store/tests/Bridge/MongoDB/StoreTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testAddSingleDocument(): void
+    public function testAddSingleDocument()
     {
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);
@@ -64,7 +64,7 @@ final class StoreTest extends TestCase
         $store->add($document);
     }
 
-    public function testAddMultipleDocuments(): void
+    public function testAddMultipleDocuments()
     {
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);
@@ -93,7 +93,7 @@ final class StoreTest extends TestCase
         $store->add($document1, $document2);
     }
 
-    public function testAddWithBulkWrite(): void
+    public function testAddWithBulkWrite()
     {
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);
@@ -145,7 +145,7 @@ final class StoreTest extends TestCase
         $store->add($document1, $document2);
     }
 
-    public function testQueryReturnsDocuments(): void
+    public function testQueryReturnsDocuments()
     {
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);
@@ -223,7 +223,7 @@ final class StoreTest extends TestCase
         $this->assertSame('Second Document', $documents[1]->metadata['title']);
     }
 
-    public function testQueryWithMinScore(): void
+    public function testQueryWithMinScore()
     {
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);
@@ -279,7 +279,7 @@ final class StoreTest extends TestCase
         $this->assertCount(0, $documents);
     }
 
-    public function testQueryWithOptions(): void
+    public function testQueryWithOptions()
     {
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);
@@ -335,7 +335,7 @@ final class StoreTest extends TestCase
         $this->assertCount(0, $documents);
     }
 
-    public function testInitializeCreatesIndex(): void
+    public function testInitializeCreatesIndex()
     {
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);
@@ -374,7 +374,7 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testInitializeWithOptions(): void
+    public function testInitializeWithOptions()
     {
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);
@@ -424,7 +424,7 @@ final class StoreTest extends TestCase
         ]);
     }
 
-    public function testInitializeWithInvalidOptions(): void
+    public function testInitializeWithInvalidOptions()
     {
         $client = $this->createMock(Client::class);
 
@@ -441,7 +441,7 @@ final class StoreTest extends TestCase
         $store->initialize(['invalid' => 'option']);
     }
 
-    public function testInitializeHandlesCommandException(): void
+    public function testInitializeHandlesCommandException()
     {
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);
@@ -474,7 +474,7 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testQueryWithCustomVectorFieldName(): void
+    public function testQueryWithCustomVectorFieldName()
     {
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);

--- a/src/store/tests/Bridge/Pinecone/StoreTest.php
+++ b/src/store/tests/Bridge/Pinecone/StoreTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testAddSingleDocument(): void
+    public function testAddSingleDocument()
     {
         $vectorResource = $this->createMock(VectorResource::class);
         $dataResource = $this->createMock(DataResource::class);
@@ -61,7 +61,7 @@ final class StoreTest extends TestCase
         $store->add($document);
     }
 
-    public function testAddMultipleDocuments(): void
+    public function testAddMultipleDocuments()
     {
         $vectorResource = $this->createMock(VectorResource::class);
         $dataResource = $this->createMock(DataResource::class);
@@ -104,7 +104,7 @@ final class StoreTest extends TestCase
         $store->add($document1, $document2);
     }
 
-    public function testAddWithNamespace(): void
+    public function testAddWithNamespace()
     {
         $vectorResource = $this->createMock(VectorResource::class);
         $dataResource = $this->createMock(DataResource::class);
@@ -139,7 +139,7 @@ final class StoreTest extends TestCase
         $store->add($document);
     }
 
-    public function testAddWithEmptyDocuments(): void
+    public function testAddWithEmptyDocuments()
     {
         $client = $this->createMock(Client::class);
 
@@ -150,7 +150,7 @@ final class StoreTest extends TestCase
         $store->add();
     }
 
-    public function testQueryReturnsDocuments(): void
+    public function testQueryReturnsDocuments()
     {
         $vectorResource = $this->createMock(VectorResource::class);
         $dataResource = $this->createMock(DataResource::class);
@@ -211,7 +211,7 @@ final class StoreTest extends TestCase
         $this->assertSame('Second Document', $results[1]->metadata['title']);
     }
 
-    public function testQueryWithNamespaceAndFilter(): void
+    public function testQueryWithNamespaceAndFilter()
     {
         $vectorResource = $this->createMock(VectorResource::class);
         $dataResource = $this->createMock(DataResource::class);
@@ -248,7 +248,7 @@ final class StoreTest extends TestCase
         $this->assertCount(0, $results);
     }
 
-    public function testQueryWithCustomOptions(): void
+    public function testQueryWithCustomOptions()
     {
         $vectorResource = $this->createMock(VectorResource::class);
         $dataResource = $this->createMock(DataResource::class);
@@ -289,7 +289,7 @@ final class StoreTest extends TestCase
         $this->assertCount(0, $results);
     }
 
-    public function testQueryWithEmptyResults(): void
+    public function testQueryWithEmptyResults()
     {
         $vectorResource = $this->createMock(VectorResource::class);
         $dataResource = $this->createMock(DataResource::class);

--- a/src/store/tests/Bridge/Postgres/StoreTest.php
+++ b/src/store/tests/Bridge/Postgres/StoreTest.php
@@ -33,7 +33,7 @@ final class StoreTest extends TestCase
         return trim($normalized);
     }
 
-    public function testAddSingleDocument(): void
+    public function testAddSingleDocument()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -65,7 +65,7 @@ final class StoreTest extends TestCase
         $store->add($document);
     }
 
-    public function testAddMultipleDocuments(): void
+    public function testAddMultipleDocuments()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -105,7 +105,7 @@ final class StoreTest extends TestCase
         $store->add($document1, $document2);
     }
 
-    public function testQueryWithoutMinScore(): void
+    public function testQueryWithoutMinScore()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -152,7 +152,7 @@ final class StoreTest extends TestCase
         $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
     }
 
-    public function testQueryWithMinScore(): void
+    public function testQueryWithMinScore()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -189,7 +189,7 @@ final class StoreTest extends TestCase
         $this->assertCount(0, $results);
     }
 
-    public function testQueryWithCustomLimit(): void
+    public function testQueryWithCustomLimit()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -223,7 +223,7 @@ final class StoreTest extends TestCase
         $this->assertCount(0, $results);
     }
 
-    public function testQueryWithCustomVectorFieldName(): void
+    public function testQueryWithCustomVectorFieldName()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -255,7 +255,7 @@ final class StoreTest extends TestCase
         $this->assertCount(0, $results);
     }
 
-    public function testInitialize(): void
+    public function testInitialize()
     {
         $pdo = $this->createMock(\PDO::class);
 
@@ -283,7 +283,7 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testInitializeWithCustomVectorSize(): void
+    public function testInitializeWithCustomVectorSize()
     {
         $pdo = $this->createMock(\PDO::class);
 
@@ -306,7 +306,7 @@ final class StoreTest extends TestCase
         $store->initialize(['vector_size' => 768]);
     }
 
-    public function testFromPdo(): void
+    public function testFromPdo()
     {
         $pdo = $this->createMock(\PDO::class);
 
@@ -315,7 +315,7 @@ final class StoreTest extends TestCase
         $this->assertInstanceOf(Store::class, $store);
     }
 
-    public function testFromDbalWithPdoDriver(): void
+    public function testFromDbalWithPdoDriver()
     {
         $pdo = $this->createMock(\PDO::class);
         $connection = $this->createMock(Connection::class);
@@ -329,7 +329,7 @@ final class StoreTest extends TestCase
         $this->assertInstanceOf(Store::class, $store);
     }
 
-    public function testFromDbalWithNonPdoDriverThrowsException(): void
+    public function testFromDbalWithNonPdoDriverThrowsException()
     {
         $connection = $this->createMock(Connection::class);
 
@@ -343,7 +343,7 @@ final class StoreTest extends TestCase
         Store::fromDbal($connection, 'test_table');
     }
 
-    public function testQueryWithNullMetadata(): void
+    public function testQueryWithNullMetadata()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);

--- a/src/store/tests/Bridge/Qdrant/StoreTest.php
+++ b/src/store/tests/Bridge/Qdrant/StoreTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testStoreCannotInitializeOnInvalidResponse(): void
+    public function testStoreCannotInitializeOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -48,7 +48,7 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testStoreCannotInitializeOnExistingCollection(): void
+    public function testStoreCannotInitializeOnExistingCollection()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -74,7 +74,7 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCanInitialize(): void
+    public function testStoreCanInitialize()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -100,7 +100,7 @@ final class StoreTest extends TestCase
         $this->assertSame(2, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotAddOnInvalidResponse(): void
+    public function testStoreCannotAddOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([], [
@@ -116,7 +116,7 @@ final class StoreTest extends TestCase
         $store->add(new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2, 0.3])));
     }
 
-    public function testStoreCanAdd(): void
+    public function testStoreCanAdd()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -138,7 +138,7 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotQueryOnInvalidResponse(): void
+    public function testStoreCannotQueryOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([], [
@@ -159,7 +159,7 @@ final class StoreTest extends TestCase
         $store->query(new Vector([0.1, 0.2, 0.3]));
     }
 
-    public function testStoreCanQuery(): void
+    public function testStoreCanQuery()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([

--- a/src/store/tests/Bridge/SurrealDB/StoreTest.php
+++ b/src/store/tests/Bridge/SurrealDB/StoreTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(Store::class)]
 final class StoreTest extends TestCase
 {
-    public function testStoreCannotInitializeOnInvalidResponse(): void
+    public function testStoreCannotInitializeOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([], [
@@ -40,7 +40,7 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testStoreCannotInitializeOnValidAuthenticationResponse(): void
+    public function testStoreCannotInitializeOnValidAuthenticationResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -63,7 +63,7 @@ final class StoreTest extends TestCase
         $store->initialize();
     }
 
-    public function testStoreCannotInitializeOnValidAuthenticationAndIndexResponse(): void
+    public function testStoreCannotInitializeOnValidAuthenticationAndIndexResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -91,7 +91,7 @@ final class StoreTest extends TestCase
         $this->assertSame(2, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotAddOnInvalidResponse(): void
+    public function testStoreCannotAddOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -124,7 +124,7 @@ final class StoreTest extends TestCase
         $store->add(new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2, 0.3])));
     }
 
-    public function testStoreCannotAddOnInvalidAddResponse(): void
+    public function testStoreCannotAddOnInvalidAddResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -157,7 +157,7 @@ final class StoreTest extends TestCase
         $store->add(new VectorDocument(Uuid::v4(), new Vector(array_fill(0, 1275, 0.1))));
     }
 
-    public function testStoreCanAdd(): void
+    public function testStoreCanAdd()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -210,7 +210,7 @@ final class StoreTest extends TestCase
         $this->assertSame(3, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotQueryOnInvalidResponse(): void
+    public function testStoreCannotQueryOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
@@ -269,7 +269,7 @@ final class StoreTest extends TestCase
         $store->query(new Vector(array_fill(0, 1275, 0.1)));
     }
 
-    public function testStoreCanQueryOnValidEmbeddings(): void
+    public function testStoreCanQueryOnValidEmbeddings()
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([

--- a/src/store/tests/Document/Loader/TextFileLoaderTest.php
+++ b/src/store/tests/Document/Loader/TextFileLoaderTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Store\Exception\RuntimeException;
 #[CoversClass(TextFileLoader::class)]
 final class TextFileLoaderTest extends TestCase
 {
-    public function testLoadWithInvalidSource(): void
+    public function testLoadWithInvalidSource()
     {
         $loader = new TextFileLoader();
 
@@ -30,7 +30,7 @@ final class TextFileLoaderTest extends TestCase
         iterator_to_array($loader('/invalid/source.txt'));
     }
 
-    public function testLoadWithValidSource(): void
+    public function testLoadWithValidSource()
     {
         $loader = new TextFileLoader();
 
@@ -43,7 +43,7 @@ final class TextFileLoaderTest extends TestCase
         $this->assertSame(1500, \strlen($document->content));
     }
 
-    public function testSourceIsPresentInMetadata(): void
+    public function testSourceIsPresentInMetadata()
     {
         $loader = new TextFileLoader();
 

--- a/src/store/tests/Document/Transformer/ChainTransformerTest.php
+++ b/src/store/tests/Document/Transformer/ChainTransformerTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(TransformerInterface::class)]
 final class ChainTransformerTest extends TestCase
 {
-    public function testChainTransformerAppliesAllTransformersInOrder(): void
+    public function testChainTransformerAppliesAllTransformersInOrder()
     {
         $transformerA = new class implements TransformerInterface {
             public function __invoke(iterable $documents, array $options = []): iterable
@@ -53,7 +53,7 @@ final class ChainTransformerTest extends TestCase
         $this->assertSame('bar-A-B', $result[1]->content);
     }
 
-    public function testChainTransformerWithNoTransformersReturnsInput(): void
+    public function testChainTransformerWithNoTransformersReturnsInput()
     {
         $chain = new ChainTransformer([]);
         $documents = [new TextDocument(Uuid::v4(), 'baz')];

--- a/src/store/tests/Document/Transformer/TextSplitTransformerTest.php
+++ b/src/store/tests/Document/Transformer/TextSplitTransformerTest.php
@@ -29,7 +29,7 @@ final class TextSplitTransformerTest extends TestCase
         $this->transformer = new TextSplitTransformer();
     }
 
-    public function testSplitReturnsSingleChunkForShortText(): void
+    public function testSplitReturnsSingleChunkForShortText()
     {
         $document = new TextDocument(Uuid::v4(), 'short text');
 
@@ -39,12 +39,12 @@ final class TextSplitTransformerTest extends TestCase
         $this->assertSame('short text', $chunks[0]->content);
     }
 
-    public function testTextLength(): void
+    public function testTextLength()
     {
         $this->assertSame(1500, mb_strlen($this->getLongText()));
     }
 
-    public function testSplitSplitsLongTextWithOverlap(): void
+    public function testSplitSplitsLongTextWithOverlap()
     {
         $document = new TextDocument(Uuid::v4(), $this->getLongText());
 
@@ -59,7 +59,7 @@ final class TextSplitTransformerTest extends TestCase
         $this->assertSame(substr($this->getLongText(), 800, 700), $chunks[1]->content);
     }
 
-    public function testSplitWithCustomChunkSizeAndOverlap(): void
+    public function testSplitWithCustomChunkSizeAndOverlap()
     {
         $document = new TextDocument(Uuid::v4(), $this->getLongText());
 
@@ -107,7 +107,7 @@ final class TextSplitTransformerTest extends TestCase
         $this->assertSame(substr($this->getLongText(), 1375, 150), $chunks[11]->content);
     }
 
-    public function testSplitWithZeroOverlap(): void
+    public function testSplitWithZeroOverlap()
     {
         $document = new TextDocument(Uuid::v4(), $this->getLongText());
 
@@ -120,7 +120,7 @@ final class TextSplitTransformerTest extends TestCase
         $this->assertSame(substr($this->getLongText(), 1000, 500), $chunks[1]->content);
     }
 
-    public function testParentIdIsSetInMetadata(): void
+    public function testParentIdIsSetInMetadata()
     {
         $document = new TextDocument(Uuid::v4(), $this->getLongText());
 
@@ -134,7 +134,7 @@ final class TextSplitTransformerTest extends TestCase
         $this->assertSame($document->id, $chunks[1]->metadata['parent_id']);
     }
 
-    public function testMetadataIsInherited(): void
+    public function testMetadataIsInherited()
     {
         $document = new TextDocument(Uuid::v4(), $this->getLongText(), new Metadata([
             'key' => 'value',
@@ -150,7 +150,7 @@ final class TextSplitTransformerTest extends TestCase
         $this->assertSame('bar', $chunks[1]->metadata['foo']);
     }
 
-    public function testSplitWithChunkSizeLargerThanText(): void
+    public function testSplitWithChunkSizeLargerThanText()
     {
         $document = new TextDocument(Uuid::v4(), 'tiny');
 
@@ -160,7 +160,7 @@ final class TextSplitTransformerTest extends TestCase
         $this->assertSame('tiny', $chunks[0]->content);
     }
 
-    public function testSplitWithOverlapGreaterThanChunkSize(): void
+    public function testSplitWithOverlapGreaterThanChunkSize()
     {
         $document = new TextDocument(Uuid::v4(), 'Abcdefg', new Metadata([]));
         self::expectException(InvalidArgumentException::class);
@@ -172,7 +172,7 @@ final class TextSplitTransformerTest extends TestCase
         ]));
     }
 
-    public function testSplitWithNegativeOverlap(): void
+    public function testSplitWithNegativeOverlap()
     {
         $document = new TextDocument(Uuid::v4(), 'Abcdefg', new Metadata([]));
         self::expectException(InvalidArgumentException::class);

--- a/src/store/tests/InMemoryStoreTest.php
+++ b/src/store/tests/InMemoryStoreTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(InMemoryStore::class)]
 final class InMemoryStoreTest extends TestCase
 {
-    public function testStoreCanSearchUsingCosineDistance(): void
+    public function testStoreCanSearchUsingCosineDistance()
     {
         $store = new InMemoryStore();
         $store->add(
@@ -45,7 +45,7 @@ final class InMemoryStoreTest extends TestCase
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->vector->getData());
     }
 
-    public function testStoreCanSearchUsingCosineDistanceAndReturnCorrectOrder(): void
+    public function testStoreCanSearchUsingCosineDistanceAndReturnCorrectOrder()
     {
         $store = new InMemoryStore();
         $store->add(
@@ -65,7 +65,7 @@ final class InMemoryStoreTest extends TestCase
         $this->assertSame([0.7, -0.3, 0.0], $result[4]->vector->getData());
     }
 
-    public function testStoreCanSearchUsingCosineDistanceWithMaxItems(): void
+    public function testStoreCanSearchUsingCosineDistanceWithMaxItems()
     {
         $store = new InMemoryStore();
         $store->add(
@@ -79,7 +79,7 @@ final class InMemoryStoreTest extends TestCase
         ]));
     }
 
-    public function testStoreCanSearchUsingAngularDistance(): void
+    public function testStoreCanSearchUsingAngularDistance()
     {
         $store = new InMemoryStore(InMemoryStore::ANGULAR_DISTANCE);
         $store->add(
@@ -93,7 +93,7 @@ final class InMemoryStoreTest extends TestCase
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
     }
 
-    public function testStoreCanSearchUsingEuclideanDistance(): void
+    public function testStoreCanSearchUsingEuclideanDistance()
     {
         $store = new InMemoryStore(InMemoryStore::EUCLIDEAN_DISTANCE);
         $store->add(
@@ -107,7 +107,7 @@ final class InMemoryStoreTest extends TestCase
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
     }
 
-    public function testStoreCanSearchUsingManhattanDistance(): void
+    public function testStoreCanSearchUsingManhattanDistance()
     {
         $store = new InMemoryStore(InMemoryStore::MANHATTAN_DISTANCE);
         $store->add(
@@ -121,7 +121,7 @@ final class InMemoryStoreTest extends TestCase
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
     }
 
-    public function testStoreCanSearchUsingChebyshevDistance(): void
+    public function testStoreCanSearchUsingChebyshevDistance()
     {
         $store = new InMemoryStore(InMemoryStore::CHEBYSHEV_DISTANCE);
         $store->add(

--- a/src/store/tests/IndexerTest.php
+++ b/src/store/tests/IndexerTest.php
@@ -45,7 +45,7 @@ use Symfony\Component\Uid\Uuid;
 #[UsesClass(VectorResult::class)]
 final class IndexerTest extends TestCase
 {
-    public function testIndexSingleDocument(): void
+    public function testIndexSingleDocument()
     {
         $document = new TextDocument($id = Uuid::v4(), 'Test content');
         $vector = new Vector([0.1, 0.2, 0.3]);
@@ -60,7 +60,7 @@ final class IndexerTest extends TestCase
         $this->assertSame($vector, $store->documents[0]->vector);
     }
 
-    public function testIndexEmptyDocumentList(): void
+    public function testIndexEmptyDocumentList()
     {
         $logger = self::createMock(LoggerInterface::class);
         $logger->expects($this->once())->method('debug')->with('No documents to index');
@@ -72,7 +72,7 @@ final class IndexerTest extends TestCase
         $this->assertSame([], $store->documents);
     }
 
-    public function testIndexDocumentWithMetadata(): void
+    public function testIndexDocumentWithMetadata()
     {
         $metadata = new Metadata(['key' => 'value']);
         $document = new TextDocument($id = Uuid::v4(), 'Test content', $metadata);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

To make Fabbot (and @nicolas-grekas) happy 😃 