### PR TITLE
[Platform][Gemini] Do tool call if any `contentPart` is a `functionCall`

### DIFF
--- a/examples/vertexai/toolcall.php
+++ b/examples/vertexai/toolcall.php
@@ -23,7 +23,7 @@ $platform = PlatformFactory::create(env('GOOGLE_CLOUD_LOCATION'), env('GOOGLE_CL
 
 $toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gemini-2.0-flash-lite', [$processor], [$processor], logger: logger());
+$agent = new Agent($platform, 'gemini-2.5-flash-lite', [$processor], [$processor], logger: logger());
 
 $messages = new MessageBag(Message::ofUser('What time is it?'));
 $result = $agent->call($messages);

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -142,12 +142,15 @@ final readonly class ResultConverter implements ResultConverterInterface
     {
         $contentParts = $choice['content']['parts'];
 
-        if (1 === \count($contentParts)) {
-            $contentPart = $contentParts[0];
-
+        // If any part is a function call, return it immediately and ignore all other parts.
+        foreach ($contentParts as $contentPart) {
             if (isset($contentPart['functionCall'])) {
                 return new ToolCallResult($this->convertToolCall($contentPart['functionCall']));
             }
+        }
+
+        if (1 === \count($contentParts)) {
+            $contentPart = $contentParts[0];
 
             if (isset($contentPart['text'])) {
                 return new TextResult($contentPart['text']);

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -129,12 +129,15 @@ final readonly class ResultConverter implements ResultConverterInterface
     {
         $contentParts = $choice['content']['parts'];
 
-        if (1 === \count($contentParts)) {
-            $contentPart = $contentParts[0];
-
+        // If any part is a function call, return it immediately and ignore all other parts.
+        foreach ($contentParts as $contentPart) {
             if (isset($contentPart['functionCall'])) {
                 return new ToolCallResult($this->convertToolCall($contentPart['functionCall']));
             }
+        }
+
+        if (1 === \count($contentParts)) {
+            $contentPart = $contentParts[0];
 
             if (isset($contentPart['text'])) {
                 return new TextResult($contentPart['text']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        |
| License       | MIT

The Gemini API may return multiple content parts even if a tool call is desired. For example, one content part can be an explanation why the tool was called. This PR adds support for this by first checking if any content part is a `functionCall`. If so, all other content parts are discarded and the function/tool call is processed.