### PR TITLE
[Mate] Use compiled container

### DIFF
--- a/src/mate/src/App.php
+++ b/src/mate/src/App.php
@@ -19,7 +19,7 @@ use Symfony\AI\Mate\Command\ServeCommand;
 use Symfony\AI\Mate\Exception\UnsupportedVersionException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Johannes Wachter <johannes@sulu.io>
@@ -30,7 +30,7 @@ final class App
     public const NAME = 'Symfony AI Mate';
     public const VERSION = '0.1.0';
 
-    public static function build(ContainerBuilder $container): Application
+    public static function build(ContainerInterface $container): Application
     {
         $logger = $container->get(LoggerInterface::class);
         \assert($logger instanceof LoggerInterface);
@@ -44,7 +44,7 @@ final class App
         $application = new Application(self::NAME, self::VERSION);
 
         self::addCommand($application, new InitCommand($rootDir));
-        self::addCommand($application, new ServeCommand($logger, $container));
+        self::addCommand($application, new ServeCommand($container, $logger));
         self::addCommand($application, new DiscoverCommand($rootDir, $logger));
         self::addCommand($application, new ClearCacheCommand($cacheDir));
 

--- a/src/mate/src/default.config.php
+++ b/src/mate/src/default.config.php
@@ -38,7 +38,14 @@ return static function (ContainerConfigurator $container): void {
             ->autowire()
             ->autoconfigure()
 
+        ->set('_build.logger', Logger::class)
+            ->private() // To be removed when we compile
+            ->arg('$logFile', $debugLogFile)
+            ->arg('$fileLogEnabled', $debugFileEnabled)
+            ->arg('$debugEnabled', $debugEnabled)
+
         ->set(LoggerInterface::class, Logger::class)
+            ->public()
             ->arg('$logFile', '%mate.debug_log_file%')
             ->arg('$fileLogEnabled', '%mate.debug_file_enabled%')
             ->arg('$debugEnabled', '%mate.debug_enabled%')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

To make sure we resolve environment variable references, and to not pass around a container builder, I suggest the ContainerFactory should return a `ContainerInterface` instead. 

~~My only issue is for the Logger used instead the `ContainerFactory` =). I suggest to write to stderr~~

I added a `_build.logger` that is used only before we we compile the container. The definition is removed before we compile. Because we use environment variables for the `_build.logger` (see below) (and not container parameters), we can take the logger from the container before the container resolve the environment variables. 

This also allows the users to configure the `LoggerInterface::class` however they want. (with or without env vars in the container)


https://github.com/symfony/ai/blob/v0.1.0/src/mate/src/default.config.php#L17-L23