### PR TITLE
[Fixtures] Remove confidence from output structure

### DIFF
--- a/fixtures/StructuredOutput/MathReasoning.php
+++ b/fixtures/StructuredOutput/MathReasoning.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\AI\Fixtures\StructuredOutput;
 
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
-
 final class MathReasoning
 {
     /**
@@ -20,9 +18,8 @@ final class MathReasoning
      */
     public function __construct(
         public array $steps,
-        #[With(minimum: 0, maximum: 100)]
-        public int $confidence,
         public string $finalAnswer,
+        public float $result,
     ) {
     }
 }

--- a/src/platform/tests/Contract/JsonSchema/FactoryTest.php
+++ b/src/platform/tests/Contract/JsonSchema/FactoryTest.php
@@ -209,10 +209,10 @@ final class FactoryTest extends TestCase
                         'additionalProperties' => false,
                     ],
                 ],
-                'confidence' => ['type' => 'integer', 'minimum' => 0, 'maximum' => 100],
                 'finalAnswer' => ['type' => 'string'],
+                'result' => ['type' => 'number'],
             ],
-            'required' => ['steps', 'confidence', 'finalAnswer'],
+            'required' => ['steps', 'finalAnswer', 'result'],
             'additionalProperties' => false,
         ];
 

--- a/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
+++ b/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
@@ -128,8 +128,8 @@ final class PlatformSubscriberTest extends TestCase
                         "output": "x = -3.75"
                     }
                 ],
-                "confidence": 100,
-                "finalAnswer": "x = -3.75"
+                "finalAnswer": "x = -3.75",
+                "result": -3.75
             }
             JSON));
         $deferred = new DeferredResult($converter, new InMemoryRawResult());
@@ -147,8 +147,8 @@ final class PlatformSubscriberTest extends TestCase
         $this->assertInstanceOf(Step::class, $structure->steps[2]);
         $this->assertInstanceOf(Step::class, $structure->steps[3]);
         $this->assertInstanceOf(Step::class, $structure->steps[4]);
-        $this->assertSame(100, $structure->confidence);
         $this->assertSame('x = -3.75', $structure->finalAnswer);
+        $this->assertSame(-3.75, $structure->result);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

I consider this a bit misleading since it makes it easy to confuse it with actual scoring or confidence known from ML or similarity search. LLMs just put a probable number there not an actual confidence in that sense.
we could also have a `int $calculationTime` and get a number as response that wouldn't really refer to the actual calculation time the model needed.