### PR TITLE
[Mate] Use .gitignore over .gitkeep for mate/src directory

### DIFF
--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -94,7 +94,7 @@ class InitCommand extends Command
         $mateSrcDir = $this->rootDir.'/mate/src';
         if (!is_dir($mateSrcDir)) {
             mkdir($mateSrcDir, 0755, true);
-            file_put_contents($mateSrcDir.'/.gitkeep', '');
+            file_put_contents($mateSrcDir.'/.gitignore', '');
             $actions[] = ['✓', 'Created', 'mate/src/ directory (for custom MCP tools)'];
         } else {
             $actions[] = ['○', 'Exists', 'mate/src/ directory'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | 
| Issues        | 
| License       | MIT

Symfony does not use the non-standard .gitkeep. We should much rather place a empty .gitignore file. 