### PR TITLE
[AI Bundle] Fix unresolved Distance enum dependencies in configuration

### DIFF
--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -18,8 +18,6 @@ use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\PlatformInterface;
-use Symfony\AI\Store\Bridge\Postgres\Distance as PostgresDistance;
-use Symfony\AI\Store\Bridge\Redis\Distance;
 use Symfony\AI\Store\Document\VectorizerInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -794,8 +792,8 @@ return static function (DefinitionConfigurator $configurator): void {
                                 ->end()
                                 ->enumNode('distance')
                                     ->info('Distance metric to use for vector similarity search')
-                                    ->enumFqcn(PostgresDistance::class)
-                                    ->defaultValue(PostgresDistance::L2)
+                                    ->values(['cosine', 'inner_product', 'l1', 'l2'])
+                                    ->defaultValue('l2')
                                 ->end()
                                 ->stringNode('dbal_connection')->cannotBeEmpty()->end()
                             ->end()
@@ -844,8 +842,8 @@ return static function (DefinitionConfigurator $configurator): void {
                                 ->end()
                                 ->enumNode('distance')
                                     ->info('Distance metric to use for vector similarity search')
-                                    ->values(Distance::cases())
-                                    ->defaultValue(Distance::Cosine)
+                                    ->values(['COSINE', 'L2', 'IP'])
+                                    ->defaultValue('COSINE')
                                 ->end()
                             ->end()
                             ->validate()

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -92,8 +92,10 @@ use Symfony\AI\Store\Bridge\MongoDb\Store as MongoDbStore;
 use Symfony\AI\Store\Bridge\Neo4j\Store as Neo4jStore;
 use Symfony\AI\Store\Bridge\OpenSearch\Store as OpenSearchStore;
 use Symfony\AI\Store\Bridge\Pinecone\Store as PineconeStore;
+use Symfony\AI\Store\Bridge\Postgres\Distance as PostgresDistance;
 use Symfony\AI\Store\Bridge\Postgres\Store as PostgresStore;
 use Symfony\AI\Store\Bridge\Qdrant\Store as QdrantStore;
+use Symfony\AI\Store\Bridge\Redis\Distance as RedisDistance;
 use Symfony\AI\Store\Bridge\Redis\Store as RedisStore;
 use Symfony\AI\Store\Bridge\Supabase\Store as SupabaseStore;
 use Symfony\AI\Store\Bridge\SurrealDb\Store as SurrealDbStore;
@@ -1437,9 +1439,7 @@ final class AiBundle extends AbstractBundle
                     ];
                 }
 
-                if (\array_key_exists('distance', $store)) {
-                    $arguments[3] = $store['distance'];
-                }
+                $arguments[3] = PostgresDistance::from($store['distance']);
 
                 $definition
                     ->setLazy(true)
@@ -1507,7 +1507,7 @@ final class AiBundle extends AbstractBundle
                         $redisClient,
                         $store['index_name'] ?? $name,
                         $store['key_prefix'],
-                        $store['distance'],
+                        RedisDistance::from($store['distance']),
                     ])
                     ->addTag('proxy', ['interface' => StoreInterface::class])
                     ->addTag('proxy', ['interface' => ManagedStoreInterface::class])

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -45,7 +45,7 @@ use Symfony\AI\Store\Bridge\MongoDb\Store as MongoDbStore;
 use Symfony\AI\Store\Bridge\Neo4j\Store as Neo4jStore;
 use Symfony\AI\Store\Bridge\OpenSearch\Store as OpenSearchStore;
 use Symfony\AI\Store\Bridge\Pinecone\Store as PineconeStore;
-use Symfony\AI\Store\Bridge\Postgres\Distance;
+use Symfony\AI\Store\Bridge\Postgres\Distance as PostgresDistance;
 use Symfony\AI\Store\Bridge\Postgres\Store as PostgresStore;
 use Symfony\AI\Store\Bridge\Qdrant\Store as QdrantStore;
 use Symfony\AI\Store\Bridge\Redis\Distance as RedisDistance;
@@ -2588,7 +2588,7 @@ class AiBundleTest extends TestCase
         $this->assertSame('my_connection', (string) $definition->getArgument(0));
         $this->assertSame('db', $definition->getArgument(1));
         $this->assertSame('foo', $definition->getArgument(2));
-        $this->assertSame(Distance::L2, $definition->getArgument(3));
+        $this->assertSame(PostgresDistance::L2, $definition->getArgument(3));
 
         $this->assertTrue($definition->hasTag('proxy'));
         $this->assertSame([
@@ -2609,7 +2609,7 @@ class AiBundleTest extends TestCase
                         'db' => [
                             'dbal_connection' => 'my_connection',
                             'vector_field' => 'foo',
-                            'distance' => Distance::L1->value,
+                            'distance' => PostgresDistance::L1->value,
                         ],
                     ],
                 ],
@@ -2625,7 +2625,7 @@ class AiBundleTest extends TestCase
         $this->assertSame('my_connection', (string) $definition->getArgument(0));
         $this->assertSame('db', $definition->getArgument(1));
         $this->assertSame('foo', $definition->getArgument(2));
-        $this->assertSame(Distance::L1, $definition->getArgument(3));
+        $this->assertSame(PostgresDistance::L1, $definition->getArgument(3));
 
         $this->assertTrue($definition->hasTag('proxy'));
         $this->assertSame([
@@ -2647,7 +2647,7 @@ class AiBundleTest extends TestCase
                             'dbal_connection' => 'my_connection',
                             'table_name' => 'foo',
                             'vector_field' => 'foo',
-                            'distance' => Distance::L1->value,
+                            'distance' => PostgresDistance::L1->value,
                         ],
                     ],
                 ],
@@ -2663,7 +2663,7 @@ class AiBundleTest extends TestCase
         $this->assertSame('my_connection', (string) $definition->getArgument(0));
         $this->assertSame('foo', $definition->getArgument(1));
         $this->assertSame('foo', $definition->getArgument(2));
-        $this->assertSame(Distance::L1, $definition->getArgument(3));
+        $this->assertSame(PostgresDistance::L1, $definition->getArgument(3));
 
         $this->assertTrue($definition->hasTag('proxy'));
         $this->assertSame([
@@ -2997,7 +2997,7 @@ class AiBundleTest extends TestCase
                         'my_redis_store' => [
                             'client' => 'foo',
                             'index_name' => 'my_vector_index',
-                            'distance' => RedisDistance::L2,
+                            'distance' => RedisDistance::L2->value,
                         ],
                     ],
                 ],
@@ -7217,7 +7217,7 @@ class AiBundleTest extends TestCase
                         'my_redis_store_with_custom_distance' => [
                             'client' => 'foo',
                             'index_name' => 'my_vector_index',
-                            'distance' => RedisDistance::L2,
+                            'distance' => RedisDistance::L2->value,
                         ],
                     ],
                     'supabase' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fixes https://github.com/symfony/ai/issues/1075
| License       | MIT

The options.php file was importing Distance enums from optional store bridge packages (postgres-store and redis-store) unconditionally. This caused errors when these packages weren't installed since PHP tries to resolve imports at parse time.

The fix uses string values for the distance configuration instead of enum references, and converts them to enums in AiBundle.php only after verifying the package is installed via willBeAvailable().