### PR TITLE
[Demo] Use TextSplitter for indexing in demo due to long blog posts

### DIFF
--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -70,6 +70,7 @@ ai:
             filters:
                 - 'app.filter.week_of_symfony'
             transformers:
+                - 'Symfony\AI\Store\Document\Transformer\TextSplitTransformer'
                 - 'Symfony\AI\Store\Document\Transformer\TextTrimTransformer'
             vectorizer: 'ai.vectorizer.openai'
             store: 'ai.store.chroma_db.symfonycon'
@@ -89,6 +90,7 @@ services:
         $store: '@ai.store.chroma_db.symfonycon'
 
     Symfony\AI\Store\Document\Loader\RssFeedLoader: ~
+    Symfony\AI\Store\Document\Transformer\TextSplitTransformer: ~
     Symfony\AI\Store\Document\Transformer\TextTrimTransformer: ~
 
     app.filter.week_of_symfony:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Currently the demo fails to index the Symfony Blog since there are longer blog posts that are too long for the token limit of the embeddings endpoint - using the splitter solves that. :partying_face: 