### PR TITLE
 Drop Symfony 6.4 support, require ^7.3|^8.0

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,10 +32,10 @@ jobs:
                         dependency-version: 'lowest'
                     # LTS version of Symfony
                     -   php-version: '8.2'
-                        symfony-version: '6.4.*'
+                        symfony-version: '7.4.*'
 
         env:
-            SYMFONY_REQUIRE: ${{ matrix.symfony-version || '>=6.4' }}
+            SYMFONY_REQUIRE: ${{ matrix.symfony-version || '>=7.3' }}
 
         steps:
             - uses: actions/checkout@v5

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -30,12 +30,15 @@ jobs:
                     # lowest deps
                     -   php-version: '8.2'
                         dependency-version: 'lowest'
-                    # LTS version of Symfony
+                    # Symfony 7.4 LTS
                     -   php-version: '8.2'
-                        symfony-version: '6.4.*'
+                        symfony-version: '7.4.*'
+                    # Symfony 8.0
+                    -   php-version: '8.4'
+                        symfony-version: '8.0.*'
 
         env:
-            SYMFONY_REQUIRE: ${{ matrix.symfony-version || '>=6.4' }}
+            SYMFONY_REQUIRE: ${{ matrix.symfony-version || '>=7.3' }}
 
         steps:
             - uses: actions/checkout@v5

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,10 @@
     "require-dev": {
         "php": ">=8.2",
         "php-cs-fixer/shim": "^3.75",
-        "symfony/filesystem": "^6.4 || ^7.0",
-        "symfony/finder": "^6.4 || ^7.0"
+        "symfony/filesystem": "^7.3|^8.0",
+        "symfony/finder": "^7.3|^8.0"
     },
+    "minimum-stability": "dev",
     "config": {
         "sort-packages": true
     }

--- a/examples/commands/stores.php
+++ b/examples/commands/stores.php
@@ -116,8 +116,10 @@ $storesIds = array_keys($factories);
 $application = new Application();
 $application->setAutoExit(false);
 $application->setCatchExceptions(false);
