### PR TITLE
 Update GitHub Actions checkout to v5

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -24,7 +24,7 @@ jobs:
                 php-version: [ '8.4' ]
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Configure environment
               run: |

--- a/.github/workflows/doctor-rst.yaml
+++ b/.github/workflows/doctor-rst.yaml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Create cache dir
               run: mkdir .cache

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -38,7 +38,7 @@ jobs:
             SYMFONY_REQUIRE: ${{ matrix.symfony-version || '>=6.4' }}
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Configure environment
               run: |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Update all workflow files to use actions/checkout@v5 instead of v4