### PR TITLE
[Agent] Add missing `branch-alias` to Scraper and Wikipedia bridges

### DIFF
--- a/src/agent/src/Bridge/Scraper/composer.json
+++ b/src/agent/src/Bridge/Scraper/composer.json
@@ -39,6 +39,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"

--- a/src/agent/src/Bridge/Wikipedia/composer.json
+++ b/src/agent/src/Bridge/Wikipedia/composer.json
@@ -36,6 +36,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
         "thanks": {
             "name": "symfony/ai",
             "url": "https://github.com/symfony/ai"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

To make the flex recipes work