### PR TITLE
[Mate] Add `debug:capabilities` command

### DIFF
--- a/.github/workflows/build-matrix.yaml
+++ b/.github/workflows/build-matrix.yaml
@@ -76,7 +76,7 @@ jobs:
 
                   # Packages (components and bundles)
                   PACKAGES="[]"
-                  for pkg in $(find src/ -mindepth 2 -type f -name composer.json -not -path "*/vendor/*" -not -path "*/Bridge/*" | xargs -I{} dirname {} | sed 's|^src/||' | grep -Ev "examples" | sort); do
+                  for pkg in $(find src/ -mindepth 2 -type f -name composer.json -not -path "*/vendor/*" -not -path "*/Bridge/*" -not -path "*/tests/*" | xargs -I{} dirname {} | sed 's|^src/||' | grep -Ev "examples" | sort); do
                       if [[ "$pkg" == *-bundle ]]; then
                           type="Bundle"
                       else

--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -290,6 +290,44 @@ Commands
 ``mate clear-cache``
     Clear the MCP server cache.
 
+``mate debug:capabilities``
+    Display all discovered MCP capabilities grouped by extension. This command is useful for:
+
+    - Verifying extension installation and capability registration
+    - Debugging missing or misconfigured extensions
+    - Understanding which package provides each capability
+    - Inspecting available tools during development
+
+    **Options:**
+
+    ``--format=FORMAT``
+        Output format: ``text`` (default) or ``json``
+
+    ``--extension=EXTENSION``
+        Filter by extension package name (e.g., ``symfony/ai-monolog-mate-extension``)
+
+    ``--type=TYPE``
+        Filter by capability type: ``tool``, ``resource``, ``prompt``, or ``template``
+
+    **Examples:**
+
+    .. code-block:: terminal
+
+        # Show all capabilities
+        $ vendor/bin/mate debug:capabilities
+
+        # Show only tools
+        $ vendor/bin/mate debug:capabilities --type=tool
+
+        # Show capabilities from specific extension
+        $ vendor/bin/mate debug:capabilities --extension=symfony/ai-monolog-mate-extension
+
+        # JSON output for scripting
+        $ vendor/bin/mate debug:capabilities --format=json
+
+        # Root project capabilities
+        $ vendor/bin/mate debug:capabilities --extension=_custom
+
 Security
 --------
 

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `StopCommand` to stop a running server
  * Add `--force-keep-alive` option to `ServeCommand` to restart server if it was stopped
+ * Add `debug:capabilities` command to display all discovered MCP capabilities grouped by extension
 
 0.1
 ---

--- a/src/mate/src/App.php
+++ b/src/mate/src/App.php
@@ -15,6 +15,7 @@ use Mcp\Server\Transport\Stdio\RunnerControl;
 use Mcp\Server\Transport\Stdio\RunnerState;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Command\ClearCacheCommand;
+use Symfony\AI\Mate\Command\DebugCapabilitiesCommand;
 use Symfony\AI\Mate\Command\DiscoverCommand;
 use Symfony\AI\Mate\Command\InitCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
@@ -50,6 +51,7 @@ final class App
         self::addCommand($application, new ServeCommand($container, $logger));
         self::addCommand($application, new DiscoverCommand($rootDir, $logger));
         self::addCommand($application, new StopCommand((string) $container->getParameter('mate.cache_dir')));
