### PR TITLE
[Platform][Store] Refactor short-circuit evaluation to classic if statements

### DIFF
--- a/src/platform/src/Bridge/Albert/PlatformFactory.php
+++ b/src/platform/src/Bridge/Albert/PlatformFactory.php
@@ -29,10 +29,18 @@ final class PlatformFactory
         string $baseUrl,
         ?HttpClientInterface $httpClient = null,
     ): Platform {
-        str_starts_with($baseUrl, 'https://') || throw new InvalidArgumentException('The Albert URL must start with "https://".');
-        !str_ends_with($baseUrl, '/') || throw new InvalidArgumentException('The Albert URL must not end with a trailing slash.');
-        preg_match('/\/v\d+$/', $baseUrl) || throw new InvalidArgumentException('The Albert URL must include an API version (e.g., /v1, /v2).');
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
+        if (!str_starts_with($baseUrl, 'https://')) {
+            throw new InvalidArgumentException('The Albert URL must start with "https://".');
+        }
+        if (str_ends_with($baseUrl, '/')) {
+            throw new InvalidArgumentException('The Albert URL must not end with a trailing slash.');
+        }
+        if (!preg_match('/\/v\d+$/', $baseUrl)) {
+            throw new InvalidArgumentException('The Albert URL must include an API version (e.g., /v1, /v2).');
+        }
+        if ('' === $apiKey) {
+            throw new InvalidArgumentException('The API key must not be empty.');
+        }
 
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 

--- a/src/platform/src/Bridge/Azure/OpenAi/EmbeddingsModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/EmbeddingsModelClient.php
@@ -34,11 +34,21 @@ final readonly class EmbeddingsModelClient implements ModelClientInterface
         #[\SensitiveParameter] private string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
-        !str_starts_with($this->baseUrl, 'http://') || throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        !str_starts_with($this->baseUrl, 'https://') || throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        '' !== $deployment || throw new InvalidArgumentException('The deployment must not be empty.');
-        '' !== $apiVersion || throw new InvalidArgumentException('The API version must not be empty.');
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
+        if (str_starts_with($this->baseUrl, 'http://')) {
+            throw new InvalidArgumentException('The base URL must not contain the protocol.');
+        }
+        if (str_starts_with($this->baseUrl, 'https://')) {
+            throw new InvalidArgumentException('The base URL must not contain the protocol.');
+        }
+        if ('' === $deployment) {
+            throw new InvalidArgumentException('The deployment must not be empty.');
+        }
+        if ('' === $apiVersion) {
+            throw new InvalidArgumentException('The API version must not be empty.');
+        }
+        if ('' === $apiKey) {
+            throw new InvalidArgumentException('The API key must not be empty.');
+        }
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/Azure/OpenAi/GptModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/GptModelClient.php
@@ -34,11 +34,21 @@ final readonly class GptModelClient implements ModelClientInterface
         #[\SensitiveParameter] private string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
-        !str_starts_with($this->baseUrl, 'http://') || throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        !str_starts_with($this->baseUrl, 'https://') || throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        '' !== $deployment || throw new InvalidArgumentException('The deployment must not be empty.');
-        '' !== $apiVersion || throw new InvalidArgumentException('The API version must not be empty.');
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
+        if (str_starts_with($this->baseUrl, 'http://')) {
+            throw new InvalidArgumentException('The base URL must not contain the protocol.');
+        }
+        if (str_starts_with($this->baseUrl, 'https://')) {
+            throw new InvalidArgumentException('The base URL must not contain the protocol.');
+        }
+        if ('' === $deployment) {
+            throw new InvalidArgumentException('The deployment must not be empty.');
+        }
+        if ('' === $apiVersion) {
+            throw new InvalidArgumentException('The API version must not be empty.');
+        }
+        if ('' === $apiKey) {
+            throw new InvalidArgumentException('The API key must not be empty.');
+        }
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/Azure/OpenAi/WhisperModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/WhisperModelClient.php
@@ -35,11 +35,21 @@ final readonly class WhisperModelClient implements ModelClientInterface
         #[\SensitiveParameter] private string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
-        !str_starts_with($this->baseUrl, 'http://') || throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        !str_starts_with($this->baseUrl, 'https://') || throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        '' !== $deployment || throw new InvalidArgumentException('The deployment must not be empty.');
-        '' !== $apiVersion || throw new InvalidArgumentException('The API version must not be empty.');
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
+        if (str_starts_with($this->baseUrl, 'http://')) {
+            throw new InvalidArgumentException('The base URL must not contain the protocol.');
+        }
+        if (str_starts_with($this->baseUrl, 'https://')) {
+            throw new InvalidArgumentException('The base URL must not contain the protocol.');
+        }
+        if ('' === $deployment) {
+            throw new InvalidArgumentException('The deployment must not be empty.');
+        }
+        if ('' === $apiVersion) {
+            throw new InvalidArgumentException('The API version must not be empty.');
+        }
+        if ('' === $apiKey) {
+            throw new InvalidArgumentException('The API key must not be empty.');
+        }
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/OpenAi/DallE/Base64Image.php
+++ b/src/platform/src/Bridge/OpenAi/DallE/Base64Image.php
@@ -21,6 +21,8 @@ final readonly class Base64Image
     public function __construct(
         public string $encodedImage,
     ) {
-        '' !== $encodedImage || throw new InvalidArgumentException('The base64 encoded image generated must be given.');
+        if ('' === $encodedImage) {
+            throw new InvalidArgumentException('The base64 encoded image generated must be given.');
+        }
     }
 }

