### PR TITLE
 Also skip example files with name starting with underscore

### DIFF
--- a/examples/runner
+++ b/examples/runner
@@ -51,7 +51,7 @@ $app = (new SingleCommandApplication('Symfony AI Example Runner'))
             ->name($filter)
             ->exclude('vendor')
             ->sortByName()
-            ->notName('bootstrap.php')
+            ->notName(['bootstrap.php', '_[a-z\-]*.php'])
             ->files();
 
         $io->comment(sprintf('Found %d example(s) to run.', count($examples)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Basically tailored for excluding files like `examples/huggingface/_model-listing.php` 