### PR TITLE
[AI Bundle] Display tool JSON schema in profiler Platform Calls

### DIFF
--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -143,7 +143,13 @@
                                                     <li>{{ key }}:
                                                         <ul>
                                                             {% for tool in value %}
-                                                                <li>{{ tool.name }}</li>
+                                                                <li>
+                                                                    <strong>{{ tool.name }}</strong>
+                                                                    {% if tool.parameters %}
+                                                                        <button class="btn btn-sm hidden" data-clipboard-text="{{ tool.parameters|json_encode|e('html_attr') }}">Copy JSON Schema</button>
+                                                                        {{ dump(tool.parameters) }}
+                                                                    {% endif %}
+                                                                </li>
                                                             {% endfor %}
                                                         </ul>
                                                     </li>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |  no 
| Docs?         | no 
| Issues        |  no
| License       | MIT

The profiler only showed tool names in Platform Calls > Options > tools. This made it difficult to debug dynamically enriched tools since the actual JSON schema sent to the API was not visible.

This change:
- Displays tool JSON schema using dump() for interactive exploration
- Adds a "Copy" button to copy the schema to clipboard

<img width="777" height="628" alt="Capture d’écran 2025-12-10 à 20 44 30" src="https://github.com/user-attachments/assets/29a54de1-682a-47b9-8c52-44c614ef0ffe" />

