### PR TITLE
[Agent][Demo][Platform] Replace `self::assert*` with `$this->assert*` in test files

### DIFF
--- a/demo/tests/SmokeTest.php
+++ b/demo/tests/SmokeTest.php
@@ -26,9 +26,9 @@ final class SmokeTest extends WebTestCase
         $client = static::createClient();
         $client->request('GET', '/');
 
-        self::assertResponseIsSuccessful();
-        self::assertSelectorTextSame('h1', 'Welcome to the LLM Chain Demo');
-        self::assertSelectorCount(5, '.card');
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextSame('h1', 'Welcome to the LLM Chain Demo');
+        $this->assertSelectorCount(5, '.card');
     }
 
     #[DataProvider('provideChats')]
@@ -37,9 +37,9 @@ final class SmokeTest extends WebTestCase
         $client = static::createClient();
         $client->request('GET', $path);
 
-        self::assertResponseIsSuccessful();
-        self::assertSelectorTextSame('h4', $expectedHeadline);
-        self::assertSelectorCount(1, '#chat-submit');
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextSame('h4', $expectedHeadline);
+        $this->assertSelectorCount(1, '#chat-submit');
     }
 
     /**

--- a/src/agent/tests/Toolbox/MetadataFactory/ReflectionFactoryTest.php
+++ b/src/agent/tests/Toolbox/MetadataFactory/ReflectionFactoryTest.php
@@ -64,7 +64,7 @@ final class ReflectionFactoryTest extends TestCase
         /** @var Tool[] $metadatas */
         $metadatas = iterator_to_array($this->factory->getTool(ToolRequiredParams::class));
 
-        self::assertToolConfiguration(
+        $this->assertToolConfiguration(
             metadata: $metadatas[0],
             className: ToolRequiredParams::class,
             name: 'tool_required_params',
@@ -96,7 +96,7 @@ final class ReflectionFactoryTest extends TestCase
 
         [$first, $second] = $metadatas;
 
-        self::assertToolConfiguration(
+        $this->assertToolConfiguration(
             metadata: $first,
             className: ToolMultiple::class,
             name: 'tool_hello_world',
@@ -115,7 +115,7 @@ final class ReflectionFactoryTest extends TestCase
             ],
         );
 
-        self::assertToolConfiguration(
+        $this->assertToolConfiguration(
             metadata: $second,
             className: ToolMultiple::class,
             name: 'tool_required_params',

--- a/src/platform/tests/Bridge/VertexAi/Gemini/ModelClientTest.php
+++ b/src/platform/tests/Bridge/VertexAi/Gemini/ModelClientTest.php
@@ -67,7 +67,7 @@ final class ModelClientTest extends TestCase
         ];
         $httpClient = new MockHttpClient(
             function ($method, $url, $options) {
-                self::assertJsonStringEqualsJsonString(
+                $this->assertJsonStringEqualsJsonString(
                     <<<'JSON'
                         {
                           "tools": [

--- a/src/platform/tests/Message/AssistantMessageTest.php
+++ b/src/platform/tests/Message/AssistantMessageTest.php
@@ -68,8 +68,8 @@ final class AssistantMessageTest extends TestCase
         $message2 = new AssistantMessage('bar');
 
         $this->assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
-        self::assertIsUuidV7($message1->getId()->toRfc4122());
-        self::assertIsUuidV7($message2->getId()->toRfc4122());
+        $this->assertIsUuidV7($message1->getId()->toRfc4122());
+        $this->assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
     public function testSameMessagesHaveDifferentUids()
@@ -78,8 +78,8 @@ final class AssistantMessageTest extends TestCase
         $message2 = new AssistantMessage('foo');
 
         $this->assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
-        self::assertIsUuidV7($message1->getId()->toRfc4122());
-        self::assertIsUuidV7($message2->getId()->toRfc4122());
+        $this->assertIsUuidV7($message1->getId()->toRfc4122());
+        $this->assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
     public function testMessageIdImplementsRequiredInterfaces()

--- a/src/platform/tests/Message/SystemMessageTest.php
+++ b/src/platform/tests/Message/SystemMessageTest.php
@@ -50,8 +50,8 @@ final class SystemMessageTest extends TestCase
         $message2 = new SystemMessage('bar');
 
         $this->assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
-        self::assertIsUuidV7($message1->getId()->toRfc4122());
-        self::assertIsUuidV7($message2->getId()->toRfc4122());
+        $this->assertIsUuidV7($message1->getId()->toRfc4122());
+        $this->assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
     public function testSameMessagesHaveDifferentUids()
@@ -60,8 +60,8 @@ final class SystemMessageTest extends TestCase
         $message2 = new SystemMessage('foo');
 
         $this->assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
-        self::assertIsUuidV7($message1->getId()->toRfc4122());
-        self::assertIsUuidV7($message2->getId()->toRfc4122());
+        $this->assertIsUuidV7($message1->getId()->toRfc4122());
+        $this->assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
     public function testMessageIdImplementsRequiredInterfaces()

--- a/src/platform/tests/Message/ToolCallMessageTest.php
+++ b/src/platform/tests/Message/ToolCallMessageTest.php
@@ -55,8 +55,8 @@ final class ToolCallMessageTest extends TestCase
         $message2 = new ToolCallMessage($toolCall, 'baz');
 
         $this->assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
-        self::assertIsUuidV7($message1->getId()->toRfc4122());
-        self::assertIsUuidV7($message2->getId()->toRfc4122());
+        $this->assertIsUuidV7($message1->getId()->toRfc4122());
+        $this->assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
     public function testSameMessagesHaveDifferentUids()
@@ -66,8 +66,8 @@ final class ToolCallMessageTest extends TestCase
         $message2 = new ToolCallMessage($toolCall, 'bar');
 
         $this->assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
-        self::assertIsUuidV7($message1->getId()->toRfc4122());
-        self::assertIsUuidV7($message2->getId()->toRfc4122());
+        $this->assertIsUuidV7($message1->getId()->toRfc4122());
+        $this->assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
     public function testMessageIdImplementsRequiredInterfaces()

--- a/src/platform/tests/Message/UserMessageTest.php
+++ b/src/platform/tests/Message/UserMessageTest.php
@@ -95,8 +95,8 @@ final class UserMessageTest extends TestCase
         $message2 = new UserMessage(new Text('bar'));
 
         $this->assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
-        self::assertIsUuidV7($message1->getId()->toRfc4122());
-        self::assertIsUuidV7($message2->getId()->toRfc4122());
+        $this->assertIsUuidV7($message1->getId()->toRfc4122());
+        $this->assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
     public function testSameMessagesHaveDifferentUids()
@@ -105,8 +105,8 @@ final class UserMessageTest extends TestCase
         $message2 = new UserMessage(new Text('foo'));
 
         $this->assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
-        self::assertIsUuidV7($message1->getId()->toRfc4122());
-        self::assertIsUuidV7($message2->getId()->toRfc4122());
+        $this->assertIsUuidV7($message1->getId()->toRfc4122());
+        $this->assertIsUuidV7($message2->getId()->toRfc4122());
     }
 
     public function testMessageIdImplementsRequiredInterfaces()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Following the codebase convention to use $this->assert* instead of self::assert* for better consistency across all test files