### PR TITLE
[Platform] Split Generic bridge into dedicated package

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -96,7 +96,11 @@ deptrac:
     - name: PlatformComponent
       collectors:
         - type: classLike
-          value: Symfony\\AI\\Platform.*
+          value: ^Symfony\\AI\\Platform\\(?!Bridge\\).*
+    - name: GenericPlatform
+      collectors:
+        - type: classLike
+          value: Symfony\\AI\\Platform\\Bridge\\Generic\\.*
     - name: StoreComponent
       collectors:
         - type: classLike
@@ -242,6 +246,8 @@ deptrac:
       - ChatComponent
       - PlatformComponent
     PlatformComponent: ~
+    GenericPlatform:
+      - PlatformComponent
     StoreComponent:
       - PlatformComponent
     AzureSearchStore:

--- a/splitsh.json
+++ b/splitsh.json
@@ -18,7 +18,10 @@
         "ai-bundle": "src/ai-bundle",
         "ai-chat": "src/chat",
         "mcp-bundle": "src/mcp-bundle",
-        "ai-platform": "src/platform",
+        "ai-platform": {
+            "prefixes": [{ "from": "src/platform", "to": "", "excludes": ["src/Bridge"] }]
+        },
+        "ai-generic-platform": "src/platform/src/Bridge/Generic",
         "ai-store": {
             "prefixes": [{ "from": "src/store", "to": "", "excludes": ["src/Bridge"] }]
         },

--- a/src/platform/src/Bridge/Generic/.gitattributes
+++ b/src/platform/src/Bridge/Generic/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/platform/src/Bridge/Generic/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/platform/src/Bridge/Generic/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/ai
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/platform/src/Bridge/Generic/.github/close-pull-request.yml
+++ b/src/platform/src/Bridge/Generic/.github/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/ai
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/platform/src/Bridge/Generic/.gitignore
+++ b/src/platform/src/Bridge/Generic/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+phpunit.xml
+.phpunit.result.cache

--- a/src/platform/src/Bridge/Generic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Generic/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+0.1
+---
+
+ * Add the bridge

--- a/src/platform/src/Bridge/Generic/LICENSE
+++ b/src/platform/src/Bridge/Generic/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2025-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/platform/src/Bridge/Generic/README.md
+++ b/src/platform/src/Bridge/Generic/README.md
@@ -1,0 +1,17 @@
+Generic Platform
+================
+
+Provides a generic OpenAI-compatible platform bridge for Symfony AI Platform.
+
+This bridge can be used with any AI provider that implements the OpenAI API format, including:
+- Self-hosted models
+- Local inference servers
+- Third-party providers with OpenAI-compatible endpoints
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/ai/issues) and
+   [send Pull Requests](https://github.com/symfony/ai/pulls)
+   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Tests\Bridge\Generic\Completions;
+namespace Symfony\AI\Platform\Bridge\Generic\Tests\Completions;
 
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Tests\Bridge\Generic\Completions;
+namespace Symfony\AI\Platform\Bridge\Generic\Tests\Completions;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Generic\Completions\ResultConverter;

--- a/src/platform/src/Bridge/Generic/Tests/Embeddings/ModelClientTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Embeddings/ModelClientTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Tests\Bridge\Generic\Embeddings;
+namespace Symfony\AI\Platform\Bridge\Generic\Tests\Embeddings;
 
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;

--- a/src/platform/src/Bridge/Generic/Tests/Embeddings/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Embeddings/ResultConverterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Tests\Bridge\Generic\Embeddings;
+namespace Symfony\AI\Platform\Bridge\Generic\Tests\Embeddings;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Generic\Embeddings\ResultConverter;

--- a/src/platform/src/Bridge/Generic/composer.json
+++ b/src/platform/src/Bridge/Generic/composer.json
@@ -1,0 +1,58 @@
+{
+    "name": "symfony/ai-generic-platform",
+    "description": "Generic OpenAI-compatible platform bridge for Symfony AI",
+    "license": "MIT",
+    "type": "symfony-ai-platform",
+    "keywords": [
+        "ai",
+        "bridge",
+        "generic",
+        "openai-compatible",
+        "platform"
+    ],
+    "authors": [
+        {
+            "name": "Christopher Hertel",
+            "email": "mail@christopher-hertel.de"
+        },
+        {
+            "name": "Oskar Stark",
+            "email": "oskarstark@googlemail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/ai-platform": "@dev",
+        "symfony/http-client": "^7.3|^8.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.13"
+    },
+    "minimum-stability": "dev",
+    "autoload": {
+        "psr-4": {
+            "Symfony\\AI\\Platform\\Bridge\\Generic\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\AI\\Platform\\Bridge\\Generic\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "0.x-dev"
+        },
+        "thanks": {
+            "name": "symfony/ai",
+            "url": "https://github.com/symfony/ai"
+        }
+    }
+}

--- a/src/platform/src/Bridge/Generic/phpunit.xml.dist
+++ b/src/platform/src/Bridge/Generic/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony AI Generic Platform Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Split the Generic platform bridge into a dedicated, independently installable Composer package following the same structure used for store bridges.

The bridge now has its own:
- composer.json with proper dependencies
- README.md, CHANGELOG.md, LICENSE
- phpunit.xml.dist for isolated testing
- .github/ templates

Tests moved from tests/Bridge/Generic/ to src/Bridge/Generic/Tests/ with updated namespaces