### PR TITLE
[AI Bundle] [AIBundle] add initialize method call during container compilation

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -507,6 +507,7 @@ final class AiBundle extends AbstractBundle
                 $definition
                     ->addTag('ai.store')
                     ->setArguments($arguments);
+                $definition->addMethodCall('initialize');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
             }
@@ -548,6 +549,7 @@ final class AiBundle extends AbstractBundle
                 $definition
                     ->addTag('ai.store')
                     ->setArguments($arguments);
+                $definition->addMethodCall('initialize');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
             }
@@ -585,6 +587,7 @@ final class AiBundle extends AbstractBundle
                 $definition
                     ->addTag('ai.store')
                     ->setArguments($arguments);
+                $definition->addMethodCall('initialize');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
             }
@@ -635,6 +638,7 @@ final class AiBundle extends AbstractBundle
                 $definition
                     ->addTag('ai.store')
                     ->setArguments($arguments);
+                $definition->addMethodCall('initialize');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
             }
@@ -675,6 +679,7 @@ final class AiBundle extends AbstractBundle
                 $definition
                     ->addTag('ai.store')
                     ->setArguments($arguments);
+                $definition->addMethodCall('initialize');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | #260 
| License       | MIT

Hi 👋🏻 

Last one for today, the method `initialize` must be called during the container compilation (not all stores implement the interface so we can't define a "routine" for it) if we want to prevent any errors at runtime.