### PR TITLE
[Platform][Gemini][VertexAI] Handle `inlineData`

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -138,7 +139,7 @@ final readonly class ResultConverter implements ResultConverterInterface
      *     }
      * } $choice
      */
-    private function convertChoice(array $choice): ToolCallResult|TextResult
+    private function convertChoice(array $choice): ToolCallResult|TextResult|BinaryResult
     {
         $contentParts = $choice['content']['parts'];
 
@@ -154,6 +155,10 @@ final readonly class ResultConverter implements ResultConverterInterface
 
             if (isset($contentPart['text'])) {
                 return new TextResult($contentPart['text']);
+            }
+
+            if (isset($contentPart['inlineData'])) {
+                return new BinaryResult($contentPart['inlineData']['data'], $contentPart['inlineData']['mimeType'] ?? null);
             }
 
             throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finishReason']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #730
| License       | MIT

Fix handling of inlineData as Binary response in ResultConverter of Google Gemini.