### PR TITLE
[Platform] Extensions to Ollama streaming

### DIFF
--- a/src/platform/src/Bridge/Ollama/OllamaMessageChunk.php
+++ b/src/platform/src/Bridge/Ollama/OllamaMessageChunk.php
@@ -18,12 +18,14 @@ final class OllamaMessageChunk
 {
     /**
      * @param array<string, mixed> $message
+     * @param array<string, mixed> $raw
      */
     public function __construct(
         public readonly string $model,
         public readonly \DateTimeImmutable $created_at,
         public readonly array $message,
         public readonly bool $done,
+        public readonly array $raw,
     ) {
     }
 
@@ -38,8 +40,18 @@ final class OllamaMessageChunk
         return $this->message['content'] ?? null;
     }
 
+    public function getThinking(): ?string
+    {
+        return $this->message['thinking'] ?? null;
+    }
+
     public function getRole(): ?string
     {
         return $this->message['role'] ?? null;
+    }
+
+    public function isDone(): bool
+    {
+        return $this->done;
     }
 }

--- a/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
+++ b/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
@@ -106,6 +106,7 @@ final class OllamaResultConverter implements ResultConverterInterface
                 new \DateTimeImmutable($data['created_at']),
                 $data['message'],
                 $data['done'],
+                $data,
             );
         }
     }

--- a/src/platform/tests/Bridge/Ollama/OllamaResultConverterTest.php
+++ b/src/platform/tests/Bridge/Ollama/OllamaResultConverterTest.php
@@ -13,11 +13,13 @@ namespace Symfony\AI\Platform\Tests\Bridge\Ollama;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Ollama\Ollama;
+use Symfony\AI\Platform\Bridge\Ollama\OllamaMessageChunk;
 use Symfony\AI\Platform\Bridge\Ollama\OllamaResultConverter;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -159,5 +161,75 @@ final class OllamaResultConverterTest extends TestCase
 
         $this->assertSame([0.3, 0.4, 0.4], $convertedContent[0]->getData());
         $this->assertSame([0.0, 0.0, 0.2], $convertedContent[1]->getData());
+    }
+
+    public function testConvertStreamingResponse()
+    {
+        $converter = new OllamaResultConverter();
+        $rawResult = new InMemoryRawResult(dataStream: $this->generateConvertStreamingStream());
+
+        $result = $converter->convert($rawResult, options: ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $chunks = $result->getContent();
+        $this->assertInstanceOf(OllamaMessageChunk::class, $chunks->current());
+        $this->assertSame('Hello', $chunks->current()->getContent());
+        $this->assertFalse($chunks->current()->isDone());
+        $this->assertSame('deepseek-r1:latest', $chunks->current()->raw['model']);
+        $this->assertArrayNotHasKey('total_duration', $chunks->current()->raw);
+        $chunks->next();
+        $this->assertInstanceOf(OllamaMessageChunk::class, $chunks->current());
+        $this->assertSame(' world!', $chunks->current()->getContent());
+        $this->assertTrue($chunks->current()->isDone());
+        $this->assertArrayHasKey('total_duration', $chunks->current()->raw);
+    }
+
+    public function testConvertThinkingStreamingResponse()
+    {
+        $converter = new OllamaResultConverter();
+        $rawResult = new InMemoryRawResult(dataStream: $this->generateConvertThinkingStreamingStream());
+
+        $result = $converter->convert($rawResult, options: ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $chunks = $result->getContent();
+        $this->assertInstanceOf(OllamaMessageChunk::class, $chunks->current());
+        $this->assertSame('', $chunks->current()->getContent());
+        $this->assertSame('Thinking', $chunks->current()->getThinking());
+        $this->assertFalse($chunks->current()->isDone());
+        $this->assertSame('deepseek-r1:latest', $chunks->current()->raw['model']);
+        $this->assertArrayNotHasKey('total_duration', $chunks->current()->raw);
+        $chunks->next();
+        $this->assertSame('', $chunks->current()->getContent());
+        $this->assertSame(' hard', $chunks->current()->getThinking());
+        $this->assertFalse($chunks->current()->isDone());
+        $chunks->next();
+        $this->assertSame('Hello', $chunks->current()->getContent());
+        $this->assertNull($chunks->current()->getThinking());
+        $this->assertFalse($chunks->current()->isDone());
+        $chunks->next();
+        $this->assertInstanceOf(OllamaMessageChunk::class, $chunks->current());
+        $this->assertSame(' world!', $chunks->current()->getContent());
+        $this->assertNull($chunks->current()->getThinking());
+        $this->assertTrue($chunks->current()->isDone());
+        $this->assertArrayHasKey('total_duration', $chunks->current()->raw);
+    }
+
+    private function generateConvertStreamingStream(): iterable
+    {
+        yield ['model' => 'deepseek-r1:latest', 'created_at' => '2025-10-29T17:15:49.631700779Z', 'message' => ['role' => 'assistant', 'content' => 'Hello'], 'done' => false];
+        yield ['model' => 'deepseek-r1:latest', 'created_at' => '2025-10-29T17:15:49.905924913Z', 'message' => ['role' => 'assistant', 'content' => ' world!'], 'done' => true,
+            'done_reason' => 'stop', 'total_duration' => 100, 'load_duration' => 10, 'prompt_eval_count' => 42, 'prompt_eval_duration' => 30, 'eval_count' => 17, 'eval_duration' => 60];
+    }
+
+    private function generateConvertThinkingStreamingStream(): iterable
+    {
+        yield ['model' => 'deepseek-r1:latest', 'created_at' => '2025-10-29T17:15:49.631700779Z', 'message' => ['role' => 'assistant', 'content' => '', 'thinking' => 'Thinking'], 'done' => false];
+        yield ['model' => 'deepseek-r1:latest', 'created_at' => '2025-10-29T17:15:49.905924913Z', 'message' => ['role' => 'assistant', 'content' => '', 'thinking' => ' hard'], 'done' => false];
+        yield ['model' => 'deepseek-r1:latest', 'created_at' => '2025-10-29T17:15:50.14497475Z', 'message' => ['role' => 'assistant', 'content' => 'Hello'], 'done' => false];
+        yield ['model' => 'deepseek-r1:latest', 'created_at' => '2025-10-29T17:15:50.367912083Z', 'message' => ['role' => 'assistant', 'content' => ' world!'], 'done' => true,
+            'done_reason' => 'stop', 'total_duration' => 100, 'load_duration' => 10, 'prompt_eval_count' => 42, 'prompt_eval_duration' => 30, 'eval_count' => 17, 'eval_duration' => 60];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | None
| License       | MIT

Adds the following things to the Ollama streaming feature:
- Some testing
- OllamaMessageChunk supports thinking (Ollama streams the tokens of the reasoning)
- OllamaMessageChunk adds raw data (like stats and token usage information at the end of the stream)

While I added this, I saw that most of the other ResultConverter::convertStream return just strings. Maybe it would be a good idea to make the API for this more consistent and allow string|MessageChunkInterface or only some MessageChunkInterface . That would make it probably easier to switch Platforms.

Since this is neither a bug nor realy a new feature, I didn't check any above. I didn't find any docs about Ollama streaming so I didn't add anything there. If needed I can try to add something. I did add tests, though 😉.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
