### PR TITLE
[Demo] Render markdown in the stream example

### DIFF
--- a/demo/src/Stream/Chat.php
+++ b/demo/src/Stream/Chat.php
@@ -57,8 +57,7 @@ final class Chat
 
         $response = '';
         foreach ($stream as $chunk) {
-            yield $chunk;
-            $response .= $chunk;
+            yield $response .= $chunk;
         }
 
         $assistantMessage = Message::ofAssistant($response);

--- a/demo/src/Stream/TwigComponent.php
+++ b/demo/src/Stream/TwigComponent.php
@@ -77,15 +77,8 @@ final class TwigComponent extends AbstractController
             $request->setSession($actualSession);
             $response = $this->chat->getAssistantResponse($messages);
 
-            $thinking = true;
-            foreach ($response as $chunk) {
-                // Remove "Thinking..." when we receive something
-                if ($thinking && trim($chunk)) {
-                    $thinking = false;
-                    yield new ServerEvent(explode("\n", $this->renderBlockView('_stream.html.twig', 'start')));
-                }
-
-                yield new ServerEvent(explode("\n", $this->renderBlockView('_stream.html.twig', 'partial', ['part' => $chunk])));
+            foreach ($response as $partialMessage) {
+                yield new ServerEvent(explode("\n", $this->renderBlockView('_stream.html.twig', 'update', ['message' => $partialMessage])));
             }
 
             yield new ServerEvent(explode("\n", $this->renderBlockView('_stream.html.twig', 'end', ['message' => $response->getReturn()])));

--- a/demo/templates/_stream.html.twig
+++ b/demo/templates/_stream.html.twig
@@ -1,9 +1,5 @@
-{% block start %}
-    <twig:Turbo:Stream:Update target="#bot-message-streamed"/>
-{% endblock %}
-
-{% block partial %}
-    <twig:Turbo:Stream:Append target="#bot-message-streamed">{{ part }}</twig:Turbo:Stream:Append>
+{% block update %}
+    <twig:Turbo:Stream:Update target="#bot-message-streamed">{{ message|markdown_to_html }}</twig:Turbo:Stream:Update>
 {% endblock %}
 
 {% block end %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix #201
| License       | MIT

Previously markdown was only converted to HTML on full page reload, now we render the whole partial message server side while streaming. This is a lot less efficient than only sending the new parts of the stream, but much easier to implement _(still no custom JS needed)_ – and I don't think we should make the demos too complex.