### PR TITLE
[MCP SDK] `ToolCallHandler` now returns `structuredContent` if applicable

### DIFF
--- a/src/mcp-sdk/src/Capability/Tool/ToolCallResult.php
+++ b/src/mcp-sdk/src/Capability/Tool/ToolCallResult.php
@@ -14,12 +14,12 @@ namespace Symfony\AI\McpSdk\Capability\Tool;
 final readonly class ToolCallResult
 {
     public function __construct(
-        public string $result,
+        public mixed $result,
         /**
          * @var "text"|"image"|"audio"|"resource"|non-empty-string
          */
         public string $type = 'text',
-        public string $mimeType = 'text/plan',
+        public string $mimeType = 'text/plain',
         public bool $isError = false,
         public ?string $uri = null,
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

As [per documentation](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content) we should include any structured content in a dedicated field
> Structured content is returned as a JSON object in the structuredContent field of a result.
For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block.


