### PR TITLE
[Platform] Remove default model names from constructor parameters

### DIFF
--- a/demo/src/Blog/Command/QueryCommand.php
+++ b/demo/src/Blog/Command/QueryCommand.php
@@ -44,7 +44,7 @@ final class QueryCommand
         $io->comment(\sprintf('Converting "%s" to vector & searching in Chroma DB ...', $search));
         $io->comment('Results are limited to 4 most similar documents.');
 
-        $platformResponse = $this->platform->invoke(new Embeddings(), $search);
+        $platformResponse = $this->platform->invoke(new Embeddings(Embeddings::TEXT_3_SMALL), $search);
         $queryResponse = $collection->query(
             queryEmbeddings: [$platformResponse->asVectors()[0]->getData()],
             nResults: 4,

--- a/examples/azure/audio-transcript.php
+++ b/examples/azure/audio-transcript.php
@@ -22,7 +22,7 @@ $platform = PlatformFactory::create(
     env('AZURE_OPENAI_KEY'),
     http_client(),
 );
-$model = new Whisper();
+$model = new Whisper(Whisper::WHISPER_1);
 $file = Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3');
 
 $result = $platform->invoke($model, $file);

--- a/examples/azure/embeddings.php
+++ b/examples/azure/embeddings.php
@@ -21,7 +21,7 @@ $platform = PlatformFactory::create(
     env('AZURE_OPENAI_KEY'),
     http_client(),
 );
-$embeddings = new Embeddings();
+$embeddings = new Embeddings(Embeddings::TEXT_3_SMALL);
 
 $result = $platform->invoke($embeddings, <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.

--- a/examples/cerebras/chat.php
+++ b/examples/cerebras/chat.php
@@ -22,6 +22,6 @@ $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('How is the weather in Tokyo today?'),
 );
-$result = $platform->invoke(new Model(), $messages);
+$result = $platform->invoke(new Model(Model::LLAMA3_1_8B), $messages);
 
 echo $result->getResult()->getContent().\PHP_EOL;

--- a/examples/cerebras/stream.php
+++ b/examples/cerebras/stream.php
@@ -23,7 +23,7 @@ $messages = new MessageBag(
     Message::ofUser('What are the top three destinations in France?'),
 );
 
-$result = $platform->invoke(new Model(), $messages, [
+$result = $platform->invoke(new Model(Model::LLAMA3_1_8B), $messages, [
     'stream' => true,
 ]);
 

--- a/examples/gemini/embeddings.php
+++ b/examples/gemini/embeddings.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$embeddings = new Embeddings();
+$embeddings = new Embeddings(Embeddings::GEMINI_EMBEDDING_EXP_03_07);
 
 $result = $platform->invoke($embeddings, <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.

--- a/examples/memory/mariadb.php
+++ b/examples/memory/mariadb.php
@@ -59,7 +59,7 @@ $store->setup();
 
 // create embeddings for documents as preparation of the chain memory
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL));
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/mistral/embeddings.php
+++ b/examples/mistral/embeddings.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Mistral\PlatformFactory;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('MISTRAL_API_KEY'), http_client());
-$model = new Embeddings();
+$model = new Embeddings(Embeddings::MISTRAL_EMBED);
 
 $result = $platform->invoke($model, <<<TEXT
     In the middle of the 20th century, food scientists began to understand the importance of vitamins and minerals in

--- a/examples/ollama/stream.php
+++ b/examples/ollama/stream.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
-$model = new Ollama();
+$model = new Ollama(Ollama::LLAMA_3_2);
 
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),

--- a/examples/ollama/structured-output-math.php
+++ b/examples/ollama/structured-output-math.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
-$model = new Ollama();
+$model = new Ollama(Ollama::LLAMA_3_2);
 
 $processor = new AgentProcessor();
 $agent = new Agent($platform, $model, [$processor], [$processor], logger: logger());

--- a/examples/ollama/toolcall.php
+++ b/examples/ollama/toolcall.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
-$model = new Ollama();
+$model = new Ollama(Ollama::LLAMA_3_2);
 
 $toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);

--- a/examples/openai/audio-transcript.php
+++ b/examples/openai/audio-transcript.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Message\Content\Audio;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$model = new Whisper();
+$model = new Whisper(Whisper::WHISPER_1);
 $file = Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3');
 
 $result = $platform->invoke($model, $file);

