### PR TITLE
[Platform] Add Gemini 3.0 Preview model

### DIFF
--- a/src/platform/src/Bridge/Gemini/ModelCatalog.php
+++ b/src/platform/src/Bridge/Gemini/ModelCatalog.php
@@ -25,6 +25,18 @@ final class ModelCatalog extends AbstractModelCatalog
     public function __construct(array $additionalModels = [])
     {
         $defaultModels = [
+            'gemini-3.0-pro-preview' => [
+                'class' => Gemini::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::INPUT_AUDIO,
+                    Capability::INPUT_PDF,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
             'gemini-2.5-flash' => [
                 'class' => Gemini::class,
                 'capabilities' => [

--- a/src/platform/src/Bridge/VertexAi/ModelCatalog.php
+++ b/src/platform/src/Bridge/VertexAi/ModelCatalog.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\VertexAi;
 
+use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\Model as EmbeddingsModel;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model as GeminiModel;
 use Symfony\AI\Platform\Capability;
@@ -31,6 +32,18 @@ final class ModelCatalog extends AbstractModelCatalog
     {
         $defaultModels = [
             // Gemini models
+            'gemini-3.0-pro-preview' => [
+                'class' => Gemini::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::INPUT_AUDIO,
+                    Capability::INPUT_PDF,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
             'gemini-2.5-pro' => [
                 'class' => GeminiModel::class,
                 'capabilities' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

This PR adds support for the new gemini-3.0-pro-preview model.
It allows developers to use Google’s latest Gemini 3.0 Pro preview model seamlessly within the existing integration.