-$application->add(new SetupStoreCommand(new ServiceLocator($factories)));
-$application->add(new DropStoreCommand(new ServiceLocator($factories)));
+$application->addCommands([
+    new SetupStoreCommand(new ServiceLocator($factories)),
+    new DropStoreCommand(new ServiceLocator($factories)),
+]);
 
 foreach ($storesIds as $store) {
     $setupOutputCode = $application->run(new ArrayInput([

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -19,17 +19,17 @@
         "symfony/ai-agent": "@dev",
         "symfony/ai-platform": "@dev",
         "symfony/ai-store": "@dev",
-        "symfony/cache": "^6.4 || ^7.0",
-        "symfony/console": "^6.4 || ^7.0",
-        "symfony/css-selector": "^6.4 || ^7.0",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/dom-crawler": "^6.4 || ^7.0",
-        "symfony/dotenv": "^6.4 || ^7.0",
-        "symfony/event-dispatcher": "^6.4 || ^7.0",
-        "symfony/filesystem": "^6.4 || ^7.0",
-        "symfony/finder": "^6.4 || ^7.0",
-        "symfony/process": "^6.4 || ^7.0",
-        "symfony/var-dumper": "^6.4 || ^7.0"
+        "symfony/cache": "^7.3|^8.0",
+        "symfony/console": "^7.3|^8.0",
+        "symfony/css-selector": "^7.3|^8.0",
+        "symfony/dependency-injection": "^7.3|^8.0",
+        "symfony/dom-crawler": "^7.3|^8.0",
+        "symfony/dotenv": "^7.3|^8.0",
+        "symfony/event-dispatcher": "^7.3|^8.0",
+        "symfony/filesystem": "^7.3|^8.0",
+        "symfony/finder": "^7.3|^8.0",
+        "symfony/process": "^7.3|^8.0",
+        "symfony/var-dumper": "^7.3|^8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1"

--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -25,23 +25,23 @@
         "phpstan/phpdoc-parser": "^2.1",
         "psr/log": "^3.0",
         "symfony/ai-platform": "@dev",
-        "symfony/clock": "^6.4 || ^7.1",
-        "symfony/http-client": "^6.4 || ^7.1",
-        "symfony/property-access": "^6.4 || ^7.1",
-        "symfony/property-info": "^6.4 || ^7.1",
-        "symfony/serializer": "^6.4 || ^7.1",
-        "symfony/type-info": "^7.2.3"
+        "symfony/clock": "^7.3|^8.0",
+        "symfony/http-client": "^7.3|^8.0",
+        "symfony/property-access": "^7.3|^8.0",
+        "symfony/property-info": "^7.3|^8.0",
+        "symfony/serializer": "^7.3|^8.0",
+        "symfony/type-info": "^7.3|^8.0"
     },
     "require-dev": {
         "mrmysql/youtube-transcript": "^0.0.5",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^11.5.13",
         "symfony/ai-store": "@dev",
-        "symfony/cache": "^6.4 || ^7.1",
-        "symfony/css-selector": "^6.4 || ^7.1",
-        "symfony/dom-crawler": "^6.4 || ^7.1",
-        "symfony/event-dispatcher": "^6.4 || ^7.1",
-        "symfony/http-foundation": "^6.4 || ^7.1",
+        "symfony/cache": "^7.3|^8.0",
+        "symfony/css-selector": "^7.3|^8.0",
+        "symfony/dom-crawler": "^7.3|^8.0",
+        "symfony/event-dispatcher": "^7.3|^8.0",
+        "symfony/http-foundation": "^7.3|^8.0",
         "symfony/translation-contracts": "^3.6"
     },
     "autoload": {
@@ -64,5 +64,6 @@
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/src/agent/tests/Toolbox/Tool/BraveTest.php
+++ b/src/agent/tests/Toolbox/Tool/BraveTest.php
@@ -23,7 +23,7 @@ final class BraveTest extends TestCase
 {
     public function testReturnsSearchResults()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/brave.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/brave.json');
         $httpClient = new MockHttpClient($result);
         $brave = new Brave($httpClient, 'test-api-key');
 
@@ -40,7 +40,7 @@ final class BraveTest extends TestCase
 
     public function testPassesCorrectParametersToApi()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/brave.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/brave.json');
         $httpClient = new MockHttpClient($result);
         $brave = new Brave($httpClient, 'test-api-key', ['extra' => 'option']);
 
@@ -66,13 +66,5 @@ final class BraveTest extends TestCase
         $results = $brave('this should return nothing');
 
         $this->assertEmpty($results);
-    }
-
-    /**
-     * This can be replaced by `JsonMockResponse::fromFile` when dropping Symfony 6.4.
-     */
-    private function jsonMockResponseFromFile(string $file): JsonMockResponse
-    {
-        return new JsonMockResponse(json_decode(file_get_contents($file), true));
     }
 }

--- a/src/agent/tests/Toolbox/Tool/FirecrawlTest.php
+++ b/src/agent/tests/Toolbox/Tool/FirecrawlTest.php
@@ -23,7 +23,7 @@ final class FirecrawlTest extends TestCase
     public function testScrape()
     {
         $httpClient = new MockHttpClient([
-            new JsonMockResponse(json_decode(file_get_contents(__DIR__.'/fixtures/firecrawl-scrape.json'), true)),
+            JsonMockResponse::fromFile(__DIR__.'/fixtures/firecrawl-scrape.json'),
         ]);
 
         $firecrawl = new Firecrawl($httpClient, 'test', 'https://127.0.0.1:3002');
@@ -39,10 +39,10 @@ final class FirecrawlTest extends TestCase
     public function testCrawl()
     {
         $httpClient = new MockHttpClient([
-            new JsonMockResponse(json_decode(file_get_contents(__DIR__.'/fixtures/firecrawl-crawl-wait.json'), true)),
-            new JsonMockResponse(json_decode(file_get_contents(__DIR__.'/fixtures/firecrawl-crawl-status.json'), true)),
-            new JsonMockResponse(json_decode(file_get_contents(__DIR__.'/fixtures/firecrawl-crawl-status-done.json'), true)),
-            new JsonMockResponse(json_decode(file_get_contents(__DIR__.'/fixtures/firecrawl-crawl.json'), true)),
+            JsonMockResponse::fromFile(__DIR__.'/fixtures/firecrawl-crawl-wait.json'),
+            JsonMockResponse::fromFile(__DIR__.'/fixtures/firecrawl-crawl-status.json'),
+            JsonMockResponse::fromFile(__DIR__.'/fixtures/firecrawl-crawl-status-done.json'),
+            JsonMockResponse::fromFile(__DIR__.'/fixtures/firecrawl-crawl.json'),
         ]);
 
         $firecrawl = new Firecrawl($httpClient, 'test', 'https://127.0.0.1:3002');
@@ -62,7 +62,7 @@ final class FirecrawlTest extends TestCase
     public function testMap()
     {
         $httpClient = new MockHttpClient([
-            new JsonMockResponse(json_decode(file_get_contents(__DIR__.'/fixtures/firecrawl-map.json'), true)),
+            JsonMockResponse::fromFile(__DIR__.'/fixtures/firecrawl-map.json'),
         ]);
 
         $firecrawl = new Firecrawl($httpClient, 'test', 'https://127.0.0.1:3002');

--- a/src/agent/tests/Toolbox/Tool/MapboxTest.php
+++ b/src/agent/tests/Toolbox/Tool/MapboxTest.php
@@ -22,7 +22,7 @@ final class MapboxTest extends TestCase
 {
     public function testGeocodeWithSingleResult()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/mapbox-geocode-single.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/mapbox-geocode-single.json');
         $httpClient = new MockHttpClient($result);
 
         $mapbox = new Mapbox($httpClient, 'test_token');
@@ -48,7 +48,7 @@ final class MapboxTest extends TestCase
 
     public function testGeocodeWithMultipleResults()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/mapbox-geocode-multiple.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/mapbox-geocode-multiple.json');
         $httpClient = new MockHttpClient($result);
 
         $mapbox = new Mapbox($httpClient, 'test_token');
@@ -83,7 +83,7 @@ final class MapboxTest extends TestCase
 
     public function testGeocodeWithNoResults()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/mapbox-geocode-empty.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/mapbox-geocode-empty.json');
         $httpClient = new MockHttpClient($result);
 
         $mapbox = new Mapbox($httpClient, 'test_token');
@@ -99,7 +99,7 @@ final class MapboxTest extends TestCase
 
     public function testReverseGeocodeWithValidCoordinates()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/mapbox-reverse-geocode.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/mapbox-reverse-geocode.json');
         $httpClient = new MockHttpClient($result);
 
         $mapbox = new Mapbox($httpClient, 'test_token');
@@ -141,7 +141,7 @@ final class MapboxTest extends TestCase
 
     public function testReverseGeocodeWithNoResults()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/mapbox-reverse-geocode-empty.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/mapbox-reverse-geocode-empty.json');
         $httpClient = new MockHttpClient($result);
 
         $mapbox = new Mapbox($httpClient, 'test_token');
@@ -153,13 +153,5 @@ final class MapboxTest extends TestCase
         ];
 
         $this->assertEquals($expected, $actual);
-    }
-
-    /**
-     * This can be replaced by `JsonMockResponse::fromFile` when dropping Symfony 6.4.
-     */
-    private function jsonMockResponseFromFile(string $file): JsonMockResponse
-    {
-        return new JsonMockResponse(json_decode(file_get_contents($file), true));
     }
 }

--- a/src/agent/tests/Toolbox/Tool/OpenMeteoTest.php
+++ b/src/agent/tests/Toolbox/Tool/OpenMeteoTest.php
@@ -22,7 +22,7 @@ final class OpenMeteoTest extends TestCase
 {
     public function testCurrent()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/openmeteo-current.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/openmeteo-current.json');
         $httpClient = new MockHttpClient($result);
 
         $openMeteo = new OpenMeteo($httpClient);
@@ -40,7 +40,7 @@ final class OpenMeteoTest extends TestCase
 
     public function testForecast()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/openmeteo-forecast.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/openmeteo-forecast.json');
         $httpClient = new MockHttpClient($result);
 
         $openMeteo = new OpenMeteo($httpClient);
@@ -68,13 +68,5 @@ final class OpenMeteoTest extends TestCase
         ];
 
         $this->assertSame($expected, $actual);
-    }
-
-    /**
-     * This can be replaced by `JsonMockResponse::fromFile` when dropping Symfony 6.4.
-     */
-    private function jsonMockResponseFromFile(string $file): JsonMockResponse
-    {
-        return new JsonMockResponse(json_decode(file_get_contents($file), true));
     }
 }

--- a/src/agent/tests/Toolbox/Tool/WikipediaTest.php
+++ b/src/agent/tests/Toolbox/Tool/WikipediaTest.php
@@ -22,7 +22,7 @@ final class WikipediaTest extends TestCase
 {
     public function testSearchWithResults()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/wikipedia-search-result.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/wikipedia-search-result.json');
         $httpClient = new MockHttpClient($result);
 
         $wikipedia = new Wikipedia($httpClient);
@@ -49,7 +49,7 @@ final class WikipediaTest extends TestCase
 
     public function testSearchWithoutResults()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/wikipedia-search-empty.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/wikipedia-search-empty.json');
         $httpClient = new MockHttpClient($result);
 
         $wikipedia = new Wikipedia($httpClient);
@@ -62,7 +62,7 @@ final class WikipediaTest extends TestCase
 
     public function testArticleWithResult()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/wikipedia-article.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/wikipedia-article.json');
         $httpClient = new MockHttpClient($result);
 
         $wikipedia = new Wikipedia($httpClient);
@@ -78,7 +78,7 @@ final class WikipediaTest extends TestCase
 
     public function testArticleWithRedirect()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/wikipedia-article-redirect.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/wikipedia-article-redirect.json');
         $httpClient = new MockHttpClient($result);
 
         $wikipedia = new Wikipedia($httpClient);
@@ -96,7 +96,7 @@ final class WikipediaTest extends TestCase
 
     public function testArticleMissing()
     {
-        $result = $this->jsonMockResponseFromFile(__DIR__.'/fixtures/wikipedia-article-missing.json');
+        $result = JsonMockResponse::fromFile(__DIR__.'/fixtures/wikipedia-article-missing.json');
         $httpClient = new MockHttpClient($result);
 
         $wikipedia = new Wikipedia($httpClient);
@@ -105,13 +105,5 @@ final class WikipediaTest extends TestCase
         $expected = 'No article with title "Blah blah blah" was found on Wikipedia.';
 
         $this->assertSame($expected, $actual);
-    }
-
-    /**
-     * This can be replaced by `JsonMockResponse::fromFile` when dropping Symfony 6.4.
-     */
-    private function jsonMockResponseFromFile(string $file): JsonMockResponse
-    {
-        return new JsonMockResponse(json_decode(file_get_contents($file), true));
     }
 }

--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -18,18 +18,18 @@
         "symfony/ai-agent": "@dev",
         "symfony/ai-platform": "@dev",
         "symfony/ai-store": "@dev",
-        "symfony/config": "^6.4 || ^7.0",
-        "symfony/console": "^6.4 || ^7.0",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/framework-bundle": "^6.4 || ^7.0",
-        "symfony/string": "^6.4 || ^7.0"
+        "symfony/config": "^7.3|^8.0",
+        "symfony/console": "^7.3|^8.0",
+        "symfony/dependency-injection": "^7.3|^8.0",
+        "symfony/framework-bundle": "^7.3|^8.0",
+        "symfony/string": "^7.3|^8.0"
     },
     "require-dev": {
         "google/auth": "^1.47",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5",
-        "symfony/expression-language": "^6.4 || ^7.0",
-        "symfony/security-core": "^6.4 || ^7.0"
+        "symfony/expression-language": "^7.3|^8.0",
+        "symfony/security-core": "^7.3|^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -44,5 +44,6 @@
     },
     "config": {
         "sort-packages": true
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -93,14 +93,14 @@ use function Symfony\Component\String\u;
  */
 final class AiBundle extends AbstractBundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 
         $container->addCompilerPass(new ProcessorCompilerPass());
     }
 
-    public function configure(DefinitionConfigurator $definition): void
+    public function configure(DefinitionConfigurator $definition): void // @phpstan-ignore-line generics.notSubtype
     {
         $definition->import('../config/options.php');
     }

--- a/src/ai-bundle/tests/Command/ChatCommandTest.php
+++ b/src/ai-bundle/tests/Command/ChatCommandTest.php
@@ -24,6 +24,7 @@ use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
@@ -39,8 +40,7 @@ final class ChatCommandTest extends TestCase
         ];
 
         $command = new ChatCommand($this->createServiceLocator($agents));
