### PR TITLE
[Run examples] Remove usage of `Agent` when not needed

### DIFF
--- a/examples/albert/chat.php
+++ b/examples/albert/chat.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Albert\PlatformFactory;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Message\Message;
@@ -20,7 +19,6 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('ALBERT_API_KEY'), env('ALBERT_API_URL'), http_client());
 
 $model = new Gpt('gpt-4o');
-$agent = new Agent($platform, $model, logger: logger());
 
 $documentContext = <<<'CONTEXT'
     Document: AI Strategy of France
@@ -44,6 +42,6 @@ $messages = new MessageBag(
     Message::ofUser('What are the main objectives of France\'s AI strategy?'),
 );
 
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/anthropic/chat.php
+++ b/examples/anthropic/chat.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,11 +19,10 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude(Claude::SONNET_37);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/anthropic/image-input-binary.php
+++ b/examples/anthropic/image-input-binary.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
@@ -21,7 +20,6 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude(Claude::SONNET_37);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(
@@ -29,6 +27,6 @@ $messages = new MessageBag(
         'Describe this image.',
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/anthropic/image-input-url.php
+++ b/examples/anthropic/image-input-url.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
@@ -21,7 +20,6 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude(Claude::SONNET_37);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(
@@ -29,6 +27,6 @@ $messages = new MessageBag(
         'Describe this image.',
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/anthropic/pdf-input-binary.php
+++ b/examples/anthropic/pdf-input-binary.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Document;
@@ -21,13 +20,12 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude(Claude::SONNET_37);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         Document::fromFile(dirname(__DIR__, 2).'/fixtures/document.pdf'),
         'What is this document about?',
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/anthropic/pdf-input-url.php
+++ b/examples/anthropic/pdf-input-url.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\DocumentUrl;
@@ -21,13 +20,12 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude(Claude::SONNET_37);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         new DocumentUrl('https://upload.wikimedia.org/wikipedia/commons/2/20/Re_example.pdf'),
         'What is this document about?',
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/anthropic/stream.php
+++ b/examples/anthropic/stream.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,16 +19,13 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 $model = new Claude();
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a thoughtful philosopher.'),
     Message::ofUser('What is the purpose of an ant?'),
 );
-$result = $agent->call($messages, [
-    'stream' => true, // enable streaming of response text
-]);
+$result = $platform->invoke($model, $messages, ['stream' => true]);
 
-foreach ($result->getContent() as $word) {
+foreach ($result->getResult()->getContent() as $word) {
     echo $word;
 }
 echo \PHP_EOL;

--- a/examples/azure/chat-gpt.php
+++ b/examples/azure/chat-gpt.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Azure\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Message\Message;
@@ -26,11 +25,10 @@ $platform = PlatformFactory::create(
 );
 $model = new Gpt(Gpt::GPT_4O_MINI);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/azure/chat-llama.php
+++ b/examples/azure/chat-llama.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Azure\Meta\PlatformFactory;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Message\Message;
@@ -20,9 +19,8 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('AZURE_LLAMA_BASEURL'), env('AZURE_LLAMA_KEY'), http_client());
 $model = new Llama(Llama::V3_3_70B_INSTRUCT);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(Message::ofUser('I am going to Paris, what should I see?'));
-$result = $agent->call($messages, [
+$result = $platform->invoke($model, $messages, [
     'max_tokens' => 2048,
     'temperature' => 0.8,
     'top_p' => 0.1,
@@ -30,4 +28,4 @@ $result = $agent->call($messages, [
     'frequency_penalty' => 0,
 ]);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/bedrock/chat-claude.php
+++ b/examples/bedrock/chat-claude.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -26,11 +25,10 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Claude('claude-3-7-sonnet-20250219');
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You answer questions in short and concise manner.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/bedrock/chat-llama.php
+++ b/examples/bedrock/chat-llama.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Message\Message;
@@ -26,11 +25,10 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Llama(Llama::V3_2_3B_INSTRUCT);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/bedrock/chat-nova.php
+++ b/examples/bedrock/chat-nova.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Bedrock\Nova\Nova;
 use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -26,11 +25,10 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Nova(Nova::PRO);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/bedrock/image-claude-binary.php
+++ b/examples/bedrock/image-claude-binary.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
@@ -27,7 +26,6 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Claude('claude-3-7-sonnet-20250219');
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(
@@ -35,6 +33,6 @@ $messages = new MessageBag(
         Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/bedrock/image-nova.php
+++ b/examples/bedrock/image-nova.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Bedrock\Nova\Nova;
 use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
@@ -27,7 +26,6 @@ if (!isset($_SERVER['AWS_ACCESS_KEY_ID'], $_SERVER['AWS_SECRET_ACCESS_KEY'], $_S
 $platform = PlatformFactory::create();
 $model = new Nova(Nova::PRO);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(
@@ -35,6 +33,6 @@ $messages = new MessageBag(
         Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/cerebras/chat.php
+++ b/examples/cerebras/chat.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Cerebras\Model;
 use Symfony\AI\Platform\Bridge\Cerebras\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -19,11 +18,10 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('CEREBRAS_API_KEY'), http_client());
 
-$agent = new Agent($platform, new Model(), logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('How is the weather in Tokyo today?'),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke(new Model(), $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/cerebras/stream.php
+++ b/examples/cerebras/stream.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Cerebras\Model;
 use Symfony\AI\Platform\Bridge\Cerebras\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -19,18 +18,16 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('CEREBRAS_API_KEY'), http_client());
 
-$agent = new Agent($platform, new Model(), logger: logger());
-
 $messages = new MessageBag(
     Message::forSystem('You are an expert in places and geography who always responds concisely.'),
     Message::ofUser('What are the top three destinations in France?'),
 );
 
-$result = $agent->call($messages, [
+$result = $platform->invoke(new Model(), $messages, [
     'stream' => true,
 ]);
 
-foreach ($result->getContent() as $word) {
+foreach ($result->getResult()->getContent() as $word) {
     echo $word;
 }
 echo \PHP_EOL;

--- a/examples/gemini/audio-input.php
+++ b/examples/gemini/audio-input.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Audio;
@@ -21,13 +20,12 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_1_5_FLASH);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         'What is this recording about?',
         Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/gemini/chat.php
+++ b/examples/gemini/chat.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,11 +19,10 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_2_FLASH);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/gemini/image-input.php
+++ b/examples/gemini/image-input.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
@@ -21,7 +20,6 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_1_5_FLASH);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(
@@ -29,6 +27,6 @@ $messages = new MessageBag(
         Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/gemini/pdf-input-binary.php
+++ b/examples/gemini/pdf-input-binary.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Document;
@@ -21,13 +20,12 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_1_5_FLASH);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         Document::fromFile(dirname(__DIR__, 2).'/fixtures/document.pdf'),
         'What is this document about?',
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/gemini/stream.php
+++ b/examples/gemini/stream.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,16 +19,15 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = new Gemini(Gemini::GEMINI_2_FLASH);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a funny clown that entertains people.'),
     Message::ofUser('What is the purpose of an ant?'),
 );
-$result = $agent->call($messages, [
+$result = $platform->invoke($model, $messages, [
     'stream' => true, // enable streaming of response text
 ]);
 
-foreach ($result->getContent() as $word) {
+foreach ($result->getResult()->getContent() as $word) {
     echo $word;
 }
 echo \PHP_EOL;

--- a/examples/lmstudio/chat.php
+++ b/examples/lmstudio/chat.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\LmStudio\Completions;
 use Symfony\AI\Platform\Bridge\LmStudio\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,13 +19,12 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('LMSTUDIO_HOST_URL'), http_client());
 $model = new Completions('gemma-3-4b-it-qat');
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$result = $agent->call($messages, [
+$result = $platform->invoke($model, $messages, [
     'max_tokens' => 500, // specific options just for this call
 ]);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/lmstudio/image-input-binary.php
+++ b/examples/lmstudio/image-input-binary.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\LmStudio\Completions;
 use Symfony\AI\Platform\Bridge\LmStudio\PlatformFactory;
 use Symfony\AI\Platform\Capability;
@@ -25,7 +24,6 @@ $model = new Completions(
     capabilities: [...Completions::DEFAULT_CAPABILITIES, Capability::INPUT_IMAGE]
 );
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(
@@ -33,6 +31,6 @@ $messages = new MessageBag(
         Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/mistral/chat-multiple.php
+++ b/examples/mistral/chat-multiple.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -18,17 +17,16 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
-$agent = new Agent($platform, new Mistral(), logger: logger());
 
 $messages = new MessageBag(
     Message::forSystem('Just give short answers.'),
     Message::ofUser('What is your favorite color?'),
 );
-$result = $agent->call($messages, [
+$result = $platform->invoke(new Mistral(), $messages, [
     'temperature' => 1.5,
     'n' => 10,
 ]);
 
-foreach ($result->getContent() as $key => $choice) {
+foreach ($result->getResult()->getContent() as $key => $choice) {
     echo sprintf('Choice #%d: %s', ++$key, $choice->getContent()).\PHP_EOL;
 }

--- a/examples/mistral/chat.php
+++ b/examples/mistral/chat.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -19,11 +18,10 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
 $model = new Mistral();
-$agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(Message::ofUser('What is the best French cheese?'));
-$result = $agent->call($messages, [
+$result = $platform->invoke($model, $messages, [
     'temperature' => 0.7,
 ]);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/mistral/image.php
+++ b/examples/mistral/image.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
@@ -20,7 +19,6 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
 $model = new Mistral(Mistral::MISTRAL_SMALL);
-$agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
@@ -29,6 +27,6 @@ $messages = new MessageBag(
         Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/mistral/pdf-input-binary.php
+++ b/examples/mistral/pdf-input-binary.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Document;
@@ -21,13 +20,12 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), httpClient: http_client());
 $model = new Mistral(Mistral::MISTRAL_SMALL);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         Document::fromFile(dirname(__DIR__, 2).'/fixtures/document.pdf'),
         'What is this document about?',
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/mistral/pdf-input-url.php
+++ b/examples/mistral/pdf-input-url.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\DocumentUrl;
@@ -21,13 +20,12 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), httpClient: http_client());
 $model = new Mistral(Mistral::MISTRAL_SMALL);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         new DocumentUrl('https://upload.wikimedia.org/wikipedia/commons/2/20/Re_example.pdf'),
         'What is this document about?',
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/mistral/stream.php
+++ b/examples/mistral/stream.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -19,14 +18,13 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
 $model = new Mistral();
-$agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(Message::ofUser('What is the eighth prime number?'));
-$result = $agent->call($messages, [
+$result = $platform->invoke($model, $messages, [
     'stream' => true,
 ]);
 
-foreach ($result->getContent() as $word) {
+foreach ($result->getResult()->getContent() as $word) {
     echo $word;
 }
 echo \PHP_EOL;

--- a/examples/ollama/chat-llama.php
+++ b/examples/ollama/chat-llama.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Ollama\Ollama;
 use Symfony\AI\Platform\Bridge\Ollama\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,15 +19,14 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
 $model = new Ollama($_SERVER['OLLAMA_MODEL'] ?? '');
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
 );
 
 try {
-    $result = $agent->call($messages);
-    echo $result->getContent().\PHP_EOL;
-} catch(InvalidArgumentException $e) {
-    echo $e->getMessage() . "\nMaybe use a different model?\n";
+    $result = $platform->invoke($model, $messages);
+    echo $result->getResult()->getContent().\PHP_EOL;
+} catch (InvalidArgumentException $e) {
+    echo $e->getMessage()."\nMaybe use a different model?\n";
 }

--- a/examples/ollama/stream.php
+++ b/examples/ollama/stream.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Ollama\Ollama;
 use Symfony\AI\Platform\Bridge\Ollama\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,17 +19,16 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
 $model = new Ollama();
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
 );
 
 // Stream the response
-$result = $agent->call($messages, ['stream' => true]);
-
+$result = $platform->invoke($model, $messages, ['stream' => true]);
 // Emit each chunk as it is received
-foreach ($result->getContent() as $chunk) {
-    echo $chunk->getContent();
+
+foreach ($result->getResult()->getContent() as $chunk) {
+    echo $chunk;
 }
 echo \PHP_EOL;

--- a/examples/openai/audio-input.php
+++ b/examples/openai/audio-input.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Audio;
@@ -21,13 +20,12 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new Gpt(Gpt::GPT_4O_AUDIO);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         'What is this recording about?',
         Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/openai/chat.php
+++ b/examples/openai/chat.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,13 +19,12 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new Gpt(Gpt::GPT_4O_MINI);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$result = $agent->call($messages, [
+$result = $platform->invoke($model, $messages, [
     'max_tokens' => 500, // specific options just for this call
 ]);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/openai/image-input-binary.php
+++ b/examples/openai/image-input-binary.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
@@ -21,7 +20,6 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new Gpt(Gpt::GPT_4O_MINI);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(
@@ -29,6 +27,6 @@ $messages = new MessageBag(
         Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/openai/image-input-url.php
+++ b/examples/openai/image-input-url.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
@@ -21,7 +20,6 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new Gpt(Gpt::GPT_4O_MINI);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(
@@ -29,6 +27,6 @@ $messages = new MessageBag(
         new ImageUrl('https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Webysther_20160423_-_Elephpant.svg/350px-Webysther_20160423_-_Elephpant.svg.png'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/openai/pdf-input-binary.php
+++ b/examples/openai/pdf-input-binary.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Document;
@@ -21,13 +20,12 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new Gpt(Gpt::GPT_4O_MINI);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         'What is this document about?',
         Document::fromFile(dirname(__DIR__, 2).'/fixtures/document.pdf'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/openai/stream.php
+++ b/examples/openai/stream.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,16 +19,15 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $model = new Gpt(Gpt::GPT_4O_MINI);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a thoughtful philosopher.'),
     Message::ofUser('What is the purpose of an ant?'),
 );
-$result = $agent->call($messages, [
+$result = $platform->invoke($model, $messages, [
     'stream' => true, // enable streaming of response text
 ]);
 
-foreach ($result->getContent() as $word) {
+foreach ($result->getResult()->getContent() as $word) {
     echo $word;
 }
 echo \PHP_EOL;

--- a/examples/openrouter/chat-gemini.php
+++ b/examples/openrouter/chat-gemini.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\OpenRouter\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
@@ -22,11 +21,10 @@ $platform = PlatformFactory::create(env('OPENROUTER_KEY'), http_client());
 // $model = new Model('google/gemini-2.0-flash-lite-001');
 $model = new Model('google/gemini-2.0-flash-exp:free');
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/perplexity/chat.php
+++ b/examples/perplexity/chat.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Perplexity\Perplexity;
 use Symfony\AI\Platform\Bridge\Perplexity\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -19,9 +18,8 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('PERPLEXITY_API_KEY'), http_client());
 $model = new Perplexity();
-$agent = new Agent($platform, $model);
 
 $messages = new MessageBag(Message::ofUser('What is the best French cheese?'));
-$response = $agent->call($messages);
+$response = $platform->invoke($model, $messages);
 
-echo $response->getContent().\PHP_EOL;
+echo $response->getResult()->getContent().\PHP_EOL;

--- a/examples/perplexity/disable-search.php
+++ b/examples/perplexity/disable-search.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Perplexity\Perplexity;
 use Symfony\AI\Platform\Bridge\Perplexity\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -19,11 +18,10 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('PERPLEXITY_API_KEY'), http_client());
 $model = new Perplexity();
-$agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(Message::ofUser('What is 2 + 2?'));
-$response = $agent->call($messages, [
+$response = $platform->invoke($model, $messages, [
     'disable_search' => true,
 ]);
 
-echo $response->getContent().\PHP_EOL;
+echo $response->getResult()->getContent().\PHP_EOL;

--- a/examples/perplexity/web-search.php
+++ b/examples/perplexity/web-search.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Perplexity\Perplexity;
 use Symfony\AI\Platform\Bridge\Perplexity\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -19,10 +18,9 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('PERPLEXITY_API_KEY'), http_client());
 $model = new Perplexity();
-$agent = new Agent($platform, $model, logger: logger());
 
 $messages = new MessageBag(Message::ofUser('What is the best French cheese?'));
-$response = $agent->call($messages, [
+$response = $platform->invoke($model, $messages, [
     'search_domain_filter' => [
         'https://en.wikipedia.org/wiki/Cheese',
     ],
@@ -31,4 +29,4 @@ $response = $agent->call($messages, [
     'search_recency_filter' => 'week',
 ]);
 
-echo $response->getContent().\PHP_EOL;
+echo $response->getResult()->getContent().\PHP_EOL;

--- a/examples/replicate/chat-llama.php
+++ b/examples/replicate/chat-llama.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Bridge\Replicate\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,11 +19,10 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('REPLICATE_API_KEY'), http_client());
 $model = new Llama();
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/vertexai/audio-input.php
+++ b/examples/vertexai/audio-input.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Audio;
@@ -21,13 +20,12 @@ require_once __DIR__.'/bootstrap.php';
 $platform = PlatformFactory::create(env('GOOGLE_CLOUD_LOCATION'), env('GOOGLE_CLOUD_PROJECT'), adc_aware_http_client());
 $model = new Model(Model::GEMINI_2_5_FLASH);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         'What is this recording about?',
         Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/vertexai/chat.php
+++ b/examples/vertexai/chat.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,11 +19,10 @@ require_once __DIR__.'/bootstrap.php';
 $platform = PlatformFactory::create(env('GOOGLE_CLOUD_LOCATION'), env('GOOGLE_CLOUD_PROJECT'), adc_aware_http_client());
 $model = new Model(Model::GEMINI_2_5_FLASH);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an expert assistant in geography.'),
     Message::ofUser('Where is Mount Fuji?'),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/vertexai/image-input.php
+++ b/examples/vertexai/image-input.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Image;
@@ -21,7 +20,6 @@ require_once __DIR__.'/bootstrap.php';
 $platform = PlatformFactory::create(env('GOOGLE_CLOUD_LOCATION'), env('GOOGLE_CLOUD_PROJECT'), adc_aware_http_client());
 $model = new Model(Model::GEMINI_2_5_PRO);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
     Message::ofUser(
@@ -29,6 +27,6 @@ $messages = new MessageBag(
         Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg'),
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/vertexai/pdf-input-binary.php
+++ b/examples/vertexai/pdf-input-binary.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Content\Document;
@@ -21,13 +20,12 @@ require_once __DIR__.'/bootstrap.php';
 $platform = PlatformFactory::create(env('GOOGLE_CLOUD_LOCATION'), env('GOOGLE_CLOUD_PROJECT'), adc_aware_http_client());
 $model = new Model(Model::GEMINI_2_5_FLASH);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::ofUser(
         Document::fromFile(dirname(__DIR__, 2).'/fixtures/document.pdf'),
         'What is this document about?',
     ),
 );
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/vertexai/server-tools.php
+++ b/examples/vertexai/server-tools.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,7 +19,6 @@ require_once __DIR__.'/bootstrap.php';
 $platform = PlatformFactory::create(env('GOOGLE_CLOUD_LOCATION'), env('GOOGLE_CLOUD_PROJECT'), adc_aware_http_client());
 
 $model = new Model(Model::GEMINI_2_5_PRO, ['server_tools' => ['url_context' => true]]);
-$agent = new Agent($platform, $model, [], [], logger: logger());
 
 $messages = new MessageBag(
     Message::ofUser(
@@ -30,6 +28,6 @@ $messages = new MessageBag(
     ),
 );
 
-$result = $agent->call($messages);
+$result = $platform->invoke($model, $messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/vertexai/stream.php
+++ b/examples/vertexai/stream.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -20,17 +19,16 @@ require_once __DIR__.'/bootstrap.php';
 $platform = PlatformFactory::create(env('GOOGLE_CLOUD_LOCATION'), env('GOOGLE_CLOUD_PROJECT'), adc_aware_http_client());
 $model = new Model(Model::GEMINI_2_5_FLASH);
 
-$agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(
     Message::forSystem('You are an expert assistant in geography.'),
     Message::ofUser('Where is Mount Fuji?'),
 );
 
-$result = $agent->call($messages, [
+$result = $platform->invoke($model, $messages, [
     'stream' => true,
 ]);
 
-foreach ($result->getContent() as $word) {
+foreach ($result->getResult()->getContent() as $word) {
     echo $word;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix #522
| License       | MIT

Remove usage of agents when not needed

Tasklist : 

- [x] Albert
- [x] Anthropic
- [x] Azure
- [x] Bedrock
- [x] Cerebras
- [x] Commands
- [x] Document
- [x] ElevenLabs
- [x] Gemini
- [x] HuggingFace
- [x] Indexer
- [x] LMStudio
- [x] Memory
- [x] Misc
- [x] Mistral
- [x] Ollama
- [x] OpenAI
- [x] OpenRouter
- [x] Perplexity
- [x] Rag
- [x] Replicate
- [x] Toolbox
- [x] Transformers
- [x] VertexAI
- [x] Voyage