--- a/examples/openai/embeddings.php
+++ b/examples/openai/embeddings.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$embeddings = new Embeddings();
+$embeddings = new Embeddings(Embeddings::TEXT_3_SMALL);
 
 $result = $platform->invoke($embeddings, <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.

--- a/examples/openai/image-output-dall-e-2.php
+++ b/examples/openai/image-output-dall-e-2.php
@@ -17,7 +17,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
 $result = $platform->invoke(
-    model: new DallE(), // Utilize Dall-E 2 version in default
+    model: new DallE(DallE::DALL_E_2),
     input: 'A cartoon-style elephant with a long trunk and large ears.',
     options: [
         'response_format' => 'url', // Generate response as URL

--- a/examples/rag/cache.php
+++ b/examples/rag/cache.php
@@ -45,7 +45,7 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/chromadb.php
+++ b/examples/rag/chromadb.php
@@ -51,7 +51,7 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/clickhouse.php
+++ b/examples/rag/clickhouse.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/cloudflare.php
+++ b/examples/rag/cloudflare.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents (keep in mind that upserting vectors is asynchronous)
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/in-memory.php
+++ b/examples/rag/in-memory.php
@@ -44,7 +44,7 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/mariadb-gemini.php
+++ b/examples/rag/mariadb-gemini.php
@@ -54,8 +54,8 @@ $store->setup(['dimensions' => 768]);
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
-$embeddings = new Embeddings(options: ['dimensions' => 768, 'task_type' => TaskType::SemanticSimilarity]);
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$embeddings = new Embeddings(Embeddings::GEMINI_EMBEDDING_EXP_03_07, ['dimensions' => 768, 'task_type' => TaskType::SemanticSimilarity]);
+$vectorizer = new Vectorizer($platform, $embeddings, logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/mariadb-openai.php
+++ b/examples/rag/mariadb-openai.php
@@ -53,7 +53,7 @@ $store->setup();
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/meilisearch.php
+++ b/examples/rag/meilisearch.php
@@ -52,7 +52,7 @@ $store->setup();
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/milvus.php
+++ b/examples/rag/milvus.php
@@ -53,7 +53,7 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/mongodb.php
+++ b/examples/rag/mongodb.php
@@ -51,7 +51,7 @@ foreach (Movies::all() as $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'));
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/neo4j.php
+++ b/examples/rag/neo4j.php
@@ -55,7 +55,7 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/pinecone.php
+++ b/examples/rag/pinecone.php
@@ -45,7 +45,7 @@ foreach (Movies::all() as $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/postgres.php
+++ b/examples/rag/postgres.php
@@ -52,7 +52,7 @@ $store->setup();
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/qdrant.php
+++ b/examples/rag/qdrant.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/surrealdb.php
+++ b/examples/rag/surrealdb.php
@@ -55,7 +55,7 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/typesense.php
+++ b/examples/rag/typesense.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/rag/weaviate.php
+++ b/examples/rag/weaviate.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $i => $movie) {
 
 // create embeddings for documents
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
-$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(), logger());
+$vectorizer = new Vectorizer($platform, $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
 $indexer->index($documents);
 

--- a/examples/replicate/chat-llama.php
+++ b/examples/replicate/chat-llama.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('REPLICATE_API_KEY'), http_client());
-$model = new Llama();
+$model = new Llama(Llama::V3_1_405B_INSTRUCT);
 
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),

--- a/examples/vertexai/embeddings.php
+++ b/examples/vertexai/embeddings.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\VertexAi\PlatformFactory;
 require_once __DIR__.'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('GOOGLE_CLOUD_LOCATION'), env('GOOGLE_CLOUD_PROJECT'), adc_aware_http_client());
-$embeddings = new Model();
+$embeddings = new Model(Model::GEMINI_EMBEDDING_001);
 
 $result = $platform->invoke($embeddings, <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.

--- a/examples/voyage/embeddings.php
+++ b/examples/voyage/embeddings.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Voyage\Voyage;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('VOYAGE_API_KEY'), http_client());
-$embeddings = new Voyage();
+$embeddings = new Voyage(Voyage::V3);
 
 $result = $platform->invoke($embeddings, <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.

--- a/examples/voyage/multiple-embeddings.php
+++ b/examples/voyage/multiple-embeddings.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Voyage\Voyage;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('VOYAGE_API_KEY'), http_client());
-$embeddings = new Voyage();
+$embeddings = new Voyage(Voyage::V3);
 
 $text1 = 'Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.';
 $text2 = 'The people of Japan were very kind and hardworking. They loved their country very much and took care of it.';

--- a/src/platform/doc/index.rst
+++ b/src/platform/doc/index.rst
@@ -36,7 +36,7 @@ For example, to use the OpenAI provider, you would typically do something like t
     $platform = PlatformFactory::create(env('OPENAI_API_KEY'));
 
     // Embeddings Model
-    $embeddings = new Embeddings();
+    $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL);
 
     // Language Model in version gpt-4o-mini
     $model = new Gpt(Gpt::GPT_4O_MINI);

--- a/src/platform/src/Bridge/Cerebras/Model.php
+++ b/src/platform/src/Bridge/Cerebras/Model.php
@@ -39,7 +39,7 @@ final class Model extends BaseModel
      * @see https://inference-docs.cerebras.ai/api-reference/chat-completions for details like options
      */
     public function __construct(
-        string $name = self::LLAMA3_1_8B,
+        string $name,
         array $capabilities = self::CAPABILITIES,
         array $options = [],
     ) {

--- a/src/platform/src/Bridge/Gemini/Embeddings.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings.php
@@ -27,7 +27,7 @@ class Embeddings extends Model
     /**
      * @param array{dimensions?: int, task_type?: TaskType|string} $options
      */
-    public function __construct(string $name = self::GEMINI_EMBEDDING_EXP_03_07, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         parent::__construct($name, [Capability::INPUT_MULTIPLE], $options);
     }

--- a/src/platform/src/Bridge/Gemini/Gemini.php
+++ b/src/platform/src/Bridge/Gemini/Gemini.php
@@ -28,7 +28,7 @@ class Gemini extends Model
     /**
      * @param array<string, mixed> $options The default options for the model usage
      */
-    public function __construct(string $name = self::GEMINI_2_PRO, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         $capabilities = [
             Capability::INPUT_MESSAGES,

--- a/src/platform/src/Bridge/Meta/Llama.php
+++ b/src/platform/src/Bridge/Meta/Llama.php
@@ -38,7 +38,7 @@ class Llama extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name = self::V3_1_405B_INSTRUCT, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         $capabilities = [
             Capability::INPUT_MESSAGES,

--- a/src/platform/src/Bridge/Ollama/Ollama.php
+++ b/src/platform/src/Bridge/Ollama/Ollama.php
@@ -64,7 +64,7 @@ class Ollama extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name = self::LLAMA_3_2, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         $capabilities = [];
 

--- a/src/platform/src/Bridge/OpenAi/DallE.php
+++ b/src/platform/src/Bridge/OpenAi/DallE.php
@@ -23,7 +23,7 @@ class DallE extends Model
     public const DALL_E_3 = 'dall-e-3';
 
     /** @param array<string, mixed> $options The default options for the model usage */
-    public function __construct(string $name = self::DALL_E_2, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         $capabilities = [
             Capability::INPUT_TEXT,

--- a/src/platform/src/Bridge/OpenAi/Embeddings.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings.php
@@ -25,7 +25,7 @@ class Embeddings extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name = self::TEXT_3_SMALL, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         parent::__construct($name, [], $options);
     }

--- a/src/platform/src/Bridge/OpenAi/Whisper.php
+++ b/src/platform/src/Bridge/OpenAi/Whisper.php
@@ -24,7 +24,7 @@ class Whisper extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name = self::WHISPER_1, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         $capabilities = [
             Capability::INPUT_AUDIO,

--- a/src/platform/src/Bridge/VertexAi/Embeddings/Model.php
+++ b/src/platform/src/Bridge/VertexAi/Embeddings/Model.php
@@ -29,7 +29,7 @@ final class Model extends BaseModel
     /**
      * @see https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api for various options
      */
-    public function __construct(string $name = self::GEMINI_EMBEDDING_001, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         parent::__construct($name, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE], $options);
     }

--- a/src/platform/src/Bridge/VertexAi/Gemini/Model.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/Model.php
@@ -30,7 +30,7 @@ final class Model extends BaseModel
      *
      * @see https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference for more details
      */
-    public function __construct(string $name = self::GEMINI_2_5_PRO, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         $capabilities = [
             Capability::INPUT_MESSAGES,

--- a/src/platform/src/Bridge/Voyage/Voyage.php
+++ b/src/platform/src/Bridge/Voyage/Voyage.php
@@ -36,7 +36,7 @@ class Voyage extends Model
     /**
      * @param array{dimensions?: int, input_type?: self::INPUT_TYPE_*, truncation?: bool} $options
      */
-    public function __construct(string $name = self::V3, array $options = [])
+    public function __construct(string $name, array $options = [])
     {
         parent::__construct($name, [Capability::INPUT_MULTIPLE], $options);
     }

--- a/src/platform/src/Model.php
+++ b/src/platform/src/Model.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\AI\Platform;
 
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
 class Model
 {
     /**
+     * @param non-empty-string     $name
      * @param Capability[]         $capabilities
      * @param array<string, mixed> $options
      */
@@ -25,8 +28,14 @@ class Model
         private readonly array $capabilities = [],
         private readonly array $options = [],
     ) {
+        if ('' === trim($name)) {
+            throw new InvalidArgumentException('Model name cannot be empty.');
+        }
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getName(): string
     {
         return $this->name;

--- a/src/platform/tests/Bridge/Azure/OpenAi/EmbeddingsModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/EmbeddingsModelClientTest.php
@@ -77,7 +77,7 @@ final class EmbeddingsModelClientTest extends TestCase
     {
         $client = new EmbeddingsModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '2023-12-01', 'api-key');
 
-        $this->assertTrue($client->supports(new Embeddings()));
+        $this->assertTrue($client->supports(new Embeddings(Embeddings::TEXT_3_SMALL)));
     }
 
     public function testItIsExecutingTheCorrectRequest()
@@ -93,6 +93,6 @@ final class EmbeddingsModelClientTest extends TestCase
 
         $httpClient = new MockHttpClient([$resultCallback]);
         $client = new EmbeddingsModelClient($httpClient, 'test.azure.com', 'embeddings-deployment', '2023-12-01', 'test-api-key');
-        $client->request(new Embeddings(), 'Hello, world!');
+        $client->request(new Embeddings(Embeddings::TEXT_3_SMALL), 'Hello, world!');
     }
 }

--- a/src/platform/tests/Bridge/Azure/OpenAi/GptModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/GptModelClientTest.php
@@ -77,7 +77,7 @@ final class GptModelClientTest extends TestCase
     {
         $client = new GptModelClient(new MockHttpClient(), 'test.azure.com', 'deployment', '2023-12-01', 'api-key');
 
-        $this->assertTrue($client->supports(new Gpt()));
+        $this->assertTrue($client->supports(new Gpt(Gpt::GPT_4O)));
     }
 
     public function testItIsExecutingTheCorrectRequest()
@@ -93,6 +93,6 @@ final class GptModelClientTest extends TestCase
 
         $httpClient = new MockHttpClient([$resultCallback]);
         $client = new GptModelClient($httpClient, 'test.azure.com', 'gpt-deployment', '2023-12-01', 'test-api-key');
-        $client->request(new Gpt(), ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
+        $client->request(new Gpt(Gpt::GPT_4O), ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
     }
 }

--- a/src/platform/tests/Bridge/Azure/OpenAi/WhisperModelClientTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/WhisperModelClientTest.php
@@ -78,7 +78,7 @@ final class WhisperModelClientTest extends TestCase
             '2023-12-01-preview',
             'test-key'
         );
-        $model = new Whisper();
+        $model = new Whisper(Whisper::WHISPER_1);
 
         $this->assertTrue($client->supports($model));
     }
@@ -95,7 +95,7 @@ final class WhisperModelClientTest extends TestCase
         ]);
 
         $client = new WhisperModelClient($httpClient, 'test.azure.com', 'whspr', '2023-12', 'test-key');
-        $client->request(new Whisper(), ['file' => 'audio-data']);
+        $client->request(new Whisper(Whisper::WHISPER_1), ['file' => 'audio-data']);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -112,7 +112,7 @@ final class WhisperModelClientTest extends TestCase
         ]);
 
         $client = new WhisperModelClient($httpClient, 'test.azure.com', 'whspr', '2023-12', 'test-key');
-        $client->request(new Whisper(), ['file' => 'audio-data'], ['task' => Task::TRANSCRIPTION]);
+        $client->request(new Whisper(Whisper::WHISPER_1), ['file' => 'audio-data'], ['task' => Task::TRANSCRIPTION]);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -129,7 +129,7 @@ final class WhisperModelClientTest extends TestCase
         ]);
 
         $client = new WhisperModelClient($httpClient, 'test.azure.com', 'whspr', '2023-12', 'test-key');
-        $client->request(new Whisper(), ['file' => 'audio-data'], ['task' => Task::TRANSLATION]);
+        $client->request(new Whisper(Whisper::WHISPER_1), ['file' => 'audio-data'], ['task' => Task::TRANSLATION]);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }

