### PR TITLE
Introduce action as indicator to indicate what one wants to do with the model

### DIFF
--- a/src/platform/src/Action.php
+++ b/src/platform/src/Action.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform;
+
+/**
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+enum Action: string
+{
+    case CHAT = 'chat';
+    case CALCULATE_EMBEDDINGS = 'embeddings';
+    case COMPLETE_CHAT = 'chat-completion';
+}

--- a/src/platform/src/Bridge/Albert/EmbeddingsModelClient.php
+++ b/src/platform/src/Bridge/Albert/EmbeddingsModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Albert;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -33,8 +34,12 @@ final readonly class EmbeddingsModelClient implements ModelClientInterface
         '' !== $baseUrl || throw new InvalidArgumentException('The base URL must not be empty.');
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Embeddings;
     }
 

--- a/src/platform/src/Bridge/Albert/EmbeddingsModelClient.php
+++ b/src/platform/src/Bridge/Albert/EmbeddingsModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Albert;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -43,8 +44,12 @@ final readonly class EmbeddingsModelClient implements ModelClientInterface
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawResultInterface
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CALCULATE_EMBEDDINGS]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/embeddings', $this->baseUrl), [
             'auth_bearer' => $this->apiKey,
             'json' => \is_array($payload) ? array_merge($payload, $options) : $payload,

--- a/src/platform/src/Bridge/Albert/GptModelClient.php
+++ b/src/platform/src/Bridge/Albert/GptModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Albert;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -38,8 +39,12 @@ final readonly class GptModelClient implements ModelClientInterface
         '' !== $baseUrl || throw new InvalidArgumentException('The base URL must not be empty.');
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Gpt;
     }
 

--- a/src/platform/src/Bridge/Albert/GptModelClient.php
+++ b/src/platform/src/Bridge/Albert/GptModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Albert;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -48,8 +49,12 @@ final readonly class GptModelClient implements ModelClientInterface
         return $model instanceof Gpt;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawResultInterface
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/chat/completions', $this->baseUrl), [
             'auth_bearer' => $this->apiKey,
             'json' => \is_array($payload) ? array_merge($payload, $options) : $payload,

--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Anthropic;
 
 use Symfony\AI\Platform\Action;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -42,8 +43,12 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Claude;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT]);
+        }
+
         if (isset($options['tools'])) {
             $options['tool_choice'] = ['type' => 'auto'];
         }

--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Anthropic;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -32,8 +33,12 @@ final readonly class ModelClient implements ModelClientInterface
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Claude;
     }
 

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Anthropic;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -31,8 +32,12 @@ use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
  */
 class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Claude;
     }
 

--- a/src/platform/src/Bridge/Azure/Meta/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Azure/Meta/LlamaModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Azure\Meta;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -39,8 +40,12 @@ final readonly class LlamaModelClient implements ModelClientInterface
         return $model instanceof Llama;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         $url = \sprintf('https://%s/chat/completions', $this->baseUrl);
 
         return new RawHttpResult($this->httpClient->request('POST', $url, [

--- a/src/platform/src/Bridge/Azure/Meta/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Azure/Meta/LlamaModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\Meta;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -29,8 +30,12 @@ final readonly class LlamaModelClient implements ModelClientInterface
     ) {
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Llama;
     }
 

--- a/src/platform/src/Bridge/Azure/Meta/LlamaResultConverter.php
+++ b/src/platform/src/Bridge/Azure/Meta/LlamaResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\Meta;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -23,8 +24,12 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final readonly class LlamaResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Llama;
     }
 

--- a/src/platform/src/Bridge/Azure/OpenAi/EmbeddingsModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/EmbeddingsModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Azure\OpenAi;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -51,8 +52,12 @@ final readonly class EmbeddingsModelClient implements ModelClientInterface
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CALCULATE_EMBEDDINGS]);
+        }
+
         $url = \sprintf('https://%s/openai/deployments/%s/embeddings', $this->baseUrl, $this->deployment);
 
         return new RawHttpResult($this->httpClient->request('POST', $url, [

--- a/src/platform/src/Bridge/Azure/OpenAi/EmbeddingsModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/EmbeddingsModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\OpenAi;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -41,8 +42,12 @@ final readonly class EmbeddingsModelClient implements ModelClientInterface
         '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Embeddings;
     }
 

--- a/src/platform/src/Bridge/Azure/OpenAi/GptModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/GptModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\OpenAi;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -41,8 +42,12 @@ final readonly class GptModelClient implements ModelClientInterface
         '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Gpt;
     }
 

--- a/src/platform/src/Bridge/Azure/OpenAi/GptModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/GptModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Azure\OpenAi;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -51,8 +52,12 @@ final readonly class GptModelClient implements ModelClientInterface
         return $model instanceof Gpt;
     }
 
-    public function request(Model $model, object|array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, object|array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         $url = \sprintf('https://%s/openai/deployments/%s/chat/completions', $this->baseUrl, $this->deployment);
 
         return new RawHttpResult($this->httpClient->request('POST', $url, [

--- a/src/platform/src/Bridge/Azure/OpenAi/WhisperModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/WhisperModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\OpenAi;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper\Task;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
@@ -42,8 +43,12 @@ final readonly class WhisperModelClient implements ModelClientInterface
         '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Whisper;
     }
 

--- a/src/platform/src/Bridge/Azure/OpenAi/WhisperModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/WhisperModelClient.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Azure\OpenAi;
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper\Task;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -52,8 +53,12 @@ final readonly class WhisperModelClient implements ModelClientInterface
         return $model instanceof Whisper;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT]);
+        }
+
         $task = $options['task'] ?? Task::TRANSCRIPTION;
         $endpoint = Task::TRANSCRIPTION === $task ? 'transcriptions' : 'translations';
         $url = \sprintf('https://%s/openai/deployments/%s/audio/%s', $this->baseUrl, $this->deployment, $endpoint);

--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Bedrock\Anthropic;
 use AsyncAws\BedrockRuntime\BedrockRuntimeClient;
 use AsyncAws\BedrockRuntime\Input\InvokeModelRequest;
 use AsyncAws\BedrockRuntime\Result\InvokeModelResponse;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -34,8 +35,12 @@ final readonly class ClaudeModelClient implements ModelClientInterface
     ) {
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Claude;
     }
 

