### PR TITLE
[Agent] Remove ai-platform from "require-dev" section of composer.json

### DIFF
--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -41,7 +41,6 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5.46",
-        "symfony/ai-platform": "@dev",
         "symfony/ai-store": "@dev",
         "symfony/event-dispatcher": "^7.3|^8.0",
         "symfony/translation": "^7.3|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        |
| License       | MIT

It's already in "require" section
