### PR TITLE
[Mate] Put log file inside `mate.root_dir`

### DIFF
--- a/src/mate/src/default.config.php
+++ b/src/mate/src/default.config.php
@@ -45,7 +45,7 @@ return static function (ContainerConfigurator $container): void {
 
         ->set(LoggerInterface::class, Logger::class)
             ->public()
-            ->arg('$logFile', '%mate.debug_log_file%')
+            ->arg('$logFile', '%mate.root_dir%/%mate.debug_log_file%')
             ->arg('$fileLogEnabled', '%mate.debug_file_enabled%')
             ->arg('$debugEnabled', '%mate.debug_enabled%')
             ->alias(Logger::class, LoggerInterface::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

If you run mate from a non-root dir, you still want the log file to be put in the project
