### PR TITLE
[Platform] Implement `RateLimitExceededException` handling across AI platforms

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Gemini\Gemini;
 
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -42,8 +43,14 @@ final readonly class ResultConverter implements ResultConverterInterface
 
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        $response = $result->getObject();
+
+        if (429 === $response->getStatusCode()) {
+            throw new RateLimitExceededException();
+        }
+
         if ($options['stream'] ?? false) {
-            return new StreamResult($this->convertStream($result->getObject()));
+            return new StreamResult($this->convertStream($response));
         }
 
         $data = $result->getData();

--- a/src/platform/src/Exception/RateLimitExceededException.php
+++ b/src/platform/src/Exception/RateLimitExceededException.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Exception;
+
+/**
+ * @author Floran Pagliai <floran.pagliai@gmail.com>
+ */
+final class RateLimitExceededException extends RuntimeException
+{
+    public function __construct(
+        private readonly ?float $retryAfter = null,
+    ) {
+        parent::__construct('Rate limit exceeded.');
+    }
+
+    public function getRetryAfter(): ?float
+    {
+        return $this->retryAfter;
+    }
+}

--- a/src/platform/tests/Bridge/Anthropic/ResultConverterRateLimitTest.php
+++ b/src/platform/tests/Bridge/Anthropic/ResultConverterRateLimitTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\Anthropic;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Anthropic\ResultConverter;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+#[CoversClass(ResultConverter::class)]
+#[Small]
+final class ResultConverterRateLimitTest extends TestCase
+{
+    public function testRateLimitExceededThrowsException()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed the rate limit for your organization"}}', [
+                'http_code' => 429,
+                'response_headers' => [
+                    'retry-after' => '60',
+                ],
+            ]),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+        $handler = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded');
+
+        try {
+            $handler->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $this->assertSame(60.0, $e->getRetryAfter());
+            throw $e;
+        }
+    }
+
+    public function testRateLimitExceededWithoutRetryAfter()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed the rate limit for your organization"}}', [
+                'http_code' => 429,
+            ]),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+        $handler = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded');
+
+        try {
+            $handler->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $this->assertNull($e->getRetryAfter());
+            throw $e;
+        }
+    }
+}

--- a/src/platform/tests/Bridge/Gemini/Gemini/ResultConverterRateLimitTest.php
+++ b/src/platform/tests/Bridge/Gemini/Gemini/ResultConverterRateLimitTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\Gemini\Gemini;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+#[CoversClass(ResultConverter::class)]
+#[Small]
+final class ResultConverterRateLimitTest extends TestCase
+{
+    public function testRateLimitExceededThrowsException()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}', [
+                'http_code' => 429,
+            ]),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent');
+        $handler = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded.');
+
+        try {
+            $handler->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $this->assertNull($e->getRetryAfter());
+            throw $e;
+        }
+    }
+}

--- a/src/platform/tests/Bridge/OpenAi/Gpt/ResultConverterRateLimitTest.php
+++ b/src/platform/tests/Bridge/OpenAi/Gpt/ResultConverterRateLimitTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\OpenAi\Gpt;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\OpenAi\Gpt\ResultConverter;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+#[CoversClass(ResultConverter::class)]
+#[Small]
+final class ResultConverterRateLimitTest extends TestCase
+{
+    public function testRateLimitExceededWithRequestsResetTime()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"error":{"message":"Rate limit reached for requests","type":"rate_limit_error"}}', [
+                'http_code' => 429,
+                'response_headers' => [
+                    'x-ratelimit-limit-requests' => '60',
+                    'x-ratelimit-remaining-requests' => '0',
+                    'x-ratelimit-reset-requests' => '20s',
+                ],
+            ]),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://api.openai.com/v1/chat/completions');
+        $handler = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded.');
+
+        try {
+            $handler->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $this->assertSame(20.0, $e->getRetryAfter());
+            throw $e;
+        }
+    }
+
+    public function testRateLimitExceededWithTokensResetTime()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"error":{"message":"Rate limit reached for tokens","type":"rate_limit_error"}}', [
+                'http_code' => 429,
+                'response_headers' => [
+                    'x-ratelimit-limit-tokens' => '150000',
+                    'x-ratelimit-remaining-tokens' => '0',
+                    'x-ratelimit-reset-tokens' => '2m30s',
+                ],
+            ]),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://api.openai.com/v1/chat/completions');
+        $handler = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded.');
+
+        try {
+            $handler->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $this->assertSame(150.0, $e->getRetryAfter());
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | #528 
| License       | MIT

  - Created a `RateLimitExceededException` to handle 429 across all AI platforms
  - Unified the handling of rate limit responses with platform-specific retry information
  - Used platform-specific header extraction for each provider:
    - Anthropic: Standard retry-after HTTP header (seconds)
    - Gemini: No retry information provided
    - OpenAI: Custom headers x-ratelimit-reset-requests and x-ratelimit-reset-tokens
