### PR TITLE
[Platform][VertexAI] Update `ResultConverter`

### DIFF
--- a/fixtures/Bridge/VertexAi/code_execution_outcome_deadline_exceeded.json
+++ b/fixtures/Bridge/VertexAi/code_execution_outcome_deadline_exceeded.json
@@ -1,0 +1,31 @@
+{
+    "candidates": [
+        {
+            "content": {
+                "parts": [
+                    {
+                        "text": "First text"
+                    },
+                    {
+                        "executableCode": {
+                            "language": "PYTHON",
+                            "code": "print('Hello, World!')"
+                        }
+                    },
+                    {
+                        "codeExecutionResult": {
+                            "outcome": "OUTCOME_DEADLINE_EXCEEDED",
+                            "output": "An error occurred during code execution."
+                        }
+                    },
+                    {
+                        "text": "Last text"
+                    }
+                ],
+                "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+        }
+    ]
+}

--- a/fixtures/Bridge/VertexAi/code_execution_outcome_failed.json
+++ b/fixtures/Bridge/VertexAi/code_execution_outcome_failed.json
@@ -1,0 +1,31 @@
+{
+    "candidates": [
+        {
+            "content": {
+                "parts": [
+                    {
+                        "text": "First text"
+                    },
+                    {
+                        "executableCode": {
+                            "language": "PYTHON",
+                            "code": "print('Hello, World!')"
+                        }
+                    },
+                    {
+                        "codeExecutionResult": {
+                            "outcome": "OUTCOME_FAILED",
+                            "output": "An error occurred during code execution."
+                        }
+                    },
+                    {
+                        "text": "Last text"
+                    }
+                ],
+                "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+        }
+    ]
+}

--- a/fixtures/Bridge/VertexAi/code_execution_outcome_ok.json
+++ b/fixtures/Bridge/VertexAi/code_execution_outcome_ok.json
@@ -1,0 +1,37 @@
+{
+    "candidates": [
+        {
+            "content": {
+                "parts": [
+                    {
+                        "text": "First text"
+                    },
+                    {
+                        "executableCode": {
+                            "language": "PYTHON",
+                            "code": "print('Hello, World!')"
+                        }
+                    },
+                    {
+                        "codeExecutionResult": {
+                            "outcome": "OUTCOME_OK",
+                            "output": "Hello, World!"
+                        }
+                    },
+                    {
+                        "text": "Second text\n"
+                    },
+                    {
+                        "text": "Third text\n"
+                    },
+                    {
+                        "text": "Fourth text"
+                    }
+                ],
+                "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+        }
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT

Same as #421 but for VertexAI bridge

This PR fixes a crash in the Gemini ResultConverter when handling responses that only contained executableCode and codeExecutionResult parts.

Rather than duplicating the code, I created a trait that is used in both bridges.
I also reused the same test fixtures.