### PR TITLE
 Refactor examples to use `print_stream` helper function

### DIFF
--- a/examples/anthropic/stream.php
+++ b/examples/anthropic/stream.php
@@ -25,7 +25,4 @@ $messages = new MessageBag(
 );
 $result = $platform->invoke($model, $messages, ['stream' => true]);
 
-foreach ($result->getResult()->getContent() as $word) {
-    echo $word;
-}
-echo \PHP_EOL;
+print_stream($result);

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -130,3 +130,11 @@ function perplexity_print_citations(Metadata $metadata): void
         echo \PHP_EOL;
     }
 }
+
+function print_stream(ResultPromise $result): void
+{
+    foreach ($result->getResult()->getContent() as $word) {
+        echo $word;
+    }
+    echo \PHP_EOL;
+}

--- a/examples/cerebras/stream.php
+++ b/examples/cerebras/stream.php
@@ -27,7 +27,4 @@ $result = $platform->invoke(new Model(Model::LLAMA3_1_8B), $messages, [
     'stream' => true,
 ]);
 
-foreach ($result->getResult()->getContent() as $word) {
-    echo $word;
-}
-echo \PHP_EOL;
+print_stream($result);

--- a/examples/gemini/stream.php
+++ b/examples/gemini/stream.php
@@ -27,7 +27,4 @@ $result = $platform->invoke($model, $messages, [
     'stream' => true, // enable streaming of response text
 ]);
 
-foreach ($result->getResult()->getContent() as $word) {
-    echo $word;
-}
-echo \PHP_EOL;
+print_stream($result);

--- a/examples/mistral/stream.php
+++ b/examples/mistral/stream.php
@@ -24,7 +24,4 @@ $result = $platform->invoke($model, $messages, [
     'stream' => true,
 ]);
 
-foreach ($result->getResult()->getContent() as $word) {
-    echo $word;
-}
-echo \PHP_EOL;
+print_stream($result);

--- a/examples/ollama/stream.php
+++ b/examples/ollama/stream.php
@@ -26,7 +26,4 @@ $messages = new MessageBag(
 
 $result = $platform->invoke($model, $messages, ['stream' => true]);
 
-foreach ($result->getResult()->getContent() as $word) {
-    echo $word;
-}
-echo \PHP_EOL;
+print_stream($result);

--- a/examples/openai/stream.php
+++ b/examples/openai/stream.php
@@ -27,7 +27,4 @@ $result = $platform->invoke($model, $messages, [
     'stream' => true, // enable streaming of response text
 ]);
 
-foreach ($result->getResult()->getContent() as $word) {
-    echo $word;
-}
-echo \PHP_EOL;
+print_stream($result);

--- a/examples/vertexai/stream.php
+++ b/examples/vertexai/stream.php
@@ -28,8 +28,4 @@ $result = $platform->invoke($model, $messages, [
     'stream' => true,
 ]);
 
-foreach ($result->getResult()->getContent() as $word) {
-    echo $word;
-}
-
-echo \PHP_EOL;
+print_stream($result);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Extract repeated streaming pattern into reusable print_stream function in examples/bootstrap.php and update all streaming examples to use it.
