### PR TITLE
 Use PHP 8.5 for PHPStan checks in CI

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -21,7 +21,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '8.4' ]
+                php-version: [ '8.5' ]
         steps:
             - name: Checkout
               uses: actions/checkout@v6


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT