### PR TITLE
[Platform] Remove temperature default values from Model classes and examples

### DIFF
--- a/examples/misc/parallel-chat-gpt.php
+++ b/examples/misc/parallel-chat-gpt.php
@@ -17,9 +17,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI, [
-    'temperature' => 0.5, // default options for the model
-]);
+$model = new Gpt(Gpt::GPT_4O_MINI);
 
 $messages = new MessageBag(
     Message::forSystem('You will be given a letter and you answer with only the next letter of the alphabet.'),

--- a/examples/openai/chat.php
+++ b/examples/openai/chat.php
@@ -18,9 +18,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI, [
-    'temperature' => 0.5, // default options for the model
-]);
+$model = new Gpt(Gpt::GPT_4O_MINI);
 
 $agent = new Agent($platform, $model, logger: logger());
 $messages = new MessageBag(

--- a/examples/openai/token-metadata.php
+++ b/examples/openai/token-metadata.php
@@ -19,9 +19,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Gpt(Gpt::GPT_4O_MINI, [
-    'temperature' => 0.5, // default options for the model
-]);
+$model = new Gpt(Gpt::GPT_4O_MINI);
 
 $agent = new Agent($platform, $model, outputProcessors: [new TokenOutputProcessor()], logger: logger());
 $messages = new MessageBag(

--- a/src/platform/src/Bridge/Anthropic/Claude.php
+++ b/src/platform/src/Bridge/Anthropic/Claude.php
@@ -36,7 +36,7 @@ class Claude extends Model
      */
     public function __construct(
         string $name = self::SONNET_37,
-        array $options = ['temperature' => 1.0, 'max_tokens' => 1000],
+        array $options = ['max_tokens' => 1000],
     ) {
         $capabilities = [
             Capability::INPUT_MESSAGES,

--- a/src/platform/src/Bridge/Bedrock/Nova/Nova.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/Nova.php
@@ -29,7 +29,7 @@ final class Nova extends Model
      */
     public function __construct(
         string $name = self::PRO,
-        array $options = ['temperature' => 1.0, 'max_tokens' => 1000],
+        array $options = ['max_tokens' => 1000],
     ) {
         $capabilities = [
             Capability::INPUT_MESSAGES,

--- a/src/platform/src/Bridge/Gemini/Gemini.php
+++ b/src/platform/src/Bridge/Gemini/Gemini.php
@@ -28,7 +28,7 @@ class Gemini extends Model
     /**
      * @param array<string, mixed> $options The default options for the model usage
      */
-    public function __construct(string $name = self::GEMINI_2_PRO, array $options = ['temperature' => 1.0])
+    public function __construct(string $name = self::GEMINI_2_PRO, array $options = [])
     {
         $capabilities = [
             Capability::INPUT_MESSAGES,

--- a/src/platform/src/Bridge/LmStudio/Completions.php
+++ b/src/platform/src/Bridge/LmStudio/Completions.php
@@ -27,7 +27,7 @@ class Completions extends Model
 
     public function __construct(
         string $name,
-        array $options = ['temperature' => 0.7],
+        array $options = [],
         array $capabilities = self::DEFAULT_CAPABILITIES,
     ) {
         parent::__construct($name, $capabilities, $options);

--- a/src/platform/src/Bridge/OpenAi/Gpt.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt.php
@@ -75,7 +75,7 @@ class Gpt extends Model
      */
     public function __construct(
         string $name = self::GPT_4O,
-        array $options = ['temperature' => 1.0],
+        array $options = [],
     ) {
         $capabilities = [
             Capability::INPUT_MESSAGES,

--- a/src/platform/tests/Bridge/OpenAi/GptTest.php
+++ b/src/platform/tests/Bridge/OpenAi/GptTest.php
@@ -28,7 +28,7 @@ final class GptTest extends TestCase
         $gpt = new Gpt();
 
         $this->assertSame(Gpt::GPT_4O, $gpt->getName());
-        $this->assertSame(['temperature' => 1.0], $gpt->getOptions());
+        $this->assertSame([], $gpt->getOptions());
     }
 
     public function testItCreatesGptWithCustomSettings()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Removed temperature defaults from constructor parameters in:
- OpenAI Gpt model (was 1.0)
- LmStudio Completions model (was 0.7)
- Gemini model (was 1.0)
- Bedrock Nova model (was 1.0)
- Anthropic Claude model (was 1.0)

Also removed temperature from example files to let models use their natural defaults.