### PR TITLE
[Platform][Mistral][Gemini] Add some missing models

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini.php
+++ b/src/platform/src/Bridge/Gemini/Gemini.php
@@ -19,6 +19,9 @@ use Symfony\AI\Platform\Model;
  */
 class Gemini extends Model
 {
+    public const GEMINI_25_FLASH = 'gemini-2.5-flash';
+    public const GEMINI_25_PRO = 'gemini-2.5-pro';
+    public const GEMINI_25_FLASH_LITE = 'gemini-2.5-flash-lite';
     public const GEMINI_2_FLASH = 'gemini-2.0-flash';
     public const GEMINI_2_PRO = 'gemini-2.0-pro-exp-02-05';
     public const GEMINI_2_FLASH_LITE = 'gemini-2.0-flash-lite-preview-02-05';

--- a/src/platform/src/Bridge/Mistral/Mistral.php
+++ b/src/platform/src/Bridge/Mistral/Mistral.php
@@ -20,13 +20,13 @@ use Symfony\AI\Platform\Model;
 final class Mistral extends Model
 {
     public const CODESTRAL = 'codestral-latest';
-    public const CODESTRAL_MAMBA = 'open-codestral-mamba';
     public const MISTRAL_LARGE = 'mistral-large-latest';
+    public const MISTRAL_MEDIUM = 'mistral-medium-latest';
     public const MISTRAL_SMALL = 'mistral-small-latest';
     public const MISTRAL_NEMO = 'open-mistral-nemo';
     public const MISTRAL_SABA = 'mistral-saba-latest';
-    public const MINISTRAL_3B = 'mistral-3b-latest';
-    public const MINISTRAL_8B = 'mistral-8b-latest';
+    public const MINISTRAL_3B = 'ministral-3b-latest';
+    public const MINISTRAL_8B = 'ministral-8b-latest';
     public const PIXSTRAL_LARGE = 'pixstral-large-latest';
     public const PIXSTRAL = 'pixstral-12b-latest';
     public const VOXTRAL_SMALL = 'voxtral-small-latest';
@@ -46,7 +46,7 @@ final class Mistral extends Model
             Capability::OUTPUT_STRUCTURED,
         ];
 
-        if (\in_array($name, [self::PIXSTRAL, self::PIXSTRAL_LARGE, self::MISTRAL_SMALL], true)) {
+        if (\in_array($name, [self::PIXSTRAL, self::PIXSTRAL_LARGE, self::MISTRAL_MEDIUM, self::MISTRAL_SMALL], true)) {
             $capabilities[] = Capability::INPUT_IMAGE;
         }
 
@@ -57,6 +57,7 @@ final class Mistral extends Model
         if (\in_array($name, [
             self::CODESTRAL,
             self::MISTRAL_LARGE,
+            self::MISTRAL_MEDIUM,
             self::MISTRAL_SMALL,
             self::MISTRAL_NEMO,
             self::MINISTRAL_3B,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

This MR adds constants for some missing models. While the Gemini models could also just be used with string literals, the Mistral Medium model does not work because it needs to get its its capabilities properly specified.
