### PR TITLE
[Platform] Add content when normalizing  ollama assistant messages

### DIFF
--- a/src/platform/src/Bridge/Ollama/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Ollama/Contract/AssistantMessageNormalizer.php
@@ -42,6 +42,7 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
      *
      * @return array{
      *     role: Role::Assistant,
+     *     content: string,
      *     tool_calls: list<array{
      *         type: 'function',
      *         function: array{
@@ -55,6 +56,7 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
     {
         return [
             'role' => Role::Assistant,
+            'content' => $data->content ?? '',
             'tool_calls' => array_values(array_map(function (ToolCall $message): array {
                 return [
                     'type' => 'function',

--- a/src/platform/tests/Bridge/Ollama/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Ollama/Contract/AssistantMessageNormalizerTest.php
@@ -72,6 +72,7 @@ final class AssistantMessageNormalizerTest extends TestCase
             new AssistantMessage('Hello'),
             [
                 'role' => Role::Assistant,
+                'content' => 'Hello',
                 'tool_calls' => [],
             ],
         ];
@@ -80,6 +81,7 @@ final class AssistantMessageNormalizerTest extends TestCase
             new AssistantMessage(toolCalls: [new ToolCall('id1', 'function1', ['param' => 'value'])]),
             [
                 'role' => Role::Assistant,
+                'content' => '',
                 'tool_calls' => [
                     [
                         'type' => 'function',
@@ -96,6 +98,7 @@ final class AssistantMessageNormalizerTest extends TestCase
             new AssistantMessage(toolCalls: [new ToolCall('id1', 'function1', [])]),
             [
                 'role' => Role::Assistant,
+                'content' => '',
                 'tool_calls' => [
                     [
                         'type' => 'function',
@@ -115,6 +118,37 @@ final class AssistantMessageNormalizerTest extends TestCase
             ]),
             [
                 'role' => Role::Assistant,
+                'content' => '',
+                'tool_calls' => [
+                    [
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'function1',
+                            'arguments' => ['param1' => 'value1'],
+                        ],
+                    ],
+                    [
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'function2',
+                            'arguments' => ['param2' => 'value2'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'assistant message with tool calls and content' => [
+            new AssistantMessage(
+                content: 'Hello',
+                toolCalls: [
+                    new ToolCall('id1', 'function1', ['param1' => 'value1']),
+                    new ToolCall('id2', 'function2', ['param2' => 'value2']),
+                ]
+            ),
+            [
+                'role' => Role::Assistant,
+                'content' => 'Hello',
                 'tool_calls' => [
                     [
                         'type' => 'function',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Docs?         | no
| Issues        | None
| License       | MIT

The assistant message for ollama chats supports `content` as well as `tool_calls`. Not providing content to assistant messages leads to loss of context especially in cases where no tools have been used. 