### PR TITLE
[Platform][Mistral] Add `DocumentNormalizer`

### DIFF
--- a/src/platform/src/Bridge/Mistral/Contract/DocumentNormalizer.php
+++ b/src/platform/src/Bridge/Mistral/Contract/DocumentNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Contract;
+
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
+use Symfony\AI\Platform\Message\Content\Document;
+use Symfony\AI\Platform\Model;
+
+class DocumentNormalizer extends ModelContractNormalizer
+{
+    /**
+     * @param Document $data
+     *
+     * @return array{type: 'document_url', document_name: string, document_url: string}
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        return [
+            'type' => 'document_url',
+            'document_name' => $data->getFilename(),
+            'document_url' => $data->asDataUrl(),
+        ];
+    }
+
+    protected function supportedDataClass(): string
+    {
+        return Document::class;
+    }
+
+    protected function supportsModel(Model $model): bool
+    {
+        return $model instanceof Mistral;
+    }
+}

--- a/src/platform/src/Bridge/Mistral/PlatformFactory.php
+++ b/src/platform/src/Bridge/Mistral/PlatformFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Mistral;
 
+use Symfony\AI\Platform\Bridge\Mistral\Contract\DocumentNormalizer;
 use Symfony\AI\Platform\Bridge\Mistral\Contract\ToolNormalizer;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Platform;
@@ -33,7 +34,10 @@ final class PlatformFactory
         return new Platform(
             [new Embeddings\ModelClient($httpClient, $apiKey), new Llm\ModelClient($httpClient, $apiKey)],
             [new Embeddings\ResultConverter(), new Llm\ResultConverter()],
-            $contract ?? Contract::create(new ToolNormalizer()),
+            $contract ?? Contract::create(
+                new ToolNormalizer(),
+                new DocumentNormalizer()
+            ),
         );
     }
 }

--- a/src/platform/tests/Bridge/Mistral/Contract/DocumentNormalizerTest.php
+++ b/src/platform/tests/Bridge/Mistral/Contract/DocumentNormalizerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\Mistral\Contract;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Medium;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Contract\DocumentNormalizer;
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Message\Content\Document;
+
+#[Medium]
+#[CoversClass(DocumentNormalizer::class)]
+final class DocumentNormalizerTest extends TestCase
+{
+    public function testSupportsNormalization()
+    {
+        $normalizer = new DocumentNormalizer();
+
+        $this->assertTrue($normalizer->supportsNormalization(new Document('some content', 'application/pdf'), context: [
+            Contract::CONTEXT_MODEL => new Mistral(),
+        ]));
+        $this->assertFalse($normalizer->supportsNormalization('not a document'));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $normalizer = new DocumentNormalizer();
+
+        $expected = [
+            Document::class => true,
+        ];
+
+        $this->assertSame($expected, $normalizer->getSupportedTypes(null));
+    }
+
+    #[DataProvider('normalizeDataProvider')]
+    public function testNormalize(Document $file, array $expected)
+    {
+        $normalizer = new DocumentNormalizer();
+
+        $normalized = $normalizer->normalize($file);
+
+        $this->assertEquals($expected, $normalized);
+    }
+
+    public static function normalizeDataProvider(): iterable
+    {
+        yield 'document from file' => [
+            Document::fromFile(\dirname(__DIR__, 3).'/fixtures/document.pdf'),
+            [
+                'type' => 'document_url',
+                'document_name' => 'document.pdf',
+                'document_url' => 'data:application/pdf;base64,'.base64_encode(file_get_contents(\dirname(__DIR__, 3).'/fixtures/document.pdf')),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

Normalizer for Document message for Mistral

See https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post for documentation:

<img width="814" height="431" alt="image" src="https://github.com/user-attachments/assets/92a5db9d-7f44-441d-a714-874bd29861d8" />
