### PR TITLE
[Platform][DeepSeek] Add `TokenUsageExtractor` tests

### DIFF
--- a/src/platform/src/Bridge/DeepSeek/Tests/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/DeepSeek/Tests/TokenUsageExtractorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\DeepSeek;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\DeepSeek\TokenUsageExtractor;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class TokenUsageExtractorTest extends TestCase
+{
+    public function testItHandlesStreamResponsesWithoutProcessing()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $this->assertNull($extractor->extract(new InMemoryRawResult(), ['stream' => true]));
+    }
+
+    public function testItDoesNothingWithoutUsageData()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $this->assertNull($extractor->extract(new InMemoryRawResult(['some' => 'data'])));
+    }
+
+    public function testItExtractsTokenUsage()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 20,
+                'total_tokens' => 30,
+                'prompt_cache_hit_tokens' => 5,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(10, $tokenUsage->getPromptTokens());
+        $this->assertSame(20, $tokenUsage->getCompletionTokens());
+        $this->assertSame(5, $tokenUsage->getCachedTokens());
+        $this->assertSame(30, $tokenUsage->getTotalTokens());
+    }
+
+    public function testItHandlesMissingUsageFields()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 10,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(10, $tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getCompletionTokens());
+        $this->assertNull($tokenUsage->getCachedTokens());
+        $this->assertNull($tokenUsage->getTotalTokens());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Add test coverage for the DeepSeek TokenUsageExtractor including tests for stream handling, missing usage data, full token extraction, and partial usage fields.