### PR TITLE
[Store] Change `vectorizeDocuments` method to `__invoke` in `Vectorizer`

### DIFF
--- a/src/store/src/Document/Vectorizer.php
+++ b/src/store/src/Document/Vectorizer.php
@@ -23,7 +23,7 @@ final readonly class Vectorizer implements VectorizerInterface
     ) {
     }
 
-    public function vectorizeDocuments(array $documents): array
+    public function __invoke(array $documents): array
     {
         if ($this->model->supports(Capability::INPUT_MULTIPLE)) {
             $result = $this->platform->invoke($this->model, array_map(fn (TextDocument $document) => $document->content, $documents));

--- a/src/store/src/Document/VectorizerInterface.php
+++ b/src/store/src/Document/VectorizerInterface.php
@@ -23,5 +23,5 @@ interface VectorizerInterface
      *
      * @return VectorDocument[]
      */
-    public function vectorizeDocuments(array $documents): array;
+    public function __invoke(array $documents): array;
 }

--- a/src/store/src/Indexer.php
+++ b/src/store/src/Indexer.php
@@ -47,13 +47,13 @@ final readonly class Indexer implements IndexerInterface
             ++$counter;
 
             if ($chunkSize === \count($chunk)) {
-                $this->store->add(...$this->vectorizer->vectorizeDocuments($chunk));
+                $this->store->add(...($this->vectorizer)($chunk));
                 $chunk = [];
             }
         }
 
         if (\count($chunk) > 0) {
-            $this->store->add(...$this->vectorizer->vectorizeDocuments($chunk));
+            $this->store->add(...($this->vectorizer)($chunk));
         }
 
         $this->logger->debug(0 === $counter ? 'No documents to index' : \sprintf('Indexed %d documents', $counter));

--- a/src/store/tests/Document/VectorizerTest.php
+++ b/src/store/tests/Document/VectorizerTest.php
@@ -67,7 +67,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer->vectorizeDocuments($documents);
+        $vectorDocuments = $vectorizer($documents);
 
         $this->assertCount(3, $vectorDocuments);
 
@@ -88,7 +88,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer->vectorizeDocuments([$document]);
+        $vectorDocuments = $vectorizer([$document]);
 
         $this->assertCount(1, $vectorDocuments);
         $this->assertInstanceOf(VectorDocument::class, $vectorDocuments[0]);
@@ -103,7 +103,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer->vectorizeDocuments([]);
+        $vectorDocuments = $vectorizer([]);
 
         $this->assertSame([], $vectorDocuments);
     }
@@ -127,7 +127,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer->vectorizeDocuments($documents);
+        $vectorDocuments = $vectorizer($documents);
 
         $this->assertCount(2, $vectorDocuments);
         $this->assertSame($metadata1, $vectorDocuments[0]->metadata);
@@ -158,7 +158,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer->vectorizeDocuments($documents);
+        $vectorDocuments = $vectorizer($documents);
 
         $this->assertCount(3, $vectorDocuments);
         $this->assertSame($id1, $vectorDocuments[0]->id);
@@ -187,7 +187,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer->vectorizeDocuments($documents);
+        $vectorDocuments = $vectorizer($documents);
 
         $this->assertCount($count, $vectorDocuments);
 
@@ -226,7 +226,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer->vectorizeDocuments([$document]);
+        $vectorDocuments = $vectorizer([$document]);
 
         $this->assertCount(1, $vectorDocuments);
         $this->assertEquals($vector, $vectorDocuments[0]->vector);
@@ -250,7 +250,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer->vectorizeDocuments($documents);
+        $vectorDocuments = $vectorizer($documents);
 
         $this->assertCount(3, $vectorDocuments);
 
@@ -313,7 +313,7 @@ final class VectorizerTest extends TestCase
         $platform = new Platform([$handler], [$handler]);
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer->vectorizeDocuments($documents);
+        $vectorDocuments = $vectorizer($documents);
 
         $this->assertCount(2, $vectorDocuments);
         $this->assertEquals($vectors[0], $vectorDocuments[0]->vector);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | --
| License       | MIT

This makes the Vectorizer class invokable, allowing it to be called directly as a function while maintaining the same functionality.