### PR TITLE
[Chat] Fix bridge component dependencies

### DIFF
--- a/src/chat/src/Bridge/Cache/Store.php
+++ b/src/chat/src/Bridge/Cache/Store.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Chat\Bridge\Cache;
 
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\AI\Agent\Exception\RuntimeException;
+use Symfony\AI\Chat\Exception\RuntimeException;
 use Symfony\AI\Chat\ManagedStoreInterface;
 use Symfony\AI\Chat\MessageStoreInterface;
 use Symfony\AI\Platform\Message\MessageBag;

--- a/src/chat/src/Bridge/HttpFoundation/SessionStore.php
+++ b/src/chat/src/Bridge/HttpFoundation/SessionStore.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Chat\Bridge\HttpFoundation;
 
-use Symfony\AI\Agent\Exception\RuntimeException;
+use Symfony\AI\Chat\Exception\RuntimeException;
 use Symfony\AI\Chat\ManagedStoreInterface;
 use Symfony\AI\Chat\MessageStoreInterface;
 use Symfony\AI\Platform\Message\MessageBag;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Use Chat RuntimeException instead of Agent RuntimeException in Cache\Store and HttpFoundation\SessionStore.
