### PR TITLE
[Mate] Add mcp:tools:list command

### DIFF
--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -369,6 +369,41 @@ Commands
         # JSON output for scripting
         $ vendor/bin/mate debug:extensions --format=json
 
+``mate mcp:tools:list``
+    List all available MCP tools with their metadata. This command provides a compact
+    overview of tools for quick reference and filtering.
+
+    **Options:**
+
+    ``--filter=PATTERN``
+        Filter tools by name pattern (supports wildcards like ``search*`` or ``*logs``)
+
+    ``--extension=EXTENSION``
+        Filter tools by extension package name
+
+    ``--format=FORMAT``
+        Output format: ``table`` (default) or ``json``
+
+    **Examples:**
+
+    .. code-block:: terminal
+
+        # List all tools
+        $ vendor/bin/mate mcp:tools:list
+
+        # Filter by name pattern
+        $ vendor/bin/mate mcp:tools:list --filter="monolog*"
+        $ vendor/bin/mate mcp:tools:list --filter="*search"
+
+        # Show tools from specific extension
+        $ vendor/bin/mate mcp:tools:list --extension=symfony/ai-monolog-mate-extension
+
+        # JSON output for scripting
+        $ vendor/bin/mate mcp:tools:list --format=json
+
+        # Combined filters
+        $ vendor/bin/mate mcp:tools:list --extension=symfony/ai-monolog-mate-extension --filter="*search"
+
 Security
 --------
 

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.3
+---
+
+ * Add `ToolsListCommand` to list all available tools
+
 0.2
 ---
 

--- a/src/mate/CLAUDE.md
+++ b/src/mate/CLAUDE.md
@@ -47,6 +47,11 @@ bin/mate clear-cache
 # Debug commands
 bin/mate debug:capabilities      # Show all MCP capabilities
 bin/mate debug:extensions        # Show extension discovery and loading status
+
+# Tool introspection
+bin/mate mcp:tools:list          # List all available MCP tools
+bin/mate mcp:tools:list --filter="search*"  # Filter tools by name pattern
+bin/mate mcp:tools:list --format=json       # Output in JSON format
 ```
 
 ## Architecture
@@ -58,7 +63,7 @@ bin/mate debug:extensions        # Show extension discovery and loading status
 - **FilteredDiscoveryLoader**: Loads MCP capabilities with feature filtering
 
 ### Key Directories
-- `src/Command/`: CLI commands (serve, init, discover, clear-cache, debug:capabilities, debug:extensions)
+- `src/Command/`: CLI commands (serve, init, discover, clear-cache, debug:capabilities, debug:extensions, mcp:tools:list)
 - `src/Container/`: DI container management
 - `src/Discovery/`: Extension discovery system
 - `src/Capability/`: Built-in MCP tools

--- a/src/mate/src/App.php
+++ b/src/mate/src/App.php
@@ -21,6 +21,7 @@ use Symfony\AI\Mate\Command\DiscoverCommand;
 use Symfony\AI\Mate\Command\InitCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
 use Symfony\AI\Mate\Command\StopCommand;
+use Symfony\AI\Mate\Command\ToolsListCommand;
 use Symfony\AI\Mate\Exception\UnsupportedVersionException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -55,6 +56,7 @@ final class App
         self::addCommand($application, new DebugCapabilitiesCommand($logger, $container));
         self::addCommand($application, new DebugExtensionsCommand($logger, $container));
         self::addCommand($application, new ClearCacheCommand($cacheDir));
+        self::addCommand($application, new ToolsListCommand($logger, $container));
 
         if (\defined('SIGUSR1') && class_exists(RunnerControl::class)) {
             $application->getSignalRegistry()->register(\SIGUSR1, function () {

--- a/src/mate/src/Command/ToolsListCommand.php
+++ b/src/mate/src/Command/ToolsListCommand.php
@@ -1,0 +1,250 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command;
+
+use Psr\Log\LoggerInterface;
+use Symfony\AI\Mate\Discovery\CapabilityCollector;
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Display available MCP tools with metadata.
+ *
+ * @phpstan-import-type Capabilities from CapabilityCollector
+ *
+ * @phpstan-type ToolData array{
+ *     name: string,
+ *     description: string|null,
+ *     handler: string,
+ *     input_schema: array<string, mixed>|null,
+ *     extension: string
+ * }
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('mcp:tools:list', 'Display available MCP tools with metadata')]
+class ToolsListCommand extends Command
+{
+    private CapabilityCollector $collector;
+
+    /**
+     * @var array<string, array{dirs: string[], includes: string[]}>
+     */
+    private array $extensions;
+
+    public function __construct(
+        LoggerInterface $logger,
+        private ContainerInterface $container,
+    ) {
+        parent::__construct(self::getDefaultName());
+
+        $rootDir = $container->getParameter('mate.root_dir');
+        \assert(\is_string($rootDir));
+
+        $extensions = $this->container->getParameter('mate.extensions') ?? [];
+        \assert(\is_array($extensions));
+        $this->extensions = $extensions;
+
+        $disabledFeatures = $this->container->getParameter('mate.disabled_features') ?? [];
+        \assert(\is_array($disabledFeatures));
+
+        $this->collector = new CapabilityCollector($rootDir, $extensions, $disabledFeatures, $logger);
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'mcp:tools:list';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Display available MCP tools with metadata';
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter by tool name pattern (supports wildcards)')
+            ->addOption('extension', null, InputOption::VALUE_REQUIRED, 'Filter by extension package name')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (table, json)', 'table')
+            ->setHelp(<<<'HELP'
+The <info>%command.name%</info> command displays all available MCP tools with their metadata.
+
+<info>Usage Examples:</info>
+
+  <comment># Show all tools</comment>
+  %command.full_name%
+
+  <comment># Filter by tool name pattern</comment>
+  %command.full_name% --filter="search*"
+  %command.full_name% --filter="*logs"
+
+  <comment># Show tools from specific extension</comment>
+  %command.full_name% --extension=symfony/ai-monolog-mate-extension
+
+  <comment># JSON output for scripting</comment>
+  %command.full_name% --format=json
+
+  <comment># Combined filters</comment>
+  %command.full_name% --extension=symfony/ai-monolog-mate-extension --filter="search*"
+
+  <comment># For detailed tool information with schema, use:</comment>
+  bin/mate.php mcp:tools:inspect <tool-name>
+HELP
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $allTools = [];
+        foreach ($this->extensions as $extensionName => $extension) {
+            $capabilities = $this->collector->collectCapabilities($extensionName, $extension);
+            foreach ($capabilities['tools'] as $toolName => $toolData) {
+                $allTools[$toolName] = array_merge($toolData, ['extension' => $extensionName]);
+            }
+        }
+
+        $extensionFilter = $input->getOption('extension');
+        if (null !== $extensionFilter) {
+            \assert(\is_string($extensionFilter));
+            $allTools = $this->filterByExtension($allTools, $extensionFilter);
+        }
+
+        $nameFilter = $input->getOption('filter');
+        if (null !== $nameFilter) {
+            \assert(\is_string($nameFilter));
+            $allTools = $this->filterByName($allTools, $nameFilter);
+        }
+
+        $format = $input->getOption('format');
+        \assert(\is_string($format));
+
+        if ('json' === $format) {
+            $this->outputJson($allTools, $output);
+
+            return Command::SUCCESS;
+        }
+
+        $this->outputTable($allTools, $io);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param array<string, ToolData> $tools
+     *
+     * @return array<string, ToolData>
+     */
+    private function filterByExtension(array $tools, string $extensionFilter): array
+    {
+        $filtered = [];
+        foreach ($tools as $toolName => $toolData) {
+            if ($toolData['extension'] === $extensionFilter) {
+                $filtered[$toolName] = $toolData;
+            }
+        }
+
+        if ([] === $filtered) {
+            $availableExtensions = array_unique(array_column($tools, 'extension'));
+            throw new InvalidArgumentException(\sprintf('No tools found for extension "%s". Available extensions: "%s"', $extensionFilter, implode(', ', $availableExtensions)));
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @param array<string, ToolData> $tools
+     *
+     * @return array<string, ToolData>
+     */
+    private function filterByName(array $tools, string $pattern): array
+    {
+        $regex = '/^'.str_replace(['\*', '\?'], ['.*', '.'], preg_quote($pattern, '/')).'$/i';
+
+        $filtered = [];
+        foreach ($tools as $toolName => $toolData) {
+            if (preg_match($regex, $toolName)) {
+                $filtered[$toolName] = $toolData;
+            }
+        }
+
+        if ([] === $filtered) {
+            throw new InvalidArgumentException(\sprintf('No tools found matching pattern "%s"', $pattern));
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @param array<string, ToolData> $tools
+     */
+    private function outputTable(array $tools, SymfonyStyle $io): void
+    {
+        $io->title('MCP Tools');
+
+        if ([] === $tools) {
+            $io->warning('No tools found');
+
+            return;
+        }
+
+        $table = new Table($output = $io);
+        $table->setHeaders(['Tool Name', 'Description', 'Handler', 'Extension']);
+
+        foreach ($tools as $toolName => $toolData) {
+            $table->addRow([
+                $toolName,
+                $this->truncate($toolData['description'] ?? '', 50),
+                $toolData['handler'],
+                $toolData['extension'],
+            ]);
+        }
+
+        $table->render();
+
+        $io->newLine();
+        $io->text(\sprintf('Total: <info>%d</info> tool(s)', \count($tools)));
+    }
+
+    /**
+     * @param array<string, ToolData> $tools
+     */
+    private function outputJson(array $tools, OutputInterface $output): void
+    {
+        $result = [
+            'tools' => $tools,
+            'summary' => [
+                'total' => \count($tools),
+            ],
+        ];
+
+        $output->writeln(json_encode($result, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+    }
+
+    private function truncate(string $text, int $length): string
+    {
+        if (\strlen($text) <= $length) {
+            return $text;
+        }
+
+        return substr($text, 0, $length - 3).'...';
+    }
+}

--- a/src/mate/tests/Command/ToolsListCommandTest.php
+++ b/src/mate/tests/Command/ToolsListCommandTest.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Command\ToolsListCommand;
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ToolsListCommandTest extends TestCase
+{
+    private string $fixturesDir;
+
+    protected function setUp(): void
+    {
+        $this->fixturesDir = __DIR__.'/../Discovery/Fixtures';
+    }
+
+    public function testExecuteDisplaysToolsList()
+    {
+        $rootDir = __DIR__.'/../..';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ]);
+
+        $command = new ToolsListCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('MCP Tools', $output);
+        $this->assertStringContainsString('Total:', $output);
+        $this->assertStringContainsString('tool(s)', $output);
+        $this->assertStringContainsString('php-version', $output);
+        $this->assertStringContainsString('operating-system', $output);
+    }
+
+    public function testExecuteWithJsonFormat()
+    {
+        $rootDir = __DIR__.'/../..';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ]);
+
+        $command = new ToolsListCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--format' => 'json']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $json = json_decode($output, true);
+        $this->assertIsArray($json);
+        $this->assertArrayHasKey('tools', $json);
+        $this->assertArrayHasKey('summary', $json);
+        $this->assertArrayHasKey('total', $json['summary']);
+        $this->assertGreaterThanOrEqual(4, $json['summary']['total']);
+        $this->assertArrayHasKey('php-version', $json['tools']);
+        $this->assertArrayHasKey('name', $json['tools']['php-version']);
+        $this->assertArrayHasKey('handler', $json['tools']['php-version']);
+        $this->assertArrayHasKey('extension', $json['tools']['php-version']);
+    }
+
+    public function testExecuteWithInvalidExtensionFilter()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new ToolsListCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No tools found for extension "invalid-extension"');
+
+        $tester->execute(['--extension' => 'invalid-extension']);
+    }
+
+    public function testExecuteWithInvalidNameFilter()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ]);
+
+        $command = new ToolsListCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No tools found matching pattern "non-existent-tool-name"');
+
+        $tester->execute(['--filter' => 'non-existent-tool-name']);
+    }
+
+    public function testTableOutputFormat()
+    {
+        $rootDir = __DIR__.'/../..';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ]);
+
+        $command = new ToolsListCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--format' => 'table']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('MCP Tools', $output);
+        $this->assertStringContainsString('Tool Name', $output);
+        $this->assertStringContainsString('Description', $output);
+        $this->assertStringContainsString('Handler', $output);
+        $this->assertStringContainsString('Extension', $output);
+    }
+
+    public function testExecuteWithNameFilterMatchingTools()
+    {
+        $rootDir = __DIR__.'/../..';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ]);
+
+        $command = new ToolsListCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--filter' => 'php-*']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('php-version', $output);
+        $this->assertStringContainsString('php-extensions', $output);
+        $this->assertStringNotContainsString('operating-system-family', $output);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | N/A
| License       | MIT

## Summary

Add new console command to list available MCP tools with metadata:
- Support filtering by tool name pattern (wildcards)
- Support filtering by extension name
- Provide both table and JSON output formats