### PR TITLE
[Platform] Remove default values from model constructors

### DIFF
--- a/src/platform/src/Bridge/Anthropic/Claude.php
+++ b/src/platform/src/Bridge/Anthropic/Claude.php
@@ -36,7 +36,7 @@ class Claude extends Model
      */
     public function __construct(
         string $name,
-        array $options = ['max_tokens' => 1000],
+        array $options = [],
     ) {
         $capabilities = [
             Capability::INPUT_MESSAGES,

--- a/src/platform/src/Bridge/Bedrock/Nova/Nova.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/Nova.php
@@ -29,7 +29,7 @@ final class Nova extends Model
      */
     public function __construct(
         string $name,
-        array $options = ['max_tokens' => 1000],
+        array $options = [],
     ) {
         $capabilities = [
             Capability::INPUT_MESSAGES,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Follows #653 
| License       | MIT

Remove hardcoded max_tokens defaults from Claude and Nova model classes to prevent potential BC breaks when these values might change in future versions. Users should explicitly specify max_tokens if needed.