-        $application = new Application();
-        $application->add($command);
+        $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
 
@@ -74,8 +74,7 @@ final class ChatCommandTest extends TestCase
         ];
 
         $command = new ChatCommand($this->createServiceLocator($agents));
-        $application = new Application();
-        $application->add($command);
+        $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
 
@@ -104,8 +103,7 @@ final class ChatCommandTest extends TestCase
         ];
 
         $command = new ChatCommand($this->createServiceLocator($agents));
-        $application = new Application();
-        $application->add($command);
+        $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
 
@@ -133,8 +131,7 @@ final class ChatCommandTest extends TestCase
         ];
 
         $command = new ChatCommand($this->createServiceLocator($agents));
-        $application = new Application();
-        $application->add($command);
+        $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
 
@@ -171,8 +168,7 @@ final class ChatCommandTest extends TestCase
         ];
 
         $command = new ChatCommand($this->createServiceLocator($agents));
-        $application = new Application();
-        $application->add($command);
+        $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
         $commandTester->setInputs(['test', 'exit']);
@@ -210,8 +206,7 @@ final class ChatCommandTest extends TestCase
         ];
 
         $command = new ChatCommand($this->createServiceLocator($agents));
-        $application = new Application();
-        $application->add($command);
+        $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
 
@@ -253,5 +248,13 @@ final class ChatCommandTest extends TestCase
         }
 
         return new ServiceLocator($factories);
