### PR TITLE
[Platform] Allow to use the `#[With]` attribute for structured output

### DIFF
--- a/fixtures/StructuredOutput/MathReasoning.php
+++ b/fixtures/StructuredOutput/MathReasoning.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Fixtures\StructuredOutput;
 
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+
 final class MathReasoning
 {
     /**
@@ -18,6 +20,8 @@ final class MathReasoning
      */
     public function __construct(
         public array $steps,
+        #[With(minimum: 0, maximum: 100)]
+        public int $confidence,
         public string $finalAnswer,
     ) {
     }

--- a/src/agent/tests/StructuredOutput/AgentProcessorTest.php
+++ b/src/agent/tests/StructuredOutput/AgentProcessorTest.php
@@ -130,6 +130,7 @@ final class AgentProcessorTest extends TestCase
                         "output": "x = -3.75"
                     }
                 ],
+                "confidence": 100,
                 "finalAnswer": "x = -3.75"
             }
             JSON);
@@ -148,6 +149,7 @@ final class AgentProcessorTest extends TestCase
         $this->assertInstanceOf(Step::class, $structure->steps[2]);
         $this->assertInstanceOf(Step::class, $structure->steps[3]);
         $this->assertInstanceOf(Step::class, $structure->steps[4]);
+        $this->assertSame(100, $structure->confidence);
         $this->assertSame('x = -3.75', $structure->finalAnswer);
     }
 

--- a/src/platform/src/Contract/JsonSchema/Attribute/With.php
+++ b/src/platform/src/Contract/JsonSchema/Attribute/With.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Exception\InvalidArgumentException;
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-#[\Attribute(\Attribute::TARGET_PARAMETER)]
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
 final readonly class With
 {
     /**

--- a/src/platform/tests/Contract/JsonSchema/FactoryTest.php
+++ b/src/platform/tests/Contract/JsonSchema/FactoryTest.php
@@ -212,9 +212,10 @@ final class FactoryTest extends TestCase
                         'additionalProperties' => false,
                     ],
                 ],
+                'confidence' => ['type' => 'integer', 'minimum' => 0, 'maximum' => 100],
                 'finalAnswer' => ['type' => 'string'],
             ],
-            'required' => ['steps', 'finalAnswer'],
+            'required' => ['steps', 'confidence', 'finalAnswer'],
             'additionalProperties' => false,
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #364
| License       | MIT

Allows the `#[With]` attribute to be set on properties thus making it usable on structured output classes.