### PR TITLE
Add `void` return type to `initialize` methods in store commands

### DIFF
--- a/src/store/src/Command/DropStoreCommand.php
+++ b/src/store/src/Command/DropStoreCommand.php
@@ -64,7 +64,7 @@ EOF
         ;
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $storeName = $input->getArgument('store');
         if (!$this->stores->has($storeName)) {

--- a/src/store/src/Command/SetupStoreCommand.php
+++ b/src/store/src/Command/SetupStoreCommand.php
@@ -62,7 +62,7 @@ EOF
         ;
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $storeName = $input->getArgument('store');
         if (!$this->stores->has($storeName)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT