### PR TITLE
[AI Bundle] Fix data_collector template for multiple parameter types

### DIFF
--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -200,7 +200,7 @@
                                 <ul>
                                     {% for name, parameter in tool.parameters.properties %}
                                         <li>
-                                            <strong>{{ name }} ({{ parameter.type }})</strong><br />
+                                            <strong>{{ name }} ({{ parameter.type is iterable ? parameter.type|join(', ') : parameter.type }})</strong><br />
                                             <i>{{ parameter.description|default() }}</i>
                                         </li>
                                     {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

The tool call parameter type can be an array (for example, when it is nullable). In this case, the entire profiler tab breaks. This fix addresses the issue by properly handling multiple types.
