### PR TITLE
[AI Bundle] Ease toolbox config in AiBundle

### DIFF
--- a/src/ai-bundle/src/Profiler/DataCollector.php
+++ b/src/ai-bundle/src/Profiler/DataCollector.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\AiBundle\Profiler;
 
-use Symfony\AI\Agent\Toolbox\ToolboxInterface;
 use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Tool\Tool;
 use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
@@ -42,7 +41,6 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
      */
     public function __construct(
         iterable $platforms,
-        private readonly ToolboxInterface $defaultToolBox,
         iterable $toolboxes,
     ) {
         $this->platforms = $platforms instanceof \Traversable ? iterator_to_array($platforms) : $platforms;
@@ -57,7 +55,7 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
     public function lateCollect(): void
     {
         $this->data = [
-            'tools' => $this->defaultToolBox->getTools(),
+            'tools' => $this->getAllTools(),
             'platform_calls' => array_merge(...array_map($this->awaitCallResults(...), $this->platforms)),
             'tool_calls' => array_merge(...array_map(fn (TraceableToolbox $toolbox) => $toolbox->calls, $this->toolboxes)),
         ];
@@ -90,6 +88,14 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
     public function getToolCalls(): array
     {
         return $this->data['tool_calls'] ?? [];
+    }
+
+    /**
+     * @return Tool[]
+     */
+    private function getAllTools(): array
+    {
+        return array_merge(...array_map(fn (TraceableToolbox $toolbox) => $toolbox->getTools(), $this->toolboxes));
     }
 
     /**

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -271,7 +271,7 @@ class AiBundleTest extends TestCase
             ],
         ]);
 
-        $this->assertSame($enabled, $container->hasDefinition('ai.fault_tolerant_toolbox'));
+        $this->assertSame($enabled, $container->hasDefinition('ai.fault_tolerant_toolbox.my_agent'));
     }
 
     public function testAgentsCanBeRegisteredAsTools()
@@ -619,12 +619,12 @@ class AiBundleTest extends TestCase
     }
 
     #[TestDox('Processors work correctly when using the default toolbox')]
-    public function testDefaultToolboxProcessorTags()
+    public function testToolboxWithoutExplicitToolsDefined()
     {
         $container = $this->buildContainer([
             'ai' => [
                 'agent' => [
-                    'agent_with_default_toolbox' => [
+                    'agent_with_tools' => [
                         'model' => 'gpt-4',
                         'tools' => true,
                     ],
@@ -632,10 +632,10 @@ class AiBundleTest extends TestCase
             ],
         ]);
 
-        $agentId = 'ai.agent.agent_with_default_toolbox';
+        $agentId = 'ai.agent.agent_with_tools';
 
         // When using default toolbox, the ai.tool.agent_processor service gets the tags
-        $defaultToolProcessor = $container->getDefinition('ai.tool.agent_processor');
+        $defaultToolProcessor = $container->getDefinition('ai.tool.agent_processor.agent_with_tools');
         $inputTags = $defaultToolProcessor->getTag('ai.agent.input_processor');
         $outputTags = $defaultToolProcessor->getTag('ai.agent.output_processor');
 

--- a/src/ai-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/ai-bundle/tests/Profiler/DataCollectorTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\AiBundle\Tests\Profiler;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\AI\Agent\Toolbox\ToolboxInterface;
 use Symfony\AI\AiBundle\Profiler\DataCollector;
 use Symfony\AI\AiBundle\Profiler\TraceablePlatform;
 use Symfony\AI\Platform\Message\Content\Text;
@@ -39,7 +38,7 @@ class DataCollectorTest extends TestCase
         $result = $traceablePlatform->invoke('gpt-4o', $messageBag, ['stream' => false]);
         $this->assertSame('Assistant response', $result->asText());
 
-        $dataCollector = new DataCollector([$traceablePlatform], $this->createStub(ToolboxInterface::class), []);
+        $dataCollector = new DataCollector([$traceablePlatform], []);
         $dataCollector->lateCollect();
 
         $this->assertCount(1, $dataCollector->getPlatformCalls());
@@ -63,7 +62,7 @@ class DataCollectorTest extends TestCase
         $result = $traceablePlatform->invoke('gpt-4o', $messageBag, ['stream' => true]);
         $this->assertSame('Assistant response', implode('', iterator_to_array($result->asStream())));
 
-        $dataCollector = new DataCollector([$traceablePlatform], $this->createStub(ToolboxInterface::class), []);
+        $dataCollector = new DataCollector([$traceablePlatform], []);
         $dataCollector->lateCollect();
 
         $this->assertCount(1, $dataCollector->getPlatformCalls());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Contains the BC break that there is no universal `ai.toolbox` with alias `ToolboxInterface::class` anymore.