### PR TITLE
 Hide binary output in by subprocesses in runner

### DIFF
--- a/examples/runner
+++ b/examples/runner
@@ -91,6 +91,9 @@ $app = (new SingleCommandApplication('Symfony AI Example Runner'))
 
                     $output = str_replace(PHP_EOL, ' ', $process->getOutput());
                     $output = strlen($output) <= 100 ? $output : substr($output, 0, 100).'...';
+                    if (str_contains($output, "\0")) {
+                        $output = '<fg=gray>[binary output]</>';
+                    }
                     $emptyOutput = 0 === strlen(trim($output));
 
                     $state = 'Running';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

**Before**
<img width="1711" height="1034" alt="image" src="https://github.com/user-attachments/assets/51bfaffa-de35-404b-b52b-6c8c135d78a4" />
 
**After**
<img width="1208" height="236" alt="image" src="https://github.com/user-attachments/assets/bdb3d5bb-cbff-48ad-9604-9ce301262eaf" />
