### PR TITLE
 Fix exceptions to use `sprintf` for string formatting

### DIFF
--- a/src/mcp-sdk/src/Server/RequestHandler/PromptGetHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/PromptGetHandler.php
@@ -58,7 +58,7 @@ final class PromptGetHandler extends BaseRequestHandler
                     ],
                 ],
                 // TODO better exception
-                default => throw new InvalidArgumentException('Unsupported PromptGet result type: '.$resultMessage->type),
+                default => throw new InvalidArgumentException(\sprintf('Unsupported PromptGet result type: %s', $resultMessage->type)),
             };
 
             $messages[] = [

--- a/src/mcp-sdk/src/Server/RequestHandler/ToolCallHandler.php
+++ b/src/mcp-sdk/src/Server/RequestHandler/ToolCallHandler.php
@@ -56,7 +56,7 @@ final class ToolCallHandler extends BaseRequestHandler
                 ],
             ],
             // TODO better exception
-            default => throw new InvalidArgumentException('Unsupported tool result type: '.$result->type),
+            default => throw new InvalidArgumentException(\sprintf('Unsupported tool result type: %s', $result->type)),
         };
 
         return new Response($message->id, [

--- a/src/platform/src/Bridge/HuggingFace/ResultConverter.php
+++ b/src/platform/src/Bridge/HuggingFace/ResultConverter.php
@@ -65,11 +65,11 @@ final readonly class ResultConverter implements PlatformResponseConverter
                 default => $content['error'],
             };
 
-            throw new InvalidArgumentException(\sprintf('API Client Error (%d): ', $httpResponse->getStatusCode()).$message);
+            throw new InvalidArgumentException(\sprintf('API Client Error (%d): "%s"', $httpResponse->getStatusCode(), $message));
         }
 
         if (200 !== $httpResponse->getStatusCode()) {
-            throw new RuntimeException('Unhandled response code: '.$httpResponse->getStatusCode());
+            throw new RuntimeException(\sprintf('Unhandled response code: %d', $httpResponse->getStatusCode()));
         }
 
         $task = $options['task'] ?? null;

--- a/src/platform/src/Bridge/Mistral/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Embeddings/ResultConverter.php
@@ -35,7 +35,7 @@ final readonly class ResultConverter implements ResultConverterInterface
         $httpResponse = $result->getObject();
 
         if (200 !== $httpResponse->getStatusCode()) {
-            throw new RuntimeException(\sprintf('Unexpected response code %d: ', $httpResponse->getStatusCode()).$httpResponse->getContent(false));
+            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $httpResponse->getStatusCode(), $httpResponse->getContent(false)));
         }
 
         $data = $result->getData();

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -50,7 +50,7 @@ final readonly class ResultConverter implements ResultConverterInterface
         }
 
         if (200 !== $code = $httpResponse->getStatusCode()) {
-            throw new RuntimeException(\sprintf('Unexpected response code %d: ', $code).$httpResponse->getContent(false));
+            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $httpResponse->getContent(false)));
         }
 
         $data = $result->getData();

--- a/src/platform/src/Vector/Vector.php
+++ b/src/platform/src/Vector/Vector.php
@@ -26,7 +26,7 @@ final class Vector implements VectorInterface
         private ?int $dimensions = null,
     ) {
         if (null !== $dimensions && $dimensions !== \count($data)) {
-            throw new InvalidArgumentException('Vector must have '.$dimensions.' dimensions');
+            throw new InvalidArgumentException(\sprintf('Vector must have %d dimensions', $dimensions));
         }
 
         if ([] === $data) {
@@ -34,7 +34,7 @@ final class Vector implements VectorInterface
         }
 
         if (\is_int($dimensions) && \count($data) !== $dimensions) {
-            throw new InvalidArgumentException('Vector must have '.$dimensions.' dimensions');
+            throw new InvalidArgumentException(\sprintf('Vector must have %d dimensions', $dimensions));
         }
 
         if (null === $this->dimensions) {

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -173,7 +173,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         if (200 !== $response->getStatusCode()) {
             $content = $response->getContent(false);
 
-            throw new RuntimeException("Could not insert data into ClickHouse. Http status code: {$response->getStatusCode()}. Response: {$content}.");
+            throw new RuntimeException(\sprintf('Could not insert data into ClickHouse. Http status code: %d. Response: "%s".', $response->getStatusCode(), $content));
         }
     }
 

--- a/src/store/tests/Bridge/ClickHouse/StoreTest.php
+++ b/src/store/tests/Bridge/ClickHouse/StoreTest.php
@@ -127,7 +127,7 @@ final class StoreTest extends TestCase
         $store = new Store($httpClient, 'test_db', 'test_table');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Could not insert data into ClickHouse. Http status code: 500. Response: Internal Server Error.');
+        $this->expectExceptionMessage('Could not insert data into ClickHouse. Http status code: 500. Response: "Internal Server Error".');
 
         $store->add($document);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Replace string concatenation and interpolation with sprintf in all exception messages for consistency and better formatting.