+        self::addCommand($application, new DebugCapabilitiesCommand($logger, $container));
         self::addCommand($application, new ClearCacheCommand($cacheDir));
 
         if (\defined('SIGUSR1') && class_exists(RunnerControl::class)) {

--- a/src/mate/src/Command/DebugCapabilitiesCommand.php
+++ b/src/mate/src/Command/DebugCapabilitiesCommand.php
@@ -1,0 +1,300 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command;
+
+use Psr\Log\LoggerInterface;
+use Symfony\AI\Mate\Discovery\CapabilityCollector;
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Display all MCP capabilities grouped by extension.
+ *
+ * @phpstan-import-type Capabilities from CapabilityCollector
+ *
+ * @phpstan-type CapabilitiesByExtension array<string, Capabilities>
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('debug:capabilities', 'Display all MCP capabilities grouped by extension')]
+class DebugCapabilitiesCommand extends Command
+{
+    private CapabilityCollector $collector;
+
+    /**
+     * @var array<string, array{dirs: string[], includes: string[]}>
+     */
+    private array $extensions;
+
+    public function __construct(
+        LoggerInterface $logger,
+        private ContainerInterface $container,
+    ) {
+        parent::__construct(self::getDefaultName());
+
+        $rootDir = $container->getParameter('mate.root_dir');
+        \assert(\is_string($rootDir));
+
+        $extensions = $this->container->getParameter('mate.extensions') ?? [];
+        \assert(\is_array($extensions));
+        $this->extensions = $extensions;
+
+        $disabledFeatures = $this->container->getParameter('mate.disabled_features') ?? [];
+        \assert(\is_array($disabledFeatures));
+
+        $this->collector = new CapabilityCollector($rootDir, $extensions, $disabledFeatures, $logger);
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'debug:capabilities';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Display all MCP capabilities grouped by extension';
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (text, json)', 'text')
+            ->addOption('extension', null, InputOption::VALUE_REQUIRED, 'Filter by extension package name')
+            ->addOption('type', null, InputOption::VALUE_REQUIRED, 'Filter by type (tool, resource, prompt, template)')
+            ->setHelp(<<<'HELP'
+The <info>%command.name%</info> command displays all discovered MCP capabilities
+grouped by their providing extension/package.
+
+<info>Usage Examples:</info>
+
+  <comment># Show all capabilities</comment>
+  %command.full_name%
+
+  <comment># Show only tools</comment>
+  %command.full_name% --type=tool
+
+  <comment># Show capabilities from specific extension</comment>
+  %command.full_name% --extension=symfony/ai-monolog-mate-extension
+
+  <comment># Show only tools from specific extension</comment>
+  %command.full_name% --extension=symfony/ai-monolog-mate-extension --type=tool
+
+  <comment># JSON output for scripting</comment>
+  %command.full_name% --format=json
+
+  <comment># Root project capabilities</comment>
+  %command.full_name% --extension=_custom
+HELP
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $capabilities = [];
+        foreach ($this->extensions as $extensionName => $extension) {
+            $capabilities[$extensionName] = $this->collector->collectCapabilities($extensionName, $extension);
+        }
+
+        $extensionFilter = $input->getOption('extension');
+        $typeFilter = $input->getOption('type');
+
+        if (null !== $extensionFilter) {
+            \assert(\is_string($extensionFilter));
+            $capabilities = $this->filterExtensions($capabilities, $extensionFilter);
+        }
+
+        if (null !== $typeFilter) {
+            \assert(\is_string($typeFilter));
+            $capabilities = $this->filterByType($capabilities, $typeFilter);
+        }
+
+        $format = $input->getOption('format');
+        \assert(\is_string($format));
+
+        if ('json' === $format) {
+            $this->outputJson($capabilities, $output);
+        } else {
+            $this->outputText($capabilities, $io);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param CapabilitiesByExtension $all
+     *
+     * @return CapabilitiesByExtension
+     */
+    private function filterExtensions(array $all, string $filter): array
+    {
+        if (!isset($all[$filter])) {
+            throw InvalidArgumentException::forExtensionNotFound($filter, array_keys($all));
+        }
+
+        return [$filter => $all[$filter]];
+    }
+
+    /**
+     * @param CapabilitiesByExtension $capabilities
+     *
+     * @return array<string, array<string, array<string, array<string, mixed>>>>
+     */
+    private function filterByType(array $capabilities, string $type): array
+    {
+        $validTypes = ['tool', 'resource', 'prompt', 'template'];
+        if (!\in_array($type, $validTypes, true)) {
+            throw InvalidArgumentException::forInvalidType($type, $validTypes);
+        }
+
+        $typeMap = [
+            'tool' => 'tools',
+            'resource' => 'resources',
+            'prompt' => 'prompts',
+            'template' => 'resource_templates',
+        ];
+
+        $filtered = [];
+        foreach ($capabilities as $extension => $caps) {
+            $filtered[$extension] = [
+                $typeMap[$type] => $caps[$typeMap[$type]],
+            ];
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @param CapabilitiesByExtension $capabilitiesByExtension
+     */
+    private function outputText(array $capabilitiesByExtension, SymfonyStyle $io): void
+    {
+        $io->title('Mate MCP Capabilities');
+
+        $totalTools = 0;
+        $totalResources = 0;
+        $totalPrompts = 0;
+        $totalTemplates = 0;
+
+        foreach ($capabilitiesByExtension as $extensionName => $capabilities) {
+            $displayName = '_custom' === $extensionName
+                ? 'Root Project'
+                : $extensionName;
+
+            $io->section($displayName);
+
+            $tools = $capabilities['tools'] ?? [];
+            if (\count($tools) > 0) {
+                $io->text(\sprintf('<info>Tools (%d)</info>', \count($tools)));
+                foreach ($tools as $name => $tool) {
+                    $io->text(\sprintf('  • %s', $name));
+                    $io->text(\sprintf('    Handler: %s', $tool['handler']));
+                    if ('' !== ($tool['description'] ?? '')) {
+                        $io->text(\sprintf('    Description: %s', $tool['description']));
+                    }
+                }
+                $io->newLine();
+                $totalTools += \count($tools);
+            }
+
+            $resources = $capabilities['resources'] ?? [];
+            if (\count($resources) > 0) {
+                $io->text(\sprintf('<info>Resources (%d)</info>', \count($resources)));
+                foreach ($resources as $uri => $resource) {
+                    $io->text(\sprintf('  • %s', $uri));
+                    $io->text(\sprintf('    Handler: %s', $resource['handler']));
+                    if ('' !== ($resource['description'] ?? '')) {
+                        $io->text(\sprintf('    Description: %s', $resource['description']));
+                    }
+                    if ('' !== ($resource['mime_type'] ?? '')) {
+                        $io->text(\sprintf('    MIME Type: %s', $resource['mime_type']));
+                    }
+                }
+                $io->newLine();
+                $totalResources += \count($resources);
+            }
+
+            $prompts = $capabilities['prompts'] ?? [];
+            if (\count($prompts) > 0) {
+                $io->text(\sprintf('<info>Prompts (%d)</info>', \count($prompts)));
+                foreach ($prompts as $name => $prompt) {
+                    $io->text(\sprintf('  • %s', $name));
+                    $io->text(\sprintf('    Handler: %s', $prompt['handler']));
+                    if ('' !== ($prompt['description'] ?? '')) {
+                        $io->text(\sprintf('    Description: %s', $prompt['description']));
+                    }
+                }
+                $io->newLine();
+                $totalPrompts += \count($prompts);
+            }
+
+            $templates = $capabilities['resource_templates'] ?? [];
+            if (\count($templates) > 0) {
+                $io->text(\sprintf('<info>Resource Templates (%d)</info>', \count($templates)));
+                foreach ($templates as $uriTemplate => $template) {
+                    $io->text(\sprintf('  • %s', $uriTemplate));
+                    $io->text(\sprintf('    Handler: %s', $template['handler']));
+                    if ('' !== ($template['description'] ?? '')) {
+                        $io->text(\sprintf('    Description: %s', $template['description']));
+                    }
+                }
+                $io->newLine();
+                $totalTemplates += \count($templates);
+            }
+        }
+
+        $io->section('Summary');
+        $io->text(\sprintf('Extensions: %d', \count($capabilitiesByExtension)));
+        $io->text(\sprintf('Tools: %d', $totalTools));
+        $io->text(\sprintf('Resources: %d', $totalResources));
+        $io->text(\sprintf('Prompts: %d', $totalPrompts));
+        $io->text(\sprintf('Templates: %d', $totalTemplates));
+    }
+
+    /**
+     * @param CapabilitiesByExtension $capabilitiesByExtension
+     */
+    private function outputJson(array $capabilitiesByExtension, OutputInterface $output): void
+    {
+        $totalTools = 0;
+        $totalResources = 0;
+        $totalPrompts = 0;
+        $totalTemplates = 0;
+
+        foreach ($capabilitiesByExtension as $caps) {
+            $totalTools += \count($caps['tools'] ?? []);
+            $totalResources += \count($caps['resources'] ?? []);
+            $totalPrompts += \count($caps['prompts'] ?? []);
+            $totalTemplates += \count($caps['resource_templates'] ?? []);
+        }
+
+        $result = [
+            'extensions' => $capabilitiesByExtension,
+            'summary' => [
+                'extensions' => \count($capabilitiesByExtension),
+                'tools' => $totalTools,
+                'resources' => $totalResources,
+                'prompts' => $totalPrompts,
+                'resource_templates' => $totalTemplates,
+            ],
+        ];
+
+        $output->writeln(json_encode($result, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/src/mate/src/Command/ServeCommand.php
+++ b/src/mate/src/Command/ServeCommand.php
@@ -52,7 +52,7 @@ class ServeCommand extends Command
         \assert(\is_string($cacheDir));
         $this->cacheDir = $cacheDir;
 
-        $extensions = $this->container->getParameter('mate._extensions') ?? [];
+        $extensions = $this->container->getParameter('mate.extensions') ?? [];
         \assert(\is_array($extensions));
 
         $disabledFeatures = $this->container->getParameter('mate.disabled_features') ?? [];

--- a/src/mate/src/Discovery/CapabilityCollector.php
+++ b/src/mate/src/Discovery/CapabilityCollector.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Discovery;
+
+use Mcp\Capability\Discovery\Discoverer;
+use Mcp\Capability\Registry\PromptReference;
+use Mcp\Capability\Registry\ResourceTemplateReference;
+use Mcp\Capability\Registry\ToolReference;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Collects MCP capabilities from discovered extensions.
+ *
+ * @phpstan-type Capabilities array{
+ *     tools: array<string, array{
+ *         name: string,
+ *         description: string|null,
+ *         handler: string,
+ *         input_schema: array<string, mixed>|null
+ *     }>,
+ *     resources: array<string, array{
+ *         uri: string,
+ *         name: string|null,
+ *         description: string|null,
+ *         handler: string,
+ *         mime_type: string|null
+ *     }>,
+ *     prompts: array<string, array{
+ *         name: string,
+ *         description: string|null,
+ *         handler: string,
+ *         arguments: array<mixed>|null
+ *     }>,
+ *     resource_templates: array<string, array{
+ *         uri_template: string,
+ *         name: string|null,
+ *         description: string|null,
+ *         handler: string
+ *     }>
+ * }
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class CapabilityCollector
+{
+    private Discoverer $discoverer;
+    private FilteredDiscoveryLoader $loader;
+
+    /**
+     * @param array<string, array{dirs: string[], includes: string[]}> $extensions
+     * @param array<string, array<string, array{enabled: bool}>>       $disabledFeatures
+     */
+    public function __construct(
+        string $rootDir,
+        array $extensions,
+        array $disabledFeatures,
+        private LoggerInterface $logger,
+    ) {
+        $this->discoverer = new Discoverer($this->logger);
+        $this->loader = new FilteredDiscoveryLoader(
+            $rootDir,
+            $extensions,
+            $disabledFeatures,
+            $this->discoverer,
+            $this->logger,
+        );
+    }
+
+    /**
+     * @param array{dirs: string[], includes: string[]} $extension
+     *
+     * @return Capabilities
+     */
+    public function collectCapabilities(string $extensionName, array $extension): array
+    {
+        $state = $this->loader->loadByExtension($extensionName, $extension);
+
+        return [
+            'tools' => $this->formatTools($state->getTools()),
+            'resources' => $this->formatResources($state->getResources()),
+            'prompts' => $this->formatPrompts($state->getPrompts()),
+            'resource_templates' => $this->formatResourceTemplates($state->getResourceTemplates()),
+        ];
+    }
+
+    private function getHandlerInfo(mixed $handler): string
+    {
+        if (\is_array($handler)) {
+            [$classOrInstance, $method] = $handler;
+            $className = \is_object($classOrInstance)
+                ? $classOrInstance::class
+                : $classOrInstance;
+
+            return "{$className}::{$method}";
+        }
+
+        if (\is_string($handler) && class_exists($handler)) {
+            return $handler;
+        }
+
+        return 'Closure';
+    }
+
+    /**
+     * @param array<string, ToolReference> $tools
+     *
+     * @return array<string, array{name: string, description: string|null, handler: string, input_schema: array<string, mixed>|null}>
+     */
+    private function formatTools(array $tools): array
+    {
+        $formatted = [];
+        foreach ($tools as $name => $toolRef) {
+            $formatted[$name] = [
+                'name' => $name,
+                'description' => $toolRef->tool->description,
+                'handler' => $this->getHandlerInfo($toolRef->handler),
+                'input_schema' => $toolRef->tool->inputSchema,
+            ];
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * @param array<string, \Mcp\Capability\Registry\ResourceReference> $resources
+     *
+     * @return array<string, array{uri: string, name: string|null, description: string|null, handler: string, mime_type: string|null}>
+     */
+    private function formatResources(array $resources): array
+    {
+        $formatted = [];
+        foreach ($resources as $uri => $resourceRef) {
+            $formatted[$uri] = [
+                'uri' => $uri,
+                'name' => $resourceRef->schema->name,
+                'description' => $resourceRef->schema->description,
+                'handler' => $this->getHandlerInfo($resourceRef->handler),
+                'mime_type' => $resourceRef->schema->mimeType,
+            ];
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * @param array<string, PromptReference> $prompts
+     *
+     * @return array<string, array{name: string, description: string|null, handler: string, arguments: array<mixed>|null}>
+     */
+    private function formatPrompts(array $prompts): array
+    {
+        $formatted = [];
+        foreach ($prompts as $name => $promptRef) {
+            $formatted[$name] = [
+                'name' => $name,
+                'description' => $promptRef->prompt->description,
+                'handler' => $this->getHandlerInfo($promptRef->handler),
+                'arguments' => $promptRef->prompt->arguments,
+            ];
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * @param array<string, ResourceTemplateReference> $templates
+     *
+     * @return array<string, array{uri_template: string, name: string|null, description: string|null, handler: string}>
+     */
+    private function formatResourceTemplates(array $templates): array
+    {
+        $formatted = [];
+        foreach ($templates as $uriTemplate => $templateRef) {
+            $formatted[$uriTemplate] = [
+                'uri_template' => $uriTemplate,
+                'name' => $templateRef->resourceTemplate->name,
+                'description' => $templateRef->resourceTemplate->description,
+                'handler' => $this->getHandlerInfo($templateRef->handler),
+            ];
+        }
+
+        return $formatted;
+    }
+}

--- a/src/mate/src/Discovery/FilteredDiscoveryLoader.php
+++ b/src/mate/src/Discovery/FilteredDiscoveryLoader.php
@@ -130,7 +130,7 @@ final class FilteredDiscoveryLoader implements LoaderInterface
         );
     }
 
-    private function isFeatureAllowed(string $extensionName, string $feature): bool
+    public function isFeatureAllowed(string $extensionName, string $feature): bool
     {
         $data = $this->disabledFeatures[$extensionName][$feature] ?? [];
 

--- a/src/mate/src/Exception/InvalidArgumentException.php
+++ b/src/mate/src/Exception/InvalidArgumentException.php
@@ -20,4 +20,27 @@ namespace Symfony\AI\Mate\Exception;
  */
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
+    /**
+     * @param array<string> $available
+     */
+    public static function forExtensionNotFound(string $extension, array $available): self
+    {
+        return new self(\sprintf(
+            'Extension "%s" not found. Available: %s',
+            $extension,
+            implode(', ', $available)
+        ));
+    }
+
+    /**
+     * @param array<string> $validTypes
+     */
+    public static function forInvalidType(string $type, array $validTypes): self
+    {
+        return new self(\sprintf(
+            'Invalid type "%s". Valid types: %s',
+            $type,
+            implode(', ', $validTypes)
+        ));
+    }
 }

--- a/src/mate/tests/Command/DebugCapabilitiesCommandTest.php
+++ b/src/mate/tests/Command/DebugCapabilitiesCommandTest.php
@@ -1,0 +1,249 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Command\DebugCapabilitiesCommand;
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class DebugCapabilitiesCommandTest extends TestCase
+{
+    private string $fixturesDir;
+
+    protected function setUp(): void
+    {
+        $this->fixturesDir = __DIR__.'/../Discovery/Fixtures';
+    }
+
+    public function testExecuteDisplaysCapabilities()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-a', 'vendor/package-b']);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugCapabilitiesCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Mate MCP Capabilities', $output);
+        $this->assertStringContainsString('Summary', $output);
+    }
+
+    public function testExecuteWithEmptyExtensions()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugCapabilitiesCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Root Project', $output);
+    }
+
+    public function testExecuteWithJsonFormat()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugCapabilitiesCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--format' => 'json']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $json = json_decode($output, true);
+        $this->assertIsArray($json);
+        $this->assertArrayHasKey('extensions', $json);
+        $this->assertArrayHasKey('summary', $json);
+        $this->assertArrayHasKey('extensions', $json['summary']);
+        $this->assertArrayHasKey('tools', $json['summary']);
+        $this->assertArrayHasKey('resources', $json['summary']);
+        $this->assertArrayHasKey('prompts', $json['summary']);
+        $this->assertArrayHasKey('resource_templates', $json['summary']);
+    }
+
+    public function testExecuteWithExtensionFilter()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-a', 'vendor/package-b']);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugCapabilitiesCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--extension' => '_custom']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Root Project', $output);
+        $this->assertStringNotContainsString('vendor/package-a', $output);
+        $this->assertStringNotContainsString('vendor/package-b', $output);
+    }
+
+    public function testExecuteWithInvalidExtensionFilter()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugCapabilitiesCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension "invalid-extension" not found');
+
+        $tester->execute(['--extension' => 'invalid-extension']);
+    }
+
+    public function testExecuteWithTypeFilter()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugCapabilitiesCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--type' => 'tool']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    public function testExecuteWithInvalidTypeFilter()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugCapabilitiesCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid type "invalid-type"');
+
+        $tester->execute(['--type' => 'invalid-type']);
+    }
+
+    public function testExecuteWithCombinedFilters()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-a']);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugCapabilitiesCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            '--extension' => 'vendor/package-a',
+            '--type' => 'tool',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    public function testExecuteWithJsonFormatAndFilters()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugCapabilitiesCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            '--format' => 'json',
+            '--extension' => '_custom',
+            '--type' => 'resource',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $json = json_decode($output, true);
+        $this->assertIsArray($json);
+        $this->assertArrayHasKey('_custom', $json['extensions']);
+        $this->assertArrayHasKey('resources', $json['extensions']['_custom']);
+        $this->assertArrayNotHasKey('tools', $json['extensions']['_custom']);
+    }
+}

--- a/src/mate/tests/Discovery/CapabilityCollectorTest.php
+++ b/src/mate/tests/Discovery/CapabilityCollectorTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Discovery;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Discovery\CapabilityCollector;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class CapabilityCollectorTest extends TestCase
+{
+    private string $fixturesDir;
+
+    protected function setUp(): void
+    {
+        $this->fixturesDir = __DIR__.'/Fixtures';
+    }
+
+    public function testCollectCapabilitiesReturnsStructure()
+    {
+        $collector = new CapabilityCollector(
+            $this->fixturesDir.'/with-ai-mate-config',
+            [],
+            [],
+            new NullLogger()
+        );
+
+        $extension = [
+            'dirs' => ['mate/src'],
+            'includes' => [],
+        ];
+
+        $capabilities = $collector->collectCapabilities('test/extension', $extension);
+
+        $this->assertArrayHasKey('tools', $capabilities);
+        $this->assertArrayHasKey('resources', $capabilities);
+        $this->assertArrayHasKey('prompts', $capabilities);
+        $this->assertArrayHasKey('resource_templates', $capabilities);
+    }
+
+    public function testCollectCapabilitiesWithEmptyDirectories()
+    {
+        $collector = new CapabilityCollector(
+            $this->fixturesDir.'/with-ai-mate-config',
+            [],
+            [],
+            new NullLogger()
+        );
+
+        $extension = [
+            'dirs' => ['mate/src'],
+            'includes' => [],
+        ];
+
+        $capabilities = $collector->collectCapabilities('test/extension', $extension);
+
+        // Empty directories should result in empty capability arrays
+        $this->assertIsArray($capabilities['tools']);
+        $this->assertIsArray($capabilities['resources']);
+        $this->assertIsArray($capabilities['prompts']);
+        $this->assertIsArray($capabilities['resource_templates']);
+    }
+
+    public function testCollectCapabilitiesWithIncludes()
+    {
+        $collector = new CapabilityCollector(
+            $this->fixturesDir.'/with-ai-mate-config',
+            [],
+            [],
+            new NullLogger()
+        );
+
+        $extension = [
+            'dirs' => [],
+            'includes' => ['mate/config.php'],
+        ];
+
+        $capabilities = $collector->collectCapabilities('test/extension', $extension);
+
+        $this->assertIsArray($capabilities['tools']);
+        $this->assertIsArray($capabilities['resources']);
+        $this->assertIsArray($capabilities['prompts']);
+        $this->assertIsArray($capabilities['resource_templates']);
+    }
+
+    public function testCollectCapabilitiesFormatsTools()
+    {
+        $collector = new CapabilityCollector(
+            $this->fixturesDir.'/with-ai-mate-config',
+            [],
+            [],
+            new NullLogger()
+        );
+
+        $extension = [
+            'dirs' => ['mate/src'],
+            'includes' => [],
+        ];
+
+        $capabilities = $collector->collectCapabilities('test/extension', $extension);
+
+        $this->assertIsArray($capabilities['tools']);
+        foreach ($capabilities['tools'] as $name => $tool) {
+            $this->assertIsString($name);
+            $this->assertArrayHasKey('name', $tool);
+            $this->assertArrayHasKey('description', $tool);
+            $this->assertArrayHasKey('handler', $tool);
+            $this->assertArrayHasKey('input_schema', $tool);
+        }
+    }
+
+    public function testCollectCapabilitiesFormatsResources()
+    {
+        $collector = new CapabilityCollector(
+            $this->fixturesDir.'/with-ai-mate-config',
+            [],
+            [],
+            new NullLogger()
+        );
+
+        $extension = [
+            'dirs' => ['mate/src'],
+            'includes' => [],
+        ];
+
+        $capabilities = $collector->collectCapabilities('test/extension', $extension);
+
+        $this->assertIsArray($capabilities['resources']);
+        foreach ($capabilities['resources'] as $uri => $resource) {
+            $this->assertIsString($uri);
+            $this->assertArrayHasKey('uri', $resource);
+            $this->assertArrayHasKey('name', $resource);
+            $this->assertArrayHasKey('description', $resource);
+            $this->assertArrayHasKey('handler', $resource);
+            $this->assertArrayHasKey('mime_type', $resource);
+        }
+    }
+
+    public function testCollectCapabilitiesFormatsPrompts()
+    {
+        $collector = new CapabilityCollector(
+            $this->fixturesDir.'/with-ai-mate-config',
+            [],
+            [],
+            new NullLogger()
+        );
+
+        $extension = [
+            'dirs' => ['mate/src'],
+            'includes' => [],
+        ];
+
+        $capabilities = $collector->collectCapabilities('test/extension', $extension);
+
+        $this->assertIsArray($capabilities['prompts']);
+        foreach ($capabilities['prompts'] as $name => $prompt) {
+            $this->assertIsString($name);
+            $this->assertArrayHasKey('name', $prompt);
+            $this->assertArrayHasKey('description', $prompt);
+            $this->assertArrayHasKey('handler', $prompt);
+            $this->assertArrayHasKey('arguments', $prompt);
+        }
+    }
+
+    public function testCollectCapabilitiesFormatsResourceTemplates()
+    {
+        $collector = new CapabilityCollector(
+            $this->fixturesDir.'/with-ai-mate-config',
+            [],
+            [],
+            new NullLogger()
+        );
+
+        $extension = [
+            'dirs' => ['mate/src'],
+            'includes' => [],
+        ];
+
+        $capabilities = $collector->collectCapabilities('test/extension', $extension);
+
+        $this->assertIsArray($capabilities['resource_templates']);
+        foreach ($capabilities['resource_templates'] as $uriTemplate => $template) {
+            $this->assertIsString($uriTemplate);
+            $this->assertArrayHasKey('uri_template', $template);
+            $this->assertArrayHasKey('name', $template);
+            $this->assertArrayHasKey('description', $template);
+            $this->assertArrayHasKey('handler', $template);
+        }
+    }
+}

--- a/src/mate/tests/Discovery/ComposerExtensionDiscoveryTest.php
+++ b/src/mate/tests/Discovery/ComposerExtensionDiscoveryTest.php
@@ -74,14 +74,14 @@ final class ComposerExtensionDiscoveryTest extends TestCase
 
     public function testWhitelistFiltering()
     {
+        $enabledExtensions = [
+            'vendor/package-a',
+        ];
+
         $discovery = new ComposerExtensionDiscovery(
             $this->fixturesDir.'/with-ai-mate-config',
             new NullLogger()
         );
-
-        $enabledExtensions = [
-            'vendor/package-a',
-        ];
 
         $extensions = $discovery->discover($enabledExtensions);
 
@@ -92,15 +92,15 @@ final class ComposerExtensionDiscoveryTest extends TestCase
 
     public function testWhitelistWithMultiplePackages()
     {
-        $discovery = new ComposerExtensionDiscovery(
-            $this->fixturesDir.'/with-ai-mate-config',
-            new NullLogger()
-        );
-
         $enabledExtensions = [
             'vendor/package-a',
             'vendor/package-b',
         ];
+
+        $discovery = new ComposerExtensionDiscovery(
+            $this->fixturesDir.'/with-ai-mate-config',
+            new NullLogger()
+        );
 
         $extensions = $discovery->discover($enabledExtensions);
 

--- a/src/mate/tests/Discovery/Fixtures/with-ai-mate-config/composer.json
+++ b/src/mate/tests/Discovery/Fixtures/with-ai-mate-config/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "test/fixture-project",
+    "description": "Test fixture with ai-mate configuration",
+    "type": "project",
+    "autoload": {
+        "psr-4": {
+            "App\\Mate\\": "mate/src"
+        }
+    },
+    "extra": {
+        "ai-mate": {
+            "scan-dirs": ["mate/src"],
+            "includes": ["mate/config.php"]
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | N/A
| License       | MIT

## Description

This PR adds a new `debug:capabilities` command to the Mate component that displays all discovered MCP capabilities (tools, resources, prompts, and resource templates) grouped by their providing extension or package.

## Usage Examples

```bash
# Show all capabilities
bin/mate debug:capabilities

# Show only tools
bin/mate debug:capabilities --type=tool

# Show capabilities from specific extension
bin/mate debug:capabilities --extension=symfony/ai-monolog-mate-extension

# JSON output for scripting
bin/mate debug:capabilities --format=json

# Root project capabilities
bin/mate debug:capabilities --extension=_custom

# Combined filtering
bin/mate debug:capabilities --extension=symfony/ai-mate --type=tool
```

## Example Output

```
Mate MCP Capabilities
=====================

Extension: symfony/ai-mate
--------------------------

Tools (4)
 • php-version
   Handler: Symfony\AI\Mate\Capability\ServerInfo::phpVersion
   Description: Get the version of PHP
 • operating-system
   Handler: Symfony\AI\Mate\Capability\ServerInfo::operatingSystem
   Description: Get the current operating system
 • operating-system-family
   Handler: Symfony\AI\Mate\Capability\ServerInfo::operatingSystemFamily
   Description: Get the current operating system family
 • php-extensions
   Handler: Symfony\AI\Mate\Capability\ServerInfo::extensions
   Description: Get a list of PHP extensions

Extension: symfony/ai-monolog-mate-extension
--------------------------------------------

Tools (7)
 • monolog-search
   Handler: Symfony\AI\Mate\Bridge\Monolog\Capability\LogSearchTool::search
   Description: Search log entries by text term with optional level, channel, environment, and date filters
 • monolog-search-regex
   Handler: Symfony\AI\Mate\Bridge\Monolog\Capability\LogSearchTool::searchRegex
   Description: Search log entries using a regex pattern
 • monolog-context-search
   Handler: Symfony\AI\Mate\Bridge\Monolog\Capability\LogSearchTool::searchContext
   Description: Search logs by context field value
 • monolog-tail
   Handler: Symfony\AI\Mate\Bridge\Monolog\Capability\LogSearchTool::tail
   Description: Get the last N log entries
 • monolog-list-files
   Handler: Symfony\AI\Mate\Bridge\Monolog\Capability\LogSearchTool::listFiles
   Description: List available log files, optionally filtered by environment
 • monolog-list-channels
   Handler: Symfony\AI\Mate\Bridge\Monolog\Capability\LogSearchTool::listChannels
   Description: List all log channels found in log files
 • monolog-by-level
   Handler: Symfony\AI\Mate\Bridge\Monolog\Capability\LogSearchTool::byLevel
   Description: Get log entries filtered by level (DEBUG, INFO, WARNING, ERROR, etc.)

Extension: symfony/ai-symfony-mate-extension
--------------------------------------------

Tools (1)
 • symfony-services
   Handler: Symfony\AI\Mate\Bridge\Symfony\Capability\ServiceTool::getAllServices
   Description: Get a list of all symfony services

Root Project
------------

Tools (1)
 • symfony-ai-features
   Handler: App\Mate\SymfonyAiFeaturesTool::getFeatures
   Description: Detects and lists all available Symfony AI features, platforms, agents, tools, and configurations in this project

Resource Templates (1)
 • time://{timezone}
   Handler: App\Mcp\ResourceTemplates\CurrentTimeResourceTemplate::getTimeByTimezone

Summary
-------

Extensions: 4
Tools: 13
Resources: 0
Prompts: 0
Templates: 1
```
