### PR TITLE
[Platform] Remove unnecessary `setAccessible()` calls

### DIFF
--- a/src/platform/tests/Bridge/HuggingFace/ModelClientTest.php
+++ b/src/platform/tests/Bridge/HuggingFace/ModelClientTest.php
@@ -37,7 +37,6 @@ final class ModelClientTest extends TestCase
     {
         $reflection = new \ReflectionClass(ModelClient::class);
         $getUrlMethod = $reflection->getMethod('getUrl');
-        $getUrlMethod->setAccessible(true);
 
         $model = new Model('test-model');
         $httpClient = new MockHttpClient();
@@ -87,7 +86,6 @@ final class ModelClientTest extends TestCase
 
         $reflection = new \ReflectionClass(ModelClient::class);
         $getPayloadMethod = $reflection->getMethod('getPayload');
-        $getPayloadMethod->setAccessible(true);
 
         $httpClient = new MockHttpClient();
         $modelClient = new ModelClient($httpClient, 'test-provider', 'test-api-key');

--- a/src/platform/tests/Bridge/LmStudio/Completions/ModelClientTest.php
+++ b/src/platform/tests/Bridge/LmStudio/Completions/ModelClientTest.php
@@ -92,7 +92,6 @@ class ModelClientTest extends TestCase
         $client = new ModelClient($httpClient, 'http://localhost:1234');
 
         $reflection = new \ReflectionProperty($client, 'httpClient');
-        $reflection->setAccessible(true);
 
         $this->assertInstanceOf(EventSourceHttpClient::class, $reflection->getValue($client));
     }
@@ -103,7 +102,6 @@ class ModelClientTest extends TestCase
         $client = new ModelClient($eventSourceHttpClient, 'http://localhost:1234');
 
         $reflection = new \ReflectionProperty($client, 'httpClient');
-        $reflection->setAccessible(true);
 
         $this->assertSame($eventSourceHttpClient, $reflection->getValue($client));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT