### PR TITLE
[Platform] Add event system for string input conversion

### DIFF
--- a/src/platform/composer.json
+++ b/src/platform/composer.json
@@ -48,6 +48,7 @@
         "phpstan/phpdoc-parser": "^2.1",
         "psr/log": "^3.0",
         "symfony/clock": "^7.3|^8.0",
+        "symfony/event-dispatcher": "^7.3|^8.0",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/property-access": "^7.3|^8.0",
         "symfony/property-info": "^7.3|^8.0",
@@ -66,7 +67,6 @@
         "symfony/ai-agent": "@dev",
         "symfony/console": "^7.3|^8.0",
         "symfony/dotenv": "^7.3|^8.0",
-        "symfony/event-dispatcher": "^7.3|^8.0",
         "symfony/finder": "^7.3|^8.0",
         "symfony/process": "^7.3|^8.0",
         "symfony/var-dumper": "^7.3|^8.0"

--- a/src/platform/src/Event/InvocationEvent.php
+++ b/src/platform/src/Event/InvocationEvent.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Event;
+
+use Symfony\AI\Platform\Model;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event dispatched before platform invocation to allow modification of input data.
+ *
+ * @author Ramy Hakam <pencilsoft1@gmail.com>
+ */
+final class InvocationEvent extends Event
+{
+    /**
+     * @param array<string, mixed>|string|object $input
+     * @param array<string, mixed>               $options
+     */
+    public function __construct(
+        private Model $model,
+        private array|string|object $input,
+        private array $options = [],
+    ) {
+    }
+
+    public function getModel(): Model
+    {
+        return $this->model;
+    }
+
+    public function setModel(Model $model): void
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * @return array<string, mixed>|string|object
+     */
+    public function getInput(): array|string|object
+    {
+        return $this->input;
+    }
+
+    /**
+     * @param array<string, mixed>|string|object $input
+     */
+    public function setInput(array|string|object $input): void
+    {
+        $this->input = $input;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+}

--- a/src/platform/src/EventListener/StringToMessageBagListener.php
+++ b/src/platform/src/EventListener/StringToMessageBagListener.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\EventListener;
+
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Event\InvocationEvent;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+/**
+ * Converts string inputs to MessageBag for models that support INPUT_MESSAGES capability.
+ *
+ * @author Ramy Hakam <pencilsoft1@gmail.com>
+ */
+final class StringToMessageBagListener
+{
+    public function __invoke(InvocationEvent $event): void
+    {
+        // Only process string inputs
+        if (!\is_string($event->getInput())) {
+            return;
+        }
+
+        // Only process models that support INPUT_MESSAGES capability
+        if (!$event->getModel()->supports(Capability::INPUT_MESSAGES)) {
+            return;
+        }
+
+        // Convert string to MessageBag with a user message
+        $event->setInput(new MessageBag(Message::ofUser($event->getInput())));
+    }
+}

--- a/src/platform/tests/Event/InvocationEventTest.php
+++ b/src/platform/tests/Event/InvocationEventTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Event\InvocationEvent;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Model;
+
+final class InvocationEventTest extends TestCase
+{
+    public function testGettersReturnCorrectValues()
+    {
+        $model = new class('test-model', [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]) extends Model {
+        };
+
+        $input = 'Hello, world!';
+        $options = ['temperature' => 0.7];
+
+        $event = new InvocationEvent($model, $input, $options);
+
+        $this->assertSame($model, $event->getModel());
+        $this->assertSame($input, $event->getInput());
+        $this->assertSame($options, $event->getOptions());
+    }
+
+    public function testSetInputChangesInput()
+    {
+        $model = new class('test-model', [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]) extends Model {
+        };
+
+        $originalInput = 'Hello, world!';
+        $newInput = new MessageBag(Message::ofUser('Hello, world!'));
+
+        $event = new InvocationEvent($model, $originalInput);
+        $event->setInput($newInput);
+
+        $this->assertSame($newInput, $event->getInput());
+    }
+
+    public function testWorksWithDifferentInputTypes()
+    {
+        $model = new class('test-model', [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]) extends Model {
+        };
+
+        // Test with string
+        $stringEvent = new InvocationEvent($model, 'string input');
+        $this->assertIsString($stringEvent->getInput());
+
+        // Test with array
+        $arrayEvent = new InvocationEvent($model, ['key' => 'value']);
+        $this->assertIsArray($arrayEvent->getInput());
+
+        // Test with object
+        $objectInput = new MessageBag();
+        $objectEvent = new InvocationEvent($model, $objectInput);
+        $this->assertSame($objectInput, $objectEvent->getInput());
+    }
+}

--- a/src/platform/tests/EventListener/StringToMessageBagListenerTest.php
+++ b/src/platform/tests/EventListener/StringToMessageBagListenerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Event\InvocationEvent;
+use Symfony\AI\Platform\EventListener\StringToMessageBagListener;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Model;
+
+final class StringToMessageBagListenerTest extends TestCase
+{
+    public function testConvertsStringInputToMessageBagForMessagesCapableModel()
+    {
+        $model = new class('test-model', [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]) extends Model {
+        };
+
+        $event = new InvocationEvent($model, 'Hello, world!');
+        $listener = new StringToMessageBagListener();
+
+        $listener($event);
+
+        $this->assertInstanceOf(MessageBag::class, $event->getInput());
+        $this->assertCount(1, $event->getInput()->getMessages());
+        $message = $event->getInput()->getMessages()[0];
+        $this->assertInstanceOf(UserMessage::class, $message);
+        $this->assertCount(1, $message->getContent());
+        $content = $message->getContent()[0];
+        $this->assertInstanceOf(Text::class, $content);
+        $this->assertSame('Hello, world!', $content->getText());
+    }
+
+    public function testDoesNotConvertStringInputForNonMessagesCapableModel()
+    {
+        $model = new class('test-model', [Capability::INPUT_TEXT, Capability::OUTPUT_TEXT]) extends Model {
+        };
+
+        $originalInput = 'Hello, world!';
+        $event = new InvocationEvent($model, $originalInput);
+        $listener = new StringToMessageBagListener();
+
+        $listener($event);
+
+        $this->assertSame($originalInput, $event->getInput());
+    }
+
+    public function testDoesNotConvertNonStringInput()
+    {
+        $model = new class('test-model', [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]) extends Model {
+        };
+
+        $originalInput = new MessageBag(Message::ofUser('Hello'));
+        $event = new InvocationEvent($model, $originalInput);
+        $listener = new StringToMessageBagListener();
+
+        $listener($event);
+
+        $this->assertSame($originalInput, $event->getInput());
+    }
+
+    public function testDoesNotConvertArrayInput()
+    {
+        $model = new class('test-model', [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]) extends Model {
+        };
+
+        $originalInput = ['key' => 'value'];
+        $event = new InvocationEvent($model, $originalInput);
+        $listener = new StringToMessageBagListener();
+
+        $listener($event);
+
+        $this->assertSame($originalInput, $event->getInput());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #326
| License       | MIT

## Description

Implements event-based input processing to resolve fatal errors when string payloads are passed to ModelClient implementations using `array_merge($payload, $options)`.

**Solution:**
- `PlatformInvokationEvent`: Dispatched before platform invocation
- `StringToMessageBagListener`: Converts strings to MessageBag for models with INPUT_MESSAGES capability
- Enables simple usage: `$platform->invoke($model, 'Hello')`

**Backward Compatible:** EventDispatcher is optional, existing code unchanged.
