### PR TITLE
[Platform] Fix Platform component dependency on Agent exceptions

### DIFF
--- a/src/platform/src/Exception/MissingModelSupportException.php
+++ b/src/platform/src/Exception/MissingModelSupportException.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\AI\Platform\Exception;
 
-use Symfony\AI\Agent\Exception\RuntimeException;
-
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Refs https://github.com/symfony/ai/pull/798
| License       | MIT

Remove incorrect import of RuntimeException from Agent component in MissingModelSupportException. The Platform component should use its own exception hierarchy and not depend on Agent exceptions.