### PR TITLE
Use child model classes as factories instead

### DIFF
--- a/demo/src/Audio/Chat.php
+++ b/demo/src/Audio/Chat.php
@@ -39,7 +39,7 @@ final class Chat
         $path = tempnam(sys_get_temp_dir(), 'audio-').'.wav';
         file_put_contents($path, base64_decode($base64audio));
 
-        $result = $this->platform->invoke(new Whisper(), Audio::fromFile($path));
+        $result = $this->platform->invoke(Whisper::create(), Audio::fromFile($path));
 
         $this->submitMessage($result->asText());
     }

--- a/demo/src/Video/TwigComponent.php
+++ b/demo/src/Video/TwigComponent.php
@@ -47,7 +47,7 @@ final class TwigComponent
             Message::ofUser($instruction, Image::fromDataUrl($image))
         );
 
-        $result = $this->platform->invoke(new Gpt(Gpt::GPT_4O_MINI), $messageBag, [
+        $result = $this->platform->invoke(Gpt::create(Gpt::GPT_4O_MINI), $messageBag, [
             'max_tokens' => 100,
         ]);
 

--- a/examples/albert/chat.php
+++ b/examples/albert/chat.php
@@ -19,7 +19,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('ALBERT_API_KEY'), env('ALBERT_API_URL'), http_client());
 
-$model = new Gpt('gpt-4o');
+$model = Gpt::create('gpt-4o');
 $agent = new Agent($platform, $model, logger: logger());
 
 $documentContext = <<<'CONTEXT'

--- a/examples/anthropic/chat.php
+++ b/examples/anthropic/chat.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
-$model = new Claude(Claude::SONNET_37);
+$model = Claude::create(Claude::SONNET_37);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/anthropic/image-input-binary.php
+++ b/examples/anthropic/image-input-binary.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
-$model = new Claude(Claude::SONNET_37);
+$model = Claude::create(Claude::SONNET_37);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/anthropic/image-input-url.php
+++ b/examples/anthropic/image-input-url.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
-$model = new Claude(Claude::SONNET_37);
+$model = Claude::create(Claude::SONNET_37);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/anthropic/pdf-input-binary.php
+++ b/examples/anthropic/pdf-input-binary.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
-$model = new Claude(Claude::SONNET_37);
+$model = Claude::create(Claude::SONNET_37);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/anthropic/pdf-input-url.php
+++ b/examples/anthropic/pdf-input-url.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
-$model = new Claude(Claude::SONNET_37);
+$model = Claude::create(Claude::SONNET_37);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/anthropic/stream.php
+++ b/examples/anthropic/stream.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
-$model = new Claude();
+$model = Claude::create();
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/anthropic/toolcall.php
+++ b/examples/anthropic/toolcall.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
-$model = new Claude();
+$model = Claude::create();
 
 $wikipedia = new Wikipedia(http_client());
 $toolbox = new Toolbox([$wikipedia], logger: logger());

--- a/examples/azure/audio-transcript.php
+++ b/examples/azure/audio-transcript.php
@@ -22,7 +22,7 @@ $platform = PlatformFactory::create(
     env('AZURE_OPENAI_KEY'),
     http_client(),
 );
-$model = new Whisper();
+$model = Whisper::create();
 $file = Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3');
 
 $result = $platform->invoke($model, $file);

--- a/examples/azure/chat-gpt.php
+++ b/examples/azure/chat-gpt.php
@@ -24,7 +24,7 @@ $platform = PlatformFactory::create(
     env('AZURE_OPENAI_KEY'),
     http_client(),
 );
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/azure/chat-llama.php
+++ b/examples/azure/chat-llama.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('AZURE_LLAMA_BASEURL'), env('AZURE_LLAMA_KEY'), http_client());
-$model = new Llama(Llama::V3_3_70B_INSTRUCT);
+$model = Llama::create(Llama::V3_3_70B_INSTRUCT);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(Message::ofUser('I am going to Paris, what should I see?'));

--- a/examples/azure/embeddings.php
+++ b/examples/azure/embeddings.php
@@ -21,7 +21,7 @@ $platform = PlatformFactory::create(
     env('AZURE_OPENAI_KEY'),
     http_client(),
 );
-$embeddings = new Embeddings();
+$embeddings = Embeddings::create();
 
 $result = $platform->invoke($embeddings, <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.

--- a/examples/bedrock/chat-claude.php
+++ b/examples/bedrock/chat-claude.php
@@ -24,7 +24,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 }
 
 $platform = PlatformFactory::create();
-$model = new Claude('claude-3-7-sonnet-20250219');
+$model = Claude::create('claude-3-7-sonnet-20250219');
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/bedrock/chat-llama.php
+++ b/examples/bedrock/chat-llama.php
@@ -24,7 +24,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 }
 
 $platform = PlatformFactory::create();
-$model = new Llama(Llama::V3_2_3B_INSTRUCT);
+$model = Llama::create(Llama::V3_2_3B_INSTRUCT);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/bedrock/chat-nova.php
+++ b/examples/bedrock/chat-nova.php
@@ -24,7 +24,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 }
 
 $platform = PlatformFactory::create();
-$model = new Nova(Nova::PRO);
+$model = Nova::create(Nova::PRO);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/bedrock/image-claude-binary.php
+++ b/examples/bedrock/image-claude-binary.php
@@ -25,7 +25,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 }
 
 $platform = PlatformFactory::create();
-$model = new Claude('claude-3-7-sonnet-20250219');
+$model = Claude::create('claude-3-7-sonnet-20250219');
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/bedrock/image-nova.php
+++ b/examples/bedrock/image-nova.php
@@ -25,7 +25,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 }
 
 $platform = PlatformFactory::create();
-$model = new Nova(Nova::PRO);
+$model = Nova::create(Nova::PRO);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/bedrock/toolcall-claude.php
+++ b/examples/bedrock/toolcall-claude.php
@@ -27,7 +27,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 }
 
 $platform = PlatformFactory::create();
-$model = new Claude('claude-3-7-sonnet-20250219');
+$model = Claude::create('claude-3-7-sonnet-20250219');
 
 $wikipedia = new Wikipedia(http_client());
 $toolbox = new Toolbox([$wikipedia]);

--- a/examples/bedrock/toolcall-nova.php
+++ b/examples/bedrock/toolcall-nova.php
@@ -27,7 +27,7 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 }
 
 $platform = PlatformFactory::create();
-$model = new Nova();
+$model = Nova::create();
 
 $wikipedia = new Wikipedia(http_client());
 $toolbox = new Toolbox([$wikipedia]);

--- a/examples/document/vectorizing.php
+++ b/examples/document/vectorizing.php
@@ -19,7 +19,7 @@ use Symfony\Component\Uid\Uuid;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$embeddings = new Embeddings(Embeddings::TEXT_3_LARGE);
+$embeddings = Embeddings::create(Embeddings::TEXT_3_LARGE);
 
 $textDocuments = [
     new TextDocument(Uuid::v4(), 'Hello World'),

--- a/examples/gemini/audio-input.php
+++ b/examples/gemini/audio-input.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$model = new Gemini(Gemini::GEMINI_1_5_FLASH);
+$model = Gemini::create(Gemini::GEMINI_1_5_FLASH);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/gemini/chat.php
+++ b/examples/gemini/chat.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$model = new Gemini(Gemini::GEMINI_2_FLASH);
+$model = Gemini::create(Gemini::GEMINI_2_FLASH);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/gemini/embeddings.php
+++ b/examples/gemini/embeddings.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$embeddings = new Embeddings();
+$embeddings = Embeddings::create();
 
 $result = $platform->invoke($embeddings, <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.

--- a/examples/gemini/image-input.php
+++ b/examples/gemini/image-input.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$model = new Gemini(Gemini::GEMINI_1_5_FLASH);
+$model = Gemini::create(Gemini::GEMINI_1_5_FLASH);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/gemini/pdf-input-binary.php
+++ b/examples/gemini/pdf-input-binary.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$model = new Gemini(Gemini::GEMINI_1_5_FLASH);
+$model = Gemini::create(Gemini::GEMINI_1_5_FLASH);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/gemini/server-tools.php
+++ b/examples/gemini/server-tools.php
@@ -23,7 +23,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 
 // Available server-side tools as of 2025-06-28: url_context, google_search, code_execution
-$llm = new Gemini('gemini-2.5-pro-preview-03-25', ['server_tools' => ['url_context' => true], 'temperature' => 1.0]);
+$llm = Gemini::create('gemini-2.5-pro-preview-03-25', options: ['server_tools' => ['url_context' => true], 'temperature' => 1.0]);
 
 $toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);

--- a/examples/gemini/stream.php
+++ b/examples/gemini/stream.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$model = new Gemini(Gemini::GEMINI_2_FLASH);
+$model = Gemini::create(Gemini::GEMINI_2_FLASH);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/gemini/structured-output-clock.php
+++ b/examples/gemini/structured-output-clock.php
@@ -23,7 +23,7 @@ use Symfony\Component\Clock\Clock as SymfonyClock;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$model = new Gemini(Gemini::GEMINI_1_5_FLASH);
+$model = Gemini::create(Gemini::GEMINI_1_5_FLASH);
 
 $clock = new Clock(new SymfonyClock());
 $toolbox = new Toolbox([$clock]);

--- a/examples/gemini/structured-output-math.php
+++ b/examples/gemini/structured-output-math.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$model = new Gemini(Gemini::GEMINI_1_5_FLASH);
+$model = Gemini::create(Gemini::GEMINI_1_5_FLASH);
 
 $processor = new AgentProcessor();
 $agent = new Agent($platform, $model, [$processor], [$processor], logger());

--- a/examples/gemini/toolcall.php
+++ b/examples/gemini/toolcall.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$llm = new Gemini(Gemini::GEMINI_2_FLASH);
+$llm = Gemini::create(Gemini::GEMINI_2_FLASH);
 
 $toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);

