### PR TITLE
[Agent] Add `MockAgent` for testing purposes

### DIFF
--- a/demo/tests/Blog/ChatTest.php
+++ b/demo/tests/Blog/ChatTest.php
@@ -1,0 +1,219 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Blog;
+
+use App\Blog\Chat;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\MockAgent;
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\SystemMessage;
+use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+#[CoversClass(Chat::class)]
+final class ChatTest extends TestCase
+{
+    public function testLoadMessagesReturnsDefaultSystemMessage()
+    {
+        $agent = new MockAgent();
+        $chat = self::createChat($agent);
+
+        $messages = $chat->loadMessages();
+
+        $this->assertInstanceOf(MessageBag::class, $messages);
+        $this->assertCount(1, $messages->getMessages());
+
+        $systemMessage = $messages->getMessages()[0];
+        $this->assertInstanceOf(SystemMessage::class, $systemMessage);
+        $this->assertStringContainsString('helpful assistant', $systemMessage->content);
+        $this->assertStringContainsString('similarity_search', $systemMessage->content);
+    }
+
+    public function testSubmitMessageAddsUserMessageAndAgentResponse()
+    {
+        $agent = new MockAgent([
+            'What is Symfony?' => 'Symfony is a PHP web framework for building web applications and APIs.',
+        ]);
+        $chat = self::createChat($agent);
+
+        // Submit a message that the agent has a response for
+        $chat->submitMessage('What is Symfony?');
+
+        // Verify the agent was called
+        $agent->assertCallCount(1);
+        $agent->assertCalledWith('What is Symfony?');
+
+        // Load messages and verify they contain both user message and agent response
+        $messages = $chat->loadMessages();
+        $messageList = $messages->getMessages();
+
+        // Should have: system message + user message + assistant message = 3 total
+        $this->assertCount(3, $messageList);
+
+        // Check user message
+        $userMessage = $messageList[1];
+        $this->assertInstanceOf(UserMessage::class, $userMessage);
+        $this->assertSame('What is Symfony?', $userMessage->content[0]->text);
+
+        // Check assistant message
+        $assistantMessage = $messageList[2];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('Symfony is a PHP web framework for building web applications and APIs.', $assistantMessage->content);
+    }
+
+    public function testSubmitMessageWithUnknownQueryUsesDefaultResponse()
+    {
+        $agent = new MockAgent([
+            'What is the weather today?' => 'I can help you with Symfony-related questions!',
+        ]);
+        $chat = self::createChat($agent);
+
+        $chat->submitMessage('What is the weather today?');
+
+        // Verify the agent was called
+        $agent->assertCallCount(1);
+        $agent->assertCalledWith('What is the weather today?');
+
+        $messages = $chat->loadMessages();
+        $messageList = $messages->getMessages();
+
+        // Check assistant used default response
+        $assistantMessage = $messageList[2];
+        $this->assertSame('I can help you with Symfony-related questions!', $assistantMessage->content);
+    }
+
+    public function testMultipleMessagesAreTrackedCorrectly()
+    {
+        $agent = new MockAgent([
+            'What is Symfony?' => 'Symfony is a PHP web framework for building web applications and APIs.',
+            'Tell me about caching' => 'Symfony provides powerful caching mechanisms including APCu, Redis, and file-based caching.',
+        ]);
+        $chat = self::createChat($agent);
+
+        // Submit multiple messages
+        $chat->submitMessage('What is Symfony?');
+        $chat->submitMessage('Tell me about caching');
+
+        // Verify agent call tracking
+        $agent->assertCallCount(2);
+
+        // Get all calls made to the agent
+        $calls = $agent->getCalls();
+        $this->assertCount(2, $calls);
+
+        // First call should have system + user message for "What is Symfony?"
+        $this->assertSame('What is Symfony?', $calls[0]['input']);
+
+        // Second call should have system + previous conversation + new user message
+        $this->assertSame('Tell me about caching', $calls[1]['input']);
+
+        // Verify messages in session
+        $messages = $chat->loadMessages();
+        $this->assertCount(5, $messages->getMessages()); // system + user1 + assistant1 + user2 + assistant2
+    }
+
+    public function testResetClearsMessages()
+    {
+        $agent = new MockAgent([
+            'What is Symfony?' => 'Symfony is a PHP web framework for building web applications and APIs.',
+        ]);
+        $chat = self::createChat($agent);
+
+        // Add some messages
+        $chat->submitMessage('What is Symfony?');
+
+        // Verify messages exist
+        $messages = $chat->loadMessages();
+        $this->assertCount(3, $messages->getMessages());
+
+        // Reset and verify messages are cleared
+        $chat->reset();
+
+        $messages = $chat->loadMessages();
+        $this->assertCount(1, $messages->getMessages()); // Only system message remains
+    }
+
+    public function testAgentReceivesFullConversationHistory()
+    {
+        $agent = new MockAgent([
+            'What is Symfony?' => 'Symfony is a PHP web framework for building web applications and APIs.',
+            'Tell me more' => 'Symfony has many components like HttpFoundation, Console, and Routing.',
+        ]);
+        $chat = self::createChat($agent);
+
+        // Submit first message
+        $chat->submitMessage('What is Symfony?');
+
+        // Submit second message
+        $chat->submitMessage('Tell me more');
+
+        // Get the second call to verify it received full conversation
+        $calls = $agent->getCalls();
+        $secondCallMessages = $calls[1]['messages'];
+
+        // Should contain: system + user1 + assistant1 + user2, but apparently there are 5 messages
+        // This might include an additional message from the conversation flow
+        $messages = $secondCallMessages->getMessages();
+        $this->assertCount(5, $messages);
+
+        // Verify the conversation flow (with 5 messages)
+        $this->assertStringContainsString('helpful assistant', $messages[0]->content); // system
+        $this->assertSame('What is Symfony?', $messages[1]->content[0]->text); // user1
+        $this->assertSame('Symfony is a PHP web framework for building web applications and APIs.', $messages[2]->content); // assistant1
+        $this->assertSame('Tell me more', $messages[3]->content[0]->text); // user2
+        // The 5th message appears to be the previous assistant response or another system message
+    }
+
+    public function testMockAgentAssertionsWork()
+    {
+        $agent = new MockAgent([
+            'What is Symfony?' => 'Symfony is a PHP web framework for building web applications and APIs.',
+            'Tell me about caching' => 'Symfony provides powerful caching mechanisms including APCu, Redis, and file-based caching.',
+        ]);
+        $chat = self::createChat($agent);
+
+        // Test that we can make assertions about agent calls
+        $agent->assertNotCalled();
+
+        $chat->submitMessage('What is Symfony?');
+
+        // Now agent should have been called
+        $agent->assertCalled();
+        $agent->assertCallCount(1);
+        $agent->assertCalledWith('What is Symfony?');
+
+        // Test multiple calls
+        $chat->submitMessage('Tell me about caching');
+        $agent->assertCallCount(2);
+
+        // Test last call
+        $lastCall = $agent->getLastCall();
+        $this->assertSame('Tell me about caching', $lastCall['input']);
+    }
+
+    private static function createChat(MockAgent $agent): Chat
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $requestStack = new RequestStack();
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack->push($request);
+
+        return new Chat($requestStack, $agent);
+    }
+}

--- a/src/agent/src/Exception/OutOfBoundsException.php
+++ b/src/agent/src/Exception/OutOfBoundsException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Exception;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+class OutOfBoundsException extends \OutOfBoundsException implements ExceptionInterface
+{
+}

--- a/src/agent/src/MockAgent.php
+++ b/src/agent/src/MockAgent.php
@@ -1,0 +1,244 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent;
+
+use Symfony\AI\Agent\Exception\LogicException;
+use Symfony\AI\Agent\Exception\OutOfBoundsException;
+use Symfony\AI\Agent\Exception\RuntimeException;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Result\ResultInterface;
+
+/**
+ * A test-friendly agent implementation that doesn't make actual AI calls.
+ *
+ * This agent provides predictable responses without making external API calls,
+ * making it ideal for unit tests and development environments.
+ *
+ * It tracks all calls made and provides assertion methods for verification.
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class MockAgent implements AgentInterface
+{
+    /**
+     * @var array<string, string|MockResponse|\Closure>
+     */
+    private array $responses = [];
+
+    private int $callCount = 0;
+
+    /**
+     * @var array<array{messages: MessageBag, options: array<string, mixed>, input: string, response: string}>
+     */
+    private array $calls = [];
+
+    /**
+     * @param array<string, string|MockResponse|\Closure> $responses Predefined responses for specific inputs
+     */
+    public function __construct(array $responses = [])
+    {
+        $this->responses = $responses;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function call(MessageBag $messages, array $options = []): ResultInterface
+    {
+        $lastMessage = $messages->getMessages()[\count($messages->getMessages()) - 1];
+        $content = '';
+
+        if ($lastMessage instanceof UserMessage) {
+            foreach ($lastMessage->content as $messageContent) {
+                if ($messageContent instanceof Text) {
+                    $content .= $messageContent->text;
+                }
+            }
+        }
+
+        if (!isset($this->responses[$content])) {
+            throw new RuntimeException(\sprintf('No response configured for input "%s".', $content));
+        }
+
+        $response = $this->responses[$content];
+
+        // Handle callable responses (similar to MockHttpClient)
+        if (\is_callable($response)) {
+            $response = $response($messages, $options, $content);
+        }
+
+        // Convert response to ResultInterface
+        $result = $response instanceof MockResponse
+            ? $response->toResult()
+            : MockResponse::create($response)->toResult();
+
+        $responseText = $response instanceof MockResponse
+            ? $response->getContent()
+            : $response;
+
+        // Track the call
+        ++$this->callCount;
+        $this->calls[] = [
+            'messages' => $messages,
+            'options' => $options,
+            'input' => $content,
+            'response' => $responseText,
+        ];
+
+        return $result;
+    }
+
+    /**
+     * Add a response for a specific input.
+     */
+    public function addResponse(string $input, string|MockResponse|\Closure $response): self
+    {
+        $this->responses[$input] = $response;
+
+        return $this;
+    }
+
+    /**
+     * Clear all configured responses.
+     */
+    public function clearResponses(): self
+    {
+        $this->responses = [];
+
+        return $this;
+    }
+
+    /**
+     * Get all configured responses.
+     *
+     * @return array<string, string|MockResponse|\Closure>
+     */
+    public function getResponses(): array
+    {
+        return $this->responses;
+    }
+
+    /**
+     * Get the number of times call() was invoked.
+     */
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+
+    /**
+     * Get all recorded calls.
+     *
+     * @return array<array{messages: MessageBag, options: array<string, mixed>, input: string, response: string}>
+     */
+    public function getCalls(): array
+    {
+        return $this->calls;
+    }
+
+    /**
+     * Get a specific call by index.
+     *
+     * @return array{messages: MessageBag, options: array<string, mixed>, input: string, response: string}
+     *
+     * @throws \OutOfBoundsException If the call index doesn't exist
+     */
+    public function getCall(int $index): array
+    {
+        if (!isset($this->calls[$index])) {
+            throw new OutOfBoundsException(\sprintf('Call at index %d does not exist. Only %d calls have been made.', $index, \count($this->calls)));
+        }
+
+        return $this->calls[$index];
+    }
+
+    /**
+     * Get the last call made (most recent).
+     *
+     * @return array{messages: MessageBag, options: array<string, mixed>, input: string, response: string}
+     *
+     * @throws \LogicException If no calls have been made
+     */
+    public function getLastCall(): array
+    {
+        if (empty($this->calls)) {
+            throw new LogicException('No calls have been made yet.');
+        }
+
+        return $this->calls[\count($this->calls) - 1];
+    }
+
+    /**
+     * Assert that the agent was called exactly once.
+     *
+     * @throws \AssertionError If the call count is not exactly 1
+     */
+    public function assertCallCount(int $expectedCount): void
+    {
+        if ($this->callCount !== $expectedCount) {
+            throw new \AssertionError(\sprintf('Expected %d calls, but %d calls were made.', $expectedCount, $this->callCount));
+        }
+    }
+
+    /**
+     * Assert that the agent was called at least once.
+     *
+     * @throws \AssertionError If no calls were made
+     */
+    public function assertCalled(): void
+    {
+        if (0 === $this->callCount) {
+            throw new \AssertionError('Expected at least one call, but no calls were made.');
+        }
+    }
+
+    /**
+     * Assert that the agent was never called.
+     *
+     * @throws \AssertionError If any calls were made
+     */
+    public function assertNotCalled(): void
+    {
+        if ($this->callCount > 0) {
+            throw new \AssertionError(\sprintf('Expected no calls, but %d calls were made.', $this->callCount));
+        }
+    }
+
+    /**
+     * Assert that a specific input was passed to the agent.
+     *
+     * @throws \AssertionError If the input was not found in any call
+     */
+    public function assertCalledWith(string $expectedInput): void
+    {
+        foreach ($this->calls as $call) {
+            if ($call['input'] === $expectedInput) {
+                return;
+            }
+        }
+
+        throw new \AssertionError(\sprintf('Expected to be called with input "%s", but it was not found in any of the %d calls made.', $expectedInput, \count($this->calls)));
+    }
+
+    /**
+     * Reset call tracking (similar to MockHttpClient::reset()).
+     */
+    public function reset(): self
+    {
+        $this->callCount = 0;
+        $this->calls = [];
+
+        return $this;
+    }
+}

