### PR TITLE
[Examples] Add `minimum-stability` `dev` to `composer.json`

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -3,6 +3,7 @@
     "description": "Example scripts about using Symfony AI",
     "license": "MIT",
     "type": "project",
+    "minimum-stability": "dev",
     "require": {
         "php": ">=8.2",
         "ext-pdo": "*",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Adds minimum-stability configuration to allow dev dependencies and development versions of packages in examples.

Needed for #277, thanks @xabbuh 