### PR TITLE
 Rename blog property to blogAgent in StreamCommand

### DIFF
--- a/demo/src/Blog/Command/StreamCommand.php
+++ b/demo/src/Blog/Command/StreamCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final readonly class StreamCommand
 {
     public function __construct(
-        private AgentInterface $blog,
+        private AgentInterface $blogAgent,
     ) {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | none
| License       | MIT

## Summary

In the StreamCommand the `__construct ` parameter was wrongly named. This leads into the following error:

```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!
!!  In DefinitionErrorExceptionPass.php line 48:
!!
!!    Cannot autowire service "App\Blog\Command\StreamCommand": argument "$blog"
!!    of method "__construct()" references interface "Symfony\AI\Agent\AgentInter
!!    face" but no such service exists. Did you mean to target one of "blogAgent"
!!    , "streamAgent", "youtubeAgent", "recipeAgent", "wikipediaAgent", "speechAg
!!    ent", "orchestratorAgent", "technicalAgent", "fallbackAgent", "supportMulti
!!    Agent" instead?
!!
!!
!!  2025-12-29T19:46:02+00:00 [info] User Deprecated: Since symfony/ux-typed 2.27.0: The package is deprecated and will be removed in 3.0. Follow the migration steps in https://github.com/symfony/ux/tree/2.x/src/Typed to keep using Typed in your Symfony application.
!!
Script @auto-scripts was called via post-update-cmd
```
