### PR TITLE
[Platform] Better error handling for structure output

### DIFF
--- a/src/platform/src/Exception/MissingModelSupportException.php
+++ b/src/platform/src/Exception/MissingModelSupportException.php
@@ -11,32 +11,34 @@
 
 namespace Symfony\AI\Platform\Exception;
 
+use Symfony\AI\Platform\Model;
+
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
 final class MissingModelSupportException extends RuntimeException
 {
-    private function __construct(string $model, string $support)
+    private function __construct(Model $model, string $support)
     {
-        parent::__construct(\sprintf('Model "%s" does not support "%s".', $model, $support));
+        parent::__construct(\sprintf('Model "%s" (%s) does not support "%s".', $model->getName(), $model::class, $support));
     }
 
-    public static function forToolCalling(string $model): self
+    public static function forToolCalling(Model $model): self
     {
         return new self($model, 'tool calling');
     }
 
-    public static function forAudioInput(string $model): self
+    public static function forAudioInput(Model $model): self
     {
         return new self($model, 'audio input');
     }
 
-    public static function forImageInput(string $model): self
+    public static function forImageInput(Model $model): self
     {
         return new self($model, 'image input');
     }
 
-    public static function forStructuredOutput(string $model): self
+    public static function forStructuredOutput(Model $model): self
     {
         return new self($model, 'structured output');
     }

--- a/src/platform/src/StructuredOutput/PlatformSubscriber.php
+++ b/src/platform/src/StructuredOutput/PlatformSubscriber.php
@@ -64,7 +64,7 @@ final class PlatformSubscriber implements EventSubscriberInterface
         }
 
         if (!$event->getModel()->supports(Capability::OUTPUT_STRUCTURED)) {
-            throw MissingModelSupportException::forStructuredOutput($event->getModel()::class);
+            throw MissingModelSupportException::forStructuredOutput($event->getModel());
         }
 
         if (!class_exists($options[self::RESPONSE_FORMAT])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Streamline the error message for Bridges with huge amount of models. 
Focus the **model name** in the exception output and **not only** the class name.

Avoid: `Model "Symfony\AI\Platform\Bridge\Generic\CompletionsModel" does not support "structured output".`
Prefer `Model "mistralai/mistral-nemo" (Symfony\AI\Platform\Bridge\Generic\CompletionsModel) does not support "structured output".`