--- a/src/platform/tests/Bridge/Gemini/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/AssistantMessageNormalizerTest.php
@@ -36,7 +36,7 @@ final class AssistantMessageNormalizerTest extends TestCase
         $normalizer = new AssistantMessageNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
-            Contract::CONTEXT_MODEL => new Gemini(),
+            Contract::CONTEXT_MODEL => new Gemini(Gemini::GEMINI_2_PRO),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not an assistant message'));
     }

--- a/src/platform/tests/Bridge/Gemini/Contract/MessageBagNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/MessageBagNormalizerTest.php
@@ -45,7 +45,7 @@ final class MessageBagNormalizerTest extends TestCase
         $normalizer = new MessageBagNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new MessageBag(), context: [
-            Contract::CONTEXT_MODEL => new Gemini(),
+            Contract::CONTEXT_MODEL => new Gemini(Gemini::GEMINI_2_PRO),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a message bag'));
     }

--- a/src/platform/tests/Bridge/Gemini/Contract/ToolCallMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/ToolCallMessageNormalizerTest.php
@@ -36,7 +36,7 @@ final class ToolCallMessageNormalizerTest extends TestCase
         $normalizer = new ToolCallMessageNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new ToolCallMessage(new ToolCall('', '', []), ''), context: [
-            Contract::CONTEXT_MODEL => new Gemini(),
+            Contract::CONTEXT_MODEL => new Gemini(Gemini::GEMINI_2_PRO),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a tool call'));
     }

