### PR TITLE
[Store] Add a way to store document content when using Chroma DB

### DIFF
--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -38,14 +38,18 @@ final readonly class Store implements StoreInterface
         $ids = [];
         $vectors = [];
         $metadata = [];
+        $originalDocuments = [];
         foreach ($documents as $document) {
             $ids[] = (string) $document->id;
             $vectors[] = $document->vector->getData();
-            $metadata[] = $document->metadata->getArrayCopy();
+            $metadataCopy = $document->metadata->getArrayCopy();
+            $originalDocuments[] = $document->metadata->getText() ?? '';
+            unset($metadataCopy[Metadata::KEY_TEXT]);
+            $metadata[] = $metadataCopy;
         }
 
         $collection = $this->client->getOrCreateCollection($this->collectionName);
-        $collection->add($ids, $vectors, $metadata);
+        $collection->add($ids, $vectors, $metadata, $originalDocuments);
     }
 
     public function query(Vector $vector, array $options = []): array

--- a/src/store/src/Document/Loader/TextFileLoader.php
+++ b/src/store/src/Document/Loader/TextFileLoader.php
@@ -35,7 +35,7 @@ final readonly class TextFileLoader implements LoaderInterface
         }
 
         yield new TextDocument(Uuid::v4(), trim($content), new Metadata([
-            'source' => $source,
+            Metadata::KEY_SOURCE => $source,
         ]));
     }
 }

--- a/src/store/src/Document/Metadata.php
+++ b/src/store/src/Document/Metadata.php
@@ -18,4 +18,58 @@ namespace Symfony\AI\Store\Document;
  */
 final class Metadata extends \ArrayObject
 {
+    public const KEY_PARENT_ID = '_parent_id';
+    public const KEY_TEXT = '_text';
+    public const KEY_SOURCE = '_source';
+
+    public function hasParentId(): bool
+    {
+        return $this->offsetExists(self::KEY_PARENT_ID);
+    }
+
+    public function getParentId(): int|string|null
+    {
+        return $this->offsetExists(self::KEY_PARENT_ID)
+            ? $this->offsetGet(self::KEY_PARENT_ID)
+            : null;
+    }
+
+    public function setParentId(int|string $parentId): void
+    {
+        $this->offsetSet(self::KEY_PARENT_ID, $parentId);
+    }
+
+    public function hasText(): bool
+    {
+        return $this->offsetExists(self::KEY_TEXT);
+    }
+
+    public function setText(string $text): void
+    {
+        $this->offsetSet(self::KEY_TEXT, $text);
+    }
+
+    public function getText(): ?string
+    {
+        return $this->offsetExists(self::KEY_TEXT)
+            ? $this->offsetGet(self::KEY_TEXT)
+            : null;
+    }
+
+    public function hasSource(): bool
+    {
+        return $this->offsetExists(self::KEY_SOURCE);
+    }
+
+    public function getSource(): ?string
+    {
+        return $this->offsetExists(self::KEY_SOURCE)
+            ? $this->offsetGet(self::KEY_SOURCE)
+            : null;
+    }
+
+    public function setSource(string $source): void
+    {
+        $this->offsetSet(self::KEY_SOURCE, $source);
+    }
 }

--- a/src/store/src/Document/Transformer/TextSplitTransformer.php
+++ b/src/store/src/Document/Transformer/TextSplitTransformer.php
@@ -57,8 +57,8 @@ final readonly class TextSplitTransformer implements TransformerInterface
                 $chunkText = mb_substr($text, $start, $end - $start);
 
                 yield new TextDocument(Uuid::v4(), $chunkText, new Metadata([
-                    'parent_id' => $document->id,
-                    'text' => $chunkText,
+                    Metadata::KEY_PARENT_ID => $document->id,
+                    Metadata::KEY_TEXT => $chunkText,
                     ...$document->metadata,
                 ]));
 

--- a/src/store/tests/Document/Loader/TextFileLoaderTest.php
+++ b/src/store/tests/Document/Loader/TextFileLoaderTest.php
@@ -52,6 +52,7 @@ final class TextFileLoaderTest extends TestCase
 
         $this->assertCount(1, $documents);
         $this->assertInstanceOf(TextDocument::class, $document = $documents[0]);
