### PR TITLE
[Examples] Fix gemini server-tools example to actually use AgentProcessor

### DIFF
--- a/examples/gemini/server-tools.php
+++ b/examples/gemini/server-tools.php
@@ -27,7 +27,7 @@ $llm = new Gemini('gemini-2.5-pro-preview-03-25', ['server_tools' => ['url_conte
 
 $toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, $llm, logger: logger());
+$agent = new Agent($platform, $llm, [$processor], [$processor], logger());
 
 $messages = new MessageBag(
     Message::ofUser(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | 
| License       | MIT

Fix the Gemini server-tools example to make use of the created `AgentProcessor` in the `Agent`.