--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
@@ -17,6 +17,7 @@ use AsyncAws\BedrockRuntime\Result\InvokeModelResponse;
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -44,8 +45,12 @@ final readonly class ClaudeModelClient implements ModelClientInterface
         return $model instanceof Claude;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawBedrockResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawBedrockResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         unset($payload['model']);
 
         if (isset($options['tools'])) {

--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeResultConverter.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Bedrock\Anthropic;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -26,8 +27,12 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final readonly class ClaudeResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Claude;
     }
 

--- a/src/platform/src/Bridge/Bedrock/Meta/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Meta/LlamaModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Bedrock\Meta;
 
 use AsyncAws\BedrockRuntime\BedrockRuntimeClient;
 use AsyncAws\BedrockRuntime\Input\InvokeModelRequest;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Model;
@@ -28,8 +29,12 @@ class LlamaModelClient implements ModelClientInterface
     ) {
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Llama;
     }
 

--- a/src/platform/src/Bridge/Bedrock/Meta/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Meta/LlamaModelClient.php
@@ -16,6 +16,7 @@ use AsyncAws\BedrockRuntime\Input\InvokeModelRequest;
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 
@@ -38,8 +39,12 @@ class LlamaModelClient implements ModelClientInterface
         return $model instanceof Llama;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawBedrockResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawBedrockResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         return new RawBedrockResult($this->bedrockRuntimeClient->invokeModel(new InvokeModelRequest([
             'modelId' => $this->getModelId($model),
             'contentType' => 'application/json',

--- a/src/platform/src/Bridge/Bedrock/Meta/LlamaResultConverter.php
+++ b/src/platform/src/Bridge/Bedrock/Meta/LlamaResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Bedrock\Meta;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -24,8 +25,12 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 class LlamaResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Llama;
     }
 

--- a/src/platform/src/Bridge/Bedrock/Nova/NovaModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/NovaModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Bedrock\Nova;
 
 use AsyncAws\BedrockRuntime\BedrockRuntimeClient;
 use AsyncAws\BedrockRuntime\Input\InvokeModelRequest;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -27,8 +28,12 @@ class NovaModelClient implements ModelClientInterface
     ) {
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Nova;
     }
 

--- a/src/platform/src/Bridge/Bedrock/Nova/NovaModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/NovaModelClient.php
@@ -15,6 +15,7 @@ use AsyncAws\BedrockRuntime\BedrockRuntimeClient;
 use AsyncAws\BedrockRuntime\Input\InvokeModelRequest;
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 
@@ -37,8 +38,12 @@ class NovaModelClient implements ModelClientInterface
         return $model instanceof Nova;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawBedrockResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawBedrockResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         $modelOptions = [];
         if (isset($options['tools'])) {
             $modelOptions['toolConfig']['tools'] = $options['tools'];

--- a/src/platform/src/Bridge/Bedrock/Nova/NovaResultConverter.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/NovaResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Bedrock\Nova;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -25,8 +26,12 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 class NovaResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Nova;
     }
 

--- a/src/platform/src/Bridge/Cerebras/ModelClient.php
+++ b/src/platform/src/Bridge/Cerebras/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Cerebras;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -40,8 +41,12 @@ final readonly class ModelClient implements ModelClientInterface
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }
 
-    public function supports(BaseModel $model): bool
+    public function supports(BaseModel $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Model;
     }
 

--- a/src/platform/src/Bridge/Cerebras/ModelClient.php
+++ b/src/platform/src/Bridge/Cerebras/ModelClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Cerebras;
 
 use Symfony\AI\Platform\Action;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -50,8 +51,12 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Model;
     }
 
-    public function request(BaseModel $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(BaseModel $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         return new RawHttpResult(
             $this->httpClient->request(
                 'POST', 'https://api.cerebras.ai/v1/chat/completions',

--- a/src/platform/src/Bridge/Cerebras/ResultConverter.php
+++ b/src/platform/src/Bridge/Cerebras/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Cerebras;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -29,8 +30,12 @@ use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
  */
 final readonly class ResultConverter implements ResultConverterInterface
 {
-    public function supports(BaseModel $model): bool
+    public function supports(BaseModel $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Model;
     }
 

--- a/src/platform/src/Bridge/Gemini/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Gemini\Embeddings;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Gemini\Embeddings;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -29,8 +30,12 @@ final readonly class ModelClient implements ModelClientInterface
     ) {
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Embeddings;
     }
 

--- a/src/platform/src/Bridge/Gemini/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Gemini\Embeddings;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Gemini\Embeddings;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -39,8 +40,12 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CALCULATE_EMBEDDINGS]);
+        }
+
         $url = \sprintf('https://generativelanguage.googleapis.com/v1beta/models/%s:%s', $model->getName(), 'batchEmbedContents');
         $modelOptions = $model->getOptions();
 

--- a/src/platform/src/Bridge/Gemini/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Gemini\Embeddings;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Gemini\Embeddings;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -24,8 +25,12 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final readonly class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Embeddings;
     }
 

--- a/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Gemini\Gemini;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -44,10 +45,15 @@ final readonly class ModelClient implements ModelClientInterface
     }
 
     /**
+     * @param Action $action
      * @throws TransportExceptionInterface When the HTTP request fails due to network issues
      */
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         $url = \sprintf(
             'https://generativelanguage.googleapis.com/v1beta/models/%s:%s',
             $model->getName(),

--- a/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Gemini\Gemini;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -33,8 +34,12 @@ final readonly class ModelClient implements ModelClientInterface
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Gemini;
     }
 

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Gemini\Gemini;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -31,8 +32,12 @@ use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
  */
 final readonly class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Gemini;
     }
 

--- a/src/platform/src/Bridge/HuggingFace/ModelClient.php
+++ b/src/platform/src/Bridge/HuggingFace/ModelClient.php
@@ -41,8 +41,9 @@ final readonly class ModelClient implements PlatformModelClient
 
     /**
      * The difference in HuggingFace here is that we treat the payload as the options for the request not only the body.
+     * @param Action $action
      */
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
         // Extract task from options if provided
         $task = $options['task'] ?? null;

--- a/src/platform/src/Bridge/HuggingFace/ModelClient.php
+++ b/src/platform/src/Bridge/HuggingFace/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\HuggingFace;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface as PlatformModelClient;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -33,7 +34,7 @@ final readonly class ModelClient implements PlatformModelClient
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
         return true;
     }

--- a/src/platform/src/Bridge/HuggingFace/ResultConverter.php
+++ b/src/platform/src/Bridge/HuggingFace/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\HuggingFace;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\HuggingFace\Output\ClassificationResult;
 use Symfony\AI\Platform\Bridge\HuggingFace\Output\FillMaskResult;
 use Symfony\AI\Platform\Bridge\HuggingFace\Output\ImageSegmentationResult;
