### PR TITLE
[Platform] Improvements on `CachedPlatform`

### DIFF
--- a/examples/misc/agent-with-cache.php
+++ b/examples/misc/agent-with-cache.php
@@ -20,7 +20,7 @@ use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
-$cachedPlatform = new CachedPlatform($platform, new TagAwareAdapter(new ArrayAdapter()));
+$cachedPlatform = new CachedPlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
 
 $agent = new Agent($cachedPlatform, 'qwen3:0.6b-q4_K_M');
 $messages = new MessageBag(

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -402,13 +402,15 @@ final class AiBundle extends AbstractBundle
                     ->setLazy(true)
                     ->setArguments([
                         new Reference($cachedPlatformConfig['platform']),
+                        new Reference(ClockInterface::class),
                         new Reference($cachedPlatformConfig['service'], ContainerInterface::NULL_ON_INVALID_REFERENCE),
                         $cachedPlatformConfig['cache_key'] ?? $name,
                     ])
                     ->addTag('proxy', ['interface' => PlatformInterface::class])
-                    ->addTag('ai.platform', ['name' => 'cache'.$name]);
+                    ->addTag('ai.platform', ['name' => 'cache.'.$name]);
 
                 $container->setDefinition('ai.platform.cache.'.$name, $definition);
+                $container->registerAliasForArgument('ai.platform.'.$type, PlatformInterface::class, $type.'_'.$name);
             }
 
             return;

--- a/src/platform/tests/CachedPlatformTest.php
+++ b/src/platform/tests/CachedPlatformTest.php
@@ -40,7 +40,7 @@ final class CachedPlatformTest extends TestCase
 
         $cachedPlatform = new CachedPlatform(
             $platform,
-            new TagAwareAdapter(new ArrayAdapter()),
+            cache: new TagAwareAdapter(new ArrayAdapter()),
         );
 
         $deferredResult = $cachedPlatform->invoke('foo', 'bar', [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | yes
| Issues        | Extracted from #1122 
| License       | MIT

Summary:

- Add `MonotonicClock` as the default implementation for `ClockInterface` argument in `CachedPlatform` to ease tests and improve precision instead of `DatetimeImmutable()`
- Add an alias for `CachedPlatform`
- Add missing `.` in the `name` tag of `CachedPlatform` definition
- Improvements on tests for arguments / tags
