### PR TITLE
[Agent] Allow translatable prompts in `SystemPromptInputProcessor`

### DIFF
--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -42,6 +42,7 @@
         "symfony/dom-crawler": "^7.3|^8.0",
         "symfony/event-dispatcher": "^7.3|^8.0",
         "symfony/http-foundation": "^7.3|^8.0",
+        "symfony/translation": "^7.3|^8.0",
         "symfony/translation-contracts": "^3.6"
     },
     "autoload": {

--- a/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
@@ -29,6 +29,7 @@ use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tool\ExecutionReference;
 use Symfony\AI\Platform\Tool\Tool;
+use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[CoversClass(SystemPromptInputProcessor::class)]
@@ -106,7 +107,7 @@ final class SystemPromptInputProcessorTest extends TestCase
     public function testIncludeToolDefinitions()
     {
         $processor = new SystemPromptInputProcessor(
-            'This is a',
+            new TranslatableMessage('This is a'),
             new class implements ToolboxInterface {
                 public function getTools(): array
                 {
@@ -130,7 +131,6 @@ final class SystemPromptInputProcessorTest extends TestCase
                 }
             },
             $this->getTranslator(),
-            true,
         );
 
         $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')));
@@ -196,7 +196,7 @@ final class SystemPromptInputProcessorTest extends TestCase
 
     public function testWithTranslatedSystemPrompt()
     {
-        $processor = new SystemPromptInputProcessor('This is a', null, $this->getTranslator(), true);
+        $processor = new SystemPromptInputProcessor(new TranslatableMessage('This is a'), null, $this->getTranslator());
 
         $input = new Input(new Gpt(), new MessageBag(Message::ofUser('This is a user message')), []);
         $processor->processInput($input);
@@ -211,11 +211,9 @@ final class SystemPromptInputProcessorTest extends TestCase
     public function testWithTranslationDomainSystemPrompt()
     {
         $processor = new SystemPromptInputProcessor(
-            'This is a',
+            new TranslatableMessage('This is a', domain: 'prompts'),
             null,
             $this->getTranslator(),
-            true,
-            'prompts'
         );
 
         $input = new Input(new Gpt(), new MessageBag(), []);
@@ -229,13 +227,12 @@ final class SystemPromptInputProcessorTest extends TestCase
 
     public function testWithMissingTranslator()
     {
-        $this->expectExceptionMessage('Prompt translation is enabled but no translator was provided');
+        $this->expectExceptionMessage('Translatable system prompt is not supported when no translator is provided.');
 
         new SystemPromptInputProcessor(
-            'This is a',
+            new TranslatableMessage('This is a'),
             null,
             null,
-            true,
         );
     }
 

--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -29,7 +29,8 @@
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5",
         "symfony/expression-language": "^7.3|^8.0",
-        "symfony/security-core": "^7.3|^8.0"
+        "symfony/security-core": "^7.3|^8.0",
+        "symfony/translation": "^7.3|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Translation\TranslatableMessage;
 
 #[CoversClass(AiBundle::class)]
 #[UsesClass(ContainerBuilder::class)]
@@ -682,10 +683,8 @@ class AiBundleTest extends TestCase
         $definition = $container->getDefinition('ai.agent.test_agent.system_prompt_processor');
         $arguments = $definition->getArguments();
 
-        $this->assertSame('You are a helpful assistant.', $arguments[0]);
+        $this->assertEquals(new TranslatableMessage('You are a helpful assistant.', domain: 'prompts'), $arguments[0]);
         $this->assertNull($arguments[1]); // include_tools is false, so null reference
-        $this->assertTrue($arguments[3]);
-        $this->assertSame('prompts', $arguments[4]);
     }
 
     #[TestDox('System prompt with include_tools enabled works correctly')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes/no
| Docs?         |  no <!-- required for new features -->
| Issues        | Fix #... 
| License       | MIT

This is a follow up of https://github.com/symfony/ai/pull/514 with a suggestion of using TranslatableMessage instance for prompts rather than the need in SystemPromptInputProcessor constructor of
- A boolean enableTranslation
- A domain

Since we're passing a TranslatableMessage this also allow to use translation parameters.

cc @OskarStark that was the suggestion in https://github.com/symfony/ai/pull/514#issuecomment-3299514958