### PR TITLE
[Platform] Standardise token usage

### DIFF
--- a/examples/openai/token-metadata.php
+++ b/examples/openai/token-metadata.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Bridge\OpenAi\TokenOutputProcessor;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Metadata\TokenUsage;
 
 require_once dirname(__DIR__).'/bootstrap.php';
 
@@ -33,8 +34,11 @@ $result = $agent->call($messages, [
 ]);
 
 $metadata = $result->getMetadata();
+$tokenUsage = $metadata->get('token_usage');
 
-echo 'Utilized Tokens: '.$metadata['total_tokens'].\PHP_EOL;
-echo '-- Prompt Tokens: '.$metadata['prompt_tokens'].\PHP_EOL;
-echo '-- Completion Tokens: '.$metadata['completion_tokens'].\PHP_EOL;
-echo 'Remaining Tokens: '.$metadata['remaining_tokens'].\PHP_EOL;
+assert($tokenUsage instanceof TokenUsage);
+
+echo 'Utilized Tokens: '.$tokenUsage->totalTokens.\PHP_EOL;
+echo '-- Prompt Tokens: '.$tokenUsage->promptTokens.\PHP_EOL;
+echo '-- Completion Tokens: '.$tokenUsage->completionTokens.\PHP_EOL;
+echo 'Remaining Tokens: '.$tokenUsage->remainingTokens.\PHP_EOL;

--- a/src/platform/src/Result/Metadata/TokenUsage.php
+++ b/src/platform/src/Result/Metadata/TokenUsage.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Metadata;
+
+/**
+ * @author Junaid Farooq <ulislam.junaid125@gmail.com>
+ */
+final class TokenUsage implements \JsonSerializable
+{
+    public function __construct(
+        public ?int $promptTokens = null,
+        public ?int $completionTokens = null,
+        public ?int $thinkingTokens = null,
+        public ?int $cachedTokens = null,
+        public ?int $remainingTokens = null,
+        public ?int $remainingTokensMinute = null,
+        public ?int $remainingTokensMonth = null,
+        public ?int $totalTokens = null,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *      prompt_tokens: ?int,
+     *      completion_tokens: ?int,
+     *      thinking_tokens: ?int,
+     *      cached_tokens: ?int,
+     *      remaining_tokens: ?int,
+     *      remaining_tokens_minute: ?int,
+     *      remaining_tokens_month: ?int,
+     *      total_tokens: ?int,
+     *  }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'prompt_tokens' => $this->promptTokens,
+            'completion_tokens' => $this->completionTokens,
+            'thinking_tokens' => $this->thinkingTokens,
+            'cached_tokens' => $this->cachedTokens,
+            'remaining_tokens' => $this->remainingTokens,
+            'remaining_tokens_minute' => $this->remainingTokensMinute,
+            'remaining_tokens_month' => $this->remainingTokensMonth,
+            'total_tokens' => $this->totalTokens,
+        ];
+    }
+}

--- a/src/platform/tests/Bridge/Mistral/TokenOutputProcessorTest.php
+++ b/src/platform/tests/Bridge/Mistral/TokenOutputProcessorTest.php
@@ -20,6 +20,7 @@ use Symfony\AI\Platform\Bridge\Mistral\TokenOutputProcessor;
 use Symfony\AI\Platform\Message\MessageBagInterface;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\Metadata\Metadata;
+use Symfony\AI\Platform\Result\Metadata\TokenUsage;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -70,9 +71,12 @@ final class TokenOutputProcessorTest extends TestCase
         $processor->processOutput($output);
 
         $metadata = $output->result->getMetadata();
-        $this->assertCount(2, $metadata);
-        $this->assertSame(1000, $metadata->get('remaining_tokens_minute'));
-        $this->assertSame(1000000, $metadata->get('remaining_tokens_month'));
+        $tokenUsage = $metadata->get('token_usage');
+
+        $this->assertCount(1, $metadata);
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(1000, $tokenUsage->remainingTokensMinute);
+        $this->assertSame(1000000, $tokenUsage->remainingTokensMonth);
     }
 
     public function testItAddsUsageTokensToMetadata()
@@ -95,12 +99,14 @@ final class TokenOutputProcessorTest extends TestCase
         $processor->processOutput($output);
 
         $metadata = $output->result->getMetadata();
-        $this->assertCount(5, $metadata);
-        $this->assertSame(1000, $metadata->get('remaining_tokens_minute'));
-        $this->assertSame(1000000, $metadata->get('remaining_tokens_month'));
-        $this->assertSame(10, $metadata->get('prompt_tokens'));
-        $this->assertSame(20, $metadata->get('completion_tokens'));
-        $this->assertSame(30, $metadata->get('total_tokens'));
+        $tokenUsage = $metadata->get('token_usage');
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(1000, $tokenUsage->remainingTokensMinute);
+        $this->assertSame(1000000, $tokenUsage->remainingTokensMonth);
+        $this->assertSame(10, $tokenUsage->promptTokens);
+        $this->assertSame(20, $tokenUsage->completionTokens);
+        $this->assertSame(30, $tokenUsage->totalTokens);
     }
 
     public function testItHandlesMissingUsageFields()
@@ -122,12 +128,14 @@ final class TokenOutputProcessorTest extends TestCase
         $processor->processOutput($output);
 
         $metadata = $output->result->getMetadata();
-        $this->assertCount(5, $metadata);
-        $this->assertSame(1000, $metadata->get('remaining_tokens_minute'));
-        $this->assertSame(1000000, $metadata->get('remaining_tokens_month'));
-        $this->assertSame(10, $metadata->get('prompt_tokens'));
-        $this->assertNull($metadata->get('completion_tokens'));
-        $this->assertNull($metadata->get('total_tokens'));
+        $tokenUsage = $metadata->get('token_usage');
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(1000, $tokenUsage->remainingTokensMinute);
+        $this->assertSame(1000000, $tokenUsage->remainingTokensMonth);
+        $this->assertSame(10, $tokenUsage->promptTokens);
+        $this->assertNull($tokenUsage->completionTokens);
+        $this->assertNull($tokenUsage->totalTokens);
     }
 
     private function createRawResponse(array $data = []): RawHttpResult


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | #208
| License       | MIT

# Changes proposed:

The PR aims to standardize the token usage extraction and its availability in the AI bundle. Essentially, the following is done:
- Makes token usage explicit by adding a dedicated dto for token information
- Populates the token usage dto inside different token output processors and then adds it to the metadata object