### PR TITLE
[Mate] Make dev explicit for mate composer docs

### DIFF
--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -10,7 +10,7 @@ Installation
 
 .. code-block:: terminal
 
-    $ composer require symfony/ai-mate
+    $ composer require --dev symfony/ai-mate
 
 Purpose
 -------
@@ -33,7 +33,7 @@ Install with composer:
 
 .. code-block:: terminal
 
-    $ composer require symfony/ai-mate
+    $ composer require --dev symfony/ai-mate
 
 Initialize configuration:
 

--- a/src/mate/README.md
+++ b/src/mate/README.md
@@ -7,7 +7,7 @@ tools. This is a development tool, not intended for production use.
 ## Installation
 
 ```bash
-composer require symfony/ai-mate
+composer require --dev symfony/ai-mate
 ```
 
 **This repository is a READ-ONLY sub-tree split**. See

--- a/src/mate/composer.json
+++ b/src/mate/composer.json
@@ -9,7 +9,8 @@
         "model-context-protocol",
         "symfony",
         "debug",
-        "development"
+        "development",
+        "dev"
     ],
     "authors": [
         {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | 
| License       | MIT

we should make it explicit that this is only required in dev and add the `dev` label for adding that on packagist as well