### PR TITLE
[Agent] Show system message first in chat command

### DIFF
--- a/src/agent/src/Agent.php
+++ b/src/agent/src/Agent.php
@@ -122,4 +122,13 @@ final readonly class Agent implements AgentInterface
 
         return $processors instanceof \Traversable ? iterator_to_array($processors) : $processors;
     }
+
+    public function getSystemMessage(): ?string
+    {
+        $input = new Input($this->model, new MessageBag(), []);
+
+        array_map(fn (InputProcessorInterface $processor) => $processor->processInput($input), $this->inputProcessors);
+
+        return $input->messages->getSystemMessage()?->content;
+    }
 }

--- a/src/agent/src/AgentInterface.php
+++ b/src/agent/src/AgentInterface.php
@@ -26,4 +26,6 @@ interface AgentInterface
      * @throws ExceptionInterface When the agent encounters an error (e.g., unsupported model capabilities, invalid arguments, network failures, or processor errors)
      */
     public function call(MessageBag $messages, array $options = []): ResultInterface;
+
+    public function getSystemMessage(): ?string;
 }

--- a/src/ai-bundle/src/Command/ChatCommand.php
+++ b/src/ai-bundle/src/Command/ChatCommand.php
@@ -126,16 +126,19 @@ final class ChatCommand extends Command
         }
 
         $agent = $this->agents->get($agentName);
+        $systemMessage = $agent->getSystemMessage();
 
         // Now start the chat
         $io = new SymfonyStyle($input, $output);
 
         $io->title(\sprintf('Chat with %s Agent', $agentName));
+        if (null !== $systemMessage) {
+            $io->writeln("<comment>System prompt: $systemMessage</comment>");
+        }
         $io->info('Type your message and press Enter. Type "exit" or "quit" to end the conversation.');
         $io->newLine();
 
         $messages = new MessageBag();
-        $systemPromptDisplayed = false;
 
         while (true) {
             $userInput = $io->ask('You');
@@ -153,13 +156,6 @@ final class ChatCommand extends Command
 
             try {
                 $result = $agent->call($messages);
-
-                // Display system prompt after first successful call
-                if (!$systemPromptDisplayed && null !== ($systemMessage = $messages->getSystemMessage())) {
-                    $io->section('System Prompt');
-                    $io->block($systemMessage->content, null, 'fg=gray', ' ', true);
-                    $systemPromptDisplayed = true;
-                }
 
                 if ($result instanceof TextResult) {
                     $io->write('<fg=yellow>Assistant</>:');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #434 
| License       | MIT

This PR introduces the `getSystemMessage()` method to `AgentInterface` and implements it in the `Agent` class.
It also uses this method in `ChatCommand` to display the system message at the start of the chat session.

Tests were added to verify the new behaviour.