--- a/src/platform/tests/Bridge/Gemini/Contract/ToolNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/ToolNormalizerTest.php
@@ -37,7 +37,7 @@ final class ToolNormalizerTest extends TestCase
         $normalizer = new ToolNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new Tool(new ExecutionReference(ToolNoParams::class), 'test', 'test'), context: [
-            Contract::CONTEXT_MODEL => new Gemini(),
+            Contract::CONTEXT_MODEL => new Gemini(Gemini::GEMINI_2_PRO),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a tool'));
     }

--- a/src/platform/tests/Bridge/Gemini/Contract/UserMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Gemini/Contract/UserMessageNormalizerTest.php
@@ -42,7 +42,7 @@ final class UserMessageNormalizerTest extends TestCase
         $normalizer = new UserMessageNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new UserMessage(new Text('Hello')), context: [
-            Contract::CONTEXT_MODEL => new Gemini(),
+            Contract::CONTEXT_MODEL => new Gemini(Gemini::GEMINI_2_PRO),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a user message'));
     }

--- a/src/platform/tests/Bridge/Ollama/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Ollama/Contract/AssistantMessageNormalizerTest.php
@@ -42,7 +42,7 @@ final class AssistantMessageNormalizerTest extends TestCase
     public function testSupportsNormalization()
     {
         $this->assertTrue($this->normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
-            Contract::CONTEXT_MODEL => new Ollama(),
+            Contract::CONTEXT_MODEL => new Ollama(Ollama::LLAMA_3_2),
         ]));
         $this->assertFalse($this->normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
             Contract::CONTEXT_MODEL => new Model('any-model'),

--- a/src/platform/tests/Bridge/Ollama/OllamaClientTest.php
+++ b/src/platform/tests/Bridge/Ollama/OllamaClientTest.php
@@ -32,7 +32,7 @@ final class OllamaClientTest extends TestCase
     {
         $client = new OllamaClient(new MockHttpClient(), 'http://localhost:1234');
 
-        $this->assertTrue($client->supports(new Ollama()));
+        $this->assertTrue($client->supports(new Ollama(Ollama::LLAMA_3_2)));
         $this->assertFalse($client->supports(new Model('any-model')));
     }
 
@@ -53,7 +53,7 @@ final class OllamaClientTest extends TestCase
         ], 'http://127.0.0.1:1234');
 
         $client = new OllamaClient($httpClient, 'http://127.0.0.1:1234');
