### PR TITLE
[Platform] Rename `DynamicModelCatalog` to `FallbackModelCatalog`

### DIFF
--- a/src/platform/src/Bridge/HuggingFace/ModelCatalog.php
+++ b/src/platform/src/Bridge/HuggingFace/ModelCatalog.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\HuggingFace;
 
-use Symfony\AI\Platform\ModelCatalog\DynamicModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class ModelCatalog extends DynamicModelCatalog
+final class ModelCatalog extends FallbackModelCatalog
 {
     // HuggingFace supports a wide range of models dynamically
     // Models are identified by repository/model format (e.g., "microsoft/DialoGPT-medium")

--- a/src/platform/src/Bridge/LmStudio/ModelCatalog.php
+++ b/src/platform/src/Bridge/LmStudio/ModelCatalog.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\LmStudio;
 
-use Symfony\AI\Platform\ModelCatalog\DynamicModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class ModelCatalog extends DynamicModelCatalog
+final class ModelCatalog extends FallbackModelCatalog
 {
     // LmStudio can use any model that is loaded locally
     // Models are dynamically available based on what's loaded in LmStudio

--- a/src/platform/src/Bridge/OpenRouter/ModelCatalog.php
+++ b/src/platform/src/Bridge/OpenRouter/ModelCatalog.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenRouter;
 
-use Symfony\AI\Platform\ModelCatalog\DynamicModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class ModelCatalog extends DynamicModelCatalog
+final class ModelCatalog extends FallbackModelCatalog
 {
     // OpenRouter provides access to many different models from various providers
     // Models are dynamically available and identified by provider/model format

--- a/src/platform/src/Bridge/TransformersPhp/ModelCatalog.php
+++ b/src/platform/src/Bridge/TransformersPhp/ModelCatalog.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\TransformersPhp;
 
-use Symfony\AI\Platform\ModelCatalog\DynamicModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class ModelCatalog extends DynamicModelCatalog
+final class ModelCatalog extends FallbackModelCatalog
 {
     // TransformersPhp can use various models from HuggingFace
     // dynamically loaded through transformers.php library

--- a/src/platform/src/ModelCatalog/FallbackModelCatalog.php
+++ b/src/platform/src/ModelCatalog/FallbackModelCatalog.php
@@ -11,8 +11,11 @@
 
 namespace Symfony\AI\Platform\ModelCatalog;
 
-/*
- * A dynamic model catalog that accepts any model name and creates models with all capabilities.
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Model;
+
+/**
+ * A fallback model catalog that accepts any model name and creates models with all capabilities.
  *
  * This class is useful for platforms that support a wide range of models dynamically
  * without needing to predefine them in a static catalog. Since we don't know what specific
@@ -20,10 +23,7 @@ namespace Symfony\AI\Platform\ModelCatalog;
  *
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-use Symfony\AI\Platform\Capability;
-use Symfony\AI\Platform\Model;
-
-class DynamicModelCatalog extends AbstractModelCatalog
+class FallbackModelCatalog extends AbstractModelCatalog
 {
     public function __construct()
     {

--- a/src/platform/src/Test/InMemoryPlatform.php
+++ b/src/platform/src/Test/InMemoryPlatform.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Platform\Test;
 
 use Symfony\AI\Platform\Model;
-use Symfony\AI\Platform\ModelCatalog\DynamicModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -37,7 +37,7 @@ class InMemoryPlatform implements PlatformInterface
      */
     public function __construct(private readonly \Closure|string $mockResult)
     {
-        $this->modelCatalog = new DynamicModelCatalog();
+        $this->modelCatalog = new FallbackModelCatalog();
     }
 
     public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult

--- a/src/platform/src/Test/ModelCatalogTestCase.php
+++ b/src/platform/src/Test/ModelCatalogTestCase.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Model;
-use Symfony\AI\Platform\ModelCatalog\DynamicModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 
 /**
@@ -61,8 +61,8 @@ abstract class ModelCatalogTestCase extends TestCase
     {
         $catalog = $this->createModelCatalog();
 
-        // Skip this test for catalogs that accept any model (like DynamicModelCatalog)
-        if ($catalog instanceof DynamicModelCatalog) {
+        // Skip this test for catalogs that accept any model (like FallbackModelCatalog)
+        if ($catalog instanceof FallbackModelCatalog) {
             $this->markTestSkipped('This catalog accepts any model name');
         }
 
@@ -77,8 +77,8 @@ abstract class ModelCatalogTestCase extends TestCase
         $catalog = $this->createModelCatalog();
         $models = $catalog->getModels();
 
-        // Skip this test for catalogs that accept any model (like DynamicModelCatalog)
-        if ($catalog instanceof DynamicModelCatalog) {
+        // Skip this test for catalogs that accept any model (like FallbackModelCatalog)
+        if ($catalog instanceof FallbackModelCatalog) {
             $this->markTestSkipped('This catalog accepts any model name');
         }
 
@@ -99,8 +99,8 @@ abstract class ModelCatalogTestCase extends TestCase
     {
         $catalog = $this->createModelCatalog();
 
-        // Skip this test for catalogs that accept any model (like DynamicModelCatalog)
-        if ($catalog instanceof DynamicModelCatalog) {
+        // Skip this test for catalogs that accept any model (like FallbackModelCatalog)
+        if ($catalog instanceof FallbackModelCatalog) {
             $this->markTestSkipped('This catalog accepts any model name');
         }
 

--- a/src/platform/tests/Bridge/TransformersPhp/ModelCatalogTest.php
+++ b/src/platform/tests/Bridge/TransformersPhp/ModelCatalogTest.php
@@ -25,7 +25,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
     public static function modelsProvider(): iterable
     {
         // TransformersPhp can use various models from HuggingFace, so we test with example model names
-        // Since it extends DynamicModelCatalog, all capabilities are provided
+        // Since it extends FallbackModelCatalog, all capabilities are provided
         yield 'microsoft/DialoGPT-medium' => ['microsoft/DialoGPT-medium', Model::class, Capability::cases()];
         yield 'sentence-transformers/all-MiniLM-L6-v2' => ['sentence-transformers/all-MiniLM-L6-v2', Model::class, Capability::cases()];
         yield 'xenova/text-generation-webui' => ['xenova/text-generation-webui', Model::class, Capability::cases()];

--- a/src/platform/tests/FallbackModelCatalogTest.php
+++ b/src/platform/tests/FallbackModelCatalogTest.php
@@ -15,16 +15,16 @@ use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
-use Symfony\AI\Platform\ModelCatalog\DynamicModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class DynamicModelCatalogTest extends TestCase
+final class FallbackModelCatalogTest extends TestCase
 {
     public function testGetModelReturnsModelWithAllCapabilities()
     {
-        $catalog = new DynamicModelCatalog();
+        $catalog = new FallbackModelCatalog();
         $model = $catalog->getModel('test-model');
 
         $this->assertInstanceOf(Model::class, $model);
@@ -38,7 +38,7 @@ final class DynamicModelCatalogTest extends TestCase
 
     public function testGetModelWithOptions()
     {
-        $catalog = new DynamicModelCatalog();
+        $catalog = new FallbackModelCatalog();
         $model = $catalog->getModel('test-model?temperature=0.7&max_tokens=1000');
 
         $this->assertInstanceOf(Model::class, $model);
@@ -59,7 +59,7 @@ final class DynamicModelCatalogTest extends TestCase
     #[TestWith(['custom-local-model'])]
     public function testGetModelAcceptsAnyModelName(string $modelName)
     {
-        $catalog = new DynamicModelCatalog();
+        $catalog = new FallbackModelCatalog();
         $model = $catalog->getModel($modelName);
 
         $this->assertInstanceOf(Model::class, $model);

--- a/src/store/tests/Document/VectorizerTest.php
+++ b/src/store/tests/Document/VectorizerTest.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\AbstractModelCatalog;
-use Symfony\AI\Platform\ModelCatalog\DynamicModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -446,7 +446,7 @@ final class VectorizerTest extends TestCase
         $vector = new Vector([0.1, 0.2, 0.3]);
         $options = ['max_tokens' => 1000, 'temperature' => 0.5];
 
-        // Use DynamicModelCatalog which provides all capabilities including INPUT_MULTIPLE
+        // Use FallbackModelCatalog which provides all capabilities including INPUT_MULTIPLE
         // This ensures batch mode is used and the test expectation matches the behavior
         $platform = PlatformTestHandler::createPlatform(new VectorResult($vector));
         $vectorizer = new Vectorizer($platform, 'test-embedding-with-batch');
@@ -464,7 +464,7 @@ final class VectorizerTest extends TestCase
 
         $vector = new Vector([0.1, 0.2, 0.3]);
 
-        // Use DynamicModelCatalog which provides all capabilities including INPUT_MULTIPLE
+        // Use FallbackModelCatalog which provides all capabilities including INPUT_MULTIPLE
         // This ensures batch mode is used and the test expectation matches the behavior
         $platform = PlatformTestHandler::createPlatform(new VectorResult($vector));
         $vectorizer = new Vectorizer($platform, 'test-embedding-with-batch');

--- a/src/store/tests/Double/PlatformTestHandler.php
+++ b/src/store/tests/Double/PlatformTestHandler.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Store\Tests\Double;
 
 use Symfony\AI\Platform\Model;
-use Symfony\AI\Platform\ModelCatalog\DynamicModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Platform;
@@ -33,7 +33,7 @@ final class PlatformTestHandler implements ModelClientInterface, ResultConverter
     ) {
     }
 
-    public static function createPlatform(?ResultInterface $create = null, ModelCatalogInterface $modelCatalog = new DynamicModelCatalog()): Platform
+    public static function createPlatform(?ResultInterface $create = null, ModelCatalogInterface $modelCatalog = new FallbackModelCatalog()): Platform
     {
         $handler = new self($create);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

The class has been renamed from DynamicModelCatalog to FallbackModelCatalog to better reflect its purpose as a fallback catalog that accepts any model name when a specific catalog is not available.