### PR TITLE
[Demo] Fix `QueryCommand` to use same embedding model as vectorizer

### DIFF
--- a/demo/src/Blog/Command/QueryCommand.php
+++ b/demo/src/Blog/Command/QueryCommand.php
@@ -44,7 +44,7 @@ final class QueryCommand
         $io->comment(\sprintf('Converting "%s" to vector & searching in Chroma DB ...', $search));
         $io->comment('Results are limited to 4 most similar documents.');
 
-        $platformResponse = $this->platform->invoke(new Embeddings(Embeddings::TEXT_3_SMALL), $search);
+        $platformResponse = $this->platform->invoke(new Embeddings(Embeddings::TEXT_ADA_002), $search);
         $queryResponse = $collection->query(
             queryEmbeddings: [$platformResponse->asVectors()[0]->getData()],
             nResults: 4,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Use TEXT_ADA_002 for query embeddings to match the vectorizer configuration, ensuring consistent embedding models between indexing and querying for better similarity search results.