### PR TITLE
[Examples] Allow probots-io/pinecone-php 1.0

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -12,7 +12,7 @@
         "google/auth": "^1.47",
         "mrmysql/youtube-transcript": "^0.0.5",
         "php-http/discovery": "^1.20",
-        "probots-io/pinecone-php": "^1.1",
+        "probots-io/pinecone-php": "^1.0",
         "psr/http-factory-implementation": "*",
         "symfony/ai-agent": "@dev",
         "symfony/ai-platform": "@dev",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | None
| License       | MIT

Hi 👋🏻 

As discussed in #335, the `Pinecone` dependency for examples must be downgraded if we want to being able to use it during functional tests (mostly commands), this also synchronize the dependency with the one defined in `Store`.