### PR TITLE
[Platform][OpenRouter] Add streaming and structure output capabilities

### DIFF
--- a/examples/openrouter/structured-output-math.php
+++ b/examples/openrouter/structured-output-math.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenRouter\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\MathReasoning;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$dispatcher = new EventDispatcher();
+$dispatcher->addSubscriber(new PlatformSubscriber());
+
+$platform = PlatformFactory::create(env('OPENROUTER_KEY'), http_client(), eventDispatcher: $dispatcher);
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful math tutor. Guide the user through the solution step by step.'),
+    Message::ofUser('how can I solve 8x + 7 = -23'),
+);
+
+$result = $platform->invoke('openai/gpt-4o-mini', $messages, ['response_format' => MathReasoning::class]);
+
+dump($result->asObject());

--- a/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.2
+---
+
+* Add support for structured output via ModelApiCatalog
+
 0.1
 ---
 

--- a/src/platform/src/Bridge/OpenRouter/ModelApiCatalog.php
+++ b/src/platform/src/Bridge/OpenRouter/ModelApiCatalog.php
@@ -101,6 +101,14 @@ final class ModelApiCatalog extends AbstractOpenRouterModelCatalog
                 }
             }
 
+            // Streaming is allowed for any model: https://openrouter.ai/docs/api/reference/streaming
+            $capabilities[] = Capability::OUTPUT_STREAMING;
+
+            // Structured Output via PlatformSubscriber
+            if (\in_array('structured_outputs', $model['supported_parameters'] ?? [])) {
+                $capabilities[] = Capability::OUTPUT_STRUCTURED;
+            }
+
             yield $model['id'] => [
                 'class' => CompletionsModel::class,
                 'capabilities' => $capabilities,

--- a/src/platform/src/Bridge/OpenRouter/ModelCatalog.php
+++ b/src/platform/src/Bridge/OpenRouter/ModelCatalog.php
@@ -2281,6 +2281,7 @@ final class ModelCatalog extends AbstractOpenRouterModelCatalog
                     Capability::INPUT_IMAGE,
                     Capability::INPUT_PDF,
                     Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STRUCTURED,
                 ],
             ],
             'openai/gpt-4o-mini-2024-07-18' => [
@@ -2763,6 +2764,11 @@ final class ModelCatalog extends AbstractOpenRouterModelCatalog
 
         if (!class_exists($modelClass)) {
             throw new InvalidArgumentException(\sprintf('Model class "%s" does not exist.', $modelClass));
+        }
+
+        if (CompletionsModel::class === $modelClass && !\in_array(Capability::OUTPUT_STREAMING, $modelConfig['capabilities'])) {
+            // Streaming is allowed for any model: https://openrouter.ai/docs/api/reference/streaming
+            $modelConfig['capabilities'][] = Capability::OUTPUT_STREAMING;
         }
 
         $model = new $modelClass($actualModelName, $modelConfig['capabilities'], $options);

--- a/src/platform/src/Bridge/OpenRouter/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/OpenRouter/Tests/ModelCatalogTest.php
@@ -32,6 +32,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
             'openrouter/auto',
             CompletionsModel::class,
             [
+                Capability::OUTPUT_STREAMING,
                 Capability::INPUT_TEXT,
                 Capability::OUTPUT_TEXT,
             ],
@@ -41,6 +42,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
             'anthropic/claude-sonnet-4.5',
             CompletionsModel::class,
             [
+                Capability::OUTPUT_STREAMING,
                 Capability::INPUT_TEXT,
                 Capability::INPUT_IMAGE,
                 Capability::INPUT_PDF,
@@ -52,6 +54,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
             'openai/gpt-5',
             CompletionsModel::class,
             [
+                Capability::OUTPUT_STREAMING,
                 Capability::INPUT_TEXT,
                 Capability::INPUT_IMAGE,
                 Capability::INPUT_PDF,
@@ -63,6 +66,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
             'google/gemini-2.5-flash-image',
             CompletionsModel::class,
             [
+                Capability::OUTPUT_STREAMING,
                 Capability::INPUT_IMAGE,
                 Capability::INPUT_TEXT,
                 Capability::OUTPUT_IMAGE,
@@ -100,7 +104,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         $this->assertInstanceOf(Model::class, $model);
         $this->assertInstanceOf(CompletionsModel::class, $model);
         $this->assertSame('unknown/model', $model->getName());
-        $this->assertSame([], $model->getCapabilities());
+        $this->assertSame([Capability::OUTPUT_STREAMING], $model->getCapabilities());
     }
 
     public function testGetModelWithPreset()
@@ -124,7 +128,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         $this->assertInstanceOf(Model::class, $model);
         $this->assertInstanceOf(CompletionsModel::class, $model);
         $this->assertSame('deepseek/deepseek-v3.1-terminus:exacto', $model->getName());
-        $this->assertSame([Capability::INPUT_TEXT, Capability::OUTPUT_TEXT], $model->getCapabilities());
+        $this->assertSame([Capability::INPUT_TEXT, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING], $model->getCapabilities());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

Openrouter support streaming options for every model. Capability is added to every model.
Furthermore, the dynamic catalog check the structure output capability and map it to the internal flag.