--- a/examples/lmstudio/chat.php
+++ b/examples/lmstudio/chat.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('LMSTUDIO_HOST_URL'), http_client());
-$model = new Completions('gemma-3-4b-it-qat');
+$model = Completions::create('gemma-3-4b-it-qat');
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/lmstudio/image-input-binary.php
+++ b/examples/lmstudio/image-input-binary.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('LMSTUDIO_HOST_URL'), http_client());
-$model = new Completions(
+$model = Completions::create(
     name: 'gemma-3-4b-it-qat',
     capabilities: [...Completions::DEFAULT_CAPABILITIES, Capability::INPUT_IMAGE]
 );

--- a/examples/memory/mariadb.php
+++ b/examples/memory/mariadb.php
@@ -58,7 +58,7 @@ $store->initialize();
 
 // create embeddings for documents as preparation of the chain memory
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
@@ -66,7 +66,7 @@ $indexer->index($documents);
 $embeddingsMemory = new EmbeddingProvider($platform, $embeddings, $store);
 $memoryProcessor = new MemoryInputProcessor($embeddingsMemory);
 
-$agent = new Agent($platform, new Gpt(Gpt::GPT_4O_MINI), [$memoryProcessor], logger: logger());
+$agent = new Agent($platform, Gpt::create(Gpt::GPT_4O_MINI), [$memoryProcessor], logger: logger());
 $messages = new MessageBag(Message::ofUser('Have we discussed about my friend John in the past? If yes, what did we talk about?'));
 $result = $agent->call($messages);
 

--- a/examples/memory/static.php
+++ b/examples/memory/static.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create($_ENV['OPENAI_API_KEY'], http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $systemPromptProcessor = new SystemPromptInputProcessor('You are a professional trainer with short, personalized advice and a motivating claim.');
 

--- a/examples/misc/chat-system-prompt.php
+++ b/examples/misc/chat-system-prompt.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $processor = new SystemPromptInputProcessor('You are Yoda and write like he speaks. But short.');
 

--- a/examples/misc/parallel-chat-gpt.php
+++ b/examples/misc/parallel-chat-gpt.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI, [
+$model = Gpt::create(Gpt::GPT_4O_MINI, [
     'temperature' => 0.5, // default options for the model
 ]);
 

--- a/examples/misc/parallel-embeddings.php
+++ b/examples/misc/parallel-embeddings.php
@@ -15,9 +15,9 @@ use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$ada = new Embeddings(Embeddings::TEXT_ADA_002);
-$small = new Embeddings(Embeddings::TEXT_3_SMALL);
-$large = new Embeddings(Embeddings::TEXT_3_LARGE);
+$ada = Embeddings::create(Embeddings::TEXT_ADA_002);
+$small = Embeddings::create(Embeddings::TEXT_3_SMALL);
+$large = Embeddings::create(Embeddings::TEXT_3_LARGE);
 
 echo 'Initiating parallel embeddings calls to platform ...'.\PHP_EOL;
 $results = [];

--- a/examples/misc/persistent-chat.php
+++ b/examples/misc/persistent-chat.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$llm = new Gpt(Gpt::GPT_4O_MINI);
+$llm = Gpt::create(Gpt::GPT_4O_MINI);
 
 $agent = new Agent($platform, $llm, logger: logger());
 $chat = new Chat($agent, new InMemoryStore());

--- a/examples/mistral/chat-multiple.php
+++ b/examples/mistral/chat-multiple.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
-$agent = new Agent($platform, new Mistral(), logger: logger());
+$agent = new Agent($platform, Mistral::create(), logger: logger());
 
 $messages = new MessageBag(
     Message::forSystem('Just give short answers.'),

--- a/examples/mistral/chat.php
+++ b/examples/mistral/chat.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
-$model = new Mistral();
+$model = Mistral::create();
 $agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(Message::ofUser('What is the best French cheese?'));

--- a/examples/mistral/embeddings.php
+++ b/examples/mistral/embeddings.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
-$model = new Embeddings();
+$model = Embeddings::create();
 
 $result = $platform->invoke($model, <<<TEXT
     In the middle of the 20th century, food scientists began to understand the importance of vitamins and minerals in

--- a/examples/mistral/image.php
+++ b/examples/mistral/image.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
-$model = new Mistral(Mistral::MISTRAL_SMALL);
+$model = Mistral::create(Mistral::MISTRAL_SMALL);
 $agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(

--- a/examples/mistral/stream.php
+++ b/examples/mistral/stream.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
-$model = new Mistral();
+$model = Mistral::create();
 $agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(Message::ofUser('What is the eighth prime number?'));

--- a/examples/mistral/structured-output-math.php
+++ b/examples/mistral/structured-output-math.php
@@ -24,7 +24,7 @@ use Symfony\Component\Serializer\Serializer;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
-$model = new Mistral(Mistral::MISTRAL_SMALL);
+$model = Mistral::create(Mistral::MISTRAL_SMALL);
 $serializer = new Serializer([new ObjectNormalizer()], [new JsonEncoder()]);
 
 $processor = new AgentProcessor(new ResponseFormatFactory(), $serializer);

--- a/examples/mistral/toolcall-stream.php
+++ b/examples/mistral/toolcall-stream.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
-$model = new Mistral();
+$model = Mistral::create();
 
 $transcriber = new YouTubeTranscriber(http_client());
 $toolbox = new Toolbox([$transcriber], logger: logger());

--- a/examples/mistral/toolcall.php
+++ b/examples/mistral/toolcall.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
-$model = new Mistral();
+$model = Mistral::create();
 
 $toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);

--- a/examples/ollama/chat-llama.php
+++ b/examples/ollama/chat-llama.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
-$model = new Ollama();
+$model = Ollama::create();
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/ollama/embeddings.php
+++ b/examples/ollama/embeddings.php
@@ -16,7 +16,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
 
-$response = $platform->invoke(new Ollama(Ollama::NOMIC_EMBED_TEXT), <<<TEXT
+$response = $platform->invoke(Ollama::create(Ollama::NOMIC_EMBED_TEXT), <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.
     The people of Japan were very kind and hardworking. They loved their country very much and took care of it. The
     country was very peaceful and prosperous. The people lived happily ever after.

--- a/examples/ollama/toolcall.php
+++ b/examples/ollama/toolcall.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
-$model = new Ollama();
+$model = Ollama::create();
 
 $toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);

--- a/examples/openai/audio-input.php
+++ b/examples/openai/audio-input.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_AUDIO);
+$model = Gpt::create(Gpt::GPT_4O_AUDIO);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/openai/audio-transcript.php
+++ b/examples/openai/audio-transcript.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Message\Content\Audio;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Whisper();
+$model = Whisper::create();
 $file = Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3');
 
 $result = $platform->invoke($model, $file);

--- a/examples/openai/chat-o1.php
+++ b/examples/openai/chat-o1.php
@@ -23,7 +23,7 @@ if (!isset($_SERVER['RUN_EXPENSIVE_EXAMPLES']) || false === filter_var($_SERVER[
 }
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::O1_PREVIEW);
+$model = Gpt::create(Gpt::O1_PREVIEW);
 
 $prompt = <<<PROMPT
     I want to build a Symfony app in PHP 8.2 that takes user questions and looks them

--- a/examples/openai/chat.php
+++ b/examples/openai/chat.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI, [
+$model = Gpt::create(Gpt::GPT_4O_MINI, [
     'temperature' => 0.5, // default options for the model
 ]);
 

--- a/examples/openai/embeddings.php
+++ b/examples/openai/embeddings.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$embeddings = new Embeddings();
+$embeddings = Embeddings::create();
 
 $result = $platform->invoke($embeddings, <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.

--- a/examples/openai/image-input-binary.php
+++ b/examples/openai/image-input-binary.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/openai/image-input-url.php
+++ b/examples/openai/image-input-url.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/openai/image-output-dall-e-2.php
+++ b/examples/openai/image-output-dall-e-2.php
@@ -17,7 +17,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
 $result = $platform->invoke(
-    model: new DallE(), // Utilize Dall-E 2 version in default
+    model: DallE::create(), // Utilize Dall-E 2 version in default
     input: 'A cartoon-style elephant with a long trunk and large ears.',
     options: [
         'response_format' => 'url', // Generate response as URL

--- a/examples/openai/image-output-dall-e-3.php
+++ b/examples/openai/image-output-dall-e-3.php
@@ -18,7 +18,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
 $result = $platform->invoke(
-    model: new DallE(name: DallE::DALL_E_3),
+    model: DallE::create(name: DallE::DALL_E_3),
     input: 'A cartoon-style elephant with a long trunk and large ears.',
     options: [
         'response_format' => 'url', // Generate response as URL

--- a/examples/openai/stream.php
+++ b/examples/openai/stream.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/openai/structured-output-clock.php
+++ b/examples/openai/structured-output-clock.php
@@ -23,7 +23,7 @@ use Symfony\Component\Clock\Clock as SymfonyClock;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $clock = new Clock(new SymfonyClock());
 $toolbox = new Toolbox([$clock], logger: logger());

--- a/examples/openai/structured-output-math.php
+++ b/examples/openai/structured-output-math.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $processor = new AgentProcessor();
 $agent = new Agent($platform, $model, [$processor], [$processor], logger());

--- a/examples/openai/token-metadata.php
+++ b/examples/openai/token-metadata.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI, [
+$model = Gpt::create(Gpt::GPT_4O_MINI, [
     'temperature' => 0.5, // default options for the model
 ]);
 

--- a/examples/openai/toolcall-stream.php
+++ b/examples/openai/toolcall-stream.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $wikipedia = new Wikipedia(http_client());
 $toolbox = new Toolbox([$wikipedia], logger: logger());

--- a/examples/openai/toolcall.php
+++ b/examples/openai/toolcall.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $transcriber = new YouTubeTranscriber(http_client());
 $toolbox = new Toolbox([$transcriber], logger: logger());

--- a/examples/rag/cache.php
+++ b/examples/rag/cache.php
@@ -43,11 +43,11 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/in-memory.php
+++ b/examples/rag/in-memory.php
@@ -42,11 +42,11 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/mariadb-gemini.php
+++ b/examples/rag/mariadb-gemini.php
@@ -52,12 +52,12 @@ $store->initialize(['dimensions' => 768]);
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$embeddings = new Embeddings(options: ['dimensions' => 768, 'task_type' => TaskType::SemanticSimilarity]);
+$embeddings = Embeddings::create(options: ['dimensions' => 768, 'task_type' => TaskType::SemanticSimilarity]);
 $vectorizer = new Vectorizer($platform, $embeddings);
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
-$model = new Gemini(Gemini::GEMINI_2_FLASH_LITE);
+$model = Gemini::create(Gemini::GEMINI_2_FLASH_LITE);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/mariadb-openai.php
+++ b/examples/rag/mariadb-openai.php
@@ -51,11 +51,11 @@ $store->initialize();
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/meilisearch.php
+++ b/examples/rag/meilisearch.php
@@ -52,11 +52,11 @@ $store->initialize();
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/mongodb.php
+++ b/examples/rag/mongodb.php
@@ -49,14 +49,14 @@ foreach (Movies::all() as $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'));
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
 // initialize the index
 $store->initialize();
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/neo4j.php
+++ b/examples/rag/neo4j.php
@@ -55,11 +55,11 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store);
 $indexer->index($documents);
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/pinecone.php
+++ b/examples/rag/pinecone.php
@@ -43,11 +43,11 @@ foreach (Movies::all() as $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/postgres.php
+++ b/examples/rag/postgres.php
@@ -51,11 +51,11 @@ $store->initialize();
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/qdrant.php
+++ b/examples/rag/qdrant.php
@@ -51,11 +51,11 @@ foreach (Movies::all() as $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/surrealdb.php
+++ b/examples/rag/surrealdb.php
@@ -55,11 +55,11 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store);
 $indexer->index($documents);
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/typesense.php
+++ b/examples/rag/typesense.php
@@ -51,11 +51,11 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = Embeddings::create());
 $indexer = new Indexer($vectorizer, $store, logger());
 $indexer->index($documents);
 
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $similaritySearch = new SimilaritySearch($platform, $embeddings, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/replicate/chat-llama.php
+++ b/examples/replicate/chat-llama.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('REPLICATE_API_KEY'), http_client());
-$model = new Llama();
+$model = Llama::create();
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/toolbox/brave.php
+++ b/examples/toolbox/brave.php
@@ -22,7 +22,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $brave = new Brave(http_client(), env('BRAVE_API_KEY'));
 $crawler = new Crawler(http_client());

--- a/examples/toolbox/clock.php
+++ b/examples/toolbox/clock.php
@@ -22,7 +22,7 @@ use Symfony\Component\Clock\Clock;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $metadataFactory = (new MemoryToolFactory())
     ->addTool(Clock::class, 'clock', 'Get the current date and time', 'now');

--- a/examples/toolbox/firecrawl-crawl.php
+++ b/examples/toolbox/firecrawl-crawl.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__) . '/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $firecrawl = new Firecrawl(
     http_client(),

--- a/examples/toolbox/firecrawl-map.php
+++ b/examples/toolbox/firecrawl-map.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__) . '/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $firecrawl = new Firecrawl(
     http_client(),

--- a/examples/toolbox/firecrawl-scrape.php
+++ b/examples/toolbox/firecrawl-scrape.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__) . '/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $firecrawl = new Firecrawl(
     http_client(),

--- a/examples/toolbox/serpapi.php
+++ b/examples/toolbox/serpapi.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $serpApi = new SerpApi(http_client(), env('SERP_API_KEY'));
 $toolbox = new Toolbox([$serpApi], logger: logger());

--- a/examples/toolbox/tavily.php
+++ b/examples/toolbox/tavily.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $tavily = new Tavily(http_client(), env('TAVILY_API_KEY'));
 $toolbox = new Toolbox([$tavily], logger: logger());

--- a/examples/toolbox/weather-event.php
+++ b/examples/toolbox/weather-event.php
@@ -24,7 +24,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI);
+$model = Gpt::create(Gpt::GPT_4O_MINI);
 
 $openMeteo = new OpenMeteo(http_client());
 $toolbox = new Toolbox([$openMeteo], logger: logger());

--- a/examples/voyage/embeddings.php
+++ b/examples/voyage/embeddings.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Voyage\Voyage;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('VOYAGE_API_KEY'), http_client());
-$embeddings = new Voyage();
+$embeddings = Voyage::create();
 
 $result = $platform->invoke($embeddings, <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.

--- a/src/agent/doc/index.rst
+++ b/src/agent/doc/index.rst
@@ -24,7 +24,7 @@ To instantiate an agent, you need to pass a ``Symfony\AI\Platform\PlatformInterf
     use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 
     $platform = PlatformFactory::create($apiKey);
-    $model = new Gpt(Gpt::GPT_4O_MINI);
+    $model = Gpt::create(Gpt::GPT_4O_MINI);
 
     $agent = new Agent($platform, $model);
 

--- a/src/agent/tests/InputProcessor/ModelOverrideInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/ModelOverrideInputProcessorTest.php
@@ -34,8 +34,8 @@ final class ModelOverrideInputProcessorTest extends TestCase
 {
     public function testProcessInputWithValidModelOption()
     {
-        $gpt = new Gpt();
-        $claude = new Claude();
+        $gpt = Gpt::create();
+        $claude = Claude::create();
         $input = new Input($gpt, new MessageBag(), ['model' => $claude]);
 
         $processor = new ModelOverrideInputProcessor();
@@ -46,7 +46,7 @@ final class ModelOverrideInputProcessorTest extends TestCase
 
     public function testProcessInputWithoutModelOption()
     {
-        $gpt = new Gpt();
+        $gpt = Gpt::create();
         $input = new Input($gpt, new MessageBag(), []);
 
         $processor = new ModelOverrideInputProcessor();
@@ -60,7 +60,7 @@ final class ModelOverrideInputProcessorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Option "model" must be an instance of "Symfony\AI\Platform\Model".');
 
-        $gpt = new Gpt();
+        $gpt = Gpt::create();
         $model = new MessageBag();
         $input = new Input($gpt, new MessageBag(), ['model' => $model]);
 

--- a/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
@@ -47,7 +47,7 @@ final class SystemPromptInputProcessorTest extends TestCase
     {
         $processor = new SystemPromptInputProcessor('This is a system prompt');
 
-        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')), []);
+        $input = new Input(Gpt::create(), new MessageBag(Message::ofUser('This is a user message')), []);
         $processor->processInput($input);
 
         $messages = $input->messages->getMessages();
@@ -65,7 +65,7 @@ final class SystemPromptInputProcessorTest extends TestCase
             Message::forSystem('This is already a system prompt'),
             Message::ofUser('This is a user message'),
         );
-        $input = new Input(new Gpt(), $messages, []);
+        $input = new Input(Gpt::create(), $messages, []);
         $processor->processInput($input);
 
         $messages = $input->messages->getMessages();
@@ -92,7 +92,7 @@ final class SystemPromptInputProcessorTest extends TestCase
             }
         );
 
-        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')), []);
+        $input = new Input(Gpt::create(), new MessageBag(Message::ofUser('This is a user message')), []);
         $processor->processInput($input);
 
         $messages = $input->messages->getMessages();
@@ -130,7 +130,7 @@ final class SystemPromptInputProcessorTest extends TestCase
             }
         );
 
-        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')), []);
+        $input = new Input(Gpt::create(), new MessageBag(Message::ofUser('This is a user message')), []);
         $processor->processInput($input);
 
         $messages = $input->messages->getMessages();
@@ -170,7 +170,7 @@ final class SystemPromptInputProcessorTest extends TestCase
             }
         );
 
-        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')), []);
+        $input = new Input(Gpt::create(), new MessageBag(Message::ofUser('This is a user message')), []);
         $processor->processInput($input);
 
         $messages = $input->messages->getMessages();

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -301,7 +301,7 @@ class AiBundleTest extends TestCase
                         'store' => 'my_azure_search_store_service_id',
                         'platform' => 'mistral_platform_service_id',
                         'model' => [
-                            'class' => 'Symfony\AI\Platform\Bridge\Mistral\Embeddings',
+                            'class' => 'Symfony\AI\Platform\Model',
                             'name' => 'mistral-embed',
                             'options' => ['dimension' => 768],
                         ],

--- a/src/platform/doc/gemini-server-tools.rst
+++ b/src/platform/doc/gemini-server-tools.rst
@@ -25,7 +25,7 @@ The URL Context tool allows Gemini to fetch and analyze content from web pages. 
 
 ::
 
-    $model = new Gemini('gemini-2.5-pro-preview-03-25', [
+    $model = Gemini::create('gemini-2.5-pro-preview-03-25', [
         'server_tools' => [
             'url_context' => true
         ]
@@ -42,7 +42,7 @@ The URL Context tool allows Gemini to fetch and analyze content from web pages. 
 
 The Google Search tool enables the model to search the web and incorporate search results into its results::
 
-    $model = new Gemini('gemini-2.5-pro-preview-03-25', [
+    $model = Gemini::create('gemini-2.5-pro-preview-03-25', [
         'server_tools' => [
             'google_search' => true
         ]
@@ -58,7 +58,7 @@ The Google Search tool enables the model to search the web and incorporate searc
 
 The Code Execution tool provides a sandboxed environment for running code::
 
-    $model = new Gemini('gemini-2.5-pro-preview-03-25', [
+    $model = Gemini::create('gemini-2.5-pro-preview-03-25', [
         'server_tools' => [
             'code_execution' => true
         ]
@@ -75,7 +75,7 @@ The Code Execution tool provides a sandboxed environment for running code::
 
 You can enable multiple server tools simultaneously::
 
-    $model = new Gemini('gemini-2.5-pro-preview-03-25', [
+    $model = Gemini::create('gemini-2.5-pro-preview-03-25', [
         'server_tools' => [
             'url_context' => true,
             'google_search' => true,

--- a/src/platform/doc/index.rst
+++ b/src/platform/doc/index.rst
@@ -36,10 +36,10 @@ For example, to use the OpenAI provider, you would typically do something like t
     $platform = PlatformFactory::create(env('OPENAI_API_KEY'));
 
     // Embeddings Model
-    $embeddings = new Embeddings();
+    $embeddings = Embeddings::create();
 
     // Language Model in version gpt-4o-mini
-    $model = new Gpt(Gpt::GPT_4O_MINI);
+    $model = Gpt::create(Gpt::GPT_4O_MINI);
 
 And with a ``Symfony\AI\Platform\PlatformInterface`` instance, and a ``Symfony\AI\Platform\Model`` instance, you can now
 use the platform to interact with the AI model::
@@ -246,7 +246,7 @@ The standalone usage results in an ``Vector`` instance::
 
     // Initialize Platform
 
-    $embeddings = new Embeddings($platform, Embeddings::TEXT_3_SMALL);
+    $embeddings = Embeddings::create(Embeddings::TEXT_3_SMALL);
 
     $vectors = $platform->invoke($embeddings, $textInput)->asVectors();
 

--- a/src/platform/src/Bridge/Anthropic/Claude.php
+++ b/src/platform/src/Bridge/Anthropic/Claude.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-class Claude extends Model
+final class Claude
 {
     public const HAIKU_3 = 'claude-3-haiku-20240307';
     public const HAIKU_35 = 'claude-3-5-haiku-latest';
@@ -34,10 +34,10 @@ class Claude extends Model
     /**
      * @param array<string, mixed> $options The default options for the model usage
      */
-    public function __construct(
+    public static function create(
         string $name = self::SONNET_37,
         array $options = ['temperature' => 1.0, 'max_tokens' => 1000],
-    ) {
+    ): Model {
         $capabilities = [
             Capability::INPUT_MESSAGES,
             Capability::INPUT_IMAGE,
@@ -46,6 +46,6 @@ class Claude extends Model
             Capability::TOOL_CALLING,
         ];
 
-        parent::__construct($name, $capabilities, $options);
+        return new Model($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/Bedrock/Nova/Nova.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/Nova.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Björn Altmann
  */
-final class Nova extends Model
+final class Nova
 {
     public const MICRO = 'nova-micro';
     public const LITE = 'nova-lite';
@@ -27,10 +27,10 @@ final class Nova extends Model
     /**
      * @param array<string, mixed> $options The default options for the model usage
      */
-    public function __construct(
+    public static function create(
         string $name = self::PRO,
         array $options = ['temperature' => 1.0, 'max_tokens' => 1000],
-    ) {
+    ): Model {
         $capabilities = [
             Capability::INPUT_MESSAGES,
             Capability::OUTPUT_TEXT,
@@ -41,6 +41,6 @@ final class Nova extends Model
             $capabilities[] = Capability::INPUT_IMAGE;
         }
 
-        parent::__construct($name, $capabilities, $options);
+        return new Model($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/Cerebras/Model.php
+++ b/src/platform/src/Bridge/Cerebras/Model.php
@@ -8,7 +8,7 @@ use \Symfony\AI\Platform\Model as BaseModel;
 /**
  * @author Junaid Farooq <ulislam.junaid125@gmail.com>
  */
-final class Model extends BaseModel
+final class Model
 {
     public const LLAMA_4_SCOUT_17B_16E_INSTRUCT = 'llama-4-scout-17b-16e-instruct';
     public const LLAMA3_1_8B = 'llama3.1-8b';
@@ -29,11 +29,11 @@ final class Model extends BaseModel
     /**
      * @see https://inference-docs.cerebras.ai/api-reference/chat-completions for details like options
      */
-    public function __construct(
+    public static function create(
         string $name = self::LLAMA3_1_8B,
         array $capabilities = self::CAPABILITIES,
         array $options = [],
-    ) {
-        parent::__construct($name, $capabilities, $options);
+    ): BaseModel {
+        return new BaseModel($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/Gemini/Embeddings.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Valtteri R <valtzu@gmail.com>
  */
-class Embeddings extends Model
+final class Embeddings
 {
     /** Supported dimensions: 3072, 1536, or 768 */
     public const GEMINI_EMBEDDING_EXP_03_07 = 'gemini-embedding-exp-03-07';
@@ -30,8 +30,8 @@ class Embeddings extends Model
     /**
      * @param array{dimensions?: int, task_type?: TaskType|string} $options
      */
-    public function __construct(string $name = self::GEMINI_EMBEDDING_EXP_03_07, array $options = [])
+    public static function create(string $name = self::GEMINI_EMBEDDING_EXP_03_07, array $options = []): Model
     {
-        parent::__construct($name, [Capability::INPUT_MULTIPLE], $options);
+        return new Model($name, [Capability::INPUT_MULTIPLE], $options);
     }
 }

--- a/src/platform/src/Bridge/Gemini/Gemini.php
+++ b/src/platform/src/Bridge/Gemini/Gemini.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Roy Garrido
  */
-class Gemini extends Model
+final class Gemini
 {
     public const GEMINI_2_FLASH = 'gemini-2.0-flash';
     public const GEMINI_2_PRO = 'gemini-2.0-pro-exp-02-05';
@@ -28,7 +28,7 @@ class Gemini extends Model
     /**
      * @param array<string, mixed> $options The default options for the model usage
      */
-    public function __construct(string $name = self::GEMINI_2_PRO, array $options = ['temperature' => 1.0])
+    public static function create(string $name = self::GEMINI_2_PRO, array $options = ['temperature' => 1.0]): Model
     {
         $capabilities = [
             Capability::INPUT_MESSAGES,
@@ -40,6 +40,6 @@ class Gemini extends Model
             Capability::TOOL_CALLING,
         ];
 
-        parent::__construct($name, $capabilities, $options);
+        return new Model($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/LmStudio/Completions.php
+++ b/src/platform/src/Bridge/LmStudio/Completions.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author André Lubian <lubiana123@gmail.com>
  */
-class Completions extends Model
+final class Completions
 {
     public const DEFAULT_CAPABILITIES = [
         Capability::INPUT_MESSAGES,
@@ -25,11 +25,11 @@ class Completions extends Model
         Capability::OUTPUT_STREAMING,
     ];
 
-    public function __construct(
+    public static function create(
         string $name,
         array $options = ['temperature' => 0.7],
         array $capabilities = self::DEFAULT_CAPABILITIES,
-    ) {
-        parent::__construct($name, $capabilities, $options);
+    ): Model {
+        return new Model($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/LmStudio/Embeddings.php
+++ b/src/platform/src/Bridge/LmStudio/Embeddings.php
@@ -16,6 +16,10 @@ use Symfony\AI\Platform\Model;
 /**
  * @author André Lubian <lubiana123@gmail.com>
  */
-class Embeddings extends Model
+final class Embeddings
 {
+    public static function create(string $name, array $capabilities = [], array $options = []): Model
+    {
+        return new Model($name, $capabilities, $options);
+    }
 }

--- a/src/platform/src/Bridge/Meta/Llama.php
+++ b/src/platform/src/Bridge/Meta/Llama.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-class Llama extends Model
+final class Llama
 {
     public const V3_3_70B_INSTRUCT = 'llama-3.3-70B-Instruct';
     public const V3_2_90B_VISION_INSTRUCT = 'llama-3.2-90b-vision-instruct';
@@ -38,13 +38,13 @@ class Llama extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name = self::V3_1_405B_INSTRUCT, array $options = [])
+    public static function create(string $name = self::V3_1_405B_INSTRUCT, array $options = []): Model
     {
         $capabilities = [
             Capability::INPUT_MESSAGES,
             Capability::OUTPUT_TEXT,
         ];
 
-        parent::__construct($name, $capabilities, $options);
+        return new Model($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/Mistral/Embeddings.php
+++ b/src/platform/src/Bridge/Mistral/Embeddings.php
@@ -17,17 +17,17 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class Embeddings extends Model
+final class Embeddings
 {
     public const MISTRAL_EMBED = 'mistral-embed';
 
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(
+    public static function create(
         string $name = self::MISTRAL_EMBED,
         array $options = [],
-    ) {
-        parent::__construct($name, [Capability::INPUT_MULTIPLE], $options);
+    ): Model {
+        return new Model($name, [Capability::INPUT_MULTIPLE], $options);
     }
 }

--- a/src/platform/src/Bridge/Mistral/Mistral.php
+++ b/src/platform/src/Bridge/Mistral/Mistral.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class Mistral extends Model
+final class Mistral
 {
     public const CODESTRAL = 'codestral-latest';
     public const CODESTRAL_MAMBA = 'open-codestral-mamba';
@@ -33,10 +33,10 @@ final class Mistral extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(
+    public static function create(
         string $name = self::MISTRAL_LARGE,
         array $options = [],
-    ) {
+    ): Model {
         $capabilities = [
             Capability::INPUT_MESSAGES,
             Capability::OUTPUT_TEXT,
@@ -61,6 +61,6 @@ final class Mistral extends Model
             $capabilities[] = Capability::TOOL_CALLING;
         }
 
-        parent::__construct($name, $capabilities, $options);
+        return new Model($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/Ollama/Ollama.php
+++ b/src/platform/src/Bridge/Ollama/Ollama.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Joshua Behrens <code@joshua-behrens.de>
  */
-class Ollama extends Model
+final class Ollama
 {
     public const DEEPSEEK_R_1 = 'deepseek-r1';
     public const GEMMA_3_N = 'gemma3n';
@@ -63,7 +63,7 @@ class Ollama extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name = self::LLAMA_3_2, array $options = [])
+    public static function create(string $name = self::LLAMA_3_2, array $options = []): Model
     {
         $capabilities = [];
 
@@ -75,6 +75,6 @@ class Ollama extends Model
             }
         }
 
-        parent::__construct($name, $capabilities, $options);
+        return new Model($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/OpenAi/DallE.php
+++ b/src/platform/src/Bridge/OpenAi/DallE.php
@@ -17,19 +17,21 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Denis Zunke <denis.zunke@gmail.com>
  */
-class DallE extends Model
+final class DallE
 {
     public const DALL_E_2 = 'dall-e-2';
     public const DALL_E_3 = 'dall-e-3';
 
-    /** @param array<string, mixed> $options The default options for the model usage */
-    public function __construct(string $name = self::DALL_E_2, array $options = [])
+    /**
+     * @param array<string, mixed> $options The default options for the model usage
+     */
+    public static function create(string $name = self::DALL_E_2, array $options = []): Model
     {
         $capabilities = [
             Capability::INPUT_TEXT,
             Capability::OUTPUT_IMAGE,
         ];
 
-        parent::__construct($name, $capabilities, $options);
+        return new Model($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/OpenAi/Embeddings.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-class Embeddings extends Model
+final class Embeddings
 {
     public const TEXT_ADA_002 = 'text-embedding-ada-002';
     public const TEXT_3_LARGE = 'text-embedding-3-large';
@@ -25,8 +25,8 @@ class Embeddings extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name = self::TEXT_3_SMALL, array $options = [])
+    public static function create(string $name = self::TEXT_3_SMALL, array $options = []): Model
     {
-        parent::__construct($name, [], $options);
+        return new Model($name, [], $options);
     }
 }

--- a/src/platform/src/Bridge/OpenAi/Gpt.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Model;
  * @author Christopher Hertel <mail@christopher-hertel.de>
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-class Gpt extends Model
+final class Gpt
 {
     public const GPT_35_TURBO = 'gpt-3.5-turbo';
     public const GPT_35_TURBO_INSTRUCT = 'gpt-3.5-turbo-instruct';
@@ -62,10 +62,10 @@ class Gpt extends Model
     /**
      * @param array<mixed> $options The default options for the model usage
      */
-    public function __construct(
+    public static function create(
         string $name = self::GPT_4O,
         array $options = ['temperature' => 1.0],
-    ) {
+    ): Model {
         $capabilities = [
             Capability::INPUT_MESSAGES,
             Capability::OUTPUT_TEXT,
@@ -85,6 +85,6 @@ class Gpt extends Model
             $capabilities[] = Capability::OUTPUT_STRUCTURED;
         }
 
-        parent::__construct($name, $capabilities, $options);
+        return new Model($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/OpenAi/Whisper.php
+++ b/src/platform/src/Bridge/OpenAi/Whisper.php
@@ -17,20 +17,20 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-class Whisper extends Model
+final class Whisper
 {
     public const WHISPER_1 = 'whisper-1';
 
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name = self::WHISPER_1, array $options = [])
+    public static function create(string $name = self::WHISPER_1, array $options = []): Model
     {
         $capabilities = [
             Capability::INPUT_AUDIO,
             Capability::OUTPUT_TEXT,
         ];
 
-        parent::__construct($name, $capabilities, $options);
+        return new Model($name, $capabilities, $options);
     }
 }

--- a/src/platform/src/Bridge/Voyage/Voyage.php
+++ b/src/platform/src/Bridge/Voyage/Voyage.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-class Voyage extends Model
+final class Voyage
 {
     public const V3 = 'voyage-3';
     public const V3_LITE = 'voyage-3-lite';
@@ -29,8 +29,8 @@ class Voyage extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name = self::V3, array $options = [])
+    public static function create(string $name = self::V3, array $options = []): Model
     {
-        parent::__construct($name, [Capability::INPUT_MULTIPLE], $options);
+        return new Model($name, [Capability::INPUT_MULTIPLE], $options);
     }
 }

--- a/src/platform/src/Model.php
+++ b/src/platform/src/Model.php
@@ -14,7 +14,7 @@ namespace Symfony\AI\Platform;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-class Model
+final class Model
 {
     /**
      * @param Capability[]         $capabilities

--- a/src/platform/tests/Bridge/Albert/EmbeddingsModelClientTest.php
+++ b/src/platform/tests/Bridge/Albert/EmbeddingsModelClientTest.php
@@ -58,7 +58,7 @@ final class EmbeddingsModelClientTest extends TestCase
             'https://albert.example.com/'
         );
 
-        $embeddingsModel = new Embeddings('text-embedding-ada-002');
+        $embeddingsModel = Embeddings::create('text-embedding-ada-002');
         $this->assertTrue($client->supports($embeddingsModel));
     }
 
@@ -70,7 +70,7 @@ final class EmbeddingsModelClientTest extends TestCase
             'https://albert.example.com/'
         );
 
-        $gptModel = new Gpt('gpt-3.5-turbo');
+        $gptModel = Gpt::create('gpt-3.5-turbo');
         $this->assertFalse($client->supports($gptModel));
     }
 
@@ -90,7 +90,7 @@ final class EmbeddingsModelClientTest extends TestCase
             'https://albert.example.com/v1'
         );
 
-        $model = new Embeddings('text-embedding-ada-002');
+        $model = Embeddings::create('text-embedding-ada-002');
         $result = $client->request($model, $payload, $options);
 
         $this->assertNotNull($capturedRequest);
@@ -151,7 +151,7 @@ final class EmbeddingsModelClientTest extends TestCase
             'https://albert.example.com/v1'
         );
 
-        $model = new Embeddings('text-embedding-ada-002');
+        $model = Embeddings::create('text-embedding-ada-002');
         $client->request($model, ['input' => 'test']);
 
         $this->assertSame('https://albert.example.com/v1/embeddings', $capturedUrl);
@@ -172,7 +172,7 @@ final class EmbeddingsModelClientTest extends TestCase
             'https://albert.example.com/v1'
         );
 
-        $model = new Embeddings('text-embedding-ada-002');
+        $model = Embeddings::create('text-embedding-ada-002');
         $client->request($model, ['input' => 'test']);
 
         $this->assertSame('https://albert.example.com/v1/embeddings', $capturedUrl);

--- a/src/platform/tests/Bridge/Albert/GptModelClientTest.php
+++ b/src/platform/tests/Bridge/Albert/GptModelClientTest.php
@@ -68,7 +68,7 @@ final class GptModelClientTest extends TestCase
         $mockResponse = new JsonMockResponse(['choices' => []]);
         $mockHttpClient->setResponseFactory([$mockResponse]);
 
-        $model = new Gpt('gpt-3.5-turbo');
+        $model = Gpt::create('gpt-3.5-turbo');
         $client->request($model, ['messages' => []]);
     }
 
@@ -89,7 +89,7 @@ final class GptModelClientTest extends TestCase
         $mockResponse = new JsonMockResponse(['choices' => []]);
         $mockHttpClient->setResponseFactory([$mockResponse]);
 
-        $model = new Gpt('gpt-3.5-turbo');
+        $model = Gpt::create('gpt-3.5-turbo');
         $client->request($model, ['messages' => []]);
     }
 
@@ -101,7 +101,7 @@ final class GptModelClientTest extends TestCase
             'https://albert.example.com/'
         );
 
-        $gptModel = new Gpt('gpt-3.5-turbo');
+        $gptModel = Gpt::create('gpt-3.5-turbo');
         $this->assertTrue($client->supports($gptModel));
     }
 
@@ -113,7 +113,7 @@ final class GptModelClientTest extends TestCase
             'https://albert.example.com/'
         );
 
-        $embeddingsModel = new Embeddings('text-embedding-ada-002');
+        $embeddingsModel = Embeddings::create('text-embedding-ada-002');
         $this->assertFalse($client->supports($embeddingsModel));
     }
 
@@ -133,7 +133,7 @@ final class GptModelClientTest extends TestCase
             'https://albert.example.com/v1'
         );
 
-        $model = new Gpt('gpt-3.5-turbo');
+        $model = Gpt::create('gpt-3.5-turbo');
         $result = $client->request($model, $payload, $options);
 
         $this->assertNotNull($capturedRequest);
@@ -200,7 +200,7 @@ final class GptModelClientTest extends TestCase
             'https://albert.example.com/v1'
         );
 
-        $model = new Gpt('gpt-3.5-turbo');
+        $model = Gpt::create('gpt-3.5-turbo');
         $client->request($model, ['messages' => []]);
 
         $this->assertSame('https://albert.example.com/v1/chat/completions', $capturedUrl);
@@ -221,7 +221,7 @@ final class GptModelClientTest extends TestCase
             'https://albert.example.com/v1'
         );
 
-        $model = new Gpt('gpt-3.5-turbo');
+        $model = Gpt::create('gpt-3.5-turbo');
         $client->request($model, ['messages' => []]);
 
         $this->assertSame('https://albert.example.com/v1/chat/completions', $capturedUrl);

--- a/src/platform/tests/Bridge/Azure/OpenAi/EmbeddingsModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/EmbeddingsModelClientTest.php
@@ -77,7 +77,7 @@ final class EmbeddingsModelClientTest extends TestCase
     {
         $client = new EmbeddingsModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '2023-12-01', 'api-key');
 
-        $this->assertTrue($client->supports(new Embeddings()));
+        $this->assertTrue($client->supports(Embeddings::create()));
     }
 
     public function testItIsExecutingTheCorrectRequest()
@@ -93,6 +93,6 @@ final class EmbeddingsModelClientTest extends TestCase
 
         $httpClient = new MockHttpClient([$resultCallback]);
         $client = new EmbeddingsModelClient($httpClient, 'test.azure.com', 'embeddings-deployment', '2023-12-01', 'test-api-key');
-        $client->request(new Embeddings(), 'Hello, world!');
+        $client->request(Embeddings::create(), 'Hello, world!');
     }
 }

--- a/src/platform/tests/Bridge/Azure/OpenAi/GptModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/GptModelClientTest.php
@@ -77,7 +77,7 @@ final class GptModelClientTest extends TestCase
     {
         $client = new GptModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '2023-12-01', 'api-key');
 
-        $this->assertTrue($client->supports(new Gpt()));
+        $this->assertTrue($client->supports(Gpt::create()));
     }
 
     public function testItIsExecutingTheCorrectRequest()
@@ -93,6 +93,6 @@ final class GptModelClientTest extends TestCase
 
         $httpClient = new MockHttpClient([$resultCallback]);
         $client = new GptModelClient($httpClient, 'test.azure.com', 'gpt-deployment', '2023-12-01', 'test-api-key');
-        $client->request(new Gpt(), ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
+        $client->request(Gpt::create(), ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
     }
 }

--- a/src/platform/tests/Bridge/Azure/OpenAi/WhisperModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/WhisperModelClientTest.php
@@ -78,7 +78,7 @@ final class WhisperModelClientTest extends TestCase
             '2023-12-01-preview',
             'test-key'
         );
-        $model = new Whisper();
+        $model = Whisper::create();
 
         $this->assertTrue($client->supports($model));
     }
@@ -95,7 +95,7 @@ final class WhisperModelClientTest extends TestCase
         ]);
 
         $client = new WhisperModelClient($httpClient, 'test.azure.com', 'whspr', '2023-12', 'test-key');
-        $model = new Whisper();
+        $model = Whisper::create();
         $payload = ['file' => 'audio-data'];
 
         $client->request($model, $payload);
@@ -115,7 +115,7 @@ final class WhisperModelClientTest extends TestCase
         ]);
 
         $client = new WhisperModelClient($httpClient, 'test.azure.com', 'whspr', '2023-12', 'test-key');
-        $model = new Whisper();
+        $model = Whisper::create();
         $payload = ['file' => 'audio-data'];
         $options = ['task' => Task::TRANSCRIPTION];
 
@@ -136,7 +136,7 @@ final class WhisperModelClientTest extends TestCase
         ]);
 
         $client = new WhisperModelClient($httpClient, 'test.azure.com', 'whspr', '2023-12', 'test-key');
-        $model = new Whisper();
+        $model = Whisper::create();
         $payload = ['file' => 'audio-data'];
         $options = ['task' => Task::TRANSLATION];
 

--- a/src/platform/tests/Bridge/Bedrock/Nova/ContractTest.php
+++ b/src/platform/tests/Bridge/Bedrock/Nova/ContractTest.php
@@ -55,7 +55,7 @@ final class ContractTest extends TestCase
             new UserMessageNormalizer(),
         );
 
-        $this->assertEquals($expected, $contract->createRequestPayload(new Nova(), $bag));
+        $this->assertEquals($expected, $contract->createRequestPayload(Nova::create(), $bag));
     }
 
     /**

--- a/src/platform/tests/Bridge/Gemini/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/AssistantMessageNormalizerTest.php
@@ -36,7 +36,7 @@ final class AssistantMessageNormalizerTest extends TestCase
         $normalizer = new AssistantMessageNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
-            Contract::CONTEXT_MODEL => new Gemini(),
+            Contract::CONTEXT_MODEL => Gemini::create(),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not an assistant message'));
     }

--- a/src/platform/tests/Bridge/Gemini/Contract/MessageBagNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/MessageBagNormalizerTest.php
@@ -46,7 +46,7 @@ final class MessageBagNormalizerTest extends TestCase
         $normalizer = new MessageBagNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new MessageBag(), context: [
-            Contract::CONTEXT_MODEL => new Gemini(),
+            Contract::CONTEXT_MODEL => Gemini::create(),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a message bag'));
     }

--- a/src/platform/tests/Bridge/Gemini/Contract/ToolCallMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/ToolCallMessageNormalizerTest.php
@@ -36,7 +36,7 @@ final class ToolCallMessageNormalizerTest extends TestCase
         $normalizer = new ToolCallMessageNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new ToolCallMessage(new ToolCall('', '', []), ''), context: [
-            Contract::CONTEXT_MODEL => new Gemini(),
+            Contract::CONTEXT_MODEL => Gemini::create(),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a tool call'));
     }

--- a/src/platform/tests/Bridge/Gemini/Contract/ToolNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/ToolNormalizerTest.php
@@ -37,7 +37,7 @@ final class ToolNormalizerTest extends TestCase
         $normalizer = new ToolNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new Tool(new ExecutionReference(ToolNoParams::class), 'test', 'test'), context: [
-            Contract::CONTEXT_MODEL => new Gemini(),
+            Contract::CONTEXT_MODEL => Gemini::create(),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a tool'));
     }

--- a/src/platform/tests/Bridge/Gemini/Contract/UserMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/UserMessageNormalizerTest.php
@@ -42,7 +42,7 @@ final class UserMessageNormalizerTest extends TestCase
         $normalizer = new UserMessageNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new UserMessage(new Text('Hello')), context: [
-            Contract::CONTEXT_MODEL => new Gemini(),
+            Contract::CONTEXT_MODEL => Gemini::create(),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a user message'));
     }

--- a/src/platform/tests/Bridge/Gemini/Embeddings/ModelClientTest.php
+++ b/src/platform/tests/Bridge/Gemini/Embeddings/ModelClientTest.php
@@ -64,7 +64,7 @@ final class ModelClientTest extends TestCase
             )
             ->willReturn($result);
 
-        $model = new Embeddings(Embeddings::GEMINI_EMBEDDING_EXP_03_07, ['dimensions' => 1536, 'task_type' => 'CLASSIFICATION']);
+        $model = Embeddings::create(Embeddings::GEMINI_EMBEDDING_EXP_03_07, ['dimensions' => 1536, 'task_type' => 'CLASSIFICATION']);
 
         $result = (new ModelClient($httpClient, 'test'))->request($model, ['payload1', 'payload2']);
         $this->assertSame(json_decode($this->getEmbeddingStub(), true), $result->getData());

--- a/src/platform/tests/Bridge/LmStudio/Completions/ModelClientTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Completions/ModelClientTest.php
@@ -31,7 +31,7 @@ class ModelClientTest extends TestCase
     {
         $client = new ModelClient(new MockHttpClient(), 'http://localhost:1234');
 
-        $this->assertTrue($client->supports(new Completions('test-model')));
+        $this->assertTrue($client->supports(Completions::create('test-model')));
     }
 
     public function testItIsExecutingTheCorrectRequest()
@@ -57,7 +57,7 @@ class ModelClientTest extends TestCase
             ],
         ];
 
-        $client->request(new Completions('test-model'), $payload);
+        $client->request(Completions::create('test-model'), $payload);
     }
 
     public function testItMergesOptionsWithPayload()
@@ -83,7 +83,7 @@ class ModelClientTest extends TestCase
             ],
         ];
 
-        $client->request(new Completions('test-model'), $payload, ['temperature' => 0.7]);
+        $client->request(Completions::create('test-model'), $payload, ['temperature' => 0.7]);
     }
 
     public function testItUsesEventSourceHttpClient()

--- a/src/platform/tests/Bridge/LmStudio/Completions/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Completions/ResultConverterTest.php
@@ -29,6 +29,6 @@ class ResultConverterTest extends TestCase
     {
         $converter = new ResultConverter();
 
-        $this->assertTrue($converter->supports(new Completions('test-model')));
+        $this->assertTrue($converter->supports(Completions::create('test-model')));
     }
 }

--- a/src/platform/tests/Bridge/LmStudio/Embeddings/ModelClientTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Embeddings/ModelClientTest.php
@@ -29,7 +29,7 @@ class ModelClientTest extends TestCase
     {
         $client = new ModelClient(new MockHttpClient(), 'http://localhost:1234');
 
-        $this->assertTrue($client->supports(new Embeddings('test-model')));
+        $this->assertTrue($client->supports(Embeddings::create('test-model')));
     }
 
     public function testItIsExecutingTheCorrectRequest()
@@ -45,7 +45,7 @@ class ModelClientTest extends TestCase
         $httpClient = new MockHttpClient([$resultCallback]);
         $client = new ModelClient($httpClient, 'http://localhost:1234');
 
-        $model = new Embeddings('test-model');
+        $model = Embeddings::create('test-model');
 
         $client->request($model, 'Hello, world!');
     }
@@ -66,7 +66,7 @@ class ModelClientTest extends TestCase
         $httpClient = new MockHttpClient([$resultCallback]);
         $client = new ModelClient($httpClient, 'http://localhost:1234');
 
-        $model = new Embeddings('test-model');
+        $model = Embeddings::create('test-model');
 
         $client->request($model, 'Hello, world!', ['custom_option' => 'value']);
     }
@@ -84,7 +84,7 @@ class ModelClientTest extends TestCase
         $httpClient = new MockHttpClient([$resultCallback]);
         $client = new ModelClient($httpClient, 'http://localhost:1234');
 
-        $model = new Embeddings('test-model');
+        $model = Embeddings::create('test-model');
 
         $client->request($model, ['Hello', 'world']);
     }

--- a/src/platform/tests/Bridge/LmStudio/Embeddings/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Embeddings/ResultConverterTest.php
@@ -84,6 +84,6 @@ class ResultConverterTest extends TestCase
     {
         $converter = new ResultConverter();
 
-        $this->assertTrue($converter->supports(new Embeddings('test-model')));
+        $this->assertTrue($converter->supports(Embeddings::create('test-model')));
     }
 }

--- a/src/platform/tests/Bridge/Ollama/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Ollama/Contract/AssistantMessageNormalizerTest.php
@@ -42,7 +42,7 @@ final class AssistantMessageNormalizerTest extends TestCase
     public function testSupportsNormalization()
     {
         $this->assertTrue($this->normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
-            Contract::CONTEXT_MODEL => new Ollama(),
+            Contract::CONTEXT_MODEL => Ollama::create(),
         ]));
         $this->assertFalse($this->normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
             Contract::CONTEXT_MODEL => new Model('any-model'),

--- a/src/platform/tests/Bridge/Ollama/OllamaResultConverterTest.php
+++ b/src/platform/tests/Bridge/Ollama/OllamaResultConverterTest.php
@@ -42,7 +42,7 @@ final class OllamaResultConverterTest extends TestCase
     {
         $converter = new OllamaResultConverter();
 
-        $this->assertTrue($converter->supports(new Ollama()));
+        $this->assertTrue($converter->supports(Ollama::create()));
         $this->assertFalse($converter->supports(new Model('any-model')));
     }
 

--- a/src/platform/tests/Bridge/Ollama/OllamaTest.php
+++ b/src/platform/tests/Bridge/Ollama/OllamaTest.php
@@ -25,7 +25,7 @@ final class OllamaTest extends TestCase
     #[DataProvider('provideModelsWithToolCallingCapability')]
     public function testModelsWithToolCallingCapability(string $modelName)
     {
-        $model = new Ollama($modelName);
+        $model = Ollama::create($modelName);
 
         $this->assertTrue(
             $model->supports(Capability::TOOL_CALLING),
@@ -36,7 +36,7 @@ final class OllamaTest extends TestCase
     #[DataProvider('provideModelsWithoutToolCallingCapability')]
     public function testModelsWithoutToolCallingCapability(string $modelName)
     {
-        $model = new Ollama($modelName);
+        $model = Ollama::create($modelName);
 
         $this->assertFalse(
             $model->supports(Capability::TOOL_CALLING),
@@ -47,7 +47,7 @@ final class OllamaTest extends TestCase
     #[DataProvider('provideModelsWithMultipleInputCapabilities')]
     public function testModelsWithMultipleInputCapabilities(string $modelName)
     {
-        $model = new Ollama($modelName);
+        $model = Ollama::create($modelName);
 
         $this->assertTrue(
             $model->supports(Capability::INPUT_MULTIPLE),

--- a/src/platform/tests/Bridge/OpenAi/DallE/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAi/DallE/ModelClientTest.php
@@ -61,7 +61,7 @@ final class ModelClientTest extends TestCase
     {
         $modelClient = new ModelClient(new MockHttpClient(), 'sk-api-key');
 
-        $this->assertTrue($modelClient->supports(new DallE()));
+        $this->assertTrue($modelClient->supports(DallE::create()));
     }
 
     public function testItIsExecutingTheCorrectRequest()
@@ -76,6 +76,6 @@ final class ModelClientTest extends TestCase
         };
         $httpClient = new MockHttpClient([$resultCallback]);
         $modelClient = new ModelClient($httpClient, 'sk-api-key');
-        $modelClient->request(new DallE(), 'foo', ['n' => 1, 'response_format' => 'url']);
+        $modelClient->request(DallE::create(), 'foo', ['n' => 1, 'response_format' => 'url']);
     }
 }

--- a/src/platform/tests/Bridge/OpenAi/DallETest.php
+++ b/src/platform/tests/Bridge/OpenAi/DallETest.php
@@ -22,7 +22,7 @@ final class DallETest extends TestCase
 {
     public function testItCreatesDallEWithDefaultSettings()
     {
-        $dallE = new DallE();
+        $dallE = DallE::create();
 
         $this->assertSame(DallE::DALL_E_2, $dallE->getName());
         $this->assertSame([], $dallE->getOptions());
@@ -30,7 +30,7 @@ final class DallETest extends TestCase
 
     public function testItCreatesDallEWithCustomSettings()
     {
-        $dallE = new DallE(DallE::DALL_E_3, ['response_format' => 'base64', 'n' => 2]);
+        $dallE = DallE::create(DallE::DALL_E_3, ['response_format' => 'base64', 'n' => 2]);
 
         $this->assertSame(DallE::DALL_E_3, $dallE->getName());
         $this->assertSame(['response_format' => 'base64', 'n' => 2], $dallE->getOptions());

--- a/src/platform/tests/Bridge/OpenAi/Whisper/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAi/Whisper/ModelClientTest.php
@@ -27,7 +27,7 @@ final class ModelClientTest extends TestCase
     public function testItSupportsWhisperModel()
     {
         $client = new ModelClient(new MockHttpClient(), 'test-key');
-        $model = new Whisper();
+        $model = Whisper::create();
 
         $this->assertTrue($client->supports($model));
     }
@@ -44,7 +44,7 @@ final class ModelClientTest extends TestCase
         ]);
 
         $client = new ModelClient($httpClient, 'test-key');
-        $model = new Whisper();
+        $model = Whisper::create();
         $payload = ['file' => 'audio-data'];
 
         $client->request($model, $payload);
@@ -64,7 +64,7 @@ final class ModelClientTest extends TestCase
         ]);
 
         $client = new ModelClient($httpClient, 'test-key');
-        $model = new Whisper();
+        $model = Whisper::create();
         $payload = ['file' => 'audio-data'];
         $options = ['task' => Task::TRANSCRIPTION];
 
@@ -85,7 +85,7 @@ final class ModelClientTest extends TestCase
         ]);
 
         $client = new ModelClient($httpClient, 'test-key');
-        $model = new Whisper();
+        $model = Whisper::create();
         $payload = ['file' => 'audio-data'];
         $options = ['task' => Task::TRANSLATION];
 

--- a/src/platform/tests/Contract/Normalizer/Message/MessageBagNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/MessageBagNormalizerTest.php
@@ -96,7 +96,7 @@ final class MessageBagNormalizerTest extends TestCase
         $innerNormalizer = $this->createMock(NormalizerInterface::class);
         $innerNormalizer->expects($this->once())
             ->method('normalize')
-            ->with($messages, null, [Contract::CONTEXT_MODEL => new Gpt()])
+            ->with($messages, null, [Contract::CONTEXT_MODEL => Gpt::create()])
             ->willReturn([
                 ['role' => 'system', 'content' => 'You are a helpful assistant'],
                 ['role' => 'user', 'content' => 'Hello'],
@@ -113,7 +113,7 @@ final class MessageBagNormalizerTest extends TestCase
         ];
 
         $this->assertSame($expected, $this->normalizer->normalize($messageBag, context: [
-            Contract::CONTEXT_MODEL => new Gpt(),
+            Contract::CONTEXT_MODEL => Gpt::create(),
         ]));
     }
 }

--- a/src/platform/tests/ContractTest.php
+++ b/src/platform/tests/ContractTest.php
@@ -83,7 +83,7 @@ final class ContractTest extends TestCase
     public static function providePayloadTestCases(): iterable
     {
         yield 'MessageBag with Gpt' => [
-            'model' => new Gpt(),
+            'model' => Gpt::create(),
             'input' => new MessageBag(
                 Message::forSystem('System message'),
                 Message::ofUser('User message'),
@@ -101,7 +101,7 @@ final class ContractTest extends TestCase
 
         $audio = Audio::fromFile(\dirname(__DIR__, 3).'/fixtures/audio.mp3');
         yield 'Audio within MessageBag with Gpt' => [
-            'model' => new Gpt(),
+            'model' => Gpt::create(),
             'input' => new MessageBag(Message::ofUser('What is this recording about?', $audio)),
             'expected' => [
                 'messages' => [
@@ -125,7 +125,7 @@ final class ContractTest extends TestCase
 
         $image = Image::fromFile(\dirname(__DIR__, 3).'/fixtures/image.jpg');
         yield 'Image within MessageBag with Gpt' => [
-            'model' => new Gpt(),
+            'model' => Gpt::create(),
             'input' => new MessageBag(
                 Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
                 Message::ofUser('Describe the image as a comedian would do it.', $image),
@@ -149,7 +149,7 @@ final class ContractTest extends TestCase
         ];
 
         yield 'ImageUrl within MessageBag with Gpt' => [
-            'model' => new Gpt(),
+            'model' => Gpt::create(),
             'input' => new MessageBag(
                 Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
                 Message::ofUser('Describe the image as a comedian would do it.', new ImageUrl('https://example.com/image.jpg')),
@@ -173,13 +173,13 @@ final class ContractTest extends TestCase
         ];
 
         yield 'Text Input with Embeddings' => [
-            'model' => new Embeddings(),
+            'model' => Embeddings::create(),
             'input' => 'This is a test input.',
             'expected' => 'This is a test input.',
         ];
 
         yield 'Longer Conversation with Gpt' => [
-            'model' => new Gpt(),
+            'model' => Gpt::create(),
             'input' => new MessageBag(
                 Message::forSystem('My amazing system prompt.'),
                 Message::ofAssistant('It is time to sleep.'),
@@ -223,7 +223,7 @@ final class ContractTest extends TestCase
         };
 
         yield 'MessageBag with custom message from Gpt' => [
-            'model' => new Gpt(),
+            'model' => Gpt::create(),
             'input' => new MessageBag($customSerializableMessage),
             'expected' => [
                 'messages' => [
@@ -240,7 +240,7 @@ final class ContractTest extends TestCase
 
         $audio = Audio::fromFile(\dirname(__DIR__, 3).'/fixtures/audio.mp3');
 
-        $actual = $contract->createRequestPayload(new Whisper(), $audio);
+        $actual = $contract->createRequestPayload(Whisper::create(), $audio);
 
         $this->assertArrayHasKey('model', $actual);
         $this->assertSame('whisper-1', $actual['model']);

--- a/src/store/tests/IndexerTest.php
+++ b/src/store/tests/IndexerTest.php
@@ -49,7 +49,7 @@ final class IndexerTest extends TestCase
     {
         $document = new TextDocument($id = Uuid::v4(), 'Test content');
         $vector = new Vector([0.1, 0.2, 0.3]);
-        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), new Embeddings());
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), Embeddings::create());
 
         $indexer = new Indexer($vectorizer, $store = new TestStore());
         $indexer->index($document);
@@ -64,7 +64,7 @@ final class IndexerTest extends TestCase
     {
         $logger = self::createMock(LoggerInterface::class);
         $logger->expects($this->once())->method('debug')->with('No documents to index');
-        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(), new Embeddings());
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(), Embeddings::create());
 
         $indexer = new Indexer($vectorizer, $store = new TestStore(), $logger);
         $indexer->index([]);
@@ -77,7 +77,7 @@ final class IndexerTest extends TestCase
         $metadata = new Metadata(['key' => 'value']);
         $document = new TextDocument($id = Uuid::v4(), 'Test content', $metadata);
         $vector = new Vector([0.1, 0.2, 0.3]);
-        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), new Embeddings());
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), Embeddings::create());
 
         $indexer = new Indexer($vectorizer, $store = new TestStore());
         $indexer->index($document);


### PR DESCRIPTION
This commit bricks several instanceof checks. Other changes needs to be done as well. See the other pull requests:

* https://github.com/symfony/ai/pull/299
* https://github.com/symfony/ai/pull/300

| Q             | A
| ------------- | ---
| Bug fix?      | "yes"
| New feature?  | no
| Docs?         | no
| Issues        | Fix #114 
| License       | MIT

In other issues and pull requests the model class should be used as a simple struct, only holding scalar values and should not have any business logic effect by inheritance. This has been the case for embeddings, completions and other API calls like Whisper audio, and Dall-e images. Right now this makes it difficult to share different instances of the model class with various providers, although a lot of providers share the same models, and therefore likely the same capabilities. This eventually will reduce the amount of code you have to write to establish new providers that replicate existing API's with a well-known subset of models or add better support for custom models like OpenAI fine-tuned models or ollamas self-built models.

This is pull request is about to suggest a way to reflector the usage of the model classes to only use the model class as a struct without using inheritance. I stick to the previous classes to simplify code changes and the current effects of different types of models being grouped in a class. The class hierarchy has been broken up, so the previously sub classes of the model class are no longer extending the model class, and the model of the class has been made final to prevent changes like this in the future. Right now, it will break instanceof checks in several classes and can only be merged if the linked requests merged. It is not part of the others, as the approach how to solve this particular issue can be discussed separately.
