### PR TITLE
[Store] Support `string|object` for `getContent` method

### DIFF
--- a/src/store/src/Document/EmbeddableDocumentInterface.php
+++ b/src/store/src/Document/EmbeddableDocumentInterface.php
@@ -15,7 +15,7 @@ interface EmbeddableDocumentInterface
 {
     public function getId(): mixed;
 
-    public function getContent(): string;
+    public function getContent(): string|object;
 
     public function getMetadata(): Metadata;
 }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| License       | MIT

As the Vectorizer currently makes assumptions about having to pass string data to `PlatformInterface::invoke`, when that method can actually take about any sort of input.

`Platform` implementations decide what data types they can handle through their normalizers. Therefore, it should be up to `platform` to handle types and not up to `store` to decide that it should only pass strings.
