### PR TITLE
[Agent] Brave] Fix validation attribute for string parameter in tool

### DIFF
--- a/src/agent/src/Toolbox/Tool/Brave.php
+++ b/src/agent/src/Toolbox/Tool/Brave.php
@@ -45,7 +45,7 @@ final readonly class Brave
      * }>
      */
     public function __invoke(
-        #[With(maximum: 500)]
+        #[With(maxLength: 500)]
         string $query,
         int $count = 20,
         #[With(minimum: 0, maximum: 9)]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Changed #[With(maximum: 500)] to #[With(maxLength: 500)] for the $query parameter since maximum is for numeric values while maxLength is for string length validation.