### PR TITLE
[Run examples] Pass OPENAI_API_KEY secret to examples runner

### DIFF
--- a/.github/workflows/run-examples.yaml
+++ b/.github/workflows/run-examples.yaml
@@ -30,6 +30,8 @@ jobs:
             - name: Run OpenAI examples
               id: run-examples
               run: ./runner openai
+              env:
+                  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
             - name: Remove label
               if: always()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

GitHub Actions secrets are not automatically exposed as environment variables. They need to be explicitly passed using the env key.