### PR TITLE
[Platform] Add ModelNotFoundException

### DIFF
--- a/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\DockerModelRunner\Completions;
 use Symfony\AI\Platform\Bridge\DockerModelRunner\Completions;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -44,6 +45,11 @@ final class ResultConverter implements ResultConverterInterface
     {
         if ($options['stream'] ?? false) {
             return new StreamResult($this->convertStream($result->getObject()));
+        }
+
+        if (404 === $result->getObject()->getStatusCode()
+            && str_contains(strtolower($result->getObject()->getContent(false)), 'model not found')) {
+            throw new ModelNotFoundException($result->getObject()->getContent(false));
         }
 
         $data = $result->getData();

--- a/src/platform/src/Bridge/DockerModelRunner/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Embeddings/ResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\DockerModelRunner\Embeddings;
 
 use Symfony\AI\Platform\Bridge\DockerModelRunner\Embeddings;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -31,6 +32,11 @@ final class ResultConverter implements ResultConverterInterface
 
     public function convert(RawResultInterface $result, array $options = []): VectorResult
     {
+        if (404 === $result->getObject()->getStatusCode()
+            && str_contains(strtolower($result->getObject()->getContent(false)), 'model not found')) {
+            throw new ModelNotFoundException($result->getObject()->getContent(false));
+        }
+
         $data = $result->getData();
 
         if (!isset($data['data'])) {

--- a/src/platform/src/Exception/ModelNotFoundException.php
+++ b/src/platform/src/Exception/ModelNotFoundException.php
@@ -14,6 +14,6 @@ namespace Symfony\AI\Platform\Exception;
 /**
  * @author Mathieu Santostefano <msantostefano@proton.me>
  */
-class ExceedContextSizeException extends InvalidArgumentException implements ExceptionInterface
+class ModelNotFoundException extends \InvalidArgumentException implements ExceptionInterface
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Following up #531 

This PR introduce `ModelNotFoundException`, useful for local model runners that return an error due to a non-existing model locally (typo in name or never downloaded model for instance).

It must be used by Ollama and LmStudio bridges. PRs are welcome.