### PR TITLE
 Add `branch-alias` for `0.x-dev` to all components/bundles

### DIFF
--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -62,6 +62,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -55,6 +55,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/chat/composer.json
+++ b/src/chat/composer.json
@@ -59,6 +59,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -45,6 +45,9 @@
         }
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/platform/composer.json
+++ b/src/platform/composer.json
@@ -93,6 +93,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/store/composer.json
+++ b/src/store/composer.json
@@ -73,6 +73,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Follows #978 
| License       | MIT

Configure Composer branch aliases to map the main branch to 0.x-dev for all components in the monorepo (agent, ai-bundle, chat, mcp-bundle, platform, and store).
