### PR TITLE
[Core] Update CI scripts on demo

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -53,9 +53,13 @@ jobs:
               uses: ramsey/composer-install@v3
               with:
                   working-directory: demo
+                  composer-options: "--no-scripts"
 
             - name: Link packages
               run: cd demo && ../link
+
+            - name: Clear the cache
+              run: cd demo && php bin/console cache:clear
 
             - name: Run PHPStan
               run: cd demo && vendor/bin/phpstan


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | See #1339 
| License       | MIT

Launching scripts trigger errors if there's files that must be linked, the cache is cleared once the link has been made.
