### PR TITLE
 Extract validation logic to reusable bash script

### DIFF
--- a/.github/scripts/validate-bridge-naming.sh
+++ b/.github/scripts/validate-bridge-naming.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Validates bridge naming conventions for Symfony AI components.
+#
+# Usage: validate-bridge-naming.sh <bridge_type> <bridge_path> [options_file]
+#
+# Arguments:
+#   bridge_type     Type of bridge (e.g., "store", "tool") - used in output messages and package suffix
+#   bridge_path     Path pattern to bridge directories (e.g., "src/store/src/Bridge/*")
+#   options_file    Optional: Path to options.php file for config key validation (only needed for stores)
+#
+# Example:
+#   validate-bridge-naming.sh store "src/store/src/Bridge/*" src/ai-bundle/config/options.php
+#   validate-bridge-naming.sh tool "src/agent/src/Bridge/*"
+
+set -e
+
+BRIDGE_TYPE="${1:?Bridge type is required (e.g., store, tool)}"
+BRIDGE_PATH="${2:?Bridge path pattern is required (e.g., src/store/src/Bridge/*)}"
+OPTIONS_FILE="${3:-}"
+
+ERRORS=0
+
+# Find all bridges with composer.json
+for composer_file in ${BRIDGE_PATH}/composer.json; do
+    if [[ ! -f "$composer_file" ]]; then
+        continue
+    fi
+
+    # Get the bridge directory name (e.g., ChromaDb)
+    bridge_dir=$(dirname "$composer_file")
+    bridge_name=$(basename "$bridge_dir")
+
+    # Get the package name from composer.json
+    package_name=$(jq -r '.name' "$composer_file")
+
+    # Expected package name format: symfony/ai-{lowercase-with-dashes}-{type}
+    # Convert PascalCase to kebab-case (e.g., ChromaDb -> chroma-db)
+    expected_kebab=$(echo "$bridge_name" | sed 's/\([a-z]\)\([A-Z]\)/\1-\2/g' | tr '[:upper:]' '[:lower:]')
+    expected_package="symfony/ai-${expected_kebab}-${BRIDGE_TYPE}"
+
+    if [[ "$package_name" != "$expected_package" ]]; then
+        echo "::error file=$composer_file::Package name '$package_name' does not match expected '$expected_package' for bridge '$bridge_name'"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✓ $bridge_name: package name '$package_name' is correct"
+    fi
+
+    # Check options.php for the config key if options file is provided
+    if [[ -n "$OPTIONS_FILE" && -f "$OPTIONS_FILE" ]]; then
+        # Expected config key should be lowercase without dashes/underscores
+        expected_config_key=$(echo "$bridge_name" | tr '[:upper:]' '[:lower:]')
+
+        # Look for ->arrayNode('configkey') in the options file
+        if ! grep -q -- "->arrayNode('$expected_config_key')" "$OPTIONS_FILE"; then
+            echo "::error file=$OPTIONS_FILE::Missing or incorrect config key for bridge '$bridge_name'. Expected '->arrayNode('$expected_config_key')' in ${BRIDGE_TYPE} configuration"
+            ERRORS=$((ERRORS + 1))
+        else
+            echo "✓ $bridge_name: config key '$expected_config_key' found in options.php"
+        fi
+    fi
+done
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo ""
+    echo "::error::Found $ERRORS naming convention violation(s)"
+    exit 1
+fi
+
+echo ""
+echo "All ${BRIDGE_TYPE} bridge naming conventions are valid!"

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -1,18 +1,18 @@
-name: Validation
+name: Validate
 
 on:
     push:
         paths:
-            - 'src/store/src/Bridge/**/composer.json'
-            - 'src/agent/src/Bridge/**/composer.json'
+            - 'src/*/src/Bridge/**/composer.json'
             - 'src/ai-bundle/config/options.php'
             - '.github/workflows/validation.yaml'
+            - '.github/scripts/validate-bridge-naming.sh'
     pull_request:
         paths:
-            - 'src/store/src/Bridge/**/composer.json'
-            - 'src/agent/src/Bridge/**/composer.json'
+            - 'src/*/src/Bridge/**/composer.json'
             - 'src/ai-bundle/config/options.php'
             - '.github/workflows/validation.yaml'
+            - '.github/scripts/validate-bridge-naming.sh'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -20,113 +20,21 @@ concurrency:
 
 jobs:
     validate_stores:
-        name: Validate Store Bridge Naming
+        name: Store Bridge Naming
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v5
 
             - name: Validate store bridge naming conventions
