### PR TITLE
[Store][Postgres] Remove redundant PHPDoc from `query` method

### DIFF
--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -127,11 +127,6 @@ final readonly class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    /**
-     * @param array<string, mixed> $options
-     *
-     * @return VectorDocument[]
-     */
     public function query(Vector $vector, array $options = []): array
     {
         $where = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

The PHPDoc comment for the query method in the Postgres Store class was identical to the interface definition and didn't add any value. The interface already documents the parameter and return types.