### PR TITLE
[Platform][Gemini][VertexAI] Fix nullable parameter type handling in `ToolNormalizer`

### DIFF
--- a/src/platform/src/Bridge/Gemini/Tests/Contract/ToolNormalizerTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Contract/ToolNormalizerTest.php
@@ -129,5 +129,82 @@ final class ToolNormalizerTest extends TestCase
                 'parameters' => null,
             ],
         ];
+
+        yield 'call with nullable parameter' => [
+            new Tool(
+                new ExecutionReference(ToolRequiredParams::class, 'bar'),
+                'tool_nullable_param',
+                'A tool with nullable parameter',
+                // @phpstan-ignore argument.type (testing array-style nullable types that get normalized)
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'type' => ['string', 'null'],
+                            'description' => 'A nullable name',
+                        ],
+                    ],
+                    'additionalProperties' => false,
+                ],
+            ),
+            [
+                'description' => 'A tool with nullable parameter',
+                'name' => 'tool_nullable_param',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                            'nullable' => true,
+                            'description' => 'A nullable name',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'call with nested nullable parameter' => [
+            new Tool(
+                new ExecutionReference(ToolRequiredParams::class, 'bar'),
+                'tool_nested_nullable',
+                'A tool with nested nullable parameter',
+                // @phpstan-ignore argument.type (testing array-style nullable types that get normalized)
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'user' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'age' => [
+                                    'type' => ['integer', 'null'],
+                                    'description' => 'User age',
+                                ],
+                            ],
+                            'additionalProperties' => false,
+                        ],
+                    ],
+                    'additionalProperties' => false,
+                ],
+            ),
+            [
+                'description' => 'A tool with nested nullable parameter',
+                'name' => 'tool_nested_nullable',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'user' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'age' => [
+                                    'type' => 'integer',
+                                    'nullable' => true,
+                                    'description' => 'User age',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/src/platform/src/Bridge/VertexAi/Tests/Contract/ToolNormalizerTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Contract/ToolNormalizerTest.php
@@ -129,5 +129,82 @@ final class ToolNormalizerTest extends TestCase
                 ],
             ],
         ];
+
+        yield 'call with nullable parameter' => [
+            new Tool(
+                new ExecutionReference(ToolRequiredParams::class, 'bar'),
+                'tool_nullable_param',
+                'A tool with nullable parameter',
+                // @phpstan-ignore argument.type (testing array-style nullable types that get normalized)
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'type' => ['string', 'null'],
+                            'description' => 'A nullable name',
+                        ],
+                    ],
+                    'additionalProperties' => false,
+                ],
+            ),
+            [
+                'description' => 'A tool with nullable parameter',
+                'name' => 'tool_nullable_param',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                            'nullable' => true,
+                            'description' => 'A nullable name',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'call with nested nullable parameter' => [
+            new Tool(
+                new ExecutionReference(ToolRequiredParams::class, 'bar'),
+                'tool_nested_nullable',
+                'A tool with nested nullable parameter',
+                // @phpstan-ignore argument.type (testing array-style nullable types that get normalized)
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'user' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'age' => [
+                                    'type' => ['integer', 'null'],
+                                    'description' => 'User age',
+                                ],
+                            ],
+                            'additionalProperties' => false,
+                        ],
+                    ],
+                    'additionalProperties' => false,
+                ],
+            ),
+            [
+                'description' => 'A tool with nested nullable parameter',
+                'name' => 'tool_nested_nullable',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'user' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'age' => [
+                                    'type' => 'integer',
+                                    'nullable' => true,
+                                    'description' => 'User age',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1127
| License       | MIT

Convert array-style nullable types like `["string", "null"]` to Gemini's required format `{"type": "string", "nullable": true}`.

This fixes the "Proto field is not repeating, cannot start list" error when using nullable parameters with Gemini and VertexAI.
