### PR TITLE
[Platform] Make `BinaryResult` properties private with getters

### DIFF
--- a/src/platform/src/Result/BinaryResult.php
+++ b/src/platform/src/Result/BinaryResult.php
@@ -19,9 +19,14 @@ use Symfony\AI\Platform\Exception\RuntimeException;
 final class BinaryResult extends BaseResult
 {
     public function __construct(
-        public string $data,
-        public ?string $mimeType = null,
+        private string $data,
+        private ?string $mimeType = null,
     ) {
+    }
+
+    public function getMimeType(): ?string
+    {
+        return $this->mimeType;
     }
 
     public function getContent(): string

--- a/src/platform/tests/Bridge/ElevenLabs/ElevenLabsConverterTest.php
+++ b/src/platform/tests/Bridge/ElevenLabs/ElevenLabsConverterTest.php
@@ -66,6 +66,6 @@ final class ElevenLabsConverterTest extends TestCase
         $result = $converter->convert($rawResult);
 
         $this->assertInstanceOf(BinaryResult::class, $result);
-        $this->assertSame('audio/mpeg', $result->mimeType);
+        $this->assertSame('audio/mpeg', $result->getMimeType());
     }
 }

--- a/src/platform/tests/Bridge/Gemini/Gemini/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/Gemini/Gemini/ResultConverterTest.php
@@ -103,7 +103,7 @@ final class ResultConverterTest extends TestCase
         $result = $converter->convert(new RawHttpResult($httpResponse));
         $this->assertInstanceOf(BinaryResult::class, $result);
         $this->assertSame('base64EncodedImageData', $result->getContent());
-        $this->assertSame('image/png', $result->mimeType);
+        $this->assertSame('image/png', $result->getMimeType());
     }
 
     public function testConvertsInlineDataWithoutMimeTypeToBinaryResult()
@@ -130,6 +130,6 @@ final class ResultConverterTest extends TestCase
         $result = $converter->convert(new RawHttpResult($httpResponse));
         $this->assertInstanceOf(BinaryResult::class, $result);
         $this->assertSame('base64EncodedData', $result->getContent());
-        $this->assertNull($result->mimeType);
+        $this->assertNull($result->getMimeType());
     }
 }

--- a/src/platform/tests/Bridge/HuggingFace/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/HuggingFace/ResultConverterTest.php
@@ -230,6 +230,6 @@ final class ResultConverterTest extends TestCase
 
         $this->assertInstanceOf(BinaryResult::class, $convertedResult);
         $this->assertSame($binaryContent, $convertedResult->getContent());
-        $this->assertSame('image/png', $convertedResult->mimeType);
+        $this->assertSame('image/png', $convertedResult->getMimeType());
     }
 }

--- a/src/platform/tests/Bridge/VertexAi/Gemini/ResultConverterTest.php
+++ b/src/platform/tests/Bridge/VertexAi/Gemini/ResultConverterTest.php
@@ -154,7 +154,7 @@ final class ResultConverterTest extends TestCase
 
         $this->assertInstanceOf(BinaryResult::class, $result);
         $this->assertSame('base64EncodedImageData', $result->getContent());
-        $this->assertSame('image/png', $result->mimeType);
+        $this->assertSame('image/png', $result->getMimeType());
     }
 
     public function testConvertsInlineDataWithoutMimeTypeToBinaryResult()
@@ -184,6 +184,6 @@ final class ResultConverterTest extends TestCase
 
         $this->assertInstanceOf(BinaryResult::class, $result);
         $this->assertSame('base64EncodedData', $result->getContent());
-        $this->assertNull($result->mimeType);
+        $this->assertNull($result->getMimeType());
     }
 }

--- a/src/platform/tests/Result/BinaryResultTest.php
+++ b/src/platform/tests/Result/BinaryResultTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\BinaryResult;
+
+final class BinaryResultTest extends TestCase
+{
+    public function testGetContent()
+    {
+        $result = new BinaryResult($expected = 'binary data');
+        $this->assertSame($expected, $result->getContent());
+    }
+
+    public function testGetMimeType()
+    {
+        $result = new BinaryResult('binary data', $expected = 'image/png');
+        $this->assertSame($expected, $result->getMimeType());
+    }
+
+    public function testGetMimeTypeReturnsNullWhenNotSet()
+    {
+        $result = new BinaryResult('binary data');
+        $this->assertNull($result->getMimeType());
+    }
+
+    public function testToBase64()
+    {
+        $data = 'Hello World';
+        $result = new BinaryResult($data);
+        $this->assertSame(base64_encode($data), $result->toBase64());
+    }
+
+    public function testToDataUri()
+    {
+        $data = 'Hello World';
+        $mimeType = 'text/plain';
+        $result = new BinaryResult($data, $mimeType);
+        $this->assertSame('data:text/plain;base64,'.base64_encode($data), $result->toDataUri());
+    }
+
+    public function testToDataUriThrowsExceptionWhenMimeTypeNotSet()
+    {
+        $result = new BinaryResult('binary data');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Mime type is not set.');
+
+        $result->toDataUri();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

- Changed data and mimeType properties from public to private
- Added getMimeType() getter
- Updated all test files to use new getter methods instead of direct property access
- Added comprehensive BinaryResultTest with tests for all methods including the new getters