### PR TITLE
[Platform][Mistral] Add 14b latest model

### DIFF
--- a/src/platform/src/Bridge/Mistral/ModelCatalog.php
+++ b/src/platform/src/Bridge/Mistral/ModelCatalog.php
@@ -106,6 +106,16 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::TOOL_CALLING,
                 ],
             ],
+            'ministral-14b-latest' => [
+                'class' => Mistral::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
             'pixstral-large-latest' => [
                 'class' => Mistral::class,
                 'capabilities' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Add missing `ministral-14b-latest` model.

NB: All new models (Mistral 3 series), are already supported as they are aliased with `-latest` suffix, which is what we have in Mistral `ModelCatalog` class.