### PR TITLE
[AI Bundle][Agent] Add support for prompt as file

### DIFF
--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -13,11 +13,8 @@ ai:
                   method: 'now'
         stream:
             model: 'gpt-4o-mini'
-            prompt: |
-                You are an example chat application where messages from the LLM are streamed to the user using
-                Server-Sent Events via `symfony/ux-turbo` / Turbo Streams. This example does not use any custom
-                javascript and solely relies on the built-in `live` & `turbo_stream` Stimulus controllers.
-                Whatever the user asks, tell them about the application & used technologies.
+            prompt:
+                file: '%kernel.project_dir%/prompts/stream-chat.txt'
             tools: false
         youtube:
             model: 'gpt-4o-mini'

--- a/demo/prompts/stream-chat.txt
+++ b/demo/prompts/stream-chat.txt
@@ -1,0 +1,4 @@
+You are an example chat application where messages from the LLM are streamed to the user using
+Server-Sent Events via `symfony/ux-turbo` / Turbo Streams. This example does not use any custom
+javascript and solely relies on the built-in `live` & `turbo_stream` Stimulus controllers.
+Whatever the user asks, tell them about the application & used technologies.

--- a/examples/misc/prompt-json-file.php
+++ b/examples/misc/prompt-json-file.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\InputProcessor\SystemPromptInputProcessor;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Message\Content\File;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create($_ENV['OPENAI_API_KEY'], http_client());
+
+// Load system prompt from a JSON file
+$promptFile = File::fromFile(dirname(__DIR__, 2).'/fixtures/prompts/code-reviewer.json');
+$systemPromptProcessor = new SystemPromptInputProcessor($promptFile);
+
+$agent = new Agent($platform, 'gpt-4o-mini', [$systemPromptProcessor], logger: logger());
+$messages = new MessageBag(Message::ofUser('Review this code: function add($a, $b) { return $a + $b; }'));
+$result = $agent->call($messages);
+
+echo $result->getContent().\PHP_EOL;

--- a/examples/misc/prompt-text-file.php
+++ b/examples/misc/prompt-text-file.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\InputProcessor\SystemPromptInputProcessor;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Message\Content\File;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create($_ENV['OPENAI_API_KEY'], http_client());
+
+// Load system prompt from a plain text file (.txt)
+$promptFile = File::fromFile(dirname(__DIR__, 2).'/fixtures/prompts/helpful-assistant.txt');
+$systemPromptProcessor = new SystemPromptInputProcessor($promptFile);
+
+$agent = new Agent($platform, 'gpt-4o-mini', [$systemPromptProcessor], logger: logger());
+$messages = new MessageBag(Message::ofUser('Can you explain what dependency injection is?'));
+$result = $agent->call($messages);
+
+echo $result->getContent().\PHP_EOL;

--- a/fixtures/prompts/code-reviewer.json
+++ b/fixtures/prompts/code-reviewer.json
@@ -1,0 +1,12 @@
+{
+  "role": "You are an expert code reviewer with deep knowledge of software engineering best practices, design patterns, and code quality.",
+  "responsibilities": [
+    "Review code for bugs and potential issues",
+    "Suggest improvements for code quality and maintainability",
+    "Identify security vulnerabilities",
+    "Recommend better design patterns when appropriate",
+    "Ensure code follows language-specific best practices"
+  ],
+  "tone": "constructive and educational",
+  "approach": "Provide thorough but concise feedback with specific suggestions and examples when helpful"
+}

--- a/fixtures/prompts/helpful-assistant.txt
+++ b/fixtures/prompts/helpful-assistant.txt
@@ -1,0 +1,8 @@
+You are a helpful and knowledgeable assistant. Your goal is to provide accurate, concise, and useful responses to user queries.
+
+Guidelines:
+- Be clear and direct in your responses
+- Provide examples when appropriate
+- If you're unsure about something, say so
+- Be respectful and professional at all times
+- Break down complex topics into understandable explanations

