### PR TITLE
[AI Bundle] Fix PHPDoc type for collected platform call data

### DIFF
--- a/src/ai-bundle/src/Profiler/DataCollector.php
+++ b/src/ai-bundle/src/Profiler/DataCollector.php
@@ -25,6 +25,14 @@ use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
  * @phpstan-import-type PlatformCallData from TraceablePlatform
  * @phpstan-import-type MessageStoreData from TraceableMessageStore
  * @phpstan-import-type ChatData from TraceableChat
+ *
+ * @phpstan-type CollectedPlatformCallData array{
+ *     model: string,
+ *     input: array<mixed>|string|object,
+ *     options: array<string, mixed>,
+ *     result: string|iterable<mixed>|object|null,
+ *     metadata: Metadata,
+ * }
  */
 final class DataCollector extends AbstractDataCollector implements LateDataCollectorInterface
 {
@@ -88,7 +96,7 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
     }
 
     /**
-     * @return PlatformCallData[]
+     * @return CollectedPlatformCallData[]
      */
     public function getPlatformCalls(): array
     {
@@ -136,13 +144,7 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
     }
 
     /**
-     * @return array{
-     *     model: string,
-     *     input: array<mixed>|string|object,
-     *     options: array<string, mixed>,
-     *     result: string|iterable<mixed>|object|null,
-     *     metadata: Metadata,
-     * }[]
+     * @return CollectedPlatformCallData[]
      */
     private function awaitCallResults(TraceablePlatform $platform): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

This PR fixes the PHPDoc type for `DataCollector::getPlatformCalls()`.

## Problem

The `PlatformCallData` type (defined in `TraceablePlatform`) declares `result: DeferredResult`. However, after `DataCollector::lateCollect()` processes the data through `awaitCallResults()`, the `result` field is transformed to `string|iterable|object|null` and a `metadata` field is added.

This causes PHPStan errors when testing code that accesses the transformed data (e.g., `assertNull($dataCollector->getPlatformCalls()[0]['result'])`).

## Solution

Introduce a new PHPDoc type `CollectedPlatformCallData` that accurately describes the data returned by `getPlatformCalls()` after transformation:

```php
@phpstan-type CollectedPlatformCallData array{
    model: string,
    input: array<mixed>|string|object,
    options: array<string, mixed>,
    result: string|iterable<mixed>|object|null,
    metadata: Metadata,
}
```