### PR TITLE
 Change StoreInterface from array to iterable

### DIFF
--- a/src/store/src/Bridge/Azure/SearchStore.php
+++ b/src/store/src/Bridge/Azure/SearchStore.php
@@ -44,13 +44,15 @@ final class SearchStore implements StoreInterface
         ]);
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $result = $this->request('search', [
             'vectorQueries' => [$this->buildVectorQuery($vector)],
         ]);
 
-        return array_map([$this, 'convertToVectorDocument'], $result['value']);
+        foreach ($result['value'] as $item) {
+            yield $this->convertToVectorDocument($item);
+        }
     }
 
     /**

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -55,7 +55,7 @@ final class Store implements StoreInterface
     /**
      * @param array{where?: array<string, string>, whereDocument?: array<string, mixed>} $options
      */
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $collection = $this->client->getOrCreateCollection($this->collectionName);
         $queryResponse = $collection->query(
@@ -65,15 +65,12 @@ final class Store implements StoreInterface
             whereDocument: $options['whereDocument'] ?? null,
         );
 
-        $documents = [];
         for ($i = 0; $i < \count($queryResponse->metadatas[0]); ++$i) {
-            $documents[] = new VectorDocument(
+            yield new VectorDocument(
                 id: Uuid::fromString($queryResponse->ids[0][$i]),
                 vector: new Vector($queryResponse->embeddings[0][$i]),
                 metadata: new Metadata($queryResponse->metadatas[0][$i]),
             );
         }
-
-        return $documents;
     }
 }

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -64,7 +64,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         $this->insertBatch($rows);
     }
 
-    public function query(Vector $vector, array $options = [], ?float $minScore = null): array
+    public function query(Vector $vector, array $options = [], ?float $minScore = null): iterable
     {
         $sql = <<<'SQL'
             SELECT
@@ -93,17 +93,14 @@ class Store implements ManagedStoreInterface, StoreInterface
             ->toArray()['data']
         ;
 
-        $documents = [];
         foreach ($results as $result) {
-            $documents[] = new VectorDocument(
+            yield new VectorDocument(
                 id: Uuid::fromString($result['id']),
                 vector: new Vector($result['embedding']),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],
             );
         }
-
-        return $documents;
     }
 
     /**

--- a/src/store/src/Bridge/Cloudflare/Store.php
+++ b/src/store/src/Bridge/Cloudflare/Store.php
@@ -71,7 +71,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         });
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $results = $this->request('POST', \sprintf('vectorize/v2/indexes/%s/query', $this->index), [
             'vector' => $vector->getData(),
@@ -79,7 +79,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
             'returnMetadata' => 'all',
         ]);
 
-        return array_map($this->convertToVectorDocument(...), $results['result']['matches']);
+        foreach ($results['result']['matches'] as $item) {
+            yield $this->convertToVectorDocument($item);
+        }
     }
 
     /**

--- a/src/store/src/Bridge/Local/CacheStore.php
+++ b/src/store/src/Bridge/Local/CacheStore.php
@@ -77,7 +77,7 @@ final class CacheStore implements ManagedStoreInterface, StoreInterface
      * } $options If maxItems is provided, only the top N results will be returned.
      *            If filter is provided, only documents matching the filter will be considered.
      */
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $documents = $this->cache->get($this->cacheKey, static fn (): array => []);
 
@@ -91,7 +91,7 @@ final class CacheStore implements ManagedStoreInterface, StoreInterface
             $vectorDocuments = array_values(array_filter($vectorDocuments, $options['filter']));
         }
 
-        return $this->distanceCalculator->calculate($vectorDocuments, $vector, $options['maxItems'] ?? null);
+        yield from $this->distanceCalculator->calculate($vectorDocuments, $vector, $options['maxItems'] ?? null);
     }
 
     public function drop(): void

--- a/src/store/src/Bridge/Local/InMemoryStore.php
+++ b/src/store/src/Bridge/Local/InMemoryStore.php
@@ -53,7 +53,7 @@ class InMemoryStore implements ManagedStoreInterface, StoreInterface
      * } $options If maxItems is provided, only the top N results will be returned.
      *            If filter is provided, only documents matching the filter will be considered.
      */
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $documents = $this->documents;
 
@@ -61,7 +61,7 @@ class InMemoryStore implements ManagedStoreInterface, StoreInterface
             $documents = array_values(array_filter($documents, $options['filter']));
         }
 
-        return $this->distanceCalculator->calculate($documents, $vector, $options['maxItems'] ?? null);
+        yield from $this->distanceCalculator->calculate($documents, $vector, $options['maxItems'] ?? null);
     }
 
     public function drop(): void

--- a/src/store/src/Bridge/Manticore/Store.php
+++ b/src/store/src/Bridge/Manticore/Store.php
@@ -82,7 +82,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         });
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $documents = $this->request('search', [
             'table' => $this->table,
@@ -94,7 +94,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
             ],
         ]);
 
-        return array_map($this->convertToVectorDocument(...), $documents['hits']['hits']);
+        foreach ($documents['hits']['hits'] as $item) {
+            yield $this->convertToVectorDocument($item);
+        }
     }
 
     /**

--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -141,7 +141,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     maxScore?: float|null,
      * } $options
      */
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $where = null;
 
