### PR TITLE
[AIBundle] Improve injection aliases

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -27,13 +27,13 @@ use Symfony\AI\AiBundle\Profiler\TraceableToolbox;
 use Symfony\AI\AiBundle\Security\Attribute\IsGrantedTool;
 use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory as AnthropicPlatformFactory;
 use Symfony\AI\Platform\Bridge\Azure\OpenAi\PlatformFactory as AzureOpenAiPlatformFactory;
+use Symfony\AI\Platform\Bridge\Cerebras\PlatformFactory as CerebrasPlatformFactory;
 use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory as GeminiPlatformFactory;
 use Symfony\AI\Platform\Bridge\LmStudio\PlatformFactory as LmStudioPlatformFactory;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory as MistralPlatformFactory;
 use Symfony\AI\Platform\Bridge\Ollama\PlatformFactory as OllamaPlatformFactory;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory as OpenAiPlatformFactory;
 use Symfony\AI\Platform\Bridge\OpenRouter\PlatformFactory as OpenRouterPlatformFactory;
-use Symfony\AI\Platform\Bridge\Cerebras\PlatformFactory as CerebrasPlatformFactory;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Platform;
@@ -56,6 +56,7 @@ use Symfony\AI\Store\InMemoryStore;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\AI\Store\VectorStoreInterface;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -106,9 +107,6 @@ final class AiBundle extends AbstractBundle
 
         foreach ($config['agent'] as $agentName => $agent) {
             $this->processAgentConfig($agentName, $agent, $builder);
-        }
-        if (1 === \count($config['agent']) && isset($agentName)) {
-            $builder->setAlias(AgentInterface::class, 'ai.agent.'.$agentName);
         }
 
         foreach ($config['store'] ?? [] as $type => $store) {
@@ -460,6 +458,7 @@ final class AiBundle extends AbstractBundle
         ;
 
         $container->setDefinition('ai.agent.'.$name, $agentDefinition);
+        $container->registerAliasForArgument('ai.agent.'.$name, AgentInterface::class, (new Target($name.'Agent'))->getParsedName());
     }
 
     /**

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -30,6 +30,21 @@ class AiBundleTest extends TestCase
         $this->buildContainer($this->getFullConfig());
     }
 
+    public function testInjectionAgentAliasIsRegistered()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasAlias('Symfony\AI\Agent\AgentInterface $myAgentAgent'));
+    }
+
     #[TestWith([true], 'enabled')]
     #[TestWith([false], 'disabled')]
     public function testFaultTolerantAgentSpecificToolbox(bool $enabled)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | None
| License       | MIT

Hi 👋🏻 

This PR aims to add "injection aliases", those allows the user to use the following code while defining X agents: 

```php
public function __construct(
    private AgentInterface $fooAgent,
) {
}
```

Why the `Agent` suffix? Because we don't know, maybe one day, a service will be called `foo` and it will trigger an error, it seems better to define a suffix and ensure that this bundle is the only one to use it.