### PR TITLE
[MCP SDK] Example update to use proper logging

### DIFF
--- a/src/mcp-sdk/composer.json
+++ b/src/mcp-sdk/composer.json
@@ -22,7 +22,8 @@
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5",
         "symfony/console": "^6.4 || ^7.0",
-        "psr/cache": "^3.0"
+        "psr/cache": "^3.0",
+        "monolog/monolog": "^3.9"
     },
     "suggest": {
         "symfony/console": "To use SymfonyConsoleTransport for STDIO",

--- a/src/mcp-sdk/examples/cli/index.php
+++ b/src/mcp-sdk/examples/cli/index.php
@@ -11,15 +11,24 @@
 
 require __DIR__.'/vendor/autoload.php';
 
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
 use Symfony\Component\Console as SymfonyConsole;
 use Symfony\Component\Console\Output\OutputInterface;
 
 $debug = (bool) ($_SERVER['DEBUG'] ?? false);
 
-// Setup input, output and logger
+// Setup input, output
 $input = new SymfonyConsole\Input\ArgvInput($argv);
 $output = new SymfonyConsole\Output\ConsoleOutput($debug ? OutputInterface::VERBOSITY_VERY_VERBOSE : OutputInterface::VERBOSITY_NORMAL);
-$logger = new SymfonyConsole\Logger\ConsoleLogger($output);
+
+// Setup *Monolog* logger, logger must output JSON to stream to STDERR
+// **WARNING** this will work only on the development stage with @modelcontextprotocol/inspector, but not in a real client
+// For real clients please consider using other types of logs (file, client logging, etc.)
+$handler = new StreamHandler('php://stderr');
+$handler->setFormatter(new JsonFormatter());
+$logger = new Logger('mcp', [$handler]);
 
 // Configure the JsonRpcHandler and build the functionality
 $jsonRpcHandler = new Symfony\AI\McpSdk\Server\JsonRpcHandler(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #306
| License       | MIT

Added `monolog` as `dev` dependency.
Swapped `ConsoleLogger` to Monolog -> STDERR with JsonFormatter.
Added commentary with explanation
