### PR TITLE
[AI Bundle] Rename `ai:chat` command to `ai:agent:call`

### DIFF
--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -21,7 +21,7 @@ use Symfony\AI\Agent\Toolbox\ToolCallArgumentResolver;
 use Symfony\AI\Agent\Toolbox\ToolFactory\AbstractToolFactory;
 use Symfony\AI\Agent\Toolbox\ToolFactory\ReflectionToolFactory;
 use Symfony\AI\Agent\Toolbox\ToolResultConverter;
-use Symfony\AI\AiBundle\Command\ChatCommand;
+use Symfony\AI\AiBundle\Command\AgentCallCommand;
 use Symfony\AI\AiBundle\Profiler\DataCollector;
 use Symfony\AI\AiBundle\Profiler\TraceableToolbox;
 use Symfony\AI\AiBundle\Security\EventListener\IsGrantedToolAttributeListener;
@@ -154,7 +154,7 @@ return static function (ContainerConfigurator $container): void {
         ->set('ai.platform.search_result_processor.perplexity', PerplexitySearchResultProcessor::class)
 
         // commands
-        ->set('ai.command.chat', ChatCommand::class)
+        ->set('ai.command.chat', AgentCallCommand::class)
             ->args([
                 tagged_locator('ai.agent', 'name'),
             ])

--- a/src/ai-bundle/src/Command/AgentCallCommand.php
+++ b/src/ai-bundle/src/Command/AgentCallCommand.php
@@ -32,10 +32,11 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
 #[AsCommand(
-    name: 'ai:chat',
-    description: 'Chat with an agent',
+    name: 'ai:agent:call',
+    aliases: ['ai:chat'],
+    description: 'Call an agent',
 )]
-final class ChatCommand extends Command
+final class AgentCallCommand extends Command
 {
     /**
      * @param ServiceLocator<AgentInterface> $agents

--- a/src/ai-bundle/tests/Command/AgentCallCommandTest.php
+++ b/src/ai-bundle/tests/Command/AgentCallCommandTest.php
@@ -17,7 +17,7 @@ namespace Symfony\AI\AiBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\AgentInterface;
-use Symfony\AI\AiBundle\Command\ChatCommand;
+use Symfony\AI\AiBundle\Command\AgentCallCommand;
 use Symfony\AI\AiBundle\Exception\RuntimeException;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
-final class ChatCommandTest extends TestCase
+final class AgentCallCommandTest extends TestCase
 {
     public function testCommandFailsWithInvalidAgent()
     {
@@ -37,7 +37,7 @@ final class ChatCommandTest extends TestCase
             'test' => $agent,
         ];
 
-        $command = new ChatCommand($this->createServiceLocator($agents));
+        $command = new AgentCallCommand($this->createServiceLocator($agents));
         $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
@@ -71,7 +71,7 @@ final class ChatCommandTest extends TestCase
             'test' => $agent,
         ];
 
-        $command = new ChatCommand($this->createServiceLocator($agents));
+        $command = new AgentCallCommand($this->createServiceLocator($agents));
         $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
@@ -100,7 +100,7 @@ final class ChatCommandTest extends TestCase
             'test' => $agent,
         ];
 
-        $command = new ChatCommand($this->createServiceLocator($agents));
+        $command = new AgentCallCommand($this->createServiceLocator($agents));
         $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
@@ -128,7 +128,7 @@ final class ChatCommandTest extends TestCase
             'test' => $agent,
         ];
 
-        $command = new ChatCommand($this->createServiceLocator($agents));
+        $command = new AgentCallCommand($this->createServiceLocator($agents));
         $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
@@ -165,7 +165,7 @@ final class ChatCommandTest extends TestCase
             'second' => $agent2,
         ];
 
-        $command = new ChatCommand($this->createServiceLocator($agents));
+        $command = new AgentCallCommand($this->createServiceLocator($agents));
         $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);
@@ -203,7 +203,7 @@ final class ChatCommandTest extends TestCase
             'test' => $agent,
         ];
 
-        $command = new ChatCommand($this->createServiceLocator($agents));
+        $command = new AgentCallCommand($this->createServiceLocator($agents));
         $application = self::createApplication($command);
 
         $commandTester = new CommandTester($command);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Follows #395 
| License       | MIT

I think we can have ai:chat command soon after #675