### PR TITLE
[AI Bundle][VertexAI] factory get called with wrong arguments

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -507,7 +507,6 @@ final class AiBundle extends AbstractBundle
                     $httpClient,
                     new Reference('ai.platform.model_catalog.vertexai.gemini'),
                     new Reference('ai.platform.contract.vertexai.gemini'),
-                    null,
                     new Reference('event_dispatcher'),
                 ])
                 ->addTag('ai.platform', ['name' => 'vertexai']);

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -46,7 +46,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class AiBundleTest extends TestCase
 {
-    #[DoesNotPerformAssertions]
     public function testExtensionLoadDoesNotThrow()
     {
         $container = $this->buildContainer($this->getFullConfig());
@@ -58,6 +57,15 @@ class AiBundleTest extends TestCase
         $platforms = $container->findTaggedServiceIds('ai.platform');
 
         foreach (array_keys($platforms) as $platformId) {
+            $def = $container->getDefinition($platformId);
+            $factor = $def->getFactory();
+
+            if (\is_array($factor)) {
+                $ref = new \ReflectionClass($factor[0]);
+                $numArgs = $ref->getMethod($factor[1])->getNumberOfParameters();
+                $this->assertGreaterThanOrEqual($numArgs, \count($def->getArguments()));
+            }
+
             try {
                 $platformService = $container->get($platformId);
                 $platformService->getModelCatalog();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT

The vertex ai factory `create´method get called with one wrong "null" parameter. This removes the eventDispatcher, because it would be the 5th argument. Since method signature still is valid with null as 4th parameter, my `AiBundleTest::testExtensionLoadDoesNotThrow` test did not catch it. 
