### PR TITLE
[Platform] Promote metadata from unwrapped into deferred result after merge

### DIFF
--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -50,13 +50,16 @@ final class DeferredResult
                 $this->convertedResult->setRawResult($this->rawResult);
             }
 
-            $this->convertedResult->getMetadata()->merge($this->getMetadata()->all());
+            $metadata = $this->convertedResult->getMetadata();
+            $metadata->merge($this->getMetadata()->all());
 
             if (null !== $tokenUsageExtractor = $this->resultConverter->getTokenUsageExtractor()) {
                 if (null !== $tokenUsage = $tokenUsageExtractor->extract($this->rawResult, $this->options)) {
-                    $this->convertedResult->getMetadata()->add('token_usage', $tokenUsage);
+                    $metadata->add('token_usage', $tokenUsage);
                 }
             }
+
+            $this->metadata->set($metadata->all());
 
             $this->isConverted = true;
         }

--- a/src/platform/tests/Result/DeferredResultTest.php
+++ b/src/platform/tests/Result/DeferredResultTest.php
@@ -136,6 +136,18 @@ final class DeferredResultTest extends TestCase
         $this->assertSame('value', $unwrappedResult->getMetadata()->get('key'));
     }
 
+    public function testMetadataGetsPromotedFromUnwrappedResult()
+    {
+        $result = new TextResult('Hello World');
+        $result->getMetadata()->add('foo', 'bar');
+        $converter = new PlainConverter($result);
+
+        $deferredResult = new DeferredResult($converter, new InMemoryRawResult());
+        $deferredResult->getResult();
+
+        $this->assertSame('bar', $deferredResult->getMetadata()->get('foo'));
+    }
+
     /**
      * Workaround for low deps because mocking the ResponseInterface leads to an exception with
      * mock creation "Type Traversable|object|array|string|null contains both object and a class type"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Was quite confusing that metadata on `DeferredResult` does not contain the metadata that gets created on converted result.

Now the logic is:
* `DeferredResult` can have `Metadata`
* Converted `ResultInterface` can have `Metadata`
* `Metadata` gets merged after conversionin `ResultInterface` => `Metadata` of `DeferredResult`  wins
* At the end merged `Metadata` gets promoted from `ResultInterface` instance back to `DeferredResult`
* Two separated instances of `Metadata` though.