### PR TITLE
[CI] Use `ramsey/composer-install` for examples dependencies

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -66,8 +66,13 @@ jobs:
               uses: ramsey/composer-install@v3
 
             - name: Install examples dependencies
+              uses: ramsey/composer-install@v3
+              with:
+                  working-directory: examples
+
+            - name: Link examples
               working-directory: examples
-              run: composer install && ../link
+              run: ../link
 
             - name: Run commands examples
               run: php examples/commands/stores.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Replace manual composer install with ramsey/composer-install action in integration tests workflow for consistency across all workflows.