### PR TITLE
[PHPStan] add phpstan analyse script

### DIFF
--- a/demo/composer.json
+++ b/demo/composer.json
@@ -100,6 +100,7 @@
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd",
             "importmap:install": "symfony-cmd"
-        }
+        },
+        "phpstan": "phpstan analyse -c phpstan.dist.neon"
     }
 }

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -53,3 +53,4 @@ CHANGELOG
  * Add model capability detection before processing
  * Add comprehensive type safety with full PHP type hints
  * Add clear exception hierarchy for different error scenarios
+* Add composer script for PHPStan static analysis workflow

--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -63,5 +63,8 @@
             "Symfony\\AI\\Fixtures\\": "../../fixtures",
             "Symfony\\AI\\PHPStan\\": "../../.phpstan/"
         }
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse -c phpstan.dist.neon"
     }
 }

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -26,3 +26,4 @@ CHANGELOG
  * Add bundle configuration with semantic validation
  * Add support for fault-tolerant tool execution
  * Add structured output configuration support
+ * Add composer script for PHPStan static analysis workflow

--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -42,5 +42,8 @@
             "Symfony\\AI\\AiBundle\\Tests\\": "tests/",
             "Symfony\\AI\\PHPStan\\": "../../.phpstan/"
         }
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse -c phpstan.dist.neon"
     }
 }

--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -20,3 +20,4 @@ CHANGELOG
  * Add service configuration for MCP server setup
  * Classes extending `\Symfony\AI\McpSdk\Capability\Tool\IdentifierInterface` automatically
    get the `mcp.tool` tag for MCP tool discovery
+ * Add composer script for PHPStan static analysis workflow

--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -36,6 +36,9 @@
             "Symfony\\AI\\PHPStan\\": "../../.phpstan"
         }
     },
+    "scripts": {
+        "phpstan": "phpstan analyse -c phpstan.dist.neon"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/mcp-sdk/composer.json
+++ b/src/mcp-sdk/composer.json
@@ -38,5 +38,8 @@
             "Symfony\\AI\\McpSdk\\Tests\\": "tests/",
             "Symfony\\AI\\PHPStan\\": "../../.phpstan/"
         }
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse -c phpstan.dist.neon"
     }
 }

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -60,5 +60,6 @@ CHANGELOG
  * Add InMemoryPlatform and InMemoryRawResult for testing Platform without external Providers calls
  * Add tool calling support for Ollama platform
  * Allow beta feature flags to be passed into Anthropic model options
+ * Add composer script for PHPStan static analysis workflow
 
 

--- a/src/platform/composer.json
+++ b/src/platform/composer.json
@@ -72,5 +72,8 @@
             "Symfony\\AI\\Fixtures\\": "../../fixtures",
             "Symfony\\AI\\PHPStan\\": "../../.phpstan/"
         }
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse -c phpstan.dist.neon"
     }
 }

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -57,3 +57,4 @@ CHANGELOG
    - Distance/similarity scoring
  * Add custom exception hierarchy with `ExceptionInterface`
  * Add support for specific exceptions for invalid arguments and runtime errors
+ * Add composer script for PHPStan static analysis workflow

--- a/src/store/composer.json
+++ b/src/store/composer.json
@@ -65,5 +65,8 @@
             "Symfony\\AI\\Store\\Tests\\": "tests/",
             "Symfony\\AI\\PHPStan\\": "../../.phpstan/"
         }
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse -c phpstan.dist.neon"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no
| Issues        |  no
| License       | MIT

This PR adds a helper script to simplify running PHPStan static analysis.  
Instead of running `php vendor/bin/phpstan analyze <path-to-file>`, contributors can now use the provided script for consistent usage.

**Benefits:**
- Makes static analysis easier for everyone.
- Reduces typo errors from manual command entry.

**How to use:**
If you want to run for all files then run 
```bash
composer phpstan 
```
If you want to run for a specific file then run 
```bash
composer phpstan  <path-to-file>
```
