### PR TITLE
[Platform] Add OpenRouter documentation and examples

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -109,21 +109,22 @@ Supported Models & Platforms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * **Language Models**
-    * `OpenAI's GPT`_ with `OpenAI`_ and `Azure`_ as Platform
+    * `OpenAI's GPT`_ with `OpenAI`_, `Azure`_ and `OpenRouter`_ as Platform
     * `Anthropic's Claude`_ with `Anthropic`_ and `AWS Bedrock`_ as Platform
-    * `Meta's Llama`_ with `Azure`_, `Ollama`_, `Replicate`_ and `AWS Bedrock`_ as Platform
+    * `Meta's Llama`_ with `Azure`_, `Ollama`_, `Replicate`_, `AWS Bedrock`_ and `OpenRouter`_ as Platform
     * `Gemini`_ with `Google`_, `Vertex AI`_ and `OpenRouter`_ as Platform
     * `Vertex AI Gen AI`_ with `Vertex AI`_ as Platform
     * `DeepSeek's R1`_ with `OpenRouter`_ as Platform
     * `Amazon's Nova`_ with `AWS Bedrock`_ as Platform
-    * `Mistral's Mistral`_ with `Mistral`_ as Platform
+    * `Mistral's Mistral`_ with `Mistral`_ and `OpenRouter`_ as Platform
     * `Albert API`_ models with `Albert`_ as Platform (French government's sovereign AI gateway)
 * **Embeddings Models**
-    * `Gemini Text Embeddings`_ with `Google`_
+    * `Gemini Text Embeddings`_ with `Google`_ and `OpenRouter`_
     * `Vertex AI Text Embeddings`_ with `Vertex AI`_
-    * `OpenAI's Text Embeddings`_ with `OpenAI`_ and `Azure`_ as Platform
+    * `OpenAI's Text Embeddings`_ with `OpenAI`_, `Azure`_ and `OpenRouter`_ as Platform
     * `Voyage's Embeddings`_ with `Voyage`_ as Platform
-    * `Mistral Embed`_ with `Mistral`_ as Platform
+    * `Mistral Embed`_ with `Mistral`_ and `OpenRouter`_ as Platform
+    * `Qwen`_ with `OpenRouter`_ as Platform
 * **Other Models**
     * `OpenAI's Dall·E`_ with `OpenAI`_ as Platform
     * `OpenAI's Whisper`_ with `OpenAI`_ and `Azure`_ as Platform
@@ -507,6 +508,7 @@ Code Examples
 .. _`DeepSeek's R1`: https://www.deepseek.com/
 .. _`Amazon's Nova`: https://nova.amazon.com
 .. _`Mistral's Mistral`: https://www.mistral.ai/
+.. _`Qwen`: https://qwen.ai/
 .. _`Albert API`: https://github.com/etalab-ia/albert-api
 .. _`Albert`: https://alliance.numerique.gouv.fr/produit/produits-interminist%C3%A9rielles/albert-api/
 .. _`Mistral`: https://www.mistral.ai/

--- a/examples/openrouter/chat-gemini-websearch.php
+++ b/examples/openrouter/chat-gemini-websearch.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenRouter\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('OPENROUTER_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::forSystem('Check the web for details that the user ask.'),
+    Message::ofUser('Who win the Formula1 GP in Brasilia at 2025-11-09?'),
+);
+
+// ":online" add web search tooling to the OpenRouter model
+$result = $platform->invoke('google/gemini-2.5-flash-lite:online', $messages);
+
+// Example result:
+// Lando Norris won the Formula 1 Grand Prix in Brasilia on November 9, 2025. This victory significantly extended his lead
+// in the Drivers' Championship [planetf1.com]. Max Verstappen finished third after starting from the pit lane [motorsportweek.com].
+
+echo $result->asText().\PHP_EOL;

--- a/examples/openrouter/set-app-title-and-url.php
+++ b/examples/openrouter/set-app-title-and-url.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenRouter\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+// Set title AND uri to track the calls in the OpenRouter Activity feed
+$client = http_client()->withOptions([
+    'headers' => [
+        'HTTP-Referer' => 'https://ai.symfony.com/',
+        'X-Title' => 'My Special Symfony AI App',
+    ],
+]);
+
+$platform = PlatformFactory::create(env('OPENROUTER_KEY'), $client);
+
+$messages = new MessageBag(
+    Message::forSystem('Output two sentences related to the user topic.'),
+    Message::ofUser('Chess'),
+);
+
+$result = $platform->invoke('google/gemini-2.5-flash-lite', $messages);
+
+echo $result->asText().\PHP_EOL;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | yes
| Issues        | 
| License       | MIT

Add OpenRouter for relevant model companies and add two more examples:

- Example for setting App-Name and App URI for OpenRouter Activity feed
- Add example using Websearch with OpenRouter (`:online` modifier)
