### PR TITLE
[Platform][Gemini] Extend gemini catalog for image preview and editing example

### DIFF
--- a/examples/gemini/.gitignore
+++ b/examples/gemini/.gitignore
@@ -1,0 +1,1 @@
+result.png

--- a/examples/gemini/image-editing.php
+++ b/examples/gemini/image-editing.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory;
+use Symfony\AI\Platform\Message\Content\Image;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::ofUser(
+        'Please colorize the elephant in red.',
+        Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg'),
+    ),
+);
+$result = $platform->invoke('gemini-2.5-flash-image', $messages);
+
+file_put_contents(__DIR__.'/result.png', $result->asBinary());
+
+echo 'Result image saved to result.png'.\PHP_EOL;

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -127,7 +127,7 @@ final class ResultConverter implements ResultConverterInterface
             }
 
             if (isset($contentPart['inlineData'])) {
-                return new BinaryResult($contentPart['inlineData']['data'], $contentPart['inlineData']['mimeType'] ?? null);
+                return BinaryResult::fromBase64($contentPart['inlineData']['data'], $contentPart['inlineData']['mimeType'] ?? null);
             }
 
             throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finishReason']));
@@ -150,7 +150,8 @@ final class ResultConverter implements ResultConverterInterface
             return new TextResult($content);
         }
 
-        throw new RuntimeException('Code execution failed.');
+        // TODO: see https://github.com/symfony/ai/issues/1053
+        throw new RuntimeException('Choice conversion failed. Potentially due to multiple content parts.');
     }
 
     /**

--- a/src/platform/src/Bridge/Gemini/ModelCatalog.php
+++ b/src/platform/src/Bridge/Gemini/ModelCatalog.php
@@ -37,6 +37,24 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::TOOL_CALLING,
                 ],
             ],
+            'gemini-3-pro-image-preview' => [
+                'class' => Gemini::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                ],
+            ],
+            'gemini-2.5-flash-image' => [
+                'class' => Gemini::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                ],
+            ],
             'gemini-2.5-flash' => [
                 'class' => Gemini::class,
                 'capabilities' => [

--- a/src/platform/src/Result/BinaryResult.php
+++ b/src/platform/src/Result/BinaryResult.php
@@ -24,6 +24,17 @@ final class BinaryResult extends BaseResult
     ) {
     }
 
+    public static function fromBase64(string $base64Data, ?string $mimeType = null): self
+    {
+        $data = base64_decode($base64Data, true);
+
+        if (false === $data) {
+            throw new RuntimeException('The provided data is not valid base64-encoded data.');
+        }
+
+        return new self($data, $mimeType);
+    }
+
     public function getMimeType(): ?string
     {
         return $this->mimeType;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1047
| License       | MIT

Adding support for `gemini-2.5-flash-image` and `gemini-3-pro-image-preview` and adding image editing example.

Ran into some issue with `inlineData` handling and multiple response parts => created #1053 as follow up, cc @lochmueller @pentiminax - not sure i'm messing with your use-cases here

**before**
<img width="636" height="425" alt="image" src="https://github.com/user-attachments/assets/1ba64b39-6b01-4955-a48a-ecd6b856628c" />

**after**
<img width="560" height="373" alt="image" src="https://github.com/user-attachments/assets/348013c5-e595-43c1-ae96-006e5e0f2809" />
