### PR TITLE
[Platform][Ollama] Better regex for qwen tool pattern

### DIFF
--- a/src/platform/src/Bridge/Ollama/Ollama.php
+++ b/src/platform/src/Bridge/Ollama/Ollama.php
@@ -23,6 +23,7 @@ class Ollama extends Model
     public const GEMMA_3_N = 'gemma3n';
     public const GEMMA_3 = 'gemma3';
     public const QWEN_3 = 'qwen3';
+    public const QWEN_3_32B = 'qwen3:32b';
     public const QWEN_2_5_VL = 'qwen2.5vl';
     public const LLAMA_3_1 = 'llama3.1';
     public const LLAMA_3_2 = 'llama3.2';
@@ -33,6 +34,7 @@ class Ollama extends Model
     public const PHI_3 = 'phi3';
     public const GEMMA_2 = 'gemma2';
     public const QWEN_2_5_CODER = 'qwen2.5-coder';
+    public const QWEN_2_5_CODER_32B = 'qwen2.5-coder:32b';
     public const GEMMA = 'gemma';
     public const QWEN = 'qwen';
     public const QWEN_2 = 'qwen2';
@@ -50,7 +52,7 @@ class Ollama extends Model
         '/^llama\D*3(\D*\d+)/' => [
             Capability::TOOL_CALLING,
         ],
-        '/^qwen\d(\.\d)?(-coder)?$/' => [
+        '/^qwen\d(\.\d)?(-coder)?(:\d+(\.\d+)?b)?$/' => [
             Capability::TOOL_CALLING,
         ],
         '/^(deepseek|mistral)/' => [

--- a/src/platform/tests/Bridge/Ollama/OllamaTest.php
+++ b/src/platform/tests/Bridge/Ollama/OllamaTest.php
@@ -64,7 +64,9 @@ final class OllamaTest extends TestCase
         yield 'qwen2' => [Ollama::QWEN_2];
         yield 'qwen2.5' => [Ollama::QWEN_2_5];
         yield 'qwen2.5-coder' => [Ollama::QWEN_2_5_CODER];
+        yield 'qwen2.5-coder:32b' => [Ollama::QWEN_2_5_CODER_32B];
         yield 'qwen3' => [Ollama::QWEN_3];
+        yield 'qwen3:32b' => [Ollama::QWEN_3_32B];
 
         // Models that match the deepseek pattern
         yield 'deepseek-r1' => [Ollama::DEEPSEEK_R_1];


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes/no <!-- required for new features -->
| Issues        |  - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

The current regex for QWEN models does not cover model size notation like `qwen3:32b` or `qwen3-coder:32b`.
I changed the regular expression to support notations with model sizes.
