### PR TITLE
[Store] Unify `Vectorizer` methods into single `vectorize()` method

### DIFF
--- a/examples/document/vectorizing-text-documents.php
+++ b/examples/document/vectorizing-text-documents.php
@@ -26,6 +26,6 @@ $textDocuments = [
 ];
 
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-large');
-$vectorDocuments = $vectorizer->vectorizeEmbeddableDocuments($textDocuments);
+$vectorDocuments = $vectorizer->vectorize($textDocuments);
 
 dump(array_map(fn (VectorDocument $document) => $document->vector->getDimensions(), $vectorDocuments));

--- a/src/store/src/Document/VectorizerInterface.php
+++ b/src/store/src/Document/VectorizerInterface.php
@@ -14,25 +14,27 @@ namespace Symfony\AI\Store\Document;
 use Symfony\AI\Platform\Vector\Vector;
 
 /**
- * Interface for converting a collection of Embeddable documents into VectorDocuments
- * and for vectorizing individual strings.
+ * Interface for vectorizing strings and EmbeddableDocuments into Vectors and VectorDocuments.
  *
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
 interface VectorizerInterface
 {
     /**
-     * @param EmbeddableDocumentInterface[] $documents
-     * @param array<string, mixed>          $options   Options to pass to the underlying platform
+     * Vectorizes strings or EmbeddableDocuments into Vectors or VectorDocuments.
      *
-     * @return VectorDocument[]
-     */
-    public function vectorizeEmbeddableDocuments(array $documents, array $options = []): array;
-
-    /**
-     * Vectorizes a single string or Stringable object into a Vector.
+     * @param string|\Stringable|EmbeddableDocumentInterface|array<string|\Stringable>|array<EmbeddableDocumentInterface> $values  The values to vectorize
+     * @param array<string, mixed>                                                                                        $options Options to pass to the underlying platform
      *
-     * @param array<string, mixed> $options Options to pass to the underlying platform
+     * @return Vector|VectorDocument|array<Vector>|array<VectorDocument>
+     *
+     * @phpstan-return (
+     *     $values is string|\Stringable ? Vector : (
+     *         $values is EmbeddableDocumentInterface ? VectorDocument : (
+     *             $values is array<string|\Stringable> ? array<Vector> : array<VectorDocument>
+     *         )
+     *     )
+     * )
      */
-    public function vectorize(string|\Stringable $string, array $options = []): Vector;
+    public function vectorize(string|\Stringable|EmbeddableDocumentInterface|array $values, array $options = []): Vector|VectorDocument|array;
 }

--- a/src/store/src/Indexer.php
+++ b/src/store/src/Indexer.php
@@ -87,13 +87,13 @@ class Indexer implements IndexerInterface
             ++$counter;
 
             if ($chunkSize === \count($chunk)) {
-                $this->store->add(...$this->vectorizer->vectorizeEmbeddableDocuments($chunk));
+                $this->store->add(...$this->vectorizer->vectorize($chunk));
                 $chunk = [];
             }
         }
 
         if ([] !== $chunk) {
-            $this->store->add(...$this->vectorizer->vectorizeEmbeddableDocuments($chunk));
+            $this->store->add(...$this->vectorizer->vectorize($chunk));
         }
 
         $this->logger->debug('Document processing completed', ['total_documents' => $counter]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Replace separate vectorizeTextDocuments() and vectorize(string) methods with a single vectorize() method that handles:
- string -> Vector
- array<string> -> array<Vector>
- TextDocument -> VectorDocument
- array<TextDocument> -> array<VectorDocument>

Add PHPStan conditional return types for proper type inference. Add validation to ensure arrays contain only strings or TextDocuments. Update all usages across codebase including tests and examples.

cc @paulinevos 