### PR TITLE
[Store] Add missing path to use the example composer file locally

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -19,6 +19,10 @@
         {
             "type": "path",
             "url": "../src/store"
+        },
+        {
+            "type": "path",
+            "url": "../src/store/src/Bridge/ChromaDb"
         }
     ],
     "require": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

One store bridge is used as composer package in the examples. But only the primary packages are included. This patch includes also the ChromaDb folder to get a valid composer installation process in the examples folder. Could be dropped, when `symfony/ai-chroma-db-store` is found via packagist...