### PR TITLE
[Platform][VertexAi] Add unit tests for ModelClient classes

### DIFF
--- a/src/platform/src/Bridge/VertexAi/Tests/Embeddings/ModelClientTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Embeddings/ModelClientTest.php
@@ -11,15 +11,35 @@
 
 namespace Symfony\AI\Platform\Bridge\VertexAi\Tests\Embeddings;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\ModelClient;
 use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\TaskType;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
 
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
 final class ModelClientTest extends TestCase
 {
+    public function testItSupportsTheCorrectModel()
+    {
+        $modelClient = new ModelClient(new MockHttpClient(), 'global', 'test-project');
+
+        $this->assertTrue($modelClient->supports(new Model('gemini-embedding-001')));
+    }
+
+    public function testItDoesNotSupportOtherModels()
+    {
+        $modelClient = new ModelClient(new MockHttpClient(), 'global', 'test-project');
+
+        $this->assertFalse($modelClient->supports(new Gpt('gpt-4o')));
+    }
+
     public function testItGeneratesTheEmbeddingSuccessfully()
     {
         $expectedResponse = [
@@ -34,6 +54,257 @@ final class ModelClientTest extends TestCase
         $model = new Model('gemini-embedding-001', options: ['outputDimensionality' => 1536, 'task_type' => TaskType::CLASSIFICATION]);
 
         $result = $client->request($model, 'test payload');
+
+        $this->assertSame($expectedResponse, $result->getData());
+    }
+
+    #[TestWith(['us-central1', 'my-project', 'text-embedding-005'])]
+    #[TestWith(['europe-west1', 'another-project', 'gemini-embedding-001'])]
+    #[TestWith(['asia-east1', 'test-project', 'text-multilingual-embedding-002'])]
+    public function testItBuildsCorrectUrlWithDifferentLocationsAndProjects(string $location, string $projectId, string $modelName)
+    {
+        $expectedUrl = \sprintf(
+            'https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict',
+            $projectId,
+            $location,
+            $modelName,
+        );
+
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url) use ($expectedUrl): HttpResponse {
+                self::assertSame('POST', $method);
+                self::assertSame($expectedUrl, $url);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, $location, $projectId);
+        $client->request(new Model($modelName), 'test');
+    }
+
+    public function testItSendsCorrectContentTypeHeader()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                self::assertContains('Content-Type: application/json', $options['headers']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-embedding-001'), 'test payload');
+    }
+
+    public function testItConvertsStringPayloadToInstances()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('instances', $body);
+                self::assertCount(1, $body['instances']);
+                self::assertSame('Hello, World!', $body['instances'][0]['content']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-embedding-001'), 'Hello, World!');
+    }
+
+    public function testItConvertsArrayPayloadToMultipleInstances()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('instances', $body);
+                self::assertCount(3, $body['instances']);
+                self::assertSame('text1', $body['instances'][0]['content']);
+                self::assertSame('text2', $body['instances'][1]['content']);
+                self::assertSame('text3', $body['instances'][2]['content']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-embedding-001'), ['text1', 'text2', 'text3']);
+    }
+
+    public function testItUsesDefaultTaskTypeRetrievalQuery()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                $body = json_decode($options['body'], true);
+
+                self::assertSame(TaskType::RETRIEVAL_QUERY, $body['instances'][0]['task_type']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-embedding-001'), 'test');
+    }
+
+    #[TestWith([TaskType::CLASSIFICATION])]
+    #[TestWith([TaskType::CLUSTERING])]
+    #[TestWith([TaskType::RETRIEVAL_DOCUMENT])]
+    #[TestWith([TaskType::RETRIEVAL_QUERY])]
+    #[TestWith([TaskType::QUESTION_ANSWERING])]
+    #[TestWith([TaskType::FACT_VERIFICATION])]
+    #[TestWith([TaskType::CODE_RETRIEVAL_QUERY])]
+    #[TestWith([TaskType::SEMANTIC_SIMILARITY])]
+    public function testItUsesTaskTypeFromModelOptions(string $taskType)
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options) use ($taskType): HttpResponse {
+                $body = json_decode($options['body'], true);
+
+                self::assertSame($taskType, $body['instances'][0]['task_type']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $model = new Model('gemini-embedding-001', options: ['task_type' => $taskType]);
+        $client->request($model, 'test');
+    }
+
+    public function testItPassesTitleFromOptions()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                $body = json_decode($options['body'], true);
+
+                self::assertSame('My Document Title', $body['instances'][0]['title']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-embedding-001'), 'test', ['title' => 'My Document Title']);
+    }
+
+    public function testItPassesTitleAsNullWhenNotProvided()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('title', $body['instances'][0]);
+                self::assertNull($body['instances'][0]['title']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-embedding-001'), 'test');
+    }
+
+    public function testItPassesOutputDimensionalityFromModelOptions()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('outputDimensionality', $body);
+                self::assertSame(768, $body['outputDimensionality']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $model = new Model('gemini-embedding-001', options: ['outputDimensionality' => 768]);
+        $client->request($model, 'test');
+    }
+
+    public function testItDoesNotIncludeTaskTypeInTopLevelPayload()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                $body = json_decode($options['body'], true);
+
+                // task_type should only be in instances, not at top level
+                self::assertArrayNotHasKey('task_type', $body);
+                // But it should be in each instance
+                self::assertArrayHasKey('task_type', $body['instances'][0]);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $model = new Model('gemini-embedding-001', options: ['task_type' => TaskType::CLASSIFICATION]);
+        $client->request($model, 'test');
+    }
+
+    public function testItMergesModelOptionsWithPayload()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('instances', $body);
+                self::assertArrayHasKey('outputDimensionality', $body);
+                self::assertSame(1536, $body['outputDimensionality']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $model = new Model('gemini-embedding-001', options: [
+            'outputDimensionality' => 1536,
+            'task_type' => TaskType::RETRIEVAL_DOCUMENT,
+        ]);
+        $client->request($model, 'test');
+    }
+
+    public function testItHandlesMultipleTextsWithSameTitleAndTaskType()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                $body = json_decode($options['body'], true);
+
+                self::assertCount(2, $body['instances']);
+
+                foreach ($body['instances'] as $instance) {
+                    self::assertSame('Document Title', $instance['title']);
+                    self::assertSame(TaskType::RETRIEVAL_DOCUMENT, $instance['task_type']);
+                }
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $model = new Model('gemini-embedding-001', options: ['task_type' => TaskType::RETRIEVAL_DOCUMENT]);
+        $client->request($model, ['text1', 'text2'], ['title' => 'Document Title']);
+    }
+
+    public function testItReturnsMultipleEmbeddings()
+    {
+        $expectedResponse = [
+            'predictions' => [
+                ['embeddings' => ['values' => [0.1, 0.2, 0.3]]],
+                ['embeddings' => ['values' => [0.4, 0.5, 0.6]]],
+                ['embeddings' => ['values' => [0.7, 0.8, 0.9]]],
+            ],
+        ];
+
+        $httpClient = new MockHttpClient(new JsonMockResponse($expectedResponse));
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $result = $client->request(new Model('gemini-embedding-001'), ['text1', 'text2', 'text3']);
 
         $this->assertSame($expectedResponse, $result->getData());
     }

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
@@ -11,14 +11,52 @@
 
 namespace Symfony\AI\Platform\Bridge\VertexAi\Tests\Gemini;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ModelClient;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
 
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
 final class ModelClientTest extends TestCase
 {
+    public function testItWrapsHttpClientInEventSourceHttpClient()
+    {
+        $httpClient = new MockHttpClient();
+        $modelClient = new ModelClient($httpClient, 'global', 'test-project');
+
+        $this->assertInstanceOf(ModelClient::class, $modelClient);
+    }
+
+    public function testItAcceptsEventSourceHttpClientDirectly()
+    {
+        $httpClient = new EventSourceHttpClient(new MockHttpClient());
+        $modelClient = new ModelClient($httpClient, 'global', 'test-project');
+
+        $this->assertInstanceOf(ModelClient::class, $modelClient);
+    }
+
+    public function testItSupportsTheCorrectModel()
+    {
+        $modelClient = new ModelClient(new MockHttpClient(), 'global', 'test-project');
+
+        $this->assertTrue($modelClient->supports(new Model('gemini-2.0-flash')));
+    }
+
+    public function testItDoesNotSupportOtherModels()
+    {
+        $modelClient = new ModelClient(new MockHttpClient(), 'global', 'test-project');
+
+        $this->assertFalse($modelClient->supports(new Gpt('gpt-4o')));
+    }
+
     public function testItInvokesTheTextModelsSuccessfully()
     {
         $payload = [
@@ -49,6 +87,88 @@ final class ModelClientTest extends TestCase
         $this->assertSame($expectedResponse, $data);
     }
 
+    #[TestWith(['us-central1', 'my-project', 'gemini-1.5-pro'])]
+    #[TestWith(['europe-west1', 'another-project', 'gemini-2.0-flash'])]
+    #[TestWith(['asia-east1', 'test-project', 'gemini-1.5-flash'])]
+    public function testItBuildsCorrectUrlWithDifferentLocationsAndProjects(string $location, string $projectId, string $modelName)
+    {
+        $expectedUrl = \sprintf(
+            'https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:generateContent',
+            $projectId,
+            $location,
+            $modelName,
+        );
+
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url) use ($expectedUrl): HttpResponse {
+                self::assertSame('POST', $method);
+                self::assertSame($expectedUrl, $url);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, $location, $projectId);
+        $client->request(new Model($modelName), ['contents' => []]);
+    }
+
+    public function testItUsesStreamGenerateContentWhenStreamOptionIsTrue()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url): HttpResponse {
+                self::assertStringContainsString(':streamGenerateContent', $url);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => []], ['stream' => true]);
+    }
+
+    public function testItUsesGenerateContentWhenStreamOptionIsFalse()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url): HttpResponse {
+                self::assertStringContainsString(':generateContent', $url);
+                self::assertStringNotContainsString(':streamGenerateContent', $url);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => []], ['stream' => false]);
+    }
+
+    public function testItConvertsStringPayloadToContentsFormat()
+    {
+        $httpClient = new MockHttpClient(
+            function (string $method, string $url, array $options): HttpResponse {
+                self::assertJsonStringEqualsJsonString(
+                    <<<'JSON'
+                        {
+                          "contents": [
+                            {
+                              "role": "user",
+                              "parts": [
+                                {"text": "Hello, World!"}
+                              ]
+                            }
+                          ]
+                        }
+                        JSON,
+                    $options['body'],
+                );
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), 'Hello, World!');
+    }
+
     public function testItPassesServerToolsFromOptions()
     {
         $payload = [
@@ -58,7 +178,7 @@ final class ModelClientTest extends TestCase
         ];
         $httpClient = new MockHttpClient(
             function ($method, $url, $options) {
-                $this->assertJsonStringEqualsJsonString(
+                self::assertJsonStringEqualsJsonString(
                     <<<'JSON'
                         {
                           "tools": [
@@ -72,11 +192,185 @@ final class ModelClientTest extends TestCase
                     $options['body'],
                 );
 
-                return new JsonMockResponse('{}');
+                return new JsonMockResponse([]);
             }
         );
 
         $client = new ModelClient($httpClient, 'global', 'test');
         $client->request(new Model('gemini-2.0-flash'), $payload, ['server_tools' => ['google_search' => true]]);
+    }
+
+    public function testItPassesServerToolsWithCustomParams()
+    {
+        $payload = ['contents' => []];
+        $httpClient = new MockHttpClient(
+            function ($method, $url, $options) {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('tools', $body);
+                self::assertCount(1, $body['tools']);
+                self::assertArrayHasKey('code_execution', $body['tools'][0]);
+                self::assertSame(['enabled' => true], $body['tools'][0]['code_execution']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), $payload, ['server_tools' => ['code_execution' => ['enabled' => true]]]);
+    }
+
+    public function testItIgnoresServerToolsWithFalsyParams()
+    {
+        $payload = ['contents' => []];
+        $httpClient = new MockHttpClient(
+            function ($method, $url, $options) {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayNotHasKey('tools', $body);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), $payload, ['server_tools' => ['google_search' => false]]);
+    }
+
+    public function testItPassesFunctionDeclarationsFromTools()
+    {
+        $payload = ['contents' => []];
+        $tools = [
+            ['name' => 'get_weather', 'description' => 'Get weather information'],
+            ['name' => 'get_time', 'description' => 'Get current time'],
+        ];
+
+        $httpClient = new MockHttpClient(
+            function ($method, $url, $options) use ($tools) {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('tools', $body);
+                self::assertCount(1, $body['tools']);
+                self::assertArrayHasKey('functionDeclarations', $body['tools'][0]);
+                self::assertSame($tools, $body['tools'][0]['functionDeclarations']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), $payload, ['tools' => $tools]);
+    }
+
+    public function testItCombinesToolsAndServerTools()
+    {
+        $payload = ['contents' => []];
+        $tools = [['name' => 'get_weather']];
+
+        $httpClient = new MockHttpClient(
+            function ($method, $url, $options) {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('tools', $body);
+                self::assertCount(2, $body['tools']);
+                self::assertArrayHasKey('functionDeclarations', $body['tools'][0]);
+                self::assertArrayHasKey('google_search', $body['tools'][1]);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), $payload, [
+            'tools' => $tools,
+            'server_tools' => ['google_search' => true],
+        ]);
+    }
+
+    public function testItHandlesResponseFormatWithJsonSchema()
+    {
+        $payload = ['contents' => []];
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+        ];
+
+        $httpClient = new MockHttpClient(
+            function ($method, $url, $options) {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('generationConfig', $body);
+                self::assertSame('application/json', $body['generationConfig']['responseMimeType']);
+                self::assertSame([
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => ['type' => 'string'],
+                    ],
+                ], $body['generationConfig']['responseSchema']);
+                self::assertArrayNotHasKey(PlatformSubscriber::RESPONSE_FORMAT, $body);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), $payload, [
+            PlatformSubscriber::RESPONSE_FORMAT => [
+                'json_schema' => [
+                    'schema' => $schema,
+                ],
+            ],
+        ]);
+    }
+
+    public function testItPassesGenerationConfigAsObject()
+    {
+        $payload = ['contents' => []];
+
+        $httpClient = new MockHttpClient(
+            function ($method, $url, $options) {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('generationConfig', $body);
+                // The generationConfig should be an object (stdClass when decoded)
+                self::assertSame(['temperature' => 0.7, 'maxOutputTokens' => 1000], $body['generationConfig']);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), $payload, [
+            'generationConfig' => [
+                'temperature' => 0.7,
+                'maxOutputTokens' => 1000,
+            ],
+        ]);
+    }
+
+    public function testItHandlesStreamWithGenerationConfig()
+    {
+        $payload = ['contents' => []];
+
+        $httpClient = new MockHttpClient(
+            function ($method, $url, $options) {
+                $body = json_decode($options['body'], true);
+
+                self::assertArrayHasKey('generation_config', $body);
+                self::assertArrayNotHasKey('generationConfig', $body);
+                self::assertArrayNotHasKey('stream', $body);
+                self::assertStringContainsString(':streamGenerateContent', $url);
+
+                return new JsonMockResponse([]);
+            }
+        );
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), $payload, [
+            'stream' => true,
+            'generationConfig' => ['temperature' => 0.5],
+        ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

This PR adds unit tests for the VertexAi bridge ModelClient classes.