--- a/src/platform/src/Bridge/OpenAi/DallE/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/DallE/ModelClient.php
@@ -30,8 +30,12 @@ final readonly class ModelClient implements ModelClientInterface
         #[\SensitiveParameter]
         private string $apiKey,
     ) {
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
-        str_starts_with($apiKey, 'sk-') || throw new InvalidArgumentException('The API key must start with "sk-".');
+        if ('' === $apiKey) {
+            throw new InvalidArgumentException('The API key must not be empty.');
+        }
+        if (!str_starts_with($apiKey, 'sk-')) {
+            throw new InvalidArgumentException('The API key must start with "sk-".');
+        }
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/OpenAi/DallE/UrlImage.php
+++ b/src/platform/src/Bridge/OpenAi/DallE/UrlImage.php
@@ -21,6 +21,8 @@ final readonly class UrlImage
     public function __construct(
         public string $url,
     ) {
-        '' !== $url || throw new InvalidArgumentException('The image url must be given.');
+        if ('' === $url) {
+            throw new InvalidArgumentException('The image url must be given.');
+        }
     }
 }

--- a/src/platform/src/Bridge/OpenAi/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings/ModelClient.php
@@ -28,8 +28,12 @@ final readonly class ModelClient implements PlatformResponseFactory
         #[\SensitiveParameter]
         private string $apiKey,
     ) {
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
-        str_starts_with($apiKey, 'sk-') || throw new InvalidArgumentException('The API key must start with "sk-".');
+        if ('' === $apiKey) {
+            throw new InvalidArgumentException('The API key must not be empty.');
+        }
+        if (!str_starts_with($apiKey, 'sk-')) {
+            throw new InvalidArgumentException('The API key must start with "sk-".');
+        }
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/OpenAi/Gpt/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ModelClient.php
@@ -32,8 +32,12 @@ final readonly class ModelClient implements PlatformResponseFactory
         private string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
-        str_starts_with($apiKey, 'sk-') || throw new InvalidArgumentException('The API key must start with "sk-".');
+        if ('' === $apiKey) {
+            throw new InvalidArgumentException('The API key must not be empty.');
+        }
+        if (!str_starts_with($apiKey, 'sk-')) {
+            throw new InvalidArgumentException('The API key must start with "sk-".');
+        }
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
@@ -28,7 +28,9 @@ final readonly class ModelClient implements BaseModelClient
         #[\SensitiveParameter]
         private string $apiKey,
     ) {
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
+        if ('' === $apiKey) {
+            throw new InvalidArgumentException('The API key must not be empty.');
+        }
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/OpenRouter/ModelClient.php
+++ b/src/platform/src/Bridge/OpenRouter/ModelClient.php
@@ -30,8 +30,12 @@ final readonly class ModelClient implements ModelClientInterface
         #[\SensitiveParameter] private string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
-        '' !== $apiKey || throw new InvalidArgumentException('The API key must not be empty.');
-        str_starts_with($apiKey, 'sk-') || throw new InvalidArgumentException('The API key must start with "sk-".');
+        if ('' === $apiKey) {
+            throw new InvalidArgumentException('The API key must not be empty.');
+        }
+        if (!str_starts_with($apiKey, 'sk-')) {
+            throw new InvalidArgumentException('The API key must start with "sk-".');
+        }
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/Replicate/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Replicate/LlamaModelClient.php
@@ -34,7 +34,9 @@ final readonly class LlamaModelClient implements ModelClientInterface
 
     public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
     {
-        $model instanceof Llama || throw new InvalidArgumentException(\sprintf('The model must be an instance of "%s".', Llama::class));
+        if (!$model instanceof Llama) {
+            throw new InvalidArgumentException(\sprintf('The model must be an instance of "%s".', Llama::class));
+        }
 
         return new RawHttpResult(
             $this->client->request(\sprintf('meta/meta-%s', $model->getName()), 'predictions', $payload)

--- a/src/platform/src/Contract/JsonSchema/Attribute/With.php
+++ b/src/platform/src/Contract/JsonSchema/Attribute/With.php
@@ -53,95 +53,141 @@ final readonly class With
         public ?bool $dependentRequired = null,
     ) {
         if (\is_array($enum)) {
-            array_filter($enum, fn ($item) => \is_string($item)) === $enum || throw new InvalidArgumentException('All enum values must be strings.');
+            if (array_filter($enum, fn ($item) => \is_string($item)) !== $enum) {
+                throw new InvalidArgumentException('All enum values must be strings.');
+            }
         }
 
         if (\is_string($const)) {
-            '' !== trim($const) || throw new InvalidArgumentException('Const string must not be empty.');
+            if ('' === trim($const)) {
+                throw new InvalidArgumentException('Const string must not be empty.');
+            }
         }
 
         if (\is_string($pattern)) {
-            '' !== trim($pattern) || throw new InvalidArgumentException('Pattern string must not be empty.');
+            if ('' === trim($pattern)) {
+                throw new InvalidArgumentException('Pattern string must not be empty.');
+            }
         }
 
         if (\is_int($minLength)) {
-            $minLength >= 0 || throw new InvalidArgumentException('MinLength must be greater than or equal to 0.');
+            if ($minLength < 0) {
+                throw new InvalidArgumentException('MinLength must be greater than or equal to 0.');
+            }
 
             if (\is_int($maxLength)) {
-                $maxLength >= $minLength || throw new InvalidArgumentException('MaxLength must be greater than or equal to minLength.');
+                if ($maxLength < $minLength) {
+                    throw new InvalidArgumentException('MaxLength must be greater than or equal to minLength.');
+                }
             }
         }
 
         if (\is_int($maxLength)) {
-            $maxLength >= 0 || throw new InvalidArgumentException('MaxLength must be greater than or equal to 0.');
+            if ($maxLength < 0) {
+                throw new InvalidArgumentException('MaxLength must be greater than or equal to 0.');
+            }
         }
 
         if (\is_int($minimum)) {
-            $minimum >= 0 || throw new InvalidArgumentException('Minimum must be greater than or equal to 0.');
+            if ($minimum < 0) {
+                throw new InvalidArgumentException('Minimum must be greater than or equal to 0.');
+            }
 
             if (\is_int($maximum)) {
-                $maximum >= $minimum || throw new InvalidArgumentException('Maximum must be greater than or equal to minimum.');
+                if ($maximum < $minimum) {
+                    throw new InvalidArgumentException('Maximum must be greater than or equal to minimum.');
+                }
             }
         }
 
         if (\is_int($maximum)) {
-            $maximum >= 0 || throw new InvalidArgumentException('Maximum must be greater than or equal to 0.');
+            if ($maximum < 0) {
+                throw new InvalidArgumentException('Maximum must be greater than or equal to 0.');
+            }
         }
 
         if (\is_int($multipleOf)) {
-            $multipleOf >= 0 || throw new InvalidArgumentException('MultipleOf must be greater than or equal to 0.');
+            if ($multipleOf < 0) {
+                throw new InvalidArgumentException('MultipleOf must be greater than or equal to 0.');
+            }
         }
 
         if (\is_int($exclusiveMinimum)) {
-            $exclusiveMinimum >= 0 || throw new InvalidArgumentException('ExclusiveMinimum must be greater than or equal to 0.');
+            if ($exclusiveMinimum < 0) {
+                throw new InvalidArgumentException('ExclusiveMinimum must be greater than or equal to 0.');
+            }
 
             if (\is_int($exclusiveMaximum)) {
-                $exclusiveMaximum >= $exclusiveMinimum || throw new InvalidArgumentException('ExclusiveMaximum must be greater than or equal to exclusiveMinimum.');
+                if ($exclusiveMaximum < $exclusiveMinimum) {
+                    throw new InvalidArgumentException('ExclusiveMaximum must be greater than or equal to exclusiveMinimum.');
+                }
             }
         }
 
         if (\is_int($exclusiveMaximum)) {
-            $exclusiveMaximum >= 0 || throw new InvalidArgumentException('ExclusiveMaximum must be greater than or equal to 0.');
+            if ($exclusiveMaximum < 0) {
+                throw new InvalidArgumentException('ExclusiveMaximum must be greater than or equal to 0.');
+            }
         }
 
         if (\is_int($minItems)) {
-            $minItems >= 0 || throw new InvalidArgumentException('MinItems must be greater than or equal to 0.');
+            if ($minItems < 0) {
+                throw new InvalidArgumentException('MinItems must be greater than or equal to 0.');
+            }
 
             if (\is_int($maxItems)) {
-                $maxItems >= $minItems || throw new InvalidArgumentException('MaxItems must be greater than or equal to minItems.');
+                if ($maxItems < $minItems) {
+                    throw new InvalidArgumentException('MaxItems must be greater than or equal to minItems.');
+                }
             }
         }
 
         if (\is_int($maxItems)) {
-            $maxItems >= 0 || throw new InvalidArgumentException('MaxItems must be greater than or equal to 0.');
+            if ($maxItems < 0) {
+                throw new InvalidArgumentException('MaxItems must be greater than or equal to 0.');
+            }
         }
 
         if (\is_bool($uniqueItems)) {
-            true === $uniqueItems || throw new InvalidArgumentException('UniqueItems must be true when specified.');
+            if (true !== $uniqueItems) {
+                throw new InvalidArgumentException('UniqueItems must be true when specified.');
+            }
         }
 
         if (\is_int($minContains)) {
-            $minContains >= 0 || throw new InvalidArgumentException('MinContains must be greater than or equal to 0.');
+            if ($minContains < 0) {
+                throw new InvalidArgumentException('MinContains must be greater than or equal to 0.');
+            }
 
             if (\is_int($maxContains)) {
-                $maxContains >= $minContains || throw new InvalidArgumentException('MaxContains must be greater than or equal to minContains.');
+                if ($maxContains < $minContains) {
+                    throw new InvalidArgumentException('MaxContains must be greater than or equal to minContains.');
+                }
             }
         }
 
         if (\is_int($maxContains)) {
-            $maxContains >= 0 || throw new InvalidArgumentException('MaxContains must be greater than or equal to 0.');
+            if ($maxContains < 0) {
+                throw new InvalidArgumentException('MaxContains must be greater than or equal to 0.');
+            }
         }
 
         if (\is_int($minProperties)) {
-            $minProperties >= 0 || throw new InvalidArgumentException('MinProperties must be greater than or equal to 0.');
+            if ($minProperties < 0) {
+                throw new InvalidArgumentException('MinProperties must be greater than or equal to 0.');
+            }
 
             if (\is_int($maxProperties)) {
-                $maxProperties >= $minProperties || throw new InvalidArgumentException('MaxProperties must be greater than or equal to minProperties.');
+                if ($maxProperties < $minProperties) {
+                    throw new InvalidArgumentException('MaxProperties must be greater than or equal to minProperties.');
+                }
             }
         }
 
         if (\is_int($maxProperties)) {
-            $maxProperties >= 0 || throw new InvalidArgumentException('MaxProperties must be greater than or equal to 0.');
+            if ($maxProperties < 0) {
+                throw new InvalidArgumentException('MaxProperties must be greater than or equal to 0.');
+            }
         }
     }
 }

--- a/src/store/src/Document/TextDocument.php
+++ b/src/store/src/Document/TextDocument.php
@@ -24,6 +24,8 @@ final readonly class TextDocument
         public string $content,
         public Metadata $metadata = new Metadata(),
     ) {
-        '' !== trim($this->content) || throw new InvalidArgumentException('The content shall not be an empty string.');
+        if ('' === trim($this->content)) {
+            throw new InvalidArgumentException('The content shall not be an empty string.');
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Replace all short-circuit evaluation patterns (`|| throw`) with classic if statements for better readability and consistency across the codebase. AFAIK this is more the Symfony-way of doing.