@@ -183,19 +183,15 @@ final class Store implements ManagedStoreInterface, StoreInterface
             $params['maxScore'] = $maxScore;
         }
 
-        $documents = [];
-
         $statement->execute($params);
 
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
-            $documents[] = new VectorDocument(
+            yield new VectorDocument(
                 id: Uuid::fromRfc4122($result['id']),
                 vector: new Vector(json_decode((string) $result['embedding'], true)),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true)),
                 score: $result['score'],
             );
         }
-
-        return $documents;
     }
 }

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -77,7 +77,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $semanticRatio = $options['semanticRatio'] ?? $this->semanticRatio;
 
@@ -96,7 +96,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
             ],
         ]);
 
-        return array_map($this->convertToVectorDocument(...), $result['hits']);
+        foreach ($result['hits'] as $item) {
+            yield $this->convertToVectorDocument($item);
+        }
     }
 
     public function drop(): void

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -100,7 +100,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $payload = [
             'collectionName' => $this->collection,
@@ -117,7 +117,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $documents = $this->request('POST', 'v2/vectordb/entities/search', $payload);
 
-        return array_map($this->convertToVectorDocument(...), $documents['data']);
+        foreach ($documents['data'] as $item) {
+            yield $this->convertToVectorDocument($item);
+        }
     }
 
     public function drop(): void

--- a/src/store/src/Bridge/MongoDb/Store.php
+++ b/src/store/src/Bridge/MongoDb/Store.php
@@ -143,7 +143,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     minScore?: float,
      * } $options
      */
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $minScore = null;
         if (\array_key_exists('minScore', $options)) {
@@ -181,18 +181,14 @@ final class Store implements ManagedStoreInterface, StoreInterface
             ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
         );
 
-        $documents = [];
-
         foreach ($results as $result) {
-            $documents[] = new VectorDocument(
+            yield new VectorDocument(
                 id: $this->toUuid($result['_id']),
                 vector: new Vector($result[$this->vectorFieldName]),
                 metadata: new Metadata($result['metadata'] ?? []),
                 score: $result['score'],
             );
         }
-
-        return $documents;
     }
 
     private function getCollection(): Collection

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -65,7 +65,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $response = $this->request('POST', \sprintf('db/%s/query/v2', $this->databaseName), [
             'statement' => \sprintf('CALL db.index.vector.queryNodes("%s", 5, $vectors) YIELD node, score RETURN node, score', $this->vectorIndexName),
@@ -74,7 +74,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
             ],
         ]);
 
-        return array_map($this->convertToVectorDocument(...), $response['data']['values']);
+        foreach ($response['data']['values'] as $item) {
+            yield $this->convertToVectorDocument($item);
+        }
     }
 
     public function drop(): void

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -57,7 +57,7 @@ final class Store implements StoreInterface
         $this->getVectors()->upsert($vectors, $this->namespace);
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $result = $this->getVectors()->query(
             vector: $vector->getData(),
@@ -67,17 +67,14 @@ final class Store implements StoreInterface
             includeValues: true,
         );
 
-        $documents = [];
         foreach ($result->json()['matches'] as $match) {
-            $documents[] = new VectorDocument(
+            yield new VectorDocument(
                 id: Uuid::fromString($match['id']),
                 vector: new Vector($match['values']),
                 metadata: new Metadata($match['metadata']),
                 score: $match['score'],
             );
         }
-
-        return $documents;
     }
 
     private function getVectors(): VectorResource

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -127,7 +127,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $where = null;
 
@@ -170,17 +170,14 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $statement->execute($params);
 
-        $documents = [];
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
-            $documents[] = new VectorDocument(
+            yield new VectorDocument(
                 id: Uuid::fromString($result['id']),
                 vector: new Vector($this->fromPgvector($result['embedding'])),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],
             );
         }
-
-        return $documents;
     }
 
     private function toPgvector(VectorInterface $vector): string

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -76,7 +76,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     offset?: positive-int
      * } $options
      */
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $payload = [
             'query' => $vector->getData(),
@@ -98,7 +98,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $response = $this->request('POST', \sprintf('collections/%s/points/query', $this->collectionName), $payload);
 
-        return array_map($this->convertToVectorDocument(...), $response['result']['points']);
+        foreach ($response['result']['points'] as $item) {
+            yield $this->convertToVectorDocument($item);
+        }
     }
 
     public function drop(): void

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -108,7 +108,7 @@ class Store implements ManagedStoreInterface, StoreInterface
      *
      * @return VectorDocument[]
      */
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $limit = $options['limit'] ?? 5;
         $maxScore = $options['maxScore'] ?? null;
@@ -135,7 +135,6 @@ class Store implements ManagedStoreInterface, StoreInterface
             return [];
         }
 
-        $documents = [];
         $numResults = $results[0];
 
         // Parse results (skip first element which is the count)
@@ -167,15 +166,13 @@ class Store implements ManagedStoreInterface, StoreInterface
                 continue;
             }
 
-            $documents[] = new VectorDocument(
+            yield new VectorDocument(
                 id: Uuid::fromString($data['$.id']),
                 vector: new Vector($data['$.embedding'] ?? []),
                 metadata: new Metadata($data['$.metadata'] ?? []),
                 score: $score,
             );
         }
