### PR TITLE
[Platform] Support boolean string conversion in `AbstractModelCatalog::parseModelName()`

### DIFF
--- a/src/platform/src/ModelCatalog/AbstractModelCatalog.php
+++ b/src/platform/src/ModelCatalog/AbstractModelCatalog.php
@@ -86,7 +86,7 @@ abstract class AbstractModelCatalog implements ModelCatalogInterface
 
             parse_str($queryString, $options);
 
-            $options = self::convertNumericStrings($options);
+            $options = self::convertScalarStrings($options);
         }
 
         // Determine catalog key: try exact match first, then fall back to base model
@@ -110,13 +110,17 @@ abstract class AbstractModelCatalog implements ModelCatalogInterface
      *
      * @param array<string, mixed> $data The array to process
      *
-     * @return array<string, mixed> The array with numeric strings converted to appropriate numeric types
+     * @return array<string, mixed> The array with numeric and boolean-like strings converted to appropriate numeric/boolean types
      */
-    private static function convertNumericStrings(array $data): array
+    private static function convertScalarStrings(array $data): array
     {
         foreach ($data as $key => $value) {
             if (\is_array($value)) {
-                $data[$key] = self::convertNumericStrings($value);
+                $data[$key] = self::convertScalarStrings($value);
+            } elseif ('true' === $value) {
+                $data[$key] = true;
+            } elseif ('false' === $value) {
+                $data[$key] = false;
             } elseif (is_numeric($value) && \is_string($value)) {
                 // Convert to int if it's a whole number, otherwise to float
                 $data[$key] = str_contains($value, '.') ? (float) $value : (int) $value;

--- a/src/platform/tests/ModelCatalog/AbstractModelCatalogTest.php
+++ b/src/platform/tests/ModelCatalog/AbstractModelCatalogTest.php
@@ -49,6 +49,21 @@ final class AbstractModelCatalogTest extends TestCase
         $this->assertSame(500, $options['max_tokens']);
     }
 
+    public function testGetModelWithBooleanQueryParameters()
+    {
+        $catalog = $this->createTestCatalog();
+        $model = $catalog->getModel('test-model?think=true&stream=false');
+
+        $this->assertSame('test-model', $model->getName());
+        $options = $model->getOptions();
+        $this->assertArrayHasKey('think', $options);
+        $this->assertIsBool($options['think']);
+        $this->assertTrue($options['think']);
+        $this->assertArrayHasKey('stream', $options);
+        $this->assertIsBool($options['stream']);
+        $this->assertFalse($options['stream']);
+    }
+
     public function testGetModelWithMultipleQueryParameters()
     {
         $catalog = $this->createTestCatalog();
@@ -66,7 +81,8 @@ final class AbstractModelCatalogTest extends TestCase
         $this->assertSame(0.7, $options['temperature']);
 
         $this->assertArrayHasKey('stream', $options);
-        $this->assertSame('true', $options['stream']);
+        $this->assertIsBool($options['stream']);
+        $this->assertTrue($options['stream']);
     }
 
     public function testGetModelWithNestedArrayQueryParameters()
@@ -123,6 +139,23 @@ final class AbstractModelCatalogTest extends TestCase
         $this->assertIsString($options['a']['b']['d']);
         $this->assertSame(456, $options['a']['e']);
         $this->assertIsInt($options['a']['e']);
+    }
+
+    public function testBooleanStringsAreConvertedRecursively()
+    {
+        $catalog = $this->createTestCatalog();
+        $model = $catalog->getModel('test-model?a[b][c]=true&a[b][d]=text&a[e]=false');
+
+        $options = $model->getOptions();
+
+        $this->assertIsArray($options['a']);
+        $this->assertIsArray($options['a']['b']);
+        $this->assertIsBool($options['a']['b']['c']);
+        $this->assertTrue($options['a']['b']['c']);
+        $this->assertIsString($options['a']['b']['d']);
+        $this->assertSame('text', $options['a']['b']['d']);
+        $this->assertIsBool($options['a']['e']);
+        $this->assertFalse($options['a']['e']);
     }
 
     private function createTestCatalog(): AbstractModelCatalog


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #713  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PR extends the query parameter normalization logic in `AbstractModelCatalog` to handle boolean-like strings (`"true"` / `"false"`) in addition to numeric strings:

- Query parameters such as `?think=true` or `?think=false` are now correctly converted to PHP booleans instead of remaining plain strings.  
- Conversion is applied recursively, so nested arrays produced by `parse_str()` also normalize their boolean values.  
- Numeric string handling is preserved as before.  

### Tests

New test cases were added to ensure:

- Boolean string parameters are converted properly (`true`/`false`).  
- Recursive conversion inside nested query arrays works as expected.  
- Mixed parameters with numbers, booleans, and plain strings remain consistent.  

