### PR TITLE
[Mate] Remove $_ENV['MATE_ROOT_DIR']

### DIFF
--- a/src/mate/bin/mate.php
+++ b/src/mate/bin/mate.php
@@ -29,9 +29,6 @@ if (!$root) {
     exit(1);
 }
 
-// Set the root directory as an environment variable using $_ENV to be thread-safe
-$_ENV['MATE_ROOT_DIR'] = $root;
-
 use Symfony\AI\Mate\App;
 use Symfony\AI\Mate\Container\ContainerFactory;
 

--- a/src/mate/src/default.config.php
+++ b/src/mate/src/default.config.php
@@ -23,7 +23,6 @@ return static function (ContainerConfigurator $container): void {
         : false;
 
     $container->parameters()
-        ->set('mate.root_dir', '%env(MATE_ROOT_DIR)%')
         ->set('mate.cache_dir', sys_get_temp_dir().'/mate')
         ->set('mate.env_file', null)
         ->set('mate.disabled_features', [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

We dont need to set `$_ENV['MATE_ROOT_DIR']`. We pass the `$rootDir` to the `ContainerFactory`. That class is also setting the `mate.root_dir` parameter. 