### PR TITLE
[AI Bundle] Correct exception message to mention both `text` and `include_tools`

### DIFF
--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -142,7 +142,7 @@ return static function (DefinitionConfigurator $configurator): void {
                                 ->ifArray()
                                 ->then(function (array $v) {
                                     if (!isset($v['text']) && !isset($v['include_tools'])) {
-                                        throw new \InvalidArgumentException('Either "text" must be configured for prompt.');
+                                        throw new \InvalidArgumentException('Either "text" or "include_tools" must be configured for prompt.');
                                     }
 
                                     return $v;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT
