### PR TITLE
[AI Bundle] Move model class validation to configuration layer

### DIFF
--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -122,7 +122,15 @@ return static function (DefinitionConfigurator $configurator): void {
                         ->end()
                         ->arrayNode('model')
                             ->children()
-                                ->scalarNode('class')->isRequired()->end()
+                                ->scalarNode('class')
+                                    ->isRequired()
+                                    ->validate()
+                                        ->ifTrue(function ($v) {
+                                            return !is_a($v, \Symfony\AI\Platform\Model::class, true);
+                                        })
+                                        ->thenInvalid('The model class "%s" must extend Symfony\AI\Platform\Model.')
+                                    ->end()
+                                ->end()
                                 ->scalarNode('name')->defaultNull()->end()
                                 ->arrayNode('options')
                                     ->variablePrototype()->end()
@@ -418,7 +426,15 @@ return static function (DefinitionConfigurator $configurator): void {
                         ->end()
                         ->arrayNode('model')
                             ->children()
-                                ->scalarNode('class')->isRequired()->end()
+                                ->scalarNode('class')
+                                    ->isRequired()
+                                    ->validate()
+                                        ->ifTrue(function ($v) {
+                                            return !is_a($v, \Symfony\AI\Platform\Model::class, true);
+                                        })
+                                        ->thenInvalid('The model class "%s" must extend Symfony\AI\Platform\Model.')
+                                    ->end()
+                                ->end()
                                 ->scalarNode('name')->defaultNull()->end()
                                 ->arrayNode('options')
                                     ->variablePrototype()->end()

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -485,10 +485,6 @@ final class AiBundle extends AbstractBundle
         // MODEL
         ['class' => $modelClass, 'name' => $modelName, 'options' => $options] = $config['model'];
 
-        if (!is_a($modelClass, Model::class, true)) {
-            throw new InvalidArgumentException(\sprintf('"%s" class is not extending Symfony\AI\Platform\Model.', $modelClass));
-        }
-
         $modelDefinition = new Definition($modelClass);
         if (null !== $modelName) {
             $modelDefinition->setArgument(0, $modelName);
@@ -1087,10 +1083,6 @@ final class AiBundle extends AbstractBundle
     private function processVectorizerConfig(string $name, array $config, ContainerBuilder $container): void
     {
         ['class' => $modelClass, 'name' => $modelName, 'options' => $options] = $config['model'];
-
-        if (!is_a($modelClass, Model::class, true)) {
-            throw new InvalidArgumentException(\sprintf('"%s" class is not extending Symfony\AI\Platform\Model.', $modelClass));
-        }
 
         $modelDefinition = (new Definition((string) $modelClass));
         if (null !== $modelName) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Move validation that checks if model classes extend Symfony\AI\Platform\Model from runtime (in AiBundle.php) to configuration validation (in options.php).

This provides earlier validation during config processing, better error reporting, and cleaner bundle code.