### PR TITLE
 Fix default scan directory in mate init command

### DIFF
--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -161,7 +161,7 @@ class InitCommand extends Command
 
         if (!isset($composerJson['extra']['ai-mate'])) {
             $composerJson['extra']['ai-mate'] = [
-                'scan-dirs' => ['mate'],
+                'scan-dirs' => ['mate/src'],
                 'includes' => ['config.php'],
             ];
             $modified = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | none
| License       | MIT

## Summary

Update the default scan directory from 'mate' to 'mate/src' to correctly point to the source directory structure used in mate projects.
