### PR TITLE
 Remove redundant mongodb/mongodb conflict from examples

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -138,9 +138,6 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-strict-rules": "^2.0"
     },
-    "conflict": {
-        "mongodb/mongodb": "<1.21"
-    },
     "minimum-stability": "dev",
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

The conflict is already declared in the required packages symfony/ai-mongo-db-store and symfony/ai-mongo-db-message-store.