### PR TITLE
[Store] Add optional `description` to Indexer for better command output

### DIFF
--- a/src/store/src/Command/IndexCommand.php
+++ b/src/store/src/Command/IndexCommand.php
@@ -96,6 +96,11 @@ EOF
 
         $io->title(\sprintf('Indexing documents using "%s" indexer', $indexer));
 
+        $description = $indexerService->getDescription();
+        if (null !== $description) {
+            $io->info($description);
+        }
+
         try {
             $indexerService->index([]);
 

--- a/src/store/src/Indexer.php
+++ b/src/store/src/Indexer.php
@@ -39,15 +39,15 @@ class Indexer implements IndexerInterface
         private StoreInterface $store,
         string|array|null $source = null,
         private array $transformers = [],
-        private LoggerInterface $logger = new NullLogger(),
         private ?string $description = null,
+        private LoggerInterface $logger = new NullLogger(),
     ) {
         $this->sources = null === $source ? [] : (array) $source;
     }
 
     public function withSource(string|array $source): self
     {
-        return new self($this->loader, $this->vectorizer, $this->store, $source, $this->transformers, $this->logger, $this->description);
+        return new self($this->loader, $this->vectorizer, $this->store, $source, $this->transformers, $this->description, $this->logger);
     }
 
     public function index(array $options = []): void

--- a/src/store/src/Indexer.php
+++ b/src/store/src/Indexer.php
@@ -40,13 +40,14 @@ class Indexer implements IndexerInterface
         string|array|null $source = null,
         private array $transformers = [],
         private LoggerInterface $logger = new NullLogger(),
+        private ?string $description = null,
     ) {
         $this->sources = null === $source ? [] : (array) $source;
     }
 
     public function withSource(string|array $source): self
     {
-        return new self($this->loader, $this->vectorizer, $this->store, $source, $this->transformers, $this->logger);
+        return new self($this->loader, $this->vectorizer, $this->store, $source, $this->transformers, $this->logger, $this->description);
     }
 
     public function index(array $options = []): void
@@ -94,6 +95,11 @@ class Indexer implements IndexerInterface
         }
 
         $this->logger->debug('Document processing completed', ['total_documents' => $counter]);
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
     }
 
     /**

--- a/src/store/src/IndexerInterface.php
+++ b/src/store/src/IndexerInterface.php
@@ -31,4 +31,9 @@ interface IndexerInterface
      * @param string|array<string> $source Source identifier (file path, URL, etc.) or array of sources
      */
     public function withSource(string|array $source): self;
+
+    /**
+     * Get the description of what this indexer does.
+     */
+    public function getDescription(): ?string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Follows #465 
| License       | MIT

Add defaultNull description parameter to IndexerInterface and Indexer class. The ai:store:index command now displays the description when available.

Not sure about this, what do you think @chr-hertel ?