### PR TITLE
[Platform][TransformersPhp] Allow passing pipeline input options

### DIFF
--- a/examples/transformers/embeddings.php
+++ b/examples/transformers/embeddings.php
@@ -32,6 +32,9 @@ $text = <<<TEXT
     country was very peaceful and prosperous. The people lived happily ever after.
     TEXT;
 
-$result = $platform->invoke('Xenova/all-MiniLM-L6-v2', $text, ['task' => Task::Embeddings]);
+$result = $platform->invoke('Xenova/all-MiniLM-L6-v2', $text, [
+    'task' => Task::Embeddings,
+    'input_options' => ['pooling' => 'mean', 'normalize' => true],
+]);
 
 print_vectors($result);

--- a/src/platform/src/Bridge/TransformersPhp/ModelClient.php
+++ b/src/platform/src/Bridge/TransformersPhp/ModelClient.php
@@ -30,6 +30,8 @@ final class ModelClient implements ModelClientInterface
             throw new InvalidArgumentException('The task option is required.');
         }
 
+        $inputOptions = $options['input_options'] ?? [];
+
         $pipeline = pipeline(
             $task,
             $model->getName(),
@@ -40,6 +42,6 @@ final class ModelClient implements ModelClientInterface
             $options['modelFilename'] ?? null,
         );
 
-        return new RawPipelineResult(new PipelineExecution($pipeline, $payload));
+        return new RawPipelineResult(new PipelineExecution($pipeline, $payload, $inputOptions));
     }
 }

--- a/src/platform/src/Bridge/TransformersPhp/PipelineExecution.php
+++ b/src/platform/src/Bridge/TransformersPhp/PipelineExecution.php
@@ -24,11 +24,13 @@ final class PipelineExecution
     private ?array $result = null;
 
     /**
-     * @param array<mixed>|string $input
+     * @param array<mixed>|string  $input
+     * @param array<string, mixed> $options Pipeline input options
      */
     public function __construct(
         private readonly Pipeline $pipeline,
         private readonly array|string $input,
+        private readonly array $options,
     ) {
     }
 
@@ -38,7 +40,7 @@ final class PipelineExecution
     public function getResult(): array
     {
         if (null === $this->result) {
-            $this->result = ($this->pipeline)($this->input);
+            $this->result = ($this->pipeline)($this->input, ...$this->options);
         }
 
         return $this->result;

--- a/src/platform/src/Bridge/TransformersPhp/Tests/PipelineExecutionTest.php
+++ b/src/platform/src/Bridge/TransformersPhp/Tests/PipelineExecutionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\TransformersPhp\Tests;
+
+use Codewithkyrian\Transformers\Pipelines\Pipeline;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\TransformersPhp\PipelineExecution;
+
+/**
+ * @author Muhammad Elhwawshy <m.elhwawshy@gmail.com>
+ */
+final class PipelineExecutionTest extends TestCase
+{
+    public function testInvokesPipelineWithCorrectArguments()
+    {
+        $input = 'How many continents are there in the world?';
+        $options = ['maxNewTokens' => 256, 'doSample' => true, 'repetitionPenalty' => 1.6];
+
+        $result = ['generated_text' => 'There are generally considered to be seven continents.'];
+
+        $pipeline = $this->createMock(Pipeline::class);
+        $pipeline->expects($this->once())
+            ->method('__invoke')
+            ->with($this->callback(static fn (...$args) => $args === [$input, ...$options]))
+            ->willReturn($result);
+
+        $this->assertSame($result, (new PipelineExecution($pipeline, $input, $options))->getResult());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes (example)
| Issues        | None
| License       | MIT

> Additional arguments can be passed to the pipeline function to customize it's behavior, but they are hugely dependent on the task you're using the pipelines for.

[Documentation](https://transformers.codewithkyrian.com/pipelines#additional-options)