### PR TITLE
[Platform] Reformat model constructor parameters to single line

### DIFF
--- a/src/platform/src/Bridge/Anthropic/Claude.php
+++ b/src/platform/src/Bridge/Anthropic/Claude.php
@@ -34,10 +34,8 @@ class Claude extends Model
     /**
      * @param array<string, mixed> $options The default options for the model usage
      */
-    public function __construct(
-        string $name,
-        array $options = [],
-    ) {
+    public function __construct(string $name, array $options = [])
+    {
         $capabilities = [
             Capability::INPUT_MESSAGES,
             Capability::INPUT_IMAGE,

--- a/src/platform/src/Bridge/Bedrock/Nova/Nova.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/Nova.php
@@ -27,10 +27,8 @@ final class Nova extends Model
     /**
      * @param array<string, mixed> $options The default options for the model usage
      */
-    public function __construct(
-        string $name,
-        array $options = [],
-    ) {
+    public function __construct(string $name, array $options = [])
+    {
         $capabilities = [
             Capability::INPUT_MESSAGES,
             Capability::OUTPUT_TEXT,

--- a/src/platform/src/Bridge/ElevenLabs/ElevenLabs.php
+++ b/src/platform/src/Bridge/ElevenLabs/ElevenLabs.php
@@ -31,10 +31,8 @@ final class ElevenLabs extends Model
     public const SCRIBE_V1 = 'scribe_v1';
     public const SCRIBE_V1_EXPERIMENTAL = 'scribe_v1_experimental';
 
-    public function __construct(
-        string $name,
-        array $options = [],
-    ) {
+    public function __construct(string $name, array $options = [])
+    {
         parent::__construct($name, [], $options);
     }
 }

--- a/src/platform/src/Bridge/Mistral/Embeddings.php
+++ b/src/platform/src/Bridge/Mistral/Embeddings.php
@@ -24,10 +24,8 @@ final class Embeddings extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(
-        string $name,
-        array $options = [],
-    ) {
+    public function __construct(string $name, array $options = [])
+    {
         parent::__construct($name, [Capability::INPUT_MULTIPLE], $options);
     }
 }

--- a/src/platform/src/Bridge/Mistral/Mistral.php
+++ b/src/platform/src/Bridge/Mistral/Mistral.php
@@ -35,10 +35,8 @@ final class Mistral extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(
-        string $name,
-        array $options = [],
-    ) {
+    public function __construct(string $name, array $options = [])
+    {
         $capabilities = [
             Capability::INPUT_MESSAGES,
             Capability::OUTPUT_TEXT,

--- a/src/platform/src/Bridge/OpenAi/Gpt.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt.php
@@ -73,10 +73,8 @@ class Gpt extends Model
     /**
      * @param array<mixed> $options The default options for the model usage
      */
-    public function __construct(
-        string $name,
-        array $options = [],
-    ) {
+    public function __construct(string $name, array $options = [])
+    {
         $capabilities = [
             Capability::INPUT_MESSAGES,
             Capability::OUTPUT_TEXT,

--- a/src/platform/src/Bridge/Perplexity/Perplexity.php
+++ b/src/platform/src/Bridge/Perplexity/Perplexity.php
@@ -28,10 +28,8 @@ final class Perplexity extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(
-        string $name,
-        array $options = [],
-    ) {
+    public function __construct(string $name, array $options = [])
+    {
         $capabilities = [
             Capability::INPUT_MESSAGES,
             Capability::INPUT_PDF,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Changed multi-line constructor parameter declarations to single line format across all model classes since default values were removed.