### PR TITLE
[Platform] Make `ExecutionReference` properties private with getters

### DIFF
--- a/src/agent/src/Toolbox/Exception/ToolNotFoundException.php
+++ b/src/agent/src/Toolbox/Exception/ToolNotFoundException.php
@@ -31,6 +31,6 @@ final class ToolNotFoundException extends \RuntimeException implements Exception
 
     public static function notFoundForReference(ExecutionReference $reference): self
     {
-        return new self(\sprintf('Tool not found for reference: %s::%s.', $reference->class, $reference->method));
+        return new self(\sprintf('Tool not found for reference: %s::%s.', $reference->getClass(), $reference->getMethod()));
     }
 }

--- a/src/agent/src/Toolbox/ToolCallArgumentResolver.php
+++ b/src/agent/src/Toolbox/ToolCallArgumentResolver.php
@@ -43,7 +43,7 @@ final readonly class ToolCallArgumentResolver
      */
     public function resolveArguments(Tool $metadata, ToolCall $toolCall): array
     {
-        $method = new \ReflectionMethod($metadata->reference->class, $metadata->reference->method);
+        $method = new \ReflectionMethod($metadata->reference->getClass(), $metadata->reference->getMethod());
 
         /** @var array<string, \ReflectionParameter> $parameters */
         $parameters = array_column($method->getParameters(), null, 'name');

--- a/src/agent/src/Toolbox/Toolbox.php
+++ b/src/agent/src/Toolbox/Toolbox.php
@@ -82,7 +82,7 @@ final class Toolbox implements ToolboxInterface
 
             $arguments = $this->argumentResolver->resolveArguments($metadata, $toolCall);
             $this->eventDispatcher?->dispatch(new ToolCallArgumentsResolved($tool, $metadata, $arguments));
-            $result = $tool->{$metadata->reference->method}(...$arguments);
+            $result = $tool->{$metadata->reference->getMethod()}(...$arguments);
             $this->eventDispatcher?->dispatch(new ToolCallSucceeded($tool, $metadata, $arguments, $result));
         } catch (ToolExecutionExceptionInterface $e) {
             $this->eventDispatcher?->dispatch(new ToolCallFailed($tool, $metadata, $arguments ?? [], $e));
@@ -109,8 +109,9 @@ final class Toolbox implements ToolboxInterface
 
     private function getExecutable(Tool $metadata): object
     {
+        $className = $metadata->reference->getClass();
         foreach ($this->tools as $tool) {
-            if ($tool instanceof $metadata->reference->class) {
+            if ($tool instanceof $className) {
                 return $tool;
             }
         }

--- a/src/agent/tests/Toolbox/MetadataFactory/ChainFactoryTest.php
+++ b/src/agent/tests/Toolbox/MetadataFactory/ChainFactoryTest.php
@@ -67,7 +67,7 @@ final class ChainFactoryTest extends TestCase
         $this->assertCount(1, $metadata);
         $this->assertSame('optional_param', $metadata[0]->name);
         $this->assertSame('Tool with optional param', $metadata[0]->description);
-        $this->assertSame('bar', $metadata[0]->reference->method);
+        $this->assertSame('bar', $metadata[0]->reference->getMethod());
     }
 
     public function testTestGetMetadataWithAttributeDoubleHit()

--- a/src/agent/tests/Toolbox/MetadataFactory/MemoryFactoryTest.php
+++ b/src/agent/tests/Toolbox/MetadataFactory/MemoryFactoryTest.php
@@ -41,7 +41,7 @@ final class MemoryFactoryTest extends TestCase
         $this->assertInstanceOf(Tool::class, $metadata[0]);
         $this->assertSame('happy_birthday', $metadata[0]->name);
         $this->assertSame('Generates birthday message', $metadata[0]->description);
-        $this->assertSame('__invoke', $metadata[0]->reference->method);
+        $this->assertSame('__invoke', $metadata[0]->reference->getMethod());
 
         $expectedParams = [
             'type' => 'object',
@@ -68,7 +68,7 @@ final class MemoryFactoryTest extends TestCase
         $this->assertInstanceOf(Tool::class, $metadata[0]);
         $this->assertSame('checkout', $metadata[0]->name);
         $this->assertSame('Buys a number of items per product', $metadata[0]->description);
-        $this->assertSame('buy', $metadata[0]->reference->method);
+        $this->assertSame('buy', $metadata[0]->reference->getMethod());
 
         $expectedParams = [
             'type' => 'object',
@@ -84,7 +84,7 @@ final class MemoryFactoryTest extends TestCase
         $this->assertInstanceOf(Tool::class, $metadata[1]);
         $this->assertSame('cancel', $metadata[1]->name);
         $this->assertSame('Cancels an order', $metadata[1]->description);
-        $this->assertSame('cancel', $metadata[1]->reference->method);
+        $this->assertSame('cancel', $metadata[1]->reference->getMethod());
 
         $expectedParams = [
             'type' => 'object',

--- a/src/agent/tests/Toolbox/MetadataFactory/ReflectionFactoryTest.php
+++ b/src/agent/tests/Toolbox/MetadataFactory/ReflectionFactoryTest.php
@@ -127,8 +127,8 @@ final class ReflectionFactoryTest extends TestCase
 
     private function assertToolConfiguration(Tool $metadata, string $className, string $name, string $description, string $method, array $parameters): void
     {
-        $this->assertSame($className, $metadata->reference->class);
-        $this->assertSame($method, $metadata->reference->method);
+        $this->assertSame($className, $metadata->reference->getClass());
+        $this->assertSame($method, $metadata->reference->getMethod());
         $this->assertSame($name, $metadata->name);
         $this->assertSame($description, $metadata->description);
         $this->assertSame($parameters, $metadata->parameters);

--- a/src/ai-bundle/src/Security/EventListener/IsGrantedToolAttributeListener.php
+++ b/src/ai-bundle/src/Security/EventListener/IsGrantedToolAttributeListener.php
@@ -37,7 +37,7 @@ class IsGrantedToolAttributeListener
     {
         $tool = $event->tool;
         $class = new \ReflectionClass($tool);
-        $method = $class->getMethod($event->metadata->reference->method);
+        $method = $class->getMethod($event->metadata->reference->getMethod());
         $classAttributes = $class->getAttributes(IsGrantedTool::class);
         $methodAttributes = $method->getAttributes(IsGrantedTool::class);
 

--- a/src/platform/src/Tool/ExecutionReference.php
+++ b/src/platform/src/Tool/ExecutionReference.php
@@ -17,8 +17,18 @@ namespace Symfony\AI\Platform\Tool;
 final class ExecutionReference
 {
     public function __construct(
-        public string $class,
-        public string $method = '__invoke',
+        private string $class,
+        private string $method = '__invoke',
     ) {
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
     }
 }

--- a/src/platform/tests/Tool/ExecutionReferenceTest.php
+++ b/src/platform/tests/Tool/ExecutionReferenceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Tool;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Tool\ExecutionReference;
+
+final class ExecutionReferenceTest extends TestCase
+{
+    public function testGetClass()
+    {
+        $reference = new ExecutionReference('MyClass');
+
+        $this->assertSame('MyClass', $reference->getClass());
+    }
+
+    public function testGetMethod()
+    {
+        $reference = new ExecutionReference('MyClass', 'myMethod');
+
+        $this->assertSame('myMethod', $reference->getMethod());
+    }
+
+    public function testGetMethodReturnsDefaultInvokeMethod()
+    {
+        $reference = new ExecutionReference('MyClass');
+
+        $this->assertSame('__invoke', $reference->getMethod());
+    }
+
+    public function testConstructorWithClassAndMethod()
+    {
+        $reference = new ExecutionReference('MyClass', 'execute');
+
+        $this->assertSame('MyClass', $reference->getClass());
+        $this->assertSame('execute', $reference->getMethod());
+    }
+
+    public function testConstructorWithOnlyClass()
+    {
+        $reference = new ExecutionReference('AnotherClass');
+
+        $this->assertSame('AnotherClass', $reference->getClass());
+        $this->assertSame('__invoke', $reference->getMethod());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

This change improves encapsulation by making the class and method properties private and providing public getter methods.