### PR TITLE
[Agent] Use named arguments for exception previous parameter

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -92,7 +92,7 @@ final readonly class ResultConverter implements ResultConverterInterface
                 try {
                     $data = json_decode($delta, true, 512, \JSON_THROW_ON_ERROR);
                 } catch (\JsonException $e) {
-                    throw new RuntimeException('Failed to decode JSON response.', 0, $e);
+                    throw new RuntimeException('Failed to decode JSON response.', previous: $e);
                 }
 
                 $choices = array_map($this->convertChoice(...), $data['candidates'] ?? []);

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -91,7 +91,7 @@ final readonly class ResultConverter implements ResultConverterInterface
                 try {
                     $data = json_decode($delta, true, 512, \JSON_THROW_ON_ERROR);
                 } catch (\JsonException $e) {
-                    throw new RuntimeException('Failed to decode JSON response.', 0, $e);
+                    throw new RuntimeException('Failed to decode JSON response.', previous: $e);
                 }
 
                 $choices = array_map($this->convertChoice(...), $data['candidates'] ?? []);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Remove unnecessary 0 code parameter and use named 'previous' argument for better code readability in RuntimeException constructors.