### PR TITLE
[Platform] add ollama toolcall support for streaming

### DIFF
--- a/examples/ollama/stream-toolcall.php
+++ b/examples/ollama/stream-toolcall.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Tool\Clock;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Ollama\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
+
+$toolbox = new Toolbox([new Clock()], logger: logger());
+$processor = new AgentProcessor($toolbox);
+$agent = new Agent($platform, env('OLLAMA_LLM'), [$processor], [$processor]);
+
+$messages = new MessageBag(Message::ofUser('What time is it?'));
+
+$result = $agent->call($messages, ['stream' => true]);
+
+foreach ($result->getContent() as $chunk) {
+    echo $chunk->getContent();
+}
+
+echo \PHP_EOL;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         |  no <!-- required for new features -->
| Issues        | Fix #806  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This PR adds the processing of ToolCalls to the convertStream function within the OllamaResultConverter.
Currently, no processing of ToolCalls is done, and Tool Calls are handed to the StreamResult as a OIllamaMessageChunk instead of returning a ToolCallResult.