-        $response = $client->request(new Ollama(), [
+        $response = $client->request(new Ollama(Ollama::LLAMA_3_2), [
             'messages' => [
                 [
                     'role' => 'user',
@@ -110,7 +110,7 @@ final class OllamaClientTest extends TestCase
         ], 'http://127.0.0.1:1234');
 
         $platform = PlatformFactory::create('http://127.0.0.1:1234', $httpClient);
-        $response = $platform->invoke(new Ollama(), [
+        $response = $platform->invoke(new Ollama(Ollama::LLAMA_3_2), [
             'messages' => [
                 [
                     'role' => 'user',

--- a/src/platform/tests/Bridge/Ollama/OllamaResultConverterTest.php
+++ b/src/platform/tests/Bridge/Ollama/OllamaResultConverterTest.php
@@ -42,7 +42,7 @@ final class OllamaResultConverterTest extends TestCase
     {
         $converter = new OllamaResultConverter();
 
-        $this->assertTrue($converter->supports(new Ollama()));
+        $this->assertTrue($converter->supports(new Ollama(Ollama::LLAMA_3_2)));
         $this->assertFalse($converter->supports(new Model('any-model')));
     }
 

--- a/src/platform/tests/Bridge/OpenAi/Contract/DocumentNormalizerTest.php
+++ b/src/platform/tests/Bridge/OpenAi/Contract/DocumentNormalizerTest.php
@@ -31,7 +31,7 @@ final class DocumentNormalizerTest extends TestCase
         $normalizer = new DocumentNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new Document('some content', 'application/pdf'), context: [
-            Contract::CONTEXT_MODEL => new Gpt(),
+            Contract::CONTEXT_MODEL => new Gpt(Gpt::GPT_4O),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a document'));
     }

--- a/src/platform/tests/Bridge/OpenAi/DallE/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAi/DallE/ModelClientTest.php
@@ -61,7 +61,7 @@ final class ModelClientTest extends TestCase
     {
         $modelClient = new ModelClient(new MockHttpClient(), 'sk-api-key');
 
-        $this->assertTrue($modelClient->supports(new DallE()));
+        $this->assertTrue($modelClient->supports(new DallE(DallE::DALL_E_2)));
     }
 
     public function testItIsExecutingTheCorrectRequest()
@@ -76,7 +76,7 @@ final class ModelClientTest extends TestCase
         };
         $httpClient = new MockHttpClient([$resultCallback]);
         $modelClient = new ModelClient($httpClient, 'sk-api-key');
-        $modelClient->request(new DallE(), 'foo', ['n' => 1, 'response_format' => 'url']);
+        $modelClient->request(new DallE(DallE::DALL_E_2), 'foo', ['n' => 1, 'response_format' => 'url']);
     }
 
     #[TestWith(['EU', 'https://eu.api.openai.com/v1/images/generations'])]
@@ -93,6 +93,6 @@ final class ModelClientTest extends TestCase
         };
         $httpClient = new MockHttpClient([$resultCallback]);
         $modelClient = new ModelClient($httpClient, 'sk-api-key', $region);
-        $modelClient->request(new DallE(), 'foo', ['n' => 1, 'response_format' => 'url']);
+        $modelClient->request(new DallE(DallE::DALL_E_2), 'foo', ['n' => 1, 'response_format' => 'url']);
     }
 }

--- a/src/platform/tests/Bridge/OpenAi/DallETest.php
+++ b/src/platform/tests/Bridge/OpenAi/DallETest.php
@@ -22,7 +22,7 @@ final class DallETest extends TestCase
 {
     public function testItCreatesDallEWithDefaultSettings()
     {
-        $dallE = new DallE();
+        $dallE = new DallE(DallE::DALL_E_2);
 
         $this->assertSame(DallE::DALL_E_2, $dallE->getName());
         $this->assertSame([], $dallE->getOptions());

--- a/src/platform/tests/Bridge/OpenAi/Embeddings/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAi/Embeddings/ModelClientTest.php
@@ -64,7 +64,7 @@ final class ModelClientTest extends TestCase
     {
         $modelClient = new ModelClient(new MockHttpClient(), 'sk-api-key');
 
-        $this->assertTrue($modelClient->supports(new Embeddings()));
+        $this->assertTrue($modelClient->supports(new Embeddings(Embeddings::TEXT_3_SMALL)));
     }
 
     public function testItIsExecutingTheCorrectRequest()
@@ -79,7 +79,7 @@ final class ModelClientTest extends TestCase
         };
         $httpClient = new MockHttpClient([$resultCallback]);
         $modelClient = new ModelClient($httpClient, 'sk-api-key');
-        $modelClient->request(new Embeddings(), 'test text', []);
+        $modelClient->request(new Embeddings(Embeddings::TEXT_3_SMALL), 'test text', []);
     }
 
     public function testItIsExecutingTheCorrectRequestWithCustomOptions()
@@ -109,7 +109,7 @@ final class ModelClientTest extends TestCase
         };
         $httpClient = new MockHttpClient([$resultCallback]);
         $modelClient = new ModelClient($httpClient, 'sk-api-key');
-        $modelClient->request(new Embeddings(), ['text1', 'text2', 'text3'], []);
+        $modelClient->request(new Embeddings(Embeddings::TEXT_3_SMALL), ['text1', 'text2', 'text3'], []);
     }
 
     #[TestWith(['EU', 'https://eu.api.openai.com/v1/embeddings'])]
@@ -126,6 +126,6 @@ final class ModelClientTest extends TestCase
         };
         $httpClient = new MockHttpClient([$resultCallback]);
         $modelClient = new ModelClient($httpClient, 'sk-api-key', $region);
-        $modelClient->request(new Embeddings(), 'test input', []);
+        $modelClient->request(new Embeddings(Embeddings::TEXT_3_SMALL), 'test input', []);
     }
 }

--- a/src/platform/tests/Bridge/OpenAi/EmbeddingsTest.php
+++ b/src/platform/tests/Bridge/OpenAi/EmbeddingsTest.php
@@ -25,7 +25,7 @@ final class EmbeddingsTest extends TestCase
 {
     public function testItCreatesEmbeddingsWithDefaultSettings()
     {
-        $embeddings = new Embeddings();
+        $embeddings = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $this->assertSame(Embeddings::TEXT_3_SMALL, $embeddings->getName());
         $this->assertSame([], $embeddings->getOptions());

--- a/src/platform/tests/Bridge/OpenAi/Gpt/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAi/Gpt/ModelClientTest.php
@@ -81,7 +81,7 @@ final class ModelClientTest extends TestCase
     {
         $modelClient = new ModelClient(new MockHttpClient(), 'sk-api-key');
 
-        $this->assertTrue($modelClient->supports(new Gpt()));
+        $this->assertTrue($modelClient->supports(new Gpt(Gpt::GPT_4O)));
     }
 
     public function testItIsExecutingTheCorrectRequest()
@@ -96,7 +96,7 @@ final class ModelClientTest extends TestCase
         };
         $httpClient = new MockHttpClient([$resultCallback]);
         $modelClient = new ModelClient($httpClient, 'sk-api-key');
-        $modelClient->request(new Gpt(), ['model' => 'gpt-4o', 'messages' => [['role' => 'user', 'content' => 'test message']]], ['temperature' => 1]);
+        $modelClient->request(new Gpt(Gpt::GPT_4O), ['model' => 'gpt-4o', 'messages' => [['role' => 'user', 'content' => 'test message']]], ['temperature' => 1]);
     }
 
     public function testItIsExecutingTheCorrectRequestWithArrayPayload()
@@ -111,7 +111,7 @@ final class ModelClientTest extends TestCase
         };
         $httpClient = new MockHttpClient([$resultCallback]);
         $modelClient = new ModelClient($httpClient, 'sk-api-key');
-        $modelClient->request(new Gpt(), ['model' => 'gpt-4o', 'messages' => [['role' => 'user', 'content' => 'Hello']]], ['temperature' => 0.7]);
+        $modelClient->request(new Gpt(Gpt::GPT_4O), ['model' => 'gpt-4o', 'messages' => [['role' => 'user', 'content' => 'Hello']]], ['temperature' => 0.7]);
     }
 
     #[TestWith(['EU', 'https://eu.api.openai.com/v1/chat/completions'])]
