### PR TITLE
[Platform] Rename to `DeferredResult` and explicit contract instead of closure

### DIFF
--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -15,7 +15,7 @@ use Symfony\AI\Agent\Exception\ExceptionInterface as AgentException;
 use Symfony\AI\Platform\Exception\ExceptionInterface as PlatformException;
 use Symfony\AI\Platform\Metadata\Metadata;
 use Symfony\AI\Platform\Metadata\TokenUsage;
-use Symfony\AI\Platform\Result\ResultPromise;
+use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Store\Exception\ExceptionInterface as StoreException;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Logger\ConsoleLogger;
@@ -120,7 +120,7 @@ function print_token_usage(Metadata $metadata): void
     $table->render();
 }
 
-function print_vectors(ResultPromise $result): void
+function print_vectors(DeferredResult $result): void
 {
     assert([] !== $result->asVectors());
     assert(array_key_exists(0, $result->asVectors()));
@@ -178,7 +178,7 @@ function perplexity_print_citations(Metadata $metadata): void
     }
 }
 
-function print_stream(ResultPromise $result): void
+function print_stream(DeferredResult $result): void
 {
     foreach ($result->asStream() as $word) {
         echo $word;

--- a/src/agent/tests/AgentTest.php
+++ b/src/agent/tests/AgentTest.php
@@ -26,9 +26,10 @@ use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
-use Symfony\AI\Platform\Result\ResultPromise;
+use Symfony\AI\Platform\Test\PlainConverter;
 
 final class AgentTest extends TestCase
 {
@@ -120,7 +121,7 @@ final class AgentTest extends TestCase
             ->with($this->isInstanceOf(Input::class));
 
         $rawResult = $this->createMock(RawResultInterface::class);
-        $response = new ResultPromise(fn () => $result, $rawResult, []);
+        $response = new DeferredResult(new PlainConverter($result), $rawResult, []);
 
         $platform->expects($this->once())
             ->method('invoke')
@@ -146,7 +147,7 @@ final class AgentTest extends TestCase
             ->with($this->isInstanceOf(Output::class));
 
         $rawResult = $this->createMock(RawResultInterface::class);
-        $response = new ResultPromise(fn () => $result, $rawResult, []);
+        $response = new DeferredResult(new PlainConverter($result), $rawResult, []);
 
         $platform->expects($this->once())
             ->method('invoke')
@@ -166,7 +167,7 @@ final class AgentTest extends TestCase
         $result = $this->createMock(ResultInterface::class);
 
         $rawResult = $this->createMock(RawResultInterface::class);
-        $response = new ResultPromise(fn () => $result, $rawResult, []);
+        $response = new DeferredResult(new PlainConverter($result), $rawResult, []);
 
         $platform->expects($this->once())
             ->method('invoke')
@@ -186,7 +187,7 @@ final class AgentTest extends TestCase
         $result = $this->createMock(ResultInterface::class);
 
         $rawResult = $this->createMock(RawResultInterface::class);
-        $response = new ResultPromise(fn () => $result, $rawResult, []);
+        $response = new DeferredResult(new PlainConverter($result), $rawResult, []);
 
         $platform->expects($this->once())
             ->method('invoke')
@@ -207,7 +208,7 @@ final class AgentTest extends TestCase
         $result = $this->createMock(ResultInterface::class);
 
         $rawResult = $this->createMock(RawResultInterface::class);
-        $response = new ResultPromise(fn () => $result, $rawResult, []);
+        $response = new DeferredResult(new PlainConverter($result), $rawResult, []);
 
         $platform->expects($this->once())
             ->method('invoke')

--- a/src/agent/tests/Memory/EmbeddingProviderTest.php
+++ b/src/agent/tests/Memory/EmbeddingProviderTest.php
@@ -20,9 +20,10 @@ use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
-use Symfony\AI\Platform\Result\ResultPromise;
 use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Test\PlainConverter;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\StoreInterface;
 
@@ -78,8 +79,8 @@ final class EmbeddingProviderTest extends TestCase
     public function testItIsNotCreatingMemoryWhenNoVectorsFound()
     {
         $vectorResult = new VectorResult($vector = new Vector([0.1, 0.2], 2));
-        $resultPromise = new ResultPromise(
-            static fn () => $vectorResult,
+        $deferredResult = new DeferredResult(
+            new PlainConverter($vectorResult),
             $this->createStub(RawResultInterface::class),
         );
 
@@ -87,7 +88,7 @@ final class EmbeddingProviderTest extends TestCase
         $platform->expects($this->once())
             ->method('invoke')
             ->with('text-embedding-3-small', 'Have we talked about the weather?')
-            ->willReturn($resultPromise);
+            ->willReturn($deferredResult);
 
         $store = $this->createMock(StoreInterface::class);
         $store->expects($this->once())
@@ -109,8 +110,8 @@ final class EmbeddingProviderTest extends TestCase
     public function testItIsCreatingMemoryWithFoundVectors()
     {
         $vectorResult = new VectorResult($vector = new Vector([0.1, 0.2], 2));
-        $resultPromise = new ResultPromise(
-            static fn () => $vectorResult,
+        $deferredResult = new DeferredResult(
+            new PlainConverter($vectorResult),
             $this->createStub(RawResultInterface::class),
         );
 
@@ -118,7 +119,7 @@ final class EmbeddingProviderTest extends TestCase
         $platform->expects($this->once())
             ->method('invoke')
             ->with('text-embedding-3-small', 'Have we talked about the weather?')
-            ->willReturn($resultPromise);
+            ->willReturn($deferredResult);
 
         $store = $this->createMock(StoreInterface::class);
         $store->expects($this->once())

--- a/src/ai-bundle/src/Command/PlatformInvokeCommand.php
+++ b/src/ai-bundle/src/Command/PlatformInvokeCommand.php
@@ -98,8 +98,7 @@ final class PlatformInvokeCommand extends Command
             $messages = new MessageBag();
             $messages->add(Message::ofUser($this->message));
 
-            $resultPromise = $this->platform->invoke($this->model, $messages);
-            $result = $resultPromise->getResult();
+            $result = $this->platform->invoke($this->model, $messages)->getResult();
 
             if ($result instanceof TextResult) {
                 $io->writeln('<info>Response:</info> '.$result->getContent());

--- a/src/ai-bundle/src/Profiler/DataCollector.php
+++ b/src/ai-bundle/src/Profiler/DataCollector.php
@@ -105,7 +105,7 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
     {
         $calls = $platform->calls;
         foreach ($calls as $key => $call) {
-            $result = $call['result']->await();
+            $result = $call['result']->getResult();
 
             if (isset($platform->resultCache[$result])) {
                 $call['result'] = $platform->resultCache[$result];

--- a/src/ai-bundle/tests/Command/PlatformInvokeCommandTest.php
+++ b/src/ai-bundle/tests/Command/PlatformInvokeCommandTest.php
@@ -15,9 +15,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\AiBundle\Command\PlatformInvokeCommand;
 use Symfony\AI\AiBundle\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
-use Symfony\AI\Platform\Result\ResultPromise;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Test\PlainConverter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -28,7 +29,7 @@ final class PlatformInvokeCommandTest extends TestCase
     {
         $textResult = new TextResult('Hello! How can I assist you?');
         $rawResult = new InMemoryRawResult([]);
-        $promise = new ResultPromise(fn () => $textResult, $rawResult);
+        $promise = new DeferredResult(new PlainConverter($textResult), $rawResult);
 
         $platform = $this->createMock(PlatformInterface::class);
         $platform->method('invoke')

--- a/src/ai-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/ai-bundle/tests/Profiler/DataCollectorTest.php
@@ -19,10 +19,11 @@ use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
-use Symfony\AI\Platform\Result\ResultPromise;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Test\PlainConverter;
 
 class DataCollectorTest extends TestCase
 {
@@ -33,7 +34,7 @@ class DataCollectorTest extends TestCase
         $messageBag = new MessageBag(Message::ofUser(new Text('Hello')));
         $result = new TextResult('Assistant response');
 
-        $platform->method('invoke')->willReturn(new ResultPromise(static fn () => $result, $this->createStub(RawResultInterface::class)));
+        $platform->method('invoke')->willReturn(new DeferredResult(new PlainConverter($result), $this->createStub(RawResultInterface::class)));
 
         $result = $traceablePlatform->invoke('gpt-4o', $messageBag, ['stream' => false]);
         $this->assertSame('Assistant response', $result->asText());
@@ -57,7 +58,7 @@ class DataCollectorTest extends TestCase
             })(),
         );
 
-        $platform->method('invoke')->willReturn(new ResultPromise(static fn () => $result, $this->createStub(RawResultInterface::class)));
+        $platform->method('invoke')->willReturn(new DeferredResult(new PlainConverter($result), $this->createStub(RawResultInterface::class)));
 
         $result = $traceablePlatform->invoke('gpt-4o', $messageBag, ['stream' => true]);
         $this->assertSame('Assistant response', implode('', iterator_to_array($result->asStream())));

--- a/src/platform/src/Platform.php
+++ b/src/platform/src/Platform.php
@@ -13,8 +13,8 @@ namespace Symfony\AI\Platform;
 
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
-use Symfony\AI\Platform\Result\ResultPromise;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -46,7 +46,7 @@ final class Platform implements PlatformInterface
         $this->resultConverters = $resultConverters instanceof \Traversable ? iterator_to_array($resultConverters) : $resultConverters;
     }
 
-    public function invoke(string $model, array|string|object $input, array $options = []): ResultPromise
+    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult
     {
         $model = $this->modelCatalog->getModel($model);
         $payload = $this->contract->createRequestPayload($model, $input);
@@ -84,11 +84,11 @@ final class Platform implements PlatformInterface
     /**
      * @param array<string, mixed> $options
      */
-    private function convertResult(Model $model, RawResultInterface $result, array $options): ResultPromise
+    private function convertResult(Model $model, RawResultInterface $result, array $options): DeferredResult
     {
         foreach ($this->resultConverters as $resultConverter) {
             if ($resultConverter->supports($model)) {
-                return new ResultPromise($resultConverter->convert(...), $result, $options);
+                return new DeferredResult($resultConverter, $result, $options);
             }
         }
 

--- a/src/platform/src/PlatformInterface.php
+++ b/src/platform/src/PlatformInterface.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Platform;
 
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Result\ResultPromise;
+use Symfony\AI\Platform\Result\DeferredResult;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -24,7 +24,7 @@ interface PlatformInterface
      * @param array<mixed>|string|object $input   The input data
      * @param array<string, mixed>       $options The options to customize the model invocation
      */
-    public function invoke(string $model, array|string|object $input, array $options = []): ResultPromise;
+    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult;
 
     public function getModelCatalog(): ModelCatalogInterface;
 }

--- a/src/platform/src/Test/ModelCatalogTestCase.php
+++ b/src/platform/src/Test/ModelCatalogTestCase.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Tests;
+namespace Symfony\AI\Platform\Test;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;

--- a/src/platform/src/Test/PlainConverter.php
+++ b/src/platform/src/Test/PlainConverter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test;
+
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\ResultConverterInterface;
+
+final readonly class PlainConverter implements ResultConverterInterface
+{
+    public function __construct(
+        private ResultInterface $result,
+    ) {
+    }
+
+    public function supports(Model $model): bool
+    {
+        return true;
+    }
+
+    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    {
+        return $this->result;
+    }
+}

--- a/src/platform/tests/Bridge/AiMlApi/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/AiMlApi/ModelCatalogTest.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Bridge\AiMlApi\Embeddings;
 use Symfony\AI\Platform\Bridge\AiMlApi\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 final class ModelCatalogTest extends ModelCatalogTestCase
 {

--- a/src/platform/tests/Bridge/Albert/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Albert/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Albert\ModelCatalog;
 use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Anthropic/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Anthropic/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Azure/Meta/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Azure/Meta/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Azure\Meta\ModelCatalog;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Azure/OpenAi/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Azure/OpenAi/ModelCatalogTest.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Bedrock/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Bedrock/ModelCatalogTest.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Bridge\Bedrock\ModelCatalog;
 use Symfony\AI\Platform\Bridge\Bedrock\Nova\Nova;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Cerebras/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Cerebras/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Cerebras\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/DeepSeek/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/DeepSeek/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\DeepSeek\DeepSeek;
 use Symfony\AI\Platform\Bridge\DeepSeek\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/DockerModelRunner/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/DockerModelRunner/ModelCatalogTest.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Bridge\DockerModelRunner\Embeddings;
 use Symfony\AI\Platform\Bridge\DockerModelRunner\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/ElevenLabs/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/ElevenLabs/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\ElevenLabs\ElevenLabs;
 use Symfony\AI\Platform\Bridge\ElevenLabs\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Gemini/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Gemini/ModelCatalogTest.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Bridge\Gemini\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Mistral/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Mistral/ModelCatalogTest.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Ollama/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Ollama/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Ollama\ModelCatalog;
 use Symfony\AI\Platform\Bridge\Ollama\Ollama;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/OpenAi/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/OpenAi/ModelCatalogTest.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Bridge\OpenAi\ModelCatalog;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Perplexity/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Perplexity/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Perplexity\ModelCatalog;
 use Symfony\AI\Platform\Bridge\Perplexity\Perplexity;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Replicate/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Replicate/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Bridge\Replicate\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Scaleway/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Scaleway/ModelCatalogTest.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Bridge\Scaleway\ModelCatalog;
 use Symfony\AI\Platform\Bridge\Scaleway\Scaleway;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/TransformersPhp/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/TransformersPhp/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\TransformersPhp\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/VertexAi/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/VertexAi/ModelCatalogTest.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model as GeminiModel;
 use Symfony\AI\Platform\Bridge\VertexAi\ModelCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/platform/tests/Bridge/Voyage/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/Voyage/ModelCatalogTest.php
@@ -15,7 +15,7 @@ use Symfony\AI\Platform\Bridge\Voyage\ModelCatalog;
 use Symfony\AI\Platform\Bridge\Voyage\Voyage;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Tests\ModelCatalogTestCase;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
 
 final class ModelCatalogTest extends ModelCatalogTestCase
 {

--- a/src/platform/tests/InMemoryPlatformTest.php
+++ b/src/platform/tests/InMemoryPlatformTest.php
@@ -10,9 +10,9 @@
  */
 
 use PHPUnit\Framework\TestCase;
-use Symfony\AI\Platform\InMemoryPlatform;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Test\InMemoryPlatform;
 use Symfony\AI\Platform\Vector\Vector;
 
 class InMemoryPlatformTest extends TestCase

--- a/src/store/tests/Document/VectorizerTest.php
+++ b/src/store/tests/Document/VectorizerTest.php
@@ -20,9 +20,10 @@ use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\AbstractModelCatalog;
 use Symfony\AI\Platform\ModelCatalog\DynamicModelCatalog;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
-use Symfony\AI\Platform\Result\ResultPromise;
 use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Test\PlainConverter;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\TextDocument;
@@ -487,7 +488,7 @@ final class VectorizerTest extends TestCase
                 $this->equalTo($text),
                 $this->equalTo($options)
             )
-            ->willReturn(new ResultPromise(fn () => new VectorResult($vector), $this->createMock(RawResultInterface::class)));
+            ->willReturn(new DeferredResult(new PlainConverter(new VectorResult($vector)), $this->createMock(RawResultInterface::class)));
 
         $vectorizer = new Vectorizer($platform, 'text-embedding-3-small');
         $result = $vectorizer->vectorize($text, $options);
@@ -508,7 +509,7 @@ final class VectorizerTest extends TestCase
                 $this->equalTo($text),
                 $this->equalTo([])
             )
-            ->willReturn(new ResultPromise(fn () => new VectorResult($vector), $this->createMock(RawResultInterface::class)));
+            ->willReturn(new DeferredResult(new PlainConverter(new VectorResult($vector)), $this->createMock(RawResultInterface::class)));
 
         $vectorizer = new Vectorizer($platform, 'text-embedding-3-small');
         $result = $vectorizer->vectorize($text);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

* Renaming `ResultPromise` to `DeferredResult` since the interface is not really promise-like
* Replacing the `\Closure` with `ResultConverterInterface` in constructor

Alternative names
* `ResultFactory` => is it a factory?
* `ResultBuilder` => is it a builder?
* `LazyResult`  => would expect the same interface as the Result
* `ResultProxy` => would expect the same interface as the Result
* `WrappedResult` => i like wraps
* `ResultContainer` => might confuse with _the_ container
* `ResultHandle` => ?