### PR TITLE
[Platform] Add the current input in the `ResultEvent`

### DIFF
--- a/src/platform/src/Event/ResultEvent.php
+++ b/src/platform/src/Event/ResultEvent.php
@@ -23,12 +23,14 @@ use Symfony\Contracts\EventDispatcher\Event;
 final class ResultEvent extends Event
 {
     /**
-     * @param array<string, mixed> $options
+     * @param array<string, mixed>               $options
+     * @param array<string, mixed>|string|object $input
      */
     public function __construct(
         private Model $model,
         private DeferredResult $deferredResult,
         private array $options = [],
+        private array|string|object $input = [],
     ) {
     }
 
@@ -66,5 +68,13 @@ final class ResultEvent extends Event
     public function setOptions(array $options): void
     {
         $this->options = $options;
+    }
+
+    /**
+     * @return array<string, mixed>|string|object
+     */
+    public function getInput(): array|string|object
+    {
+        return $this->input;
     }
 }

--- a/src/platform/src/Platform.php
+++ b/src/platform/src/Platform.php
@@ -66,7 +66,7 @@ final class Platform implements PlatformInterface
 
         $result = $this->convertResult($model, $this->doInvoke($model, $payload, $options), $options);
 
-        $event = new ResultEvent($model, $result, $options);
+        $event = new ResultEvent($model, $result, $options, $input);
         $this->eventDispatcher?->dispatch($event);
 
         return $event->getDeferredResult();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        |
| License       | MIT

this allow to be reconciled a `InvocationEvent` with a `ResultEvent`


Let's say I want to log every call the a platform, I could do that : 
```php
use Symfony\AI\Platform\Event\InvocationEvent;
use Symfony\AI\Platform\Event\ResultEvent;
use Symfony\Component\EventDispatcher\Attribute\AsEventListener;

class Logger
{
    #[AsEventListener()]
    public function logInvocationEvent(InvocationEvent $event): void
    {
        dump($event);
    }

    #[AsEventListener()]
    public function logResultEvent(ResultEvent $event): void
    {
        $event->getDeferredResult()->getResult();
        dd($event);
    }
}
```

But for now, I have no way of reconciling the invocation and the result.