### PR TITLE
[Agent] Support translations for system input processor

### DIFF
--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -54,3 +54,4 @@ CHANGELOG
  * Add model capability detection before processing
  * Add comprehensive type safety with full PHP type hints
  * Add clear exception hierarchy for different error scenarios
+ * Add translation support for system prompts

--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -41,7 +41,8 @@
         "symfony/css-selector": "^6.4 || ^7.1",
         "symfony/dom-crawler": "^6.4 || ^7.1",
         "symfony/event-dispatcher": "^6.4 || ^7.1",
-        "symfony/http-foundation": "^6.4 || ^7.1"
+        "symfony/http-foundation": "^6.4 || ^7.1",
+        "symfony/translation-contracts": "^3.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Store\Document\VectorizerInterface;
 use Symfony\AI\Store\StoreInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 return static function (DefinitionConfigurator $configurator): void {
     $configurator->rootNode()
@@ -154,6 +155,12 @@ return static function (DefinitionConfigurator $configurator): void {
                                 })
                                 ->thenInvalid('The "text" cannot be empty.')
                             ->end()
+                            ->validate()
+                                ->ifTrue(function ($v) {
+                                    return \is_array($v) && $v['enabled'] && !interface_exists(TranslatorInterface::class);
+                                })
+                                ->thenInvalid('System prompt translation is enabled, but no translator is present. Try running `composer require symfony/translation`.')
+                            ->end()
                             ->children()
                                 ->scalarNode('text')
                                     ->info('The system prompt text')
@@ -161,6 +168,14 @@ return static function (DefinitionConfigurator $configurator): void {
                                 ->booleanNode('include_tools')
                                     ->info('Include tool definitions at the end of the system prompt')
                                     ->defaultFalse()
+                                ->end()
+                                ->booleanNode('enable_translation')
+                                    ->info('Enable translation for the system prompt')
+                                    ->defaultFalse()
+                                ->end()
+                                ->scalarNode('translation_domain')
+                                    ->info('The translation domain for the system prompt')
+                                    ->defaultNull()
                                 ->end()
                             ->end()
                         ->end()

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -611,6 +611,9 @@ final class AiBundle extends AbstractBundle
                 ->setArguments([
                     $config['prompt']['text'],
                     $includeTools ? new Reference('ai.toolbox.'.$name) : null,
+                    new Reference('translator', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                    $config['prompt']['enable_translation'],
+                    $config['prompt']['translation_domain'],
                     new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
                 ])
                 ->addTag('ai.agent.input_processor', ['agent' => $agentId, 'priority' => -30]);

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -471,11 +471,13 @@ class AiBundleTest extends TestCase
         $firstSystemPrompt = $container->getDefinition('ai.agent.first_agent.system_prompt_processor');
         $firstSystemTags = $firstSystemPrompt->getTag('ai.agent.input_processor');
         $this->assertSame($firstAgentId, $firstSystemTags[0]['agent']);
+        $this->assertCount(3, array_filter($firstSystemPrompt->getArguments()));
 
         // Second agent system prompt processor
         $secondSystemPrompt = $container->getDefinition('ai.agent.second_agent.system_prompt_processor');
         $secondSystemTags = $secondSystemPrompt->getTag('ai.agent.input_processor');
         $this->assertSame($secondAgentId, $secondSystemTags[0]['agent']);
+        $this->assertCount(3, array_filter($secondSystemPrompt->getArguments()));
     }
 
     #[TestDox('Processors work correctly when using the default toolbox')]
@@ -658,6 +660,8 @@ class AiBundleTest extends TestCase
                         'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
                         'prompt' => [
                             'text' => 'You are a helpful assistant.',
+                            'enable_translation' => true,
+                            'translation_domain' => 'prompts',
                         ],
                         'tools' => [
                             ['service' => 'some_tool', 'description' => 'Test tool'],
@@ -673,6 +677,8 @@ class AiBundleTest extends TestCase
 
         $this->assertSame('You are a helpful assistant.', $arguments[0]);
         $this->assertNull($arguments[1]); // include_tools is false, so null reference
+        $this->assertTrue($arguments[3]);
+        $this->assertSame('prompts', $arguments[4]);
     }
 
     #[TestDox('System prompt with include_tools enabled works correctly')]


### PR DESCRIPTION
So that system prompts can be written in any locale

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no (there's no documentation for system input, so not sure where to put it. Open to ideas! <!-- required for new features -->
| Issues        | Fix #370  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This adds an optional translator to the `SystemInputProcessor` which, if set, will translate the configured system prompt.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
