### PR TITLE
[Platform][Mistral] Add support for Voxtral models with audio input and tool-calling

### DIFF
--- a/src/platform/src/Bridge/Mistral/Mistral.php
+++ b/src/platform/src/Bridge/Mistral/Mistral.php
@@ -29,6 +29,8 @@ final class Mistral extends Model
     public const MINISTRAL_8B = 'mistral-8b-latest';
     public const PIXSTRAL_LARGE = 'pixstral-large-latest';
     public const PIXSTRAL = 'pixstral-12b-latest';
+    public const VOXTRAL_SMALL = 'voxtral-small-latest';
+    public const VOXTRAL_MINI = 'voxtral-mini-latest';
 
     /**
      * @param array<string, mixed> $options
@@ -48,6 +50,10 @@ final class Mistral extends Model
             $capabilities[] = Capability::INPUT_IMAGE;
         }
 
+        if (\in_array($name, [self::VOXTRAL_SMALL, self::VOXTRAL_MINI], true)) {
+            $capabilities[] = Capability::INPUT_AUDIO;
+        }
+
         if (\in_array($name, [
             self::CODESTRAL,
             self::MISTRAL_LARGE,
@@ -57,6 +63,8 @@ final class Mistral extends Model
             self::MINISTRAL_8B,
             self::PIXSTRAL,
             self::PIXSTRAL_LARGE,
+            self::VOXTRAL_MINI,
+            self::VOXTRAL_SMALL,
         ], true)) {
             $capabilities[] = Capability::TOOL_CALLING;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | Yes
| Docs?         | no
| Issues        | --
| License       | MIT


This pull request extends the Mistral integration to add support for the `VOXTRAL` models, which are specialized for processing audio data. This enables the transcription of audio files through the Mistral platform.

**Key Changes:**

*   **New Model Constants:** In the `Mistral` class, the constants `VOXTRAL_SMALL` and `VOXTRAL_MINI` have been added.
*   **Audio Capability:** The `Capability::INPUT_AUDIO` is now correctly assigned to the models when one of the VOXTRAL models is selected.
*   **Usage Example:** A new `ai:mistral` command has been created to demonstrate the functionality. It shows how to send an audio file (`audio.mp3`) to the `VOXTRAL_SMALL` model for transcription.

**Usage Example (`AiMistralCommand.php`):**

```php
// ...

// Select the VOXTRAL_SMALL model
$model = new Mistral(Mistral::VOXTRAL_SMALL);

// ...

// Call the agent with a system message and an audio file as user input
$messages = new MessageBag(
    Message::forSystem('You are an assistant for audio transcriptions.'),
    Message::ofUser(
        'Please give me the content of the audio file',
        Audio::fromFile(dirname(__DIR__, 2).'/audio.mp3'),
    ),
);

$result = $agent->call($messages)->getContent();

// ...
```