-
-        return $documents;
     }
 
     private function toRedisVector(VectorInterface $vector): string

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -61,7 +61,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $vectors = json_encode($vector->getData());
 
@@ -70,7 +70,9 @@ class Store implements ManagedStoreInterface, StoreInterface
             $this->vectorFieldName, $this->strategy, $this->vectorFieldName, $vectors, $this->table, $this->vectorFieldName, $vectors,
         ));
 
-        return array_map($this->convertToVectorDocument(...), $results[0]['result']);
+        foreach ($results[0]['result'] as $item) {
+            yield $this->convertToVectorDocument($item);
+        }
     }
 
     public function drop(): void

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -69,7 +69,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $documents = $this->request('POST', 'multi_search', [
             'searches' => [
@@ -81,7 +81,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
             ],
         ]);
 
-        return array_map($this->convertToVectorDocument(...), $documents['results'][0]['hits']);
+        foreach ($documents['results'][0]['hits'] as $item) {
+            yield $this->convertToVectorDocument($item);
+        }
     }
 
     public function drop(): void

--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -55,7 +55,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         $results = $this->request('POST', 'v1/graphql', [
             'query' => \sprintf('{
@@ -73,7 +73,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
             }', $this->collection, implode(', ', $vector->getData())),
         ]);
 
-        return array_map($this->convertToVectorDocument(...), $results['data']['Get'][$this->collection]);
+        foreach ($results['data']['Get'][$this->collection] as $item) {
+            yield $this->convertToVectorDocument($item);
+        }
     }
 
     public function drop(): void

--- a/src/store/src/StoreInterface.php
+++ b/src/store/src/StoreInterface.php
@@ -24,7 +24,7 @@ interface StoreInterface
     /**
      * @param array<string, mixed> $options
      *
-     * @return VectorDocument[]
+     * @return iterable<VectorDocument>
      */
-    public function query(Vector $vector, array $options = []): array;
+    public function query(Vector $vector, array $options = []): iterable;
 }

--- a/src/store/tests/Bridge/Azure/SearchStoreTest.php
+++ b/src/store/tests/Bridge/Azure/SearchStoreTest.php
@@ -167,7 +167,7 @@ final class SearchStoreTest extends TestCase
             '2023-11-01',
         );
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -216,7 +216,7 @@ final class SearchStoreTest extends TestCase
             'custom_vector_field',
         );
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -247,7 +247,7 @@ final class SearchStoreTest extends TestCase
         $this->expectExceptionMessage('HTTP 400 returned');
         $this->expectExceptionCode(400);
 
-        $store->query(new Vector([0.1, 0.2, 0.3]));
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
     }
 
     public function testQueryWithNullVector()
@@ -277,7 +277,7 @@ final class SearchStoreTest extends TestCase
             '2023-11-01',
         );
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);

--- a/src/store/tests/Bridge/ChromaDb/StoreTest.php
+++ b/src/store/tests/Bridge/ChromaDb/StoreTest.php
@@ -168,7 +168,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = $store->query($queryVector);
+        $documents = iterator_to_array($store->query($queryVector));
 
         $this->assertCount(2, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
@@ -213,7 +213,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = $store->query($queryVector, ['where' => $whereFilter]);
+        $documents = iterator_to_array($store->query($queryVector, ['where' => $whereFilter]));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
@@ -257,7 +257,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = $store->query($queryVector, ['whereDocument' => $whereDocumentFilter]);
+        $documents = iterator_to_array($store->query($queryVector, ['whereDocument' => $whereDocumentFilter]));
 
         $this->assertCount(2, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
@@ -302,10 +302,10 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = $store->query($queryVector, [
+        $documents = iterator_to_array($store->query($queryVector, [
             'where' => $whereFilter,
             'whereDocument' => $whereDocumentFilter,
-        ]);
+        ]));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
@@ -349,7 +349,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = $store->query($queryVector, ['where' => $whereFilter]);
+        $documents = iterator_to_array($store->query($queryVector, ['where' => $whereFilter]));
 
         $this->assertCount(0, $documents);
     }
@@ -399,7 +399,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = $store->query($queryVector, $options);
+        $documents = iterator_to_array($store->query($queryVector, $options));
 
         $this->assertCount(1, $documents);
     }

--- a/src/store/tests/Bridge/ClickHouse/StoreTest.php
+++ b/src/store/tests/Bridge/ClickHouse/StoreTest.php
@@ -152,7 +152,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'test_db', 'test_table');
 
-        $results = $store->query($queryVector);
+        $results = iterator_to_array($store->query($queryVector));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -175,10 +175,10 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'test_db', 'test_table');
 
-        $results = $store->query($queryVector, [
+        $results = iterator_to_array($store->query($queryVector, [
             'limit' => 10,
             'params' => ['custom_param' => 'test_value'],
-        ]);
+        ]));
 
         $this->assertCount(0, $results);
     }
@@ -197,9 +197,9 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'test_db', 'test_table');
 
-        $results = $store->query($queryVector, [
+        $results = iterator_to_array($store->query($queryVector, [
             'where' => "JSONExtractString(metadata, 'type') = 'document'",
-        ]);
+        ]));
 
         $this->assertCount(0, $results);
     }
@@ -226,7 +226,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'test_db', 'test_table');
 
