### PR TITLE
[Platform][OpenAI][Whisper] Validate API key to use OpenAI key format

### DIFF
--- a/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Whisper/ModelClient.php
@@ -30,6 +30,9 @@ final readonly class ModelClient implements BaseModelClient
         if ('' === $apiKey) {
             throw new InvalidArgumentException('The API key must not be empty.');
         }
+        if (!str_starts_with($apiKey, 'sk-')) {
+            throw new InvalidArgumentException('The API key must start with "sk-".');
+        }
     }
 
     public function supports(Model $model): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Changed test key from `test-key` to `sk-test-key` to match OpenAI's API key format convention where keys start with `sk-`.