### PR TITLE
[Platform] Fix fatal error with string payloads

### DIFF
--- a/src/platform/src/Bridge/Albert/EmbeddingsModelClient.php
+++ b/src/platform/src/Bridge/Albert/EmbeddingsModelClient.php
@@ -38,11 +38,11 @@ final readonly class EmbeddingsModelClient implements ModelClientInterface
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface
+    public function request(Model $model, array $payload, array $options = []): RawResultInterface
     {
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/embeddings', $this->baseUrl), [
             'auth_bearer' => $this->apiKey,
-            'json' => \is_array($payload) ? array_merge($payload, $options) : $payload,
+            'json' => array_merge($payload, $options),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Albert/GptModelClient.php
+++ b/src/platform/src/Bridge/Albert/GptModelClient.php
@@ -43,11 +43,11 @@ final readonly class GptModelClient implements ModelClientInterface
         return $model instanceof Gpt;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface
+    public function request(Model $model, array $payload, array $options = []): RawResultInterface
     {
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/chat/completions', $this->baseUrl), [
             'auth_bearer' => $this->apiKey,
-            'json' => \is_array($payload) ? array_merge($payload, $options) : $payload,
+            'json' => array_merge($payload, $options),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -37,7 +37,7 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Claude;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         $headers = [
             'x-api-key' => $this->apiKey,

--- a/src/platform/src/Bridge/Azure/Meta/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Azure/Meta/LlamaModelClient.php
@@ -34,7 +34,7 @@ final readonly class LlamaModelClient implements ModelClientInterface
         return $model instanceof Llama;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         $url = \sprintf('https://%s/chat/completions', $this->baseUrl);
 

--- a/src/platform/src/Bridge/Azure/OpenAi/EmbeddingsModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/EmbeddingsModelClient.php
@@ -46,7 +46,7 @@ final readonly class EmbeddingsModelClient implements ModelClientInterface
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         $url = \sprintf('https://%s/openai/deployments/%s/embeddings', $this->baseUrl, $this->deployment);
 

--- a/src/platform/src/Bridge/Azure/OpenAi/GptModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/GptModelClient.php
@@ -46,7 +46,7 @@ final readonly class GptModelClient implements ModelClientInterface
         return $model instanceof Gpt;
     }
 
-    public function request(Model $model, object|array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, object|array $payload, array $options = []): RawHttpResult
     {
         $url = \sprintf('https://%s/openai/deployments/%s/chat/completions', $this->baseUrl, $this->deployment);
 

--- a/src/platform/src/Bridge/Azure/OpenAi/WhisperModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/WhisperModelClient.php
@@ -47,7 +47,7 @@ final readonly class WhisperModelClient implements ModelClientInterface
         return $model instanceof Whisper;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         $task = $options['task'] ?? Task::TRANSCRIPTION;
         $endpoint = Task::TRANSCRIPTION === $task ? 'transcriptions' : 'translations';

--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
@@ -39,7 +39,7 @@ final readonly class ClaudeModelClient implements ModelClientInterface
         return $model instanceof Claude;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawBedrockResult
+    public function request(Model $model, array $payload, array $options = []): RawBedrockResult
     {
         unset($payload['model']);
 

--- a/src/platform/src/Bridge/Bedrock/Meta/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Meta/LlamaModelClient.php
@@ -33,7 +33,7 @@ class LlamaModelClient implements ModelClientInterface
         return $model instanceof Llama;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawBedrockResult
+    public function request(Model $model, array $payload, array $options = []): RawBedrockResult
     {
         return new RawBedrockResult($this->bedrockRuntimeClient->invokeModel(new InvokeModelRequest([
             'modelId' => $this->getModelId($model),

--- a/src/platform/src/Bridge/Bedrock/Nova/NovaModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/NovaModelClient.php
@@ -32,7 +32,7 @@ class NovaModelClient implements ModelClientInterface
         return $model instanceof Nova;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawBedrockResult
+    public function request(Model $model, array $payload, array $options = []): RawBedrockResult
     {
         $modelOptions = [];
         if (isset($options['tools'])) {

--- a/src/platform/src/Bridge/Cerebras/ModelClient.php
+++ b/src/platform/src/Bridge/Cerebras/ModelClient.php
@@ -45,7 +45,7 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Model;
     }
 
-    public function request(BaseModel $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(BaseModel $model, array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult(
             $this->httpClient->request(
@@ -55,7 +55,7 @@ final readonly class ModelClient implements ModelClientInterface
                         'Content-Type' => 'application/json',
                         'Authorization' => \sprintf('Bearer %s', $this->apiKey),
                     ],
-                    'json' => \is_array($payload) ? array_merge($payload, $options) : $payload,
+                    'json' => array_merge($payload, $options),
                 ]
             )
         );

--- a/src/platform/src/Bridge/ElevenLabs/ElevenLabsClient.php
+++ b/src/platform/src/Bridge/ElevenLabs/ElevenLabsClient.php
@@ -35,12 +35,8 @@ final readonly class ElevenLabsClient implements ModelClientInterface
         return $model instanceof ElevenLabs;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface
+    public function request(Model $model, array $payload, array $options = []): RawResultInterface
     {
-        if (!\is_array($payload)) {
-            throw new InvalidArgumentException(\sprintf('The payload must be an array, received "%s".', get_debug_type($payload)));
-        }
-
         if (\in_array($model->getName(), [ElevenLabs::SCRIBE_V1, ElevenLabs::SCRIBE_V1_EXPERIMENTAL], true)) {
             return $this->doSpeechToTextRequest($model, $payload, $options);
         }
@@ -58,7 +54,7 @@ final readonly class ElevenLabsClient implements ModelClientInterface
      * @param array<string|int, mixed> $payload
      * @param array<string, mixed>     $options
      */
-    private function doSpeechToTextRequest(Model $model, array|string $payload, array $options): RawHttpResult
+    private function doSpeechToTextRequest(Model $model, array $payload, array $options): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/speech-to-text', $this->hostUrl), [
             'headers' => [
@@ -75,7 +71,7 @@ final readonly class ElevenLabsClient implements ModelClientInterface
      * @param array<string|int, mixed> $payload
      * @param array<string, mixed>     $options
      */
-    private function doTextToSpeechRequest(Model $model, array|string $payload, array $options): RawHttpResult
+    private function doTextToSpeechRequest(Model $model, array $payload, array $options): RawHttpResult
     {
         if (!\array_key_exists('voice', $model->getOptions())) {
             throw new InvalidArgumentException('The voice option is required.');

--- a/src/platform/src/Bridge/Gemini/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings/ModelClient.php
@@ -34,7 +34,7 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         $url = \sprintf('https://generativelanguage.googleapis.com/v1beta/models/%s:%s', $model->getName(), 'batchEmbedContents');
         $modelOptions = $model->getOptions();
@@ -52,7 +52,7 @@ final readonly class ModelClient implements ModelClientInterface
                         'taskType' => $modelOptions['task_type'] ?? null,
                         'title' => $options['title'] ?? null,
                     ]),
-                    \is_array($payload) ? $payload : [$payload],
+                    $payload,
                 ),
             ],
         ]));

--- a/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
@@ -41,7 +41,7 @@ final readonly class ModelClient implements ModelClientInterface
     /**
      * @throws TransportExceptionInterface When the HTTP request fails due to network issues
      */
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         $url = \sprintf(
             'https://generativelanguage.googleapis.com/v1beta/models/%s:%s',

--- a/src/platform/src/Bridge/HuggingFace/ModelClient.php
+++ b/src/platform/src/Bridge/HuggingFace/ModelClient.php
@@ -41,7 +41,7 @@ final readonly class ModelClient implements PlatformModelClient
     /**
      * The difference in HuggingFace here is that we treat the payload as the options for the request not only the body.
      */
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         // Extract task from options if provided
         $task = $options['task'] ?? null;
@@ -71,7 +71,7 @@ final readonly class ModelClient implements PlatformModelClient
      *
      * @return array<string, mixed>
      */
-    private function getPayload(array|string $payload, array $options): array
+    private function getPayload(array $payload, array $options): array
     {
         // Expect JSON input if string or not
         if (\is_string($payload) || !(isset($payload['body']) || isset($payload['json']))) {

--- a/src/platform/src/Bridge/LmStudio/Completions/ModelClient.php
+++ b/src/platform/src/Bridge/LmStudio/Completions/ModelClient.php
@@ -37,7 +37,7 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $model instanceof Completions;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/v1/chat/completions', $this->hostUrl), [
             'json' => array_merge($options, $payload),

--- a/src/platform/src/Bridge/LmStudio/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/LmStudio/Embeddings/ModelClient.php
@@ -34,7 +34,7 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/v1/embeddings', $this->hostUrl), [
             'json' => array_merge($options, [

--- a/src/platform/src/Bridge/Mistral/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Embeddings/ModelClient.php
@@ -38,7 +38,7 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.mistral.ai/v1/embeddings', [
             'auth_bearer' => $this->apiKey,

--- a/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
@@ -38,7 +38,7 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Mistral;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,

--- a/src/platform/src/Bridge/Ollama/OllamaClient.php
+++ b/src/platform/src/Bridge/Ollama/OllamaClient.php
@@ -33,7 +33,7 @@ final readonly class OllamaClient implements ModelClientInterface
         return $model instanceof Ollama;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         $response = $this->httpClient->request('POST', \sprintf('%s/api/show', $this->hostUrl), [
             'json' => [
@@ -58,7 +58,7 @@ final readonly class OllamaClient implements ModelClientInterface
      * @param array<string|int, mixed> $payload
      * @param array<string, mixed>     $options
      */
-    private function doCompletionRequest(array|string $payload, array $options = []): RawHttpResult
+    private function doCompletionRequest(array $payload, array $options = []): RawHttpResult
     {
         // Revert Ollama's default streaming behavior
         $options['stream'] ??= false;
@@ -78,7 +78,7 @@ final readonly class OllamaClient implements ModelClientInterface
      * @param array<string|int, mixed> $payload
      * @param array<string, mixed>     $options
      */
-    private function doEmbeddingsRequest(Model $model, array|string $payload, array $options = []): RawHttpResult
+    private function doEmbeddingsRequest(Model $model, array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/api/embed', $this->hostUrl), [
             'json' => array_merge($options, [

--- a/src/platform/src/Bridge/OpenAi/DallE/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/DallE/ModelClient.php
@@ -39,7 +39,7 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof DallE;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.openai.com/v1/images/generations', [
             'auth_bearer' => $this->apiKey,

--- a/src/platform/src/Bridge/OpenAi/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings/ModelClient.php
@@ -37,7 +37,7 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $model instanceof Embeddings;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.openai.com/v1/embeddings', [
             'auth_bearer' => $this->apiKey,

--- a/src/platform/src/Bridge/OpenAi/Gpt/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ModelClient.php
@@ -41,7 +41,7 @@ final readonly class ModelClient implements PlatformResponseFactory
         return $model instanceof Gpt;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.openai.com/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,

--- a/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
@@ -36,7 +36,7 @@ final readonly class ModelClient implements BaseModelClient
         return $model instanceof Whisper;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         $task = $options['task'] ?? Task::TRANSCRIPTION;
         $endpoint = Task::TRANSCRIPTION === $task ? 'transcriptions' : 'translations';

--- a/src/platform/src/Bridge/OpenRouter/ModelClient.php
+++ b/src/platform/src/Bridge/OpenRouter/ModelClient.php
@@ -39,7 +39,7 @@ final readonly class ModelClient implements ModelClientInterface
         return true;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', 'https://openrouter.ai/api/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,

--- a/src/platform/src/Bridge/Replicate/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Replicate/LlamaModelClient.php
@@ -32,7 +32,7 @@ final readonly class LlamaModelClient implements ModelClientInterface
         return $model instanceof Llama;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array $payload, array $options = []): RawHttpResult
     {
         $model instanceof Llama || throw new InvalidArgumentException(\sprintf('The model must be an instance of "%s".', Llama::class));
 

--- a/src/platform/src/Bridge/TransformersPhp/ModelClient.php
+++ b/src/platform/src/Bridge/TransformersPhp/ModelClient.php
@@ -24,7 +24,7 @@ final readonly class ModelClient implements ModelClientInterface
         return true;
     }
 
-    public function request(Model $model, array|string $payload, array $options = []): RawPipelineResult
+    public function request(Model $model, array $payload, array $options = []): RawPipelineResult
     {
         if (null === $task = $options['task'] ?? null) {
             throw new InvalidArgumentException('The task option is required.');

--- a/src/platform/src/Bridge/TransformersPhp/PipelineExecution.php
+++ b/src/platform/src/Bridge/TransformersPhp/PipelineExecution.php
@@ -28,7 +28,7 @@ final class PipelineExecution
      */
     public function __construct(
         private readonly Pipeline $pipeline,
-        private readonly array|string $input,
+        private readonly array $input,
     ) {
     }
 

--- a/src/platform/src/Bridge/Voyage/ModelClient.php
+++ b/src/platform/src/Bridge/Voyage/ModelClient.php
@@ -32,7 +32,7 @@ final readonly class ModelClient implements ModelClientInterface
         return $model instanceof Voyage;
     }
 
-    public function request(Model $model, object|string|array $payload, array $options = []): RawHttpResult
+    public function request(Model $model, object|array $payload, array $options = []): RawHttpResult
     {
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.voyageai.com/v1/embeddings', [
             'auth_bearer' => $this->apiKey,

--- a/src/platform/src/ModelClientInterface.php
+++ b/src/platform/src/ModelClientInterface.php
@@ -24,5 +24,5 @@ interface ModelClientInterface
      * @param array<string|int, mixed> $payload
      * @param array<string, mixed>     $options
      */
-    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface;
+    public function request(Model $model, array $payload, array $options = []): RawResultInterface;
 }

--- a/src/store/tests/Double/PlatformTestHandler.php
+++ b/src/store/tests/Double/PlatformTestHandler.php
@@ -43,7 +43,7 @@ final class PlatformTestHandler implements ModelClientInterface, ResultConverter
         return true;
     }
 
-    public function request(Model $model, array|string|object $payload, array $options = []): RawHttpResult
+    public function request(Model $model, array|object $payload, array $options = []): RawHttpResult
     {
         ++$this->createCalls;
 


### PR DESCRIPTION
…lementations

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #326 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Issue
The `ModelClientInterface` allows array|string $payload, but all implementations use `array_merge($payload, $options)` without type checking, causing fatal errors when string payloads are passed.

Fix
Remove unnecessary string support from the interface since all implementations expect arrays:
