### PR TITLE
[Platform][OpenAI] Improve error reporting for Bad Request

### DIFF
--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -48,6 +49,11 @@ final class ResultConverter implements ResultConverterInterface
         if (401 === $response->getStatusCode()) {
             $errorMessage = json_decode($response->getContent(false), true)['error']['message'];
             throw new AuthenticationException($errorMessage);
+        }
+
+        if (400 === $response->getStatusCode()) {
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? 'Bad Request';
+            throw new BadRequestException($errorMessage);
         }
 
         if (429 === $response->getStatusCode()) {

--- a/src/platform/src/Exception/BadRequestException.php
+++ b/src/platform/src/Exception/BadRequestException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Exception;
+
+/**
+ * @author Oscar Esteve <oscarsdt@gmail.com>
+ */
+class BadRequestException extends RuntimeException
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #528
| License       | MIT

I've noted an interesting initiative at https://github.com/symfony/ai/pull/574 to handle non-valid response codes in a more structured and scalable way. This approach makes sense to me, but it may require further reflection. With this PR, I aim to contribute a humble and specific use case for OpenAI, along with an Exception class that could be reused for the other bridges.