### PR TITLE
[AI Bundle] Fix traceable platform service naming to include platform type to avoid collisions

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -176,7 +176,7 @@ final class AiBundle extends AbstractBundle
                     ->setDecoratedService($platform)
                     ->setArguments([new Reference('.inner')])
                     ->addTag('ai.traceable_platform');
-                $suffix = u($platform)->afterLast('.')->toString();
+                $suffix = u($platform)->after('ai.platform.')->toString();
                 $builder->setDefinition('ai.traceable_platform.'.$suffix, $traceablePlatformDefinition);
             }
         }

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -7006,6 +7006,45 @@ class AiBundleTest extends TestCase
         $this->assertTrue($listenerDefinition->hasTag('kernel.event_subscriber'));
     }
 
+    public function testTraceablePlatformServiceNamingIncludesPlatformType()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'azure' => [
+                        'eu' => [
+                            'api_key' => 'azure_key',
+                            'base_url' => 'myazure.openai.azure.com/',
+                            'deployment' => 'gpt-35-turbo',
+                            'api_version' => '2024-02-15-preview',
+                        ],
+                        'us' => [
+                            'api_key' => 'azure_key_us',
+                            'base_url' => 'myazure-us.openai.azure.com/',
+                            'deployment' => 'gpt-4',
+                            'api_version' => '2024-02-15-preview',
+                        ],
+                    ],
+                    'anthropic' => [
+                        'api_key' => 'anthropic_key',
+                    ],
+                ],
+            ],
+        ]);
+
+        // Verify that traceable platforms include the full platform type to avoid naming collisions
+        // For multi-instance platforms like azure, the service name should be ai.traceable_platform.azure.{instance}
+        $this->assertTrue($container->hasDefinition('ai.traceable_platform.azure.eu'));
+        $this->assertTrue($container->hasDefinition('ai.traceable_platform.azure.us'));
+
+        // For single-instance platforms like anthropic, the service name should be ai.traceable_platform.anthropic
+        $this->assertTrue($container->hasDefinition('ai.traceable_platform.anthropic'));
+
+        // Verify the old naming pattern (just the suffix) is NOT used - this would have caused collisions
+        $this->assertFalse($container->hasDefinition('ai.traceable_platform.eu'));
+        $this->assertFalse($container->hasDefinition('ai.traceable_platform.us'));
+    }
+
     private function buildContainer(array $configuration): ContainerBuilder
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Fixes traceable platform service naming to include the full platform type in the service name and prevents naming collisions when multiple platform types have instances with the same name

**Before:**
- `ai.platform.azure.eu` → `ai.traceable_platform.eu`
- `ai.platform.generic.eu` → `ai.traceable_platform.eu` (collision!)

**After:**
- `ai.platform.azure.eu` → `ai.traceable_platform.azure.eu`
- `ai.platform.generic.eu` → `ai.traceable_platform.generic.eu`

Follows discussion in https://github.com/symfony/ai/pull/1206/files#r2636918060