### PR TITLE
[Agent] Use ToolResult already in ToolboxInterface

### DIFF
--- a/src/agent/src/Toolbox/AgentProcessor.php
+++ b/src/agent/src/Toolbox/AgentProcessor.php
@@ -99,9 +99,8 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
 
                 $results = [];
                 foreach ($toolCalls as $toolCall) {
-                    $result = $this->toolbox->execute($toolCall);
-                    $results[] = new ToolResult($toolCall, $result);
-                    $messages->add(Message::ofToolCall($toolCall, $this->resultConverter->convert($result)));
+                    $results[] = $toolResult = $this->toolbox->execute($toolCall);
+                    $messages->add(Message::ofToolCall($toolCall, $this->resultConverter->convert($toolResult)));
                 }
 
                 $event = new ToolCallsExecuted(...$results);

--- a/src/agent/src/Toolbox/FaultTolerantToolbox.php
+++ b/src/agent/src/Toolbox/FaultTolerantToolbox.php
@@ -33,16 +33,19 @@ final readonly class FaultTolerantToolbox implements ToolboxInterface
         return $this->innerToolbox->getTools();
     }
 
-    public function execute(ToolCall $toolCall): mixed
+    public function execute(ToolCall $toolCall): ToolResult
     {
         try {
             return $this->innerToolbox->execute($toolCall);
         } catch (ToolExecutionExceptionInterface $e) {
-            return $e->getToolCallResult();
+            return new ToolResult($toolCall, $e->getToolCallResult());
         } catch (ToolNotFoundException) {
             $names = array_map(fn (Tool $metadata) => $metadata->getName(), $this->getTools());
 
-            return \sprintf('Tool "%s" was not found, please use one of these: %s', $toolCall->getName(), implode(', ', $names));
+            return new ToolResult(
+                $toolCall,
+                \sprintf('Tool "%s" was not found, please use one of these: %s', $toolCall->getName(), implode(', ', $names))
+            );
         }
     }
 }

--- a/src/agent/src/Toolbox/Toolbox.php
+++ b/src/agent/src/Toolbox/Toolbox.php
@@ -72,7 +72,7 @@ final class Toolbox implements ToolboxInterface
         return $this->map = $map;
     }
 
-    public function execute(ToolCall $toolCall): mixed
+    public function execute(ToolCall $toolCall): ToolResult
     {
         $metadata = $this->getMetadata($toolCall);
         $tool = $this->getExecutable($metadata);
@@ -93,7 +93,7 @@ final class Toolbox implements ToolboxInterface
             throw ToolExecutionException::executionFailed($toolCall, $e);
         }
 
-        return $result;
+        return new ToolResult($toolCall, $result);
     }
 
     private function getMetadata(ToolCall $toolCall): Tool

--- a/src/agent/src/Toolbox/ToolboxInterface.php
+++ b/src/agent/src/Toolbox/ToolboxInterface.php
@@ -30,5 +30,5 @@ interface ToolboxInterface
      * @throws ToolExecutionExceptionInterface if the tool execution fails
      * @throws ToolNotFoundException           if the tool is not found
      */
-    public function execute(ToolCall $toolCall): mixed;
+    public function execute(ToolCall $toolCall): ToolResult;
 }

--- a/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Input;
 use Symfony\AI\Agent\InputProcessor\SystemPromptInputProcessor;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
+use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Fixtures\Tool\ToolNoParams;
 use Symfony\AI\Fixtures\Tool\ToolRequiredParams;
 use Symfony\AI\Platform\Message\Content\File;
@@ -72,9 +73,9 @@ final class SystemPromptInputProcessorTest extends TestCase
                     return [];
                 }
 
-                public function execute(ToolCall $toolCall): mixed
+                public function execute(ToolCall $toolCall): ToolResult
                 {
-                    return null;
+                    return new ToolResult($toolCall, null);
                 }
             },
         );
@@ -110,9 +111,9 @@ final class SystemPromptInputProcessorTest extends TestCase
                     ];
                 }
 
-                public function execute(ToolCall $toolCall): mixed
+                public function execute(ToolCall $toolCall): ToolResult
                 {
-                    return null;
+                    return new ToolResult($toolCall, null);
                 }
             },
             $this->getTranslator(),
@@ -153,9 +154,9 @@ final class SystemPromptInputProcessorTest extends TestCase
                     ];
                 }
 
-                public function execute(ToolCall $toolCall): mixed
+                public function execute(ToolCall $toolCall): ToolResult
                 {
-                    return null;
+                    return new ToolResult($toolCall, null);
                 }
             },
         );

--- a/src/agent/tests/Toolbox/AgentProcessorTest.php
+++ b/src/agent/tests/Toolbox/AgentProcessorTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Agent\Input;
 use Symfony\AI\Agent\Output;
 use Symfony\AI\Agent\Toolbox\AgentProcessor;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
