### PR TITLE
[Platform] Add missing platform keywords to `composer.json`

### DIFF
--- a/src/platform/composer.json
+++ b/src/platform/composer.json
@@ -4,9 +4,26 @@
     "description": "PHP library for interacting with AI platform provider.",
     "keywords": [
         "ai",
+        "albert",
+        "anthropic",
+        "azure",
+        "bedrock",
+        "cerebras",
+        "elevenlabs",
+        "gemini",
         "huggingface",
+        "inference",
+        "llama",
+        "lmstudio",
+        "meta",
+        "mistral",
+        "ollama",
+        "openai",
+        "openrouter",
+        "replicate",
         "transformers",
-        "inference"
+        "vertexai",
+        "voyage"
     ],
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT
