### PR TITLE
[AiBundle][VertexAI] Fix service definition

### DIFF
--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -25,6 +25,7 @@
         "symfony/string": "^6.4 || ^7.0"
     },
     "require-dev": {
+        "google/auth": "^1.47",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5",
         "symfony/expression-language": "^6.4 || ^7.0",

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -369,6 +369,10 @@ class AiBundleTest extends TestCase
                     'voyage' => [
                         'api_key' => 'voyage_key_full',
                     ],
+                    'vertexai' => [
+                        'location' => 'global',
+                        'project_id' => '123',
+                    ],
                 ],
                 'agent' => [
                     'my_chat_agent' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #419
| License       | MIT

Fix a couple of VertexAI issues:

1. Bundle config was not working at all since instances were created build-time instead of building `Definition`s
2. Access token was fetched build-time

To add tests, we'd need to add `google/auth` to dev dependencies. If that's ok, I'll do that and remove exclusion from `phpstan.dist.neon`.