+use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\ToolCallMessage;
@@ -72,12 +73,15 @@ class AgentProcessorTest extends TestCase
 
     public function testProcessOutputWithToolCallResponseKeepingMessages()
     {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
         $toolbox = $this->createMock(ToolboxInterface::class);
-        $toolbox->expects($this->once())->method('execute')->willReturn('Test response');
+        $toolbox
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Test response'));
 
         $messageBag = new MessageBag();
-
-        $result = new ToolCallResult(new ToolCall('id1', 'tool1', ['arg1' => 'value1']));
+        $result = new ToolCallResult($toolCall);
 
         $agent = $this->createStub(AgentInterface::class);
 
@@ -95,12 +99,15 @@ class AgentProcessorTest extends TestCase
 
     public function testProcessOutputWithToolCallResponseForgettingMessages()
     {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
         $toolbox = $this->createMock(ToolboxInterface::class);
-        $toolbox->expects($this->once())->method('execute')->willReturn('Test response');
+        $toolbox
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Test response'));
 
         $messageBag = new MessageBag();
-
-        $result = new ToolCallResult(new ToolCall('id1', 'tool1', ['arg1' => 'value1']));
+        $result = new ToolCallResult($toolCall);
 
         $agent = $this->createStub(AgentInterface::class);
 

--- a/src/agent/tests/Toolbox/FaultTolerantToolboxTest.php
+++ b/src/agent/tests/Toolbox/FaultTolerantToolboxTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
 use Symfony\AI\Agent\Toolbox\Exception\ToolNotFoundException;
 use Symfony\AI\Agent\Toolbox\FaultTolerantToolbox;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
+use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Fixtures\Tool\ToolNoParams;
 use Symfony\AI\Fixtures\Tool\ToolRequiredParams;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -37,7 +38,7 @@ final class FaultTolerantToolboxTest extends TestCase
         $toolCall = new ToolCall('987654321', 'tool_foo');
         $actual = $faultTolerantToolbox->execute($toolCall);
 
-        $this->assertSame($expected, $actual);
+        $this->assertSame($expected, $actual->getResult());
     }
 
     public function testFaultyToolCall()
@@ -52,7 +53,7 @@ final class FaultTolerantToolboxTest extends TestCase
         $toolCall = new ToolCall('123456789', 'tool_xyz');
         $actual = $faultTolerantToolbox->execute($toolCall);
 
-        $this->assertSame($expected, $actual);
+        $this->assertSame($expected, $actual->getResult());
     }
 
     public function testCustomToolExecutionException()
@@ -72,7 +73,7 @@ final class FaultTolerantToolboxTest extends TestCase
         $toolCall = new ToolCall('123456789', 'tool_xyz');
         $actual = $faultTolerantToolbox->execute($toolCall);
 
-        $this->assertSame($expected, $actual);
+        $this->assertSame($expected, $actual->getResult());
     }
 
     private function createFaultyToolbox(\Closure $exceptionFactory): ToolboxInterface
@@ -93,7 +94,7 @@ final class FaultTolerantToolboxTest extends TestCase
                 ];
             }
 
-            public function execute(ToolCall $toolCall): mixed
+            public function execute(ToolCall $toolCall): ToolResult
             {
                 throw ($this->exceptionFactory)($toolCall);
             }

--- a/src/agent/tests/Toolbox/ToolboxTest.php
+++ b/src/agent/tests/Toolbox/ToolboxTest.php
@@ -21,6 +21,7 @@ use Symfony\AI\Agent\Toolbox\Toolbox;
 use Symfony\AI\Agent\Toolbox\ToolFactory\ChainFactory;
 use Symfony\AI\Agent\Toolbox\ToolFactory\MemoryToolFactory;
 use Symfony\AI\Agent\Toolbox\ToolFactory\ReflectionToolFactory;
+use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Fixtures\Tool\ToolCustomException;
 use Symfony\AI\Fixtures\Tool\ToolDate;
 use Symfony\AI\Fixtures\Tool\ToolException;
@@ -180,9 +181,11 @@ final class ToolboxTest extends TestCase
     #[DataProvider('executeProvider')]
     public function testExecute(string $expected, string $toolName, array $toolPayload = [])
     {
-        $this->assertSame(
-            $expected,
-            $this->toolbox->execute(new ToolCall('call_1234', $toolName, $toolPayload)),
+        $toolCall = new ToolCall('call_1234', $toolName, $toolPayload);
+
+        $this->assertEquals(
+            new ToolResult($toolCall, $expected),
+            $this->toolbox->execute($toolCall),
         );
     }
 
@@ -244,7 +247,7 @@ final class ToolboxTest extends TestCase
         $toolbox = new Toolbox([new ToolNoAttribute1()], $memoryFactory);
         $result = $toolbox->execute(new ToolCall('call_1234', 'happy_birthday', ['name' => 'John', 'years' => 30]));
 
-        $this->assertSame('Happy Birthday, John! You are 30 years old.', $result);
+        $this->assertSame('Happy Birthday, John! You are 30 years old.', $result->getResult());
     }
 
     public function testToolboxMapWithOverrideViaChain()

