### PR TITLE
[Chat][HttpFoundation] Rename `SessionStore` to `MessageStore`

### DIFF
--- a/examples/chat/persistent-chat-session.php
+++ b/examples/chat/persistent-chat-session.php
@@ -10,7 +10,7 @@
  */
 
 use Symfony\AI\Agent\Agent;
-use Symfony\AI\Chat\Bridge\HttpFoundation\SessionStore;
+use Symfony\AI\Chat\Bridge\HttpFoundation\MessageStore;
 use Symfony\AI\Chat\Chat;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Message\Message;
@@ -30,7 +30,7 @@ $request->setSession(new Session(new MockArraySessionStorage()));
 $requestStack = new RequestStack();
 $requestStack->push($request);
 
-$store = new SessionStore($requestStack, 'chat');
+$store = new MessageStore($requestStack, 'chat');
 $store->setup();
 
 $agent = new Agent($platform, 'gpt-4o-mini');

--- a/examples/commands/message-stores.php
+++ b/examples/commands/message-stores.php
@@ -15,7 +15,7 @@ use Doctrine\DBAL\DriverManager;
 use MongoDB\Client as MongoDbClient;
 use Symfony\AI\Chat\Bridge\Cache\Store as CacheStore;
 use Symfony\AI\Chat\Bridge\Doctrine\DoctrineDbalMessageStore;
-use Symfony\AI\Chat\Bridge\HttpFoundation\SessionStore;
+use Symfony\AI\Chat\Bridge\HttpFoundation\MessageStore as SessionMessageStore;
 use Symfony\AI\Chat\Bridge\Meilisearch\MessageStore as MeilisearchMessageStore;
 use Symfony\AI\Chat\Bridge\MongoDb\MessageStore as MongoDbMessageStore;
 use Symfony\AI\Chat\Bridge\Pogocache\MessageStore as PogocacheMessageStore;
@@ -73,14 +73,14 @@ $factories = [
     ], [
         new JsonEncoder(),
     ])),
-    'session' => static function (): SessionStore {
+    'session' => static function (): SessionMessageStore {
         $request = Request::create('/');
         $request->setSession(new Session(new MockArraySessionStorage()));
 
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
-        return new SessionStore($requestStack, 'symfony');
+        return new SessionMessageStore($requestStack, 'symfony');
     },
     'surrealdb' => static fn (): SurrealDbMessageStore => new SurrealDbMessageStore(
         httpClient: http_client(),

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -39,7 +39,7 @@ use Symfony\AI\AiBundle\Security\Attribute\IsGrantedTool;
 use Symfony\AI\Chat\Bridge\Cache\Store as CacheMessageStore;
 use Symfony\AI\Chat\Bridge\Cloudflare\MessageStore as CloudflareMessageStore;
 use Symfony\AI\Chat\Bridge\Doctrine\DoctrineDbalMessageStore;
-use Symfony\AI\Chat\Bridge\HttpFoundation\SessionStore;
+use Symfony\AI\Chat\Bridge\HttpFoundation\MessageStore as SessionMessageStore;
 use Symfony\AI\Chat\Bridge\Meilisearch\MessageStore as MeilisearchMessageStore;
 use Symfony\AI\Chat\Bridge\MongoDb\MessageStore as MongoDbMessageStore;
 use Symfony\AI\Chat\Bridge\Pogocache\MessageStore as PogocacheMessageStore;
@@ -1961,7 +1961,7 @@ final class AiBundle extends AbstractBundle
 
         if ('session' === $type) {
             foreach ($messageStores as $name => $messageStore) {
-                $definition = new Definition(SessionStore::class);
+                $definition = new Definition(SessionMessageStore::class);
                 $definition
                     ->setLazy(true)
                     ->setArguments([

--- a/src/chat/src/Bridge/HttpFoundation/MessageStore.php
+++ b/src/chat/src/Bridge/HttpFoundation/MessageStore.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class SessionStore implements ManagedStoreInterface, MessageStoreInterface
+final class MessageStore implements ManagedStoreInterface, MessageStoreInterface
 {
     private readonly SessionInterface $session;
 
@@ -30,7 +30,7 @@ final class SessionStore implements ManagedStoreInterface, MessageStoreInterface
         private readonly string $sessionKey = 'messages',
     ) {
         if (!class_exists(RequestStack::class)) {
-            throw new RuntimeException('For using the SessionStore as message store, the symfony/http-foundation package is required. Try running "composer require symfony/http-foundation".');
+            throw new RuntimeException('For using the MessageStore as message store, the symfony/http-foundation package is required. Try running "composer require symfony/http-foundation".');
         }
 
         $this->session = $requestStack->getSession();

--- a/src/chat/tests/Bridge/HttpFoundation/MessageStoreTest.php
+++ b/src/chat/tests/Bridge/HttpFoundation/MessageStoreTest.php
@@ -12,13 +12,13 @@
 namespace Symfony\AI\Chat\Tests\Bridge\HttpFoundation;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\AI\Chat\Bridge\HttpFoundation\SessionStore;
+use Symfony\AI\Chat\Bridge\HttpFoundation\MessageStore;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
-final class SessionStoreTest extends TestCase
+final class MessageStoreTest extends TestCase
 {
     public function testSetupStoresEmptyMessageBag()
     {
@@ -33,7 +33,7 @@ final class SessionStoreTest extends TestCase
             ->method('set')
             ->with('messages', $this->isInstanceOf(MessageBag::class));
 
-        $store = new SessionStore($requestStack, 'messages');
+        $store = new MessageStore($requestStack, 'messages');
         $store->setup();
     }
 
@@ -50,7 +50,7 @@ final class SessionStoreTest extends TestCase
             ->method('set')
             ->with('custom_key', $this->isInstanceOf(MessageBag::class));
 
-        $store = new SessionStore($requestStack, 'custom_key');
+        $store = new MessageStore($requestStack, 'custom_key');
         $store->setup();
     }
 
@@ -70,7 +70,7 @@ final class SessionStoreTest extends TestCase
             ->method('set')
             ->with('messages', $messageBag);
 
-        $store = new SessionStore($requestStack, 'messages');
+        $store = new MessageStore($requestStack, 'messages');
         $store->save($messageBag);
     }
 
@@ -91,7 +91,7 @@ final class SessionStoreTest extends TestCase
             ->with('messages', $this->isInstanceOf(MessageBag::class))
             ->willReturn($messageBag);
 
-        $store = new SessionStore($requestStack, 'messages');
+        $store = new MessageStore($requestStack, 'messages');
         $result = $store->load();
 
         $this->assertSame($messageBag, $result);
@@ -112,7 +112,7 @@ final class SessionStoreTest extends TestCase
             ->with('messages', $this->isInstanceOf(MessageBag::class))
             ->willReturn(new MessageBag());
 
-        $store = new SessionStore($requestStack, 'messages');
+        $store = new MessageStore($requestStack, 'messages');
         $result = $store->load();
 
         $this->assertInstanceOf(MessageBag::class, $result);
@@ -132,7 +132,7 @@ final class SessionStoreTest extends TestCase
             ->method('remove')
             ->with('messages');
 
-        $store = new SessionStore($requestStack, 'messages');
+        $store = new MessageStore($requestStack, 'messages');
         $store->drop();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Renamed HttpFoundation\SessionStore to HttpFoundation\MessageStore for consistency with other message store bridges in the chat component.