### PR TITLE
[AI Bundle] Rename `system_prompt` to `prompt` and `prompt` key to `text`

### DIFF
--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -18,7 +18,7 @@ ai:
             model:
                 class: 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'
                 name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI
-            system_prompt: |
+            prompt: |
                 You are an example chat application where messages from the LLM are streamed to the user using
                 Server-Sent Events via `symfony/ux-turbo` / Turbo Streams. This example does not use any custom
                 javascript and solely relies on the built-in `live` & `turbo_stream` Stimulus controllers.
@@ -35,8 +35,8 @@ ai:
                 name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI
                 options:
                     temperature: 0.5
-            system_prompt:
-                prompt: 'Please answer the users question based on Wikipedia and provide a link to the article.'
+            prompt:
+                text: 'Please answer the users question based on Wikipedia and provide a link to the article.'
                 include_tools: true
             tools:
                 - 'Symfony\AI\Agent\Toolbox\Tool\Wikipedia'
@@ -44,7 +44,7 @@ ai:
             model:
                 class: 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'
                 name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI
-            system_prompt: 'You are a friendly chatbot that likes to have a conversation with users and asks them some questions.'
+            prompt: 'You are a friendly chatbot that likes to have a conversation with users and asks them some questions.'
             tools:
                 # Agent in agent 🤯
                 - agent: 'blog'

--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -130,19 +130,19 @@ return static function (DefinitionConfigurator $configurator): void {
                             ->end()
                         ->end()
                         ->booleanNode('structured_output')->defaultTrue()->end()
-                        ->arrayNode('system_prompt')
+                        ->arrayNode('prompt')
                             ->info('The system prompt configuration')
                             ->beforeNormalization()
                                 ->ifString()
                                 ->then(function (string $v) {
-                                    return ['prompt' => $v];
+                                    return ['text' => $v];
                                 })
                             ->end()
                             ->beforeNormalization()
                                 ->ifArray()
                                 ->then(function (array $v) {
-                                    if (!isset($v['prompt']) && !isset($v['include_tools'])) {
-                                        throw new \InvalidArgumentException('Either "prompt" must be configured for system_prompt.');
+                                    if (!isset($v['text']) && !isset($v['include_tools'])) {
+                                        throw new \InvalidArgumentException('Either "text" must be configured for prompt.');
                                     }
 
                                     return $v;
@@ -150,12 +150,12 @@ return static function (DefinitionConfigurator $configurator): void {
                             ->end()
                             ->validate()
                                 ->ifTrue(function ($v) {
-                                    return \is_array($v) && '' === trim($v['prompt'] ?? '');
+                                    return \is_array($v) && '' === trim($v['text'] ?? '');
                                 })
-                                ->thenInvalid('The "prompt" cannot be empty.')
+                                ->thenInvalid('The "text" cannot be empty.')
                             ->end()
                             ->children()
-                                ->scalarNode('prompt')
+                                ->scalarNode('text')
                                     ->info('The system prompt text')
                                 ->end()
                                 ->booleanNode('include_tools')

--- a/src/ai-bundle/doc/index.rst
+++ b/src/ai-bundle/doc/index.rst
@@ -71,8 +71,8 @@ Configuration
                 model:
                     class: 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'
                     name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI
-                system_prompt: # The system prompt configuration
-                    prompt: 'You are a helpful assistant that can answer questions.' # The prompt text
+                prompt: # The system prompt configuration
+                    text: 'You are a helpful assistant that can answer questions.' # The prompt text
                     include_tools: true # Include tool definitions at the end of the system prompt
                 tools:
                     # Referencing a service with #[AsTool] attribute
@@ -158,7 +158,7 @@ For basic usage, specify the system prompt as a simple string:
                 model:
                     class: 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'
                     name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI
-                system_prompt: 'You are a helpful assistant.'
+                prompt: 'You are a helpful assistant.'
 
 **Advanced Configuration**
 
@@ -172,13 +172,13 @@ For more control, such as including tool definitions in the system prompt, use t
                 model:
                     class: 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'
                     name: !php/const Symfony\AI\Platform\Bridge\OpenAi\Gpt::GPT_4O_MINI
-                system_prompt:
-                    prompt: 'You are a helpful assistant that can answer questions.'
+                prompt:
+                    text: 'You are a helpful assistant that can answer questions.'
                     include_tools: true # Include tool definitions at the end of the system prompt
 
 The array format supports these options:
 
-* ``prompt`` (string, required): The system prompt text that will be sent to the AI model
+* ``text`` (string, required): The system prompt text that will be sent to the AI model
 * ``include_tools`` (boolean, optional): When set to ``true``, tool definitions will be appended to the system prompt
 
 

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -604,12 +604,12 @@ final class AiBundle extends AbstractBundle
         }
 
         // SYSTEM PROMPT
-        if (isset($config['system_prompt'])) {
-            $includeTools = isset($config['system_prompt']['include_tools']) && $config['system_prompt']['include_tools'];
+        if (isset($config['prompt'])) {
+            $includeTools = isset($config['prompt']['include_tools']) && $config['prompt']['include_tools'];
 
             $systemPromptInputProcessorDefinition = (new Definition(SystemPromptInputProcessor::class))
                 ->setArguments([
-                    $config['system_prompt']['prompt'],
+                    $config['prompt']['text'],
                     $includeTools ? new Reference('ai.toolbox.'.$name) : null,
                     new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
                 ])

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -389,7 +389,7 @@ class AiBundleTest extends TestCase
                             ['service' => 'some_tool', 'description' => 'Test tool'],
                         ],
                         'structured_output' => true,
-                        'system_prompt' => 'You are a test assistant.',
+                        'prompt' => 'You are a test assistant.',
                     ],
                 ],
             ],
@@ -440,14 +440,14 @@ class AiBundleTest extends TestCase
                         'tools' => [
                             ['service' => 'tool_one', 'description' => 'Tool for first agent'],
                         ],
-                        'system_prompt' => 'First agent prompt',
+                        'prompt' => 'First agent prompt',
                     ],
                     'second_agent' => [
                         'model' => ['class' => 'Symfony\AI\Platform\Bridge\Anthropic\Claude'],
                         'tools' => [
                             ['service' => 'tool_two', 'description' => 'Tool for second agent'],
                         ],
-                        'system_prompt' => 'Second agent prompt',
+                        'prompt' => 'Second agent prompt',
                     ],
                 ],
             ],
