### PR TITLE
[Platform][Gemini] Fix `ResultConverter` to handle `gemini-2.5-flash` multi-part thinking responses

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -146,11 +146,20 @@ final class ResultConverter implements ResultConverterInterface
             }
         }
 
+        // Fallback for multi-part text responses (e.g., thinking + response)
+        if ('' === $content) {
+            foreach ($contentParts as $contentPart) {
+                if (isset($contentPart['text'])) {
+                    $content .= $contentPart['text'];
+                }
+            }
+        }
+
         if ('' !== $content) {
             return new TextResult($content);
         }
 
-        throw new RuntimeException('Code execution failed.');
+        throw new RuntimeException('Response does not contain any text content.');
     }
 
     /**


### PR DESCRIPTION
 ## Problem

  When using Gemini 2.5 models (e.g., `gemini-2.5-flash`), the API can return multi-part responses that include
  "thinking" content alongside the actual response. This is similar to Claude's extended thinking feature.

  Example response structure:
  - Part 0: Analysis/thinking text with `thoughtSignature` field
  - Part 1: Actual response content

  The current `ResultConverter::convertChoice()` method doesn't handle this case. It only processes:
  1. Function calls
  2. Single text parts
  3. Code execution results

  When multiple text parts exist without code execution, the method throws `RuntimeException('Code execution
  failed.')` which is incorrect and confusing.

  ## Solution

  Added fallback logic to concatenate all text parts when no code execution results are present. This allows
  multi-part thinking responses to be processed correctly as `TextResult`.

  ## Changes

  - Modified `convertChoice()` to concatenate text from all parts when code execution is not detected
  - Updated error message to be more accurate ("no text content" instead of "code execution failed")
  - Added test coverage for multi-part thinking responses

  ## Testing

  Tested with `gemini-2.5-flash` model returning thinking + JSON response structure.