### PR TITLE
[AI Bundle][Demo] Make vectorizers configurable

### DIFF
--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -53,11 +53,15 @@ ai:
         chroma_db:
             symfonycon:
                 collection: 'symfony_blog'
-    indexer:
-        default:
+    vectorizer:
+        openai_embeddings:
             model:
                 class: 'Symfony\AI\Platform\Bridge\OpenAi\Embeddings'
                 name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Embeddings::TEXT_ADA_002
+    indexer:
+        default:
+            vectorizer: 'ai.vectorizer.openai_embeddings'
+            store: 'ai.store.chroma_db.symfonycon'
 
 services:
     _defaults:

--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -16,6 +16,7 @@ use MongoDB\Client as MongoDbClient;
 use Probots\Pinecone\Client as PineconeClient;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Store\Document\VectorizerInterface;
 use Symfony\AI\Store\StoreInterface;
 
 return static function (DefinitionConfigurator $configurator): void {
@@ -371,14 +372,10 @@ return static function (DefinitionConfigurator $configurator): void {
                     ->end()
                 ->end()
             ->end()
-            ->arrayNode('indexer')
+            ->arrayNode('vectorizer')
                 ->useAttributeAsKey('name')
                 ->arrayPrototype()
                     ->children()
-                        ->scalarNode('store')
-                            ->info('Service name of store')
-                            ->defaultValue(StoreInterface::class)
-                        ->end()
                         ->scalarNode('platform')
                             ->info('Service name of platform')
                             ->defaultValue(PlatformInterface::class)
@@ -391,6 +388,21 @@ return static function (DefinitionConfigurator $configurator): void {
                                     ->variablePrototype()->end()
                                 ->end()
                             ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->arrayNode('indexer')
+                ->useAttributeAsKey('name')
+                ->arrayPrototype()
+                    ->children()
+                        ->scalarNode('vectorizer')
+                            ->info('Service name of vectorizer')
+                            ->defaultValue(VectorizerInterface::class)
+                        ->end()
+                        ->scalarNode('store')
+                            ->info('Service name of store')
+                            ->defaultValue(StoreInterface::class)
                         ->end()
                     ->end()
                 ->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Refs #465 
| License       | MIT

Add support for configuring vectorizers via ai.yaml configuration, allowing reuse across multiple indexers and centralized vectorizer management.