@@ -38,7 +39,7 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final readonly class ResultConverter implements PlatformResponseConverter
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
         return true;
     }

--- a/src/platform/src/Bridge/LmStudio/Completions/ModelClient.php
+++ b/src/platform/src/Bridge/LmStudio/Completions/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\LmStudio\Completions;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\LmStudio\Completions;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface as PlatformResponseFactory;
@@ -32,8 +33,12 @@ final readonly class ModelClient implements PlatformResponseFactory
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Completions;
     }
 

--- a/src/platform/src/Bridge/LmStudio/Completions/ModelClient.php
+++ b/src/platform/src/Bridge/LmStudio/Completions/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\LmStudio\Completions;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\LmStudio\Completions;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface as PlatformResponseFactory;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -42,8 +43,12 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $model instanceof Completions;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::COMPLETE_CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/v1/chat/completions', $this->hostUrl), [
             'json' => array_merge($options, $payload),
         ]));

--- a/src/platform/src/Bridge/LmStudio/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/LmStudio/Completions/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\LmStudio\Completions;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\LmStudio\Completions;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt\ResultConverter as OpenAiResponseConverter;
 use Symfony\AI\Platform\Model;
@@ -28,8 +29,12 @@ final class ResultConverter implements ResultConverterInterface
     ) {
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Completions;
     }
 

--- a/src/platform/src/Bridge/LmStudio/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/LmStudio/Embeddings/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\LmStudio\Embeddings;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\LmStudio\Embeddings;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface as PlatformResponseFactory;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -39,8 +40,12 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CALCULATE_EMBEDDINGS]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/v1/embeddings', $this->hostUrl), [
             'json' => array_merge($options, [
                 'model' => $model->getName(),

--- a/src/platform/src/Bridge/LmStudio/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/LmStudio/Embeddings/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\LmStudio\Embeddings;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\LmStudio\Embeddings;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface as PlatformResponseFactory;
@@ -29,8 +30,12 @@ final readonly class ModelClient implements PlatformResponseFactory
     ) {
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Embeddings;
     }
 

--- a/src/platform/src/Bridge/LmStudio/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/LmStudio/Embeddings/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\LmStudio\Embeddings;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\LmStudio\Embeddings;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -25,8 +26,12 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Embeddings;
     }
 

--- a/src/platform/src/Bridge/Mistral/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Embeddings/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Mistral\Embeddings;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Mistral\Embeddings;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -33,8 +34,12 @@ final readonly class ModelClient implements ModelClientInterface
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Embeddings;
     }
 

--- a/src/platform/src/Bridge/Mistral/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Embeddings/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Mistral\Embeddings;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Mistral\Embeddings;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -43,8 +44,12 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CALCULATE_EMBEDDINGS]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.mistral.ai/v1/embeddings', [
             'auth_bearer' => $this->apiKey,
             'headers' => [

--- a/src/platform/src/Bridge/Mistral/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Embeddings/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Mistral\Embeddings;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Mistral\Embeddings;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -25,8 +26,12 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final readonly class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Embeddings;
     }
 

--- a/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Mistral\Llm;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -43,8 +44,12 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Mistral;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,
             'headers' => [

--- a/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Mistral\Llm;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -33,8 +34,12 @@ final readonly class ModelClient implements ModelClientInterface
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Mistral;
     }
 

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Mistral\Llm;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -33,8 +34,12 @@ use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
  */
 final readonly class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Mistral;
     }
 

--- a/src/platform/src/Bridge/Ollama/OllamaClient.php
+++ b/src/platform/src/Bridge/Ollama/OllamaClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Ollama;
 
 use Symfony\AI\Platform\Action;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -50,7 +51,7 @@ final readonly class OllamaClient implements ModelClientInterface
         };
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
         $response = $this->httpClient->request('POST', \sprintf('%s/api/show', $this->hostUrl), [
             'json' => [
@@ -67,7 +68,7 @@ final readonly class OllamaClient implements ModelClientInterface
         return match (true) {
             \in_array('completion', $capabilities, true) => $this->doCompletionRequest($payload, $options),
             \in_array('embedding', $capabilities, true) => $this->doEmbeddingsRequest($model, $payload, $options),
-            default => throw new InvalidArgumentException(\sprintf('Unsupported model "%s": "%s".', $model::class, $model->getName())),
+            default => throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT, Action::CALCULATE_EMBEDDINGS], new InvalidArgumentException(\sprintf('Unsupported model "%s": "%s".', $model::class, $model->getName()))),
         };
     }
 

--- a/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
+++ b/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Ollama;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -27,8 +28,12 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final readonly class OllamaResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action && Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Ollama;
     }
 

--- a/src/platform/src/Bridge/OpenAi/DallE/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/DallE/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenAi\DallE;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\DallE;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -34,7 +35,7 @@ final readonly class ModelClient implements ModelClientInterface
         str_starts_with($apiKey, 'sk-') || throw new InvalidArgumentException('The API key must start with "sk-".');
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
         return $model instanceof DallE;
     }

--- a/src/platform/src/Bridge/OpenAi/DallE/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/DallE/ModelClient.php
@@ -40,7 +40,7 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof DallE;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.openai.com/v1/images/generations', [
             'auth_bearer' => $this->apiKey,

--- a/src/platform/src/Bridge/OpenAi/DallE/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/DallE/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenAi\DallE;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\DallE;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -25,7 +26,7 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final readonly class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
         return $model instanceof DallE;
     }

--- a/src/platform/src/Bridge/OpenAi/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -32,8 +33,12 @@ final readonly class ModelClient implements PlatformResponseFactory
         str_starts_with($apiKey, 'sk-') || throw new InvalidArgumentException('The API key must start with "sk-".');
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Embeddings;
     }
 

--- a/src/platform/src/Bridge/OpenAi/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface as PlatformResponseFactory;
@@ -42,8 +43,12 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CALCULATE_EMBEDDINGS]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.openai.com/v1/embeddings', [
             'auth_bearer' => $this->apiKey,
             'json' => array_merge($options, [

--- a/src/platform/src/Bridge/OpenAi/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -25,8 +26,12 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Embeddings;
     }
 

--- a/src/platform/src/Bridge/OpenAi/Gpt/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -36,8 +37,12 @@ final readonly class ModelClient implements PlatformResponseFactory
         str_starts_with($apiKey, 'sk-') || throw new InvalidArgumentException('The API key must start with "sk-".');
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Gpt;
     }
 

