### PR TITLE
 Add OpenAI example demonstrating streaming with sources

### DIFF
--- a/examples/openai/agent-stream-sources.php
+++ b/examples/openai/agent-stream-sources.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Tool\Clock;
+use Symfony\AI\Agent\Toolbox\Tool\Tavily;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\Component\Clock\Clock as SymfonyClock;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+
+$clock = new Clock(new SymfonyClock());
+$tavily = new Tavily(http_client(), env('TAVILY_API_KEY'));
+$toolbox = new Toolbox([$clock, $tavily], logger: logger());
+$processor = new AgentProcessor($toolbox, includeSources: true);
+$agent = new Agent($platform, 'gpt-4o', [$processor], [$processor]);
+
+$prompt = <<<PROMPT
+    Summarize the latest game of the Dallas Cowboys. When and where was it? Who was the opponent, what was the result,
+    and how was the game and the weather in the city. Use tools for the research and only answer based on information
+    given in the context - don't make up information.
+    PROMPT;
+
+$result = $agent->call(new MessageBag(Message::ofUser($prompt)), ['stream' => true]);
+
+foreach ($result->getContent() as $word) {
+    echo $word;
+}
+echo \PHP_EOL;
+
+echo 'Used sources:'.\PHP_EOL;
+foreach ($result->getMetadata()->get('sources', []) as $source) {
+    echo sprintf(' - %s (%s)', $source->getName(), $source->getReference()).\PHP_EOL;
+}
+echo \PHP_EOL;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Follows #868 
| License       | MIT

This example shows how to use the Agent with OpenAI platform to stream responses while collecting source metadata from tools like Tavily. This demonstrates the fix for issue #833 where sources metadata was unavailable during streaming.

<img width="2852" height="454" alt="CleanShot 2025-11-14 at 10 11 21@2x" src="https://github.com/user-attachments/assets/474eb2ed-af88-4e97-81a5-42ad4434b8c6" />

Weird that the clock is used as source, isn't? 🤔 
