### PR TITLE
[AI Bundle] Fix arguments in DoctrineDbalMessageStore definition

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -1838,7 +1838,6 @@ final class AiBundle extends AbstractBundle
                 $definition
                     ->setLazy(true)
                     ->setArguments([
-                        $dbalMessageStore['connection'],
                         $dbalMessageStore['table_name'] ?? $name,
                         new Reference(\sprintf('doctrine.dbal.%s_connection', $dbalMessageStore['connection'])),
                         new Reference('serializer'),

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -6379,11 +6379,10 @@ class AiBundleTest extends TestCase
         $definition = $container->getDefinition('ai.message_store.doctrine.dbal.default');
 
         $this->assertSame('default', (string) $definition->getArgument(0));
-        $this->assertSame('default', (string) $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(1));
+        $this->assertSame('doctrine.dbal.default_connection', (string) $definition->getArgument(1));
         $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
-        $this->assertSame('doctrine.dbal.default_connection', (string) $definition->getArgument(2));
-        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
-        $this->assertSame('serializer', (string) $definition->getArgument(3));
+        $this->assertSame('serializer', (string) $definition->getArgument(2));
 
         $this->assertSame([
             ['interface' => MessageStoreInterface::class],
@@ -6411,12 +6410,11 @@ class AiBundleTest extends TestCase
 
         $definition = $container->getDefinition('ai.message_store.doctrine.dbal.default');
 
-        $this->assertSame('default', (string) $definition->getArgument(0));
-        $this->assertSame('foo', (string) $definition->getArgument(1));
+        $this->assertSame('foo', (string) $definition->getArgument(0));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(1));
+        $this->assertSame('doctrine.dbal.default_connection', (string) $definition->getArgument(1));
         $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
-        $this->assertSame('doctrine.dbal.default_connection', (string) $definition->getArgument(2));
-        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
-        $this->assertSame('serializer', (string) $definition->getArgument(3));
+        $this->assertSame('serializer', (string) $definition->getArgument(2));
 
         $this->assertSame([
             ['interface' => MessageStoreInterface::class],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Docs?         | no 
| Issues        | None
| License       | MIT

Fixes arguments in DoctrineDbalMessageStore definition, as the connection name is absent from the class' constructor arguments.
