### PR TITLE
 [Mate] Fix mate logger failing when log directory doesn't exist

### DIFF
--- a/src/mate/src/Service/Logger.php
+++ b/src/mate/src/Service/Logger.php
@@ -47,6 +47,8 @@ class Logger extends AbstractLogger
         );
 
         if ($this->fileLogEnabled || !\defined('STDERR')) {
+            $this->ensureDirectoryExists($this->logFile);
+
             $result = @file_put_contents($this->logFile, $logMessage, \FILE_APPEND);
             if (false === $result) {
                 $errorMessage = \sprintf('Failed to write to log file: "%s"', $this->logFile);
@@ -60,6 +62,17 @@ class Logger extends AbstractLogger
             }
         } else {
             fwrite(\STDERR, $logMessage);
+        }
+    }
+
+    private function ensureDirectoryExists(string $filePath): void
+    {
+        $directory = \dirname($filePath);
+
+        if (!is_dir($directory)) {
+            if (!@mkdir($directory, 0755, true) && !is_dir($directory)) {
+                throw new FileWriteException(\sprintf('Failed to create log directory: "%s"', $directory));
+            }
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | N/A
| License       | MIT

### Summary

The mate logger was failing to start when the configured log file path included a non-existing directory, because file_put_contents() does not automatically create parent directories.

Changes:
- Add ensureDirectoryExists() method to Logger service
- Automatically creates parent directories with 0755 permissions
- Throws clear exception if directory creation fails due to permissions
- Add test coverage for automatic directory creation
- Add test for permission-based directory creation failures
- Update existing test to expect directory creation error message