### PR TITLE
[Mate] Add `debug:extensions` command

### DIFF
--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -328,6 +328,47 @@ Commands
         # Root project capabilities
         $ vendor/bin/mate debug:capabilities --extension=_custom
 
+``mate debug:extensions``
+    Display detailed information about discovered and loaded MCP extensions. This command is useful for:
+
+    - Understanding which extensions are discovered vs enabled vs loaded
+    - Debugging extension loading issues
+    - Verifying extension configuration from ``mate/extensions.php``
+    - Inspecting scan directories and include files
+    - Troubleshooting why an extension isn't providing capabilities
+
+    **Status Indicators:**
+
+    ``[enabled]``
+        Extension is configured to load in ``mate/extensions.php``
+
+    ``[loaded]``
+        Extension successfully loaded into the DI container
+
+    ``[not loaded]``
+        Extension failed to load (package removed, error, etc.) - useful for troubleshooting
+
+    **Options:**
+
+    ``--format=FORMAT``
+        Output format: ``text`` (default) or ``json``
+
+    ``--show-all``
+        Show all discovered extensions including disabled ones
+
+    **Examples:**
+
+    .. code-block:: terminal
+
+        # Show enabled extensions
+        $ vendor/bin/mate debug:extensions
+
+        # Show all extensions (including disabled)
+        $ vendor/bin/mate debug:extensions --show-all
+
+        # JSON output for scripting
+        $ vendor/bin/mate debug:extensions --format=json
+
 Security
 --------
 

--- a/src/mate/CLAUDE.md
+++ b/src/mate/CLAUDE.md
@@ -43,6 +43,10 @@ bin/mate serve
 
 # Clear cache
 bin/mate clear-cache
