### PR TITLE
[Platform] `OllamaApiCatalog` capability resolution fix

### DIFF
--- a/src/platform/src/Bridge/Ollama/OllamaApiCatalog.php
+++ b/src/platform/src/Bridge/Ollama/OllamaApiCatalog.php
@@ -44,7 +44,7 @@ final class OllamaApiCatalog implements ModelCatalogInterface
         $capabilities = array_map(
             static fn (string $capability): Capability => match ($capability) {
                 'embedding' => Capability::EMBEDDINGS,
-                'completion' => Capability::INPUT_TEXT,
+                'completion' => Capability::INPUT_MESSAGES,
                 'tools' => Capability::TOOL_CALLING,
                 'thinking' => Capability::THINKING,
                 'vision' => Capability::INPUT_IMAGE,

--- a/src/platform/tests/Bridge/Ollama/OllamaApiCatalogTest.php
+++ b/src/platform/tests/Bridge/Ollama/OllamaApiCatalogTest.php
@@ -34,7 +34,7 @@ final class OllamaApiCatalogTest extends TestCase
 
         $this->assertSame('foo', $model->getName());
         $this->assertSame([
-            Capability::INPUT_TEXT,
+            Capability::INPUT_MESSAGES,
         ], $model->getCapabilities());
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -66,7 +66,7 @@ final class OllamaApiCatalogTest extends TestCase
         $this->assertSame(Ollama::class, $model['class']);
         $this->assertCount(1, $model['capabilities']);
         $this->assertSame([
-            Capability::INPUT_TEXT,
+            Capability::INPUT_MESSAGES,
         ], $model['capabilities']);
         $this->assertSame(2, $httpClient->getRequestsCount());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Fix a wrong usage of `Capability`, the `OllamaClient` is using `INPUT_MESSAGES` when the `OllamaApiCatalog` is resolving an `INPUT_TEXT` capability.