@@ -128,6 +128,6 @@ final class ModelClientTest extends TestCase
         };
         $httpClient = new MockHttpClient([$resultCallback]);
         $modelClient = new ModelClient($httpClient, 'sk-api-key', $region);
-        $modelClient->request(new Gpt(), ['messages' => []], []);
+        $modelClient->request(new Gpt(Gpt::GPT_4O), ['messages' => []], []);
     }
 }

--- a/src/platform/tests/Bridge/OpenAi/GptTest.php
+++ b/src/platform/tests/Bridge/OpenAi/GptTest.php
@@ -25,7 +25,7 @@ final class GptTest extends TestCase
 {
     public function testItCreatesGptWithDefaultSettings()
     {
-        $gpt = new Gpt();
+        $gpt = new Gpt(Gpt::GPT_4O);
 
         $this->assertSame(Gpt::GPT_4O, $gpt->getName());
         $this->assertSame([], $gpt->getOptions());

--- a/src/platform/tests/Bridge/OpenAi/Whisper/ModelClientTest.php
+++ b/src/platform/tests/Bridge/OpenAi/Whisper/ModelClientTest.php
@@ -58,7 +58,7 @@ final class ModelClientTest extends TestCase
     public function testItSupportsWhisperModel()
     {
         $client = new ModelClient(new MockHttpClient(), 'sk-test-key');
-        $this->assertTrue($client->supports(new Whisper()));
+        $this->assertTrue($client->supports(new Whisper(Whisper::WHISPER_1)));
     }
 
     public function testItUsesTranscriptionEndpointByDefault()
@@ -73,7 +73,7 @@ final class ModelClientTest extends TestCase
         ]);
 
         $client = new ModelClient($httpClient, 'sk-test-key');
-        $client->request(new Whisper(), ['file' => 'audio-data']);
+        $client->request(new Whisper(Whisper::WHISPER_1), ['file' => 'audio-data']);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -90,7 +90,7 @@ final class ModelClientTest extends TestCase
         ]);
 
         $client = new ModelClient($httpClient, 'sk-test-key');
-        $client->request(new Whisper(), ['file' => 'audio-data'], ['task' => Task::TRANSCRIPTION]);
+        $client->request(new Whisper(Whisper::WHISPER_1), ['file' => 'audio-data'], ['task' => Task::TRANSCRIPTION]);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -107,7 +107,7 @@ final class ModelClientTest extends TestCase
         ]);
 
         $client = new ModelClient($httpClient, 'sk-test-key');
-        $client->request(new Whisper(), ['file' => 'audio-data'], ['task' => Task::TRANSLATION]);
+        $client->request(new Whisper(Whisper::WHISPER_1), ['file' => 'audio-data'], ['task' => Task::TRANSLATION]);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -127,7 +127,7 @@ final class ModelClientTest extends TestCase
         ]);
 
         $client = new ModelClient($httpClient, 'sk-test-key', $region);
-        $client->request(new Whisper(), ['file' => 'audio-data']);
+        $client->request(new Whisper(Whisper::WHISPER_1), ['file' => 'audio-data']);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -147,7 +147,7 @@ final class ModelClientTest extends TestCase
         ]);
 
         $client = new ModelClient($httpClient, 'sk-test-key', $region);
-        $client->request(new Whisper(), ['file' => 'audio-data'], ['task' => Task::TRANSLATION]);
+        $client->request(new Whisper(Whisper::WHISPER_1), ['file' => 'audio-data'], ['task' => Task::TRANSLATION]);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }

