### PR TITLE
 Make `LoaderInterface::load()` `$source` parameter optional

### DIFF
--- a/src/store/src/Document/Loader/InMemoryLoader.php
+++ b/src/store/src/Document/Loader/InMemoryLoader.php
@@ -30,7 +30,7 @@ final class InMemoryLoader implements LoaderInterface
     ) {
     }
 
-    public function load(?string $source, array $options = []): iterable
+    public function load(?string $source = null, array $options = []): iterable
     {
         yield from $this->documents;
     }

--- a/src/store/src/Document/Loader/RssFeedLoader.php
+++ b/src/store/src/Document/Loader/RssFeedLoader.php
@@ -41,7 +41,7 @@ final class RssFeedLoader implements LoaderInterface
     /**
      * @param array{uuid_namespace?: string} $options
      */
-    public function load(?string $source, array $options = []): iterable
+    public function load(?string $source = null, array $options = []): iterable
     {
         if (!class_exists(Crawler::class)) {
             throw new RuntimeException('For using the RSS loader, the Symfony DomCrawler component is required. Try running "composer require symfony/dom-crawler".');

--- a/src/store/src/Document/Loader/TextFileLoader.php
+++ b/src/store/src/Document/Loader/TextFileLoader.php
@@ -23,7 +23,7 @@ use Symfony\Component\Uid\Uuid;
  */
 final class TextFileLoader implements LoaderInterface
 {
-    public function load(?string $source, array $options = []): iterable
+    public function load(?string $source = null, array $options = []): iterable
     {
         if (null === $source) {
             throw new InvalidArgumentException('TextFileLoader requires a file path as source, null given.');

--- a/src/store/src/Document/LoaderInterface.php
+++ b/src/store/src/Document/LoaderInterface.php
@@ -22,5 +22,5 @@ interface LoaderInterface
      *
      * @return iterable<EmbeddableDocumentInterface> iterable of embeddable documents loaded from the source
      */
-    public function load(?string $source, array $options = []): iterable;
+    public function load(?string $source = null, array $options = []): iterable;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

The source parameter in LoaderInterface::load() is now optional with a default value of null. This change makes the API more flexible, particularly for the InMemoryLoader and other loaders which doesn't require a source.