### PR TITLE
[Platform] Move stream up in convert function, in front of $response access

### DIFF
--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -35,16 +35,16 @@ class ResultConverter implements ResultConverterInterface
 
     public function convert(RawHttpResult|RawResultInterface $result, array $options = []): ResultInterface
     {
+        if ($options['stream'] ?? false) {
+            return new StreamResult($this->convertStream($result));
+        }
+
         $response = $result->getObject();
 
         if (429 === $response->getStatusCode()) {
             $retryAfter = $response->getHeaders(false)['retry-after'][0] ?? null;
             $retryAfterValue = $retryAfter ? (int) $retryAfter : null;
             throw new RateLimitExceededException($retryAfterValue);
-        }
-
-        if ($options['stream'] ?? false) {
-            return new StreamResult($this->convertStream($result));
         }
 
         $data = $result->getData();

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -42,14 +42,14 @@ final class ResultConverter implements ResultConverterInterface
 
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if ($options['stream'] ?? false) {
+            return new StreamResult($this->convertStream($result));
+        }
+
         $response = $result->getObject();
 
         if (429 === $response->getStatusCode()) {
             throw new RateLimitExceededException();
-        }
-
-        if ($options['stream'] ?? false) {
-            return new StreamResult($this->convertStream($result));
         }
 
         $data = $result->getData();

--- a/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
@@ -44,6 +44,10 @@ class ResultConverter implements ResultConverterInterface
 
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if ($options['stream'] ?? false) {
+            return new StreamResult($this->convertStream($result));
+        }
+
         $response = $result->getObject();
 
         if (401 === $response->getStatusCode()) {
@@ -58,10 +62,6 @@ class ResultConverter implements ResultConverterInterface
 
         if (429 === $response->getStatusCode()) {
             throw new RateLimitExceededException();
-        }
-
-        if ($options['stream'] ?? false) {
-            return new StreamResult($this->convertStream($result));
         }
 
         $data = $result->getData();

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -39,11 +39,11 @@ final class ResultConverter implements ResultConverterInterface
      */
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
-        $httpResponse = $result->getObject();
-
         if ($options['stream'] ?? false) {
             return new StreamResult($this->convertStream($result));
         }
+
+        $httpResponse = $result->getObject();
 
         if (200 !== $code = $httpResponse->getStatusCode()) {
             throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $httpResponse->getContent(false)));

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -49,6 +49,10 @@ final class ResultConverter implements ResultConverterInterface
 
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if ($options['stream'] ?? false) {
+            return new StreamResult($this->convertStream($result));
+        }
+
         $response = $result->getObject();
 
         if (401 === $response->getStatusCode()) {
@@ -68,10 +72,6 @@ final class ResultConverter implements ResultConverterInterface
                 ?? null;
 
             throw new RateLimitExceededException($resetTime ? self::parseResetTime($resetTime) : null);
-        }
-
-        if ($options['stream'] ?? false) {
-            return new StreamResult($this->convertStream($result));
         }
 
         $data = $result->getData();

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -42,14 +42,14 @@ final class ResultConverter implements ResultConverterInterface
 
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if ($options['stream'] ?? false) {
+            return new StreamResult($this->convertStream($result));
+        }
+
         $response = $result->getObject();
 
         if (429 === $response->getStatusCode()) {
             throw new RateLimitExceededException();
-        }
-
-        if ($options['stream'] ?? false) {
-            return new StreamResult($this->convertStream($result));
         }
 
         $data = $result->getData();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

By design, I suggest checking the stream output always first in the Result converter. Reason: If the response is really a AsyncResponse, then even a "getStatusCode" on the response trigger the initialize process of the async handling. I suggest handling the stream in the first line of the convert will avoid this problem.

Any thought related to this?