### PR TITLE
[Platform] Remove unused code in Vector constructor and add missing tests

### DIFF
--- a/src/platform/src/Vector/Vector.php
+++ b/src/platform/src/Vector/Vector.php
@@ -33,10 +33,6 @@ final class Vector implements VectorInterface
             throw new InvalidArgumentException('Vector must have at least one dimension.');
         }
 
-        if (\is_int($dimensions) && \count($data) !== $dimensions) {
-            throw new InvalidArgumentException(\sprintf('Vector must have %d dimensions', $dimensions));
-        }
-
         if (null === $this->dimensions) {
             $this->dimensions = \count($data);
         }

--- a/src/platform/tests/Vector/VectorTest.php
+++ b/src/platform/tests/Vector/VectorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Tests\Vector;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Platform\Vector\VectorInterface;
 
@@ -31,5 +32,28 @@ final class VectorTest extends TestCase
 
         $this->assertSame($vectors, $vector->getData());
         $this->assertSame(3, $vector->getDimensions());
+    }
+
+    public function testWithExplicitDimensions()
+    {
+        $vector = new Vector([1.0, 2.0, 3.0], 3);
+
+        $this->assertSame(3, $vector->getDimensions());
+    }
+
+    public function testThrowsOnDimensionMismatch()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Vector must have 5 dimensions');
+
+        new Vector([1.0, 2.0], 5);
+    }
+
+    public function testThrowsOnEmptyData()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Vector must have at least one dimension');
+
+        new Vector([]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no  
| Docs?         | no 
| License       | MIT

 The `Vector` constructor had duplicate validation code. The second check (line 36-38) could never be reached because the first check (line 28-30) already handles the same condition.

  Given [`$dimensions` is typed `?int`](https://github.com/symfony/ai/blob/main/src/platform/src/Vector/Vector.php#L26):
  - `null !== $dimensions` = "dimensions is not null"
  - `\is_int($dimensions)` = "dimensions is an int"

  When `$dimensions` is not null, it is an int. So both conditions are equivalent, making the second check unused code.

  This PR:

  - Removes the unreachable duplicate check
  - Adds missing test coverage for dimension validation
