### PR TITLE
[Platform] Rename MessageBag::prepend to actual use-case withSystemMessage

### DIFF
--- a/src/agent/src/InputProcessor/SystemPromptInputProcessor.php
+++ b/src/agent/src/InputProcessor/SystemPromptInputProcessor.php
@@ -85,6 +85,6 @@ final class SystemPromptInputProcessor implements InputProcessorInterface
                 PROMPT;
         }
 
-        $input->setMessageBag($messages->prepend(Message::forSystem($message)));
+        $input->setMessageBag($messages->withSystemMessage(Message::forSystem($message)));
     }
 }

--- a/src/agent/src/Memory/MemoryInputProcessor.php
+++ b/src/agent/src/Memory/MemoryInputProcessor.php
@@ -77,8 +77,7 @@ final class MemoryInputProcessor implements InputProcessorInterface
         }
 
         $messages = $input->getMessageBag()
-            ->withoutSystemMessage()
-            ->prepend(Message::forSystem($combinedMessage));
+            ->withSystemMessage(Message::forSystem($combinedMessage));
 
         $input->setMessageBag($messages);
     }

--- a/src/ai-bundle/tests/Command/AgentCallCommandTest.php
+++ b/src/ai-bundle/tests/Command/AgentCallCommandTest.php
@@ -193,7 +193,7 @@ final class AgentCallCommandTest extends TestCase
             ->willReturnCallback(function (MessageBag $messages) use ($result) {
                 // Simulate SystemPromptInputProcessor behavior - add system prompt if not present
                 if (null === $messages->getSystemMessage()) {
-                    $messages->prepend(Message::forSystem('System prompt'));
+                    $messages->withSystemMessage(Message::forSystem('System prompt'));
                 }
 
                 return $result;

--- a/src/platform/src/Message/MessageBag.php
+++ b/src/platform/src/Message/MessageBag.php
@@ -105,9 +105,12 @@ class MessageBag implements \Countable, \IteratorAggregate
         return $messages;
     }
 
-    public function prepend(MessageInterface $message): self
+    /**
+     * Clones the MessageBag without previous system message and prepends the given one.
+     */
+    public function withSystemMessage(SystemMessage $message): self
     {
-        $messages = clone $this;
+        $messages = $this->withoutSystemMessage();
         $messages->messages = array_merge([$message], $messages->messages);
 
         return $messages;

--- a/src/platform/tests/Message/MessageBagTest.php
+++ b/src/platform/tests/Message/MessageBagTest.php
@@ -113,7 +113,7 @@ final class MessageBagTest extends TestCase
         $this->assertSame('Hello, world!', $userMessage->getContent()[0]->getText());
     }
 
-    public function testPrepend()
+    public function testWithSystemMessage()
     {
         $messageBag = new MessageBag(
             Message::ofAssistant('It is time to sleep.'),
@@ -121,7 +121,7 @@ final class MessageBagTest extends TestCase
         );
 
         $newMessage = Message::forSystem('My amazing system prompt.');
-        $newMessageBag = $messageBag->prepend($newMessage);
+        $newMessageBag = $messageBag->withSystemMessage($newMessage);
 
         $this->assertCount(2, $messageBag);
         $this->assertCount(3, $newMessageBag);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

The actual use case is to mess with the system prompt - let's make it explicit by renaming the method.