### PR TITLE
 Feature/treat nullable fields as required

### DIFF
--- a/src/agent/tests/StructuredOutput/ResponseFormatFactoryTest.php
+++ b/src/agent/tests/StructuredOutput/ResponseFormatFactoryTest.php
@@ -38,7 +38,7 @@ final class ResponseFormatFactoryTest extends TestCase
                         'isActive' => ['type' => 'boolean'],
                         'age' => ['type' => ['integer', 'null']],
                     ],
-                    'required' => ['id', 'name', 'createdAt', 'isActive'],
+                    'required' => ['id', 'name', 'createdAt', 'isActive', 'age'],
                     'additionalProperties' => false,
                 ],
                 'strict' => true,

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.1
 ---
 
+ * Add nullables as required in structured outputs
  * Add support for Albert API for French/EU data sovereignty
  * Add unified abstraction layer for interacting with various AI models and providers
  * Add support for 16+ AI providers:

--- a/src/platform/src/Contract/JsonSchema/Factory.php
+++ b/src/platform/src/Contract/JsonSchema/Factory.php
@@ -117,7 +117,9 @@ final readonly class Factory
                 if (!isset($schema['anyOf'])) {
                     $schema['type'] = [$schema['type'], 'null'];
                 }
-            } elseif (!($element instanceof \ReflectionParameter && $element->isOptional())) {
+            }
+
+            if (!($element instanceof \ReflectionParameter && $element->isOptional())) {
                 $result['required'][] = $name;
             }
 

--- a/src/platform/tests/Contract/JsonSchema/FactoryTest.php
+++ b/src/platform/tests/Contract/JsonSchema/FactoryTest.php
@@ -183,7 +183,7 @@ final class FactoryTest extends TestCase
                 'isActive' => ['type' => 'boolean'],
                 'age' => ['type' => ['integer', 'null']],
             ],
-            'required' => ['id', 'name', 'createdAt', 'isActive'],
+            'required' => ['id', 'name', 'createdAt', 'isActive', 'age'],
             'additionalProperties' => false,
         ];
 
@@ -304,7 +304,7 @@ final class FactoryTest extends TestCase
                     ],
                 ],
             ],
-            'required' => [],
+            'required' => ['time'],
             'additionalProperties' => false,
         ];
 
@@ -347,7 +347,7 @@ final class FactoryTest extends TestCase
                     'enum' => ['Foo', 'Bar', null],
                 ],
             ],
-            'required' => ['name', 'taxRate'],
+            'required' => ['name', 'taxRate', 'category'],
             'additionalProperties' => false,
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #585
| License       | MIT

Context: https://github.com/symfony/ai/pull/585#issuecomment-3433969608

Summary: Nullable fields must be present in the required list of their parent output structure, otherwise platforms (like openai) will reject the call.

Proof of work: https://github.com/symfony/ai/pull/585#issuecomment-3434446636

`structured-output-union-types.php` output:
```php
file:///~/ai/examples/openai/structured-output-union-types.php#L33 Symfony\AI\Fixtures\StructuredOutput\UnionType\UnionTypeDtofile:///~/ai/fixtures/StructuredOutput/UnionType/UnionTypeDto.php#L14 {#310
  +time: Symfony\AI\Fixtures\StructuredOutput\UnionType\HumanReadableTimeUnionfile:///~/ai/fixtures/StructuredOutput/UnionType/HumanReadableTimeUnion.php#L14 {#316
    +readableTime: "2023-10-07T19:32:10Z"
  }
}
```

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