-        $results = $store->query($queryVector);
+        $results = iterator_to_array($store->query($queryVector));
 
         $this->assertCount(1, $results);
         $this->assertSame([], $results[0]->metadata->getArrayCopy());

--- a/src/store/tests/Bridge/Cloudflare/StoreTest.php
+++ b/src/store/tests/Bridge/Cloudflare/StoreTest.php
@@ -197,7 +197,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "https://api.cloudflare.com/client/v4/accounts/foo/vectorize/v2/indexes/random/query".');
         $this->expectExceptionCode(400);
-        $store->query(new Vector([0.1, 0.2, 0.3]));
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
     }
 
     public function testStoreCanQuery()
@@ -232,7 +232,7 @@ final class StoreTest extends TestCase
             'random',
         );
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, $results);
         $this->assertSame(1, $mockHttpClient->getRequestsCount());

--- a/src/store/tests/Bridge/Local/CacheStoreTest.php
+++ b/src/store/tests/Bridge/Local/CacheStoreTest.php
@@ -28,7 +28,7 @@ final class CacheStoreTest extends TestCase
         $store = new CacheStore(new ArrayAdapter());
         $store->setup();
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(0, $result);
     }
 
@@ -41,12 +41,12 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(3, $result);
 
         $store->drop();
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(0, $result);
     }
 
@@ -59,7 +59,7 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(3, $result);
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->vector->getData());
 
@@ -69,7 +69,7 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(6, $result);
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->vector->getData());
     }
@@ -85,7 +85,7 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(5, $result);
         $this->assertSame([0.0, 0.1, 0.6], $result[0]->vector->getData());
         $this->assertSame([0.1, 0.1, 0.5], $result[1]->vector->getData());
@@ -103,9 +103,9 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         );
 
-        $this->assertCount(1, $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $this->assertCount(1, iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'maxItems' => 1,
-        ]));
+        ])));
     }
 
     public function testStoreCanSearchUsingAngularDistance()
@@ -116,7 +116,7 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         );
 
-        $result = $store->query(new Vector([1.2, 2.3, 3.4]));
+        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
@@ -130,7 +130,7 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 2.0, 3.0])),
         );
 
-        $result = $store->query(new Vector([1.2, 2.3, 3.4]));
+        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
@@ -144,7 +144,7 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         );
 
-        $result = $store->query(new Vector([1.2, 2.3, 3.4]));
+        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
@@ -158,7 +158,7 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         );
 
-        $result = $store->query(new Vector([1.2, 2.3, 3.4]));
+        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
@@ -173,9 +173,9 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['category' => 'products', 'enabled' => false])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'filter' => fn (VectorDocument $doc) => 'products' === $doc->metadata['category'],
-        ]);
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertSame('products', $result[0]->metadata['category']);
@@ -192,10 +192,10 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6]), new Metadata(['category' => 'products'])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'filter' => fn (VectorDocument $doc) => 'products' === $doc->metadata['category'],
             'maxItems' => 2,
-        ]);
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertSame('products', $result[0]->metadata['category']);
@@ -211,9 +211,9 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['price' => 50, 'stock' => 10])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'filter' => fn (VectorDocument $doc) => $doc->metadata['price'] <= 150 && $doc->metadata['stock'] > 0,
-        ]);
+        ]));
 
         $this->assertCount(2, $result);
     }
@@ -227,9 +227,9 @@ final class CacheStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['options' => ['size' => 'S', 'color' => 'red']])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'filter' => fn (VectorDocument $doc) => 'S' === $doc->metadata['options']['size'],
-        ]);
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertSame('S', $result[0]->metadata['options']['size']);
@@ -246,9 +246,9 @@ final class CacheStoreTest extends TestCase
         );
 
         $allowedBrands = ['Nike', 'Adidas', 'Puma'];
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'filter' => fn (VectorDocument $doc) => \in_array($doc->metadata['brand'] ?? '', $allowedBrands, true),
-        ]);
+        ]));
 
         $this->assertCount(2, $result);
     }

--- a/src/store/tests/Bridge/Local/InMemoryStoreTest.php
+++ b/src/store/tests/Bridge/Local/InMemoryStoreTest.php
@@ -27,7 +27,7 @@ final class InMemoryStoreTest extends TestCase
         $store = new InMemoryStore();
         $store->setup();
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(0, $result);
     }
 
@@ -40,12 +40,12 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(3, $result);
 
         $store->drop();
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(0, $result);
     }
 
@@ -58,7 +58,7 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(3, $result);
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->vector->getData());
 
@@ -68,7 +68,7 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(6, $result);
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->vector->getData());
     }
@@ -84,7 +84,7 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]));
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(5, $result);
         $this->assertSame([0.0, 0.1, 0.6], $result[0]->vector->getData());
         $this->assertSame([0.1, 0.1, 0.5], $result[1]->vector->getData());
@@ -102,9 +102,9 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         );
 
-        $this->assertCount(1, $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $this->assertCount(1, iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'maxItems' => 1,
-        ]));
+        ])));
     }
 
     public function testStoreCanSearchUsingAngularDistance()
@@ -115,7 +115,7 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         );
 
