### PR TITLE
[Agent] Make `$options` parameter default to empty array in `Input` and `Output`

### DIFF
--- a/src/agent/src/Input.php
+++ b/src/agent/src/Input.php
@@ -25,7 +25,7 @@ final class Input
     public function __construct(
         public Model $model,
         public MessageBag $messages,
-        private array $options,
+        private array $options = [],
     ) {
     }
 

--- a/src/agent/src/Output.php
+++ b/src/agent/src/Output.php
@@ -27,7 +27,7 @@ final class Output
         public readonly Model $model,
         public ResultInterface $result,
         public readonly MessageBag $messages,
-        public readonly array $options,
+        public readonly array $options = [],
     ) {
     }
 }

--- a/src/agent/tests/InputProcessor/ModelOverrideInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/ModelOverrideInputProcessorTest.php
@@ -48,7 +48,7 @@ final class ModelOverrideInputProcessorTest extends TestCase
     public function testProcessInputWithoutModelOption()
     {
         $gpt = new Gpt();
-        $input = new Input($gpt, new MessageBag(), []);
+        $input = new Input($gpt, new MessageBag());
 
         $processor = new ModelOverrideInputProcessor();
         $processor->processInput($input);

--- a/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
@@ -47,7 +47,7 @@ final class SystemPromptInputProcessorTest extends TestCase
     {
         $processor = new SystemPromptInputProcessor('This is a system prompt');
 
-        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')), []);
+        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')));
         $processor->processInput($input);
 
         $messages = $input->messages->getMessages();
@@ -65,7 +65,7 @@ final class SystemPromptInputProcessorTest extends TestCase
             Message::forSystem('This is already a system prompt'),
             Message::ofUser('This is a user message'),
         );
-        $input = new Input(new Gpt(), $messages, []);
+        $input = new Input(new Gpt(), $messages);
         $processor->processInput($input);
 
         $messages = $input->messages->getMessages();
@@ -92,7 +92,7 @@ final class SystemPromptInputProcessorTest extends TestCase
             }
         );
 
-        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')), []);
+        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')));
         $processor->processInput($input);
 
         $messages = $input->messages->getMessages();
@@ -130,7 +130,7 @@ final class SystemPromptInputProcessorTest extends TestCase
             }
         );
 
-        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')), []);
+        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')));
         $processor->processInput($input);
 
         $messages = $input->messages->getMessages();
@@ -170,7 +170,7 @@ final class SystemPromptInputProcessorTest extends TestCase
             }
         );
 
-        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')), []);
+        $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')));
         $processor->processInput($input);
 
         $messages = $input->messages->getMessages();

--- a/src/agent/tests/StructuredOutput/AgentProcessorTest.php
+++ b/src/agent/tests/StructuredOutput/AgentProcessorTest.php
@@ -56,7 +56,7 @@ final class AgentProcessorTest extends TestCase
         $processor = new AgentProcessor(new ConfigurableResponseFormatFactory());
 
         $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
-        $input = new Input($model, new MessageBag(), []);
+        $input = new Input($model, new MessageBag());
 
         $processor->processInput($input);
 
@@ -162,7 +162,7 @@ final class AgentProcessorTest extends TestCase
         $model = self::createMock(Model::class);
         $result = new TextResult('');
 
-        $output = new Output($model, $result, new MessageBag(), []);
+        $output = new Output($model, $result, new MessageBag());
 
         $processor->processOutput($output);
 

--- a/src/agent/tests/Toolbox/AgentProcessorTest.php
+++ b/src/agent/tests/Toolbox/AgentProcessorTest.php
@@ -49,7 +49,7 @@ class AgentProcessorTest extends TestCase
 
         $model = new Model('gpt-4', [Capability::TOOL_CALLING]);
         $processor = new AgentProcessor($toolbox);
-        $input = new Input($model, new MessageBag(), []);
+        $input = new Input($model, new MessageBag());
 
         $processor->processInput($input);
 
@@ -65,7 +65,7 @@ class AgentProcessorTest extends TestCase
 
         $model = new Model('gpt-4', [Capability::TOOL_CALLING]);
         $processor = new AgentProcessor($toolbox);
-        $input = new Input($model, new MessageBag(), []);
+        $input = new Input($model, new MessageBag());
 
         $processor->processInput($input);
 
@@ -94,7 +94,7 @@ class AgentProcessorTest extends TestCase
 
         $model = new Model('gpt-3');
         $processor = new AgentProcessor($this->createStub(ToolboxInterface::class));
-        $input = new Input($model, new MessageBag(), []);
+        $input = new Input($model, new MessageBag());
 
         $processor->processInput($input);
     }
@@ -115,7 +115,7 @@ class AgentProcessorTest extends TestCase
         $processor = new AgentProcessor($toolbox, keepToolMessages: true);
         $processor->setAgent($agent);
 
-        $output = new Output($model, $result, $messageBag, []);
+        $output = new Output($model, $result, $messageBag);
 
         $processor->processOutput($output);
 
@@ -140,7 +140,7 @@ class AgentProcessorTest extends TestCase
         $processor = new AgentProcessor($toolbox, keepToolMessages: false);
         $processor->setAgent($agent);
 
-        $output = new Output($model, $result, $messageBag, []);
+        $output = new Output($model, $result, $messageBag);
 
         $processor->processOutput($output);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT