### PR TITLE
[Doc] markup issue in docs/components/platform.rst

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -317,7 +317,7 @@ To achieve this, the ``Symfony\AI\Platform\StructuredOutput\PlatformSubscriber``
 Array Structures as Output
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Also PHP array structures as `response_format` are supported, which also requires the event subscriber mentioned above. On
+Also PHP array structures as ``response_format`` are supported, which also requires the event subscriber mentioned above. On
 top this example uses the feature through the agent to leverage tool calling::
 
     use Symfony\AI\Platform\Message\Message;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        |
| License       | MIT


Fix [this](https://symfony.com/doc/current/ai/components/platform.html#array-structures-as-output): 
<img width="381" height="158" alt="image" src="https://github.com/user-attachments/assets/6335d02c-e304-4239-867f-185e97dcecaa" />

