### PR TITLE
[Store] Support `\Stringable` in `VectorizerInterface::vectorize`

### DIFF
--- a/src/store/src/Document/Vectorizer.php
+++ b/src/store/src/Document/Vectorizer.php
@@ -67,11 +67,11 @@ final readonly class Vectorizer implements VectorizerInterface
         return $vectorDocuments;
     }
 
-    public function vectorize(string $string): Vector
+    public function vectorize(string|\Stringable $string): Vector
     {
-        $this->logger->debug('Vectorizing string', ['string' => $string]);
+        $this->logger->debug('Vectorizing string', ['string' => (string) $string]);
 
-        $result = $this->platform->invoke($this->model, $string);
+        $result = $this->platform->invoke($this->model, (string) $string);
         $vectors = $result->asVectors();
 
         if (!isset($vectors[0])) {

--- a/src/store/src/Document/VectorizerInterface.php
+++ b/src/store/src/Document/VectorizerInterface.php
@@ -29,7 +29,7 @@ interface VectorizerInterface
     public function vectorizeTextDocuments(array $documents): array;
 
     /**
-     * Vectorizes a single string into a Vector.
+     * Vectorizes a single string or Stringable object into a Vector.
      */
-    public function vectorize(string $string): Vector;
+    public function vectorize(string|\Stringable $string): Vector;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Allow string|\Stringable parameter type for the vectorize method to support objects implementing Stringable interface.