-        $this->assertSame($source, $document->metadata['source']);
+        $this->assertSame($source, $document->metadata['_source']);
+        $this->assertSame($source, $document->metadata->getSource());
     }
 }

--- a/src/store/tests/Document/MetadataTest.php
+++ b/src/store/tests/Document/MetadataTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests\Document;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Store\Document\Metadata;
+
+#[CoversClass(Metadata::class)]
+final class MetadataTest extends TestCase
+{
+    public function testMetadataExtendsArrayObject()
+    {
+        $metadata = new Metadata();
+
+        $this->assertInstanceOf(\ArrayObject::class, $metadata);
+    }
+
+    public function testMetadataCanBeInitializedWithData()
+    {
+        $data = ['title' => 'Test Document', 'category' => 'test'];
+        $metadata = new Metadata($data);
+
+        $this->assertSame('Test Document', $metadata['title']);
+        $this->assertSame('test', $metadata['category']);
+        $this->assertSame($data, $metadata->getArrayCopy());
+    }
+
+    public function testConstants()
+    {
+        $this->assertSame('_parent_id', Metadata::KEY_PARENT_ID);
+        $this->assertSame('_text', Metadata::KEY_TEXT);
+        $this->assertSame('_source', Metadata::KEY_SOURCE);
+    }
+
+    #[DataProvider('parentIdProvider')]
+    public function testParentIdMethods(int|string|null $parentId)
+    {
+        $metadata = new Metadata();
+
+        // Initially should not have parent ID
+        $this->assertFalse($metadata->hasParentId());
+        $this->assertNull($metadata->getParentId());
+
+        // Set parent ID
+        $metadata->setParentId($parentId);
+
+        $this->assertTrue($metadata->hasParentId());
+        $this->assertSame($parentId, $metadata->getParentId());
+    }
+
+    /**
+     * @return \Iterator<string, array{parentId: int|string|null}>
+     */
+    public static function parentIdProvider(): \Iterator
+    {
+        yield 'integer parent id' => [
+            'parentId' => 123,
+        ];
+
+        yield 'string parent id' => [
+            'parentId' => 'parent-123',
+        ];
+    }
+
+    #[DataProvider('textProvider')]
+    public function testTextMethods(?string $text)
+    {
+        $metadata = new Metadata();
+
+        // Initially should not have text
+        $this->assertFalse($metadata->hasText());
+        $this->assertNull($metadata->getText());
+
+        // Set text
+        $metadata->setText($text);
+
+        $this->assertTrue($metadata->hasText());
+        $this->assertSame($text, $metadata->getText());
+    }
+
+    /**
+     * @return \Iterator<string, array{text: string|null}>
+     */
+    public static function textProvider(): \Iterator
+    {
+        yield 'string text' => [
+            'text' => 'This is some text content',
+        ];
+
+        yield 'empty string text' => [
+            'text' => '',
+        ];
+    }
+
+    #[DataProvider('sourceProvider')]
+    public function testSourceMethods(?string $source)
+    {
+        $metadata = new Metadata();
+
+        // Initially should not have source
+        $this->assertFalse($metadata->hasSource());
+        $this->assertNull($metadata->getSource());
+
+        // Set source
+        $metadata->setSource($source);
+
+        $this->assertTrue($metadata->hasSource());
+        $this->assertSame($source, $metadata->getSource());
+    }
+
+    /**
+     * @return \Iterator<string, array{source: string|null}>
+     */
+    public static function sourceProvider(): \Iterator
+    {
+        yield 'string source' => [
+            'source' => 'document.pdf',
+        ];
+
+        yield 'empty string source' => [
+            'source' => '',
+        ];
+    }
+
+    public function testMetadataInitializedWithSpecialKeys()
+    {
+        $data = [
+            Metadata::KEY_PARENT_ID => 'parent-123',
+            Metadata::KEY_TEXT => 'This is the text content',
+            Metadata::KEY_SOURCE => 'document.pdf',
+            'title' => 'Test Document',
+        ];
+
+        $metadata = new Metadata($data);
+
+        // Test parent ID
+        $this->assertTrue($metadata->hasParentId());
+        $this->assertSame('parent-123', $metadata->getParentId());
+
+        // Test text
+        $this->assertTrue($metadata->hasText());
+        $this->assertSame('This is the text content', $metadata->getText());
+
+        // Test source
+        $this->assertTrue($metadata->hasSource());
+        $this->assertSame('document.pdf', $metadata->getSource());
+
+        // Test regular metadata
+        $this->assertSame('Test Document', $metadata['title']);
+    }
+
+    public function testArrayObjectBehavior()
+    {
+        $metadata = new Metadata();
+
+        // Test setting and getting values
+        $metadata['title'] = 'Test Document';
+        $metadata['category'] = 'test';
+
+        $this->assertSame('Test Document', $metadata['title']);
+        $this->assertSame('test', $metadata['category']);
+
+        // Test isset
+        $this->assertTrue(isset($metadata['title']));
+        $this->assertFalse(isset($metadata['nonexistent']));
+
+        // Test unset
+        unset($metadata['category']);
+        $this->assertFalse(isset($metadata['category']));
+
+        // Test count
+        $this->assertCount(1, $metadata);
+    }
+
+    public function testIteratorBehavior()
+    {
+        $data = ['title' => 'Test Document', 'category' => 'test', 'author' => 'John Doe'];
+        $metadata = new Metadata($data);
+
+        $iteratedData = [];
+        foreach ($metadata as $key => $value) {
+            $iteratedData[$key] = $value;
+        }
+
+        $this->assertSame($data, $iteratedData);
+    }
+
+    public function testGettersReturnNullForMissingKeys()
+    {
+        $metadata = new Metadata();
+
+        $this->assertNull($metadata->getParentId());
+        $this->assertNull($metadata->getText());
+        $this->assertNull($metadata->getSource());
+    }
+
+    public function testHasMethodsReturnFalseForMissingKeys()
+    {
+        $metadata = new Metadata();
+
+        $this->assertFalse($metadata->hasParentId());
+        $this->assertFalse($metadata->hasText());
+        $this->assertFalse($metadata->hasSource());
+    }
+
+    public function testOverwritingSpecialKeys()
+    {
+        $metadata = new Metadata();
+
+        // Set initial values
+        $metadata->setParentId('parent-1');
+        $metadata->setText('initial text');
+        $metadata->setSource('initial.pdf');
+
+        // Overwrite values
+        $metadata->setParentId('parent-2');
+        $metadata->setText('updated text');
+        $metadata->setSource('updated.pdf');
+
+        $this->assertSame('parent-2', $metadata->getParentId());
+        $this->assertSame('updated text', $metadata->getText());
+        $this->assertSame('updated.pdf', $metadata->getSource());
+    }
+}

--- a/src/store/tests/Document/Transformer/TextSplitTransformerTest.php
+++ b/src/store/tests/Document/Transformer/TextSplitTransformerTest.php
@@ -130,8 +130,8 @@ final class TextSplitTransformerTest extends TestCase
         ]));
 
         $this->assertCount(2, $chunks);
-        $this->assertSame($document->id, $chunks[0]->metadata['parent_id']);
-        $this->assertSame($document->id, $chunks[1]->metadata['parent_id']);
+        $this->assertSame($document->id, $chunks[0]->metadata['_parent_id']);
+        $this->assertSame($document->id, $chunks[1]->metadata['_parent_id']);
     }
 
     public function testMetadataIsInherited()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | N/A
| License       | MIT

This is just a draft for now to explain what I am trying to achieve - I would like to be able to store the original document content in the Chroma DB records, but the `VectorDocument` currently has no way to pass that in, other than the metadata. I feel like this requirement will not be specific just to Chroma DB, but various databases used for embeddings will support storing of the original document content along with the vectors.

Any suggestions on how to approach this holistically? Should the `VectorDocument` be expanded with optional field like `?string $content = null`?

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
