### PR TITLE
[CI] Only run bridge validation when corresponding bridge folder changes

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -25,8 +25,33 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    changes:
+        name: Detect Changes
+        runs-on: ubuntu-latest
+        outputs:
+            store: ${{ steps.filter.outputs.store }}
+            tool: ${{ steps.filter.outputs.tool }}
+            platform: ${{ steps.filter.outputs.platform }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Filter paths
+              id: filter
+              uses: dorny/paths-filter@v3
+              with:
+                  filters: |
+                      store:
+                        - 'src/store/src/Bridge/**'
+                      tool:
+                        - 'src/agent/src/Bridge/**'
+                      platform:
+                        - 'src/platform/src/Bridge/**'
+
     validate_stores:
         name: Store Bridges
+        needs: changes
+        if: needs.changes.outputs.store == 'true'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -43,6 +68,8 @@ jobs:
 
     validate_tools:
         name: Tool Bridges
+        needs: changes
+        if: needs.changes.outputs.tool == 'true'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -59,6 +86,8 @@ jobs:
 
     validate_platforms:
         name: Platform Bridges
+        needs: changes
+        if: needs.changes.outputs.platform == 'true'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -72,3 +101,4 @@ jobs:
 
             - name: Validate platform bridges have required files
               run: .github/scripts/validate-bridge-files.sh platform
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Use dorny/paths-filter to detect which bridge folders have changes and conditionally run only the relevant validation jobs.