### PR TITLE
[Mate] add github template for mate component to close PRs

### DIFF
--- a/src/mate/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/mate/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/ai
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/mate/.github/workflows/close-pull-request.yml
+++ b/src/mate/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: superbrothers/close-pull-request@v3
+        with:
+          comment: |
+            Thanks for your Pull Request! We love contributions.
+
+            However, you should instead open your PR on the main repository:
+            https://github.com/symfony/ai
+
+            This repository is what we call a "subtree split": a read-only subset of that main repository.
+            We're looking forward to your PR there!


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

This is to make sure we are doing the same as other components. We dont want someone to open a PR to our read-only repos