### PR TITLE
[Store] remove `minScore` parameter from `VectorStoreInterface::query`

### DIFF
--- a/src/store/doc/index.rst
+++ b/src/store/doc/index.rst
@@ -85,7 +85,7 @@ This leads to a store implementing two methods::
             // Implementation to add a document to the store
         }
 
-        public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+        public function query(Vector $vector, array $options = []): array
         {
             // Implementation to query the store for documents
             return [];

--- a/src/store/src/Bridge/Azure/SearchStore.php
+++ b/src/store/src/Bridge/Azure/SearchStore.php
@@ -44,7 +44,7 @@ final readonly class SearchStore implements VectorStoreInterface
         ]);
     }
 
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    public function query(Vector $vector, array $options = []): array
     {
         $result = $this->request('search', [
             'vectorQueries' => [$this->buildVectorQuery($vector)],

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -48,7 +48,7 @@ final readonly class Store implements VectorStoreInterface
         $collection->add($ids, $vectors, $metadata);
     }
 
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    public function query(Vector $vector, array $options = []): array
     {
         $collection = $this->client->getOrCreateCollection($this->collectionName);
         $queryResponse = $collection->query(

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -48,7 +48,7 @@ final readonly class Store implements InitializableStoreInterface, VectorStoreIn
         );
     }
 
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    public function query(Vector $vector, array $options = []): array
     {
         $result = $this->request('POST', \sprintf('indexes/%s/search', $this->indexName), [
             'vector' => $vector->getData(),

--- a/src/store/src/Bridge/MongoDb/Store.php
+++ b/src/store/src/Bridge/MongoDb/Store.php
@@ -103,11 +103,18 @@ final readonly class Store implements VectorStoreInterface, InitializableStoreIn
      * @param array{
      *     limit?: positive-int,
      *     numCandidates?: positive-int,
-     *     filter?: array<mixed>
+     *     filter?: array<mixed>,
+     *     minScore?: float,
      * } $options
      */
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    public function query(Vector $vector, array $options = []): array
     {
+        $minScore = null;
+        if (\array_key_exists('minScore', $options)) {
+            $minScore = $options['minScore'];
+            unset($options['minScore']);
+        }
+
         $pipeline = [
             [
                 '$vectorSearch' => array_merge([

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -55,7 +55,7 @@ final readonly class Store implements InitializableStoreInterface, VectorStoreIn
         }
     }
 
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    public function query(Vector $vector, array $options = []): array
     {
         $response = $this->request('POST', \sprintf('db/%s/query/v2', $this->databaseName), [
             'statement' => \sprintf('CALL db.index.vector.queryNodes("%s", 5, $vectors) YIELD node, score RETURN node, score', $this->vectorIndexName),

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -57,7 +57,7 @@ final readonly class Store implements VectorStoreInterface
         $this->getVectors()->upsert($vectors, $this->namespace);
     }
 
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    public function query(Vector $vector, array $options = []): array
     {
         $result = $this->getVectors()->query(
             vector: $vector->getData(),

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -49,7 +49,7 @@ final readonly class Store implements InitializableStoreInterface, VectorStoreIn
      *     offset?: positive-int
      * } $options
      */
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    public function query(Vector $vector, array $options = []): array
     {
         $payload = [
             'vector' => $vector->getData(),

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -51,7 +51,7 @@ final class Store implements InitializableStoreInterface, VectorStoreInterface
         }
     }
 
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    public function query(Vector $vector, array $options = []): array
     {
         $vectors = json_encode($vector->getData());
 

--- a/src/store/src/InMemoryStore.php
+++ b/src/store/src/InMemoryStore.php
@@ -46,7 +46,7 @@ final class InMemoryStore implements VectorStoreInterface
      *     maxItems?: positive-int
      * } $options If maxItems is provided, only the top N results will be returned
      */
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    public function query(Vector $vector, array $options = []): array
     {
         $strategy = match ($this->distance) {
             self::COSINE_DISTANCE => $this->cosineDistance(...),

--- a/src/store/src/VectorStoreInterface.php
+++ b/src/store/src/VectorStoreInterface.php
@@ -24,5 +24,5 @@ interface VectorStoreInterface extends StoreInterface
      *
      * @return VectorDocument[]
      */
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array;
+    public function query(Vector $vector, array $options = []): array;
 }

--- a/src/store/tests/Bridge/MongoDb/StoreTest.php
+++ b/src/store/tests/Bridge/MongoDb/StoreTest.php
@@ -274,7 +274,7 @@ final class StoreTest extends TestCase
             'test-index',
         );
 
-        $documents = $store->query(new Vector([0.1, 0.2, 0.3]), [], 0.8);
+        $documents = $store->query(new Vector([0.1, 0.2, 0.3]), ['minScore' => 0.8]);
 
         $this->assertCount(0, $documents);
     }

--- a/src/store/tests/Bridge/Postgres/StoreTest.php
+++ b/src/store/tests/Bridge/Postgres/StoreTest.php
@@ -106,7 +106,7 @@ final class StoreTest extends TestCase
         $store->add($document1, $document2);
     }
 
-    public function testQueryWithoutMinScore()
+    public function testQueryWithoutMaxScore()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -153,7 +153,7 @@ final class StoreTest extends TestCase
         $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
     }
 
-    public function testQueryChangedDistanceMethodWithoutMinScore()
+    public function testQueryChangedDistanceMethodWithoutMaxScore()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -200,7 +200,7 @@ final class StoreTest extends TestCase
         $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
     }
 
-    public function testQueryWithMinScore()
+    public function testQueryWithMaxScore()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -209,7 +209,7 @@ final class StoreTest extends TestCase
 
         $expectedSql = 'SELECT id, embedding AS embedding, metadata, (embedding <-> :embedding) AS score
              FROM embeddings_table
-             WHERE (embedding <-> :embedding) >= :minScore
+             WHERE (embedding <-> :embedding) <= :maxScore
              ORDER BY score ASC
              LIMIT 5';
 
@@ -224,7 +224,7 @@ final class StoreTest extends TestCase
             ->method('execute')
             ->with([
                 'embedding' => '[0.1,0.2,0.3]',
-                'minScore' => 0.8,
+                'maxScore' => 0.8,
             ]);
 
         $statement->expects($this->once())
@@ -232,12 +232,12 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), [], 0.8);
+        $results = $store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]);
 
         $this->assertCount(0, $results);
     }
 
-    public function testQueryWithMinScoreAndDifferentDistance()
+    public function testQueryWithMaxScoreAndDifferentDistance()
     {
         $pdo = $this->createMock(\PDO::class);
         $statement = $this->createMock(\PDOStatement::class);
@@ -246,7 +246,7 @@ final class StoreTest extends TestCase
 
         $expectedSql = 'SELECT id, embedding AS embedding, metadata, (embedding <=> :embedding) AS score
              FROM embeddings_table
-             WHERE (embedding <=> :embedding) >= :minScore
+             WHERE (embedding <=> :embedding) <= :maxScore
              ORDER BY score ASC
              LIMIT 5';
 
@@ -261,7 +261,7 @@ final class StoreTest extends TestCase
             ->method('execute')
             ->with([
                 'embedding' => '[0.1,0.2,0.3]',
-                'minScore' => 0.8,
+                'maxScore' => 0.8,
             ]);
 
         $statement->expects($this->once())
@@ -269,7 +269,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), [], 0.8);
+        $results = $store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]);
 
         $this->assertCount(0, $results);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #195
| License       | MIT

As discussed within #197 and #195 i have removed the `minScore` argument from the `VectorStoreInterface` as this is semantically not correct for any store. Most stores has never implemented this filter mechanism. It originated from the MongoDB store where it is correct with the internal scoring system but for stores like MariaDB and Postgres the distance calculations are more correct with a `maxScore` option as their results are sorted from `0` as exact match to larger float values for the distance. 

I have changed those two stores and left the MongoDB store with the minScore implementation. 

This is a break in the implementation as the interface has changed.
