### PR TITLE
 Fix Mate resource exclusion on php-cs-fixer config

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -66,7 +66,8 @@ return (new PhpCsFixer\Config())
             ->exclude(['ai.symfony.com', 'var', 'vendor'])
             ->notPath([
                 'demo/config/reference.php',
-                'src/mate/resources/mate/(config|extensions).php',
+                'src/mate/resources/mate/config.php',
+                'src/mate/resources/mate/extensions.php',
             ])
     )
 ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... 
| License       | MIT

I messed it up while merging #1247 