### PR TITLE
 Remove message store bridge path repositories

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -19,42 +19,6 @@
         {
             "type": "path",
             "url": "../src/store"
-        },
-        {
-            "type": "path",
-            "url": "../src/chat/src/Bridge/Cache"
-        },
-        {
-            "type": "path",
-            "url": "../src/chat/src/Bridge/Cloudflare"
-        },
-        {
-            "type": "path",
-            "url": "../src/chat/src/Bridge/Doctrine"
-        },
-        {
-            "type": "path",
-            "url": "../src/chat/src/Bridge/Session"
-        },
-        {
-            "type": "path",
-            "url": "../src/chat/src/Bridge/Meilisearch"
-        },
-        {
-            "type": "path",
-            "url": "../src/chat/src/Bridge/MongoDb"
-        },
-        {
-            "type": "path",
-            "url": "../src/chat/src/Bridge/Pogocache"
-        },
-        {
-            "type": "path",
-            "url": "../src/chat/src/Bridge/Redis"
-        },
-        {
-            "type": "path",
-            "url": "../src/chat/src/Bridge/SurrealDb"
         }
     ],
     "require": {

--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -3,44 +3,6 @@
     "description": "Integration bundle for Symfony AI components",
     "license": "MIT",
     "type": "symfony-bundle",
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../chat/src/Bridge/Cache"
-        },
-        {
-            "type": "path",
-            "url": "../chat/src/Bridge/Cloudflare"
-        },
-        {
-            "type": "path",
-            "url": "../chat/src/Bridge/Doctrine"
-        },
-        {
-            "type": "path",
-            "url": "../chat/src/Bridge/Meilisearch"
-        },
-        {
-            "type": "path",
-            "url": "../chat/src/Bridge/MongoDb"
-        },
-        {
-            "type": "path",
-            "url": "../chat/src/Bridge/Pogocache"
-        },
-        {
-            "type": "path",
-            "url": "../chat/src/Bridge/Redis"
-        },
-        {
-            "type": "path",
-            "url": "../chat/src/Bridge/Session"
-        },
-        {
-            "type": "path",
-            "url": "../chat/src/Bridge/SurrealDb"
-        }
-    ],
     "authors": [
         {
             "name": "Christopher Hertel",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

The message store bridge packages now exist as proper packages, so the path repository entries are no longer needed.