### PR TITLE
[Run examples][CI] Add workflow which can be run by adding a label

### DIFF
--- a/.github/workflows/run-examples.yaml
+++ b/.github/workflows/run-examples.yaml
@@ -1,0 +1,28 @@
+name: Run Examples
+
+on:
+    pull_request:
+        types: [labeled]
+
+jobs:
+    run-examples:
+        if: github.event.label.name == 'Run examples'
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Echo Hello World
+              run: echo "Hello World"
+
+            - name: Remove label
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      await github.rest.issues.removeLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                        name: 'Run examples'
+                      });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Refs #518
| License       | MIT

@fabpot @nicolas-grekas can you please add the label `Run examples`, I will then be able to modify the workflow after merge in a follow-up PR. Thanks