+    }
+
+    private static function createApplication(Command $command): Application
+    {
+        $application = new Application();
+        $application->addCommands([$command]);
+
+        return $application;
     }
 }

--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "symfony/config": "^6.4 || ^7.0",
-        "symfony/console": "^6.4 || ^7.0",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/framework-bundle": "^6.4 || ^7.0",
-        "symfony/http-foundation": "^6.4 || ^7.0",
-        "symfony/http-kernel": "^6.4 || ^7.0",
+        "symfony/config": "^7.3|^8.0",
+        "symfony/console": "^7.3|^8.0",
+        "symfony/dependency-injection": "^7.3|^8.0",
+        "symfony/framework-bundle": "^7.3|^8.0",
+        "symfony/http-foundation": "^7.3|^8.0",
+        "symfony/http-kernel": "^7.3|^8.0",
         "symfony/mcp-sdk": "@dev",
-        "symfony/routing": "^6.4 || ^7.0"
+        "symfony/routing": "^7.3|^8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",

--- a/src/mcp-sdk/composer.json
+++ b/src/mcp-sdk/composer.json
@@ -16,13 +16,13 @@
     "require": {
         "php": "^8.2",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/uid": "^6.4 || ^7.0"
+        "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5",
         "psr/cache": "^3.0",
-        "symfony/console": "^6.4 || ^7.0"
+        "symfony/console": "^7.3|^8.0"
     },
     "suggest": {
         "psr/cache": "To use CachePoolStore with SSE Transport",
@@ -38,5 +38,6 @@
             "Symfony\\AI\\McpSdk\\Tests\\": "tests/",
             "Symfony\\AI\\PHPStan\\": "../../.phpstan/"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/src/mcp-sdk/examples/cli/composer.json
+++ b/src/mcp-sdk/examples/cli/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/console": "^7.2",
+        "symfony/console": "^7.3|^8.0",
         "symfony/mcp-sdk": "@dev"
     },
     "minimum-stability": "stable",

