### PR TITLE
[Store] Remove duplicate class comment from `Indexer`

### DIFF
--- a/src/store/src/Indexer.php
+++ b/src/store/src/Indexer.php
@@ -17,8 +17,6 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\VectorizerInterface;
 
 /**
- * Converts a collection of TextDocuments into VectorDocuments and pushes them to a store implementation.
- *
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
 final readonly class Indexer implements IndexerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

The comment was already present on `IndexerInterface` and duplicated on the implementation class.