### PR TITLE
 Qdrant sync

### DIFF
--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -607,6 +607,7 @@ return static function (DefinitionConfigurator $configurator): void {
                                 ->stringNode('collection_name')->cannotBeEmpty()->end()
                                 ->integerNode('dimensions')->end()
                                 ->stringNode('distance')->end()
+                                ->booleanNode('async')->defaultFalse()->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -1102,6 +1102,10 @@ final class AiBundle extends AbstractBundle
                     $arguments[5] = $store['distance'];
                 }
 
+                if (\array_key_exists('async', $store)) {
+                    $arguments[6] = $store['async'];
+                }
+
                 $definition = new Definition(QdrantStore::class);
                 $definition
                     ->addTag('ai.store')

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -2942,6 +2942,7 @@ class AiBundleTest extends TestCase
                             'collection_name' => 'foo',
                             'dimensions' => 768,
                             'distance' => 'Cosine',
+                            'async' => false,
                         ],
                     ],
                     'redis' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| License       | MIT

Currently, Qdrant PUT operations are async. This forces the user to add checking after the request happens to determine if it was successful or not.

This adds an option to make operations sync so you can handle any errors immediately instead of polling after until the operation completes.