### PR TITLE
[Platform] Rename `FileNormalizer` to `DocumentNormalizer` in OpenAI contract

### DIFF
--- a/src/platform/src/Bridge/OpenAi/Contract/DocumentNormalizer.php
+++ b/src/platform/src/Bridge/OpenAi/Contract/DocumentNormalizer.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Guillermo Lengemann <guillermo.lengemann@gmail.com>
  */
-class FileNormalizer extends ModelContractNormalizer
+class DocumentNormalizer extends ModelContractNormalizer
 {
     /**
      * @param File $data

--- a/src/platform/src/Bridge/OpenAi/Contract/OpenAiContract.php
+++ b/src/platform/src/Bridge/OpenAi/Contract/OpenAiContract.php
@@ -24,7 +24,7 @@ final readonly class OpenAiContract extends Contract
     {
         return parent::create(
             new AudioNormalizer(),
-            new FileNormalizer(),
+            new DocumentNormalizer(),
             ...$normalizer
         );
     }

--- a/src/platform/tests/Bridge/OpenAi/Contract/DocumentNormalizerTest.php
+++ b/src/platform/tests/Bridge/OpenAi/Contract/DocumentNormalizerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\TestCase;
-use Symfony\AI\Platform\Bridge\OpenAi\Contract\FileNormalizer;
+use Symfony\AI\Platform\Bridge\OpenAi\Contract\DocumentNormalizer;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Contract\Normalizer\Message\MessageBagNormalizer;
@@ -23,13 +23,13 @@ use Symfony\AI\Platform\Message\Content\Document;
 use Symfony\AI\Platform\Message\Content\File;
 
 #[Medium]
-#[CoversClass(FileNormalizer::class)]
+#[CoversClass(DocumentNormalizer::class)]
 #[CoversClass(MessageBagNormalizer::class)]
 final class DocumentNormalizerTest extends TestCase
 {
     public function testSupportsNormalization()
     {
-        $normalizer = new FileNormalizer();
+        $normalizer = new DocumentNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new Document('some content', 'application/pdf'), context: [
             Contract::CONTEXT_MODEL => new Gpt(),
@@ -42,7 +42,7 @@ final class DocumentNormalizerTest extends TestCase
 
     public function testGetSupportedTypes()
     {
-        $normalizer = new FileNormalizer();
+        $normalizer = new DocumentNormalizer();
 
         $expected = [
             File::class => true,
@@ -54,7 +54,7 @@ final class DocumentNormalizerTest extends TestCase
     #[DataProvider('normalizeDataProvider')]
     public function testNormalize(File $file, array $expected)
     {
-        $normalizer = new FileNormalizer();
+        $normalizer = new DocumentNormalizer();
 
         $normalized = $normalizer->normalize($file);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

This change renames the `FileNormalizer` to `DocumentNormalizer` in the OpenAI contract to better reflect its purpose of normalizing document files.