-        $result = $store->query(new Vector([1.2, 2.3, 3.4]));
+        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
@@ -129,7 +129,7 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 2.0, 3.0])),
         );
 
-        $result = $store->query(new Vector([1.2, 2.3, 3.4]));
+        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
@@ -143,7 +143,7 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         );
 
-        $result = $store->query(new Vector([1.2, 2.3, 3.4]));
+        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
@@ -157,7 +157,7 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         );
 
-        $result = $store->query(new Vector([1.2, 2.3, 3.4]));
+        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
@@ -172,9 +172,9 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['category' => 'products', 'enabled' => false])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'filter' => fn (VectorDocument $doc) => 'products' === $doc->metadata['category'],
-        ]);
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertSame('products', $result[0]->metadata['category']);
@@ -191,10 +191,10 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6]), new Metadata(['category' => 'products'])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'filter' => fn (VectorDocument $doc) => 'products' === $doc->metadata['category'],
             'maxItems' => 2,
-        ]);
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertSame('products', $result[0]->metadata['category']);
@@ -210,9 +210,9 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['price' => 50, 'stock' => 10])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'filter' => fn (VectorDocument $doc) => $doc->metadata['price'] <= 150 && $doc->metadata['stock'] > 0,
-        ]);
+        ]));
 
         $this->assertCount(2, $result);
     }
@@ -226,9 +226,9 @@ final class InMemoryStoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['options' => ['size' => 'S', 'color' => 'red']])),
         );
 
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'filter' => fn (VectorDocument $doc) => 'S' === $doc->metadata['options']['size'],
-        ]);
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertSame('S', $result[0]->metadata['options']['size']);
@@ -245,9 +245,9 @@ final class InMemoryStoreTest extends TestCase
         );
 
         $allowedBrands = ['Nike', 'Adidas', 'Puma'];
-        $result = $store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
             'filter' => fn (VectorDocument $doc) => \in_array($doc->metadata['brand'] ?? '', $allowedBrands, true),
-        ]);
+        ]));
 
         $this->assertCount(2, $result);
     }

--- a/src/store/tests/Bridge/Manticore/StoreTest.php
+++ b/src/store/tests/Bridge/Manticore/StoreTest.php
@@ -159,7 +159,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:9308/search".');
         $this->expectExceptionCode(400);
-        $store->query(new Vector([0.1, 0.2, 0.3]));
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
     }
 
     public function testStoreCanQuery()
@@ -192,7 +192,7 @@ final class StoreTest extends TestCase
         ]);
 
         $store = new Store($httpClient, 'http://127.0.0.1:9308', 'bar', 'random');
-        $documents = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $documents);
         $this->assertSame(1, $httpClient->getRequestsCount());

--- a/src/store/tests/Bridge/MariaDb/StoreTest.php
+++ b/src/store/tests/Bridge/MariaDb/StoreTest.php
@@ -63,7 +63,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector($vectorData), ['maxScore' => $maxScore]);
+        $results = iterator_to_array($store->query(new Vector($vectorData), ['maxScore' => $maxScore]));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -111,7 +111,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector($vectorData));
+        $results = iterator_to_array($store->query(new Vector($vectorData)));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -150,7 +150,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = $store->query(new Vector($vectorData), ['limit' => 10]);
+        $results = iterator_to_array($store->query(new Vector($vectorData), ['limit' => 10]));
 
         $this->assertCount(0, $results);
     }
@@ -188,7 +188,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), ['where' => 'metadata->>\'category\' = \'products\'']);
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['where' => 'metadata->>\'category\' = \'products\'']));
 
         $this->assertCount(0, $results);
     }
@@ -230,10 +230,10 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
             'maxScore' => 0.5,
             'where' => 'metadata->>\'active\' = \'true\'',
-        ]);
+        ]));
 
         $this->assertCount(0, $results);
     }
@@ -286,13 +286,13 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
             'where' => 'metadata->>\'crawlId\' = :crawlId AND id != :currentId',
             'params' => [
                 'crawlId' => $crawlId,
                 'currentId' => $uuid->toRfc4122(),
             ],
-        ]);
+        ]));
 
         $this->assertCount(1, $results);
         $this->assertSame(0.85, $results[0]->score);

--- a/src/store/tests/Bridge/Meilisearch/StoreTest.php
+++ b/src/store/tests/Bridge/Meilisearch/StoreTest.php
@@ -186,7 +186,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:7700/indexes/test/search".');
         $this->expectExceptionCode(400);
-        $store->query(new Vector([0.1, 0.2, 0.3]));
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
     }
 
     public function testStoreCanQuery()
@@ -228,7 +228,7 @@ final class StoreTest extends TestCase
             embeddingsDimension: 3,
         );
 
-        $vectors = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $vectors = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertSame(1, $httpClient->getRequestsCount());
         $this->assertCount(2, $vectors);
@@ -269,7 +269,7 @@ final class StoreTest extends TestCase
             embeddingsDimension: 3,
         );
 
