### PR TITLE
[Platform][Voyage] Include all returned vectors rather than just the first

### DIFF
--- a/src/platform/src/Bridge/Voyage/ResultConverter.php
+++ b/src/platform/src/Bridge/Voyage/ResultConverter.php
@@ -37,8 +37,11 @@ final readonly class ResultConverter implements ResultConverterInterface
             throw new RuntimeException('Response does not contain embedding data.');
         }
 
-        $vectors = array_map(fn (array $data) => new Vector($data['embedding']), $result['data']);
-
-        return new VectorResult($vectors[0]);
+        return new VectorResult(
+            ...array_map(
+                static fn (array $data) => new Vector($data['embedding']),
+                $result['data'],
+            ),
+        );
     }
 }

--- a/src/platform/tests/Bridge/Voyage/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/Voyage/ResultConverterTest.php
@@ -74,8 +74,9 @@ class ResultConverterTest extends TestCase
         $vectorResult = $converter->convert(new RawHttpResult($result));
 
         $this->assertInstanceOf(VectorResult::class, $vectorResult);
-        // The converter returns only the first vector
+        $this->assertCount(2, $vectorResult->getContent());
         $this->assertSame([0.1, 0.2, 0.3], $vectorResult->getContent()[0]->getData());
+        $this->assertSame([0.4, 0.5, 0.6], $vectorResult->getContent()[1]->getData());
     }
 
     public function testItThrowsExceptionWhenResponseDoesNotContainData()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT

When indexing multiple documents, only the first vector was returned, leading to an undefined array key error