### PR TITLE
[Demo] Convert blog commands to invokable commands

### DIFF
--- a/demo/src/Blog/Command/EmbedCommand.php
+++ b/demo/src/Blog/Command/EmbedCommand.php
@@ -14,22 +14,18 @@ namespace App\Blog\Command;
 use App\Blog\Embedder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand('app:blog:embed', description: 'Create embeddings for Symfony blog and push to ChromaDB.')]
-final class EmbedCommand extends Command
+final class EmbedCommand
 {
     public function __construct(
         private readonly Embedder $embedder,
     ) {
-        parent::__construct();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    public function __invoke(SymfonyStyle $io): int
     {
-        $io = new SymfonyStyle($input, $output);
         $io->title('Loading RSS of Symfony blog as embeddings into ChromaDB');
 
         $this->embedder->embedBlog();

--- a/demo/src/Blog/Command/QueryCommand.php
+++ b/demo/src/Blog/Command/QueryCommand.php
@@ -16,23 +16,19 @@ use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand('app:blog:query', description: 'Test command for querying the blog collection in Chroma DB.')]
-final class QueryCommand extends Command
+final class QueryCommand
 {
     public function __construct(
         private readonly Client $chromaClient,
         private readonly PlatformInterface $platform,
     ) {
-        parent::__construct();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    public function __invoke(SymfonyStyle $io): int
     {
-        $io = new SymfonyStyle($input, $output);
         $io->title('Testing Chroma DB Connection');
 
         $io->comment('Connecting to Chroma DB ...');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Convert `EmbedCommand` and `QueryCommand` to use Symfony 7.3's invokable commands feature by removing `Command` inheritance and using `__invoke` method instead of `execute()`.