-        $vectors = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $vectors = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
         $expected = [
             'title' => 'The Matrix',
             'description' => 'A science fiction action film.',
@@ -328,7 +328,7 @@ final class StoreTest extends TestCase
         $store = new Store($httpClient, 'http://localhost:7700', 'key', 'index', semanticRatio: 0.7);
 
         $vector = new Vector([0.1, 0.2, 0.3]);
-        $store->query($vector);
+        iterator_to_array($store->query($vector));
 
         $request = $httpClient->getRequestsCount() > 0 ? $responses[0]->getRequestOptions() : null;
         $this->assertNotNull($request);
@@ -348,8 +348,7 @@ final class StoreTest extends TestCase
         $httpClient = new MockHttpClient($responses);
         $store = new Store($httpClient, 'http://localhost:7700', 'key', 'index', semanticRatio: 0.5);
 
-        $vector = new Vector([0.1, 0.2, 0.3]);
-        $store->query($vector, ['semanticRatio' => 0.2]);
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['semanticRatio' => 0.2]));
 
         $request = $responses[0]->getRequestOptions();
         $body = json_decode($request['body'], true);
@@ -366,7 +365,7 @@ final class StoreTest extends TestCase
         $store = new Store($httpClient, 'http://localhost:7700', 'key', 'index');
 
         $vector = new Vector([0.1, 0.2, 0.3]);
-        $store->query($vector, ['semanticRatio' => 2.0]);
+        iterator_to_array($store->query($vector, ['semanticRatio' => 2.0]));
     }
 
     public function testQueryWithPureKeywordSearch()
@@ -392,7 +391,7 @@ final class StoreTest extends TestCase
         $store = new Store($httpClient, 'http://localhost:7700', 'key', 'index');
 
         $vector = new Vector([0.1, 0.2, 0.3]);
-        $results = $store->query($vector, ['semanticRatio' => 0.0]);
+        $results = iterator_to_array($store->query($vector, ['semanticRatio' => 0.0]));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -414,7 +413,7 @@ final class StoreTest extends TestCase
         $store = new Store($httpClient, 'http://localhost:7700', 'key', 'index', semanticRatio: 0.5);
 
         $vector = new Vector([0.1, 0.2, 0.3]);
-        $store->query($vector);
+        iterator_to_array($store->query($vector));
 
         $request = $responses[0]->getRequestOptions();
         $body = json_decode($request['body'], true);

--- a/src/store/tests/Bridge/Milvus/StoreTest.php
+++ b/src/store/tests/Bridge/Milvus/StoreTest.php
@@ -195,7 +195,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:19530/v2/vectordb/entities/search".');
         $this->expectExceptionCode(400);
-        $store->query(new Vector([0.1, 0.2, 0.3]));
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
     }
 
     public function testStoreCanQuery()
@@ -231,7 +231,7 @@ final class StoreTest extends TestCase
             'test',
         );
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, $results);
         $this->assertSame(1, $httpClient->getRequestsCount());

--- a/src/store/tests/Bridge/MongoDb/StoreTest.php
+++ b/src/store/tests/Bridge/MongoDb/StoreTest.php
@@ -210,7 +210,7 @@ final class StoreTest extends TestCase
             'test-index',
         );
 
-        $documents = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, $documents);
         $this->assertInstanceOf(VectorDocument::class, $documents[0]);
@@ -274,7 +274,7 @@ final class StoreTest extends TestCase
             'test-index',
         );
 
-        $documents = $store->query(new Vector([0.1, 0.2, 0.3]), ['minScore' => 0.8]);
+        $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['minScore' => 0.8]));
 
         $this->assertCount(0, $documents);
     }
@@ -326,11 +326,11 @@ final class StoreTest extends TestCase
             'test-index',
         );
 
-        $documents = $store->query(new Vector([0.1, 0.2, 0.3]), [
+        $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
             'limit' => 10,
             'numCandidates' => 500,
             'filter' => ['category' => 'test'],
-        ]);
+        ]));
 
         $this->assertCount(0, $documents);
     }
@@ -558,7 +558,7 @@ final class StoreTest extends TestCase
             'custom_embeddings',
         );
 
-        $documents = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $documents);
         $this->assertSame([0.1, 0.2, 0.3], $documents[0]->vector->getData());

--- a/src/store/tests/Bridge/Neo4j/StoreTest.php
+++ b/src/store/tests/Bridge/Neo4j/StoreTest.php
@@ -288,7 +288,7 @@ final class StoreTest extends TestCase
         $store->setup();
         $store->add(new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2, 0.3])));
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, $results);
         $this->assertSame(3, $httpClient->getRequestsCount());

--- a/src/store/tests/Bridge/Pinecone/StoreTest.php
+++ b/src/store/tests/Bridge/Pinecone/StoreTest.php
@@ -196,7 +196,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($client);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -241,7 +241,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($client, 'test-namespace', ['category' => 'test'], 5);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(0, $results);
     }
@@ -278,11 +278,11 @@ final class StoreTest extends TestCase
 
         $store = new Store($client);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
             'namespace' => 'custom-namespace',
             'filter' => ['type' => 'document'],
             'topK' => 10,
-        ]);
+        ]));
 
         $this->assertCount(0, $results);
     }
@@ -312,7 +312,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($client);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(0, $results);
     }

--- a/src/store/tests/Bridge/Postgres/StoreTest.php
+++ b/src/store/tests/Bridge/Postgres/StoreTest.php
@@ -137,7 +137,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -186,7 +186,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -229,7 +229,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]);
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]));
 
         $this->assertCount(0, $results);
     }
