### PR TITLE
[Mate] Add error handling for PID file creation in ServeCommand

### DIFF
--- a/src/mate/src/Command/ServeCommand.php
+++ b/src/mate/src/Command/ServeCommand.php
@@ -110,12 +110,16 @@ class ServeCommand extends Command
             ->build();
 
         $pidFileName = \sprintf('%s/server_%d.pid', $this->cacheDir, getmypid());
-        file_put_contents($pidFileName, getmypid());
+        if (false === @file_put_contents($pidFileName, (string) getmypid())) {
+            $this->logger->warning('Failed to create PID file', ['path' => $pidFileName]);
+        }
 
         try {
             $server->run(new StdioTransport());
         } finally {
-            unlink($pidFileName);
+            if (file_exists($pidFileName)) {
+                @unlink($pidFileName);
+            }
         }
 
         return Command::SUCCESS;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        |  none
| License       | MIT

## Summary

- Check return value of file_put_contents() when creating PID file
- Log warning if PID file creation fails instead of silently failing
- Add file_exists() check before cleanup in finally block
- Use error suppression operator to prevent PHP warnings