### PR TITLE
 Swap cache configuration params in `message_store` docs

### DIFF
--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -1093,8 +1093,8 @@ Message stores are defined in the ``message_store`` section of your configuratio
     ai:
         # ...
         message_store:
-            youtube:
-                cache:
+            cache:
+                youtube:
                     service: 'cache.app'
                     key: 'youtube'
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

The first key of the `message_store` should be the type, e.g. `cache`, `cloudflare`, `doctrine` etc