-              run: |
-                  #!/bin/bash
-                  set -e
-
-                  ERRORS=0
-
-                  # Find all store bridges with composer.json
-                  for composer_file in src/store/src/Bridge/*/composer.json; do
-                      if [[ ! -f "$composer_file" ]]; then
-                          continue
-                      fi
-
-                      # Get the bridge directory name (e.g., ChromaDb)
-                      bridge_dir=$(dirname "$composer_file")
-                      bridge_name=$(basename "$bridge_dir")
-
-                      # Get the package name from composer.json
-                      package_name=$(jq -r '.name' "$composer_file")
-
-                      # Expected package name format: symfony/ai-{lowercase-with-dashes}-store
-                      # Convert PascalCase to kebab-case (e.g., ChromaDb -> chroma-db)
-                      expected_kebab=$(echo "$bridge_name" | sed 's/\([a-z]\)\([A-Z]\)/\1-\2/g' | tr '[:upper:]' '[:lower:]')
-                      expected_package="symfony/ai-${expected_kebab}-store"
-
-                      if [[ "$package_name" != "$expected_package" ]]; then
-                          echo "::error file=$composer_file::Package name '$package_name' does not match expected '$expected_package' for bridge '$bridge_name'"
-                          ERRORS=$((ERRORS + 1))
-                      else
-                          echo "✓ $bridge_name: package name '$package_name' is correct"
-                      fi
-
-                      # Check options.php for the config key (should be lowercase without dashes/underscores)
-                      expected_config_key=$(echo "$bridge_name" | tr '[:upper:]' '[:lower:]')
-                      options_file="src/ai-bundle/config/options.php"
-
-                      if [[ -f "$options_file" ]]; then
-                          # Look for ->arrayNode('configkey') under the store section
-                          if ! grep -q -- "->arrayNode('$expected_config_key')" "$options_file"; then
-                              echo "::error file=$options_file::Missing or incorrect config key for bridge '$bridge_name'. Expected '->arrayNode('$expected_config_key')' in store configuration"
-                              ERRORS=$((ERRORS + 1))
-                          else
-                              echo "✓ $bridge_name: config key '$expected_config_key' found in options.php"
-                          fi
-                      fi
-                  done
-
-                  if [[ $ERRORS -gt 0 ]]; then
-                      echo ""
-                      echo "::error::Found $ERRORS naming convention violation(s)"
-                      exit 1
-                  fi
-
-                  echo ""
-                  echo "All store bridge naming conventions are valid!"
+              run: .github/scripts/validate-bridge-naming.sh store "src/store/src/Bridge/*" src/ai-bundle/config/options.php
 
     validate_tools:
-        name: Validate Tool Bridge Naming
+        name: Tool Bridge Naming
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v5
 
             - name: Validate tool bridge naming conventions
-              run: |
-                  #!/bin/bash
-                  set -e
-
-                  ERRORS=0
-
-                  # Find all tool bridges with composer.json
-                  for composer_file in src/agent/src/Bridge/*/composer.json; do
-                      if [[ ! -f "$composer_file" ]]; then
-                          continue
-                      fi
-
-                      # Get the bridge directory name (e.g., OpenMeteo)
-                      bridge_dir=$(dirname "$composer_file")
-                      bridge_name=$(basename "$bridge_dir")
-
-                      # Get the package name from composer.json
-                      package_name=$(jq -r '.name' "$composer_file")
-
-                      # Expected package name format: symfony/ai-{lowercase-with-dashes}-tool
-                      # Convert PascalCase to kebab-case (e.g., OpenMeteo -> open-meteo)
-                      expected_kebab=$(echo "$bridge_name" | sed 's/\([a-z]\)\([A-Z]\)/\1-\2/g' | tr '[:upper:]' '[:lower:]')
-                      expected_package="symfony/ai-${expected_kebab}-tool"
-
-                      if [[ "$package_name" != "$expected_package" ]]; then
-                          echo "::error file=$composer_file::Package name '$package_name' does not match expected '$expected_package' for bridge '$bridge_name'"
-                          ERRORS=$((ERRORS + 1))
-                      else
-                          echo "✓ $bridge_name: package name '$package_name' is correct"
-                      fi
-                  done
-
-                  if [[ $ERRORS -gt 0 ]]; then
-                      echo ""
-                      echo "::error::Found $ERRORS naming convention violation(s)"
-                      exit 1
-                  fi
-
-                  echo ""
-                  echo "All tool bridge naming conventions are valid!"
+              run: .github/scripts/validate-bridge-naming.sh tool "src/agent/src/Bridge/*"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Move duplicated bridge naming validation logic from workflow to .github/scripts/validate-bridge-naming.sh for better maintainability.