### PR TITLE
[Platform] PoC trait for handling providers api errors

### DIFF
--- a/src/platform/src/ResultConverterStatusExceptionTrait.php
+++ b/src/platform/src/ResultConverterStatusExceptionTrait.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform;
+
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Floran Pagliai <floran.pagliai@gmail.com>
+ */
+trait ResultConverterStatusExceptionTrait
+{
+    /**
+     * Handle HTTP status codes and throw appropriate exceptions.
+     *
+     * @throws AuthenticationException When status code is 401
+     * @throws RateLimitExceededException When status code is 429
+     * @throws RuntimeException For other error status codes
+     */
+    protected function validateStatusCode(ResponseInterface $response): void
+    {
+        $statusCode = $response->getStatusCode();
+
+        if (200 <= $statusCode && 300 > $statusCode) {
+            return;
+        }
+
+        switch ($statusCode) {
+            case 401:
+                $this->handleAuthenticationError($response);
+            case 429:
+                $this->handleRateLimitExceeded($response);
+            default:
+                $this->handleGenericError($response);
+        }
+    }
+
+    protected function handleAuthenticationError(ResponseInterface $response): void
+    {
+        $message = $this->extractErrorMessage($response, 'Authentication failed');
+        throw new AuthenticationException($message);
+    }
+
+    protected function handleRateLimitExceeded(ResponseInterface $response): void
+    {
+        $retryAfter = $this->extractRetryAfterValue($response);
+        // https://github.com/symfony/ai/pull/538
+//        throw new RateLimitExceededException($retryAfter);
+    }
+
+    protected function handleGenericError(ResponseInterface $response): void
+    {
+        $message = $this->extractErrorMessage($response, 'API error: ' . $response->getStatusCode());
+        throw new RuntimeException($message);
+    }
+
+    protected function extractRetryAfterValue(ResponseInterface $response): ?float
+    {
+        $headers = $response->getHeaders(false);
+
+        if (isset($headers['retry-after'][0])) {
+            return (float) $headers['retry-after'][0];
+        }
+
+        return null;
+    }
+
+    protected function extractErrorMessage(ResponseInterface $response, string $defaultMessage): string
+    {
+        try {
+            $data = json_decode($response->getContent(false), true, 512, JSON_THROW_ON_ERROR);
+
+            if (isset($data['error']['message'])) {
+                return $data['error']['message'];
+            }
+
+            if (isset($data['message'])) {
+                return $data['message'];
+            }
+
+            if (isset($data['error']) && is_string($data['error'])) {
+                return $data['error'];
+            }
+
+            if (isset($data['error_description'])) {
+                return $data['error_description'];
+            }
+        } catch (\Throwable) {
+            // Fallback to default message if JSON parsing fails
+        }
+
+        return $defaultMessage;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | #528 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

 I've created a simple trait to standardize HTTP response status code handling across different platform bridges. Currently, each bridge implements its own error handling, leading to inconsistent exception behavior and code duplication.

  The ResultConverterStatusExceptionTrait

  This trait provides:
  - Common method validateStatusCode() for checking HTTP response status codes
  - Standardized handling of 401, 429, and other error codes
  - Extension points for platform-specific headers (like OpenAI's x-ratelimit headers)
  - Consistent error message extraction from responses

Need feedback:
- Is this trait approach the right way to standardize error handling? Or would you prefer a different pattern?
- Should the trait be more or less opinionated about which status codes to handle?
- Are there other common error patterns that should be included?
- Is the naming appropriate and in line with conventions?

  Depending on feedback, I plan to implement this in all ResultConverters to standardize error handling across platforms.