### PR TITLE
[Store][Qdrant] Use the correct key for making a query

### DIFF
--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -52,7 +52,7 @@ final readonly class Store implements InitializableStoreInterface, VectorStoreIn
     public function query(Vector $vector, array $options = []): array
     {
         $payload = [
-            'vector' => $vector->getData(),
+            'query' => $vector->getData(),
             'with_payload' => true,
             'with_vector' => true,
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

Using the function as-is provided the data, all with a score of 0. Passing the vector correctly, I was able to get results with scoring as expected.

Ref: https://qdrant.tech/documentation/concepts/search/