### PR TITLE
[Mate] Remove exception factory methods

### DIFF
--- a/src/mate/src/App.php
+++ b/src/mate/src/App.php
@@ -76,7 +76,7 @@ final class App
         } elseif (method_exists($application, 'add')) {
             $application->add($command);
         } else {
-            throw UnsupportedVersionException::forConsole();
+            throw new UnsupportedVersionException('Unsupported version of symfony/console. We cannot add commands.');
         }
     }
 }

--- a/src/mate/src/Bridge/Monolog/Exception/LogFileNotFoundException.php
+++ b/src/mate/src/Bridge/Monolog/Exception/LogFileNotFoundException.php
@@ -20,8 +20,8 @@ use Symfony\AI\Mate\Exception\InvalidArgumentException;
  */
 class LogFileNotFoundException extends InvalidArgumentException
 {
-    public static function forPath(string $path): self
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
-        return new self(\sprintf('Log file not found: "%s"', $path));
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/mate/src/Bridge/Monolog/Service/LogReader.php
+++ b/src/mate/src/Bridge/Monolog/Service/LogReader.php
@@ -89,7 +89,7 @@ final class LogReader
     public function readFile(string $filePath, ?SearchCriteria $criteria = null): \Generator
     {
         if (!file_exists($filePath)) {
-            throw LogFileNotFoundException::forPath($filePath);
+            throw new LogFileNotFoundException(\sprintf('Log file not found: "%s"', $filePath));
         }
 
         yield from $this->readFiles([$filePath], $criteria);

--- a/src/mate/src/Bridge/Symfony/Exception/FileNotFoundException.php
+++ b/src/mate/src/Bridge/Symfony/Exception/FileNotFoundException.php
@@ -20,8 +20,8 @@ use Symfony\AI\Mate\Exception\InvalidArgumentException;
  */
 class FileNotFoundException extends InvalidArgumentException
 {
-    public static function forContainerXml(string $path): self
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
-        return new self(\sprintf('Container XML at "%s" does not exist', $path));
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/mate/src/Bridge/Symfony/Exception/XmlContainerCouldNotBeLoadedException.php
+++ b/src/mate/src/Bridge/Symfony/Exception/XmlContainerCouldNotBeLoadedException.php
@@ -20,13 +20,8 @@ use Symfony\AI\Mate\Exception\InvalidArgumentException;
  */
 class XmlContainerCouldNotBeLoadedException extends InvalidArgumentException
 {
-    public static function forContainerDoesNotExist(string $path): self
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
-        return new self(\sprintf('Container "%s" does not exist', $path));
-    }
-
-    public static function forContainerCannotBeParsed(string $path): self
-    {
-        return new self(\sprintf('Container "%s" cannot be parsed', $path));
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/mate/src/Bridge/Symfony/Exception/XmlContainerPathIsNotConfiguredException.php
+++ b/src/mate/src/Bridge/Symfony/Exception/XmlContainerPathIsNotConfiguredException.php
@@ -11,15 +11,17 @@
 
 namespace Symfony\AI\Mate\Bridge\Symfony\Exception;
 
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
+
 /**
  * @internal
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class XmlContainerPathIsNotConfiguredException extends XmlContainerCouldNotBeLoadedException
+class XmlContainerPathIsNotConfiguredException extends InvalidArgumentException
 {
-    public static function emptyPath(): self
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
-        return new self('Failed to configure path to Symfony container. You passed an empty string');
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/mate/src/Bridge/Symfony/Service/ContainerProvider.php
+++ b/src/mate/src/Bridge/Symfony/Service/ContainerProvider.php
@@ -136,21 +136,21 @@ class ContainerProvider
     private function parseXml(string $containerXmlPath): \SimpleXMLElement
     {
         if ('' === $containerXmlPath) {
-            throw XmlContainerPathIsNotConfiguredException::emptyPath();
+            throw new XmlContainerPathIsNotConfiguredException('Failed to configure path to Symfony container. You passed an empty string.');
         }
 
         if (!file_exists($containerXmlPath)) {
-            throw FileNotFoundException::forContainerXml($containerXmlPath);
+            throw new FileNotFoundException(\sprintf('Container XML at "%s" does not exist', $containerXmlPath));
         }
 
         $fileContents = file_get_contents($containerXmlPath);
         if (false === $fileContents) {
-            throw XmlContainerCouldNotBeLoadedException::forContainerDoesNotExist($containerXmlPath);
+            throw new XmlContainerCouldNotBeLoadedException(\sprintf('Container "%s" does not exist', $containerXmlPath));
         }
 
         $xml = @simplexml_load_string($fileContents);
         if (false === $xml) {
-            throw XmlContainerCouldNotBeLoadedException::forContainerCannotBeParsed($containerXmlPath);
+            throw new XmlContainerCouldNotBeLoadedException(\sprintf('Container "%s" cannot be parsed', $containerXmlPath));
         }
 
         return $xml;

--- a/src/mate/src/Command/DebugCapabilitiesCommand.php
+++ b/src/mate/src/Command/DebugCapabilitiesCommand.php
@@ -146,7 +146,7 @@ HELP
     private function filterExtensions(array $all, string $filter): array
     {
         if (!isset($all[$filter])) {
-            throw InvalidArgumentException::forExtensionNotFound($filter, array_keys($all));
+            throw new InvalidArgumentException(\sprintf('Extension "%s" not found. Available: "%s"', $filter, implode(', ', array_keys($all))));
         }
 
         return [$filter => $all[$filter]];
@@ -161,7 +161,7 @@ HELP
     {
         $validTypes = ['tool', 'resource', 'prompt', 'template'];
         if (!\in_array($type, $validTypes, true)) {
-            throw InvalidArgumentException::forInvalidType($type, $validTypes);
+            throw new InvalidArgumentException(\sprintf('Invalid type "%s". Valid types: "%s"', $type, implode(', ', $validTypes)));
         }
 
         $typeMap = [

--- a/src/mate/src/Container/ContainerFactory.php
+++ b/src/mate/src/Container/ContainerFactory.php
@@ -222,7 +222,7 @@ final class ContainerFactory
         }
 
         if (!class_exists(Dotenv::class)) {
-            throw MissingDependencyException::forDotenv();
+            throw new MissingDependencyException('Cannot load any environment file with out Symfony Dotenv. Please run run "composer require symfony/dotenv" and try again.');
         }
 
         $extra = [];

--- a/src/mate/src/Exception/FileWriteException.php
+++ b/src/mate/src/Exception/FileWriteException.php
@@ -18,8 +18,8 @@ namespace Symfony\AI\Mate\Exception;
  */
 class FileWriteException extends RuntimeException
 {
-    public static function forLogFile(string $path): self
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
-        return new self(\sprintf('Failed to write to log file: %s', $path));
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/mate/src/Exception/InvalidArgumentException.php
+++ b/src/mate/src/Exception/InvalidArgumentException.php
@@ -20,27 +20,4 @@ namespace Symfony\AI\Mate\Exception;
  */
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
-    /**
-     * @param array<string> $available
-     */
-    public static function forExtensionNotFound(string $extension, array $available): self
-    {
-        return new self(\sprintf(
-            'Extension "%s" not found. Available: %s',
-            $extension,
-            implode(', ', $available)
-        ));
-    }
-
-    /**
-     * @param array<string> $validTypes
-     */
-    public static function forInvalidType(string $type, array $validTypes): self
-    {
-        return new self(\sprintf(
-            'Invalid type "%s". Valid types: %s',
-            $type,
-            implode(', ', $validTypes)
-        ));
-    }
 }

--- a/src/mate/src/Exception/MissingDependencyException.php
+++ b/src/mate/src/Exception/MissingDependencyException.php
@@ -19,8 +19,8 @@ namespace Symfony\AI\Mate\Exception;
  */
 class MissingDependencyException extends RuntimeException
 {
-    public static function forDotenv(): self
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
-        return new self('Cannot load any environment file with out Symfony Dotenv. Please run run "composer require symfony/dotenv" and try again.');
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/mate/src/Exception/UnsupportedVersionException.php
+++ b/src/mate/src/Exception/UnsupportedVersionException.php
@@ -19,8 +19,8 @@ namespace Symfony\AI\Mate\Exception;
  */
 class UnsupportedVersionException extends RuntimeException
 {
-    public static function forConsole(): self
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
-        return new self('Unsupported version of symfony/console. We cannot add commands.');
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/mate/src/Service/Logger.php
+++ b/src/mate/src/Service/Logger.php
@@ -54,7 +54,7 @@ class Logger extends AbstractLogger
                     fwrite(\STDERR, $logMessage);
                 }
 
-                throw FileWriteException::forLogFile($this->logFile);
+                throw new FileWriteException(\sprintf('Failed to write to log file: "%s"', $this->logFile));
             }
         } else {
             fwrite(\STDERR, $logMessage);

--- a/src/mate/tests/Service/LoggerTest.php
+++ b/src/mate/tests/Service/LoggerTest.php
@@ -89,7 +89,7 @@ final class LoggerTest extends TestCase
         $logger = new Logger($invalidPath, fileLogEnabled: true);
 
         $this->expectException(FileWriteException::class);
-        $this->expectExceptionMessage('Failed to write to log file: /invalid/path/that/does/not/exist/test.log');
+        $this->expectExceptionMessage('Failed to write to log file: "/invalid/path/that/does/not/exist/test.log"');
 
         $logger->info('This should fail');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | none
| License       | MIT

## Summary

Remove static factory methods from all exception classes in the mate component
and replace them with constructor parameters that format messages internally.