--- a/src/platform/src/Bridge/OpenAi/Gpt/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface as PlatformResponseFactory;
@@ -46,8 +47,12 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $model instanceof Gpt;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.openai.com/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,
             'json' => array_merge($options, $payload),

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -35,8 +36,12 @@ use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
  */
 final class ResultConverter implements PlatformResponseConverter
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Gpt;
     }
 

--- a/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface as BaseModelClient;
@@ -41,8 +42,12 @@ final readonly class ModelClient implements BaseModelClient
         return $model instanceof Whisper;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         $task = $options['task'] ?? Task::TRANSCRIPTION;
         $endpoint = Task::TRANSCRIPTION === $task ? 'transcriptions' : 'translations';
         unset($options['task']);

--- a/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -31,8 +32,12 @@ final readonly class ModelClient implements BaseModelClient
         '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Whisper;
     }
 

--- a/src/platform/src/Bridge/OpenAi/Whisper/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Whisper/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -23,8 +24,12 @@ use Symfony\AI\Platform\ResultConverterInterface as BaseResponseConverter;
  */
 final class ResultConverter implements BaseResponseConverter
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Whisper;
     }
 

--- a/src/platform/src/Bridge/OpenRouter/ModelClient.php
+++ b/src/platform/src/Bridge/OpenRouter/ModelClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\OpenRouter;
 
 use Symfony\AI\Platform\Action;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -44,8 +45,12 @@ final readonly class ModelClient implements ModelClientInterface
         return true;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', 'https://openrouter.ai/api/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,
             'json' => array_merge($options, $payload),

--- a/src/platform/src/Bridge/OpenRouter/ModelClient.php
+++ b/src/platform/src/Bridge/OpenRouter/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenRouter;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -34,8 +35,12 @@ final readonly class ModelClient implements ModelClientInterface
         str_starts_with($apiKey, 'sk-') || throw new InvalidArgumentException('The API key must start with "sk-".');
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return true;
     }
 

--- a/src/platform/src/Bridge/OpenRouter/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenRouter/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenRouter;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -23,8 +24,12 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final readonly class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return true;
     }
 

--- a/src/platform/src/Bridge/Replicate/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Replicate/LlamaModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Replicate;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -27,8 +28,12 @@ final readonly class LlamaModelClient implements ModelClientInterface
     ) {
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Llama;
     }
 

--- a/src/platform/src/Bridge/Replicate/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Replicate/LlamaModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Replicate;
 
 use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -37,8 +38,12 @@ final readonly class LlamaModelClient implements ModelClientInterface
         return $model instanceof Llama;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawHttpResult
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CHAT, Action::COMPLETE_CHAT]);
+        }
+
         $model instanceof Llama || throw new InvalidArgumentException(\sprintf('The model must be an instance of "%s".', Llama::class));
 
         return new RawHttpResult(

--- a/src/platform/src/Bridge/Replicate/LlamaResultConverter.php
+++ b/src/platform/src/Bridge/Replicate/LlamaResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Replicate;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -24,8 +25,12 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final readonly class LlamaResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CHAT !== $action) {
+            return false;
+        }
+
         return $model instanceof Llama;
     }
 

--- a/src/platform/src/Bridge/TransformersPhp/ModelClient.php
+++ b/src/platform/src/Bridge/TransformersPhp/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\TransformersPhp;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -19,7 +20,7 @@ use function Codewithkyrian\Transformers\Pipelines\pipeline;
 
 final readonly class ModelClient implements ModelClientInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
         return true;
     }

--- a/src/platform/src/Bridge/TransformersPhp/ModelClient.php
+++ b/src/platform/src/Bridge/TransformersPhp/ModelClient.php
@@ -25,7 +25,7 @@ final readonly class ModelClient implements ModelClientInterface
         return true;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawPipelineResult
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawPipelineResult
     {
         if (null === $task = $options['task'] ?? null) {
             throw new InvalidArgumentException('The task option is required.');

--- a/src/platform/src/Bridge/TransformersPhp/ResultConverter.php
+++ b/src/platform/src/Bridge/TransformersPhp/ResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\TransformersPhp;
 
 use Codewithkyrian\Transformers\Pipelines\Task;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -20,8 +21,12 @@ use Symfony\AI\Platform\ResultConverterInterface;
 
 final readonly class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::COMPLETE_CHAT !== $action && Action::CHAT !== $action) {
+            return false;
+        }
+
         return true;
     }
 

--- a/src/platform/src/Bridge/Voyage/ModelClient.php
+++ b/src/platform/src/Bridge/Voyage/ModelClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Voyage;
 
 use Symfony\AI\Platform\Action;
+use Symfony\AI\Platform\Exception\InvalidActionArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -37,8 +38,12 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Voyage;
     }
 
-    public function request(Model $model, object|string|array $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, object|string|array $payload, array $options = []): RawHttpResult
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return throw new InvalidActionArgumentException($model, $action, [Action::CALCULATE_EMBEDDINGS]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.voyageai.com/v1/embeddings', [
             'auth_bearer' => $this->apiKey,
             'json' => [

--- a/src/platform/src/Bridge/Voyage/ModelClient.php
+++ b/src/platform/src/Bridge/Voyage/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Voyage;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -27,8 +28,12 @@ final readonly class ModelClient implements ModelClientInterface
     ) {
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Voyage;
     }
 

--- a/src/platform/src/Bridge/Voyage/ResultConverter.php
+++ b/src/platform/src/Bridge/Voyage/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Voyage;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -24,8 +25,12 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final readonly class ResultConverter implements ResultConverterInterface
 {
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
+        if (Action::CALCULATE_EMBEDDINGS !== $action) {
+            return false;
+        }
+
         return $model instanceof Voyage;
     }
 

--- a/src/platform/src/Exception/InvalidActionArgumentException.php
+++ b/src/platform/src/Exception/InvalidActionArgumentException.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Exception;
+
+use Symfony\AI\Platform\Action;
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Joshua Behrens <code@joshua-behrens.de>
+ */
+class InvalidActionArgumentException extends InvalidArgumentException
+{
+    /**
+     * @param list<Action> $expectedActions
+     */
+    public function __construct(
+        public readonly Model $model,
+        public readonly Action $invalidAction,
+        public readonly array $expectedActions,
+        ?\Throwable $previous = null,
+        int $code = 0,
+    ) {
+        $expectedAsString = implode(', ', array_map(static fn (Action $action): string => $action->name, $this->expectedActions));
+        parent::__construct(
+            'Tried invalid action ' . $this->invalidAction->name . ' on model ' . $this->model->getName() . ' where actions ' . $expectedAsString . ' where expected',
+            $code,
+            $previous,
+        );
+    }
+}

--- a/src/platform/src/ModelClientInterface.php
+++ b/src/platform/src/ModelClientInterface.php
@@ -24,5 +24,5 @@ interface ModelClientInterface
      * @param array<string|int, mixed> $payload
      * @param array<string, mixed>     $options
      */
-    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface;
+    public function request(Model $model, Action $action, array|string $payload, array $options = []): RawResultInterface;
 }

