### PR TITLE
[Store] Rename `__invoke` methods in interfaces to descriptive names

### DIFF
--- a/src/store/src/Document/Loader/TextFileLoader.php
+++ b/src/store/src/Document/Loader/TextFileLoader.php
@@ -22,7 +22,7 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class TextFileLoader implements LoaderInterface
 {
-    public function __invoke(string $source, array $options = []): iterable
+    public function load(string $source, array $options = []): iterable
     {
         if (!is_file($source)) {
             throw new RuntimeException(\sprintf('File "%s" does not exist.', $source));

--- a/src/store/src/Document/LoaderInterface.php
+++ b/src/store/src/Document/LoaderInterface.php
@@ -22,5 +22,5 @@ interface LoaderInterface
      *
      * @return iterable<TextDocument> iterable of TextDocuments loaded from the source
      */
-    public function __invoke(string $source, array $options = []): iterable;
+    public function load(string $source, array $options = []): iterable;
 }

--- a/src/store/src/Document/Transformer/ChainTransformer.php
+++ b/src/store/src/Document/Transformer/ChainTransformer.php
@@ -28,10 +28,10 @@ final readonly class ChainTransformer implements TransformerInterface
         $this->transformers = $transformers instanceof \Traversable ? iterator_to_array($transformers) : $transformers;
     }
 
-    public function __invoke(iterable $documents, array $options = []): iterable
+    public function transform(iterable $documents, array $options = []): iterable
     {
         foreach ($this->transformers as $transformer) {
-            $documents = $transformer($documents, $options);
+            $documents = $transformer->transform($documents, $options);
         }
 
         return $documents;

--- a/src/store/src/Document/Transformer/ChunkDelayTransformer.php
+++ b/src/store/src/Document/Transformer/ChunkDelayTransformer.php
@@ -33,7 +33,7 @@ final readonly class ChunkDelayTransformer implements TransformerInterface
     /**
      * @param array{chunk_size?: int, delay?: int} $options
      */
-    public function __invoke(iterable $documents, array $options = []): iterable
+    public function transform(iterable $documents, array $options = []): iterable
     {
         $chunkSize = $options[self::OPTION_CHUNK_SIZE] ?? 50;
         $delay = $options[self::OPTION_DELAY] ?? 10;

--- a/src/store/src/Document/Transformer/TextSplitTransformer.php
+++ b/src/store/src/Document/Transformer/TextSplitTransformer.php
@@ -32,7 +32,7 @@ final readonly class TextSplitTransformer implements TransformerInterface
     /**
      * @param array{chunk_size?: int, overlap?: int} $options
      */
-    public function __invoke(iterable $documents, array $options = []): iterable
+    public function transform(iterable $documents, array $options = []): iterable
     {
         $chunkSize = $options[self::OPTION_CHUNK_SIZE] ?? 1000;
         $overlap = $options[self::OPTION_OVERLAP] ?? 200;

--- a/src/store/src/Document/TransformerInterface.php
+++ b/src/store/src/Document/TransformerInterface.php
@@ -26,5 +26,5 @@ interface TransformerInterface
      *
      * @return iterable<TextDocument>
      */
-    public function __invoke(iterable $documents, array $options = []): iterable;
+    public function transform(iterable $documents, array $options = []): iterable;
 }

--- a/src/store/src/Document/Vectorizer.php
+++ b/src/store/src/Document/Vectorizer.php
@@ -26,7 +26,7 @@ final readonly class Vectorizer implements VectorizerInterface
     ) {
     }
 
-    public function __invoke(array $documents): array
+    public function vectorize(array $documents): array
     {
         $documentCount = \count($documents);
         $this->logger->info('Starting vectorization process', ['document_count' => $documentCount]);

--- a/src/store/src/Document/VectorizerInterface.php
+++ b/src/store/src/Document/VectorizerInterface.php
@@ -23,5 +23,5 @@ interface VectorizerInterface
      *
      * @return VectorDocument[]
      */
-    public function __invoke(array $documents): array;
+    public function vectorize(array $documents): array;
 }

--- a/src/store/src/Indexer.php
+++ b/src/store/src/Indexer.php
@@ -45,13 +45,13 @@ final readonly class Indexer implements IndexerInterface
             ++$counter;
 
             if ($chunkSize === \count($chunk)) {
-                $this->store->add(...($this->vectorizer)($chunk));
+                $this->store->add(...$this->vectorizer->vectorize($chunk));
                 $chunk = [];
             }
         }
 
         if (\count($chunk) > 0) {
-            $this->store->add(...($this->vectorizer)($chunk));
+            $this->store->add(...$this->vectorizer->vectorize($chunk));
         }
 
         $this->logger->debug(0 === $counter ? 'No documents to index' : \sprintf('Indexed %d documents', $counter));

--- a/src/store/tests/Document/Loader/TextFileLoaderTest.php
+++ b/src/store/tests/Document/Loader/TextFileLoaderTest.php
@@ -27,14 +27,14 @@ final class TextFileLoaderTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('File "/invalid/source.txt" does not exist.');
 
-        iterator_to_array($loader('/invalid/source.txt'));
+        iterator_to_array($loader->load('/invalid/source.txt'));
     }
 
     public function testLoadWithValidSource()
     {
         $loader = new TextFileLoader();
 
-        $documents = iterator_to_array($loader(\dirname(__DIR__, 5).'/fixtures/lorem.txt'));
+        $documents = iterator_to_array($loader->load(\dirname(__DIR__, 5).'/fixtures/lorem.txt'));
 
         $this->assertCount(1, $documents);
         $this->assertInstanceOf(TextDocument::class, $document = $documents[0]);
@@ -48,7 +48,7 @@ final class TextFileLoaderTest extends TestCase
         $loader = new TextFileLoader();
 
         $source = \dirname(__DIR__, 5).'/fixtures/lorem.txt';
-        $documents = iterator_to_array($loader($source));
+        $documents = iterator_to_array($loader->load($source));
 
         $this->assertCount(1, $documents);
         $this->assertInstanceOf(TextDocument::class, $document = $documents[0]);

--- a/src/store/tests/Document/Transformer/ChainTransformerTest.php
+++ b/src/store/tests/Document/Transformer/ChainTransformerTest.php
@@ -24,7 +24,7 @@ final class ChainTransformerTest extends TestCase
     public function testChainTransformerAppliesAllTransformersInOrder()
     {
         $transformerA = new class implements TransformerInterface {
-            public function __invoke(iterable $documents, array $options = []): iterable
+            public function transform(iterable $documents, array $options = []): iterable
             {
                 foreach ($documents as $document) {
                     yield new TextDocument($document->id, $document->content.'-A');
@@ -33,7 +33,7 @@ final class ChainTransformerTest extends TestCase
         };
 
         $transformerB = new class implements TransformerInterface {
-            public function __invoke(iterable $documents, array $options = []): iterable
+            public function transform(iterable $documents, array $options = []): iterable
             {
                 foreach ($documents as $document) {
                     yield new TextDocument($document->id, $document->content.'-B');
@@ -47,7 +47,7 @@ final class ChainTransformerTest extends TestCase
             new TextDocument(Uuid::v4(), 'bar'),
         ];
 
-        $result = iterator_to_array($chain->__invoke($documents));
+        $result = iterator_to_array($chain->transform($documents));
 
         $this->assertSame('foo-A-B', $result[0]->content);
         $this->assertSame('bar-A-B', $result[1]->content);
@@ -58,7 +58,7 @@ final class ChainTransformerTest extends TestCase
         $chain = new ChainTransformer([]);
         $documents = [new TextDocument(Uuid::v4(), 'baz')];
 
-        $result = iterator_to_array($chain->__invoke($documents));
+        $result = iterator_to_array($chain->transform($documents));
 
         $this->assertSame('baz', $result[0]->content);
     }

--- a/src/store/tests/Document/Transformer/ChunkDelayTransformerTest.php
+++ b/src/store/tests/Document/Transformer/ChunkDelayTransformerTest.php
@@ -35,7 +35,7 @@ final class ChunkDelayTransformerTest extends TestCase
             $documents[] = new TextDocument(Uuid::v4(), 'content-'.$i);
         }
 
-        $result = iterator_to_array($transformer($documents));
+        $result = iterator_to_array($transformer->transform($documents));
 
         $this->assertCount(30, $result);
         for ($i = 0; $i < 30; ++$i) {
@@ -57,7 +57,7 @@ final class ChunkDelayTransformerTest extends TestCase
             $documents[] = new TextDocument(Uuid::v4(), 'content-'.$i);
         }
 
-        $result = iterator_to_array($transformer($documents, [
+        $result = iterator_to_array($transformer->transform($documents, [
             ChunkDelayTransformer::OPTION_CHUNK_SIZE => 50,
             ChunkDelayTransformer::OPTION_DELAY => 5,
         ]));
@@ -79,7 +79,7 @@ final class ChunkDelayTransformerTest extends TestCase
             $documents[] = new TextDocument(Uuid::v4(), 'content-'.$i);
         }
 
-        $result = iterator_to_array($transformer($documents, [
+        $result = iterator_to_array($transformer->transform($documents, [
             ChunkDelayTransformer::OPTION_CHUNK_SIZE => 10,
             ChunkDelayTransformer::OPTION_DELAY => 2,
         ]));
@@ -100,7 +100,7 @@ final class ChunkDelayTransformerTest extends TestCase
             $documents[] = new TextDocument(Uuid::v4(), 'content-'.$i);
         }
 
-        $result = iterator_to_array($transformer($documents, [
+        $result = iterator_to_array($transformer->transform($documents, [
             ChunkDelayTransformer::OPTION_CHUNK_SIZE => 5,
             ChunkDelayTransformer::OPTION_DELAY => 0,
         ]));
@@ -119,7 +119,7 @@ final class ChunkDelayTransformerTest extends TestCase
             new TextDocument(Uuid::v4(), 'third'),
         ];
 
-        $result = iterator_to_array($transformer($documents, [
+        $result = iterator_to_array($transformer->transform($documents, [
             ChunkDelayTransformer::OPTION_CHUNK_SIZE => 2,
             ChunkDelayTransformer::OPTION_DELAY => 1,
         ]));
@@ -137,7 +137,7 @@ final class ChunkDelayTransformerTest extends TestCase
 
         $transformer = new ChunkDelayTransformer($clock);
 
-        $result = iterator_to_array($transformer([]));
+        $result = iterator_to_array($transformer->transform([]));
 
         $this->assertCount(0, $result);
     }
@@ -153,7 +153,7 @@ final class ChunkDelayTransformerTest extends TestCase
 
         $documents = [new TextDocument(Uuid::v4(), 'single')];
 
-        $result = iterator_to_array($transformer($documents, [
+        $result = iterator_to_array($transformer->transform($documents, [
             ChunkDelayTransformer::OPTION_CHUNK_SIZE => 1,
             ChunkDelayTransformer::OPTION_DELAY => 5,
         ]));
@@ -176,7 +176,7 @@ final class ChunkDelayTransformerTest extends TestCase
             $documents[] = new TextDocument(Uuid::v4(), 'content-'.$i);
         }
 
-        $result = iterator_to_array($transformer($documents, [
+        $result = iterator_to_array($transformer->transform($documents, [
             ChunkDelayTransformer::OPTION_CHUNK_SIZE => 10,
             ChunkDelayTransformer::OPTION_DELAY => 3,
         ]));
@@ -198,7 +198,7 @@ final class ChunkDelayTransformerTest extends TestCase
             $documents[] = new TextDocument(Uuid::v4(), 'content-'.$i);
         }
 
-        $result = iterator_to_array($transformer($documents, [
+        $result = iterator_to_array($transformer->transform($documents, [
             ChunkDelayTransformer::OPTION_CHUNK_SIZE => 5,
             ChunkDelayTransformer::OPTION_DELAY => 1,
         ]));
@@ -220,7 +220,7 @@ final class ChunkDelayTransformerTest extends TestCase
             $documents[] = new TextDocument(Uuid::v4(), 'content-'.$i);
         }
 
-        $generator = $transformer($documents, [
+        $generator = $transformer->transform($documents, [
             ChunkDelayTransformer::OPTION_CHUNK_SIZE => 3,
             ChunkDelayTransformer::OPTION_DELAY => 1,
         ]);
@@ -248,7 +248,7 @@ final class ChunkDelayTransformerTest extends TestCase
 
         $startTime = $clock->now();
 
-        iterator_to_array($transformer($documents, [
+        iterator_to_array($transformer->transform($documents, [
             ChunkDelayTransformer::OPTION_CHUNK_SIZE => 5,
             ChunkDelayTransformer::OPTION_DELAY => 30,
         ]));

--- a/src/store/tests/Document/Transformer/TextSplitTransformerTest.php
+++ b/src/store/tests/Document/Transformer/TextSplitTransformerTest.php
@@ -33,7 +33,7 @@ final class TextSplitTransformerTest extends TestCase
     {
         $document = new TextDocument(Uuid::v4(), 'short text');
 
-        $chunks = iterator_to_array(($this->transformer)([$document]));
+        $chunks = iterator_to_array($this->transformer->transform([$document]));
 
         $this->assertCount(1, $chunks);
         $this->assertSame('short text', $chunks[0]->content);
@@ -48,7 +48,7 @@ final class TextSplitTransformerTest extends TestCase
     {
         $document = new TextDocument(Uuid::v4(), $this->getLongText());
 
-        $chunks = iterator_to_array(($this->transformer)([$document]));
+        $chunks = iterator_to_array($this->transformer->transform([$document]));
 
         $this->assertCount(2, $chunks);
 
@@ -63,7 +63,7 @@ final class TextSplitTransformerTest extends TestCase
     {
         $document = new TextDocument(Uuid::v4(), $this->getLongText());
 
-        $chunks = iterator_to_array(($this->transformer)([$document], [
+        $chunks = iterator_to_array($this->transformer->transform([$document], [
             TextSplitTransformer::OPTION_CHUNK_SIZE => 150,
             TextSplitTransformer::OPTION_OVERLAP => 25,
         ]));
@@ -111,7 +111,7 @@ final class TextSplitTransformerTest extends TestCase
     {
         $document = new TextDocument(Uuid::v4(), $this->getLongText());
 
-        $chunks = iterator_to_array(($this->transformer)([$document], [
+        $chunks = iterator_to_array($this->transformer->transform([$document], [
             TextSplitTransformer::OPTION_OVERLAP => 0,
         ]));
 
@@ -124,7 +124,7 @@ final class TextSplitTransformerTest extends TestCase
     {
         $document = new TextDocument(Uuid::v4(), $this->getLongText());
 
-        $chunks = iterator_to_array(($this->transformer)([$document], [
+        $chunks = iterator_to_array($this->transformer->transform([$document], [
             TextSplitTransformer::OPTION_CHUNK_SIZE => 1000,
             TextSplitTransformer::OPTION_OVERLAP => 200,
         ]));
@@ -141,7 +141,7 @@ final class TextSplitTransformerTest extends TestCase
             'foo' => 'bar',
         ]));
 
-        $chunks = iterator_to_array(($this->transformer)([$document]));
+        $chunks = iterator_to_array($this->transformer->transform([$document]));
 
         $this->assertCount(2, $chunks);
         $this->assertSame('value', $chunks[0]->metadata['key']);
@@ -154,7 +154,7 @@ final class TextSplitTransformerTest extends TestCase
     {
         $document = new TextDocument(Uuid::v4(), 'tiny');
 
-        $chunks = iterator_to_array(($this->transformer)([$document]));
+        $chunks = iterator_to_array($this->transformer->transform([$document]));
 
         $this->assertCount(1, $chunks);
         $this->assertSame('tiny', $chunks[0]->content);
@@ -166,7 +166,7 @@ final class TextSplitTransformerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Overlap must be non-negative and less than chunk size.');
 
-        iterator_to_array(($this->transformer)([$document], [
+        iterator_to_array($this->transformer->transform([$document], [
             TextSplitTransformer::OPTION_CHUNK_SIZE => 10,
             TextSplitTransformer::OPTION_OVERLAP => 20,
         ]));
@@ -178,7 +178,7 @@ final class TextSplitTransformerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Overlap must be non-negative and less than chunk size.');
 
-        iterator_to_array(($this->transformer)([$document], [
+        iterator_to_array($this->transformer->transform([$document], [
             TextSplitTransformer::OPTION_CHUNK_SIZE => 10,
             TextSplitTransformer::OPTION_OVERLAP => -1,
         ]));

--- a/src/store/tests/Document/VectorizerTest.php
+++ b/src/store/tests/Document/VectorizerTest.php
@@ -67,7 +67,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer($documents);
+        $vectorDocuments = $vectorizer->vectorize($documents);
 
         $this->assertCount(3, $vectorDocuments);
 
@@ -88,7 +88,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer([$document]);
+        $vectorDocuments = $vectorizer->vectorize([$document]);
 
         $this->assertCount(1, $vectorDocuments);
         $this->assertInstanceOf(VectorDocument::class, $vectorDocuments[0]);
@@ -103,7 +103,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer([]);
+        $vectorDocuments = $vectorizer->vectorize([]);
 
         $this->assertSame([], $vectorDocuments);
     }
@@ -127,7 +127,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer($documents);
+        $vectorDocuments = $vectorizer->vectorize($documents);
 
         $this->assertCount(2, $vectorDocuments);
         $this->assertSame($metadata1, $vectorDocuments[0]->metadata);
@@ -158,7 +158,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer($documents);
+        $vectorDocuments = $vectorizer->vectorize($documents);
 
         $this->assertCount(3, $vectorDocuments);
         $this->assertSame($id1, $vectorDocuments[0]->id);
@@ -187,7 +187,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer($documents);
+        $vectorDocuments = $vectorizer->vectorize($documents);
 
         $this->assertCount($count, $vectorDocuments);
 
@@ -226,7 +226,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer([$document]);
+        $vectorDocuments = $vectorizer->vectorize([$document]);
 
         $this->assertCount(1, $vectorDocuments);
         $this->assertEquals($vector, $vectorDocuments[0]->vector);
@@ -250,7 +250,7 @@ final class VectorizerTest extends TestCase
         $model = new Embeddings();
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer($documents);
+        $vectorDocuments = $vectorizer->vectorize($documents);
 
         $this->assertCount(3, $vectorDocuments);
 
@@ -313,7 +313,7 @@ final class VectorizerTest extends TestCase
         $platform = new Platform([$handler], [$handler]);
 
         $vectorizer = new Vectorizer($platform, $model);
-        $vectorDocuments = $vectorizer($documents);
+        $vectorDocuments = $vectorizer->vectorize($documents);
 
         $this->assertCount(2, $vectorDocuments);
         $this->assertEquals($vectors[0], $vectorDocuments[0]->vector);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Discussed with @chr-hertel upfront.

Replace generic `__invoke` methods with descriptive names:
- `TransformerInterface::__invoke` → `transform`
- `VectorizerInterface::__invoke` → `vectorize`
- `LoaderInterface::__invoke` → `load`

This improves code readability and makes the intent of each interface clearer. Updated all implementations and usages throughout the codebase.
