### PR TITLE
[AI Bundle] Add missing store bridge packages to require-dev

### DIFF
--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -38,6 +38,8 @@
         "symfony/ai-chroma-db-store": "@dev",
         "symfony/ai-mongo-db-store": "@dev",
         "symfony/ai-pinecone-store": "@dev",
+        "symfony/ai-postgres-store": "@dev",
+        "symfony/ai-redis-store": "@dev",
         "symfony/expression-language": "^7.3|^8.0",
         "symfony/security-core": "^7.3|^8.0",
         "symfony/translation": "^7.3|^8.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fixes #1075
| License       | MIT

The options.php configuration imports Distance enums from symfony/ai-postgres-store and symfony/ai-redis-store, but these packages were split out and not added to require-dev.