+
+# Debug commands
+bin/mate debug:capabilities      # Show all MCP capabilities
+bin/mate debug:extensions        # Show extension discovery and loading status
 ```
 
 ## Architecture
@@ -54,7 +58,7 @@ bin/mate clear-cache
 - **FilteredDiscoveryLoader**: Loads MCP capabilities with feature filtering
 
 ### Key Directories
-- `src/Command/`: CLI commands (serve, init, discover, clear-cache)
+- `src/Command/`: CLI commands (serve, init, discover, clear-cache, debug:capabilities, debug:extensions)
 - `src/Container/`: DI container management
 - `src/Discovery/`: Extension discovery system
 - `src/Capability/`: Built-in MCP tools

--- a/src/mate/src/App.php
+++ b/src/mate/src/App.php
@@ -16,6 +16,7 @@ use Mcp\Server\Transport\Stdio\RunnerState;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Command\ClearCacheCommand;
 use Symfony\AI\Mate\Command\DebugCapabilitiesCommand;
+use Symfony\AI\Mate\Command\DebugExtensionsCommand;
 use Symfony\AI\Mate\Command\DiscoverCommand;
 use Symfony\AI\Mate\Command\InitCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
@@ -52,6 +53,7 @@ final class App
         self::addCommand($application, new DiscoverCommand($rootDir, $logger));
         self::addCommand($application, new StopCommand((string) $container->getParameter('mate.cache_dir')));
         self::addCommand($application, new DebugCapabilitiesCommand($logger, $container));
+        self::addCommand($application, new DebugExtensionsCommand($logger, $container));
         self::addCommand($application, new ClearCacheCommand($cacheDir));
 
         if (\defined('SIGUSR1') && class_exists(RunnerControl::class)) {

--- a/src/mate/src/Command/DebugCapabilitiesCommand.php
+++ b/src/mate/src/Command/DebugCapabilitiesCommand.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Display all MCP capabilities grouped by extension.
  *
  * @phpstan-import-type Capabilities from CapabilityCollector
+ * @phpstan-import-type ExtensionData from DebugExtensionsCommand
  *
  * @phpstan-type CapabilitiesByExtension array<string, Capabilities>
  *
@@ -37,7 +38,7 @@ class DebugCapabilitiesCommand extends Command
     private CapabilityCollector $collector;
 
     /**
-     * @var array<string, array{dirs: string[], includes: string[]}>
+     * @var array<string, ExtensionData>
      */
     private array $extensions;
 

--- a/src/mate/src/Command/DebugExtensionsCommand.php
+++ b/src/mate/src/Command/DebugExtensionsCommand.php
@@ -1,0 +1,269 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command;
+
+use Psr\Log\LoggerInterface;
+use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Display detailed information about discovered and loaded MCP extensions.
+ *
+ * @phpstan-type ExtensionData array{dirs: string[], includes: string[]}
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('debug:extensions', 'Display detailed information about discovered and loaded MCP extensions')]
+class DebugExtensionsCommand extends Command
+{
+    /**
+     * @var array<string, ExtensionData>
+     */
+    private array $discoveredExtensions;
+
+    /**
+     * @var ExtensionData
+     */
+    private array $rootProjectConfig;
+
+    /**
+     * @var string[]
+     */
+    private array $enabledExtensions;
+
+    /**
+     * @var array<string, ExtensionData>
+     */
+    private array $loadedExtensions;
+
+    private string $rootDir;
+
+    public function __construct(
+        LoggerInterface $logger,
+        ContainerInterface $container,
+    ) {
+        parent::__construct(self::getDefaultName());
+
+        $this->rootDir = $container->getParameter('mate.root_dir');
+        \assert(\is_string($this->rootDir));
+
+        $this->enabledExtensions = $container->getParameter('mate.enabled_extensions') ?? [];
+        \assert(\is_array($this->enabledExtensions));
+
+        $this->loadedExtensions = $container->getParameter('mate.extensions') ?? [];
+        \assert(\is_array($this->loadedExtensions));
+
+        $extensionDiscovery = new ComposerExtensionDiscovery($this->rootDir, $logger);
+        $this->discoveredExtensions = $extensionDiscovery->discover();
+        $this->rootProjectConfig = $extensionDiscovery->discoverRootProject();
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'debug:extensions';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Display detailed information about discovered and loaded MCP extensions';
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (text, json)', 'text')
+            ->addOption('show-all', null, InputOption::VALUE_NONE, 'Show all discovered extensions including disabled ones')
+            ->setHelp(<<<'HELP'
+The <info>%command.name%</info> command displays detailed information about MCP extension
+discovery and loading.
+
+<info>Usage Examples:</info>
+
+  <comment># Show enabled extensions</comment>
+  %command.full_name%
+
+  <comment># Show all discovered extensions (including disabled)</comment>
+  %command.full_name% --show-all
+
+  <comment># JSON output for scripting</comment>
+  %command.full_name% --format=json
+
+<info>Extension Information:</info>
+
+  • Discovery status (discovered vs enabled)
+  • Scan directories being monitored
+  • Include files being loaded
+  • Whether extension provides any capabilities
+  • Configuration source (composer.json extra.ai-mate)
+
+<info>Extension Types:</info>
+
+  • <fg=green>Enabled</>: Active and loaded into container
+  • <fg=yellow>Disabled</>: Discovered but disabled in mate/extensions.php
+  • <fg=cyan>Root Project</>: Project-specific capabilities from mate/src/
+HELP
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $showAll = $input->getOption('show-all');
+        $format = $input->getOption('format');
+        \assert(\is_string($format));
+
+        if ('json' === $format) {
+            $this->outputJson($output);
+        } else {
+            $this->outputText($showAll, $io);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function outputText(bool $showAll, SymfonyStyle $io): void
+    {
+        $io->title('MCP Extension Discovery');
+
+        $io->section('Root Project');
+        $this->displayExtensionDetails($io, '_custom', $this->rootProjectConfig, true, true);
+
+        $enabledCount = 0;
+        $disabledCount = 0;
+
+        $enabledExtensions = [];
+        $disabledExtensions = [];
+
+        foreach ($this->discoveredExtensions as $packageName => $data) {
+            $isEnabled = \in_array($packageName, $this->enabledExtensions, true);
+
+            if ($isEnabled) {
+                ++$enabledCount;
+                $enabledExtensions[$packageName] = $data;
+            } else {
+                ++$disabledCount;
+                $disabledExtensions[$packageName] = $data;
+            }
+        }
+
+        if (\count($enabledExtensions) > 0) {
+            $io->section(\sprintf('Enabled Extensions (%d)', $enabledCount));
+            foreach ($enabledExtensions as $packageName => $data) {
+                $isLoaded = isset($this->loadedExtensions[$packageName]);
+                $this->displayExtensionDetails($io, $packageName, $data, true, $isLoaded);
+            }
+        }
+
+        if ($showAll && \count($disabledExtensions) > 0) {
+            $io->section(\sprintf('Disabled Extensions (%d)', $disabledCount));
+            foreach ($disabledExtensions as $packageName => $data) {
+                $isLoaded = isset($this->loadedExtensions[$packageName]);
+                $this->displayExtensionDetails($io, $packageName, $data, false, $isLoaded);
+            }
+        }
+
+        $io->section('Summary');
+        $io->text(\sprintf('Total discovered: %d', \count($this->discoveredExtensions) + 1)); // +1 for root project
+        $io->text(\sprintf('Enabled: %d', $enabledCount + 1)); // +1 for root project
+        $io->text(\sprintf('Disabled: %d', $disabledCount));
+        $io->text(\sprintf('Loaded: %d', \count($this->loadedExtensions)));
+
+        if (!$showAll && $disabledCount > 0) {
+            $io->note(\sprintf('Use --show-all to see %d disabled extension%s', $disabledCount, 1 === $disabledCount ? '' : 's'));
+        }
+    }
+
+    /**
+     * @param array{dirs: string[], includes: string[]} $data
+     */
+    private function displayExtensionDetails(
+        SymfonyStyle $io,
+        string $packageName,
+        array $data,
+        bool $isEnabled,
+        bool $isLoaded,
+    ): void {
+        $status = $isEnabled ? '<fg=green>enabled</>' : '<fg=yellow>disabled</>';
+        $loadedStatus = $isLoaded ? '<fg=green>loaded</>' : '<fg=red>not loaded</>';
+
+        $io->text(\sprintf('<info>%s</info> [%s] [%s]', $packageName, $status, $loadedStatus));
+
+        if (\count($data['dirs']) > 0) {
+            $io->text(\sprintf('  Scan directories (%d):', \count($data['dirs'])));
+            foreach ($data['dirs'] as $dir) {
+                $io->text(\sprintf('    • %s', $dir));
+            }
+        } else {
+            $io->text('  <fg=gray>No scan directories</>');
+        }
+
+        if (\count($data['includes']) > 0) {
+            $io->text(\sprintf('  Include files (%d):', \count($data['includes'])));
+            foreach ($data['includes'] as $file) {
+                $io->text(\sprintf('    • %s', $file));
+            }
+        } else {
+            $io->text('  <fg=gray>No include files</>');
+        }
+
+        $io->newLine();
+    }
+
+    private function outputJson(OutputInterface $output): void
+    {
+        $extensions = [];
+
+        $extensions['_custom'] = [
+            'type' => 'root_project',
+            'status' => 'enabled',
+            'loaded' => true,
+            'scan_dirs' => $this->rootProjectConfig['dirs'],
+            'includes' => $this->rootProjectConfig['includes'],
+        ];
+
+        foreach ($this->discoveredExtensions as $packageName => $data) {
+            $isEnabled = \in_array($packageName, $this->enabledExtensions, true);
+            $isLoaded = isset($this->loadedExtensions[$packageName]);
+
+            $extensions[$packageName] = [
+                'type' => 'vendor_extension',
+                'status' => $isEnabled ? 'enabled' : 'disabled',
+                'loaded' => $isLoaded,
+                'scan_dirs' => $data['dirs'],
+                'includes' => $data['includes'],
+            ];
+        }
+
+        $enabledCount = array_reduce($extensions, fn ($count, $ext) => 'enabled' === $ext['status'] ? $count + 1 : $count, 0);
+        $disabledCount = \count($extensions) - $enabledCount;
+        $loadedCount = array_reduce($extensions, fn ($count, $ext) => $ext['loaded'] ? $count + 1 : $count, 0);
+
+        $result = [
+            'extensions' => $extensions,
+            'summary' => [
+                'total_discovered' => \count($extensions),
+                'enabled' => $enabledCount,
+                'disabled' => $disabledCount,
+                'loaded' => $loadedCount,
+            ],
+        ];
+
+        $output->writeln(json_encode($result, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/src/mate/src/Container/ContainerFactory.php
+++ b/src/mate/src/Container/ContainerFactory.php
@@ -66,6 +66,7 @@ final class ContainerFactory
     private function loadExtensions(ContainerBuilder $container, ComposerExtensionDiscovery $extensionDiscovery, LoggerInterface $logger): void
     {
         $enabledExtensions = $this->getEnabledExtensions();
+        $container->setParameter('mate.enabled_extensions', $enabledExtensions);
         if ([] === $enabledExtensions) {
             $container->setParameter('mate.extensions', [
                 '_custom' => $extensionDiscovery->discoverRootProject(),

--- a/src/mate/tests/Command/DebugExtensionsCommandTest.php
+++ b/src/mate/tests/Command/DebugExtensionsCommandTest.php
@@ -1,0 +1,247 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Command\DebugExtensionsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class DebugExtensionsCommandTest extends TestCase
+{
+    private string $fixturesDir;
+
+    protected function setUp(): void
+    {
+        $this->fixturesDir = __DIR__.'/../Discovery/Fixtures';
+    }
+
+    public function testExecuteDisplaysExtensions()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-a', 'vendor/package-b']);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['vendor/vendor/package-a/src'], 'includes' => []],
+            'vendor/package-b' => ['dirs' => ['vendor/vendor/package-b/lib'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugExtensionsCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('MCP Extension Discovery', $output);
+        $this->assertStringContainsString('Root Project', $output);
+        $this->assertStringContainsString('vendor/package-a', $output);
+        $this->assertStringContainsString('vendor/package-b', $output);
+        $this->assertStringContainsString('Summary', $output);
+    }
+
+    public function testExecuteShowsEnabledExtensionsOnly()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-a']);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['vendor/vendor/package-a/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugExtensionsCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('vendor/package-a', $output);
+        $this->assertStringContainsString('enabled', $output);
+        // vendor/package-b should not be shown as enabled
+        $this->assertStringNotContainsString('Disabled Extensions', $output);
+    }
+
+    public function testExecuteWithShowAllFlag()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-a']);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['vendor/vendor/package-a/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugExtensionsCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--show-all' => true]);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('vendor/package-a', $output);
+        $this->assertStringContainsString('vendor/package-b', $output);
+        $this->assertStringContainsString('Disabled Extensions', $output);
+    }
+
+    public function testExecuteWithJsonFormat()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-a']);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['vendor/vendor/package-a/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugExtensionsCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--format' => 'json']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $json = json_decode($output, true);
+        $this->assertIsArray($json);
+        $this->assertArrayHasKey('extensions', $json);
+        $this->assertArrayHasKey('summary', $json);
+        $this->assertArrayHasKey('_custom', $json['extensions']);
+        $this->assertArrayHasKey('vendor/package-a', $json['extensions']);
+        $this->assertArrayHasKey('total_discovered', $json['summary']);
+        $this->assertArrayHasKey('enabled', $json['summary']);
+        $this->assertArrayHasKey('disabled', $json['summary']);
+        $this->assertArrayHasKey('loaded', $json['summary']);
+    }
+
+    public function testExecuteShowsExtensionDetails()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-a']);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['vendor/vendor/package-a/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugExtensionsCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Scan directories', $output);
+        $this->assertStringContainsString('vendor/vendor/package-a/src', $output);
+    }
+
+    public function testExecuteHandlesNoLoadedExtensions()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugExtensionsCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Root Project', $output);
+    }
+
+    public function testExecuteShowsLoadedStatus()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-a']);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['vendor/vendor/package-a/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugExtensionsCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('loaded', $output);
+    }
+
+    public function testExecuteJsonFormatContainsExtensionMetadata()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-a']);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['vendor/vendor/package-a/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugExtensionsCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--format' => 'json']);
+
+        $json = json_decode($tester->getDisplay(), true);
+        $this->assertArrayHasKey('type', $json['extensions']['_custom']);
+        $this->assertSame('root_project', $json['extensions']['_custom']['type']);
+        $this->assertArrayHasKey('status', $json['extensions']['_custom']);
+        $this->assertArrayHasKey('loaded', $json['extensions']['_custom']);
+        $this->assertArrayHasKey('scan_dirs', $json['extensions']['_custom']);
+        $this->assertArrayHasKey('includes', $json['extensions']['_custom']);
+
+        $this->assertArrayHasKey('type', $json['extensions']['vendor/package-a']);
+        $this->assertSame('vendor_extension', $json['extensions']['vendor/package-a']['type']);
+    }
+
+    public function testExecuteShowsIncludeFiles()
+    {
+        $rootDir = $this->fixturesDir.'/with-includes';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', ['vendor/package-with-includes']);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-with-includes' => [
+                'dirs' => [],
+                'includes' => [$rootDir.'/vendor/vendor/package-with-includes/config/config.php'],
+            ],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new DebugExtensionsCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Include files', $output);
+        $this->assertStringContainsString('config/config.php', $output);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | none
| License       | MIT

## Description

This PR adds a new `debug:extensions` command to the Mate component, complementing the existing `debug:capabilities` command for a complete debugging workflow.

The command provides detailed information about MCP extension discovery and loading, helping developers troubleshoot extension issues by showing:

- **Discovery status**: Which extensions were discovered vs actually enabled
- **Loading status**: Which enabled extensions successfully loaded into the DI container
- **Configuration details**: Scan directories and include files per extension
- **Root project**: Special `_custom` extension for project-specific capabilities

This is particularly useful when debugging why certain extensions aren't providing expected capabilities, or when verifying that `mate/extensions.php` configuration is working correctly.

## Usage Examples

```bash
# Show enabled extensions only (default)
bin/mate debug:extensions

# Show all discovered extensions including disabled ones
bin/mate debug:extensions --show-all

# JSON output for scripting
bin/mate debug:extensions --format=json
```

## Example Output

```
MCP Extension Discovery
=======================

Root Project
------------

_custom [enabled] [loaded]
  Scan directories (1):
    • mate/src
  Include files (1):
    • mate/config.php

Enabled Extensions (2)
----------------------

symfony/ai-mate-monolog [enabled] [loaded]
  Scan directories (1):
    • vendor/symfony/ai-mate/src/Bridge/Monolog/Capability
  Include files (1):
    • vendor/symfony/ai-mate/src/Bridge/Monolog/config.php

symfony/ai-mate-symfony [enabled] [loaded]
  Scan directories (1):
    • vendor/symfony/ai-mate/src/Bridge/Symfony/Capability
  Include files (1):
    • vendor/symfony/ai-mate/src/Bridge/Symfony/config.php

Summary
-------

Total discovered: 3
Enabled: 3
Disabled: 0
Loaded: 3
```