### PR TITLE
 Update links to documentation

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -19,7 +19,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](../../docs/index.rst)
+- [Documentation](https://symfony.com/doc/current/ai/components/agent.html)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/ai-bundle/README.md
+++ b/src/ai-bundle/README.md
@@ -18,7 +18,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](../../docs/index.rst)
+- [Documentation](https://symfony.com/doc/current/ai/bundles/ai-bundle.html)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/chat/README.md
+++ b/src/chat/README.md
@@ -19,7 +19,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](../../docs/index.rst)
+- [Documentation](https://symfony.com/doc/current/ai/components/chat.html)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/mcp-bundle/README.md
+++ b/src/mcp-bundle/README.md
@@ -21,7 +21,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](../../docs/index.rst)
+- [Documentation](https://symfony.com/doc/current/ai/bundles/mcp-bundle.html)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/platform/README.md
+++ b/src/platform/README.md
@@ -18,7 +18,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](../../docs/index.rst)
+- [Documentation](https://symfony.com/doc/current/ai/components/platform.html)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/store/README.md
+++ b/src/store/README.md
@@ -18,7 +18,7 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
-- [Documentation](../../docs/index.rst)
+- [Documentation](https://symfony.com/doc/current/ai/components/store.html)
 - [Report issues](https://github.com/symfony/ai/issues) and
   [send Pull Requests](https://github.com/symfony/ai/pulls)
   in the [main Symfony AI repository](https://github.com/symfony/ai)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | 
| License       | MIT

I noticed the readme links were broken. I'll add a link directly to the documentation webpage
