### PR TITLE
[Platform][Ollama] Fix request options for client

### DIFF
--- a/src/platform/src/Bridge/Ollama/Tests/OllamaClientTest.php
+++ b/src/platform/src/Bridge/Ollama/Tests/OllamaClientTest.php
@@ -20,6 +20,7 @@ use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -171,5 +172,188 @@ final class OllamaClientTest extends TestCase
         $regularResult = $converter->convert($regularRawResult, ['stream' => false]);
 
         $this->assertNotInstanceOf(StreamResult::class, $regularResult);
+    }
+
+    public function testChatRequestMovesNonTopLevelOptionsIntoNestedOptions()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame('POST', $method);
+            $this->assertSame('http://127.0.0.1:1234/api/chat', $url);
+
+            $json = $this->decodeRequestJson($options);
+
+            $this->assertTrue($json['stream']);
+            $this->assertFalse($json['think']);
+
+            $this->assertArrayHasKey('options', $json);
+            $this->assertIsArray($json['options']);
+            $this->assertSame(0.2, $json['options']['temperature']);
+            $this->assertSame(64, $json['options']['num_predict']);
+
+            $this->assertArrayNotHasKey('temperature', $json);
+            $this->assertArrayNotHasKey('num_predict', $json);
+
+            return new JsonMockResponse([
+                'model' => 'llama3.2',
+                'message' => ['role' => 'assistant', 'content' => 'ok'],
+                'done' => true,
+            ]);
+        }, 'http://127.0.0.1:1234');
+
+        $client = new OllamaClient($httpClient, 'http://127.0.0.1:1234');
+
+        $client->request(
+            new Ollama('llama3.2', [Capability::INPUT_MESSAGES]),
+            [
+                'model' => 'llama3.2',
+                'messages' => [
+                    ['role' => 'user', 'content' => 'hi'],
+                ],
+            ],
+            [
+                'stream' => true,
+                'think' => false,
+                'temperature' => 0.2,
+                'num_predict' => 64,
+            ]
+        );
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testChatRequestMergesExplicitNestedOptionsWithFlatOptions()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $json = $this->decodeRequestJson($options);
+
+            $this->assertArrayHasKey('options', $json);
+            $this->assertSame(0.2, $json['options']['temperature']);
+            $this->assertSame(64, $json['options']['num_predict']);
+            $this->assertSame(1024, $json['options']['num_ctx']);
+
+            return new JsonMockResponse([
+                'model' => 'llama3.2',
+                'message' => ['role' => 'assistant', 'content' => 'ok'],
+                'done' => true,
+            ]);
+        }, 'http://127.0.0.1:1234');
+
+        $client = new OllamaClient($httpClient, 'http://127.0.0.1:1234');
+
+        $client->request(
+            new Ollama('llama3.2', [Capability::INPUT_MESSAGES]),
+            [
+                'model' => 'llama3.2',
+                'messages' => [
+                    ['role' => 'user', 'content' => 'hi'],
+                ],
+            ],
+            [
+                'temperature' => 0.2,
+                'options' => [
+                    'num_predict' => 64,
+                    'num_ctx' => 1024,
+                ],
+            ]
+        );
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testChatRequestKeepsStructuredOutputFormatOnTopLevel()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $json = $this->decodeRequestJson($options);
+
+            $this->assertArrayHasKey('format', $json);
+            $this->assertArrayNotHasKey('format', $json['options'] ?? []);
+
+            return new JsonMockResponse([
+                'model' => 'llama3.2',
+                'message' => ['role' => 'assistant', 'content' => '{"ok":true}'],
+                'done' => true,
+            ]);
+        }, 'http://127.0.0.1:1234');
+
+        $client = new OllamaClient($httpClient, 'http://127.0.0.1:1234');
+
+        $client->request(
+            new Ollama('llama3.2', [Capability::INPUT_MESSAGES]),
+            [
+                'model' => 'llama3.2',
+                'messages' => [
+                    ['role' => 'user', 'content' => 'respond in json'],
+                ],
+            ],
+            [
+                PlatformSubscriber::RESPONSE_FORMAT => [
+                    'type' => 'json_schema',
+                    'json_schema' => [
+                        'name' => 'x',
+                        'schema' => ['type' => 'object'],
+                    ],
+                ],
+                'temperature' => 0.2,
+            ]
+        );
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testEmbedRequestMovesNonTopLevelOptionsIntoNestedOptions()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame('POST', $method);
+            $this->assertSame('http://127.0.0.1:1234/api/embed', $url);
+
+            $json = $this->decodeRequestJson($options);
+
+            $this->assertSame('embeddinggemma', $json['model']);
+            $this->assertSame('hello', $json['input']);
+
+            $this->assertFalse($json['truncate']);
+            $this->assertSame(512, $json['dimensions']);
+
+            $this->assertArrayHasKey('options', $json);
+            $this->assertSame(0.1, $json['options']['temperature']);
+
+            $this->assertArrayNotHasKey('temperature', $json);
+
+            return new JsonMockResponse([
+                'model' => 'embeddinggemma',
+                'embeddings' => [[0.1, 0.2]],
+            ]);
+        }, 'http://127.0.0.1:1234');
+
+        $client = new OllamaClient($httpClient, 'http://127.0.0.1:1234');
+
+        $client->request(
+            new Ollama('embeddinggemma', [Capability::EMBEDDINGS]),
+            'hello',
+            [
+                'truncate' => false,
+                'dimensions' => 512,
+                'temperature' => 0.1,
+            ]
+        );
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeRequestJson(array $options): array
+    {
+        $this->assertArrayHasKey('body', $options, 'Expected "body" in MockHttpClient options.');
+        $this->assertIsString($options['body']);
+
+        $data = json_decode($options['body'], true, 512, \JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($data);
+
+        return $data;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #1289 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Ollama expects model runtime parameters (e.g. `temperature`, `num_ctx`, `num_predict`, etc.) to be sent inside a nested `options` object. This PR adjusts the Ollama bridge so that:

- documented **top-level** request fields remain on the root for:
  - `/api/chat`: `stream`, `format`, `keep_alive`, `tools`, `think`, `logprobs`, `top_logprobs`
  - `/api/embed`: `truncate`, `keep_alive`, `dimensions`
- all other (non-top-level) parameters are moved into `options`

This makes Symfony AI requests compatible with Ollama’s request schema and prevents runtime params from being ignored.

## Changes

- Add top-level key allow-lists for chat and embed requests
- Normalize request options:
  - keep known top-level keys on root
  - merge all remaining keys into `options`
- Add tests verifying:
  - non-top-level params are nested under `options`
  - top-level keys stay on the root
  - structured output `format` stays top-level for chat
  - embedding request options are normalized as expected

## Ollama API docs
`/api/chat` - https://docs.ollama.com/api/chat
`/api/embed` - https://docs.ollama.com/api/embed