--- a/src/platform/tests/Bridge/OpenAi/WhisperTest.php
+++ b/src/platform/tests/Bridge/OpenAi/WhisperTest.php
@@ -25,7 +25,7 @@ final class WhisperTest extends TestCase
 {
     public function testItCreatesWhisperWithDefaultSettings()
     {
-        $whisper = new Whisper();
+        $whisper = new Whisper(Whisper::WHISPER_1);
 
         $this->assertSame(Whisper::WHISPER_1, $whisper->getName());
         $this->assertSame([], $whisper->getOptions());

--- a/src/platform/tests/Bridge/VertexAi/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/VertexAi/Contract/AssistantMessageNormalizerTest.php
@@ -36,7 +36,7 @@ final class AssistantMessageNormalizerTest extends TestCase
         $normalizer = new AssistantMessageNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
-            Contract::CONTEXT_MODEL => new Model(),
+            Contract::CONTEXT_MODEL => new Model(Model::GEMINI_2_5_PRO),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not an assistant message'));
     }

--- a/src/platform/tests/Bridge/VertexAi/Contract/MessageBagNormalizerTest.php
+++ b/src/platform/tests/Bridge/VertexAi/Contract/MessageBagNormalizerTest.php
@@ -45,7 +45,7 @@ final class MessageBagNormalizerTest extends TestCase
         $normalizer = new MessageBagNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new MessageBag(), context: [
-            Contract::CONTEXT_MODEL => new Model(),
+            Contract::CONTEXT_MODEL => new Model(Model::GEMINI_2_5_PRO),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a message bag'));
     }

--- a/src/platform/tests/Bridge/VertexAi/Contract/ToolCallMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/VertexAi/Contract/ToolCallMessageNormalizerTest.php
@@ -36,7 +36,7 @@ final class ToolCallMessageNormalizerTest extends TestCase
         $normalizer = new ToolCallMessageNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new ToolCallMessage(new ToolCall('', '', []), ''), context: [
-            Contract::CONTEXT_MODEL => new Model(),
+            Contract::CONTEXT_MODEL => new Model(Model::GEMINI_2_5_PRO),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a tool call'));
     }

--- a/src/platform/tests/Bridge/VertexAi/Contract/ToolNormalizerTest.php
+++ b/src/platform/tests/Bridge/VertexAi/Contract/ToolNormalizerTest.php
@@ -37,7 +37,7 @@ final class ToolNormalizerTest extends TestCase
         $normalizer = new ToolNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new Tool(new ExecutionReference(ToolNoParams::class), 'test', 'test'), context: [
-            Contract::CONTEXT_MODEL => new Model(),
+            Contract::CONTEXT_MODEL => new Model(Model::GEMINI_2_5_PRO),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a tool'));
     }

--- a/src/platform/tests/Bridge/VertexAi/Contract/UserMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/VertexAi/Contract/UserMessageNormalizerTest.php
@@ -42,7 +42,7 @@ final class UserMessageNormalizerTest extends TestCase
         $normalizer = new UserMessageNormalizer();
 
         $this->assertTrue($normalizer->supportsNormalization(new UserMessage(new Text('Hello')), context: [
-            Contract::CONTEXT_MODEL => new Model(),
+            Contract::CONTEXT_MODEL => new Model(Model::GEMINI_2_5_PRO),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not a user message'));
     }

--- a/src/platform/tests/Contract/Normalizer/Message/MessageBagNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/MessageBagNormalizerTest.php
@@ -95,7 +95,7 @@ final class MessageBagNormalizerTest extends TestCase
         $innerNormalizer = $this->createMock(NormalizerInterface::class);
         $innerNormalizer->expects($this->once())
             ->method('normalize')
-            ->with($messages, null, [Contract::CONTEXT_MODEL => new Gpt()])
+            ->with($messages, null, [Contract::CONTEXT_MODEL => new Gpt(Gpt::GPT_4O)])
             ->willReturn([
                 ['role' => 'system', 'content' => 'You are a helpful assistant'],
                 ['role' => 'user', 'content' => 'Hello'],
@@ -112,7 +112,7 @@ final class MessageBagNormalizerTest extends TestCase
         ];
 
         $this->assertSame($expected, $this->normalizer->normalize($messageBag, context: [
-            Contract::CONTEXT_MODEL => new Gpt(),
+            Contract::CONTEXT_MODEL => new Gpt(Gpt::GPT_4O),
         ]));
     }
 }

--- a/src/platform/tests/ContractTest.php
+++ b/src/platform/tests/ContractTest.php
@@ -83,7 +83,7 @@ final class ContractTest extends TestCase
     public static function providePayloadTestCases(): iterable
     {
         yield 'MessageBag with Gpt' => [
-            'model' => new Gpt(),
+            'model' => new Gpt(Gpt::GPT_4O),
             'input' => new MessageBag(
                 Message::forSystem('System message'),
                 Message::ofUser('User message'),
@@ -101,7 +101,7 @@ final class ContractTest extends TestCase
 
         $audio = Audio::fromFile(\dirname(__DIR__, 3).'/fixtures/audio.mp3');
         yield 'Audio within MessageBag with Gpt' => [
-            'model' => new Gpt(),
+            'model' => new Gpt(Gpt::GPT_4O),
             'input' => new MessageBag(Message::ofUser('What is this recording about?', $audio)),
             'expected' => [
                 'messages' => [
@@ -125,7 +125,7 @@ final class ContractTest extends TestCase
 
         $image = Image::fromFile(\dirname(__DIR__, 3).'/fixtures/image.jpg');
         yield 'Image within MessageBag with Gpt' => [
-            'model' => new Gpt(),
+            'model' => new Gpt(Gpt::GPT_4O),
             'input' => new MessageBag(
                 Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
                 Message::ofUser('Describe the image as a comedian would do it.', $image),
@@ -149,7 +149,7 @@ final class ContractTest extends TestCase
         ];
 
         yield 'ImageUrl within MessageBag with Gpt' => [
-            'model' => new Gpt(),
+            'model' => new Gpt(Gpt::GPT_4O),
             'input' => new MessageBag(
                 Message::forSystem('You are an image analyzer bot that helps identify the content of images.'),
                 Message::ofUser('Describe the image as a comedian would do it.', new ImageUrl('https://example.com/image.jpg')),
@@ -173,13 +173,13 @@ final class ContractTest extends TestCase
         ];
 
         yield 'Text Input with Embeddings' => [
-            'model' => new Embeddings(),
+            'model' => new Embeddings(Embeddings::TEXT_3_SMALL),
             'input' => 'This is a test input.',
             'expected' => 'This is a test input.',
         ];
 
         yield 'Longer Conversation with Gpt' => [
-            'model' => new Gpt(),
+            'model' => new Gpt(Gpt::GPT_4O),
             'input' => new MessageBag(
                 Message::forSystem('My amazing system prompt.'),
                 Message::ofAssistant('It is time to sleep.'),
@@ -223,7 +223,7 @@ final class ContractTest extends TestCase
         };
 
         yield 'MessageBag with custom message from Gpt' => [
-            'model' => new Gpt(),
+            'model' => new Gpt(Gpt::GPT_4O),
             'input' => new MessageBag($customSerializableMessage),
             'expected' => [
                 'messages' => [
@@ -240,7 +240,7 @@ final class ContractTest extends TestCase
 
         $audio = Audio::fromFile(\dirname(__DIR__, 3).'/fixtures/audio.mp3');
 
-        $actual = $contract->createRequestPayload(new Whisper(), $audio);
+        $actual = $contract->createRequestPayload(new Whisper(Whisper::WHISPER_1), $audio);
 
         $this->assertArrayHasKey('model', $actual);
         $this->assertSame('whisper-1', $actual['model']);

--- a/src/store/tests/Document/VectorizerTest.php
+++ b/src/store/tests/Document/VectorizerTest.php
@@ -65,7 +65,7 @@ final class VectorizerTest extends TestCase
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult(...$vectors));
 
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $vectorDocuments = $vectorizer->vectorizeTextDocuments($documents);
@@ -86,7 +86,7 @@ final class VectorizerTest extends TestCase
         $vector = new Vector([0.1, 0.2, 0.3]);
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult($vector));
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $vectorDocuments = $vectorizer->vectorizeTextDocuments([$document]);
@@ -101,7 +101,7 @@ final class VectorizerTest extends TestCase
     public function testVectorizeEmptyDocumentsArray()
     {
         $platform = PlatformTestHandler::createPlatform(new VectorResult());
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $vectorDocuments = $vectorizer->vectorizeTextDocuments([]);
@@ -125,7 +125,7 @@ final class VectorizerTest extends TestCase
         ];
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult(...$vectors));
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $vectorDocuments = $vectorizer->vectorizeTextDocuments($documents);
@@ -156,7 +156,7 @@ final class VectorizerTest extends TestCase
         ];
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult(...$vectors));
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $vectorDocuments = $vectorizer->vectorizeTextDocuments($documents);
@@ -185,7 +185,7 @@ final class VectorizerTest extends TestCase
         $platform = PlatformTestHandler::createPlatform(
             $count > 0 ? new VectorResult(...$vectors) : new VectorResult()
         );
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $vectorDocuments = $vectorizer->vectorizeTextDocuments($documents);
@@ -224,7 +224,7 @@ final class VectorizerTest extends TestCase
         $vector = new Vector($dimensions);
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult($vector));
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $vectorDocuments = $vectorizer->vectorizeTextDocuments([$document]);
@@ -248,7 +248,7 @@ final class VectorizerTest extends TestCase
         ];
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult(...$vectors));
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $vectorDocuments = $vectorizer->vectorizeTextDocuments($documents);
@@ -327,7 +327,7 @@ final class VectorizerTest extends TestCase
         $vector = new Vector([0.1, 0.2, 0.3]);
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult($vector));
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $result = $vectorizer->vectorize($text);
@@ -342,7 +342,7 @@ final class VectorizerTest extends TestCase
         $vector = new Vector([0.5, 0.6, 0.7]);
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult($vector));
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $result = $vectorizer->vectorize($text);
@@ -357,7 +357,7 @@ final class VectorizerTest extends TestCase
         $vector = new Vector([0.0, 0.0, 0.0]);
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult($vector));
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $result = $vectorizer->vectorize($text);
@@ -371,7 +371,7 @@ final class VectorizerTest extends TestCase
         $text = 'Test string';
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult());
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
 
@@ -400,7 +400,7 @@ final class VectorizerTest extends TestCase
             )
             ->willReturn(new ResultPromise(fn () => new VectorResult($vector), $this->createMock(RawResultInterface::class)));
 
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $result = $vectorizer->vectorizeTextDocuments($documents, $options);
@@ -427,7 +427,7 @@ final class VectorizerTest extends TestCase
             )
             ->willReturn(new ResultPromise(fn () => new VectorResult($vector), $this->createMock(RawResultInterface::class)));
 
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $result = $vectorizer->vectorizeTextDocuments($documents);
@@ -452,7 +452,7 @@ final class VectorizerTest extends TestCase
             )
             ->willReturn(new ResultPromise(fn () => new VectorResult($vector), $this->createMock(RawResultInterface::class)));
 
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $result = $vectorizer->vectorize($text, $options);
@@ -475,7 +475,7 @@ final class VectorizerTest extends TestCase
             )
             ->willReturn(new ResultPromise(fn () => new VectorResult($vector), $this->createMock(RawResultInterface::class)));
 
