### PR TITLE
[AI Bundle] Improvements on `lazy` / `proxy` usages

### DIFF
--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -442,7 +442,7 @@ return static function (DefinitionConfigurator $configurator): void {
                             ->treatNullLike(['enabled' => true])
                             ->beforeNormalization()
                                 ->ifArray()
-                                ->then(function (array $v) {
+                                ->then(function (array $v): array {
                                     return [
                                         'enabled' => $v['enabled'] ?? true,
                                         'services' => $v['services'] ?? $v,
@@ -564,7 +564,7 @@ return static function (DefinitionConfigurator $configurator): void {
                                 ->stringNode('table')->isRequired()->cannotBeEmpty()->end()
                             ->end()
                             ->validate()
-                                ->ifTrue(static fn ($v) => !isset($v['dsn']) && !isset($v['http_client']))
+                                ->ifTrue(static fn ($v): bool => !isset($v['dsn']) && !isset($v['http_client']))
                                 ->thenInvalid('Either "dsn" or "http_client" must be configured.')
                             ->end()
                         ->end()
@@ -819,11 +819,11 @@ return static function (DefinitionConfigurator $configurator): void {
                                 ->stringNode('dbal_connection')->cannotBeEmpty()->end()
                             ->end()
                             ->validate()
-                                ->ifTrue(static fn ($v) => !isset($v['dsn']) && !isset($v['dbal_connection']))
+                                ->ifTrue(static fn (array $v): bool => !isset($v['dsn']) && !isset($v['dbal_connection']))
                                 ->thenInvalid('Either "dsn" or "dbal_connection" must be configured.')
                             ->end()
                             ->validate()
-                                ->ifTrue(static fn ($v) => isset($v['dsn'], $v['dbal_connection']))
+                                ->ifTrue(static fn (array $v): bool => isset($v['dsn'], $v['dbal_connection']))
                                 ->thenInvalid('Either "dsn" or "dbal_connection" can be configured, but not both.')
                             ->end()
                         ->end()

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -929,7 +929,7 @@ final class AiBundle extends AbstractBundle
      * @param array<string, mixed> $stores
      * @param array<string, mixed> $setupStoresOptions
      */
-    private function processStoreConfig(string $type, array $stores, ContainerBuilder $container, &$setupStoresOptions): void
+    private function processStoreConfig(string $type, array $stores, ContainerBuilder $container, array &$setupStoresOptions): void
     {
         if ('azure_search' === $type) {
             foreach ($stores as $name => $store) {
@@ -947,8 +947,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(AzureSearchStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -961,6 +963,7 @@ final class AiBundle extends AbstractBundle
                 $arguments = [
                     new Reference($store['service']),
                     new Definition(DistanceCalculator::class),
+                    $store['cache_key'] ?? $name,
                 ];
 
                 if (\array_key_exists('strategy', $store) && null !== $store['strategy']) {
@@ -974,13 +977,11 @@ final class AiBundle extends AbstractBundle
                     $arguments[1] = new Reference('ai.store.distance_calculator.'.$name);
                 }
 
-                $arguments[2] = \array_key_exists('cache_key', $store) && null !== $store['cache_key']
-                    ? $store['cache_key']
-                    : $name;
-
                 $definition = new Definition(CacheStore::class);
                 $definition
+                    ->setLazy(true)
                     ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
                     ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
@@ -993,10 +994,12 @@ final class AiBundle extends AbstractBundle
             foreach ($stores as $name => $store) {
                 $definition = new Definition(ChromaDbStore::class);
                 $definition
+                    ->setLazy(true)
                     ->setArguments([
                         new Reference($store['client']),
                         $store['collection'],
                     ])
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
                     ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
@@ -1019,11 +1022,13 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(ClickHouseStore::class);
                 $definition
+                    ->setLazy(true)
                     ->setArguments([
                         $httpClient,
                         $store['database'],
                         $store['table'],
                     ])
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
                     ->addTag('ai.store')
                 ;
 
@@ -1056,8 +1061,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(CloudflareStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1095,7 +1102,9 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(ManticoreStore::class);
                 $definition
+                    ->setLazy(true)
                     ->addTag('ai.store')
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
                     ->setArguments($arguments);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
@@ -1116,8 +1125,10 @@ final class AiBundle extends AbstractBundle
                 $definition = new Definition(MariaDbStore::class);
                 $definition->setFactory([MariaDbStore::class, 'fromDbal']);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $serviceId = 'ai.store.'.$type.'.'.$name;
                 $container->setDefinition($serviceId, $definition);
@@ -1155,8 +1166,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(MeilisearchStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1166,7 +1179,9 @@ final class AiBundle extends AbstractBundle
 
         if ('memory' === $type) {
             foreach ($stores as $name => $store) {
-                $arguments = [];
+                $arguments = [
+                    new Definition(DistanceCalculator::class),
+                ];
 
                 if (\array_key_exists('strategy', $store) && null !== $store['strategy']) {
                     if (!$container->hasDefinition('ai.store.distance_calculator.'.$name)) {
@@ -1181,8 +1196,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(InMemoryStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1214,8 +1231,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(MilvusStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1242,8 +1261,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(MongoDbStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1281,8 +1302,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(Neo4jStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1307,8 +1330,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(PineconeStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1339,8 +1364,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(QdrantStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1359,14 +1386,15 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(RedisStore::class);
                 $definition
-                    ->addTag('ai.store')
+                    ->setLazy(true)
                     ->setArguments([
                         $redisClient,
                         $store['index_name'],
                         $store['key_prefix'],
                         $store['distance'],
                     ])
-                ;
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
             }
@@ -1405,8 +1433,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(SurrealDbStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1433,8 +1463,10 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(TypesenseStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1444,17 +1476,17 @@ final class AiBundle extends AbstractBundle
 
         if ('weaviate' === $type) {
             foreach ($stores as $name => $store) {
-                $arguments = [
-                    new Reference('http_client'),
-                    $store['endpoint'],
-                    $store['api_key'],
-                    $store['collection'],
-                ];
-
                 $definition = new Definition(WeaviateStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments([
+                        new Reference('http_client'),
+                        $store['endpoint'],
+                        $store['api_key'],
+                        $store['collection'],
+                    ])
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1495,8 +1527,10 @@ final class AiBundle extends AbstractBundle
                 }
 
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -1530,11 +1564,14 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(SupabaseStore::class);
                 $definition
-                    ->addTag('ai.store')
-                    ->setArguments($arguments);
+                    ->setLazy(true)
+                    ->setArguments($arguments)
+                    ->addTag('proxy', ['interface' => StoreInterface::class])
+                    ->addTag('ai.store');
 
                 $container->setDefinition('ai.store.supabase.'.$name, $definition);
-                $container->registerAliasForArgument('ai.store.'.$name, StoreInterface::class, (new Target($name.'Store'))->getParsedName());
+                $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
+                $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $type.'_'.$name);
             }
         }
     }
@@ -1750,10 +1787,12 @@ final class AiBundle extends AbstractBundle
     {
         $definition = new Definition(Chat::class);
         $definition
+            ->setLazy(true)
             ->setArguments([
                 new Reference($configuration['agent']),
                 new Reference($configuration['message_store']),
             ])
+            ->addTag('proxy', ['interface' => ChatInterface::class])
             ->addTag('ai.chat');
 
         $container->setDefinition('ai.chat.'.$name, $definition);

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -27,6 +27,7 @@ use Symfony\AI\Chat\MessageStoreInterface;
 use Symfony\AI\Platform\Bridge\Ollama\OllamaApiCatalog;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Store\Bridge\Local\DistanceCalculator;
 use Symfony\AI\Store\Document\Filter\TextContainsFilter;
 use Symfony\AI\Store\Document\Loader\InMemoryLoader;
 use Symfony\AI\Store\Document\Transformer\TextTrimTransformer;
@@ -483,7 +484,9 @@ class AiBundleTest extends TestCase
         $this->assertTrue($container->hasDefinition('ai.store.memory.my_memory_store_with_custom_strategy'));
 
         $definition = $container->getDefinition('ai.store.memory.my_memory_store_with_custom_strategy');
-        $this->assertCount(0, $definition->getArguments());
+        $this->assertCount(1, $definition->getArguments());
+        $this->assertInstanceOf(Definition::class, $definition->getArgument(0));
+        $this->assertSame(DistanceCalculator::class, $definition->getArgument(0)->getClass());
     }
 
     public function testInMemoryStoreWithCustomStrategyCanBeConfigured()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Related to #855 
| License       | MIT

Summary:

* Add missing `lazy` to vector stores
* Add `proxy` usage for vector stores (already used for message stores)
* Sorting method calls on `Definition` usages (lazy, arguments, tags)
* Remove a call to `Target::getParsedName()` (non compliant with recent discussions about injection aliases)