### PR TITLE
[Chat] Fix MongoDB identifier context in MessageNormalizer denormalize

### DIFF
--- a/src/chat/src/Bridge/MongoDb/MessageStore.php
+++ b/src/chat/src/Bridge/MongoDb/MessageStore.php
@@ -79,7 +79,9 @@ final class MessageStore implements ManagedStoreInterface, MessageStoreInterface
         ]);
 
         return new MessageBag(...array_map(
-            fn (array $message): MessageInterface => $this->serializer->denormalize($message, MessageInterface::class),
+            fn (array $message): MessageInterface => $this->serializer->denormalize($message, MessageInterface::class, context: [
+                'identifier' => '_id',
+            ]),
             $cursor->toArray(),
         ));
     }

--- a/src/chat/src/MessageNormalizer.php
+++ b/src/chat/src/MessageNormalizer.php
@@ -74,8 +74,9 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
             default => throw new LogicException(\sprintf('Unknown message type "%s".', $type)),
         };
 
+        $identifier = $context['identifier'] ?? 'id';
         /** @var AbstractUid&TimeBasedUidInterface&Uuid $existingUuid */
-        $existingUuid = Uuid::fromString($data['id']);
+        $existingUuid = Uuid::fromString($data[$identifier]);
 
         $messageWithExistingUuid = $message->withId($existingUuid);
 

--- a/src/chat/tests/Bridge/MongoDb/MessageStoreTest.php
+++ b/src/chat/tests/Bridge/MongoDb/MessageStoreTest.php
@@ -89,7 +89,7 @@ final class MessageStoreTest extends TestCase
 
         $cursor = $this->createMock(CursorInterface::class);
         $cursor->expects($this->once())->method('toArray')->willReturn([
-            $serializer->normalize(Message::ofUser('Hello world')),
+            $serializer->normalize(Message::ofUser('Hello world'), context: ['identifier' => '_id']),
         ]);
 
         $collection = $this->createMock(Collection::class);

--- a/src/chat/tests/MessageNormalizerTest.php
+++ b/src/chat/tests/MessageNormalizerTest.php
@@ -76,4 +76,19 @@ final class MessageNormalizerTest extends TestCase
         $this->assertSame(Role::User, $message->getRole());
         $this->assertArrayHasKey('addedAt', $message->getMetadata()->all());
     }
+
+    public function testItCanDenormalizeWithCustomIdentifier()
+    {
+        $normalizer = new MessageNormalizer();
+        $message = Message::ofUser('Hello World');
+
+        // Normalize with _id (like MongoDB)
+        $payload = $normalizer->normalize($message, context: ['identifier' => '_id']);
+        $this->assertArrayHasKey('_id', $payload);
+        $this->assertArrayNotHasKey('id', $payload);
+
+        $denormalized = $normalizer->denormalize($payload, MessageInterface::class, context: ['identifier' => '_id']);
+
+        $this->assertSame($message->getId()->toRfc4122(), $denormalized->getId()->toRfc4122());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The `MessageNormalizer::denormalize()` method was ignoring the `identifier` context option, always using hardcoded `'id'` key to restore the UUID.

This caused issues with MongoDB store which uses `_id` as the identifier (MongoDB's primary key convention). When saving messages, the store correctly passed `context: ['identifier' => '_id']` to `normalize()`, but `load()` called `denormalize()` without context, and even if it did, the method ignored it.

**Changes:**
- `MessageNormalizer::denormalize()` now uses `$context['identifier'] ?? 'id'` to read the UUID
- `MongoDb\MessageStore::load()` now passes the `identifier` context to `denormalize()`
- Fixed the MongoDB test to simulate real MongoDB behavior (data with `_id` key)
- Added test for custom identifier roundtrip
