### PR TITLE
 Add bump script for updating symfony/ai-* dependency versions

### DIFF
--- a/bump
+++ b/bump
@@ -1,0 +1,86 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require __DIR__.'/vendor/autoload.php';
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Bumps the version constraint for symfony/ai-* dependencies across the monorepo.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+
+$version = $argv[1] ?? null;
+
+if (!$version) {
+    echo 'Bumps the version constraint for symfony/ai-* dependencies across the monorepo.'.PHP_EOL.PHP_EOL;
+    echo "Usage: $argv[0] <version-constraint>".PHP_EOL.PHP_EOL;
+    echo 'Examples:'.PHP_EOL;
+    echo "  $argv[0] ^0.1".PHP_EOL;
+    echo "  $argv[0] ~0.1.0".PHP_EOL;
+    echo "  $argv[0] @dev".PHP_EOL.PHP_EOL;
+    exit(1);
+}
+
+$filesystem = new Filesystem();
+$totalUpdates = 0;
+
+// Find all composer.json files in src, demo, and examples directories
+$finder = new Finder();
+$finder->files()
+    ->name('composer.json')
+    ->in([__DIR__.'/src', __DIR__.'/demo', __DIR__.'/examples'])
+    ->exclude('vendor');
+
+echo sprintf('Found %d composer.json files to process:'.PHP_EOL, $finder->count());
+
+foreach ($finder as $file) {
+    $composerFile = $file->getRealPath();
+    $content = $file->getContents();
+    $data = json_decode($content, true);
+
+    if (!$data) {
+        echo \sprintf(' ⚠ Skipping "%s" (invalid JSON)'.PHP_EOL, $file->getRelativePathname());
+        continue;
+    }
+
+    $modified = false;
+    $fileUpdates = 0;
+
+    foreach ($data['require'] ?? [] as $package => $constraint) {
+        if (str_starts_with($package, 'symfony/ai-')) {
+            $data['require'][$package] = $version;
+            $modified = true;
+            ++$fileUpdates;
+        }
+    }
+
+    foreach ($data['require-dev'] ?? [] as $package => $constraint) {
+        if (str_starts_with($package, 'symfony/ai-')) {
+            $data['require-dev'][$package] = $version;
+            $modified = true;
+            ++$fileUpdates;
+        }
+    }
+
+    // Write back if modified
+    if ($modified) {
+        $newContent = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n";
+        $filesystem->dumpFile($composerFile, $newContent);
+        $totalUpdates += $fileUpdates;
+        echo \sprintf(' ✓ Saved "%s" with %d change(s)'.PHP_EOL, str_replace(__DIR__.'/', '', $file->getRealPath()), $fileUpdates);
+    }
+}
+
+echo PHP_EOL.sprintf('✅ Successfully updated %d dependency constraints in %d files to "%s".'.PHP_EOL, $totalUpdates, $finder->count(), $version);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Add a new `bump` script at the repository root that updates version constraints for all symfony/ai-* dependencies across the monorepo.

## Features

1. **Accepts version constraint as argument** - Examples: `^0.1`, `~0.1.0`, `@dev`

2. **Scans all relevant directories** - Automatically finds `composer.json` files in:
   - `src/` (all components)
   - `demo/`
   - `examples/`
   - Including bridges in `src/*/src/Bridge/*`

3. **Updates `symfony/ai-*` dependencies** - Changes version constraints in both:
   - `require` section
   - `require-dev` section

4. **Helpful CLI output** showing:
   - Number of composer.json files found
   - Summary of files saved with change counts
   - Total number of dependency constraints updated

## Usage

```bash
# Show help
./bump

# Bump all symfony/ai-* dependencies to ^0.1
./bump "^0.1"

# Use @dev version
./bump "@dev"

# Use specific version
./bump "~0.1.0"
```

Similar to the existing `link` script, this tool helps maintain consistent versioning across all components during releases.

<img width="629" height="1251" alt="image" src="https://github.com/user-attachments/assets/61d6c3c4-4b35-4112-8c6c-865587decd2d" />
