### PR TITLE
[Platform] Add automatic enum validation for backed enums

### DIFF
--- a/fixtures/Tool/EnumMode.php
+++ b/fixtures/Tool/EnumMode.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Fixtures\Tool;
+
+enum EnumMode: string
+{
+    case AND = 'and';
+    case OR = 'or';
+    case NOT = 'not';
+}

--- a/fixtures/Tool/EnumPriority.php
+++ b/fixtures/Tool/EnumPriority.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Fixtures\Tool;
+
+enum EnumPriority: int
+{
+    case LOW = 1;
+    case MEDIUM = 5;
+    case HIGH = 10;
+}

--- a/fixtures/Tool/ToolWithBackedEnums.php
+++ b/fixtures/Tool/ToolWithBackedEnums.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Fixtures\Tool;
+
+class ToolWithBackedEnums
+{
+    /**
+     * Search using enum parameters without attributes.
+     *
+     * @param array<string> $searchTerms The search terms
+     * @param EnumMode      $mode        The search mode
+     * @param EnumPriority  $priority    The search priority
+     * @param EnumMode|null $fallback    Optional fallback mode
+     */
+    public function __invoke(array $searchTerms, EnumMode $mode, EnumPriority $priority, ?EnumMode $fallback = null): array
+    {
+        return [
+            'terms' => $searchTerms,
+            'mode' => $mode->value,
+            'priority' => $priority->value,
+            'fallback' => $fallback?->value,
+        ];
+    }
+}

--- a/src/platform/tests/Contract/JsonSchema/FactoryTest.php
+++ b/src/platform/tests/Contract/JsonSchema/FactoryTest.php
@@ -21,6 +21,7 @@ use Symfony\AI\Fixtures\StructuredOutput\User;
 use Symfony\AI\Fixtures\Tool\ToolNoParams;
 use Symfony\AI\Fixtures\Tool\ToolOptionalParam;
 use Symfony\AI\Fixtures\Tool\ToolRequiredParams;
+use Symfony\AI\Fixtures\Tool\ToolWithBackedEnums;
 use Symfony\AI\Fixtures\Tool\ToolWithToolParameterAttribute;
 use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
 use Symfony\AI\Platform\Contract\JsonSchema\DescriptionParser;
@@ -262,6 +263,40 @@ final class FactoryTest extends TestCase
         ];
 
         $actual = $this->factory->buildProperties(ExampleDto::class);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testBuildParametersWithBackedEnums()
+    {
+        $actual = $this->factory->buildParameters(ToolWithBackedEnums::class, '__invoke');
+        $expected = [
+            'type' => 'object',
+            'properties' => [
+                'searchTerms' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'description' => 'The search terms',
+                ],
+                'mode' => [
+                    'type' => 'string',
+                    'enum' => ['and', 'or', 'not'],
+                    'description' => 'The search mode',
+                ],
+                'priority' => [
+                    'type' => 'integer',
+                    'enum' => [1, 5, 10],
+                    'description' => 'The search priority',
+                ],
+                'fallback' => [
+                    'type' => ['string', 'null'],
+                    'enum' => ['and', 'or', 'not'],
+                    'description' => 'Optional fallback mode',
+                ],
+            ],
+            'required' => ['searchTerms', 'mode', 'priority'],
+            'additionalProperties' => false,
+        ];
 
         $this->assertSame($expected, $actual);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #492
| License       | MIT

Add automatic enum validation for PHP's backed enum types (string and int) without requiring the `#[With]` attribute. This enables tool methods to use enums as parameters with automatic JSON schema generation that includes the enum values for validation.