@@ -656,8 +656,8 @@ class AiBundleTest extends TestCase
                 'agent' => [
                     'test_agent' => [
                         'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
-                        'system_prompt' => [
-                            'prompt' => 'You are a helpful assistant.',
+                        'prompt' => [
+                            'text' => 'You are a helpful assistant.',
                         ],
                         'tools' => [
                             ['service' => 'some_tool', 'description' => 'Test tool'],
@@ -683,8 +683,8 @@ class AiBundleTest extends TestCase
                 'agent' => [
                     'test_agent' => [
                         'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
-                        'system_prompt' => [
-                            'prompt' => 'You are a helpful assistant.',
+                        'prompt' => [
+                            'text' => 'You are a helpful assistant.',
                             'include_tools' => true,
                         ],
                         'tools' => [
@@ -704,16 +704,16 @@ class AiBundleTest extends TestCase
         $this->assertSame('ai.toolbox.test_agent', (string) $arguments[1]);
     }
 
-    #[TestDox('System prompt with only prompt key defaults include_tools to false')]
-    public function testSystemPromptWithOnlyPromptKey()
+    #[TestDox('System prompt with only text key defaults include_tools to false')]
+    public function testSystemPromptWithOnlyTextKey()
     {
         $container = $this->buildContainer([
             'ai' => [
                 'agent' => [
                     'test_agent' => [
                         'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
-                        'system_prompt' => [
-                            'prompt' => 'You are a helpful assistant.',
+                        'prompt' => [
+                            'text' => 'You are a helpful assistant.',
                         ],
                         'tools' => [
                             ['service' => 'some_tool', 'description' => 'Test tool'],
@@ -756,8 +756,8 @@ class AiBundleTest extends TestCase
                 'agent' => [
                     'test_agent' => [
                         'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
-                        'system_prompt' => [
-                            'prompt' => 'Valid prompt',
+                        'prompt' => [
+                            'text' => 'Valid prompt',
                             'include_tools' => true,
                         ],
                         'tools' => [
@@ -777,19 +777,19 @@ class AiBundleTest extends TestCase
         $this->assertSame('ai.toolbox.test_agent', (string) $arguments[1]);
     }
 
-    #[TestDox('Empty prompt in array structure throws configuration exception')]
-    public function testEmptyPromptInArrayThrowsException()
+    #[TestDox('Empty text in array structure throws configuration exception')]
+    public function testEmptyTextInArrayThrowsException()
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The "prompt" cannot be empty.');
+        $this->expectExceptionMessage('The "text" cannot be empty.');
 
         $this->buildContainer([
             'ai' => [
                 'agent' => [
                     'test_agent' => [
                         'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
-                        'system_prompt' => [
-                            'prompt' => '',
+                        'prompt' => [
+                            'text' => '',
                         ],
                     ],
                 ],
@@ -797,18 +797,18 @@ class AiBundleTest extends TestCase
         ]);
     }
 
-    #[TestDox('System prompt array without prompt key throws configuration exception')]
-    public function testSystemPromptArrayWithoutPromptKeyThrowsException()
+    #[TestDox('System prompt array without text key throws configuration exception')]
+    public function testSystemPromptArrayWithoutTextKeyThrowsException()
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The "prompt" cannot be empty.');
+        $this->expectExceptionMessage('The "text" cannot be empty.');
 
         $this->buildContainer([
             'ai' => [
                 'agent' => [
                     'test_agent' => [
                         'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
-                        'system_prompt' => [
+                        'prompt' => [
                             'include_tools' => true,
                         ],
                     ],
@@ -825,7 +825,7 @@ class AiBundleTest extends TestCase
                 'agent' => [
                     'test_agent' => [
                         'model' => ['class' => 'Symfony\AI\Platform\Bridge\OpenAi\Gpt'],
-                        'system_prompt' => 'You are a helpful assistant.',
+                        'prompt' => 'You are a helpful assistant.',
                         'tools' => [
                             ['service' => 'some_tool', 'description' => 'Test tool'],
                         ],
@@ -1270,8 +1270,8 @@ class AiBundleTest extends TestCase
                         ],
                         'structured_output' => false,
                         'track_token_usage' => true,
-                        'system_prompt' => [
-                            'prompt' => 'You are a helpful assistant.',
+                        'prompt' => [
+                            'text' => 'You are a helpful assistant.',
                             'include_tools' => true,
                         ],
                         'tools' => [
@@ -1285,7 +1285,7 @@ class AiBundleTest extends TestCase
                     ],
                     'another_agent' => [
                         'model' => ['class' => 'Symfony\AI\Platform\Bridge\Anthropic\Claude', 'name' => 'claude-3-opus-20240229'],
-                        'system_prompt' => 'Be concise.',
+                        'prompt' => 'Be concise.',
                     ],
                 ],
                 'store' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Follows #576 
| License       | MIT

- Renamed system_prompt configuration key to prompt for clearer naming
- Renamed nested 'prompt' key to 'text' in array configuration to avoid confusion
- Updated all configuration examples in demo
- Updated documentation with new configuration structure
- Updated all tests to use new configuration structure
- Maintained backward compatibility through configuration normalization

I prefer `text`, as this way, we can introduce `file` and validate that only one can be set. I am planning to support twig and json prompts in the future.