@@ -268,7 +268,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]);
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]));
 
         $this->assertCount(0, $results);
     }
@@ -304,7 +304,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = $store->query(new Vector([0.7, 0.8, 0.9]), ['limit' => 10]);
+        $results = iterator_to_array($store->query(new Vector([0.7, 0.8, 0.9]), ['limit' => 10]));
 
         $this->assertCount(0, $results);
     }
@@ -338,7 +338,7 @@ final class StoreTest extends TestCase
             ->method('fetchAll')
             ->willReturn([]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(0, $results);
     }
@@ -476,7 +476,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $results);
         $this->assertSame([], $results[0]->metadata->getArrayCopy());
@@ -513,7 +513,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), ['where' => 'metadata->>\'category\' = \'products\'']);
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['where' => 'metadata->>\'category\' = \'products\'']));
 
         $this->assertCount(0, $results);
     }
@@ -552,10 +552,10 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
             'maxScore' => 0.5,
             'where' => 'metadata->>\'active\' = \'true\'',
-        ]);
+        ]));
 
         $this->assertCount(0, $results);
     }
@@ -605,13 +605,13 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
             'where' => 'metadata->>\'crawlId\' = :crawlId AND id != :currentId',
             'params' => [
                 'crawlId' => $crawlId,
                 'currentId' => $uuid->toRfc4122(),
             ],
-        ]);
+        ]));
 
         $this->assertCount(1, $results);
         $this->assertSame(0.85, $results[0]->score);

--- a/src/store/tests/Bridge/Qdrant/StoreTest.php
+++ b/src/store/tests/Bridge/Qdrant/StoreTest.php
@@ -227,7 +227,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:6333/collections/test/points/query".');
         $this->expectExceptionCode(400);
-        $store->query(new Vector([0.1, 0.2, 0.3]));
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
     }
 
     public function testStoreCanQuery()
@@ -255,7 +255,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'http://127.0.0.1:6333', 'test', 'test');
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertSame(1, $httpClient->getRequestsCount());
         $this->assertCount(2, $results);
@@ -286,13 +286,13 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'http://127.0.0.1:6333', 'test', 'test');
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
             'filter' => [
                 'must' => [
                     ['key' => 'foo', 'match' => ['value' => 'bar']],
                 ],
             ],
-        ]);
+        ]));
 
         $this->assertSame(1, $httpClient->getRequestsCount());
         $this->assertCount(2, $results);

--- a/src/store/tests/Bridge/Redis/StoreTest.php
+++ b/src/store/tests/Bridge/Redis/StoreTest.php
@@ -126,7 +126,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -165,7 +165,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -192,7 +192,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]);
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]));
 
         $this->assertCount(0, $results); // Should be filtered out due to maxScore
     }
@@ -216,7 +216,7 @@ final class StoreTest extends TestCase
             )
             ->willReturn([0]); // No results
 
-        $results = $store->query(new Vector([0.7, 0.8, 0.9]), ['limit' => 10]);
+        $results = iterator_to_array($store->query(new Vector([0.7, 0.8, 0.9]), ['limit' => 10]));
 
         $this->assertCount(0, $results);
     }
@@ -240,7 +240,7 @@ final class StoreTest extends TestCase
             )
             ->willReturn([0]); // No results
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), ['where' => '@metadata_category:products']);
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['where' => '@metadata_category:products']));
 
         $this->assertCount(0, $results);
     }
@@ -273,10 +273,10 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
             'where' => '@metadata_active:true',
             'maxScore' => 0.8,
-        ]);
+        ]));
 
         $this->assertCount(0, $results);
     }
@@ -301,7 +301,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $results);
         $this->assertSame([], $results[0]->metadata->getArrayCopy());
@@ -319,7 +319,7 @@ final class StoreTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Failed to execute query: "Search failed".');
 
-        $store->query(new Vector([0.1, 0.2, 0.3]));
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
     }
 
     public function testInitialize()
@@ -463,7 +463,7 @@ final class StoreTest extends TestCase
             )
             ->willReturn([0]);
 
-        $store->query(new Vector([0.1, 0.2, 0.3]));
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
     }
 
     public function testQueryEmptyResults()
@@ -475,7 +475,7 @@ final class StoreTest extends TestCase
             ->method('rawCommand')
             ->willReturn([0]); // No results
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(0, $results);
     }
@@ -489,7 +489,7 @@ final class StoreTest extends TestCase
             ->method('rawCommand')
             ->willReturn(null); // Invalid results
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(0, $results);
     }
@@ -511,7 +511,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(0, $results); // Should skip documents without required fields
     }

--- a/src/store/tests/Bridge/Supabase/StoreTest.php
+++ b/src/store/tests/Bridge/Supabase/StoreTest.php
@@ -94,14 +94,14 @@ class StoreTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Supabase query failed: Query failed');
-        $store->query($queryVector);
+        iterator_to_array($store->query($queryVector));
     }
 
     public function testQueryWithDefaultOptions()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse([]));
         $store = $this->createStore($httpClient);
-        $result = $store->query(new Vector([1.0, 2.0]));
+        $result = iterator_to_array($store->query(new Vector([1.0, 2.0])));
 
         $this->assertSame([], $result);
         $this->assertSame(1, $httpClient->getRequestsCount());
