### PR TITLE
[Mate] Add support for _composer_autoload_path super global

### DIFF
--- a/src/mate/bin/mate.php
+++ b/src/mate/bin/mate.php
@@ -15,6 +15,10 @@ $autoloadPaths = [
     __DIR__.'/../vendor/autoload.php', // Package autoloader (fallback)
 ];
 
+if (isset($GLOBALS['_composer_autoload_path'])) {
+    array_unshift($autoloadPaths, $GLOBALS['_composer_autoload_path']);
+}
+
 $root = null;
 foreach ($autoloadPaths as $autoloadPath) {
     if (file_exists($autoloadPath)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | no
| License       | MIT

If `$_GLOBALS['_composer_autoload_path']` is defined, then use it. It is defined my composer on each "bin" script.

(See your `vendor/bin/*`)