### PR TITLE
[AI Bundle] Remove dependency from AI bundle to OpenAI Bridge

### DIFF
--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Config\Definition\Configurator;
 use Codewithkyrian\ChromaDB\Client as ChromaDbClient;
 use MongoDB\Client as MongoDbClient;
 use Probots\Pinecone\Client as PineconeClient;
-use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\PlatformInterface;
@@ -166,7 +165,7 @@ return static function (DefinitionConfigurator $configurator): void {
                             ->scalarNode('region')
                                 ->defaultNull()
                                 ->validate()
-                                    ->ifNotInArray([null, PlatformFactory::REGION_EU, PlatformFactory::REGION_US])
+                                    ->ifNotInArray([null, 'EU', 'US'])
                                     ->thenInvalid('The region must be either "EU" (https://eu.api.openai.com), "US" (https://us.api.openai.com) or null (https://api.openai.com)')
                                 ->end()
                                 ->info('The region for OpenAI API (EU, US, or null for default)')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1202
| License       | MIT

Remove the constants of the open AI Bridge in the AI Bundle configuration to remove the hard dependency. I think it is the better solution instead of adding the bridge to the composer.json.