### PR TITLE
[Mate] Add descriptions to CLI commands

### DIFF
--- a/src/mate/src/Command/ClearCacheCommand.php
+++ b/src/mate/src/Command/ClearCacheCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -23,6 +24,7 @@ use Symfony\Component\Finder\Finder;
  * @author Johannes Wachter <johannes@sulu.io>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[AsCommand('clear-cache', 'Clear the MCP server cache')]
 class ClearCacheCommand extends Command
 {
     public function __construct(

--- a/src/mate/src/Command/DiscoverCommand.php
+++ b/src/mate/src/Command/DiscoverCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Mate\Command;
 
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Discovery\ComposerTypeDiscovery;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,6 +28,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * @author Johannes Wachter <johannes@sulu.io>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[AsCommand('discover', 'Discover MCP bridges installed via Composer')]
 class DiscoverCommand extends Command
 {
     public function __construct(

--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -23,6 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * @author Johannes Wachter <johannes@sulu.io>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[AsCommand('init', 'Initialize Mate configuration and directory structure')]
 class InitCommand extends Command
 {
     public function __construct(

--- a/src/mate/src/Command/ServeCommand.php
+++ b/src/mate/src/Command/ServeCommand.php
@@ -22,6 +22,7 @@ use Symfony\AI\Mate\App;
 use Symfony\AI\Mate\Discovery\ComposerTypeDiscovery;
 use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
 use Symfony\AI\Mate\Discovery\ServiceDiscovery;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,6 +34,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * @author Johannes Wachter <johannes@sulu.io>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
+#[AsCommand('serve', 'Starts the MCP server with stdio transport')]
 class ServeCommand extends Command
 {
     private ComposerTypeDiscovery $discovery;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no 
| Issues        | 
| License       | MIT

This is just a minor. I just wanted to make sure we can use `./vendor/bin/mate list` on Symfony 8.0 and get a nice description. 
