### PR TITLE
[CI] Fix bridge test matrix include creating jobs without bridge info

### DIFF
--- a/.github/workflows/build-matrix.yaml
+++ b/.github/workflows/build-matrix.yaml
@@ -15,12 +15,21 @@ on:
             store-bridges:
                 description: 'List of store bridges'
                 value: ${{ jobs.matrix.outputs.store-bridges }}
+            store-bridges-include:
+                description: 'Store bridges includes for test matrix'
+                value: ${{ jobs.matrix.outputs.store-bridges-include }}
             tool-bridges:
                 description: 'List of tool bridges'
                 value: ${{ jobs.matrix.outputs.tool-bridges }}
+            tool-bridges-include:
+                description: 'Tool bridges includes for test matrix'
+                value: ${{ jobs.matrix.outputs.tool-bridges-include }}
             platform-bridges:
                 description: 'List of platform bridges'
                 value: ${{ jobs.matrix.outputs.platform-bridges }}
+            platform-bridges-include:
+                description: 'Platform bridges includes for test matrix'
+                value: ${{ jobs.matrix.outputs.platform-bridges-include }}
 
 jobs:
     matrix:
@@ -31,8 +40,11 @@ jobs:
             packages-include: ${{ steps.set-matrix.outputs.packages-include }}
             bridges: ${{ steps.set-matrix.outputs.bridges }}
             store-bridges: ${{ steps.set-matrix.outputs.store-bridges }}
+            store-bridges-include: ${{ steps.set-matrix.outputs.store-bridges-include }}
             tool-bridges: ${{ steps.set-matrix.outputs.tool-bridges }}
+            tool-bridges-include: ${{ steps.set-matrix.outputs.tool-bridges-include }}
             platform-bridges: ${{ steps.set-matrix.outputs.platform-bridges }}
+            platform-bridges-include: ${{ steps.set-matrix.outputs.platform-bridges-include }}
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -75,6 +87,31 @@ jobs:
                   echo "store-bridges=$(echo "$STORE_BRIDGES" | jq -c 'map(del(.type))')" >> $GITHUB_OUTPUT
                   echo "tool-bridges=$(echo "$TOOL_BRIDGES" | jq -c 'map(del(.type))')" >> $GITHUB_OUTPUT
                   echo "platform-bridges=$(echo "$PLATFORM_BRIDGES" | jq -c 'map({bridge: .bridge})')" >> $GITHUB_OUTPUT
+
+                  # Bridge includes (8.2 lowest, 8.2 highest, 8.5 highest)
+                  STORE_BRIDGES_INCLUDE=$(echo "$STORE_BRIDGES" | jq -c '
+                      . as $bridges |
+                      ($bridges | map({bridge: {component: .component, bridge: .bridge}, "php-version": "8.2", "dependency-version": "lowest"})) +
+                      ($bridges | map({bridge: {component: .component, bridge: .bridge}, "php-version": "8.2", "dependency-version": "highest"})) +
+                      ($bridges | map({bridge: {component: .component, bridge: .bridge}, "php-version": "8.5", "dependency-version": "highest"}))
+                  ')
+                  echo "store-bridges-include=$STORE_BRIDGES_INCLUDE" >> $GITHUB_OUTPUT
+
+                  TOOL_BRIDGES_INCLUDE=$(echo "$TOOL_BRIDGES" | jq -c '
+                      . as $bridges |
+                      ($bridges | map({bridge: {component: .component, bridge: .bridge}, "php-version": "8.2", "dependency-version": "lowest"})) +
+                      ($bridges | map({bridge: {component: .component, bridge: .bridge}, "php-version": "8.2", "dependency-version": "highest"})) +
+                      ($bridges | map({bridge: {component: .component, bridge: .bridge}, "php-version": "8.5", "dependency-version": "highest"}))
+                  ')
+                  echo "tool-bridges-include=$TOOL_BRIDGES_INCLUDE" >> $GITHUB_OUTPUT
+
+                  PLATFORM_BRIDGES_INCLUDE=$(echo "$PLATFORM_BRIDGES" | jq -c '
+                      . as $bridges |
+                      ($bridges | map({bridge: {bridge: .bridge}, "php-version": "8.2", "dependency-version": "lowest"})) +
+                      ($bridges | map({bridge: {bridge: .bridge}, "php-version": "8.2", "dependency-version": "highest"})) +
+                      ($bridges | map({bridge: {bridge: .bridge}, "php-version": "8.5", "dependency-version": "highest"}))
+                  ')
+                  echo "platform-bridges-include=$PLATFORM_BRIDGES_INCLUDE" >> $GITHUB_OUTPUT
 
                   # Package includes (lowest, Symfony 7.4, Symfony 8.0)
                   PACKAGES_INCLUDE=$(echo "$PACKAGES" | jq -c '

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,12 +76,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                bridge: ${{ fromJson(needs.matrix.outputs.store-bridges) }}
-                php-version: ['8.2', '8.5']
-                dependency-version: ['highest']
-                include:
-                    -   php-version: '8.2'
-                        dependency-version: 'lowest'
+                include: ${{ fromJson(needs.matrix.outputs.store-bridges-include) }}
 
         steps:
             - name: Checkout
@@ -115,12 +110,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                bridge: ${{ fromJson(needs.matrix.outputs.tool-bridges) }}
-                php-version: ['8.2', '8.5']
-                dependency-version: ['highest']
-                include:
-                    -   php-version: '8.2'
-                        dependency-version: 'lowest'
+                include: ${{ fromJson(needs.matrix.outputs.tool-bridges-include) }}
 
         steps:
             - name: Checkout
@@ -154,12 +144,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                bridge: ${{ fromJson(needs.matrix.outputs.platform-bridges) }}
-                php-version: ['8.2', '8.5']
-                dependency-version: ['highest']
-                include:
-                    -   php-version: '8.2'
-                        dependency-version: 'lowest'
+                include: ${{ fromJson(needs.matrix.outputs.platform-bridges-include) }}
 
         steps:
             - name: Checkout


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

The `include` directive in GitHub Actions matrix adds separate combinations rather than multiplying with existing matrix values. This caused jobs to be created with only php-version and dependency-version set, but no bridge object, resulting in "Unable to find working directory at 'src/src/Bridge/'" errors.

Fix by generating full include arrays in build-matrix.yaml with the bridge info nested under a 'bridge' key. Each bridge now gets tested with:
- PHP 8.2 lowest
- PHP 8.2 highest
- PHP 8.5 highest

# error
<img width="1084" height="176" alt="CleanShot 2025-12-18 at 11 59 55@2x" src="https://github.com/user-attachments/assets/fbe4e9a5-607f-448b-836e-26e48ccb67f1" />
<img width="1872" height="1340" alt="CleanShot 2025-12-18 at 12 00 18@2x" src="https://github.com/user-attachments/assets/d3d082ff-5efb-4857-bb62-dc10591b4ab5" />