--- a/src/ai-bundle/src/Profiler/DataCollector.php
+++ b/src/ai-bundle/src/Profiler/DataCollector.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\AiBundle\Profiler;
 
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
-use Symfony\AI\Platform\Model;
+use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Tool\Tool;
 use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,7 +23,6 @@ use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
  * @author Christopher Hertel <mail@christopher-hertel.de>
  *
  * @phpstan-import-type PlatformCallData from TraceablePlatform
- * @phpstan-import-type ToolCallData from TraceableToolbox
  */
 final class DataCollector extends AbstractDataCollector implements LateDataCollectorInterface
 {
@@ -86,7 +85,7 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
     }
 
     /**
-     * @return ToolCallData[]
+     * @return ToolResult[]
      */
     public function getToolCalls(): array
     {

--- a/src/ai-bundle/src/Profiler/TraceableToolbox.php
+++ b/src/ai-bundle/src/Profiler/TraceableToolbox.php
@@ -12,20 +12,16 @@
 namespace Symfony\AI\AiBundle\Profiler;
 
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
+use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Result\ToolCall;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
- *
- * @phpstan-type ToolCallData array{
- *     call: ToolCall,
- *     result: string,
- * }
  */
 final class TraceableToolbox implements ToolboxInterface
 {
     /**
-     * @var ToolCallData[]
+     * @var ToolResult[]
      */
     public array $calls = [];
 
@@ -39,15 +35,8 @@ final class TraceableToolbox implements ToolboxInterface
         return $this->toolbox->getTools();
     }
 
-    public function execute(ToolCall $toolCall): mixed
+    public function execute(ToolCall $toolCall): ToolResult
     {
-        $result = $this->toolbox->execute($toolCall);
-
-        $this->calls[] = [
-            'call' => $toolCall,
-            'result' => $result,
-        ];
-
-        return $result;
+        return $this->calls[] = $this->toolbox->execute($toolCall);
     }
 }

--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -221,25 +221,25 @@
 
     <h3>Tool Calls</h3>
     {% if collector.toolCalls|length %}
-        {% for call in collector.toolCalls %}
+        {% for toolResult in collector.toolCalls %}
             <table class="table">
                 <thead>
                     <tr>
-                        <th colspan="2">{{ call.call.name }}</th>
+                        <th colspan="2">{{ toolResult.toolCall.name }}</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
                         <th>ID</th>
-                        <td>{{ call.call.id }}</td>
+                        <td>{{ toolResult.toolCall.id }}</td>
                     </tr>
                     <tr>
                         <th>Arguments</th>
-                        <td>{{ dump(call.call.arguments) }}</td>
+                        <td>{{ dump(toolResult.toolCall.arguments) }}</td>
                     </tr>
                     <tr>
                         <th>Result</th>
-                        <td>{{ dump(call.result) }}</td>
+                        <td>{{ dump(toolResult.result) }}</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/ai-bundle/tests/Profiler/TraceableToolboxTest.php
+++ b/src/ai-bundle/tests/Profiler/TraceableToolboxTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\AiBundle\Tests\Profiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
+use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\AiBundle\Profiler\TraceableToolbox;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tool\ExecutionReference;
@@ -40,10 +41,10 @@ final class TraceableToolboxTest extends TestCase
 
         $result = $traceableToolbox->execute($toolCall);
 
-        $this->assertSame('tool_result', $result);
+        $this->assertSame('tool_result', $result->getResult());
         $this->assertCount(1, $traceableToolbox->calls);
-        $this->assertSame($toolCall, $traceableToolbox->calls[0]['call']);
-        $this->assertSame('tool_result', $traceableToolbox->calls[0]['result']);
+        $this->assertSame($toolCall, $traceableToolbox->calls[0]->getToolCall());
+        $this->assertSame('tool_result', $traceableToolbox->calls[0]->getResult());
     }
 
     /**
@@ -62,9 +63,9 @@ final class TraceableToolboxTest extends TestCase
                 return $this->tools;
             }
 
-            public function execute(ToolCall $toolCall): string
+            public function execute(ToolCall $toolCall): ToolResult
             {
-                return 'tool_result';
+                return new ToolResult($toolCall, 'tool_result');
             }
         };
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

`ToolResult` got introduce later, but should have gone directly into the `ToolboxInterface` instead of only living in the `AgentProcessor`