### PR TITLE
[Agent] Remove tool calling capability validation from `AgentProcessor`

### DIFF
--- a/src/agent/src/Toolbox/AgentProcessor.php
+++ b/src/agent/src/Toolbox/AgentProcessor.php
@@ -13,14 +13,12 @@ namespace Symfony\AI\Agent\Toolbox;
 
 use Symfony\AI\Agent\AgentAwareInterface;
 use Symfony\AI\Agent\AgentAwareTrait;
-use Symfony\AI\Agent\Exception\MissingModelSupportException;
 use Symfony\AI\Agent\Input;
 use Symfony\AI\Agent\InputProcessorInterface;
 use Symfony\AI\Agent\Output;
 use Symfony\AI\Agent\OutputProcessorInterface;
 use Symfony\AI\Agent\Toolbox\Event\ToolCallsExecuted;
 use Symfony\AI\Agent\Toolbox\StreamResult as ToolboxStreamResponse;
-use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -46,10 +44,6 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
 
     public function processInput(Input $input): void
     {
-        if (!$input->model->supports(Capability::TOOL_CALLING)) {
-            throw MissingModelSupportException::forToolCalling($input->model::class);
-        }
-
         $toolMap = $this->toolbox->getTools();
         if ([] === $toolMap) {
             return;

--- a/src/agent/tests/Toolbox/AgentProcessorTest.php
+++ b/src/agent/tests/Toolbox/AgentProcessorTest.php
@@ -13,7 +13,6 @@ namespace Symfony\AI\Agent\Tests\Toolbox;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\AgentInterface;
-use Symfony\AI\Agent\Exception\MissingModelSupportException;
 use Symfony\AI\Agent\Input;
 use Symfony\AI\Agent\Output;
 use Symfony\AI\Agent\Toolbox\AgentProcessor;
@@ -74,17 +73,6 @@ class AgentProcessorTest extends TestCase
         $processor->processInput($input);
 
         $this->assertSame(['tools' => [$tool2]], $input->getOptions());
-    }
-
-    public function testProcessInputWithUnsupportedToolCallingWillThrowException()
-    {
-        $this->expectException(MissingModelSupportException::class);
-
-        $model = new Model('gpt-3');
-        $processor = new AgentProcessor($this->createStub(ToolboxInterface::class));
-        $input = new Input($model, new MessageBag());
-
-        $processor->processInput($input);
     }
 
     public function testProcessOutputWithToolCallResponseKeepingMessages()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix https://github.com/symfony/ai/issues/678
| License       | MIT

This removes the exception that was thrown when models don't support tool calling capabilities, allowing AgentProcessor to work with any model regardless of their declared capabilities.