### PR TITLE
[Mate] Add dev label for composer to render "--dev" on packagist

### DIFF
--- a/src/mate/src/Bridge/Monolog/composer.json
+++ b/src/mate/src/Bridge/Monolog/composer.json
@@ -8,7 +8,8 @@
         "mcp",
         "monolog",
         "logs",
-        "bridge"
+        "bridge",
+        "dev"
     ],
     "authors": [
         {

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -8,7 +8,8 @@
         "mcp",
         "symfony",
         "debug",
-        "bridge"
+        "bridge",
+        "dev"
     ],
     "authors": [
         {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Controls this part of the packagist detail page

<img width="656" height="327" alt="image" src="https://github.com/user-attachments/assets/3552a267-055f-400a-9c76-7a7dcea855af" />

see https://packagist.org/packages/symfony/ai-mate
vs https://packagist.org/packages/symfony/ai-symfony-mate-extension

cc @wachterjohannes 