### PR TITLE
 Docs/fix readme links

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -19,7 +19,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](doc/index.rst)
+- [Documentation](../../docs/index.rst)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/ai-bundle/README.md
+++ b/src/ai-bundle/README.md
@@ -18,7 +18,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](doc/index.rst)
+- [Documentation](../../docs/index.rst)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/chat/README.md
+++ b/src/chat/README.md
@@ -19,7 +19,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](doc/index.rst)
+- [Documentation](../../docs/index.rst)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/mcp-bundle/README.md
+++ b/src/mcp-bundle/README.md
@@ -21,7 +21,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](doc/index.rst)
+- [Documentation](../../docs/index.rst)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/platform/README.md
+++ b/src/platform/README.md
@@ -18,7 +18,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](doc/index.rst)
+- [Documentation](../../docs/index.rst)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/store/README.md
+++ b/src/store/README.md
@@ -18,7 +18,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](doc/index.rst)
+- [Documentation](../../docs/index.rst)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)


### PR DESCRIPTION
| Q             | A |
|---------------|---|
| Bug fix?      | yes |
| New feature?  | no |
| Docs?         | yes |
| Issues        | Fixes #785 |
| License       | MIT |

## Description

This pull request fixes broken documentation links in various README files that currently point to non-existent paths.

Updated all documentation links to point to the correct location: `../../docs/index.rst` (the main documentation entry point).

**Files modified:**
- `src/agent/README.md`
- `src/chat/README.md`
- `src/platform/README.md`
- `src/store/README.md`
- `src/ai-bundle/README.md`
- `src/mcp-bundle/README.md`

**Change type:** Simple find-and-replace of broken relative paths
