### PR TITLE
[Store][MariaDB] Use UUID type instead of Binary

### DIFF
--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -66,7 +66,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             \sprintf(
                 <<<'SQL'
                     CREATE TABLE IF NOT EXISTS %1$s (
-                        id BINARY(16) NOT NULL PRIMARY KEY,
+                        id UUID NOT NULL PRIMARY KEY,
                         metadata JSON,
                         %2$s VECTOR(%4$d) NOT NULL,
                         VECTOR INDEX %3$s (%2$s)
@@ -126,7 +126,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         foreach ($documents as $document) {
             $operation = [
-                'id' => $document->id->toBinary(),
+                'id' => $document->id->toRfc4122(),
                 'metadata' => json_encode($document->metadata->getArrayCopy()),
                 'vector' => json_encode($document->vector->getData()),
             ];
@@ -173,7 +173,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
             $documents[] = new VectorDocument(
-                id: Uuid::fromBinary($result['id']),
+                id: Uuid::fromRfc4122($result['id']),
                 vector: new Vector(json_decode((string) $result['embedding'], true)),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true)),
                 score: $result['score'],

--- a/src/store/tests/Bridge/MariaDb/StoreTest.php
+++ b/src/store/tests/Bridge/MariaDb/StoreTest.php
@@ -56,7 +56,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([
                 [
-                    'id' => $uuid->toBinary(),
+                    'id' => $uuid->toRfc4122(),
                     'embedding' => json_encode($vectorData),
                     'metadata' => json_encode(['title' => 'Test Document']),
                     'score' => 0.85,
@@ -104,7 +104,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([
                 [
-                    'id' => $uuid->toBinary(),
+                    'id' => $uuid->toRfc4122(),
                     'embedding' => json_encode($vectorData),
                     'metadata' => json_encode(['title' => 'Test Document']),
                     'score' => 0.95,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        |
| License       | MIT

Binary type is really painful
It needs to be casted to be able to read it. There is no native function
to do that in MariaDB. And except for HUGE amount of data, it does not
make a big deference from char(36). I mean, there is a trade off to find
between perf and DX.

ANYWAY, MariaDB comes from a native UUID type that solves all issues!
Let's use it.
