### PR TITLE
[Agent] Reorder memory and system prompt

### DIFF
--- a/src/agent/src/Memory/MemoryInputProcessor.php
+++ b/src/agent/src/Memory/MemoryInputProcessor.php
@@ -70,13 +70,15 @@ final readonly class MemoryInputProcessor implements InputProcessorInterface
         }
 
         $systemMessage = $input->messages->getSystemMessage()->content ?? '';
+
+        $combinedMessage = self::MEMORY_PROMPT_MESSAGE.$memory;
         if ('' !== $systemMessage) {
-            $systemMessage .= \PHP_EOL.\PHP_EOL;
+            $combinedMessage .= \PHP_EOL.\PHP_EOL.'# System Prompt'.\PHP_EOL.\PHP_EOL.$systemMessage;
         }
 
         $messages = $input->messages
             ->withoutSystemMessage()
-            ->prepend(Message::forSystem($systemMessage.self::MEMORY_PROMPT_MESSAGE.$memory));
+            ->prepend(Message::forSystem($combinedMessage));
 
         $input->messages = $messages;
     }

--- a/src/agent/tests/Memory/MemoryInputProcessorTest.php
+++ b/src/agent/tests/Memory/MemoryInputProcessorTest.php
@@ -86,8 +86,6 @@ final class MemoryInputProcessorTest extends TestCase
         $this->assertArrayNotHasKey('use_memory', $input->getOptions());
         $this->assertSame(
             <<<MARKDOWN
-                You are a helpful and kind assistant.
-
                 # Conversation Memory
                 This is the memory I have found for this conversation. The memory has more weight to answer user input,
                 so try to answer utilizing the memory as much as possible. Your answer must be changed to fit the given
@@ -95,6 +93,10 @@ final class MemoryInputProcessorTest extends TestCase
                 reference it as this is just for your reference.
 
                 First memory content
+
+                # System Prompt
+
+                You are a helpful and kind assistant.
                 MARKDOWN,
             $input->messages->getSystemMessage()->content,
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Follows #580
| License       | MIT

- Memory content now appears first (from my POV it is best practice), followed by system prompt
- Added `# System Prompt` headline separator between sections

cc @DZunke fyi, as you provided this feature