### PR TITLE
[Platform] Add `IteratorAggregate` to `MessageBag`

### DIFF
--- a/src/platform/src/Message/MessageBag.php
+++ b/src/platform/src/Message/MessageBag.php
@@ -15,8 +15,10 @@ use Symfony\AI\Platform\Metadata\MetadataAwareTrait;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
+ *
+ * @implements \IteratorAggregate<int, MessageInterface>
  */
-class MessageBag implements \Countable
+class MessageBag implements \Countable, \IteratorAggregate
 {
     use MetadataAwareTrait;
 
@@ -125,5 +127,13 @@ class MessageBag implements \Countable
     public function count(): int
     {
         return \count($this->messages);
+    }
+
+    /**
+     * @return \ArrayIterator<int, MessageInterface>
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->messages);
     }
 }

--- a/src/platform/tests/Message/MessageBagTest.php
+++ b/src/platform/tests/Message/MessageBagTest.php
@@ -262,4 +262,42 @@ final class MessageBagTest extends TestCase
         // Should only return the text content, ignoring the image
         $this->assertSame('Text content', $userText);
     }
+
+    public function testGetIterator()
+    {
+        $systemMessage = Message::forSystem('My amazing system prompt.');
+        $assistantMessage = Message::ofAssistant('It is time to sleep.');
+        $userMessage = Message::ofUser('Hello, world!');
+
+        $messageBag = new MessageBag($systemMessage, $assistantMessage, $userMessage);
+
+        $iterator = $messageBag->getIterator();
+
+        $this->assertInstanceOf(\ArrayIterator::class, $iterator);
+        $this->assertCount(3, $iterator);
+
+        $messages = iterator_to_array($iterator);
+        $this->assertSame($systemMessage, $messages[0]);
+        $this->assertSame($assistantMessage, $messages[1]);
+        $this->assertSame($userMessage, $messages[2]);
+    }
+
+    public function testMessageBagIsIterable()
+    {
+        $systemMessage = Message::forSystem('My amazing system prompt.');
+        $assistantMessage = Message::ofAssistant('It is time to sleep.');
+        $userMessage = Message::ofUser('Hello, world!');
+
+        $messageBag = new MessageBag($systemMessage, $assistantMessage, $userMessage);
+
+        $collectedMessages = [];
+        foreach ($messageBag as $index => $message) {
+            $collectedMessages[$index] = $message;
+        }
+
+        $this->assertCount(3, $collectedMessages);
+        $this->assertSame($systemMessage, $collectedMessages[0]);
+        $this->assertSame($assistantMessage, $collectedMessages[1]);
+        $this->assertSame($userMessage, $collectedMessages[2]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Allow iterating over MessageBag using foreach by implementing IteratorAggregate interface with ArrayIterator.

Extracted from 
* #1020 

cc @lochmueller