### PR TITLE
[Platform] Rework platform by introducing Connectors

### DIFF
--- a/examples/openai/connector.php
+++ b/examples/openai/connector.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAI\Connector;
+use Symfony\AI\Platform\Bridge\OpenAI\GPT;
+use Symfony\AI\Platform\ConnectorPlatform;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once dirname(__DIR__).'/vendor/autoload.php';
+(new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
+
+if (!isset($_SERVER['OPENAI_API_KEY'])) {
+    echo 'Please set the OPENAI_API_KEY environment variable.'.\PHP_EOL;
+    exit(1);
+}
+
+$connector = new Connector($_SERVER['OPENAI_API_KEY']);
+$model = new GPT(GPT::GPT_4O_MINI, [
+    'temperature' => 0.5, // default options for the model
+]);
+
+$platform = new ConnectorPlatform($connector);
+
+$result = $platform->call($model, new MessageBag(
+    Message::forSystem('You are a pirate and you write funny.'),
+    Message::ofUser('What is the Symfony framework?'),
+));
+
+echo $result->asText().\PHP_EOL;

--- a/src/platform/src/Bridge/OpenAi/Connector.php
+++ b/src/platform/src/Bridge/OpenAi/Connector.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Symfony\AI\Platform\Bridge\OpenAi;
+
+use Symfony\AI\Platform\Bridge\OpenAi\Contract\OpenAiContract;
+use Symfony\AI\Platform\Connector\HttpResult;
+use Symfony\AI\Platform\Connector\ResultInterface;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Connector\HttpConnector;
+use Symfony\AI\Platform\Result\ResultInterface as ConverterResult;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class Connector extends HttpConnector
+{
+    const BASE_URL = 'https://api.openai.com/v1';
+
+    public function __construct(
+        #[\SensitiveParameter] private readonly string $apiKey,
+        private readonly ?string $region = null,
+        private readonly ?HttpClientInterface $httpClient = null,
+    ) {
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Gpt
+            || $model instanceof DallE
+            || $model instanceof Embeddings
+            || $model instanceof Whisper;
+    }
+
+    public function getContract(): Contract
+    {
+        return OpenAiContract::create();
+    }
+
+    protected function initHttpClient(): EventSourceHttpClient
+    {
+        $httpClient = $this->httpClient instanceof EventSourceHttpClient
+            ? $this->httpClient : new EventSourceHttpClient($this->httpClient);
+
+        return $httpClient->withOptions(['auth_bearer' => $this->apiKey]);
+    }
+
+    protected function getEndpoint(Model $model): string
+    {
+        $baseUrl = match ($this->region) {
+            null => 'https://api.openai.com',
+            PlatformFactory::REGION_EU => 'https://eu.api.openai.com',
+            PlatformFactory::REGION_US => 'https://us.api.openai.com',
+            default => throw new InvalidArgumentException(\sprintf('Invalid region "%s". Valid options are: "%s", "%s", or null.', $this->region, PlatformFactory::REGION_EU, PlatformFactory::REGION_US)),
+        };
+
+        return match (get_class($model)) {
+            Gpt::class => $baseUrl.'/chat/completions',
+            DallE::class => $baseUrl.'/images/generations',
+            Embeddings::class => $baseUrl.'/embeddings',
+            Whisper::class => $baseUrl.'/audio/transcriptions',
+            default => throw new InvalidArgumentException('Unsupported model type.'),
+        };
+    }
+
+    public function isError(ResultInterface $result): bool
+    {
+        return false;
+    }
+
+    public function handleStream(Model $model, HttpResult|ResultInterface $result, array $options): StreamResult
+    {
+        return match (get_class($model)) {
+            Gpt::class => (new Gpt\ResultConverter())->convert($result->getRawObject(), $options),
+            default => throw new InvalidArgumentException('Unsupported model type for streaming.'),
+        };
+    }
+
+    public function handleError(Model $model, ResultInterface $result): never
+    {
+        // TODO: Implement handleError() method.
+    }
+
+    public function handleResult(Model $model, HttpResult|ResultInterface $result, array $options): ConverterResult
+    {
+        return match (get_class($model)) {
+            Gpt::class => (new Gpt\ResultConverter())->convert($result->getRawObject(), $options),
+            DallE::class => (new DallEModelClient())->convert($result->getRawObject(), $options),
+            Embeddings::class => (new EmbeddingsResponseConverter())->convert($result->getRawObject(), $options),
+            Whisper::class => (new WhisperResponseConverter())->convert($result->getRawObject(), $options),
+            default => throw new InvalidArgumentException('Unsupported model type for streaming.'),
+        };
+    }
+}

--- a/src/platform/src/Connector/ConnectorInterface.php
+++ b/src/platform/src/Connector/ConnectorInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Symfony\AI\Platform\Connector;
+
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\ResultInterface as ConverterResult;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+interface ConnectorInterface
+{
+    public function getContract(): Contract;
+
+    /**
+     * @param array<int|string, mixed>|string $payload
+     * @param array<string, mixed>            $options
+     *
+     * @return array<string, mixed>
+     */
+    public function call(Model $model, array|string $payload, array $options): ResultPromise;
+
+    public function isError(ResultInterface $result): bool;
+
+    public function handleStream(Model $model, ResultInterface $result, array $options): StreamResult;
+
+    /**
+     * @throws ConnectorException
+     */
+    public function handleError(Model $model, ResultInterface $result): never;
+
+    public function handleResult(Model $model, ResultInterface $result, array $options): ConverterResult;
+}

--- a/src/platform/src/Connector/HttpConnector.php
+++ b/src/platform/src/Connector/HttpConnector.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\AI\Platform\Connector;
+
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Model;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+abstract class HttpConnector implements ConnectorInterface
+{
+    public function getContract(): Contract
+    {
+        return Contract::create();
+    }
+
+    public function call(Model $model, array|string $payload, array $options): ResultPromise
+    {
+        $response = $this->initHttpClient()->request('POST', $this->getEndpoint($model), [
+            'json' => $payload,
+        ]);
+
+        return new ResultPromise(new HttpResult($response), $options);
+    }
+
+    abstract protected function initHttpClient(): EventSourceHttpClient;
+
+    abstract protected function getEndpoint(Model $model): string;
+}

--- a/src/platform/src/Connector/HttpResult.php
+++ b/src/platform/src/Connector/HttpResult.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\AI\Platform\Connector;
+
+use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponseInterface;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de
+ */
+final readonly class HttpResult implements ResultInterface
+{
+    public function __construct(
+        private HttpResponseInterface $response,
+    ) {
+    }
+
+    public function getRawData(): array
+    {
+        return $this->response->toArray(false);
+    }
+
+    public function getRawObject(): HttpResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/platform/src/Connector/ResultInterface.php
+++ b/src/platform/src/Connector/ResultInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\AI\Platform\Connector;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+interface ResultInterface
+{
+    /**
+     * Returns an array representation of the raw result data.
+     *
+     * @return array<string, mixed>
+     */
+    public function getRawData(): array;
+
+    /**
+     * Returns the raw result object.
+     *
+     * @return object
+     */
+    public function getRawObject(): object;
+}

--- a/src/platform/src/Connector/ResultPromise.php
+++ b/src/platform/src/Connector/ResultPromise.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Connector;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\UnexpectedResultTypeException;
+use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\ResultInterface as ConverterResult;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Vector\Vector;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ResultPromise
+{
+    private \Closure $resultConverter;
+    private bool $isConverted = false;
+    private ConverterResult $convertedResult;
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(
+        private readonly ResultInterface $result,
+        private readonly array $options = [],
+    ) {
+    }
+
+    public function registerConverter(\Closure $resultConverter): void
+    {
+        if (isset($this->resultConverter)) {
+            throw new RuntimeException('A result converter has already been registered for this promise.');
+        }
+
+        $this->resultConverter = $resultConverter;
+    }
+
+    public function getResult(): ConverterResult
+    {
+        return $this->await();
+    }
+
+    public function getRawResponse(): ResultInterface
+    {
+        return $this->result;
+    }
+
+    public function await(): ConverterResult
+    {
+        if (!$this->isConverted) {
+            if (!isset($this->resultConverter)) {
+                throw new RuntimeException('No result converter registered to handle the raw result.');
+            }
+
+            $this->convertedResult = ($this->resultConverter)($this->result, $this->options);
+
+            if (null === $this->convertedResult->getRawResponse()) {
+                // Fallback to set the raw response when it was not handled by the response converter itself
+                $this->convertedResult->setRawResponse($this->result);
+            }
+
+            $this->isConverted = true;
+        }
+
+        return $this->convertedResult;
+    }
+
+    public function asText(): string
+    {
+        return $this->as(TextResult::class)->getContent();
+    }
+
+    public function asObject(): object
+    {
+        return $this->as(ObjectResult::class)->getContent();
+    }
+
+    public function asBinary(): string
+    {
+        return $this->as(BinaryResult::class)->getContent();
+    }
+
+    public function asBase64(): string
+    {
+        $response = $this->as(BinaryResult::class);
+
+        \assert($response instanceof BinaryResult);
+
+        return $response->toDataUri();
+    }
+
+    /**
+     * @return Vector[]
+     */
+    public function asVectors(): array
+    {
+        return $this->as(VectorResult::class)->getContent();
+    }
+
+    public function asStream(): \Generator
+    {
+        yield from $this->as(StreamResult::class)->getContent();
+    }
+
+    /**
+     * @return ToolCall[]
+     */
+    public function asToolCalls(): array
+    {
+        return $this->as(ToolCallResult::class)->getContent();
+    }
+
+    /**
+     * @param class-string $type
+     */
+    private function as(string $type): ConverterResult
+    {
+        $response = $this->getResult();
+
+        if (!$response instanceof $type) {
+            throw new UnexpectedResultTypeException($type, $response::class);
+        }
+
+        return $response;
+    }
+}

--- a/src/platform/src/ConnectorPlatform.php
+++ b/src/platform/src/ConnectorPlatform.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Symfony\AI\Platform;
+
+use Symfony\AI\Platform\Connector\ConnectorInterface;
+use Symfony\AI\Platform\Connector\ResultInterface as RawResultInterface;
+use Symfony\AI\Platform\Connector\ResultPromise;
+use Symfony\AI\Platform\Result\ResultInterface;
+
+final readonly class ConnectorPlatform
+{
+    public function __construct(
+        private ConnectorInterface $connector,
+    ) {
+    }
+
+    public function call(Model $model, object|array|string $input, array $options = []): ResultPromise
+    {
+        $contract = $this->connector->getContract();
+        $payload = $contract->createRequestPayload($model, $input);
+        $options = array_merge($model->getOptions(), $options);
+
+        if (isset($options['tools'])) {
+            $options['tools'] = $contract->createToolOption($options['tools'], $model);
+        }
+
+        $options['model'] = $model;
+
+        $promise = $this->connector->call($model, $payload, $options);
+        $promise->registerConverter($this->convertResult(...));
+
+        return $promise;
+    }
+
+    private function convertResult(RawResultInterface $result, array $options): ResultInterface
+    {
+        if ($options['stream'] ?? false) {
+            return $this->connector->handleStream($options['model'], $result, $options);
+        }
+
+        if ($this->connector->isError($result)) {
+            $this->connector->handleError($options['model'], $result);
+        }
+
+        return $this->connector->handleResult($options['model'], $result, $options);
+    }
+}

--- a/src/platform/src/Exception/ConnectorException.php
+++ b/src/platform/src/Exception/ConnectorException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\AI\Platform\Exception;
+
+final class ConnectorException extends \Exception implements ExceptionInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

This introduces another concept for encapsulating the connection concerns of Bridges.
This could be the base for streamlining HTTP error handling more easy, bringing an easy extension point for an default openai-compatible and http based connection, and reducing the effort for Platform bridges.
this is not working, but just a sketch - with some fantasy together with #136 and #640 

@OskarStark just revived an old branch of mine, what's good what's not? happy to trash that and start from sketch, but I'm just still not happy with ModelClient and HTTP connection handling
have a look at `src/platform/src/Bridge/OpenAi/Connector.php`