### PR TITLE
Remove redundant `doctrine/dbal` dependency from examples

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -23,7 +23,6 @@
     ],
     "require": {
         "php": ">=8.2",
-        "doctrine/dbal": "^3.3|^4.0",
         "symfony/ai-agent": "^0.1",
         "symfony/ai-ai-ml-api-platform": "^0.1",
         "symfony/ai-albert-platform": "^0.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

The `doctrine/dbal` dependency is already required transitively through `symfony/ai-doctrine-message-store`.