### PR TITLE
[Platform] Improvements on Uuid handling & `MessageNormalizer`

### DIFF
--- a/src/chat/src/MessageNormalizer.php
+++ b/src/chat/src/MessageNormalizer.php
@@ -28,6 +28,9 @@ use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
@@ -71,12 +74,17 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
             default => throw new LogicException(\sprintf('Unknown message type "%s".', $type)),
         };
 
-        $message->getMetadata()->set([
+        /** @var AbstractUid&TimeBasedUidInterface&Uuid $existingUuid */
+        $existingUuid = Uuid::fromString($data['id']);
+
+        $messageWithExistingUuid = $message->withId($existingUuid);
+
+        $messageWithExistingUuid->getMetadata()->set([
             ...$data['metadata'],
             'addedAt' => $data['addedAt'],
         ]);
 
-        return $message;
+        return $messageWithExistingUuid;
     }
 
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool

--- a/src/chat/tests/MessageNormalizerTest.php
+++ b/src/chat/tests/MessageNormalizerTest.php
@@ -54,10 +54,11 @@ final class MessageNormalizerTest extends TestCase
 
     public function testItCanDenormalize()
     {
+        $uuid = Uuid::v7()->toRfc4122();
         $normalizer = new MessageNormalizer();
 
         $message = $normalizer->denormalize([
-            'id' => Uuid::v7()->toRfc4122(),
+            'id' => $uuid,
             'type' => UserMessage::class,
             'content' => '',
             'contentAsBase64' => [
@@ -71,6 +72,7 @@ final class MessageNormalizerTest extends TestCase
             'addedAt' => (new \DateTimeImmutable())->getTimestamp(),
         ], MessageInterface::class);
 
+        $this->assertSame($uuid, $message->getId()->toRfc4122());
         $this->assertSame(Role::User, $message->getRole());
         $this->assertArrayHasKey('addedAt', $message->getMetadata()->all());
     }

--- a/src/platform/src/Message/AssistantMessage.php
+++ b/src/platform/src/Message/AssistantMessage.php
@@ -13,8 +13,6 @@ namespace Symfony\AI\Platform\Message;
 
 use Symfony\AI\Platform\Metadata\MetadataAwareTrait;
 use Symfony\AI\Platform\Result\ToolCall;
-use Symfony\Component\Uid\AbstractUid;
-use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -22,9 +20,8 @@ use Symfony\Component\Uid\Uuid;
  */
 final class AssistantMessage implements MessageInterface
 {
+    use IdentifierAwareTrait;
     use MetadataAwareTrait;
-
-    private readonly AbstractUid&TimeBasedUidInterface $id;
 
     /**
      * @param ?ToolCall[] $toolCalls
@@ -39,11 +36,6 @@ final class AssistantMessage implements MessageInterface
     public function getRole(): Role
     {
         return Role::Assistant;
-    }
-
-    public function getId(): AbstractUid&TimeBasedUidInterface
-    {
-        return $this->id;
     }
 
     public function hasToolCalls(): bool

--- a/src/platform/src/Message/IdentifierAwareTrait.php
+++ b/src/platform/src/Message/IdentifierAwareTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message;
+
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\TimeBasedUidInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+trait IdentifierAwareTrait
+{
+    private AbstractUid&TimeBasedUidInterface $id;
+
+    public function withId(AbstractUid&TimeBasedUidInterface $id): self
+    {
+        $clone = clone $this;
+        $clone->id = $id;
+
+        return $clone;
+    }
+
+    public function getId(): AbstractUid&TimeBasedUidInterface
+    {
+        return $this->id;
+    }
+}

--- a/src/platform/src/Message/MessageInterface.php
+++ b/src/platform/src/Message/MessageInterface.php
@@ -25,6 +25,8 @@ interface MessageInterface
 
     public function getId(): AbstractUid&TimeBasedUidInterface;
 
+    public function withId(AbstractUid&TimeBasedUidInterface $id): self;
+
     /**
      * @return string|Template|ContentInterface[]|null
      */

--- a/src/platform/src/Message/SystemMessage.php
+++ b/src/platform/src/Message/SystemMessage.php
@@ -12,8 +12,6 @@
 namespace Symfony\AI\Platform\Message;
 
 use Symfony\AI\Platform\Metadata\MetadataAwareTrait;
-use Symfony\Component\Uid\AbstractUid;
-use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -21,9 +19,8 @@ use Symfony\Component\Uid\Uuid;
  */
 final class SystemMessage implements MessageInterface
 {
+    use IdentifierAwareTrait;
     use MetadataAwareTrait;
-
-    private readonly AbstractUid&TimeBasedUidInterface $id;
 
     public function __construct(
         private readonly string|Template $content,
@@ -34,11 +31,6 @@ final class SystemMessage implements MessageInterface
     public function getRole(): Role
     {
         return Role::System;
-    }
-
-    public function getId(): AbstractUid&TimeBasedUidInterface
-    {
-        return $this->id;
     }
 
     public function getContent(): string|Template

--- a/src/platform/src/Message/ToolCallMessage.php
+++ b/src/platform/src/Message/ToolCallMessage.php
@@ -13,8 +13,6 @@ namespace Symfony\AI\Platform\Message;
 
 use Symfony\AI\Platform\Metadata\MetadataAwareTrait;
 use Symfony\AI\Platform\Result\ToolCall;
-use Symfony\Component\Uid\AbstractUid;
-use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -22,9 +20,8 @@ use Symfony\Component\Uid\Uuid;
  */
 final class ToolCallMessage implements MessageInterface
 {
+    use IdentifierAwareTrait;
     use MetadataAwareTrait;
-
-    private readonly AbstractUid&TimeBasedUidInterface $id;
 
     public function __construct(
         private readonly ToolCall $toolCall,
@@ -36,11 +33,6 @@ final class ToolCallMessage implements MessageInterface
     public function getRole(): Role
     {
         return Role::ToolCall;
-    }
-
-    public function getId(): AbstractUid&TimeBasedUidInterface
-    {
-        return $this->id;
     }
 
     public function getToolCall(): ToolCall

--- a/src/platform/src/Message/UserMessage.php
+++ b/src/platform/src/Message/UserMessage.php
@@ -17,8 +17,6 @@ use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Metadata\MetadataAwareTrait;
-use Symfony\Component\Uid\AbstractUid;
-use Symfony\Component\Uid\TimeBasedUidInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -26,14 +24,13 @@ use Symfony\Component\Uid\Uuid;
  */
 final class UserMessage implements MessageInterface
 {
+    use IdentifierAwareTrait;
     use MetadataAwareTrait;
 
     /**
      * @var ContentInterface[]
      */
     private readonly array $content;
-
-    private readonly AbstractUid&TimeBasedUidInterface $id;
 
     public function __construct(
         ContentInterface ...$content,
@@ -45,11 +42,6 @@ final class UserMessage implements MessageInterface
     public function getRole(): Role
     {
         return Role::User;
-    }
-
-    public function getId(): AbstractUid&TimeBasedUidInterface
-    {
-        return $this->id;
     }
 
     /**

--- a/src/platform/tests/ContractTest.php
+++ b/src/platform/tests/ContractTest.php
@@ -23,15 +23,13 @@ use Symfony\AI\Platform\Message\Content\Audio;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\IdentifierAwareTrait;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\MessageInterface;
 use Symfony\AI\Platform\Message\Role;
 use Symfony\AI\Platform\Metadata\MetadataAwareTrait;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Uid\AbstractUid;
-use Symfony\Component\Uid\TimeBasedUidInterface;
-use Symfony\Component\Uid\Uuid;
 
 final class ContractTest extends TestCase
 {
@@ -174,16 +172,12 @@ final class ContractTest extends TestCase
         ];
 
         $customSerializableMessage = new class implements MessageInterface, \JsonSerializable {
+            use IdentifierAwareTrait;
             use MetadataAwareTrait;
 
             public function getRole(): Role
             {
                 return Role::User;
-            }
-
-            public function getId(): AbstractUid&TimeBasedUidInterface
-            {
-                return Uuid::v7();
             }
 
             public function getContent(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | None
| License       | MIT

Summary:

* When using `MessageNormalizer::denormalize()`, it looks like we're recreating a new `Uuid::v7()` in the constructor
* Due to this behavior, when persisting messages, they're receiving a new uuid even on older ones
* This PR introduce a `IdentifierAwareTrait` that expose two methods `getId()` and `withId`, the last one allows to either specify an exiting Uuid or use a `v7` one