@@ -111,7 +111,7 @@ class StoreTest extends TestCase
     {
         $httpClient = new MockHttpClient(new JsonMockResponse([]));
         $store = $this->createStore($httpClient);
-        $result = $store->query(new Vector([1.0, 2.0]), ['limit' => 1]);
+        $result = iterator_to_array($store->query(new Vector([1.0, 2.0]), ['limit' => 1]));
 
         $this->assertSame([], $result);
         $this->assertSame(1, $httpClient->getRequestsCount());
@@ -121,12 +121,10 @@ class StoreTest extends TestCase
     {
         $httpClient = new MockHttpClient(new JsonMockResponse([]));
         $store = $this->createStore($httpClient);
-        $wrongDimensionVector = new Vector([1.0]);
-        $store = $this->createStore($httpClient);
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Vector dimension mismatch: expected 2');
-        $store->query($wrongDimensionVector);
+        iterator_to_array($store->query(new Vector([1.0])));
     }
 
     public function testQuerySuccess()
@@ -142,7 +140,7 @@ class StoreTest extends TestCase
         ];
         $httpClient = new MockHttpClient(new JsonMockResponse($expectedResponse));
         $store = $this->createStore($httpClient, 3);
-        $result = $store->query(new Vector([1.0, 2.0, 3.0]), ['max_items' => 5, 'min_score' => 0.7]);
+        $result = iterator_to_array($store->query(new Vector([1.0, 2.0, 3.0]), ['max_items' => 5, 'min_score' => 0.7]));
 
         $this->assertCount(1, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
@@ -174,7 +172,7 @@ class StoreTest extends TestCase
         $httpClient = new MockHttpClient(new JsonMockResponse($expectedResponse));
         $store = $this->createStore($httpClient, 2);
 
-        $result = $store->query(new Vector([1.0, 2.0]), ['max_items' => 2, 'min_score' => 0.8]);
+        $result = iterator_to_array($store->query(new Vector([1.0, 2.0]), ['max_items' => 2, 'min_score' => 0.8]));
 
         $this->assertCount(2, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
@@ -205,7 +203,7 @@ class StoreTest extends TestCase
         $httpClient = new MockHttpClient(new JsonMockResponse($expectedResponse));
         $store = $this->createStore($httpClient, 3);
 
-        $result = $store->query(new Vector([1.0, 2.0, 3.0]));
+        $result = iterator_to_array($store->query(new Vector([1.0, 2.0, 3.0])));
 
         $document = $result[0];
         $metadata = $document->metadata->getArrayCopy();

--- a/src/store/tests/Bridge/SurrealDb/StoreTest.php
+++ b/src/store/tests/Bridge/SurrealDb/StoreTest.php
@@ -326,7 +326,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:8000/sql".');
         $this->expectExceptionCode(400);
-        $store->query(new Vector(array_fill(0, 1275, 0.1)));
+        iterator_to_array($store->query(new Vector(array_fill(0, 1275, 0.1))));
     }
 
     public function testStoreCanQueryOnValidEmbeddings()
@@ -400,7 +400,7 @@ final class StoreTest extends TestCase
 
         $store->add(new VectorDocument(Uuid::v4(), new Vector(array_fill(0, 1275, 0.1))));
 
-        $results = $store->query(new Vector(array_fill(0, 1275, 0.1)));
+        $results = iterator_to_array($store->query(new Vector(array_fill(0, 1275, 0.1))));
 
         $this->assertCount(2, $results);
     }

--- a/src/store/tests/Bridge/Typesense/StoreTest.php
+++ b/src/store/tests/Bridge/Typesense/StoreTest.php
@@ -168,7 +168,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:8108/multi_search".');
         $this->expectExceptionCode(400);
-        $store->query(new Vector([0.1, 0.2, 0.3]));
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
     }
 
     public function testStoreCanQuery()
@@ -209,7 +209,7 @@ final class StoreTest extends TestCase
             'test',
         );
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, $results);
         $this->assertSame(1, $httpClient->getRequestsCount());

--- a/src/store/tests/Bridge/Weaviate/StoreTest.php
+++ b/src/store/tests/Bridge/Weaviate/StoreTest.php
@@ -207,7 +207,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 422 returned for "http://127.0.0.1:8080/v1/graphql".');
         $this->expectExceptionCode(422);
-        $store->query(new Vector([0.1, 0.2, 0.3]));
+        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
     }
 
     public function testStoreCanQuery()
@@ -242,7 +242,7 @@ final class StoreTest extends TestCase
             'test',
         );
 
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, $results);
         $this->assertSame(1, $httpClient->getRequestsCount());

--- a/src/store/tests/Double/TestStore.php
+++ b/src/store/tests/Double/TestStore.php
@@ -31,7 +31,7 @@ final class TestStore implements StoreInterface
         $this->documents = array_merge($this->documents, $documents);
     }
 
-    public function query(Vector $vector, array $options = []): array
+    public function query(Vector $vector, array $options = []): iterable
     {
         throw new RuntimeException('Not yet implemented.');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | feature
| Docs?         | no
| Issues        | Fix #998
| License       | MIT

- Change StoreInterface
- Use iterable and yield (and yield from) for all storages
- Use iterator_to_array for existing test cases

Refs: #998