### PR TITLE
[Run examples] Remove `symfony/ai-store` dependency

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -52,7 +52,6 @@
         "symfony/ai-scraper-tool": "@dev",
         "symfony/ai-serp-api-tool": "@dev",
         "symfony/ai-similarity-search-tool": "@dev",
-        "symfony/ai-store": "@dev",
         "symfony/ai-supabase-store": "@dev",
         "symfony/ai-surreal-db-store": "@dev",
         "symfony/ai-tavily-tool": "@dev",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

We already require the dedicated store packages.