### PR TITLE
[AI Bundle] Change Azure Contract to OpenAI for Whisper support

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -186,7 +186,7 @@ final class AiBundle extends AbstractBundle
                         $config['api_version'],
                         $config['api_key'],
                         new Reference('http_client', ContainerInterface::NULL_ON_INVALID_REFERENCE),
-                        new Reference('ai.platform.contract.default'),
+                        new Reference('ai.platform.contract.openai'),
                     ])
                     ->addTag('ai.platform');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

For Whisper support on Azure we also need the OpenAI contract instead of the default one.