### PR TITLE
[AI Bundle] Restructure `system_prompt` configuration to nest `include_tools`

### DIFF
--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -35,8 +35,9 @@ ai:
                 name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI
                 options:
                     temperature: 0.5
-            system_prompt: 'Please answer the users question based on Wikipedia and provide a link to the article.'
-            include_tools: true
+            system_prompt:
+                prompt: 'Please answer the users question based on Wikipedia and provide a link to the article.'
+                include_tools: true
             tools:
                 - 'Symfony\AI\Agent\Toolbox\Tool\Wikipedia'
         audio:

--- a/src/ai-bundle/doc/index.rst
+++ b/src/ai-bundle/doc/index.rst
@@ -71,8 +71,9 @@ Configuration
                 model:
                     class: 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'
                     name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI
-                system_prompt: 'You are a helpful assistant that can answer questions.' # The default system prompt of the agent
-                include_tools: true # Include tool definitions at the end of the system prompt
+                system_prompt: # The system prompt configuration
+                    prompt: 'You are a helpful assistant that can answer questions.' # The prompt text
+                    include_tools: true # Include tool definitions at the end of the system prompt
                 tools:
                     # Referencing a service with #[AsTool] attribute
                     - 'Symfony\AI\Agent\Toolbox\Tool\SimilaritySearch'
@@ -143,6 +144,43 @@ Configuration
             research:
                 vectorizer: 'ai.vectorizer.mistral_embeddings'
                 store: 'ai.store.memory.research'
+
+System Prompt Configuration
+---------------------------
+
+For basic usage, specify the system prompt as a simple string:
+
+.. code-block:: yaml
+
+    ai:
+        agent:
+            my_agent:
+                model:
+                    class: 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'
+                    name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI
+                system_prompt: 'You are a helpful assistant.'
+
+**Advanced Configuration**
+
+For more control, such as including tool definitions in the system prompt, use the array format:
+
+.. code-block:: yaml
+
+    ai:
+        agent:
+            my_agent:
+                model:
+                    class: 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'
+                    name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI
+                system_prompt:
+                    prompt: 'You are a helpful assistant that can answer questions.'
+                    include_tools: true # Include tool definitions at the end of the system prompt
+
+The array format supports these options:
+
+* ``prompt`` (string, required): The system prompt text that will be sent to the AI model
+* ``include_tools`` (boolean, optional): When set to ``true``, tool definitions will be appended to the system prompt
+
 
 Usage
 -----

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -604,11 +604,13 @@ final class AiBundle extends AbstractBundle
         }
 
         // SYSTEM PROMPT
-        if (\is_string($config['system_prompt'])) {
+        if (isset($config['system_prompt'])) {
+            $includeTools = isset($config['system_prompt']['include_tools']) && $config['system_prompt']['include_tools'];
+
             $systemPromptInputProcessorDefinition = (new Definition(SystemPromptInputProcessor::class))
                 ->setArguments([
-                    $config['system_prompt'],
-                    $config['include_tools'] ? new Reference('ai.toolbox.'.$name) : null,
+                    $config['system_prompt']['prompt'],
+                    $includeTools ? new Reference('ai.toolbox.'.$name) : null,
                     new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
                 ])
                 ->addTag('ai.agent.input_processor', ['agent' => $agentId, 'priority' => -30]);


### PR DESCRIPTION
| Q | A |
|---|---|
| Bug fix? | no |
| New feature? | yes |
| Docs? | yes |
| Issues | Eases implementation of [#514](https://github.com/symfony/ai/pull/514) |
| License | MIT |

## Summary

Restructures `system_prompt` configuration to nest `include_tools` for better organization and ergonomics.

## Changes

- Move `include_tools` from agent level to `system_prompt` level
- Support both string (simple) and array (advanced) formats

## Before

```yaml
system_prompt: 'You are helpful.'
include_tools: true
```

## After

### simple
```yaml
system_prompt: 'You are helpful.'
```

### advanced
```yaml
system_prompt:
    prompt: 'You are helpful.'
    include_tools: true
```