### PR TITLE
[Mate] Allow user to configure protocol version

### DIFF
--- a/src/mate/src/Command/ServeCommand.php
+++ b/src/mate/src/Command/ServeCommand.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Mate\Command;
 
 use Mcp\Capability\Discovery\Discoverer;
+use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\Icon;
 use Mcp\Server;
 use Mcp\Server\Session\FileSessionStore;
@@ -83,6 +84,7 @@ class ServeCommand extends Command
         );
 
         $server = Server::builder()
+            ->setProtocolVersion(ProtocolVersion::tryFrom($this->container->getParameter('mate.mcp_protocol_version') ?? ProtocolVersion::V2025_03_26->value) ?? ProtocolVersion::V2025_03_26)
             ->setServerInfo(
                 App::NAME,
                 App::VERSION,

--- a/src/mate/src/default.config.php
+++ b/src/mate/src/default.config.php
@@ -30,6 +30,7 @@ return static function (ContainerConfigurator $container): void {
         ->set('mate.debug_log_file', $debugLogFile)
         ->set('mate.debug_file_enabled', $debugFileEnabled)
         ->set('mate.debug_enabled', $debugEnabled)
+        ->set('mate.mcp_protocol_version', '2025-03-26')
     ;
 
     $container->services()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        |
| License       | MIT

Not all AI application supports all versions. Jetbrains AI supports `2025-03-26` (that is why it is default). This PR will allow the user to configure the version themselves. 
