### PR TITLE
[AiBundle][LMStudio] Replace `symfony_ai.` tag prefix with `ai.` prefix

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -383,7 +383,7 @@ final class AiBundle extends AbstractBundle
         }
 
         if ('lmstudio' === $type) {
-            $platformId = 'symfony_ai.platform.lmstudio';
+            $platformId = 'ai.platform.lmstudio';
             $definition = (new Definition(Platform::class))
                 ->setFactory(LmStudioPlatformFactory::class.'::create')
                 ->setLazy(true)
@@ -393,7 +393,7 @@ final class AiBundle extends AbstractBundle
                     new Reference('http_client', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                     new Reference('ai.platform.contract.default'),
                 ])
-                ->addTag('symfony_ai.platform');
+                ->addTag('ai.platform');
 
             $container->setDefinition($platformId, $definition);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Change lmstudio platform service ID and tag from 'symfony_ai' to 'ai.' to align with consistent naming convention used throughout the bundle.