### PR TITLE
[Examples] Fix `env()` function to check for empty string values

### DIFF
--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -25,7 +25,7 @@ require_once __DIR__.'/vendor/autoload.php';
 
 function env(string $var)
 {
-    if (!isset($_SERVER[$var])) {
+    if (!isset($_SERVER[$var]) || '' === $_SERVER[$var]) {
         printf('Please set the "%s" environment variable to run this example.', $var);
         exit(1);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

The env() function now checks both isset() and empty string to properly handle environment variables defined in .env but with empty values.