--- a/src/platform/composer.json
+++ b/src/platform/composer.json
@@ -47,13 +47,13 @@
         "phpdocumentor/reflection-docblock": "^5.4",
         "phpstan/phpdoc-parser": "^2.1",
         "psr/log": "^3.0",
-        "symfony/clock": "^6.4 || ^7.1",
-        "symfony/http-client": "^6.4 || ^7.1",
-        "symfony/property-access": "^6.4 || ^7.1",
-        "symfony/property-info": "^6.4 || ^7.1",
-        "symfony/serializer": "^6.4 || ^7.1",
-        "symfony/type-info": "^7.2.3",
-        "symfony/uid": "^6.4 || ^7.1"
+        "symfony/clock": "^7.3|^8.0",
+        "symfony/http-client": "^7.3|^8.0",
+        "symfony/property-access": "^7.3|^8.0",
+        "symfony/property-info": "^7.3|^8.0",
+        "symfony/serializer": "^7.3|^8.0",
+        "symfony/type-info": "^7.3|^8.0",
+        "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {
         "async-aws/bedrock-runtime": "^0.1.0",
@@ -63,12 +63,12 @@
         "phpstan/phpstan-symfony": "^2.0.6",
         "phpunit/phpunit": "^11.5",
         "symfony/ai-agent": "@dev",
