### PR TITLE
[MCP Bundle] Fix services when monolog is not installed

### DIFF
--- a/src/mcp-bundle/config/services.php
+++ b/src/mcp-bundle/config/services.php
@@ -15,12 +15,16 @@ use Mcp\Server;
 use Mcp\Server\Builder;
 
 return static function (ContainerConfigurator $container): void {
-    $container->services()
-        ->set('monolog.logger.mcp')
+    if (class_exists(\Symfony\Bundle\MonologBundle\MonologBundle::class)) {
+        $container->services()
+            ->set('monolog.logger.mcp')
             ->parent('monolog.logger_prototype')
             ->args(['mcp'])
             ->tag('monolog.logger', ['channel' => 'mcp'])
+        ;
+    }
 
+    $container->services()
         ->set('mcp.server.builder', Builder::class)
             ->factory([Server::class, 'builder'])
             ->call('setServerInfo', [param('mcp.app'), param('mcp.version')])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #830
| License       | MIT

As said on the issue, when monolog is not installed, the container can't compile the services.
The solution here is to register the service only if the bundle is installed