### PR TITLE
[AI Bundle][Store] Skip processing empty store configurations

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -979,6 +979,10 @@ final class AiBundle extends AbstractBundle
      */
     private function processStoreConfig(string $type, array $stores, ContainerBuilder $container, array &$setupStoresOptions): void
     {
+        if ([] === $stores) {
+            return;
+        }
+
         if ('azuresearch' === $type) {
             if (!ContainerBuilder::willBeAvailable('symfony/ai-azure-search-store', AzureSearchStore::class, ['symfony/ai-bundle'])) {
                 throw new RuntimeException('Azure Search store configuration requires "symfony/ai-azure-search-store" package. Try running "composer require symfony/ai-azure-search-store".');

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -717,6 +717,25 @@ class AiBundleTest extends TestCase
         $this->assertTrue($container->hasAlias('Symfony\AI\Store\StoreInterface'));
     }
 
+    #[TestDox('Configuring only one store type does not require packages for other store types')]
+    public function testConfiguringOnlyOneStoreTypeDoesNotRequireOtherStorePackages()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'store' => [
+                    'chromadb' => [
+                        'my_store' => [
+                            'collection' => 'test_collection',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.store.chromadb.my_store'));
+        $this->assertFalse($container->hasDefinition('ai.store.azuresearch.my_store'));
+    }
+
     public function testChromaDbStoreWithCustomClientCanBeConfigured()
     {
         $container = $this->buildContainer([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1083
| License       | MIT

Fix the issue where configuring only one store type (e.g., chromadb) would cause errors for other unconfigured store types. The configuration system populates all store types with empty arrays by default, and the processStoreConfig method was checking for package availability before checking if any stores were actually configured.