### PR TITLE
[Evaluator] Add component

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -33,6 +33,7 @@
         "symfony/ai-doctrine-message-store": "^0.11",
         "symfony/ai-elasticsearch-store": "^0.11",
         "symfony/ai-eleven-labs-platform": "^0.11",
+        "symfony/ai-evaluator": "^0.11",
         "symfony/ai-failover-platform": "^0.11",
         "symfony/ai-gemini-platform": "^0.11",
         "symfony/ai-generic-platform": "^0.11",

--- a/examples/evaluator/evaluator-output-end-with.php
+++ b/examples/evaluator/evaluator-output-end-with.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Evaluator\Evaluator;
+use Symfony\AI\Evaluator\Scorer\EndWith;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+
+$evaluator = new Evaluator([
+    new EndWith('Christopher.'),
+]);
+
+$result = $platform->invoke('gpt-4o-mini', new MessageBag(
+    Message::forSystem('You are a helpful assistant. You only answer with short sentences.'),
+    Message::ofUser('My name is Christopher.'),
+    Message::ofUser('What is my name?')
+));
+
+$score = $evaluator->evaluate($result);
+
+assert(1.0 === $score);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/evaluator/evaluator-output-end-with.php
+++ b/examples/evaluator/evaluator-output-end-with.php
@@ -11,13 +11,13 @@
 
 use Symfony\AI\Evaluator\Evaluator;
 use Symfony\AI\Evaluator\Scorer\EndWith;
-use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 
 require_once dirname(__DIR__).'/bootstrap.php';
 
