### PR TITLE
[Agent][Scraper] Require `masterminds/html5` ^2.8 for CI lowest

### DIFF
--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -33,6 +33,7 @@
         "symfony/type-info": "^7.3|^8.0"
     },
     "require-dev": {
+        "masterminds/html5": "^2.8",
         "mrmysql/youtube-transcript": "^0.0.5",
         "nyholm/psr7": "^1.8",
         "php-http/discovery": "^1.19",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Follows #969 
| License       | MIT

The Scraper tool tests require a newer version of masterminds/html5 to work correctly in the monorepo CI environment. Version 2.8 handles directory traversal more gracefully.