### PR TITLE
[Platform] Rename `asBase64` to `asDataUri` on `DeferredResult` for clarity and add optional mimeType arg

### DIFF
--- a/examples/huggingface/text-to-image.php
+++ b/examples/huggingface/text-to-image.php
@@ -20,4 +20,4 @@ $result = $platform->invoke('black-forest-labs/FLUX.1-dev', 'Astronaut riding a 
     'task' => Task::TEXT_TO_IMAGE,
 ]);
 
-echo $result->asBase64().\PHP_EOL;
+echo $result->asDataUri().\PHP_EOL;

--- a/src/platform/src/Result/BinaryResult.php
+++ b/src/platform/src/Result/BinaryResult.php
@@ -39,12 +39,12 @@ final class BinaryResult extends BaseResult
         return base64_encode($this->data);
     }
 
-    public function toDataUri(): string
+    public function toDataUri(?string $mimeType = null): string
     {
-        if (null === $this->mimeType) {
+        if (null === ($mimeType ?? $this->mimeType)) {
             throw new RuntimeException('Mime type is not set.');
         }
 
-        return 'data:'.$this->mimeType.';base64,'.$this->toBase64();
+        return 'data:'.($mimeType ?? $this->mimeType).';base64,'.$this->toBase64();
     }
 }

--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -90,13 +90,13 @@ final class DeferredResult
     /**
      * @throws ExceptionInterface
      */
-    public function asBase64(): string
+    public function asDataUri(?string $mimeType = null): string
     {
         $result = $this->as(BinaryResult::class);
 
         \assert($result instanceof BinaryResult);
 
-        return $result->toDataUri();
+        return $result->toDataUri($mimeType);
     }
 
     /**

--- a/src/platform/tests/Result/BinaryResultTest.php
+++ b/src/platform/tests/Result/BinaryResultTest.php
@@ -58,4 +58,13 @@ final class BinaryResultTest extends TestCase
 
         $result->toDataUri();
     }
+
+    public function testToDataUriWithMimeTypeExplicitlySet()
+    {
+        $result = new BinaryResult('binary data');
+        $actual = $result->toDataUri('image/jpeg');
+        $expected = 'data:image/jpeg;base64,'.base64_encode('binary data');
+
+        $this->assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Just more consistent and convenient, see #861 