### PR TITLE
Fix `#[\SensitiveParameter]` formatting to single line

### DIFF
--- a/src/agent/src/Toolbox/Tool/Brave.php
+++ b/src/agent/src/Toolbox/Tool/Brave.php
@@ -26,8 +26,7 @@ final readonly class Brave
      */
     public function __construct(
         private HttpClientInterface $httpClient,
-        #[\SensitiveParameter]
-        private string $apiKey,
+        #[\SensitiveParameter] private string $apiKey,
         private array $options = [],
     ) {
     }

--- a/src/platform/src/Bridge/Anthropic/PlatformFactory.php
+++ b/src/platform/src/Bridge/Anthropic/PlatformFactory.php
@@ -23,8 +23,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final readonly class PlatformFactory
 {
     public static function create(
-        #[\SensitiveParameter]
-        string $apiKey,
+        #[\SensitiveParameter] string $apiKey,
         ?HttpClientInterface $httpClient = null,
         ?Contract $contract = null,
     ): Platform {

--- a/src/platform/src/Bridge/Azure/OpenAi/PlatformFactory.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/PlatformFactory.php
@@ -29,8 +29,7 @@ final readonly class PlatformFactory
         string $baseUrl,
         string $deployment,
         string $apiVersion,
-        #[\SensitiveParameter]
-        string $apiKey,
+        #[\SensitiveParameter] string $apiKey,
         ?HttpClientInterface $httpClient = null,
         ?Contract $contract = null,
     ): Platform {

--- a/src/platform/src/Bridge/Gemini/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings/ModelClient.php
@@ -24,8 +24,7 @@ final readonly class ModelClient implements ModelClientInterface
 {
     public function __construct(
         private HttpClientInterface $httpClient,
-        #[\SensitiveParameter]
-        private string $apiKey,
+        #[\SensitiveParameter] private string $apiKey,
     ) {
     }
 

--- a/src/platform/src/Bridge/Gemini/PlatformFactory.php
+++ b/src/platform/src/Bridge/Gemini/PlatformFactory.php
@@ -27,8 +27,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final readonly class PlatformFactory
 {
     public static function create(
-        #[\SensitiveParameter]
-        string $apiKey,
+        #[\SensitiveParameter] string $apiKey,
         ?HttpClientInterface $httpClient = null,
         ?Contract $contract = null,
     ): Platform {

--- a/src/platform/src/Bridge/HuggingFace/ModelClient.php
+++ b/src/platform/src/Bridge/HuggingFace/ModelClient.php
@@ -27,8 +27,7 @@ final readonly class ModelClient implements PlatformModelClient
     public function __construct(
         HttpClientInterface $httpClient,
         private string $provider,
-        #[\SensitiveParameter]
-        private string $apiKey,
+        #[\SensitiveParameter] private string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }

--- a/src/platform/src/Bridge/HuggingFace/PlatformFactory.php
+++ b/src/platform/src/Bridge/HuggingFace/PlatformFactory.php
@@ -24,8 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final readonly class PlatformFactory
 {
     public static function create(
-        #[\SensitiveParameter]
-        string $apiKey,
+        #[\SensitiveParameter] string $apiKey,
         string $provider = Provider::HF_INFERENCE,
         ?HttpClientInterface $httpClient = null,
         ?Contract $contract = null,

--- a/src/platform/src/Bridge/Mistral/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Embeddings/ModelClient.php
@@ -27,8 +27,7 @@ final readonly class ModelClient implements ModelClientInterface
 
     public function __construct(
         HttpClientInterface $httpClient,
-        #[\SensitiveParameter]
-        private string $apiKey,
+        #[\SensitiveParameter] private string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }

--- a/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
@@ -27,8 +27,7 @@ final readonly class ModelClient implements ModelClientInterface
 
     public function __construct(
         HttpClientInterface $httpClient,
-        #[\SensitiveParameter]
-        private string $apiKey,
+        #[\SensitiveParameter] private string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }

--- a/src/platform/src/Bridge/OpenAi/DallE/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/DallE/ModelClient.php
@@ -27,8 +27,7 @@ final readonly class ModelClient implements ModelClientInterface
 {
     public function __construct(
         private HttpClientInterface $httpClient,
-        #[\SensitiveParameter]
-        private string $apiKey,
+        #[\SensitiveParameter] private string $apiKey,
     ) {
         if ('' === $apiKey) {
             throw new InvalidArgumentException('The API key must not be empty.');

--- a/src/platform/src/Bridge/OpenAi/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings/ModelClient.php
@@ -25,8 +25,7 @@ final readonly class ModelClient implements PlatformResponseFactory
 {
     public function __construct(
         private HttpClientInterface $httpClient,
-        #[\SensitiveParameter]
-        private string $apiKey,
+        #[\SensitiveParameter] private string $apiKey,
     ) {
         if ('' === $apiKey) {
             throw new InvalidArgumentException('The API key must not be empty.');

--- a/src/platform/src/Bridge/OpenAi/Gpt/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ModelClient.php
@@ -28,8 +28,7 @@ final readonly class ModelClient implements PlatformResponseFactory
 
     public function __construct(
         HttpClientInterface $httpClient,
-        #[\SensitiveParameter]
-        private string $apiKey,
+        #[\SensitiveParameter] private string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
         if ('' === $apiKey) {

--- a/src/platform/src/Bridge/OpenAi/PlatformFactory.php
+++ b/src/platform/src/Bridge/OpenAi/PlatformFactory.php
@@ -25,8 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final readonly class PlatformFactory
 {
     public static function create(
-        #[\SensitiveParameter]
-        string $apiKey,
+        #[\SensitiveParameter] string $apiKey,
         ?HttpClientInterface $httpClient = null,
         ?Contract $contract = null,
     ): Platform {

--- a/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
@@ -25,8 +25,7 @@ final readonly class ModelClient implements BaseModelClient
 {
     public function __construct(
         private HttpClientInterface $httpClient,
-        #[\SensitiveParameter]
-        private string $apiKey,
+        #[\SensitiveParameter] private string $apiKey,
     ) {
         if ('' === $apiKey) {
             throw new InvalidArgumentException('The API key must not be empty.');

--- a/src/platform/src/Bridge/OpenRouter/PlatformFactory.php
+++ b/src/platform/src/Bridge/OpenRouter/PlatformFactory.php
@@ -25,8 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class PlatformFactory
 {
     public static function create(
-        #[\SensitiveParameter]
-        string $apiKey,
+        #[\SensitiveParameter] string $apiKey,
         ?HttpClientInterface $httpClient = null,
         ?Contract $contract = null,
     ): Platform {

--- a/src/platform/src/Bridge/Replicate/PlatformFactory.php
+++ b/src/platform/src/Bridge/Replicate/PlatformFactory.php
@@ -24,8 +24,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class PlatformFactory
 {
     public static function create(
-        #[\SensitiveParameter]
-        string $apiKey,
+        #[\SensitiveParameter] string $apiKey,
         ?HttpClientInterface $httpClient = null,
         ?Contract $contract = null,
     ): Platform {

--- a/src/platform/src/Bridge/Voyage/PlatformFactory.php
+++ b/src/platform/src/Bridge/Voyage/PlatformFactory.php
@@ -22,8 +22,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class PlatformFactory
 {
     public static function create(
-        #[\SensitiveParameter]
-        string $apiKey,
+        #[\SensitiveParameter] string $apiKey,
         ?HttpClientInterface $httpClient = null,
         ?Contract $contract = null,
     ): Platform {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Changed multi-line #[\SensitiveParameter] attributes to single-line format for better readability and consistency across the codebase.
