### PR TITLE
[AI Bundle] Require model class in `ai.model` configuration

### DIFF
--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -16,6 +16,7 @@ use MongoDB\Client as MongoDbClient;
 use Probots\Pinecone\Client as PineconeClient;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Store\Bridge\Postgres\Distance as PostgresDistance;
 use Symfony\AI\Store\Bridge\Redis\Distance;
@@ -223,6 +224,23 @@ return static function (DefinitionConfigurator $configurator): void {
                     ->end()
                     ->arrayPrototype()
                         ->children()
+                            ->stringNode('class')
+                                ->info('The fully qualified class name of the model (must extend '.Model::class.')')
+                                ->defaultValue(Model::class)
+                                ->cannotBeEmpty()
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !class_exists($v);
+                                    })
+                                    ->thenInvalid('The model class "%s" does not exist.')
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_a($v, Model::class, true);
+                                    })
+                                    ->thenInvalid('The model class "%s" must extend '.Model::class.'.')
+                                ->end()
+                            ->end()
                             ->arrayNode('capabilities')
                                 ->info('Array of capabilities that this model supports')
                                 ->enumPrototype(Capability::class)

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -3323,6 +3323,64 @@ class AiBundleTest extends TestCase
         $this->assertTrue($surrealDbMessageStoreDefinition->hasTag('ai.message_store'));
     }
 
+    #[TestDox('Model configuration defaults class to Model::class')]
+    #[DoesNotPerformAssertions]
+    public function testModelConfigurationDefaultsClassToModel()
+    {
+        // Should not throw - class defaults to Model::class
+        $this->buildContainer([
+            'ai' => [
+                'model' => [
+                    'openai' => [
+                        'my-custom-model' => [
+                            'capabilities' => ['input-text', 'output-text'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    #[TestDox('Model configuration throws exception when class does not exist')]
+    public function testModelConfigurationThrowsExceptionWhenClassDoesNotExist()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        $this->buildContainer([
+            'ai' => [
+                'model' => [
+                    'openai' => [
+                        'my-custom-model' => [
+                            'class' => 'NonExistentModelClass',
+                            'capabilities' => ['input-text', 'output-text'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    #[TestDox('Model configuration throws exception when class does not extend Model')]
+    public function testModelConfigurationThrowsExceptionWhenClassDoesNotExtendModel()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('must extend');
+
+        $this->buildContainer([
+            'ai' => [
+                'model' => [
+                    'openai' => [
+                        'my-custom-model' => [
+                            'class' => \stdClass::class,
+                            'capabilities' => ['input-text', 'output-text'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     private function buildContainer(array $configuration): ContainerBuilder
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

The ai.model configuration now requires providing a model class that extends Symfony\AI\Platform\Model. This ensures type safety and proper model registration.