### PR TITLE
 Fix json_decode calls

### DIFF
--- a/src/platform/src/Bridge/DeepSeek/ResultConverter.php
+++ b/src/platform/src/Bridge/DeepSeek/ResultConverter.php
@@ -179,7 +179,7 @@ final class ResultConverter implements ResultConverterInterface
      */
     private function convertToolCall(array $toolCall): ToolCall
     {
-        $arguments = json_decode($toolCall['function']['arguments'], true, \JSON_THROW_ON_ERROR);
+        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
 
         return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }

--- a/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
@@ -186,7 +186,7 @@ final class ResultConverter implements ResultConverterInterface
      */
     private function convertToolCall(array $toolCall): ToolCall
     {
-        $arguments = json_decode($toolCall['function']['arguments'], true, \JSON_THROW_ON_ERROR);
+        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
 
         return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -179,7 +179,7 @@ final readonly class ResultConverter implements ResultConverterInterface
      */
     private function convertToolCall(array $toolCall): ToolCall
     {
-        $arguments = json_decode((string) $toolCall['function']['arguments'], true, \JSON_THROW_ON_ERROR);
+        $arguments = json_decode((string) $toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
 
         return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -204,7 +204,7 @@ final class ResultConverter implements ResultConverterInterface
      */
     private function convertToolCall(array $toolCall): ToolCall
     {
-        $arguments = json_decode($toolCall['function']['arguments'], true, \JSON_THROW_ON_ERROR);
+        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
 
         return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }

--- a/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
@@ -174,7 +174,7 @@ final class ResultConverter implements ResultConverterInterface
      */
     private function convertToolCall(array $toolCall): ToolCall
     {
-        $arguments = json_decode($toolCall['function']['arguments'], true, \JSON_THROW_ON_ERROR);
+        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
 
         return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

`JSON_THROW_ON_ERROR` was passed as the third arg instead of the fourth one.