### PR TITLE
[Docs] Replace literalinclude with links to example files

### DIFF
--- a/docs/cookbook/chatbot-with-memory.rst
+++ b/docs/cookbook/chatbot-with-memory.rst
@@ -30,9 +30,7 @@ The complete implementation consists of three main parts:
 Complete Example
 ~~~~~~~~~~~~~~~~
 
-.. literalinclude:: ../../examples/memory/static.php
-   :language: php
-   :linenos:
+See the complete example: `static.php <https://github.com/symfony/ai/blob/main/examples/memory/static.php>`_
 
 Key Components
 --------------

--- a/docs/cookbook/rag-implementation.rst
+++ b/docs/cookbook/rag-implementation.rst
@@ -39,9 +39,7 @@ Prerequisites
 Complete Implementation
 -----------------------
 
-.. literalinclude:: ../../examples/rag/in-memory.php
-   :language: php
-   :linenos:
+See the complete example: `in-memory.php <https://github.com/symfony/ai/blob/main/examples/rag/in-memory.php>`_
 
 Step-by-Step Breakdown
 ----------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | --
| License       | MIT

The literalinclude directive was causing issues in the documentation build. Replaced it with direct links to the example files in the GitHub repository. This keeps the documentation clean and ensures readers always see the most up-to-date version of the examples.