### PR TITLE
[MCP Bundle] Fix dependency injection and method-based / invokable support

### DIFF
--- a/demo/src/Mcp/Tools/CurrentTimeTool.php
+++ b/demo/src/Mcp/Tools/CurrentTimeTool.php
@@ -12,12 +12,18 @@
 namespace App\Mcp\Tools;
 
 use Mcp\Capability\Attribute\McpTool;
+use Psr\Log\LoggerInterface;
 
 /**
  * @author Tom Hart <tom.hart.221@gmail.com>
  */
 class CurrentTimeTool
 {
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
     /**
      * Returns the current time in UTC.
      *
@@ -26,6 +32,8 @@ class CurrentTimeTool
     #[McpTool(name: 'current-time')]
     public function getCurrentTime(string $format = 'Y-m-d H:i:s'): string
     {
+        $this->logger->info('CurrentTimeTool called', ['format' => $format]);
+
         return (new \DateTime('now', new \DateTimeZone('UTC')))->format($format);
     }
 }

--- a/docs/bundles/mcp-bundle.rst
+++ b/docs/bundles/mcp-bundle.rst
@@ -113,6 +113,33 @@ Dynamic resources with parameters:
 
 All capabilities are automatically discovered in the ``src/`` directory when the server starts.
 
+Attribute Placement Patterns
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The MCP SDK, and therefore the MCP Bundle, supports two patterns for placing attributes on your capabilities:
+
+**Invokable Pattern** - Attribute on a class with ``__invoke()`` method::
+
+    #[McpTool(name: 'my-tool')]
+    class MyTool
+    {
+        public function __invoke(string $param): string
+        {
+            // Implementation
+        }
+    }
+
+**Method-Based Pattern** - Multiple attributes on individual methods::
+
+    class MyTools
+    {
+        #[McpTool(name: 'tool-one')]
+        public function toolOne(): string { }
+
+        #[McpTool(name: 'tool-two')]
+        public function toolTwo(): string { }
+    }
+
 Transport Types
 ...............
 

--- a/src/mcp-bundle/src/DependencyInjection/McpPass.php
+++ b/src/mcp-bundle/src/DependencyInjection/McpPass.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\McpBundle\DependencyInjection;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 final class McpPass implements CompilerPassInterface
 {
@@ -35,7 +36,12 @@ final class McpPass implements CompilerPassInterface
             return;
         }
 
-        $serviceLocatorRef = ServiceLocatorTagPass::register($container, $allMcpServices);
+        $serviceReferences = [];
+        foreach (array_keys($allMcpServices) as $serviceId) {
+            $serviceReferences[$serviceId] = new Reference($serviceId);
+        }
+
+        $serviceLocatorRef = ServiceLocatorTagPass::register($container, $serviceReferences);
 
         $container->getDefinition('mcp.server.builder')
             ->addMethodCall('setContainer', [$serviceLocatorRef]);

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -75,7 +75,7 @@ final class McpBundle extends AbstractBundle
         foreach ($mcpAttributes as $attributeClass => $tag) {
             $builder->registerAttributeForAutoconfiguration(
                 $attributeClass,
-                static function (ChildDefinition $definition) use ($tag): void {
+                static function (ChildDefinition $definition, object $attribute, \Reflector $reflector) use ($tag): void {
                     $definition->addTag($tag);
                 }
             );

--- a/src/mcp-bundle/tests/DependencyInjection/McpPassTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpPassTest.php
@@ -13,8 +13,10 @@ namespace Symfony\AI\McpBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpBundle\DependencyInjection\McpPass;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @covers \Symfony\AI\McpBundle\DependencyInjection\McpPass
@@ -53,6 +55,18 @@ final class McpPassTest extends TestCase
         $this->assertArrayHasKey('prompt_service', $services);
         $this->assertArrayHasKey('resource_service', $services);
         $this->assertArrayHasKey('template_service', $services);
+
+        // Verify services are ServiceClosureArguments wrapping References
+        $this->assertInstanceOf(ServiceClosureArgument::class, $services['tool_service']);
+        $this->assertInstanceOf(ServiceClosureArgument::class, $services['prompt_service']);
+        $this->assertInstanceOf(ServiceClosureArgument::class, $services['resource_service']);
+        $this->assertInstanceOf(ServiceClosureArgument::class, $services['template_service']);
+
+        // Verify the underlying values are References
+        $this->assertInstanceOf(Reference::class, $services['tool_service']->getValues()[0]);
+        $this->assertInstanceOf(Reference::class, $services['prompt_service']->getValues()[0]);
+        $this->assertInstanceOf(Reference::class, $services['resource_service']->getValues()[0]);
+        $this->assertInstanceOf(Reference::class, $services['template_service']->getValues()[0]);
     }
 
     public function testDoesNothingWhenNoMcpServicesTagged()
@@ -115,5 +129,13 @@ final class McpPassTest extends TestCase
         $this->assertArrayHasKey('prompt_service', $services);
         $this->assertArrayNotHasKey('resource_service', $services);
         $this->assertArrayNotHasKey('template_service', $services);
+
+        // Verify services are ServiceClosureArguments wrapping References
+        $this->assertInstanceOf(ServiceClosureArgument::class, $services['tool_service']);
+        $this->assertInstanceOf(ServiceClosureArgument::class, $services['prompt_service']);
+
+        // Verify the underlying values are References
+        $this->assertInstanceOf(Reference::class, $services['tool_service']->getValues()[0]);
+        $this->assertInstanceOf(Reference::class, $services['prompt_service']->getValues()[0]);
     }
 }


### PR DESCRIPTION
 | Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Docs?         | yes
| Issues        | https://github.com/symfony/ai/issues/755
| License       | MIT

** [MCP Bundle]  Fix dependency injection and method-based / invokable support**

  This commit fixes critical issues preventing MCP tools with constructor
  dependencies from working and enables method-based attributes support.

  Changes:
  - Fix McpPass to use Reference objects for ServiceLocator registration
    Previously passed tag arrays directly, causing crashes when tools had
    constructor dependencies

  - Fix McpBundle::registerMcpAttributes() closure signature
    Added missing object $attribute and \Reflector $reflector parameters.
    Without these parameters, Symfony's AttributeAutoconfigurationPass only
    scans class-level attributes and skips method-level ones entirely

  - Add LoggerInterface to CurrentTimeTool to demonstrate DI works

  - Update documentation to reflect both patterns are supported
    Added examples showing invokable and method-based patterns both work
    with full DI support

  - Improve McpPassTest to verify ServiceLocator uses References
    Previous tests only checked presence, not type of values