### PR TITLE
[Agent] Fix tool result conversion hand over

### DIFF
--- a/src/agent/src/Toolbox/ToolResultConverter.php
+++ b/src/agent/src/Toolbox/ToolResultConverter.php
@@ -28,8 +28,10 @@ final readonly class ToolResultConverter
     ) {
     }
 
-    public function convert(mixed $result): ?string
+    public function convert(ToolResult $toolResult): ?string
     {
+        $result = $toolResult->getResult();
+
         if (null === $result || \is_string($result)) {
             return $result;
         }

--- a/src/agent/tests/Toolbox/ToolResultConverterTest.php
+++ b/src/agent/tests/Toolbox/ToolResultConverterTest.php
@@ -13,17 +13,20 @@ namespace Symfony\AI\Agent\Tests\Toolbox;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Agent\Toolbox\ToolResultConverter;
 use Symfony\AI\Fixtures\StructuredOutput\UserWithConstructor;
+use Symfony\AI\Platform\Result\ToolCall;
 
 final class ToolResultConverterTest extends TestCase
 {
     #[DataProvider('provideResults')]
     public function testConvert(mixed $result, ?string $expected)
     {
+        $toolResult = new ToolResult(new ToolCall('123456789', 'tool_name'), $result);
         $converter = new ToolResultConverter();
 
-        $this->assertSame($expected, $converter->convert($result));
+        $this->assertSame($expected, $converter->convert($toolResult));
     }
 
     public static function provideResults(): \Generator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Another example why `mixed` is dangerous - phpstan, phpunit, and runtime didn't complain ... yay :expressionless: 