### PR TITLE
[CI] Use `REQUIRED_PHP_EXTENSIONS` env instead of `--ignore-platform-req`

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -14,6 +14,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
 
+env:
+    REQUIRED_PHP_EXTENSIONS: 'mongodb, redis'
+
 jobs:
     phpstan:
         name: PHPStan
@@ -29,7 +32,7 @@ jobs:
             - name: Configure environment
               run: |
                   echo COLUMNS=120 >> $GITHUB_ENV
-                  echo COMPOSER_UP='composer update --no-progress --no-interaction --no-scripts --ansi --ignore-platform-req=ext-mongodb' >> $GITHUB_ENV
+                  echo COMPOSER_UP='composer update --no-progress --no-interaction --no-scripts --ansi' >> $GITHUB_ENV
                   echo PHPSTAN='vendor/bin/phpstan' >> $GITHUB_ENV
 
                   PACKAGES=$(find src/ -mindepth 2 -type f -name composer.json -not -path "*/vendor/*" -not -path "*/Bridge/*" -printf '%h\n' | sed 's/^src\///' | grep -Ev "examples" | sort |  tr '\n' ' ')
@@ -40,6 +43,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-version }}
+                  extensions: "${{ env.REQUIRED_PHP_EXTENSIONS }}"
 
             - name: Get composer cache directory
               id: composer-cache

--- a/.github/workflows/deptrac.yaml
+++ b/.github/workflows/deptrac.yaml
@@ -14,6 +14,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
 
+env:
+    REQUIRED_PHP_EXTENSIONS: 'mongodb, redis'
+
 jobs:
     deptrac:
         name: deptrac
@@ -25,12 +28,13 @@ jobs:
             - name: Configure environment
               run: |
                   echo COLUMNS=120 >> $GITHUB_ENV
-                  echo COMPOSER_UP='composer update --prefer-lowest --no-progress --no-interaction --ansi --ignore-platform-req=ext-mongodb' >> $GITHUB_ENV
+                  echo COMPOSER_UP='composer update --prefer-lowest --no-progress --no-interaction --ansi' >> $GITHUB_ENV
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.5'
+                  extensions: "${{ env.REQUIRED_PHP_EXTENSIONS }}"
 
             - name: Get composer cache directory
               id: composer-cache

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -47,7 +47,7 @@ jobs:
             - name: Configure environment
               run: |
                   echo COLUMNS=120 >> $GITHUB_ENV
-                  echo COMPOSER_UP='composer update ${{ matrix.dependency-version == 'lowest' && '--prefer-lowest --prefer-stable' || '' }} --no-progress --no-interaction --ansi --ignore-platform-req=ext-mongodb' >> $GITHUB_ENV
+                  echo COMPOSER_UP='composer update ${{ matrix.dependency-version == 'lowest' && '--prefer-lowest --prefer-stable' || '' }} --no-progress --no-interaction --ansi' >> $GITHUB_ENV
                   echo PHPUNIT='vendor/bin/phpunit' >> $GITHUB_ENV
                   [ 'lowest' = '${{ matrix.dependency-version }}' ] && export SYMFONY_DEPRECATIONS_HELPER=weak
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,7 +15,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    REQUIRED_PHP_EXTENSIONS: 'mongodb'
+    REQUIRED_PHP_EXTENSIONS: 'mongodb, redis'
 
 jobs:
     php:
@@ -46,7 +46,7 @@ jobs:
             - name: Configure environment
               run: |
                   echo COLUMNS=120 >> $GITHUB_ENV
-                  echo COMPOSER_UP='composer update ${{ matrix.dependency-version == 'lowest' && '--prefer-lowest --prefer-stable' || '' }} --no-progress --no-interaction --ansi --ignore-platform-req=ext-mongodb' >> $GITHUB_ENV
+                  echo COMPOSER_UP='composer update ${{ matrix.dependency-version == 'lowest' && '--prefer-lowest --prefer-stable' || '' }} --no-progress --no-interaction --ansi' >> $GITHUB_ENV
                   echo PHPUNIT='vendor/bin/phpunit' >> $GITHUB_ENV
                   [ 'lowest' = '${{ matrix.dependency-version }}' ] && export SYMFONY_DEPRECATIONS_HELPER=weak
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

- Add REQUIRED_PHP_EXTENSIONS env to code-quality and deptrac workflows
- Install mongodb and redis extensions via setup-php instead of ignoring platform requirements
- Remove --ignore-platform-req=ext-mongodb from all composer commands
- Standardize all workflows to use 'mongodb, redis' extensions