### PR TITLE
 Use `assertSame()` over `assertEquals()` where appropriate

### DIFF
--- a/src/agent/tests/AgentTest.php
+++ b/src/agent/tests/AgentTest.php
@@ -105,7 +105,7 @@ final class AgentTest extends TestCase
 
         $agent = new Agent($platform, 'gpt-4o');
 
-        $this->assertEquals('gpt-4o', $agent->getModel());
+        $this->assertSame('gpt-4o', $agent->getModel());
     }
 
     public function testCallProcessesInputThroughProcessors()

--- a/src/agent/tests/Toolbox/ToolboxEventDispatcherTest.php
+++ b/src/agent/tests/Toolbox/ToolboxEventDispatcherTest.php
@@ -63,7 +63,7 @@ final class ToolboxEventDispatcherTest extends TestCase
             $this->toolbox->execute(new ToolCall('call_1234', 'tool_exception'));
         } catch (\Throwable) {
         }
-        $this->assertEquals([
+        $this->assertSame([
             ToolCallArgumentsResolved::class,
             ToolCallFailed::class,
         ], $this->dispatchedEvents);
@@ -75,7 +75,7 @@ final class ToolboxEventDispatcherTest extends TestCase
             $this->toolbox->execute(new ToolCall('call_1234', 'tool_custom_exception'));
         } catch (\Throwable) {
         }
-        $this->assertEquals([
+        $this->assertSame([
             ToolCallArgumentsResolved::class,
             ToolCallFailed::class,
         ], $this->dispatchedEvents);
@@ -87,7 +87,7 @@ final class ToolboxEventDispatcherTest extends TestCase
             $this->toolbox->execute(new ToolCall('call_1234', 'tool_no_params'));
         } catch (\Throwable) {
         }
-        $this->assertEquals([
+        $this->assertSame([
             ToolCallArgumentsResolved::class,
             ToolCallSucceeded::class,
         ], $this->dispatchedEvents);

--- a/src/ai-bundle/tests/Command/AgentCallCommandTest.php
+++ b/src/ai-bundle/tests/Command/AgentCallCommandTest.php
@@ -217,14 +217,14 @@ final class AgentCallCommandTest extends TestCase
             // If system prompt is not shown, let's not assert it
             // This happens because the MessageBag is not preserved across calls in our mock
             $this->assertStringContainsString('Response', $output);
-            $this->assertEquals(2, substr_count($output, 'Response'));
+            $this->assertSame(2, substr_count($output, 'Response'));
         } else {
             // System prompt should appear only once (after first message)
-            $this->assertEquals(1, substr_count($output, 'System Prompt'));
+            $this->assertSame(1, substr_count($output, 'System Prompt'));
             $this->assertStringContainsString('System prompt', $output);
 
             // Both responses should be shown
-            $this->assertEquals(2, substr_count($output, 'Response'));
+            $this->assertSame(2, substr_count($output, 'Response'));
         }
     }
 

--- a/src/platform/src/Bridge/Anthropic/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ModelClientTest.php
@@ -31,13 +31,13 @@ class ModelClientTest extends TestCase
     public function testAnthropicBetaHeaderIsSetWithSingleBetaFeature()
     {
         $this->httpClient = new MockHttpClient(function ($method, $url, $options) {
-            $this->assertEquals('POST', $method);
-            $this->assertEquals('https://api.anthropic.com/v1/messages', $url);
+            self::assertSame('POST', $method);
+            self::assertSame('https://api.anthropic.com/v1/messages', $url);
 
             $headers = $this->parseHeaders($options['headers']);
 
             $this->assertArrayHasKey('anthropic-beta', $headers);
-            $this->assertEquals('feature-1', $headers['anthropic-beta']);
+            self::assertSame('feature-1', $headers['anthropic-beta']);
 
             return new JsonMockResponse('{"success": true}');
         });
@@ -54,7 +54,7 @@ class ModelClientTest extends TestCase
             $headers = $this->parseHeaders($options['headers']);
 
             $this->assertArrayHasKey('anthropic-beta', $headers);
-            $this->assertEquals('feature-1,feature-2,feature-3', $headers['anthropic-beta']);
+            self::assertSame('feature-1,feature-2,feature-3', $headers['anthropic-beta']);
 
             return new JsonMockResponse('{"success": true}');
         });

--- a/src/store/src/Bridge/Qdrant/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Qdrant/Tests/StoreTest.php
@@ -156,7 +156,7 @@ final class StoreTest extends TestCase
 
         $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use ($document): JsonMockResponse {
             self::assertArrayHasKey('wait', $options['query']);
-            self::assertEquals('true', $options['query']['wait']);
+            self::assertSame('true', $options['query']['wait']);
 
             return new JsonMockResponse([
                 'time' => 0.002,
@@ -188,7 +188,7 @@ final class StoreTest extends TestCase
 
         $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): JsonMockResponse {
             self::assertArrayHasKey('wait', $options['query']);
-            self::assertEquals('false', $options['query']['wait']);
+            self::assertSame('false', $options['query']['wait']);
 
             return new JsonMockResponse([
                 'time' => 0.002,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Replace assertEquals() with assertSame() for primitive type comparisons (strings, integers, class name arrays) in test files to ensure strict type checking.
