### PR TITLE
[Mate] Support SF5.4 and SF6.4

### DIFF
--- a/.github/workflows/build-matrix.yaml
+++ b/.github/workflows/build-matrix.yaml
@@ -150,6 +150,10 @@ jobs:
                       ($pkgs | map(. + {"php-version": "8.5", "symfony-version": "8.0.*"}))
                       | map({package: {path: .path, type: .type, name: .name}} + (. | del(.path, .type, .name)))
                   ')
+
+                  # Add Mate package (Symfony 5.4, Symfony 6.4)
+                  PACKAGES_INCLUDE=$(echo "$PACKAGES_INCLUDE" | jq -c --arg mate "$mate" '. + [{package: {"path":"mate","type":"Component","name":"Mate"}, "php-version": "8.2", "symfony-version": "5.4.*"}]')
+                  PACKAGES_INCLUDE=$(echo "$PACKAGES_INCLUDE" | jq -c --arg mate "$mate" '. + [{package: {"path":"mate","type":"Component","name":"Mate"}, "php-version": "8.2", "symfony-version": "6.4.*"}]')
                   echo "packages-include=$PACKAGES_INCLUDE" >> $GITHUB_OUTPUT
 
                   # Message store bridges (for tests)

--- a/src/mate/composer.json
+++ b/src/mate/composer.json
@@ -33,10 +33,10 @@
         "php": ">=8.2",
         "mcp/sdk": "^0.2",
         "psr/log": "^2.0|^3.0",
-        "symfony/config": "^7.3|^8.0",
-        "symfony/console": "^7.3|^8.0",
-        "symfony/dependency-injection": "^7.3|^8.0",
-        "symfony/finder": "^7.3|^8.0"
+        "symfony/config": "^5.4|^6.4|^7.3|^8.0",
+        "symfony/console": "^5.4|^6.4|^7.3|^8.0",
+        "symfony/dependency-injection": "^5.4|^6.4|^7.3|^8.0",
+        "symfony/finder": "^5.4|^6.4|^7.3|^8.0"
     },
     "require-dev": {
         "ext-simplexml": "*",
@@ -44,7 +44,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5.46",
-        "symfony/dotenv": "^7.3|^8.0"
+        "symfony/dotenv": "^5.4|^6.4|^7.3|^8.0"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Mate is a platform/foundation. We want everyone to be able to build on top of it. By lowering the requirements to 5.4 (the lowest supported version) we allow this compatibility. 

Since the only dependencies are super stable components, I dont think this will make maintenance more difficult. 

Blocked by https://github.com/modelcontextprotocol/php-sdk/pull/202
