### PR TITLE
 Simplify `validate-bridge-*.sh` arguments

### DIFF
--- a/.github/scripts/validate-bridge-naming.sh
+++ b/.github/scripts/validate-bridge-naming.sh
@@ -2,21 +2,26 @@
 #
 # Validates bridge naming conventions for Symfony AI components.
 #
-# Usage: validate-bridge-naming.sh <bridge_type> <bridge_path> [options_file]
+# Usage: validate-bridge-naming.sh <bridge_type> [component] [options_file]
 #
 # Arguments:
 #   bridge_type     Type of bridge (e.g., "store", "tool") - used in output messages and package suffix
-#   bridge_path     Path pattern to bridge directories (e.g., "src/store/src/Bridge/*")
+#   component       Name of the parent component (e.g., agent, platform, store)
+#                   If not provided, defaults to bridge_type
 #   options_file    Optional: Path to options.php file for config key validation (only needed for stores)
 #
 # Example:
-#   validate-bridge-naming.sh store "src/store/src/Bridge/*" src/ai-bundle/config/options.php
-#   validate-bridge-naming.sh tool "src/agent/src/Bridge/*"
+#   validate-bridge-naming.sh store
+#   validate-bridge-naming.sh store store src/ai-bundle/config/options.php
+#   validate-bridge-naming.sh tool agent
+#
+# The script builds the bridge path internally as: src/${component}/src/Bridge/*
 
 set -e
 
 BRIDGE_TYPE="${1:?Bridge type is required (e.g., store, tool)}"
-BRIDGE_PATH="${2:?Bridge path pattern is required (e.g., src/store/src/Bridge/*)}"
+COMPONENT="${2:-$BRIDGE_TYPE}"
+BRIDGE_PATH="src/${COMPONENT}/src/Bridge/*"
 OPTIONS_FILE="${3:-}"
 
 ERRORS=0

--- a/.github/scripts/validate-bridge-splitsh.sh
+++ b/.github/scripts/validate-bridge-splitsh.sh
@@ -2,20 +2,24 @@
 #
 # Validates that all bridge directories are configured in splitsh.json.
 #
-# Usage: validate-bridge-splitsh.sh <bridge_type> <bridge_path>
+# Usage: validate-bridge-splitsh.sh <bridge_type> [component]
 #
 # Arguments:
 #   bridge_type     Type of bridge (e.g., "store", "tool") - used in output messages
-#   bridge_path     Path pattern to bridge directories (e.g., "src/store/src/Bridge/*")
+#   component       Name of the parent component (e.g., agent, platform, store)
+#                   If not provided, defaults to bridge_type
 #
 # Example:
-#   validate-bridge-splitsh.sh store "src/store/src/Bridge/*"
-#   validate-bridge-splitsh.sh tool "src/agent/src/Bridge/*"
+#   validate-bridge-splitsh.sh store
+#   validate-bridge-splitsh.sh tool agent
+#
+# The script builds the bridge path internally as: src/${component}/src/Bridge/*
 
 set -e
 
 BRIDGE_TYPE="${1:?Bridge type is required (e.g., store, tool)}"
-BRIDGE_PATH="${2:?Bridge path pattern is required (e.g., src/store/src/Bridge/*)}"
+COMPONENT="${2:-$BRIDGE_TYPE}"
+BRIDGE_PATH="src/${COMPONENT}/src/Bridge/*"
 
 SPLITSH_FILE="splitsh.json"
 

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -31,10 +31,10 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Validate store bridge naming conventions
-              run: .github/scripts/validate-bridge-naming.sh store "src/store/src/Bridge/*" src/ai-bundle/config/options.php
+              run: .github/scripts/validate-bridge-naming.sh store store src/ai-bundle/config/options.php
 
             - name: Validate store bridges are in splitsh.json
-              run: .github/scripts/validate-bridge-splitsh.sh store "src/store/src/Bridge/*"
+              run: .github/scripts/validate-bridge-splitsh.sh store
 
     validate_tools:
         name: Tool Bridges
@@ -44,7 +44,7 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Validate tool bridge naming conventions
-              run: .github/scripts/validate-bridge-naming.sh tool "src/agent/src/Bridge/*"
+              run: .github/scripts/validate-bridge-naming.sh tool agent
 
             - name: Validate tool bridges are in splitsh.json
-              run: .github/scripts/validate-bridge-splitsh.sh tool "src/agent/src/Bridge/*"
+              run: .github/scripts/validate-bridge-splitsh.sh tool agent


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Build bridge path internally from component name instead of requiring full path pattern as argument.