### PR TITLE
[Agent] Rename `MemoryProviderInterface::loadMemory` to `load`

### DIFF
--- a/src/agent/src/Memory/EmbeddingProvider.php
+++ b/src/agent/src/Memory/EmbeddingProvider.php
@@ -32,7 +32,7 @@ final readonly class EmbeddingProvider implements MemoryProviderInterface
     ) {
     }
 
-    public function loadMemory(Input $input): array
+    public function load(Input $input): array
     {
         $messages = $input->messages->getMessages();
         /** @var MessageInterface|null $userMessage */

--- a/src/agent/src/Memory/MemoryInputProcessor.php
+++ b/src/agent/src/Memory/MemoryInputProcessor.php
@@ -52,7 +52,7 @@ final readonly class MemoryInputProcessor implements InputProcessorInterface
 
         $memory = '';
         foreach ($this->memoryProviders as $provider) {
-            $memoryMessages = $provider->loadMemory($input);
+            $memoryMessages = $provider->load($input);
 
             if (0 === \count($memoryMessages)) {
                 continue;

--- a/src/agent/src/Memory/MemoryProviderInterface.php
+++ b/src/agent/src/Memory/MemoryProviderInterface.php
@@ -21,5 +21,5 @@ interface MemoryProviderInterface
     /**
      * @return list<Memory>
      */
-    public function loadMemory(Input $input): array;
+    public function load(Input $input): array;
 }

--- a/src/agent/src/Memory/StaticMemoryProvider.php
+++ b/src/agent/src/Memory/StaticMemoryProvider.php
@@ -28,7 +28,7 @@ final readonly class StaticMemoryProvider implements MemoryProviderInterface
         $this->memory = $memory;
     }
 
-    public function loadMemory(Input $input): array
+    public function load(Input $input): array
     {
         if (0 === \count($this->memory)) {
             return [];

--- a/src/agent/tests/Memory/EmbeddingProviderTest.php
+++ b/src/agent/tests/Memory/EmbeddingProviderTest.php
@@ -55,7 +55,7 @@ final class EmbeddingProviderTest extends TestCase
             $store,
         );
 
-        $embeddingProvider->loadMemory(new Input(
+        $embeddingProvider->load(new Input(
             $this->createStub(Model::class),
             new MessageBag(),
             [],
@@ -76,7 +76,7 @@ final class EmbeddingProviderTest extends TestCase
             $store,
         );
 
-        $embeddingProvider->loadMemory(new Input(
+        $embeddingProvider->load(new Input(
             $this->createStub(Model::class),
             new MessageBag(Message::forSystem('This is a system message')),
             [],
@@ -97,7 +97,7 @@ final class EmbeddingProviderTest extends TestCase
             $store,
         );
 
-        $embeddingProvider->loadMemory(new Input(
+        $embeddingProvider->load(new Input(
             $this->createStub(Model::class),
             new MessageBag(Message::ofUser(new ImageUrl('foo.jpg'))),
             [],
@@ -129,7 +129,7 @@ final class EmbeddingProviderTest extends TestCase
             $store,
         );
 
-        $memory = $embeddingProvider->loadMemory(new Input(
+        $memory = $embeddingProvider->load(new Input(
             $this->createStub(Model::class),
             new MessageBag(Message::ofUser(new Text('Have we talked about the weather?'))),
             [],
@@ -166,7 +166,7 @@ final class EmbeddingProviderTest extends TestCase
             $store,
         );
 
-        $memory = $embeddingProvider->loadMemory(new Input(
+        $memory = $embeddingProvider->load(new Input(
             $this->createStub(Model::class),
             new MessageBag(Message::ofUser(new Text('Have we talked about the weather?'))),
             [],

--- a/src/agent/tests/Memory/MemoryInputProcessorTest.php
+++ b/src/agent/tests/Memory/MemoryInputProcessorTest.php
@@ -64,12 +64,12 @@ final class MemoryInputProcessorTest extends TestCase
     {
         $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
         $firstMemoryProvider->expects($this->once())
-            ->method('loadMemory')
+            ->method('load')
             ->willReturn([new Memory('First memory content')]);
 
         $secondMemoryProvider = $this->createMock(MemoryProviderInterface::class);
         $secondMemoryProvider->expects($this->once())
-            ->method('loadMemory')
+            ->method('load')
             ->willReturn([]);
 
         $memoryInputProcessor = new MemoryInputProcessor(
@@ -106,7 +106,7 @@ final class MemoryInputProcessorTest extends TestCase
     {
         $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
         $firstMemoryProvider->expects($this->once())
-            ->method('loadMemory')
+            ->method('load')
             ->willReturn([new Memory('First memory content')]);
 
         $memoryInputProcessor = new MemoryInputProcessor($firstMemoryProvider);
@@ -136,7 +136,7 @@ final class MemoryInputProcessorTest extends TestCase
     {
         $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
         $firstMemoryProvider->expects($this->once())
-            ->method('loadMemory')
+            ->method('load')
             ->willReturn([new Memory('First memory content'), new Memory('Second memory content')]);
 
         $memoryInputProcessor = new MemoryInputProcessor($firstMemoryProvider);
@@ -167,7 +167,7 @@ final class MemoryInputProcessorTest extends TestCase
     {
         $firstMemoryProvider = $this->createMock(MemoryProviderInterface::class);
         $firstMemoryProvider->expects($this->once())
-            ->method('loadMemory')
+            ->method('load')
             ->willReturn([]);
 
         $memoryInputProcessor = new MemoryInputProcessor($firstMemoryProvider);

--- a/src/agent/tests/Memory/StaticMemoryProviderTest.php
+++ b/src/agent/tests/Memory/StaticMemoryProviderTest.php
@@ -33,7 +33,7 @@ final class StaticMemoryProviderTest extends TestCase
     {
         $provider = new StaticMemoryProvider();
 
-        $memory = $provider->loadMemory(new Input(
+        $memory = $provider->load(new Input(
             $this->createStub(Model::class),
             new MessageBag(),
             []
@@ -49,7 +49,7 @@ final class StaticMemoryProviderTest extends TestCase
             $fact2 = 'Water is wet',
         );
 
-        $memory = $provider->loadMemory(new Input(
+        $memory = $provider->load(new Input(
             $this->createStub(Model::class),
             new MessageBag(),
             []


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Simplify the method name by removing the redundant 'Memory' prefix. This improves readability and follows interface naming conventions.