### PR TITLE
[Store][ChromaDB] Add query filtering

### DIFF
--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -52,12 +52,17 @@ final readonly class Store implements StoreInterface
         $collection->add($ids, $vectors, $metadata, $originalDocuments);
     }
 
+    /**
+     * @param array{where?: array<string, string>, whereDocument?: array<string, mixed>} $options
+     */
     public function query(Vector $vector, array $options = []): array
     {
         $collection = $this->client->getOrCreateCollection($this->collectionName);
         $queryResponse = $collection->query(
             queryEmbeddings: [$vector->getData()],
             nResults: 4,
+            where: $options['where'] ?? null,
+            whereDocument: $options['whereDocument'] ?? null,
         );
 
         $documents = [];

--- a/src/store/tests/Bridge/ChromaDb/StoreTest.php
+++ b/src/store/tests/Bridge/ChromaDb/StoreTest.php
@@ -108,7 +108,8 @@ final class StoreTest extends TestCase
                 new VectorDocument(
                     Uuid::fromString('01234567-89ab-cdef-0123-456789abcdef'),
                     new Vector([0.1, 0.2, 0.3]),
-                    new Metadata(['_text' => 'This is the content of document 1', 'title' => 'Document 1'])),
+                    new Metadata(['_text' => 'This is the content of document 1', 'title' => 'Document 1'])
+                ),
                 new VectorDocument(
                     Uuid::fromString('fedcba98-7654-3210-fedc-ba9876543210'),
                     new Vector([0.4, 0.5, 0.6]),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| License       | MIT

Very simple update allowing to add ChromaDB filters using the `$options` array parameter (actually unused for ChromaDB).
Before, we needed to create kind of a _fake_ decorator as I did [here](https://github.com/valx76/SymfonyAI-POC/blob/master/src/AI/StoreDecorator.php) (I didn't find any other way)..

I noticed the `query` method doesn't have any test yet so I imagine it'll be done in the future, which is why there is no test update in this PR.