-        "symfony/console": "^6.4 || ^7.1",
-        "symfony/dotenv": "^6.4 || ^7.1",
-        "symfony/event-dispatcher": "^6.4 || ^7.1",
-        "symfony/finder": "^6.4 || ^7.1",
-        "symfony/process": "^6.4 || ^7.1",
-        "symfony/var-dumper": "^6.4 || ^7.1"
+        "symfony/console": "^7.3|^8.0",
+        "symfony/dotenv": "^7.3|^8.0",
+        "symfony/event-dispatcher": "^7.3|^8.0",
+        "symfony/finder": "^7.3|^8.0",
+        "symfony/process": "^7.3|^8.0",
+        "symfony/var-dumper": "^7.3|^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -94,5 +94,6 @@
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -24,7 +24,6 @@ use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
-use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
 
 /**
@@ -82,12 +81,7 @@ class ResultConverter implements ResultConverterInterface
                 continue;
             }
 
-            try {
-                $data = $chunk->getArrayData();
-            } catch (JsonException) {
-                // try catch only needed for Symfony 6.4
-                continue;
-            }
+            $data = $chunk->getArrayData();
 
             if ('content_block_delta' != $data['type'] || !isset($data['delta']['text'])) {
                 continue;

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -25,7 +25,6 @@ use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
-use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
 
 /**
@@ -72,12 +71,7 @@ final readonly class ResultConverter implements ResultConverterInterface
                 continue;
             }
 
-            try {
-                $data = $chunk->getArrayData();
-            } catch (JsonException) {
-                // try catch only needed for Symfony 6.4
-                continue;
-            }
+            $data = $chunk->getArrayData();
 
             if ($this->streamIsToolCall($data)) {
                 $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -28,7 +28,6 @@ use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
-use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
 
 /**
@@ -91,12 +90,7 @@ final class ResultConverter implements ResultConverterInterface
                 continue;
             }
 
-            try {
-                $data = $chunk->getArrayData();
-            } catch (JsonException) {
-                // try catch only needed for Symfony 6.4
-                continue;
-            }
+            $data = $chunk->getArrayData();
 
             if ($this->streamIsToolCall($data)) {
                 $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);

--- a/src/platform/src/Bridge/Perplexity/ResultConverter.php
+++ b/src/platform/src/Bridge/Perplexity/ResultConverter.php
@@ -23,7 +23,6 @@ use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\ResultConverterInterface as PlatformResponseConverter;
 use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
-use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
 
 /**
@@ -66,12 +65,7 @@ final class ResultConverter implements PlatformResponseConverter
                 continue;
             }
 
-            try {
-                $data = $chunk->getArrayData();
-            } catch (JsonException) {
-                // try catch only needed for Symfony 6.4
-                continue;
-            }
+            $data = $chunk->getArrayData();
 
             if (isset($data['choices'][0]['delta']['content'])) {
                 yield $data['choices'][0]['delta']['content'];

--- a/src/store/composer.json
+++ b/src/store/composer.json
@@ -36,9 +36,9 @@
         "ext-fileinfo": "*",
         "psr/log": "^3.0",
         "symfony/ai-platform": "@dev",
-        "symfony/clock": "^6.4 || ^7.1",
-        "symfony/http-client": "^6.4 || ^7.1",
-        "symfony/uid": "^6.4 || ^7.1"
+        "symfony/clock": "^7.3|^8.0",
+        "symfony/http-client": "^7.3|^8.0",
+        "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {
         "codewithkyrian/chromadb-php": "^0.2.1 || ^0.3 || ^0.4",
@@ -74,5 +74,6 @@
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/src/store/tests/Document/Loader/RssFeedLoaderTest.php
+++ b/src/store/tests/Document/Loader/RssFeedLoaderTest.php
@@ -40,7 +40,7 @@ final class RssFeedLoaderTest extends TestCase
 
     public function testLoadWithValidRssFeed()
     {
-        $httpClient = new MockHttpClient([new MockResponse(file_get_contents(__DIR__.'/../../fixtures/symfony-blog.rss'))]);
+        $httpClient = new MockHttpClient([MockResponse::fromFile(__DIR__.'/../../fixtures/symfony-blog.rss')]);
         $loader = new RssFeedLoader($httpClient);
 
         $documents = iterator_to_array($loader->load('https://feeds.feedburner.com/symfony/blog'));
@@ -122,7 +122,7 @@ XML;
 
     public function testLoadReturnsIterableOfTextDocuments()
     {
-        $httpClient = new MockHttpClient([new MockResponse(file_get_contents(__DIR__.'/../../fixtures/symfony-blog.rss'))]);
+        $httpClient = new MockHttpClient([MockResponse::fromFile(__DIR__.'/../../fixtures/symfony-blog.rss')]);
         $loader = new RssFeedLoader($httpClient);
         $result = $loader->load('https://feeds.feedburner.com/symfony/blog');
 
@@ -135,12 +135,12 @@ XML;
 
     public function testLoadGeneratesConsistentUuids()
     {
-        $httpClient = new MockHttpClient([new MockResponse(file_get_contents(__DIR__.'/../../fixtures/symfony-blog.rss'))]);
+        $httpClient = new MockHttpClient([MockResponse::fromFile(__DIR__.'/../../fixtures/symfony-blog.rss')]);
         $loader = new RssFeedLoader($httpClient);
         $documents1 = iterator_to_array($loader->load('https://feeds.feedburner.com/symfony/blog'));
 
         // Load same feed again
-        $httpClient2 = new MockHttpClient([new MockResponse(file_get_contents(__DIR__.'/../../fixtures/symfony-blog.rss'))]);
+        $httpClient2 = new MockHttpClient([MockResponse::fromFile(__DIR__.'/../../fixtures/symfony-blog.rss')]);
         $loader2 = new RssFeedLoader($httpClient2);
         $documents2 = iterator_to_array($loader2->load('https://feeds.feedburner.com/symfony/blog'));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

- Update all composer.json files to require Symfony ^7.3|^8.0
- Minimum supported version is now Symfony 7.3 LTS

Needs
- [x] https://github.com/CodeWithKyrian/transformers-php/pull/94
- [x] https://github.com/CodeWithKyrian/platform-package-installer/pull/3
- [x] https://github.com/CodeWithKyrian/platform-package-installer/pull/4