### PR TITLE
[Demo][Mate] Exclude `demo/mate` folder from PHP-CS-Fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -63,7 +63,7 @@ return (new PhpCsFixer\Config())
     ->setFinder(
         (new PhpCsFixer\Finder())
             ->in(__DIR__)
-            ->exclude(['ai.symfony.com', 'var', 'vendor'])
+            ->exclude(['ai.symfony.com', 'demo/mate', 'var', 'vendor'])
             ->notPath([
                 'demo/config/reference.php',
                 'src/mate/resources/mate/config.php',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

The demo/mate directory contains user-facing configuration files that should not be auto-formatted, similar to src/mate/resources/mate.

cc @wachterjohannes 

I have modified files in:
* https://github.com/symfony/ai/pull/1298