### PR TITLE
[Demo][CI] Use `ramsey/composer-install`

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -62,19 +62,6 @@ jobs:
                   tools: flex
                   extensions: "${{ env.REQUIRED_PHP_EXTENSIONS }}"
 
-            - name: Get composer cache directory
-              id: composer-cache
-              run: |
-                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            - name: Cache packages dependencies
-              uses: actions/cache@v4
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-packages-${{ matrix.php-version }}-${{ matrix.dependency-version }}-${{ matrix.symfony-version }}-${{ hashFiles('src/**/composer.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-composer-packages-${{ matrix.php-version }}-${{ matrix.dependency-version }}-${{ matrix.symfony-version }}
-
             - name: Install root dependencies
               uses: ramsey/composer-install@v3
 
@@ -101,21 +88,10 @@ jobs:
                   tools: flex
                   extensions: "${{ env.REQUIRED_PHP_EXTENSIONS }}"
 
-            - name: Get composer cache directory
-              id: composer-cache
-              run: |
-                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            - name: Cache demo dependencies
-              uses: actions/cache@v4
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-demo-8.4-${{ hashFiles('demo/composer.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-composer-demo-8.4
-
             - name: Install demo dependencies
-              run: composer install --no-progress --no-interaction --ansi
+              uses: ramsey/composer-install@v3
+              with:
+                  working-directory: demo
 
             - name: Run demo tests
               run: vendor/bin/phpunit


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Replace manual composer caching with ramsey/composer-install@v3 which provides better caching and more reliable dependency management for both examples and demo jobs.