### PR TITLE
[Mate] Rename ComposerTypeDiscovery to ComposerExtensionDiscovery

### DIFF
--- a/src/mate/CLAUDE.md
+++ b/src/mate/CLAUDE.md
@@ -50,7 +50,7 @@ bin/mate clear-cache
 ### Core Classes
 - **App**: Console application builder
 - **ContainerFactory**: DI container management with extension discovery
-- **ComposerTypeDiscovery**: Discovers MCP extensions via `extra.ai-mate` in composer.json
+- **ComposerExtensionDiscovery**: Discovers MCP extensions via `extra.ai-mate` in composer.json
 - **FilteredDiscoveryLoader**: Loads MCP capabilities with feature filtering
 
 ### Key Directories

--- a/src/mate/src/Command/DiscoverCommand.php
+++ b/src/mate/src/Command/DiscoverCommand.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Mate\Command;
 
 use Psr\Log\LoggerInterface;
-use Symfony\AI\Mate\Discovery\ComposerTypeDiscovery;
+use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -56,7 +56,7 @@ class DiscoverCommand extends Command
         $io->text('Scanning for packages with <info>extra.ai-mate</info> configuration...');
         $io->newLine();
 
-        $discovery = new ComposerTypeDiscovery($this->rootDir, $this->logger);
+        $discovery = new ComposerExtensionDiscovery($this->rootDir, $this->logger);
 
         $extensions = $discovery->discover();
 

--- a/src/mate/src/Container/ContainerFactory.php
+++ b/src/mate/src/Container/ContainerFactory.php
@@ -13,7 +13,7 @@ namespace Symfony\AI\Mate\Container;
 
 use Mcp\Capability\Discovery\Discoverer;
 use Psr\Log\LoggerInterface;
-use Symfony\AI\Mate\Discovery\ComposerTypeDiscovery;
+use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
 use Symfony\AI\Mate\Exception\MissingDependencyException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -43,7 +43,7 @@ final class ContainerFactory
         $logger = $container->get('_build.logger');
         \assert($logger instanceof LoggerInterface);
 
-        $composerDiscovery = new ComposerTypeDiscovery($this->rootDir, $logger);
+        $composerDiscovery = new ComposerExtensionDiscovery($this->rootDir, $logger);
 
         $this->loadExtensions($container, $composerDiscovery, $logger);
         $this->loadUserServices($container, $composerDiscovery, $logger);
@@ -63,7 +63,7 @@ final class ContainerFactory
         $container->setParameter('mate.root_dir', $this->rootDir);
     }
 
-    private function loadExtensions(ContainerBuilder $container, ComposerTypeDiscovery $composerDiscovery, LoggerInterface $logger): void
+    private function loadExtensions(ContainerBuilder $container, ComposerExtensionDiscovery $composerDiscovery, LoggerInterface $logger): void
     {
         $enabledExtensions = $this->getEnabledExtensions();
         if ([] === $enabledExtensions) {
@@ -229,7 +229,7 @@ final class ContainerFactory
         (new Dotenv())->load($this->rootDir.\DIRECTORY_SEPARATOR.$envFile, ...$extra);
     }
 
-    private function loadUserServices(ContainerBuilder $container, ComposerTypeDiscovery $composerDiscovery, LoggerInterface $logger): void
+    private function loadUserServices(ContainerBuilder $container, ComposerExtensionDiscovery $composerDiscovery, LoggerInterface $logger): void
     {
         $rootProject = $composerDiscovery->discoverRootProject();
 

--- a/src/mate/src/Discovery/ComposerExtensionDiscovery.php
+++ b/src/mate/src/Discovery/ComposerExtensionDiscovery.php
@@ -29,7 +29,7 @@ use Psr\Log\LoggerInterface;
  * @author Johannes Wachter <johannes@sulu.io>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class ComposerTypeDiscovery
+final class ComposerExtensionDiscovery
 {
     /**
      * @var array<string, array{
@@ -85,7 +85,15 @@ final class ComposerTypeDiscovery
      */
     public function discoverRootProject(): array
     {
-        $composerContent = file_get_contents($this->rootDir.'/composer.json');
+        $composerPath = $this->rootDir.'/composer.json';
+        if (!file_exists($composerPath)) {
+            return [
+                'dirs' => [],
+                'includes' => [],
+            ];
+        }
+
+        $composerContent = file_get_contents($composerPath);
         if (false === $composerContent) {
             return [
                 'dirs' => [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | none
| License       | MIT

## Summary

- Rename class ComposerTypeDiscovery to ComposerExtensionDiscovery
- Add file existence check in discoverRootProject() method to prevent warnings
- Update all references in tests, commands, and container factory