-$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
 
 $evaluator = new Evaluator([
     new EndWith('Christopher.'),

--- a/examples/evaluator/evaluator-output-start-with.php
+++ b/examples/evaluator/evaluator-output-start-with.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Evaluator\Evaluator;
+use Symfony\AI\Evaluator\Scorer\StartWith;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+
+$evaluator = new Evaluator([
+    new StartWith('Your name is'),
+]);
+
+$result = $platform->invoke('gpt-4o-mini', new MessageBag(
+    Message::forSystem('You are a helpful assistant. You only answer with short sentences.'),
+    Message::ofUser('My name is Christopher.'),
+    Message::ofUser('What is my name?')
+));
+
+$score = $evaluator->evaluate($result);
+
+assert(1.0 === $score);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/evaluator/evaluator-output-start-with.php
+++ b/examples/evaluator/evaluator-output-start-with.php
@@ -11,13 +11,13 @@
 
 use Symfony\AI\Evaluator\Evaluator;
 use Symfony\AI\Evaluator\Scorer\StartWith;
-use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 
 require_once dirname(__DIR__).'/bootstrap.php';
 
-$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
 
 $evaluator = new Evaluator([
     new StartWith('Your name is'),

--- a/splitsh.json
+++ b/splitsh.json
@@ -30,6 +30,9 @@
         "ai-pogocache-message-store": "src/chat/src/Bridge/Pogocache",
         "ai-redis-message-store": "src/chat/src/Bridge/Redis",
         "ai-surreal-db-message-store": "src/chat/src/Bridge/SurrealDb",
+        "ai-evaluator": {
+            "prefixes": [{ "from": "src/evaluator", "to": "", "excludes": ["src/Bridge"] }]
+        },
         "ai-mate": {
             "prefixes": [{ "from": "src/mate", "to": "", "excludes": ["src/Bridge", "composer-plugin"] }]
         },

--- a/src/ai-bundle/src/Profiler/TraceableEvaluator.php
+++ b/src/ai-bundle/src/Profiler/TraceableEvaluator.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\AiBundle\Profiler;
+
+use Psr\Clock\ClockInterface;
+use Symfony\AI\Evaluator\EvaluatorInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\Component\Clock\MonotonicClock;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ *
+ * @phpstan-type EvaluatorData array{
+ *     score: float,
+ *     evaluated_at: \DateTimeImmutable,
+ * }
+ */
+final class TraceableEvaluator implements EvaluatorInterface
+{
+    public array $data = [];
+
+    public function __construct(
+        private readonly EvaluatorInterface $evaluator,
+        private readonly ClockInterface $clock = new MonotonicClock(),
+    ) {
+    }
+
+    public function evaluate(DeferredResult $deferredResult, array $options = []): float
+    {
+        $score = $this->evaluator->evaluate($deferredResult, $options);
+
+        $this->data = [
+            'score' => $score,
+            'evaluated_at' => $this->clock->now(),
+        ];
+
+        return $score;
+    }
+}

--- a/src/ai-bundle/src/Profiler/TraceableEvaluator.php
+++ b/src/ai-bundle/src/Profiler/TraceableEvaluator.php
@@ -26,6 +26,9 @@ use Symfony\Component\Clock\MonotonicClock;
  */
 final class TraceableEvaluator implements EvaluatorInterface
 {
+    /**
+     * @var EvaluatorData|array{}
+     */
     public array $data = [];
 
     public function __construct(
@@ -34,6 +37,9 @@ final class TraceableEvaluator implements EvaluatorInterface
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function evaluate(DeferredResult $deferredResult, array $options = []): float
     {
         $score = $this->evaluator->evaluate($deferredResult, $options);

--- a/src/ai-bundle/src/Profiler/TraceableScorer.php
+++ b/src/ai-bundle/src/Profiler/TraceableScorer.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\AiBundle\Profiler;
+
+use Psr\Clock\ClockInterface;
+use Symfony\AI\Evaluator\AbstractScorer;
+use Symfony\AI\Evaluator\ScorerInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\Component\Clock\MonotonicClock;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ *
+ * @phpstan-type ScorerData array{
+ *     name: string,
+ *     score: float,
+ *     reason: ?string,
+ *     scored_at: \DateTimeImmutable
+ * }
+ */
+final class TraceableScorer implements ScorerInterface
+{
+    /**
+     * @var array{
+     *     name: string,
+     *     score: float,
+     *     reason: ?string,
+     *     scored_at: \DateTimeImmutable
+     * }
+     */
+    public array $data;
+
+    public function __construct(
+        private readonly ScorerInterface $scorer,
+        private readonly ClockInterface $clock = new MonotonicClock(),
+    ) {
+    }
+
+    public function score(DeferredResult $deferredResult, array $options = []): float
+    {
+        $score = $this->scorer->score($deferredResult, $options);
+
+        $this->data = [
+            'name' => $this->scorer::class,
+            'score' => $score,
+            'reason' => $this->scorer instanceof AbstractScorer ? $this->scorer->getReason() : null,
+            'scored_at' => $this->clock->now(),
+        ];
+
+        return $score;
+    }
+}

--- a/src/ai-bundle/src/Profiler/TraceableScorer.php
+++ b/src/ai-bundle/src/Profiler/TraceableScorer.php
@@ -45,6 +45,9 @@ final class TraceableScorer implements ScorerInterface
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function score(DeferredResult $deferredResult, array $options = []): float
     {
         $score = $this->scorer->score($deferredResult, $options);

--- a/src/evaluator/.gitattributes
+++ b/src/evaluator/.gitattributes
@@ -1,0 +1,6 @@
+/.github export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpstan.dist.neon export-ignore
+phpunit.xml.dist export-ignore

--- a/src/evaluator/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/evaluator/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/ai
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/evaluator/.github/workflows/close-pull-request.yml
+++ b/src/evaluator/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: superbrothers/close-pull-request@v3
+        with:
+          comment: |
+            Thanks for your Pull Request! We love contributions.
+
+            However, you should instead open your PR on the main repository:
+            https://github.com/symfony/ai
+
+            This repository is what we call a "subtree split": a read-only subset of that main repository.
+            We're looking forward to your PR there!

--- a/src/evaluator/AGENTS.md
+++ b/src/evaluator/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md
+
+AI agent guidance for the Chat component.
+
+## Component Overview
+
+Library for building chats with agents using messages. Built on Platform and Agent components.
+
+## Architecture
+
+### Core Classes
+- **Chat** (`src/Chat.php`): Main orchestration class
+- **ChatInterface**: Contract for implementations
+- **MessageStoreInterface** High-level conversation storage interface
+- **ManagedStoreInterface** High-level store management interface
+
+### Key Features
+- **Bridge** (`src/Bridge/`): Storage capacity for messages and conversations
+
+## Essential Commands
+
+### Testing
+```bash
+vendor/bin/phpunit
+vendor/bin/phpunit tests/ChatTest.php
+vendor/bin/phpunit --coverage-html coverage/
+```
+
+### Code Quality
+```bash
+vendor/bin/phpstan analyse
+cd ../../.. && vendor/bin/php-cs-fixer fix src/chat/
+```
+
+## Processing Architecture
+
+### Built-in bridges
+- **CacheStore**: PSR-16 compliant storage
+- **InMemoryStore**: In-memory storage
+- **SessionStore**: Symfony HttpFoundation session storage
+
+## Dependencies
+
+- **Platform component**: Required for AI communication
+- **Agent component**: Required for agent interaction
+- **Symfony**: HttpFoundation
+
+## Testing Patterns
+
+- Use `MockHttpClient` over response mocking
+- Test bridges independently
+- Prefer `self::assert*` in tests
+
+## Development Notes
+
+- Component is experimental (BC breaks possible)
+- Add `@author` tags to new classes
+- Use component-specific exceptions from `src/Exception/`
+- Follow `@Symfony` PHP CS Fixer rules

--- a/src/evaluator/CHANGELOG.md
+++ b/src/evaluator/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+0.1
+---
+
+ * Add the component

--- a/src/evaluator/CHANGELOG.md
+++ b/src/evaluator/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-0.1
----
+0.12
+----
 
  * Add the component

--- a/src/evaluator/CLAUDE.md
+++ b/src/evaluator/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in the Evaluator component.
+
+## Component Overview
+
+Library for building chats with agents using messages. Built on Platform and Agent components.
+
+## Architecture
+
+### Core Classes
+- **Chat** (`src/Chat.php`): Main orchestration class
+- **ChatInterface**: Contract for implementations
+- **MessageStoreInterface** High-level conversation storage interface
+- **ManagedStoreInterface** High-level store management interface
+
+### Key Features
+- **Bridge** (`src/Bridge/`): Storage capacity for messages and conversations
+
+## Essential Commands
+
+### Testing
+```bash
+vendor/bin/phpunit
+vendor/bin/phpunit tests/ChatTests.php
+vendor/bin/phpunit --coverage-html coverage/
+```
+
+### Code Quality
+```bash
+vendor/bin/phpstan analyse
+cd ../../.. && vendor/bin/php-cs-fixer fix src/chat/
+```
+
+## Processing Architecture
+
+### Built-in bridges
+- **CacheStore**: PSR-16 compliant storage
+- **InMemoryStore**: In-memory storage
+- **SessionStore**: Symfony HttpFoundation session storage
+
+## Dependencies
+
+- **Platform component**: Required for AI communication
+- **Agent component**: Required for agent interaction
+- **Symfony**: HttpFoundation
+
+## Testing Patterns
+
+- Use `MockHttpClient` over response mocking
+- Test bridges independently
+- Prefer `self::assert*` in tests
+
+## Development Notes
+
+- All new classes should have `@author` tags
+- Use component-specific exceptions from `src/Exception/`
+- Follow Symfony coding standards with `@Symfony` PHP CS Fixer rules
+- The component is marked as experimental and subject to BC breaks

--- a/src/evaluator/LICENSE
+++ b/src/evaluator/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2025-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/evaluator/README.md
+++ b/src/evaluator/README.md
@@ -1,0 +1,24 @@
+# Symfony AI - Evaluator Component
+
+The Evaluator component provides an unified API to evaluate and score inputs from platforms / agents.
+
+**This Component is experimental**.
+[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
+are not covered by Symfony's
+[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
+
+## Installation
+
+```bash
+composer require symfony/ai-evaluator
+```
+
+**This repository is a READ-ONLY sub-tree split**. See
+https://github.com/symfony/ai to create issues or submit pull requests.
+
+## Resources
+
+- [Documentation](doc/index.rst)
+- [Report issues](https://github.com/symfony/ai/issues) and
+  [send Pull Requests](https://github.com/symfony/ai/pulls)
+  in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/evaluator/composer.json
+++ b/src/evaluator/composer.json
@@ -34,7 +34,9 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Symfony\\AI\\Evaluator\\Tests\\": "tests/"
+            "Symfony\\AI\\Evaluator\\Tests\\": "tests/",
+            "Symfony\\AI\\Fixtures\\": "../../fixtures",
+            "Symfony\\AI\\PHPStan\\": "../../.phpstan/"
         }
     },
     "config": {

--- a/src/evaluator/composer.json
+++ b/src/evaluator/composer.json
@@ -1,0 +1,52 @@
+{
+    "name": "symfony/ai-evaluator",
+    "type": "library",
+    "description": "",
+    "keywords": [],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Christopher Hertel",
+            "email": "mail@christopher-hertel.de"
+        },
+        {
+            "name": "Oskar Stark",
+            "email": "oskarstark@googlemail.com"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/ai-platform": "^0.2",
+        "symfony/uid": "^6.4 || ^7.1",
+        "symfony/validator": "^6.4 || ^7.1",
+        "symfony/string": "^6.4 || ^7.1"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^2.1.17",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.5.46"
+    },
+    "autoload": {
+        "psr-4": {
+            "Symfony\\AI\\Evaluator\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\AI\\Evaluator\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "branch-alias": {
+            "dev-main": "0.3.x-dev"
+        },
+        "sort-packages": true
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ai",
+            "url": "https://github.com/symfony/ai"
+        }
+    }
+}

--- a/src/evaluator/composer.json
+++ b/src/evaluator/composer.json
@@ -16,16 +16,16 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/ai-platform": "^0.2",
-        "symfony/uid": "^6.4 || ^7.1",
-        "symfony/validator": "^6.4 || ^7.1",
-        "symfony/string": "^6.4 || ^7.1"
+        "symfony/ai-platform": "^0.11",
+        "symfony/uid": "^7.3|^8.0",
+        "symfony/validator": "^7.3|^8.0",
+        "symfony/string": "^7.3|^8.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^2.1.17",
+        "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5.46"
+        "phpunit/phpunit": "^11.5.53"
     },
     "autoload": {
         "psr-4": {

--- a/src/evaluator/phpstan.dist.neon
+++ b/src/evaluator/phpstan.dist.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../.phpstan/extension.neon
+
+parameters:
+    level: 6
+    paths:
+        - src/
+        - tests/
+    treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"

--- a/src/evaluator/phpstan.dist.neon
+++ b/src/evaluator/phpstan.dist.neon
@@ -1,4 +1,5 @@
 includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
     - ../../.phpstan/extension.neon
 
 parameters:
@@ -6,7 +7,22 @@ parameters:
     paths:
         - src/
         - tests/
+    excludePaths:
+        - src/Bridge/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -
             message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+        -
+            message: '#^Call to( static)? method PHPUnit\\Framework\\Assert::.* will always evaluate to true\.$#'
+            reportUnmatched: false
+        -
+            identifier: 'symfonyAi.forbidNativeException'
+            path: tests/*
+            reportUnmatched: false
+
+services:
+    - # Conditionally enabled by bleeding edge in phpstan/phpstan-phpunit 2.x
+        class: PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension
+        tags:
+            - phpstan.ignoreErrorExtension

--- a/src/evaluator/phpstan.dist.neon
+++ b/src/evaluator/phpstan.dist.neon
@@ -8,7 +8,7 @@ parameters:
         - src/
         - tests/
     excludePaths:
-        - src/Bridge/
+        - src/Bridge/ (?)
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/evaluator/phpunit.xml.dist
+++ b/src/evaluator/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true"
+         executionOrder="random"
+         requireCoverageMetadata="true"
+         beStrictAboutCoverageMetadata="true"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/evaluator/phpunit.xml.dist
+++ b/src/evaluator/phpunit.xml.dist
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheDirectory=".phpunit.cache"
          colors="true"
          executionOrder="random"
-         requireCoverageMetadata="true"
-         beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
-         failOnWarning="true"
->
+         failOnWarning="true">
     <testsuites>
-        <testsuite name="default">
+        <testsuite name="symfony/ai-evaluator">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/src/evaluator/src/AbstractScorer.php
+++ b/src/evaluator/src/AbstractScorer.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Evaluator;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+abstract class AbstractScorer implements ScorerInterface
+{
+    private ?string $reason = null;
+
+    public function setReason(?string $reason): void
+    {
+        $this->reason = $reason;
+    }
+
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+}

--- a/src/evaluator/src/Evaluator.php
+++ b/src/evaluator/src/Evaluator.php
@@ -16,12 +16,12 @@ use Symfony\AI\Platform\Result\DeferredResult;
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-final readonly class Evaluator implements EvaluatorInterface
+final class Evaluator implements EvaluatorInterface
 {
     /**
      * @var ScorerInterface[]
      */
-    public function __construct(private iterable $scorers)
+    public function __construct(private readonly iterable $scorers)
     {
     }
 

--- a/src/evaluator/src/Evaluator.php
+++ b/src/evaluator/src/Evaluator.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Evaluator;
+
+use Symfony\AI\Platform\Result\DeferredResult;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final readonly class Evaluator implements EvaluatorInterface
+{
+    /**
+     * @var ScorerInterface[]
+     */
+    public function __construct(private iterable $scorers)
+    {
+    }
+
+    public function evaluate(DeferredResult $deferredResult, array $options = []): float
+    {
+        $score = 0.0;
+
+        if ([] === $this->scorers) {
+            return $score;
+        }
+
+        foreach ($this->scorers as $scorer) {
+            $score += $scorer->score($deferredResult, $options);
+        }
+
+        if (0.0 === $score) {
+            return $score;
+        }
+
+        return $score / \count($this->scorers);
+    }
+}

--- a/src/evaluator/src/Evaluator.php
+++ b/src/evaluator/src/Evaluator.php
@@ -19,12 +19,16 @@ use Symfony\AI\Platform\Result\DeferredResult;
 final class Evaluator implements EvaluatorInterface
 {
     /**
-     * @var ScorerInterface[]
+     * @param iterable<ScorerInterface> $scorers
      */
-    public function __construct(private readonly iterable $scorers)
-    {
+    public function __construct(
+        private readonly iterable $scorers,
+    ) {
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function evaluate(DeferredResult $deferredResult, array $options = []): float
     {
         $score = 0.0;

--- a/src/evaluator/src/EvaluatorInterface.php
+++ b/src/evaluator/src/EvaluatorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Evaluator;
+
+use Symfony\AI\Platform\Result\DeferredResult;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+interface EvaluatorInterface
+{
+    public function evaluate(DeferredResult $deferredResult, array $options = []): float;
+}

--- a/src/evaluator/src/EvaluatorStrategy.php
+++ b/src/evaluator/src/EvaluatorStrategy.php
@@ -11,15 +11,9 @@
 
 namespace Symfony\AI\Evaluator;
 
-use Symfony\AI\Platform\Result\DeferredResult;
-
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-interface EvaluatorInterface
+enum EvaluatorStrategy: string
 {
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function evaluate(DeferredResult $deferredResult, array $options = []): float;
 }

--- a/src/evaluator/src/Listener/EvaluatorListener.php
+++ b/src/evaluator/src/Listener/EvaluatorListener.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Evaluator\Listener;
+
+use Symfony\AI\Evaluator\EvaluatorInterface;
+use Symfony\AI\Platform\Event\ResultEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class EvaluatorListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly EvaluatorInterface $evaluator,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ResultEvent::class => 'onResult',
+        ];
+    }
+
+    public function onResult(ResultEvent $event): void
+    {
+        $deferredResult = $event->getDeferredResult();
+
+        $score = $this->evaluator->evaluate($deferredResult, $event->getOptions());
+
+        $deferredResult->getMetadata()->add('score', $score);
+    }
+}

--- a/src/evaluator/src/Scorer/EndWith.php
+++ b/src/evaluator/src/Scorer/EndWith.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Evaluator\Scorer;
+
+use Symfony\AI\Evaluator\AbstractScorer;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\Component\String\UnicodeString;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class EndWith extends AbstractScorer
+{
+    public function __construct(
+        private readonly string $suffix,
+    ) {
+    }
+
+    public function score(DeferredResult $deferredResult, array $options = []): float
+    {
+        $text = $deferredResult->asText();
+
+        $string = new UnicodeString($text);
+
+        if (0 === $string->length()) {
+            return 0.0;
+        }
+
+        return $string->endsWith($this->suffix) ? 1.0 : 0.0;
+    }
+}

--- a/src/evaluator/src/Scorer/EndWith.php
+++ b/src/evaluator/src/Scorer/EndWith.php
@@ -25,6 +25,9 @@ final class EndWith extends AbstractScorer
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function score(DeferredResult $deferredResult, array $options = []): float
     {
         $text = $deferredResult->asText();

--- a/src/evaluator/src/Scorer/StartWith.php
+++ b/src/evaluator/src/Scorer/StartWith.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Evaluator\Scorer;
+
+use Symfony\AI\Evaluator\AbstractScorer;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\Component\String\UnicodeString;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class StartWith extends AbstractScorer
+{
+    public function __construct(
+        private readonly string $prefix,
+    ) {
+    }
+
+    public function score(DeferredResult $deferredResult, array $options = []): float
+    {
+        $text = $deferredResult->asText();
+
+        $string = new UnicodeString($text);
+
+        if (0 === $string->length()) {
+            return 0.0;
+        }
+
+        return $string->startsWith($this->prefix) ? 1.0 : 0.0;
+    }
+}

--- a/src/evaluator/src/Scorer/StartWith.php
+++ b/src/evaluator/src/Scorer/StartWith.php
@@ -25,6 +25,9 @@ final class StartWith extends AbstractScorer
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function score(DeferredResult $deferredResult, array $options = []): float
     {
         $text = $deferredResult->asText();

--- a/src/evaluator/src/Scorer/ToolCallScorer.php
+++ b/src/evaluator/src/Scorer/ToolCallScorer.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Evaluator\Scorer;
+
+use Symfony\AI\Evaluator\ScorerInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\ToolCall;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class ToolCallScorer implements ScorerInterface
+{
+    /**
+     * @param list<string> $toolCalls The names of the tools expected to be called
+     */
+    public function __construct(
+        private readonly array $toolCalls,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function score(DeferredResult $deferredResult, array $options = []): float
+    {
+        if ([] === $this->toolCalls) {
+            return 0.0;
+        }
+
+        $calledTools = array_map(
+            static fn (ToolCall $toolCall): string => $toolCall->getName(),
+            $deferredResult->asToolCalls(),
+        );
+
+        if ([] === $calledTools) {
+            return 0.0;
+        }
+
+        return \count(array_intersect($this->toolCalls, $calledTools)) / \count($this->toolCalls);
+    }
+}

--- a/src/evaluator/src/ScorerInterface.php
+++ b/src/evaluator/src/ScorerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Evaluator;
+
+use Symfony\AI\Platform\Result\DeferredResult;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+interface ScorerInterface
+{
+    public function score(DeferredResult $deferredResult, array $options = []): float;
+}

--- a/src/evaluator/src/ScorerInterface.php
+++ b/src/evaluator/src/ScorerInterface.php
@@ -18,5 +18,8 @@ use Symfony\AI\Platform\Result\DeferredResult;
  */
 interface ScorerInterface
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     public function score(DeferredResult $deferredResult, array $options = []): float;
 }

--- a/src/evaluator/tests/EvaluatorTest.php
+++ b/src/evaluator/tests/EvaluatorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Evaluator\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Evaluator\Evaluator;
+use Symfony\AI\Evaluator\Scorer\StartWith;
+use Symfony\AI\Platform\PlainConverter;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\TextResult;
+
+final class EvaluatorTest extends TestCase
+{
+    public function testEvaluatorCanEvaluateWithoutScorers()
+    {
+        $evaluator = new Evaluator([]);
+
+        $score = $evaluator->evaluate(new DeferredResult(new PlainConverter(new TextResult('foo')), new InMemoryRawResult()));
+
+        $this->assertSame(0.0, $score);
+    }
+
+    public function testEvaluatorCanEvaluateWithoutMatchingScorers()
+    {
+        $evaluator = new Evaluator([
+            new StartWith('foo'),
+        ]);
+
+        $score = $evaluator->evaluate(new DeferredResult(new PlainConverter(new TextResult('bar')), new InMemoryRawResult()));
+
+        $this->assertSame(0.0, $score);
+    }
+
+    public function testEvaluatorCanEvaluateWithMatchingScorers()
+    {
+        $evaluator = new Evaluator([
+            new StartWith('foo'),
+        ]);
+
+        $score = $evaluator->evaluate(new DeferredResult(new PlainConverter(new TextResult('foo')), new InMemoryRawResult()));
+
+        $this->assertSame(1.0, $score);
+    }
+}

--- a/src/evaluator/tests/Scorer/EndWithTest.php
+++ b/src/evaluator/tests/Scorer/EndWithTest.php
@@ -13,18 +13,18 @@ namespace Symfony\AI\Evaluator\Tests\Scorer;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Symfony\AI\Evaluator\Scorer\StartWith;
+use Symfony\AI\Evaluator\Scorer\EndWith;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\TextResult;
 
-final class StartWithTest extends TestCase
+final class EndWithTest extends TestCase
 {
     #[DataProvider('provideContext')]
     public function testScore(DeferredResult $deferredResult, float $expectedScore)
     {
-        $scorer = new StartWith('bar');
+        $scorer = new EndWith('bar');
 
         $score = $scorer->score($deferredResult);
 

--- a/src/evaluator/tests/Scorer/StartWithTest.php
+++ b/src/evaluator/tests/Scorer/StartWithTest.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Evaluator\Tests\Scorer;
+
+use PHPUnit\Framework\TestCase;
+
+final class StartWithTest extends TestCase
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | --
| License       | MIT

This PR (as a POC for now) introduce the `Evaluator` component, this component is mainly used to evaluate and add a score to output from platforms / agents, I moved it to a new directory as a mirror of the `Validator` component, the goal is to allows to add new scorers without impacting the platforms (even if they can define their own scorers).

The PR is built around the following concepts:

- An `Evaluator` that receive `Scorers` and compute the final score
- `ScorerInterface` implementations that defines score using `score` method (could be improved, I'm not locked on the name) 
- An `AbstractScorer` used to define a reason (mostly used for "LLM as judge" scorers) for a score
- An implementation on `AiBundle` via the Profiler and a subscriber (no configuration for now).
