### PR TITLE
[Platform][Mistral] Extend catalog - add devstral open models

### DIFF
--- a/src/platform/src/Bridge/Mistral/ModelCatalog.php
+++ b/src/platform/src/Bridge/Mistral/ModelCatalog.php
@@ -35,6 +35,26 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::TOOL_CALLING,
                 ],
             ],
+            'devstral-medium-latest' => [
+                'class' => Mistral::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            'devstral-small-latest' => [
+                'class' => Mistral::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
             'mistral-large-latest' => [
                 'class' => Mistral::class,
                 'capabilities' => [

--- a/src/platform/src/Bridge/Mistral/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/ModelCatalogTest.php
@@ -26,6 +26,8 @@ final class ModelCatalogTest extends ModelCatalogTestCase
     public static function modelsProvider(): iterable
     {
         yield 'codestral-latest' => ['codestral-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
+        yield 'devstral-medium-latest' => ['devstral-medium-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
+        yield 'devstral-small-latest' => ['devstral-small-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
         yield 'mistral-large-latest' => ['mistral-large-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
         yield 'mistral-medium-latest' => ['mistral-medium-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::INPUT_IMAGE, Capability::TOOL_CALLING]];
         yield 'mistral-small-latest' => ['mistral-small-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::INPUT_IMAGE, Capability::TOOL_CALLING]];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | -
| License       | MIT


The PR adds two missing open models (open-source) from Mistral, to the Mistral Platform Catalog.

Please let me know if there is a different recommended way to use models outside of the AI bundle Catalogs.

[Mistral Model List](https://mistral.ai/pricing#api-pricing)
Filter by: **Coding** & **Open model**

Usage example:
```
ai:
    platform:
        mistral:
            api_key: '%env(MISTRAL_API_KEY)%'

    agent:
        default:
            model: 'devstral-medium-latest'
#            model: 'devstral-small-latest'
```