### PR TITLE
 Add tag for every agents

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -380,6 +380,7 @@ final class AiBundle extends AbstractBundle
 
         // AGENT
         $agentDefinition = (new Definition(Agent::class))
+            ->addTag('ai.agent')
             ->setArgument(0, new Reference($config['platform']))
             ->setArgument(1, new Reference('ai.agent.'.$name.'.model'));
 

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -49,6 +49,21 @@ class AiBundleTest extends TestCase
         $this->assertTrue($container->hasAlias('Symfony\AI\Agent\AgentInterface $myAgentAgent'));
     }
 
+    public function testAgentHasTag()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertArrayHasKey('ai.agent.my_agent', $container->findTaggedServiceIds('ai.agent'));
+    }
+
     #[TestWith([true], 'enabled')]
     #[TestWith([false], 'disabled')]
     public function testFaultTolerantAgentSpecificToolbox(bool $enabled)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This allows an easier manipulation of all agents with a CompilerPass and findTaggedServiceIds.
This also allow to inject all agents with `AutowireIterator`.