### PR TITLE
 Remove redundant `vectorFieldName` parameter from MariaDB example

### DIFF
--- a/examples/memory/mariadb.php
+++ b/examples/memory/mariadb.php
@@ -34,7 +34,6 @@ $store = Store::fromDbal(
     connection: DriverManager::getConnection((new DsnParser())->parse($_ENV['MARIADB_URI'])),
     tableName: 'my_table_memory',
     indexName: 'my_index',
-    vectorFieldName: 'embedding',
 );
 
 // our data


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

The 'embedding' value is the default for vectorFieldName parameter, so it can be omitted to simplify the example code.