### PR TITLE
[Platform] Remove Symfony 6.4 compatibility code

### DIFF
--- a/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
@@ -28,7 +28,6 @@ use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
-use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
 
 /**
@@ -79,12 +78,7 @@ final class ResultConverter implements ResultConverterInterface
                 continue;
             }
 
-            try {
-                $data = $chunk->getArrayData();
-            } catch (JsonException) {
-                // try catch only needed for Symfony 6.4
-                continue;
-            }
+            $data = $chunk->getArrayData();
 
             if ($this->streamIsToolCall($data)) {
                 $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);

--- a/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
@@ -26,7 +26,6 @@ use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
-use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
 
 /**
@@ -67,12 +66,7 @@ final class ResultConverter implements ResultConverterInterface
                 continue;
             }
 
-            try {
-                $data = $chunk->getArrayData();
-            } catch (JsonException) {
-                // try catch only needed for Symfony 6.4
-                continue;
-            }
+            $data = $chunk->getArrayData();
 
             if ($this->streamIsToolCall($data)) {
                 $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Remove try-catch blocks for JsonException that were only needed for Symfony 6.4 compatibility in stream processing methods.