### PR TITLE
[Chat] Fix keys access for `Cloudflare`

### DIFF
--- a/src/chat/src/Bridge/Cloudflare/MessageStore.php
+++ b/src/chat/src/Bridge/Cloudflare/MessageStore.php
@@ -157,6 +157,6 @@ final class MessageStore implements ManagedStoreInterface, MessageStoreInterface
 
         reset($filteredNamespaces);
 
-        return $filteredNamespaces[0];
+        return array_values($filteredNamespaces)[0];
     }
 }

--- a/src/chat/src/Bridge/Cloudflare/Tests/MessageStoreTest.php
+++ b/src/chat/src/Bridge/Cloudflare/Tests/MessageStoreTest.php
@@ -56,6 +56,62 @@ final class MessageStoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testMessageStoreCannotSetupOnExistingNamespaceOnSecondPageWithExistingIndices()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'result' => [
+                    [
+                        'id' => Uuid::v7()->toRfc4122(),
+                        'title' => 'bar',
+                        'supports_url_encoding' => false,
+                    ],
+                ],
+                'result_info' => [
+                    'count' => 1,
+                    'page' => 1,
+                    'total_count' => 3,
+                    'total_pages' => 2,
+                ],
+                'success' => true,
+                'errors' => [],
+                'messages' => [],
+            ], [
+                'http_code' => 200,
+            ]),
+            new JsonMockResponse([
+                'result' => [
+                    [
+                        'id' => Uuid::v7()->toRfc4122(),
+                        'title' => 'second',
+                        'supports_url_encoding' => false,
+                    ],
+                    [
+                        'id' => Uuid::v7()->toRfc4122(),
+                        'title' => 'foo',
+                        'supports_url_encoding' => false,
+                    ],
+                ],
+                'result_info' => [
+                    'count' => 2,
+                    'page' => 2,
+                    'total_count' => 3,
+                    'total_pages' => 2,
+                ],
+                'success' => true,
+                'errors' => [],
+                'messages' => [],
+            ], [
+                'http_code' => 200,
+            ]),
+        ]);
+
+        $messageStore = new MessageStore($httpClient, 'foo', 'bar', 'random');
+        $messageStore->setup();
+
+        $this->assertSame(2, $httpClient->getRequestsCount());
+    }
+
     public function testMessageStoreCannotSetupOnExistingNamespaceOnSecondPage()
     {
         $httpClient = new MockHttpClient([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Detected via #821 
| License       | MIT

After the `reset`, if the element has the key `12`, the final array will keep it as it, need to reindex the array before returning it 😓 