### PR TITLE
[Demo] Remove unused `nyholm/nsa` dependency

### DIFF
--- a/demo/composer.json
+++ b/demo/composer.json
@@ -56,7 +56,6 @@
         "symfony/symfony": "*"
     },
     "require-dev": {
-        "nyholm/nsa": "^1.3",
         "php-cs-fixer/shim": "^3.75",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

The nyholm/nsa library was declared as a dev dependency but not used anywhere in the codebase. Standard PHP reflection is used instead for accessing private properties in tests.