### PR TITLE
[CI] Wait for Docker services to be healthy before running tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -44,6 +44,23 @@ jobs:
               working-directory: examples
               run: docker compose up -d
 
+            - name: Wait for services to be healthy
+              working-directory: examples
+              run: |
+                  echo "Waiting for all services to be healthy..."
+                  for i in {1..60}; do
+                      if docker compose ps --format json | jq -s -e 'all(.[]; .Health == "healthy" or .Health == "")' > /dev/null 2>&1; then
+                          echo "All services are healthy!"
+                          exit 0
+                      fi
+                      echo "Attempt $i/60: Some services are still starting..."
+                      docker compose ps
+                      sleep 5
+                  done
+                  echo "Timeout waiting for services to be healthy"
+                  docker compose ps
+                  exit 1
+
             - name: Configure environment
               run: |
                   echo COLUMNS=120 >> $GITHUB_ENV


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         |
| Issues        | 
| License       | MIT

Adding a wait step in integration-tests workflow that checks all Docker Compose services are healthy before running store commands. In this PR #1109 I had the issue that OpenSearch integrations tests would sometimes pass sometimes not. 

The step waits up to 5 minutes, checking every 5 seconds, for all services to report either "healthy" status or have no healthcheck defined.

I did as many checks as I could on my local macos machine for all services in compose.yaml and at least it works on my machine, but I am not a bash expert, so do not hold back with your reviews 😄 