### PR TITLE
[Store] Add `$options` argument to `ManagedStoreInterface::drop()`

### DIFF
--- a/src/store/src/Bridge/Cache/Store.php
+++ b/src/store/src/Bridge/Cache/Store.php
@@ -91,7 +91,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         yield from $this->distanceCalculator->calculate($vectorDocuments, $vector, $options['maxItems'] ?? null);
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->cache->clear();
     }

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -48,7 +48,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         $this->execute('POST', $sql);
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->execute('POST', 'DROP TABLE IF EXISTS {{ table }}');
     }

--- a/src/store/src/Bridge/Cloudflare/Store.php
+++ b/src/store/src/Bridge/Cloudflare/Store.php
@@ -52,7 +52,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->request('DELETE', \sprintf('vectorize/v2/indexes/%s', $this->index));
     }

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -54,7 +54,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $indexExistResponse = $this->httpClient->request('HEAD', \sprintf('%s/%s', $this->endpoint, $this->indexName));
 

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -50,7 +50,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ));
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->request('cli', \sprintf('DROP TABLE %s', $this->table));
     }

--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -76,7 +76,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->connection->exec(\sprintf('DROP TABLE IF EXISTS %s', $this->tableName));
     }

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -101,7 +101,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->request('DELETE', \sprintf('indexes/%s', $this->indexName), []);
     }

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -122,7 +122,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->request('POST', 'v2/vectordb/databases/drop', [
             'dbName' => $this->database,

--- a/src/store/src/Bridge/MongoDb/Store.php
+++ b/src/store/src/Bridge/MongoDb/Store.php
@@ -99,7 +99,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->getCollection()->drop();
     }

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -79,7 +79,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->request('POST', \sprintf('db/%s/query/v2', $this->databaseName), [
             'statement' => 'MATCH (n) DETACH DELETE n',

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -60,7 +60,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $indexExistResponse = $this->httpClient->request('HEAD', \sprintf('%s/%s', $this->endpoint, $this->indexName));
 

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -75,7 +75,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->connection->exec(\sprintf('DROP TABLE IF EXISTS %s', $this->tableName));
     }

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -103,7 +103,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->request('DELETE', \sprintf('collections/%s', $this->collectionName));
     }

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -67,7 +67,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         $this->redis->clearLastError();
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         try {
             $this->redis->rawCommand('FT.DROPINDEX', $this->indexName);

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -75,7 +75,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->authenticate();
 

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -86,7 +86,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->request('DELETE', \sprintf('collections/%s', $this->collection), []);
     }

--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -78,7 +78,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->request('DELETE', \sprintf('v1/schema/%s', $this->collection), []);
     }

--- a/src/store/src/InMemory/Store.php
+++ b/src/store/src/InMemory/Store.php
@@ -65,7 +65,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         yield from $this->distanceCalculator->calculate($documents, $vector, $options['maxItems'] ?? null);
     }
 
-    public function drop(): void
+    public function drop(array $options = []): void
     {
         $this->documents = [];
     }

--- a/src/store/src/ManagedStoreInterface.php
+++ b/src/store/src/ManagedStoreInterface.php
@@ -21,5 +21,8 @@ interface ManagedStoreInterface
      */
     public function setup(array $options = []): void;
 
-    public function drop(): void;
+    /**
+     * @param array<mixed> $options
+     */
+    public function drop(array $options = []): void;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| License       | MIT

As requested here https://github.com/symfony/ai/pull/865#pullrequestreview-3573291456
I'm splitting the PR into two parts. First, add `array $options` to the `ManagedStoreInterface`, and in another PR I'll implement a `ManagedStore` for Pinecone 