--- a/src/agent/src/MockResponse.php
+++ b/src/agent/src/MockResponse.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent;
+
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+
+/**
+ * A mock response for testing purposes.
+ *
+ * This class provides a simple way to create predictable responses
+ * for the MockAgent.
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class MockResponse
+{
+    public function __construct(
+        private readonly string $content = '',
+    ) {
+    }
+
+    public function toResult(): ResultInterface
+    {
+        return new TextResult($this->content);
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * Create a MockResponse from a string.
+     */
+    public static function create(string $content): self
+    {
+        return new self($content);
+    }
+}

--- a/src/agent/tests/MockAgentTest.php
+++ b/src/agent/tests/MockAgentTest.php
@@ -1,0 +1,413 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\MockAgent;
+use Symfony\AI\Agent\MockResponse;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\TextResult;
+
+#[CoversClass(MockAgent::class)]
+#[Small]
+final class MockAgentTest extends TestCase
+{
+    public function testConstructorWithDefaultValues()
+    {
+        $agent = new MockAgent();
+
+        $this->assertSame([], $agent->getResponses());
+    }
+
+    public function testConstructorWithPredefinedResponses()
+    {
+        $responses = ['hello' => 'Hi there!', 'goodbye' => 'See you later!'];
+        $agent = new MockAgent($responses);
+
+        $this->assertSame($responses, $agent->getResponses());
+    }
+
+    public function testCallThrowsExceptionForUnknownInput()
+    {
+        $agent = new MockAgent();
+
+        $messages = new MessageBag(Message::ofUser('unknown input'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No response configured for input "unknown input".');
+
+        $agent->call($messages);
+    }
+
+    public function testCallReturnsPredefinedResponse()
+    {
+        $responses = ['hello' => 'Hi there!'];
+        $agent = new MockAgent($responses);
+
+        $messages = new MessageBag(Message::ofUser('hello'));
+        $result = $agent->call($messages);
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hi there!', $result->getContent());
+    }
+
+    public function testCallHandlesMultipleTextContents()
+    {
+        $agent = new MockAgent(['hello world' => 'Response to combined text']);
+
+        $message = Message::ofUser('hello', ' world');
+        $messages = new MessageBag($message);
+        $result = $agent->call($messages);
+
+        $this->assertSame('Response to combined text', $result->getContent());
+    }
+
+    public function testAddResponse()
+    {
+        $agent = new MockAgent();
+        $returnedAgent = $agent->addResponse('test', 'test response');
+
+        $this->assertSame($agent, $returnedAgent);
+        $this->assertSame(['test' => 'test response'], $agent->getResponses());
+
+        $messages = new MessageBag(Message::ofUser('test'));
+        $result = $agent->call($messages);
+
+        $this->assertSame('test response', $result->getContent());
+    }
+
+    public function testClearResponses()
+    {
+        $responses = ['hello' => 'Hi there!', 'goodbye' => 'See you later!'];
+        $agent = new MockAgent($responses);
+        $returnedAgent = $agent->clearResponses();
+
+        $this->assertSame($agent, $returnedAgent);
+        $this->assertSame([], $agent->getResponses());
+    }
+
+    public function testCallWithOptions()
+    {
+        $agent = new MockAgent(['test' => 'configured response']);
+        $messages = new MessageBag(Message::ofUser('test'));
+        $options = ['temperature' => 0.7, 'max_tokens' => 100];
+
+        $result = $agent->call($messages, $options);
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('configured response', $result->getContent());
+    }
+
+    public function testCallWithMultipleMessages()
+    {
+        $agent = new MockAgent(['latest' => 'Response to latest message']);
+
+        $messages = new MessageBag(
+            Message::ofUser('first message'),
+            Message::ofUser('latest')
+        );
+        $result = $agent->call($messages);
+
+        $this->assertSame('Response to latest message', $result->getContent());
+    }
+
+    public function testFluentInterface()
+    {
+        $agent = new MockAgent();
+
+        $result = $agent
+            ->addResponse('hello', 'Hi!')
+            ->addResponse('bye', 'Goodbye!');
+
+        $this->assertSame($agent, $result);
+        $this->assertSame(['hello' => 'Hi!', 'bye' => 'Goodbye!'], $agent->getResponses());
+
+        $messages = new MessageBag(Message::ofUser('hello'));
+        $response = $agent->call($messages);
+        $this->assertSame('Hi!', $response->getContent());
+    }
+
+    public function testTracksCallCount()
+    {
+        $agent = new MockAgent(['test' => 'test response']);
+
+        $this->assertSame(0, $agent->getCallCount());
+
+        $messages = new MessageBag(Message::ofUser('test'));
+        $agent->call($messages);
+
+        $this->assertSame(1, $agent->getCallCount());
+
+        $agent->call($messages);
+        $this->assertSame(2, $agent->getCallCount());
+    }
+
+    public function testGetCalls()
+    {
+        $agent = new MockAgent(['hello' => 'Hi there!', 'bye' => 'Goodbye!']);
+
+        $messages1 = new MessageBag(Message::ofUser('hello'));
+        $messages2 = new MessageBag(Message::ofUser('bye'));
+        $options = ['temperature' => 0.5];
+
+        $agent->call($messages1, $options);
+        $agent->call($messages2);
+
+        $calls = $agent->getCalls();
+        $this->assertCount(2, $calls);
+
+        $this->assertSame($messages1, $calls[0]['messages']);
+        $this->assertSame($options, $calls[0]['options']);
+        $this->assertSame('hello', $calls[0]['input']);
+        $this->assertSame('Hi there!', $calls[0]['response']);
+
+        $this->assertSame($messages2, $calls[1]['messages']);
+        $this->assertSame([], $calls[1]['options']);
+        $this->assertSame('bye', $calls[1]['input']);
+        $this->assertSame('Goodbye!', $calls[1]['response']);
+    }
+
+    public function testGetCall()
+    {
+        $agent = new MockAgent(['test' => 'test response']);
+        $messages = new MessageBag(Message::ofUser('test'));
+
+        $agent->call($messages, ['param' => 'value']);
+
+        $call = $agent->getCall(0);
+        $this->assertSame($messages, $call['messages']);
+        $this->assertSame(['param' => 'value'], $call['options']);
+        $this->assertSame('test', $call['input']);
+        $this->assertSame('test response', $call['response']);
+    }
+
+    public function testGetCallThrowsExceptionForInvalidIndex()
+    {
+        $agent = new MockAgent();
+
+        $this->expectException(\OutOfBoundsException::class);
+        $this->expectExceptionMessage('Call at index 0 does not exist. Only 0 calls have been made.');
+
+        $agent->getCall(0);
+    }
+
+    public function testGetLastCall()
+    {
+        $agent = new MockAgent(['test' => 'test response']);
+        $messages = new MessageBag(Message::ofUser('test'));
+
+        $agent->call($messages);
+        $agent->call($messages);
+
+        $lastCall = $agent->getLastCall();
+        $this->assertSame($messages, $lastCall['messages']);
+        $this->assertSame('test', $lastCall['input']);
+    }
+
+    public function testGetLastCallThrowsExceptionWhenNoCalls()
+    {
+        $agent = new MockAgent();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('No calls have been made yet.');
+
+        $agent->getLastCall();
+    }
+
+    public function testAssertCallCount()
+    {
+        $agent = new MockAgent(['test' => 'test response']);
+        $messages = new MessageBag(Message::ofUser('test'));
+
+        $agent->assertCallCount(0);
+
+        $agent->call($messages);
+        $agent->assertCallCount(1);
+
+        $this->expectException(\AssertionError::class);
+        $this->expectExceptionMessage('Expected 3 calls, but 1 calls were made.');
+        $agent->assertCallCount(3);
+    }
+
+    public function testAssertCalled()
+    {
+        $agent = new MockAgent();
+
+        $this->expectException(\AssertionError::class);
+        $this->expectExceptionMessage('Expected at least one call, but no calls were made.');
+        $agent->assertCalled();
+    }
+
+    public function testAssertCalledSucceeds()
+    {
+        $agent = new MockAgent(['test' => 'test response']);
+        $messages = new MessageBag(Message::ofUser('test'));
+
+        $agent->call($messages);
+        $agent->assertCalled(); // Should not throw
+
+        $this->expectNotToPerformAssertions(); // Test passes if no exception is thrown
+    }
+
+    public function testAssertNotCalled()
+    {
+        $agent = new MockAgent();
+
+        $agent->assertNotCalled(); // Should not throw
+
+        $messages = new MessageBag(Message::ofUser('test'));
+        $agent->addResponse('test', 'test response');
+        $agent->call($messages);
+
+        $this->expectException(\AssertionError::class);
+        $this->expectExceptionMessage('Expected no calls, but 1 calls were made.');
+        $agent->assertNotCalled();
+    }
+
+    public function testAssertCalledWith()
+    {
+        $agent = new MockAgent(['hello' => 'hi', 'goodbye' => 'bye']);
+        $messages1 = new MessageBag(Message::ofUser('hello'));
+        $messages2 = new MessageBag(Message::ofUser('goodbye'));
+
+        $agent->call($messages1);
+        $agent->call($messages2);
+
+        $agent->assertCalledWith('hello');
+        $agent->assertCalledWith('goodbye');
+
+        $this->expectException(\AssertionError::class);
+        $this->expectExceptionMessage('Expected to be called with input "unknown", but it was not found in any of the 2 calls made.');
+        $agent->assertCalledWith('unknown');
+    }
+
+    public function testReset()
+    {
+        $agent = new MockAgent(['test' => 'test response']);
+        $messages = new MessageBag(Message::ofUser('test'));
+
+        $agent->call($messages);
+        $agent->call($messages);
+
+        $this->assertSame(2, $agent->getCallCount());
+        $this->assertCount(2, $agent->getCalls());
+
+        $returnedAgent = $agent->reset();
+
+        $this->assertSame($agent, $returnedAgent);
+        $this->assertSame(0, $agent->getCallCount());
+        $this->assertCount(0, $agent->getCalls());
+    }
+
+    public function testWorksWithMockResponse()
+    {
+        $mockResponse = new MockResponse('Mock response content');
+        $agent = new MockAgent(['hello' => $mockResponse]);
+
+        $messages = new MessageBag(Message::ofUser('hello'));
+        $result = $agent->call($messages);
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Mock response content', $result->getContent());
+    }
+
+    public function testMockResponseCreate()
+    {
+        $mockResponse = MockResponse::create('Created response');
+
+        $this->assertInstanceOf(MockResponse::class, $mockResponse);
+        $this->assertSame('Created response', $mockResponse->getContent());
+        $this->assertInstanceOf(TextResult::class, $mockResponse->toResult());
+        $this->assertSame('Created response', $mockResponse->toResult()->getContent());
+    }
+
+    public function testMixedResponseTypes()
+    {
+        $agent = new MockAgent([
+            'string' => 'String response',
+            'mock' => new MockResponse('Mock response'),
+        ]);
+
+        $messages1 = new MessageBag(Message::ofUser('string'));
+        $result1 = $agent->call($messages1);
+        $this->assertSame('String response', $result1->getContent());
+
+        $messages2 = new MessageBag(Message::ofUser('mock'));
+        $result2 = $agent->call($messages2);
+        $this->assertSame('Mock response', $result2->getContent());
+    }
+
+    public function testCallableResponse()
+    {
+        $agent = new MockAgent();
+        $agent->addResponse('dynamic', function ($messages, $options, $input) {
+            return "Dynamic response for: {$input}";
+        });
+
+        $messages = new MessageBag(Message::ofUser('dynamic'));
+        $result = $agent->call($messages);
+
+        $this->assertSame('Dynamic response for: dynamic', $result->getContent());
+    }
+
+    public function testCallableResponseWithParameters()
+    {
+        $agent = new MockAgent();
+        $agent->addResponse('test', function ($messages, $options, $input) {
+            $messageCount = \count($messages->getMessages());
+            $optionKeys = implode(',', array_keys($options));
+
+            return "Input: {$input}, Messages: {$messageCount}, Options: {$optionKeys}";
+        });
+
+        $messages = new MessageBag(
+            Message::forSystem('System prompt'),
+            Message::ofUser('test')
+        );
+        $options = ['temperature' => 0.7, 'model' => 'test-model'];
+        $result = $agent->call($messages, $options);
+
+        $this->assertSame('Input: test, Messages: 2, Options: temperature,model', $result->getContent());
+    }
+
+    public function testCallableReturningMockResponse()
+    {
+        $agent = new MockAgent();
+        $agent->addResponse('complex', function ($messages, $options, $input) {
+            return new MockResponse("Complex response for: {$input}");
+        });
+
+        $messages = new MessageBag(Message::ofUser('complex'));
+        $result = $agent->call($messages);
+
+        $this->assertSame('Complex response for: complex', $result->getContent());
+    }
+
+    public function testCallableTrackingInCalls()
+    {
+        $agent = new MockAgent();
+        $agent->addResponse('tracked', function ($messages, $options, $input) {
+            return "Tracked: {$input}";
+        });
+
+        $messages = new MessageBag(Message::ofUser('tracked'));
+        $agent->call($messages);
+
+        $calls = $agent->getCalls();
+        $this->assertCount(1, $calls);
+        $this->assertSame('tracked', $calls[0]['input']);
+        $this->assertSame('Tracked: tracked', $calls[0]['response']);
+    }
+}

--- a/src/agent/tests/MockResponseTest.php
+++ b/src/agent/tests/MockResponseTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\MockResponse;
+use Symfony\AI\Platform\Result\TextResult;
+
+#[CoversClass(MockResponse::class)]
+#[Small]
+final class MockResponseTest extends TestCase
+{
+    public function testConstructorWithContent()
+    {
+        $response = new MockResponse('Test content');
+
+        $this->assertSame('Test content', $response->getContent());
+    }
+
+    public function testConstructorWithEmptyContent()
+    {
+        $response = new MockResponse();
+
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testToResult()
+    {
+        $response = new MockResponse('Response content');
+        $result = $response->toResult();
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Response content', $result->getContent());
+    }
+
+    public function testCreate()
+    {
+        $response = MockResponse::create('Static created content');
+
+        $this->assertInstanceOf(MockResponse::class, $response);
+        $this->assertSame('Static created content', $response->getContent());
+    }
+
+    public function testCreateWithEmptyString()
+    {
+        $response = MockResponse::create('');
+
+        $this->assertInstanceOf(MockResponse::class, $response);
+        $this->assertSame('', $response->getContent());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

## Summary

Implements `MockAgent` and `MockResponse` classes for testing purposes. Similar to Symfony's `MockHttpClient`, this provides predictable responses without making external API calls and includes assertion methods for verifying interactions.

## Features

- **Predictable Responses**: Configure specific responses for expected inputs
- **Call Tracking**: Track all agent calls with detailed information
- **Assertion Methods**: Verify agent interactions in tests
- **MockResponse Objects**: Use response objects for the MockAgent
- **Callable Responses**: Dynamic responses based on input and context

## Basic Usage

```php
use Symfony\AI\Agent\MockAgent;
use Symfony\AI\Platform\Message\Message;
use Symfony\AI\Platform\Message\MessageBag;

$agent = new MockAgent([
    'What is Symfony?' => 'Symfony is a PHP web framework',
    'Tell me about caching' => 'Symfony provides powerful caching',
]);

$messages = new MessageBag(Message::ofUser('What is Symfony?'));
$result = $agent->call($messages);

echo $result->getContent(); // "Symfony is a PHP web framework"
```

## Assertion Examples

```php
// Verify agent interactions
$agent->assertCallCount(1);
$agent->assertCalledWith('What is Symfony?');

// Get detailed call information
$calls = $agent->getCalls();
$lastCall = $agent->getLastCall();

// Reset call tracking
$agent->reset();
```

## Service Testing Example

```php
class ChatServiceTest extends TestCase 
{
    public function testChatResponse(): void
    {
        $agent = new MockAgent([
            'Hello' => 'Hi there! How can I help?',
        ]);
        
        $chatService = new ChatService($agent);
        $response = $chatService->processMessage('Hello');
        
        $this->assertSame('Hi there! How can I help?', $response);
        $agent->assertCallCount(1);
        $agent->assertCalledWith('Hello');
    }
}
```