### PR TITLE
[Agent][Brave] Make field `description` optional

### DIFF
--- a/src/agent/src/Bridge/Brave/Brave.php
+++ b/src/agent/src/Bridge/Brave/Brave.php
@@ -70,12 +70,16 @@ final class Brave implements HasSourcesInterface
 
         foreach ($results as $result) {
             $this->addSource(
-                new Source($result['title'] ?? '', $result['url'] ?? '', $result['description'] ?? '')
+                new Source($result['title'], $result['url'], $result['description'] ?? '')
             );
         }
 
         return array_map(static function (array $result) {
-            return ['title' => $result['title'], 'description' => $result['description'], 'url' => $result['url']];
+            return [
+                'title' => $result['title'],
+                'description' => $result['description'] ?? '',
+                'url' => $result['url'],
+            ];
         }, $data['web']['results'] ?? []);
     }
 }

--- a/src/agent/src/Bridge/Brave/Tests/BraveTest.php
+++ b/src/agent/src/Bridge/Brave/Tests/BraveTest.php
@@ -64,4 +64,26 @@ final class BraveTest extends TestCase
 
         $this->assertEmpty($results);
     }
+
+    public function testHandlesMissingDescription()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'web' => [
+                'results' => [
+                    [
+                        'title' => 'Test Title',
+                        'url' => 'https://example.com',
+                    ],
+                ],
+            ],
+        ]));
+        $brave = new Brave($httpClient, 'test-api-key');
+
+        $results = $brave('test query');
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Test Title', $results[0]['title']);
+        $this->assertSame('', $results[0]['description']);
+        $this->assertSame('https://example.com', $results[0]['url']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | not applicable <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

The `Brave` tool fails when the Brave Search API returns results without a `description` field. According to the [Brave API documentation](https://api-dashboard.search.brave.com/app/documentation/web-search/responses), the `description` field is **optional**, but the current implementation assumes it's always present.

**Error**: `Undefined array key "description"` wrapped in `ToolExecutionException`

**User-visible error**: `"An error occurred while executing tool \"brave_search\"."`