### PR TITLE
 Use dynamic paths in bridge PHPStan configs

### DIFF
--- a/src/agent/src/Bridge/Brave/phpstan.dist.neon
+++ b/src/agent/src/Bridge/Brave/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Brave.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/agent/src/Bridge/Clock/phpstan.dist.neon
+++ b/src/agent/src/Bridge/Clock/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Clock.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/agent/src/Bridge/Firecrawl/phpstan.dist.neon
+++ b/src/agent/src/Bridge/Firecrawl/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Firecrawl.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/agent/src/Bridge/Mapbox/phpstan.dist.neon
+++ b/src/agent/src/Bridge/Mapbox/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Mapbox.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/agent/src/Bridge/OpenMeteo/phpstan.dist.neon
+++ b/src/agent/src/Bridge/OpenMeteo/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - OpenMeteo.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/agent/src/Bridge/Scraper/phpstan.dist.neon
+++ b/src/agent/src/Bridge/Scraper/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Scraper.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/agent/src/Bridge/SerpApi/phpstan.dist.neon
+++ b/src/agent/src/Bridge/SerpApi/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - SerpApi.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/agent/src/Bridge/SimilaritySearch/phpstan.dist.neon
+++ b/src/agent/src/Bridge/SimilaritySearch/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - SimilaritySearch.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/agent/src/Bridge/Tavily/phpstan.dist.neon
+++ b/src/agent/src/Bridge/Tavily/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Tavily.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/agent/src/Bridge/Wikipedia/phpstan.dist.neon
+++ b/src/agent/src/Bridge/Wikipedia/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Wikipedia.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/agent/src/Bridge/Youtube/phpstan.dist.neon
+++ b/src/agent/src/Bridge/Youtube/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - YoutubeTranscriber.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/chat/src/Bridge/Cache/phpstan.dist.neon
+++ b/src/chat/src/Bridge/Cache/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - MessageStore.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/chat/src/Bridge/Cloudflare/phpstan.dist.neon
+++ b/src/chat/src/Bridge/Cloudflare/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - MessageStore.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/chat/src/Bridge/Doctrine/phpstan.dist.neon
+++ b/src/chat/src/Bridge/Doctrine/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - DoctrineDbalMessageStore.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/chat/src/Bridge/Meilisearch/phpstan.dist.neon
+++ b/src/chat/src/Bridge/Meilisearch/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - MessageStore.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/chat/src/Bridge/MongoDb/phpstan.dist.neon
+++ b/src/chat/src/Bridge/MongoDb/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - MessageStore.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/chat/src/Bridge/Pogocache/phpstan.dist.neon
+++ b/src/chat/src/Bridge/Pogocache/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - MessageStore.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/chat/src/Bridge/Redis/phpstan.dist.neon
+++ b/src/chat/src/Bridge/Redis/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - MessageStore.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/chat/src/Bridge/Session/phpstan.dist.neon
+++ b/src/chat/src/Bridge/Session/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - MessageStore.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/chat/src/Bridge/SurrealDb/phpstan.dist.neon
+++ b/src/chat/src/Bridge/SurrealDb/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - MessageStore.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/AzureSearch/phpstan.dist.neon
+++ b/src/store/src/Bridge/AzureSearch/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - SearchStore.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Cache/phpstan.dist.neon
+++ b/src/store/src/Bridge/Cache/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/ChromaDb/phpstan.dist.neon
+++ b/src/store/src/Bridge/ChromaDb/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/ClickHouse/phpstan.dist.neon
+++ b/src/store/src/Bridge/ClickHouse/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Cloudflare/phpstan.dist.neon
+++ b/src/store/src/Bridge/Cloudflare/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Elasticsearch/phpstan.dist.neon
+++ b/src/store/src/Bridge/Elasticsearch/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/ManticoreSearch/phpstan.dist.neon
+++ b/src/store/src/Bridge/ManticoreSearch/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/MariaDb/phpstan.dist.neon
+++ b/src/store/src/Bridge/MariaDb/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Meilisearch/phpstan.dist.neon
+++ b/src/store/src/Bridge/Meilisearch/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Milvus/phpstan.dist.neon
+++ b/src/store/src/Bridge/Milvus/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/MongoDb/phpstan.dist.neon
+++ b/src/store/src/Bridge/MongoDb/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Neo4j/phpstan.dist.neon
+++ b/src/store/src/Bridge/Neo4j/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/OpenSearch/phpstan.dist.neon
+++ b/src/store/src/Bridge/OpenSearch/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Pinecone/phpstan.dist.neon
+++ b/src/store/src/Bridge/Pinecone/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Postgres/phpstan.dist.neon
+++ b/src/store/src/Bridge/Postgres/phpstan.dist.neon
@@ -4,9 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
-        - Distance.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Qdrant/phpstan.dist.neon
+++ b/src/store/src/Bridge/Qdrant/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Redis/phpstan.dist.neon
+++ b/src/store/src/Bridge/Redis/phpstan.dist.neon
@@ -4,9 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
-        - Distance.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Supabase/phpstan.dist.neon
+++ b/src/store/src/Bridge/Supabase/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/SurrealDb/phpstan.dist.neon
+++ b/src/store/src/Bridge/SurrealDb/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Typesense/phpstan.dist.neon
+++ b/src/store/src/Bridge/Typesense/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/store/src/Bridge/Weaviate/phpstan.dist.neon
+++ b/src/store/src/Bridge/Weaviate/phpstan.dist.neon
@@ -4,8 +4,10 @@ includes:
 parameters:
     level: 6
     paths:
-        - Store.php
+        - .
         - Tests/
+    excludePaths:
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Instead of specifying individual files, use `.` with `excludePaths: vendor/` to automatically include any new files added to bridge directories.