### PR TITLE
[MCP Bundle] Bump mcp/sdk requirement to ^0.2

### DIFF
--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "mcp/sdk": "^0.1",
+        "mcp/sdk": "^0.2",
         "php-http/discovery": "^1.20",
         "symfony/config": "^7.3|^8.0",
         "symfony/console": "^7.3|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

Drops support for mcp/sdk 0.1.