### PR TITLE
[AI Bundle] Improvement on alias for store

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -697,7 +697,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -729,7 +730,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -744,7 +746,8 @@ final class AiBundle extends AbstractBundle
                     ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -771,7 +774,8 @@ final class AiBundle extends AbstractBundle
                 ;
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -802,6 +806,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -832,7 +838,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -857,7 +864,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -889,7 +897,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -916,7 +925,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -954,7 +964,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -979,7 +990,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -1006,7 +1018,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -1047,7 +1060,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -1074,7 +1088,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
 
@@ -1093,6 +1108,8 @@ final class AiBundle extends AbstractBundle
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
     }

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -29,6 +29,7 @@ use Symfony\AI\Store\Document\Filter\TextContainsFilter;
 use Symfony\AI\Store\Document\Loader\InMemoryLoader;
 use Symfony\AI\Store\Document\Transformer\TextTrimTransformer;
 use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\StoreInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -98,6 +99,37 @@ class AiBundleTest extends TestCase
 
         $this->assertTrue($container->hasAlias(AgentInterface::class));
         $this->assertTrue($container->hasAlias(AgentInterface::class.' $myAgentAgent'));
+    }
+
+    public function testInjectionStoreAliasIsRegistered()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'store' => [
+                    'memory' => [
+                        'main' => [
+                            'strategy' => 'cosine',
+                        ],
+                        'secondary_with_custom_strategy' => [
+                            'strategy' => 'manhattan',
+                        ],
+                    ],
+                    'weaviate' => [
+                        'main' => [
+                            'endpoint' => 'http://localhost:8080',
+                            'api_key' => 'bar',
+                            'collection' => 'my_weaviate_collection',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasAlias(StoreInterface::class.' $main'));
+        $this->assertTrue($container->hasAlias('.'.StoreInterface::class.' $secondary_with_custom_strategy'));
+        $this->assertTrue($container->hasAlias(StoreInterface::class.' $secondaryWithCustomStrategy'));
+        $this->assertTrue($container->hasAlias('.'.StoreInterface::class.' $weaviate_main'));
+        $this->assertTrue($container->hasAlias(StoreInterface::class.' $weaviateMain'));
     }
 
     public function testAgentHasTag()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix none
| License       | MIT

Hi 👋🏻 

A small improvement for the store alias, this approach allows to use the same name for various store (like `foo` for a memory one, a qdrant one, etc) without injection issues.