-        $model = new Embeddings();
+        $model = new Embeddings(Embeddings::TEXT_3_SMALL);
 
         $vectorizer = new Vectorizer($platform, $model);
         $result = $vectorizer->vectorize($text);

--- a/src/store/tests/IndexerTest.php
+++ b/src/store/tests/IndexerTest.php
@@ -51,7 +51,7 @@ final class IndexerTest extends TestCase
         $document = new TextDocument($id = Uuid::v4(), 'Test content');
         $vector = new Vector([0.1, 0.2, 0.3]);
         $loader = new InMemoryLoader([$document]);
-        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), new Embeddings());
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), new Embeddings(Embeddings::TEXT_3_SMALL));
 
         $indexer = new Indexer($loader, $vectorizer, $store = new TestStore());
         $indexer->index();
@@ -65,7 +65,7 @@ final class IndexerTest extends TestCase
     public function testIndexEmptyDocumentList()
     {
         $loader = new InMemoryLoader([]);
-        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(), new Embeddings());
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(), new Embeddings(Embeddings::TEXT_3_SMALL));
 
         $indexer = new Indexer($loader, $vectorizer, $store = new TestStore());
         $indexer->index();
@@ -79,7 +79,7 @@ final class IndexerTest extends TestCase
         $document = new TextDocument($id = Uuid::v4(), 'Test content', $metadata);
         $vector = new Vector([0.1, 0.2, 0.3]);
         $loader = new InMemoryLoader([$document]);
-        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), new Embeddings());
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), new Embeddings(Embeddings::TEXT_3_SMALL));
 
         $indexer = new Indexer($loader, $vectorizer, $store = new TestStore());
         $indexer->index();
@@ -99,7 +99,7 @@ final class IndexerTest extends TestCase
 
         // InMemoryLoader doesn't use source parameter, so we'll test withSource method's immutability
         $loader = new InMemoryLoader([$document1]);
-        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), new Embeddings());
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), new Embeddings(Embeddings::TEXT_3_SMALL));
 
         // Create indexer with initial source
         $indexer = new Indexer($loader, $vectorizer, $store = new TestStore(), 'source1');
@@ -128,7 +128,7 @@ final class IndexerTest extends TestCase
 
         // InMemoryLoader returns all documents regardless of source
         $loader = new InMemoryLoader([$document1, $document2]);
-        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), new Embeddings());
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), new Embeddings(Embeddings::TEXT_3_SMALL));
 
         // Create indexer with single source
         $indexer = new Indexer($loader, $vectorizer, $store1 = new TestStore(), 'source1');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Removes default model names from all Model class constructors to prevent breaking changes when default models are changed. Model names must now be explicitly provided when instantiating model classes.