### PR TITLE
[AiBundle] Register fault tolerant default toolbox

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -356,11 +356,9 @@ final class AiBundle extends AbstractBundle
                 $container->setDefinition('ai.toolbox.'.$name, $toolboxDefinition);
 
                 if ($config['fault_tolerant_toolbox']) {
-                    $faultTolerantToolboxDefinition = (new Definition('ai.fault_tolerant_toolbox.'.$name))
-                        ->setClass(FaultTolerantToolbox::class)
+                    $container->setDefinition('ai.fault_tolerant_toolbox.'.$name, new Definition(FaultTolerantToolbox::class))
                         ->setArguments([new Reference('.inner')])
                         ->setDecoratedService('ai.toolbox.'.$name);
-                    $container->setDefinition('ai.fault_tolerant_toolbox.'.$name, $faultTolerantToolboxDefinition);
                 }
 
                 if ($container->getParameter('kernel.debug')) {
@@ -379,6 +377,12 @@ final class AiBundle extends AbstractBundle
                 $inputProcessors[] = new Reference('ai.tool.agent_processor.'.$name);
                 $outputProcessors[] = new Reference('ai.tool.agent_processor.'.$name);
             } else {
+                if ($config['fault_tolerant_toolbox'] && !$container->hasDefinition('ai.fault_tolerant_toolbox')) {
+                    $container->setDefinition('ai.fault_tolerant_toolbox', new Definition(FaultTolerantToolbox::class))
+                        ->setArguments([new Reference('.inner')])
+                        ->setDecoratedService('ai.toolbox');
+                }
+
                 $inputProcessors[] = new Reference('ai.tool.agent_processor');
                 $outputProcessors[] = new Reference('ai.tool.agent_processor');
             }

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\AiBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\AiBundle\AiBundle;
@@ -27,6 +28,46 @@ class AiBundleTest extends TestCase
     public function testExtensionLoadDoesNotThrow()
     {
         $this->buildContainer($this->getFullConfig());
+    }
+
+    #[TestWith([true], 'enabled')]
+    #[TestWith([false], 'disabled')]
+    public function testFaultTolerantAgentSpecificToolbox(bool $enabled)
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
+                        'tools' => [
+                            ['service' => 'some_service', 'description' => 'Some tool'],
+                        ],
+                        'fault_tolerant_toolbox' => $enabled,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame($enabled, $container->hasDefinition('ai.fault_tolerant_toolbox.my_agent'));
+    }
+
+    #[TestWith([true], 'enabled')]
+    #[TestWith([false], 'disabled')]
+    public function testFaultTolerantDefaultToolbox(bool $enabled)
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
+                        'tools' => true,
+                        'fault_tolerant_toolbox' => $enabled,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame($enabled, $container->hasDefinition('ai.fault_tolerant_toolbox'));
     }
 
     public function testAgentsCanBeRegisteredAsTools()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix https://github.com/php-llm/llm-chain-bundle/issues/102
| License       | MIT

Fault tolerant toolbox was never registered if you used `tools: true` instead of defining tools explicitly. 