--- a/src/platform/src/ModelClientInterface.php
+++ b/src/platform/src/ModelClientInterface.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Result\RawResultInterface;
  */
 interface ModelClientInterface
 {
-    public function supports(Model $model): bool;
+    public function supports(Model $model, Action $action): bool;
 
     /**
      * @param array<string|int, mixed> $payload

--- a/src/platform/src/Platform.php
+++ b/src/platform/src/Platform.php
@@ -53,19 +53,19 @@ final class Platform implements PlatformInterface
             $options['tools'] = $this->contract->createToolOption($options['tools'], $model);
         }
 
-        $result = $this->doInvoke($model, $payload, $options);
+        $result = $this->doInvoke($model, $action, $payload, $options);
 
-        return $this->convertResult($model, $result, $options);
+        return $this->convertResult($model, $action, $result, $options);
     }
 
     /**
      * @param array<string, mixed> $payload
      * @param array<string, mixed> $options
      */
-    private function doInvoke(Model $model, array|string $payload, array $options = []): RawResultInterface
+    private function doInvoke(Model $model, Action $action, array|string $payload, array $options = []): RawResultInterface
     {
         foreach ($this->modelClients as $modelClient) {
-            if ($modelClient->supports($model)) {
+            if ($modelClient->supports($model, $action)) {
                 return $modelClient->request($model, $payload, $options);
             }
         }
@@ -76,10 +76,10 @@ final class Platform implements PlatformInterface
     /**
      * @param array<string, mixed> $options
      */
-    private function convertResult(Model $model, RawResultInterface $result, array $options): ResultPromise
+    private function convertResult(Model $model, Action $action, RawResultInterface $result, array $options): ResultPromise
     {
         foreach ($this->resultConverters as $resultConverter) {
-            if ($resultConverter->supports($model)) {
+            if ($resultConverter->supports($model, $action)) {
                 return new ResultPromise($resultConverter->convert(...), $result, $options);
             }
         }

--- a/src/platform/src/Platform.php
+++ b/src/platform/src/Platform.php
@@ -44,7 +44,7 @@ final class Platform implements PlatformInterface
         $this->resultConverters = $resultConverters instanceof \Traversable ? iterator_to_array($resultConverters) : $resultConverters;
     }
 
-    public function invoke(Model $model, array|string|object $input, array $options = []): ResultPromise
+    public function invoke(Model $model, array|string|object $input, array $options = [], Action $action = Action::CHAT): ResultPromise
     {
         $payload = $this->contract->createRequestPayload($model, $input);
         $options = array_merge($model->getOptions(), $options);
@@ -66,7 +66,7 @@ final class Platform implements PlatformInterface
     {
         foreach ($this->modelClients as $modelClient) {
             if ($modelClient->supports($model, $action)) {
-                return $modelClient->request($model, $payload, $options);
+                return $modelClient->request($model, $action, $payload, $options);
             }
         }
 

--- a/src/platform/src/ResultConverterInterface.php
+++ b/src/platform/src/ResultConverterInterface.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Result\ResultInterface;
  */
 interface ResultConverterInterface
 {
-    public function supports(Model $model): bool;
+    public function supports(Model $model, Action $action): bool;
 
     /**
      * @param array<string, mixed> $options

--- a/src/platform/tests/Bridge/Albert/EmbeddingsModelClientTest.php
+++ b/src/platform/tests/Bridge/Albert/EmbeddingsModelClientTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Albert\EmbeddingsModelClient;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
@@ -59,7 +60,7 @@ final class EmbeddingsModelClientTest extends TestCase
         );
 
         $embeddingsModel = new Embeddings('text-embedding-ada-002');
-        $this->assertTrue($client->supports($embeddingsModel));
+        $this->assertTrue($client->supports($embeddingsModel, Action::CALCULATE_EMBEDDINGS));
     }
 
     public function testDoesNotSupportNonEmbeddingsModel()
@@ -71,7 +72,7 @@ final class EmbeddingsModelClientTest extends TestCase
         );
 
         $gptModel = new Gpt('gpt-3.5-turbo');
-        $this->assertFalse($client->supports($gptModel));
+        $this->assertFalse($client->supports($gptModel, Action::CALCULATE_EMBEDDINGS));
     }
 
     #[DataProvider('providePayloadToJson')]

--- a/src/platform/tests/Bridge/Albert/EmbeddingsModelClientTest.php
+++ b/src/platform/tests/Bridge/Albert/EmbeddingsModelClientTest.php
@@ -92,7 +92,7 @@ final class EmbeddingsModelClientTest extends TestCase
         );
 
         $model = new Embeddings('text-embedding-ada-002');
-        $result = $client->request($model, $payload, $options);
+        $result = $client->request($model, Action::CALCULATE_EMBEDDINGS, $payload, $options);
 
         $this->assertNotNull($capturedRequest);
         $this->assertSame('POST', $capturedRequest['method']);
@@ -153,7 +153,7 @@ final class EmbeddingsModelClientTest extends TestCase
         );
 
         $model = new Embeddings('text-embedding-ada-002');
-        $client->request($model, ['input' => 'test']);
+        $client->request($model, Action::CALCULATE_EMBEDDINGS, ['input' => 'test']);
 
         $this->assertSame('https://albert.example.com/v1/embeddings', $capturedUrl);
     }
@@ -174,7 +174,7 @@ final class EmbeddingsModelClientTest extends TestCase
         );
 
         $model = new Embeddings('text-embedding-ada-002');
-        $client->request($model, ['input' => 'test']);
+        $client->request($model, Action::CALCULATE_EMBEDDINGS, ['input' => 'test']);
 
         $this->assertSame('https://albert.example.com/v1/embeddings', $capturedUrl);
     }

--- a/src/platform/tests/Bridge/Albert/GptModelClientTest.php
+++ b/src/platform/tests/Bridge/Albert/GptModelClientTest.php
@@ -70,7 +70,7 @@ final class GptModelClientTest extends TestCase
         $mockHttpClient->setResponseFactory([$mockResponse]);
 
         $model = new Gpt('gpt-3.5-turbo');
-        $client->request($model, ['messages' => []]);
+        $client->request($model, Action::CHAT, ['messages' => []]);
     }
 
     public function testConstructorAcceptsEventSourceHttpClient()
@@ -91,7 +91,7 @@ final class GptModelClientTest extends TestCase
         $mockHttpClient->setResponseFactory([$mockResponse]);
 
         $model = new Gpt('gpt-3.5-turbo');
-        $client->request($model, ['messages' => []]);
+        $client->request($model, Action::CHAT, ['messages' => []]);
     }
 
     public function testSupportsGptModel()
@@ -135,7 +135,7 @@ final class GptModelClientTest extends TestCase
         );
 
         $model = new Gpt('gpt-3.5-turbo');
-        $result = $client->request($model, $payload, $options);
+        $result = $client->request($model, Action::COMPLETE_CHAT, $payload, $options);
 
         $this->assertNotNull($capturedRequest);
         $this->assertSame('POST', $capturedRequest['method']);
@@ -202,7 +202,7 @@ final class GptModelClientTest extends TestCase
         );
 
         $model = new Gpt('gpt-3.5-turbo');
-        $client->request($model, ['messages' => []]);
+        $client->request($model, Action::COMPLETE_CHAT, ['messages' => []]);
 
         $this->assertSame('https://albert.example.com/v1/chat/completions', $capturedUrl);
     }
@@ -223,7 +223,7 @@ final class GptModelClientTest extends TestCase
         );
 
         $model = new Gpt('gpt-3.5-turbo');
-        $client->request($model, ['messages' => []]);
+        $client->request($model, Action::COMPLETE_CHAT, ['messages' => []]);
 
         $this->assertSame('https://albert.example.com/v1/chat/completions', $capturedUrl);
     }

--- a/src/platform/tests/Bridge/Albert/GptModelClientTest.php
+++ b/src/platform/tests/Bridge/Albert/GptModelClientTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Albert\GptModelClient;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
@@ -102,7 +103,7 @@ final class GptModelClientTest extends TestCase
         );
 
         $gptModel = new Gpt('gpt-3.5-turbo');
-        $this->assertTrue($client->supports($gptModel));
+        $this->assertTrue($client->supports($gptModel, Action::CHAT));
     }
 
     public function testDoesNotSupportNonGptModel()
@@ -114,7 +115,7 @@ final class GptModelClientTest extends TestCase
         );
 
         $embeddingsModel = new Embeddings('text-embedding-ada-002');
-        $this->assertFalse($client->supports($embeddingsModel));
+        $this->assertFalse($client->supports($embeddingsModel, Action::CALCULATE_EMBEDDINGS));
     }
 
     #[DataProvider('providePayloadToJson')]

--- a/src/platform/tests/Bridge/Azure/OpenAi/EmbeddingsModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/EmbeddingsModelClientTest.php
@@ -94,6 +94,6 @@ final class EmbeddingsModelClientTest extends TestCase
 
         $httpClient = new MockHttpClient([$resultCallback]);
         $client = new EmbeddingsModelClient($httpClient, 'test.azure.com', 'embeddings-deployment', '2023-12-01', 'test-api-key');
-        $client->request(new Embeddings(), 'Hello, world!');
+        $client->request(new Embeddings(), Action::CALCULATE_EMBEDDINGS, 'Hello, world!');
     }
 }

--- a/src/platform/tests/Bridge/Azure/OpenAi/EmbeddingsModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/EmbeddingsModelClientTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Azure\OpenAi\EmbeddingsModelClient;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
@@ -77,7 +78,7 @@ final class EmbeddingsModelClientTest extends TestCase
     {
         $client = new EmbeddingsModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '2023-12-01', 'api-key');
 
-        $this->assertTrue($client->supports(new Embeddings()));
+        $this->assertTrue($client->supports(new Embeddings(), Action::CALCULATE_EMBEDDINGS));
     }
 
     public function testItIsExecutingTheCorrectRequest()

--- a/src/platform/tests/Bridge/Azure/OpenAi/GptModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/GptModelClientTest.php
@@ -94,6 +94,6 @@ final class GptModelClientTest extends TestCase
 
         $httpClient = new MockHttpClient([$resultCallback]);
         $client = new GptModelClient($httpClient, 'test.azure.com', 'gpt-deployment', '2023-12-01', 'test-api-key');
-        $client->request(new Gpt(), ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
+        $client->request(new Gpt(), Action::COMPLETE_CHAT, ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
     }
 }

--- a/src/platform/tests/Bridge/Azure/OpenAi/GptModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/GptModelClientTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Azure\OpenAi\GptModelClient;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
@@ -77,7 +78,7 @@ final class GptModelClientTest extends TestCase
     {
         $client = new GptModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '2023-12-01', 'api-key');
 
-        $this->assertTrue($client->supports(new Gpt()));
+        $this->assertTrue($client->supports(new Gpt(), Action::CHAT));
     }
 
     public function testItIsExecutingTheCorrectRequest()

--- a/src/platform/tests/Bridge/Azure/OpenAi/WhisperModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/WhisperModelClientTest.php
@@ -99,7 +99,7 @@ final class WhisperModelClientTest extends TestCase
         $model = new Whisper();
         $payload = ['file' => 'audio-data'];
 
-        $client->request($model, $payload);
+        $client->request($model, Action::CHAT, $payload);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -120,7 +120,7 @@ final class WhisperModelClientTest extends TestCase
         $payload = ['file' => 'audio-data'];
         $options = ['task' => Task::TRANSCRIPTION];
 
-        $client->request($model, $payload, $options);
+        $client->request($model, Action::CHAT, $payload, $options);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -141,7 +141,7 @@ final class WhisperModelClientTest extends TestCase
         $payload = ['file' => 'audio-data'];
         $options = ['task' => Task::TRANSLATION];
 
-        $client->request($model, $payload, $options);
+        $client->request($model, Action::CHAT, $payload, $options);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }

--- a/src/platform/tests/Bridge/Azure/OpenAi/WhisperModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/WhisperModelClientTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Azure\OpenAi\WhisperModelClient;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper\Task;
@@ -80,7 +81,7 @@ final class WhisperModelClientTest extends TestCase
         );
         $model = new Whisper();
 
-        $this->assertTrue($client->supports($model));
+        $this->assertTrue($client->supports($model, Action::CHAT));
     }
 
     public function testItUsesTranscriptionEndpointByDefault()

--- a/src/platform/tests/Bridge/Cerebras/ModelClientTest.php
+++ b/src/platform/tests/Bridge/Cerebras/ModelClientTest.php
@@ -83,7 +83,7 @@ class ModelClientTest extends TestCase
             ],
         ];
 
-        $result = $client->request(new Model(Model::LLAMA_3_3_70B), $payload);
+        $result = $client->request(new Model(Model::LLAMA_3_3_70B), Action::COMPLETE_CHAT, $payload);
         $data = $result->getData();
         $info = $result->getObject()->getInfo();
 

--- a/src/platform/tests/Bridge/Cerebras/ModelClientTest.php
+++ b/src/platform/tests/Bridge/Cerebras/ModelClientTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Cerebras\Model;
 use Symfony\AI\Platform\Bridge\Cerebras\ModelClient;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
@@ -56,7 +57,7 @@ class ModelClientTest extends TestCase
     {
         $client = new ModelClient(new MockHttpClient(), 'csk-1234567890abcdef');
 
-        self::assertTrue($client->supports(new Model(Model::GPT_OSS_120B)));
+        self::assertTrue($client->supports(new Model(Model::GPT_OSS_120B), Action::CHAT));
     }
 
     public function testItSuccessfullyInvokesTheModel()

--- a/src/platform/tests/Bridge/Cerebras/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/Cerebras/ResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Cerebras\Model;
 use Symfony\AI\Platform\Bridge\Cerebras\ModelClient;
 use Symfony\AI\Platform\Bridge\Cerebras\ResultConverter;
@@ -32,6 +33,6 @@ class ResultConverterTest extends TestCase
     {
         $client = new ModelClient(new MockHttpClient(), 'csk-1234567890abcdef');
 
-        $this->assertTrue($client->supports(new Model(Model::GPT_OSS_120B)));
+        $this->assertTrue($client->supports(new Model(Model::GPT_OSS_120B), Action::CHAT));
     }
 }

--- a/src/platform/tests/Bridge/Gemini/Embeddings/ModelClientTest.php
+++ b/src/platform/tests/Bridge/Gemini/Embeddings/ModelClientTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Gemini\Embeddings;
 use Symfony\AI\Platform\Bridge\Gemini\Embeddings\ModelClient;
 use Symfony\AI\Platform\Result\VectorResult;
@@ -66,7 +67,7 @@ final class ModelClientTest extends TestCase
 
         $model = new Embeddings(Embeddings::GEMINI_EMBEDDING_EXP_03_07, ['dimensions' => 1536, 'task_type' => 'CLASSIFICATION']);
 
-        $result = (new ModelClient($httpClient, 'test'))->request($model, ['payload1', 'payload2']);
+        $result = (new ModelClient($httpClient, 'test'))->request($model, Action::CALCULATE_EMBEDDINGS, ['payload1', 'payload2']);
         $this->assertSame(json_decode($this->getEmbeddingStub(), true), $result->getData());
     }
 

--- a/src/platform/tests/Bridge/LmStudio/Completions/ModelClientTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Completions/ModelClientTest.php
@@ -58,7 +58,7 @@ class ModelClientTest extends TestCase
             ],
         ];
 
-        $client->request(new Completions('test-model'), $payload);
+        $client->request(new Completions('test-model'), Action::COMPLETE_CHAT, $payload);
     }
 
     public function testItMergesOptionsWithPayload()
@@ -84,7 +84,7 @@ class ModelClientTest extends TestCase
             ],
         ];
 
-        $client->request(new Completions('test-model'), $payload, ['temperature' => 0.7]);
+        $client->request(new Completions('test-model'), Action::COMPLETE_CHAT, $payload, ['temperature' => 0.7]);
     }
 
     public function testItUsesEventSourceHttpClient()

--- a/src/platform/tests/Bridge/LmStudio/Completions/ModelClientTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Completions/ModelClientTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\LmStudio\Completions;
 use Symfony\AI\Platform\Bridge\LmStudio\Completions\ModelClient;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
@@ -31,7 +32,7 @@ class ModelClientTest extends TestCase
     {
         $client = new ModelClient(new MockHttpClient(), 'http://localhost:1234');
 
-        $this->assertTrue($client->supports(new Completions('test-model')));
+        $this->assertTrue($client->supports(new Completions('test-model'), Action::CHAT));
     }
 
     public function testItIsExecutingTheCorrectRequest()

--- a/src/platform/tests/Bridge/LmStudio/Completions/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Completions/ResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\LmStudio\Completions;
 use Symfony\AI\Platform\Bridge\LmStudio\Completions\ResultConverter;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt\ResultConverter as OpenAiResultConverter;
@@ -29,6 +30,6 @@ class ResultConverterTest extends TestCase
     {
         $converter = new ResultConverter();
 
-        $this->assertTrue($converter->supports(new Completions('test-model')));
+        $this->assertTrue($converter->supports(new Completions('test-model'), Action::COMPLETE_CHAT));
     }
 }

--- a/src/platform/tests/Bridge/LmStudio/Embeddings/ModelClientTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Embeddings/ModelClientTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\LmStudio\Embeddings;
 use Symfony\AI\Platform\Bridge\LmStudio\Embeddings\ModelClient;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -29,7 +30,7 @@ class ModelClientTest extends TestCase
     {
         $client = new ModelClient(new MockHttpClient(), 'http://localhost:1234');
 
-        $this->assertTrue($client->supports(new Embeddings('test-model')));
+        $this->assertTrue($client->supports(new Embeddings('test-model'), Action::CALCULATE_EMBEDDINGS));
     }
 
     public function testItIsExecutingTheCorrectRequest()

--- a/src/platform/tests/Bridge/LmStudio/Embeddings/ModelClientTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Embeddings/ModelClientTest.php
@@ -48,7 +48,7 @@ class ModelClientTest extends TestCase
 
         $model = new Embeddings('test-model');
 
-        $client->request($model, 'Hello, world!');
+        $client->request($model, Action::CALCULATE_EMBEDDINGS, 'Hello, world!');
     }
 
     public function testItMergesOptionsWithPayload()
@@ -69,7 +69,7 @@ class ModelClientTest extends TestCase
 
         $model = new Embeddings('test-model');
 
-        $client->request($model, 'Hello, world!', ['custom_option' => 'value']);
+        $client->request($model, Action::CALCULATE_EMBEDDINGS, 'Hello, world!', ['custom_option' => 'value']);
     }
 
     public function testItHandlesArrayInput()
@@ -87,6 +87,6 @@ class ModelClientTest extends TestCase
 
         $model = new Embeddings('test-model');
 
-        $client->request($model, ['Hello', 'world']);
+        $client->request($model, Action::CALCULATE_EMBEDDINGS, ['Hello', 'world']);
     }
 }

--- a/src/platform/tests/Bridge/LmStudio/Embeddings/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Embeddings/ResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\LmStudio\Embeddings;
 use Symfony\AI\Platform\Bridge\LmStudio\Embeddings\ResultConverter;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -84,6 +85,6 @@ class ResultConverterTest extends TestCase
     {
         $converter = new ResultConverter();
 
-        $this->assertTrue($converter->supports(new Embeddings('test-model')));
+        $this->assertTrue($converter->supports(new Embeddings('test-model'), Action::CALCULATE_EMBEDDINGS));
     }
 }

--- a/src/platform/tests/Bridge/Ollama/OllamaResultConverterTest.php
+++ b/src/platform/tests/Bridge/Ollama/OllamaResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\Ollama\Ollama;
 use Symfony\AI\Platform\Bridge\Ollama\OllamaResultConverter;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -42,8 +43,8 @@ final class OllamaResultConverterTest extends TestCase
     {
         $converter = new OllamaResultConverter();
 
-        $this->assertTrue($converter->supports(new Ollama()));
-        $this->assertFalse($converter->supports(new Model('any-model')));
+        $this->assertTrue($converter->supports(new Ollama(), Action::CHAT));
+        $this->assertFalse($converter->supports(new Model('any-model'), Action::CHAT));
     }
 
     public function testConvertTextResponse()

--- a/src/platform/tests/Bridge/OpenAi/DallE/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAi/DallE/ModelClientTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\DallE;
 use Symfony\AI\Platform\Bridge\OpenAi\DallE\ModelClient;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
@@ -61,7 +62,7 @@ final class ModelClientTest extends TestCase
     {
         $modelClient = new ModelClient(new MockHttpClient(), 'sk-api-key');
 
-        $this->assertTrue($modelClient->supports(new DallE()));
+        $this->assertTrue($modelClient->supports(new DallE(), Action::CHAT));
     }
 
     public function testItIsExecutingTheCorrectRequest()

--- a/src/platform/tests/Bridge/OpenAi/DallE/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAi/DallE/ModelClientTest.php
@@ -77,6 +77,6 @@ final class ModelClientTest extends TestCase
         };
         $httpClient = new MockHttpClient([$resultCallback]);
         $modelClient = new ModelClient($httpClient, 'sk-api-key');
-        $modelClient->request(new DallE(), 'foo', ['n' => 1, 'response_format' => 'url']);
+        $modelClient->request(new DallE(), Action::CHAT, 'foo', ['n' => 1, 'response_format' => 'url']);
     }
 }

--- a/src/platform/tests/Bridge/OpenAi/Whisper/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAi/Whisper/ModelClientTest.php
@@ -48,7 +48,7 @@ final class ModelClientTest extends TestCase
         $model = new Whisper();
         $payload = ['file' => 'audio-data'];
 
-        $client->request($model, $payload);
+        $client->request($model, Action::CHAT, $payload);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -69,7 +69,7 @@ final class ModelClientTest extends TestCase
         $payload = ['file' => 'audio-data'];
         $options = ['task' => Task::TRANSCRIPTION];
 
-        $client->request($model, $payload, $options);
+        $client->request($model, Action::CHAT, $payload, $options);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -90,7 +90,7 @@ final class ModelClientTest extends TestCase
         $payload = ['file' => 'audio-data'];
         $options = ['task' => Task::TRANSLATION];
 
-        $client->request($model, $payload, $options);
+        $client->request($model, Action::CHAT, $payload, $options);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }

--- a/src/platform/tests/Bridge/OpenAi/Whisper/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAi/Whisper/ModelClientTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Tests\Bridge\OpenAi\Whisper;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper\ModelClient;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper\Task;
@@ -29,7 +30,7 @@ final class ModelClientTest extends TestCase
         $client = new ModelClient(new MockHttpClient(), 'test-key');
         $model = new Whisper();
 
-        $this->assertTrue($client->supports($model));
+        $this->assertTrue($client->supports($model, Action::CHAT));
     }
 
     public function testItUsesTranscriptionEndpointByDefault()

--- a/src/store/tests/Double/PlatformTestHandler.php
+++ b/src/store/tests/Double/PlatformTestHandler.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Store\Tests\Double;
 
+use Symfony\AI\Platform\Action;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Platform;
@@ -38,7 +39,7 @@ final class PlatformTestHandler implements ModelClientInterface, ResultConverter
         return new Platform([$handler], [$handler]);
     }
 
-    public function supports(Model $model): bool
+    public function supports(Model $model, Action $action): bool
     {
         return true;
     }

--- a/src/store/tests/Double/PlatformTestHandler.php
+++ b/src/store/tests/Double/PlatformTestHandler.php
@@ -44,7 +44,7 @@ final class PlatformTestHandler implements ModelClientInterface, ResultConverter
         return true;
     }
 
-    public function request(Model $model, array|string|object $payload, array $options = []): RawHttpResult
+    public function request(Model $model, Action $action, array|string|object $payload, array $options = []): RawHttpResult
     {
         ++$this->createCalls;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | zes
| Docs?         | no
| Issues        | Fix #114 
| License       | MIT

In other issues and pull requests the model class should be used as a simple struct, only holding scalar values and should not have any business logic effect by inheritance. This has been the case for embeddings, completions and other API calls like Whisper audio, and Dall-e images. Right now this makes it difficult to share different instances of the model class with various providers, although a lot of providers share the same models, and therefore likely the same capabilities. This eventually will reduce the amount of code you have to write to establish new providers that replicate existing API's with a well-known subset of models or add better support for custom models like OpenAI fine-tuned models or ollamas self-built models.

I see this action parameter / enum as an addition to the model. The action and model in here are like method and path in HTTP as the resource can be used in multiple different ways. Without this additional business logic effect by inheritance, it is now impossible to understand what you want to do with the model. Some models can differentiate between chat and chat completion. Right now the differentiation has been done by the model class inheritance. Some other tasks like embeddings for document indexing has been an expectation towards the model, that has been passed into the indexer. The indexer was not able to precisely use the model for an embedding. It had to trust the platform and model that it will be given an answer with an embedding result. Having the code be this unpredictable makes it difficult to maintain and work with. Same for usage of whisper and dall-e. They maybe need to get specific actions later as well.