### PR TITLE
[AI Bundle] Add parsing of model names with colon notation in config

### DIFF
--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -252,6 +252,10 @@ return static function (DefinitionConfigurator $configurator): void {
                                             throw new InvalidConfigurationException('Model name cannot be empty.');
                                         }
 
+                                        if (isset($parsed['scheme'])) {
+                                            $model = $parsed['scheme'].':'.$model;
+                                        }
+
                                         if (isset($parsed['query'])) {
                                             // If options array is also provided, throw an error
                                             if ([] !== $options) {
@@ -657,6 +661,10 @@ return static function (DefinitionConfigurator $configurator): void {
 
                                         if ('' === $model) {
                                             throw new InvalidConfigurationException('Model name cannot be empty.');
+                                        }
+
+                                        if (isset($parsed['scheme'])) {
+                                            $model = $parsed['scheme'].':'.$model;
                                         }
 
                                         if (isset($parsed['query'])) {

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -2518,6 +2518,53 @@ class AiBundleTest extends TestCase
         $this->assertTrue($container->hasDefinition('ai.tool.agent_processor.orchestrator'));
     }
 
+    #[TestDox('Agent model configuration preserves colon notation in model names (e.g., qwen3:0.6b)')]
+    #[TestWith(['qwen3:0.6b'])]
+    #[TestWith(['deepseek-r1:70b'])]
+    #[TestWith(['qwen3-coder:30b'])]
+    #[TestWith(['qwen3:0.6b?think=false'])]
+    public function testModelConfigurationWithColonNotation(string $model)
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'test' => [
+                        'model' => [
+                            'name' => $model,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $agentDefinition = $container->getDefinition('ai.agent.test');
+
+        $this->assertSame($model, $agentDefinition->getArgument(1));
+    }
+
+    #[TestDox('Vectorizer model configuration preserves colon notation in model names (e.g., bge-m3:1024)')]
+    #[TestWith(['bge-m3:567m'])]
+    #[TestWith(['nomic-embed-text:137m-v1.5-fp16'])]
+    #[TestWith(['qwen3-embedding:0.6b?normalize=true'])]
+    public function testVectorizerConfigurationWithColonNotation(string $model)
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'vectorizer' => [
+                    'test' => [
+                        'model' => [
+                            'name' => $model,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $definition = $container->getDefinition('ai.vectorizer.test');
+
+        $this->assertSame($model, $definition->getArgument(1));
+    }
+
     private function buildContainer(array $configuration): ContainerBuilder
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

In #712, support for Ollama models with colon notation was added.
However, in the bundle configuration, `parse_url()` incorrectly treated the part before the colon as a URI scheme and discarded it.
As a result, model names were normalized to an empty or incomplete string, causing configuration errors.
 
```php
$parsed = parse_url('qwen3:0.6b'); // ['path' => '0.6b', 'scheme' => 'qwen' ]
$model = $parsed['path']; // "0.6b" ❌
```

This change ensures that model names written in colon notation are preserved correctly when parsing bundle configuration, allowing proper usage of Ollama models in Symfony projects.