--- a/src/ai-bundle/doc/index.rst
+++ b/src/ai-bundle/doc/index.rst
@@ -275,10 +275,61 @@ For more control, such as including tool definitions in the system prompt, use t
 
 The array format supports these options:
 
-* ``text`` (string, required): The system prompt text that will be sent to the AI model
+* ``text`` (string): The system prompt text that will be sent to the AI model (either ``text`` or ``file`` is required)
+* ``file`` (string): Path to a file containing the system prompt (either ``text`` or ``file`` is required)
 * ``include_tools`` (boolean, optional): When set to ``true``, tool definitions will be appended to the system prompt
 * ``enable_translation`` (boolean, optional): When set to ``true``, enables translation for the system prompt text (requires symfony/translation)
 * ``translation_domain`` (string, optional): The translation domain to use for the system prompt translation
+
+.. note::
+
+    You cannot use both ``text`` and ``file`` simultaneously. Choose one option based on your needs.
+
+**File-Based Prompts**
+
+For better organization and reusability, you can store system prompts in external files. This is particularly useful for:
+
+* Long, complex prompts with multiple sections
+* Prompts shared across multiple agents or projects
+* Version-controlled prompt templates
+* JSON-structured prompts with specific formatting
+
+Configure the prompt with a file path:
+
+.. code-block:: yaml
+
+    ai:
+        agent:
+            my_agent:
+                model: 'gpt-4o-mini'
+                prompt:
+                    file: '%kernel.project_dir%/prompts/assistant.txt'
+
+The file can be in any text format (.txt, .json, .md, etc.). The entire content of the file will be used as the system prompt text.
+
+**Example Text File** (``prompts/assistant.txt``):
+
+.. code-block:: text
+
+    You are a helpful and knowledgeable assistant.
+
+    Guidelines:
+    - Be clear and direct in your responses
+    - Provide examples when appropriate
+    - Be respectful and professional at all times
+
+**Example JSON File** (``prompts/code-reviewer.json``):
+
+.. code-block:: json
+
+    {
+      "role": "You are an expert code reviewer",
+      "responsibilities": [
+        "Review code for bugs and potential issues",
+        "Suggest improvements for code quality"
+      ],
+      "tone": "constructive and educational"
+    }
 
 **Translation Support**
 

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -835,11 +835,29 @@ class AiBundleTest extends TestCase
         ]);
     }
 
-    #[TestDox('System prompt array without text key throws configuration exception')]
+    #[TestDox('System prompt array without text or file throws configuration exception')]
     public function testSystemPromptArrayWithoutTextKeyThrowsException()
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The "text" cannot be empty.');
+        $this->expectExceptionMessage('Either "text" or "file" must be configured for prompt.');
+
+        $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'test_agent' => [
+                        'model' => 'gpt-4',
+                        'prompt' => [],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    #[TestDox('System prompt with only include_tools throws configuration exception')]
+    public function testSystemPromptWithOnlyIncludeToolsThrowsException()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Either "text" or "file" must be configured for prompt.');
 
         $this->buildContainer([
             'ai' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | --
| License       | MIT

Support files like:
```json

{
  "role": "You are an expert code reviewer with deep knowledge of software engineering best practices, design patterns, and code quality.",
  "responsibilities": [
    "Review code for bugs and potential issues",
    "Suggest improvements for code quality and maintainability",
    "Identify security vulnerabilities",
    "Recommend better design patterns when appropriate",
    "Ensure code follows language-specific best practices"
  ],
  "tone": "constructive and educational",
  "approach": "Provide thorough but concise feedback with specific suggestions and examples when helpful"
}
```
but also TXT or MD files are supported.

### AI Bundle config
```yaml
ai:
    agent
        my-agent:
            model: 'gpt-4o-mini'
            prompt:
                file: '%kernel.project_dir%/prompts/code-reviewer.json'
```

### Proof
<img width="2088" height="668" alt="CleanShot 2025-10-02 at 11 59 17@2x" src="https://github.com/user-attachments/assets/986ee5a1-2557-408b-8c78-2fff2c5914aa" />

