### PR TITLE
[AI Bundle] Make expression_language service optional

### DIFF
--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -126,7 +126,7 @@ return static function (ContainerConfigurator $container): void {
         $container->services()
             ->set('ai.platform.template_renderer.expression', ExpressionLanguageTemplateRenderer::class)
                 ->args([
-                    service('expression_language'),
+                    service('expression_language')->nullOnInvalid(),
                 ])
                 ->tag('ai.platform.template_renderer');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

The `ai.platform.template_renderer.expression` service was configured to depend on `expression_language` without `>nullOnInvalid()`.

This causes a container build failure when:
   1. The `ExpressionLanguage` class exists (installed as a transitive dependency)
   2. But the `expression_language` service is not registered in the application

**Error:**
```The service "ai.platform.template_renderer.expression" has a dependency on a non-existent service "expression_language"```

**Fix:** 
Add `->nullOnInvalid()` to make the service optional, consistent with other similar usages in the same file (e.g.,`ai.security.is_granted_attribute_listener` at line 203)