### PR TITLE
[Platform][Gemini+OpenAI] Show error details to simplify localization of the cause

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -56,6 +56,10 @@ final readonly class ResultConverter implements ResultConverterInterface
         $data = $result->getData();
 
         if (!isset($data['candidates'][0]['content']['parts'][0])) {
+            if (isset($data['error'])) {
+                throw new RuntimeException(\sprintf('Error "%s" - "%s": "%s".', $data['error']['code'], $data['error']['status'], $data['error']['message']));
+            }
+
             throw new RuntimeException('Response does not contain any content.');
         }
 

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -73,6 +73,10 @@ final class ResultConverter implements ResultConverterInterface
             throw new ContentFilterException($data['error']['message']);
         }
 
+        if (isset($data['error'])) {
+            throw new RuntimeException(\sprintf('Error "%s"-%s (%s): "%s".', $data['error']['code'], $data['error']['type'], $data['error']['param'], $data['error']['message']));
+        }
+
         if (!isset($data['choices'])) {
             throw new RuntimeException('Response does not contain choices.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Instead of always showing `Response does not contain any content.` or `Response does not contain choices.`, this MR exposes the original error message from Gemini/OpeNAI.

For example: `Error 400 - INVALID_ARGUMENT: A schema in GenerationConfig in the request exceeds the maximum allowed nesting depth.`.