### PR TITLE
[AI Bundle] Fix profiler serialization error with unconsumed streams

### DIFF
--- a/src/ai-bundle/src/Profiler/DataCollector.php
+++ b/src/ai-bundle/src/Profiler/DataCollector.php
@@ -155,7 +155,8 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
             if (isset($platform->resultCache[$result])) {
                 $call['result'] = $platform->resultCache[$result];
             } else {
-                $call['result'] = $result->getContent();
+                $content = $result->getContent();
+                $call['result'] = $content instanceof \Generator ? null : $content;
             }
 
             $call['metadata'] = $result->getMetadata();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1121
| License       | MIT

## Summary

Fix serialization error when using streaming models with the profiler.

When using a streaming agent, the `DataCollector` tries to serialize a `Generator` object which PHP doesn't allow. This happens when the stream hasn't been consumed before the profiler collects data.

**Error:**
```
Serialization of 'Generator' is not allowed
```

**Fix:**
Return `null` instead of the raw `Generator` when the stream hasn't been consumed. The actual content is only available after the stream is iterated, so there's nothing to display anyway.

- If stream is consumed → profiler shows the accumulated content (via `resultCache`)
- If stream is not consumed → profiler shows `null` instead of crashing
