### PR TITLE
[Platform] Respect SSE comments in streaming mode

### DIFF
--- a/src/platform/src/Result/RawHttpResult.php
+++ b/src/platform/src/Result/RawHttpResult.php
@@ -55,6 +55,11 @@ final class RawHttpResult implements RawResultInterface
                     continue;
                 }
 
+                if (str_starts_with(trim($delta), ':')) {
+                    // SEE comments via Spec https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+                    continue;
+                }
+
                 yield json_decode($delta, true, flags: \JSON_THROW_ON_ERROR);
             }
         }

--- a/src/platform/tests/Result/StreamResultTest.php
+++ b/src/platform/tests/Result/StreamResultTest.php
@@ -32,4 +32,22 @@ final class StreamResultTest extends TestCase
         $this->assertSame('data1', $content[0]);
         $this->assertSame('data2', $content[1]);
     }
+
+    public function testGetContentInclSseComments()
+    {
+        $generator = (static function () {
+            yield 'data1';
+            yield ': this is just a comment';
+            yield 'data2';
+        })();
+
+        $result = new StreamResult($generator);
+        $this->assertInstanceOf(\Generator::class, $result->getContent());
+
+        $content = iterator_to_array($result->getContent());
+
+        $this->assertCount(2, $content);
+        $this->assertSame('data1', $content[0]);
+        $this->assertSame('data2', $content[1]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

I have same problems with OpenRouter streaming mode, because openrouter send a `: OPENROUTER PROCESSING` to keep the SSE connection `open` (details on https://openrouter.ai/docs/api/reference/streaming#additional-information ). The current integration of the RawHttpResult do not handle that. As described in the OpenRouter documentation,  the handling of SSE comments based on the Spec https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation is not handled in the right way. We have to drop lines starting with a `:` because these are comments and cannot be handled via json_decode.

Fixed the integration and add a test incl. a comment.
