### PR TITLE
 Fix mate configuration file path resolution

### DIFF
--- a/demo/composer.json
+++ b/demo/composer.json
@@ -108,7 +108,7 @@
                 "mate/src"
             ],
             "includes": [
-                "config.php"
+                "mate/config.php"
             ]
         }
     },

--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -43,8 +43,8 @@ Initialize configuration:
 
 This creates:
 
-* ``.mate/`` directory with configuration files
-* ``mate/`` directory for custom extensions
+* ``mate/`` directory with configuration files
+* ``mate/src`` directory for custom extensions
 * ``mcp.json`` for MCP client configuration
 
 It also updates your ``composer.json`` with the following configuration:
@@ -54,13 +54,13 @@ It also updates your ``composer.json`` with the following configuration:
     {
         "autoload": {
             "psr-4": {
-                "App\\Mate\\": "mate/"
+                "App\\Mate\\": "mate/src"
             }
         },
         "extra": {
             "ai-mate": {
-                "scan-dirs": ["mate"],
-                "includes": ["services.php"]
+                "scan-dirs": ["mate/src"],
+                "includes": ["mate/config.php"]
             }
         }
     }
@@ -86,7 +86,7 @@ Start the MCP server:
 Add Custom Tools
 ----------------
 
-The easiest way to add tools is to create a ``mate`` folder next to your ``src`` and ``tests`` directories,
+The easiest way to add tools is to create a ``mate/src`` folder next to your ``src`` and ``tests`` directories,
 then add a class with a method using the ``#[McpTool]`` attribute::
 
     // mate/MyTool.php
@@ -109,11 +109,11 @@ More about attributes and how to configure Prompts, Resources and more can be fo
 Configuration
 -------------
 
-The configuration folder is called ``.mate`` and is located in your project's root directory.
+The configuration folder is called ``mate`` and is located in your project's root directory.
 It contains two important files:
 
-* ``.mate/extensions.php`` - Enable/disable extensions
-* ``.mate/services.php`` - Configure settings
+* ``mate/extensions.php`` - Enable/disable extensions
+* ``mate/config.php`` - Configure settings
 
 .. tip::
 
@@ -124,7 +124,7 @@ Extensions Configuration
 
 ::
 
-    // .mate/extensions.php
+    // mate/extensions.php
     // This file is managed by 'mate discover'
     // You can manually edit to enable/disable extensions
 
@@ -138,7 +138,7 @@ Services Configuration
 
 ::
 
-    // .mate/services.php
+    // mate/config.php
     use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
     return static function (ContainerConfigurator $container): void {
@@ -184,7 +184,7 @@ Adding Third-Party Extensions
 
        $ composer require vendor/symfony-tools
 
-2. Discover available tools (auto-generates/updates ``.mate/extensions.php``):
+2. Discover available tools (auto-generates/updates ``mate/extensions.php``):
 
    .. code-block:: terminal
 
@@ -192,7 +192,7 @@ Adding Third-Party Extensions
 
 3. Optionally disable specific extensions::
 
-       // .mate/extensions.php
+       // mate/extensions.php
        return [
            'vendor/symfony-tools' => ['enabled' => true],
            'vendor/unwanted-tools' => ['enabled' => false],
@@ -274,13 +274,13 @@ Commands
 --------
 
 ``mate init``
-    Initialize AI Mate configuration and create the ``.mate/`` directory.
+    Initialize AI Mate configuration and create the ``mate/`` directory.
 
 ``mate discover``
     Scan for MCP extensions in installed packages. This command will:
 
     - Scan your vendor directory for packages with ``extra.ai-mate`` configuration
-    - Generate or update ``.mate/extensions.php`` with discovered extensions
+    - Generate or update ``mate/extensions.php`` with discovered extensions
     - Preserve existing enabled/disabled states for known extensions
     - Default new extensions to enabled
 
@@ -294,7 +294,7 @@ Security
 --------
 
 For security, no vendor extensions are enabled by default. You must explicitly enable packages
-in ``.mate/extensions.php`` by setting their ``enabled`` flag to ``true``.
+in ``mate/extensions.php`` by setting their ``enabled`` flag to ``true``.
 
 The local ``mate/`` directory is always enabled for rapid development.
 

--- a/docs/components/mate/creating-extensions.rst
+++ b/docs/components/mate/creating-extensions.rst
@@ -60,7 +60,7 @@ The ``extra.ai-mate`` section is required for your package to be discovered as a
     $ composer require vendor/my-extension
     $ vendor/bin/mate discover
 
-The ``discover`` command will automatically add your extension to ``.mate/extensions.php``::
+The ``discover`` command will automatically add your extension to ``mate/extensions.php``::
 
     return [
         'vendor/my-extension' => ['enabled' => true],
@@ -136,7 +136,7 @@ Service Includes
 Security
 ~~~~~~~~
 
-Extensions must be explicitly enabled in ``.mate/extensions.php``:
+Extensions must be explicitly enabled in ``mate/extensions.php``:
 
 - The ``discover`` command automatically adds discovered extensions
 - All extensions default to ``enabled: true`` when discovered
@@ -174,7 +174,7 @@ If your extensions aren't being found:
 
    .. code-block:: terminal
 
-       $ cat .mate/extensions.php
+       $ cat mate/extensions.php
 
    Verify your package is listed and ``enabled`` is ``true``.
 
@@ -183,7 +183,7 @@ Extensions Not Loading
 
 If extensions are discovered but not loading:
 
-1. **Check enabled status** in ``.mate/extensions.php``::
+1. **Check enabled status** in ``mate/extensions.php``::
 
        return [
            'vendor/my-extension' => ['enabled' => true],  // Must be true

--- a/docs/components/mate/troubleshooting.rst
+++ b/docs/components/mate/troubleshooting.rst
@@ -57,7 +57,7 @@ If the server starts but immediately crashes:
 
    .. code-block:: terminal
 
-       $ php -r "require 'vendor/autoload.php'; include '.mate/services.php';"
+       $ php -r "require 'vendor/autoload.php'; include 'mate/config.php';"
 
 3. **Check for circular dependencies** in your service configuration.
 

--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -162,7 +162,7 @@ class InitCommand extends Command
         if (!isset($composerJson['extra']['ai-mate'])) {
             $composerJson['extra']['ai-mate'] = [
                 'scan-dirs' => ['mate/src'],
-                'includes' => ['config.php'],
+                'includes' => ['mate/config.php'],
             ];
             $modified = true;
             $actions[] = ['✓', 'Added', 'extra.ai-mate configuration'];

--- a/src/mate/src/Container/ContainerFactory.php
+++ b/src/mate/src/Container/ContainerFactory.php
@@ -145,7 +145,7 @@ final class ContainerFactory
         $logger = $container->get(LoggerInterface::class);
         \assert($logger instanceof LoggerInterface);
 
-        $loader = new PhpFileLoader($container, new FileLocator($this->rootDir.'/mate'));
+        $loader = new PhpFileLoader($container, new FileLocator($this->rootDir));
         foreach ($rootProject['includes'] as $include) {
             try {
                 $loader->load($include);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | none
| License       | MIT

## Summary

Update the default configuration path from 'config.php' to 'mate/config.php' and adjust the FileLocator base directory to correctly resolve includes relative to the project root directory.

This ensures the mate init command creates proper configuration paths and the ContainerFactory can load configuration files correctly.