### PR TITLE
[Agent] Add `branch-alias` for tool bridges

### DIFF
--- a/src/agent/src/Bridge/Brave/composer.json
+++ b/src/agent/src/Bridge/Brave/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/ai-brave-tool",
     "description": "Brave Search AI tool bridge for Symfony applications.",
     "license": "MIT",
-    "type": "library",
+    "type": "symfony-ai-tool",
     "keywords": ["ai", "bridge", "brave", "agent", "tool"],
     "authors": [
         {
@@ -36,6 +36,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/agent/src/Bridge/Firecrawl/composer.json
+++ b/src/agent/src/Bridge/Firecrawl/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/ai-firecrawl-tool",
     "description": "Firecrawl AI tool bridge for Symfony applications.",
     "license": "MIT",
-    "type": "library",
+    "type": "symfony-ai-tool",
     "keywords": ["ai", "bridge", "firecrawl", "agent", "tool"],
     "authors": [
         {
@@ -36,6 +36,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/agent/src/Bridge/Mapbox/composer.json
+++ b/src/agent/src/Bridge/Mapbox/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/ai-mapbox-tool",
     "description": "Mapbox AI tool bridge for Symfony applications.",
     "license": "MIT",
-    "type": "library",
+    "type": "symfony-ai-tool",
     "keywords": ["ai", "bridge", "mapbox", "agent", "tool", "geocoding"],
     "authors": [
         {
@@ -32,6 +32,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/agent/src/Bridge/OpenMeteo/composer.json
+++ b/src/agent/src/Bridge/OpenMeteo/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/ai-open-meteo-tool",
     "description": "OpenMeteo weather AI tool bridge for Symfony applications.",
     "license": "MIT",
-    "type": "library",
+    "type": "symfony-ai-tool",
     "keywords": ["ai", "bridge", "openmeteo", "weather", "agent", "tool"],
     "authors": [
         {
@@ -32,6 +32,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/agent/src/Bridge/SerpApi/composer.json
+++ b/src/agent/src/Bridge/SerpApi/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/ai-serp-api-tool",
     "description": "SerpApi AI tool bridge for Symfony applications.",
     "license": "MIT",
-    "type": "library",
+    "type": "symfony-ai-tool",
     "keywords": ["ai", "bridge", "serpapi", "agent", "tool"],
     "authors": [
         {
@@ -32,6 +32,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/agent/src/Bridge/Tavily/composer.json
+++ b/src/agent/src/Bridge/Tavily/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/ai-tavily-tool",
     "description": "Tavily AI tool bridge for Symfony applications.",
     "license": "MIT",
-    "type": "library",
+    "type": "symfony-ai-tool",
     "keywords": ["ai", "bridge", "tavily", "agent", "tool"],
     "authors": [
         {
@@ -36,6 +36,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Add branch-alias configuration to all Agent Bridge composer.json files to map dev-main to 0.x-dev for proper version resolution.