### PR TITLE
 Add mcp:tools:inspect command for detailed tool introspection

### DIFF
--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -404,6 +404,33 @@ Commands
         # Combined filters
         $ vendor/bin/mate mcp:tools:list --extension=symfony/ai-monolog-mate-extension --filter="*search"
 
+``mate mcp:tools:inspect``
+    Display detailed information about a specific MCP tool including its full JSON schema.
+    This command is useful for understanding tool parameters and requirements.
+
+    **Arguments:**
+
+    ``tool-name``
+        Name of the tool to inspect (required)
+
+    **Options:**
+
+    ``--format=FORMAT``
+        Output format: ``text`` (default) or ``json``
+
+    **Examples:**
+
+    .. code-block:: terminal
+
+        # Inspect a specific tool
+        $ vendor/bin/mate mcp:tools:inspect php-version
+
+        # Inspect extension tool
+        $ vendor/bin/mate mcp:tools:inspect search-logs
+
+        # JSON output for scripting
+        $ vendor/bin/mate mcp:tools:inspect php-version --format=json
+
 Security
 --------
 

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `extension: false` flag in `extra.ai-mate` composer.json configuration to exclude packages from being discovered as extensions
+ * Add `ToolsInspectCommand` to inspect a specific tool
  * Add `ToolsListCommand` to list all available tools
 
 0.2

--- a/src/mate/CLAUDE.md
+++ b/src/mate/CLAUDE.md
@@ -52,6 +52,8 @@ bin/mate debug:extensions        # Show extension discovery and loading status
 bin/mate mcp:tools:list          # List all available MCP tools
 bin/mate mcp:tools:list --filter="search*"  # Filter tools by name pattern
 bin/mate mcp:tools:list --format=json       # Output in JSON format
+bin/mate mcp:tools:inspect php-version      # Inspect specific tool with schema
+bin/mate mcp:tools:inspect php-version --format=json  # Output in JSON format
 ```
 
 ## Architecture
@@ -63,7 +65,7 @@ bin/mate mcp:tools:list --format=json       # Output in JSON format
 - **FilteredDiscoveryLoader**: Loads MCP capabilities with feature filtering
 
 ### Key Directories
-- `src/Command/`: CLI commands (serve, init, discover, clear-cache, debug:capabilities, debug:extensions, mcp:tools:list)
+- `src/Command/`: CLI commands (serve, init, discover, clear-cache, debug:capabilities, debug:extensions, mcp:tools:list, mcp:tools:inspect)
 - `src/Container/`: DI container management
 - `src/Discovery/`: Extension discovery system
 - `src/Capability/`: Built-in MCP tools

--- a/src/mate/src/App.php
+++ b/src/mate/src/App.php
@@ -21,6 +21,7 @@ use Symfony\AI\Mate\Command\DiscoverCommand;
 use Symfony\AI\Mate\Command\InitCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
 use Symfony\AI\Mate\Command\StopCommand;
+use Symfony\AI\Mate\Command\ToolsInspectCommand;
 use Symfony\AI\Mate\Command\ToolsListCommand;
 use Symfony\AI\Mate\Exception\UnsupportedVersionException;
 use Symfony\Component\Console\Application;
@@ -57,6 +58,7 @@ final class App
         self::addCommand($application, new DebugExtensionsCommand($logger, $container));
         self::addCommand($application, new ClearCacheCommand($cacheDir));
         self::addCommand($application, new ToolsListCommand($logger, $container));
+        self::addCommand($application, new ToolsInspectCommand($logger, $container));
 
         if (\defined('SIGUSR1') && class_exists(RunnerControl::class)) {
             $application->getSignalRegistry()->register(\SIGUSR1, function () {

--- a/src/mate/src/Command/ToolsInspectCommand.php
+++ b/src/mate/src/Command/ToolsInspectCommand.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command;
+
+use Psr\Log\LoggerInterface;
+use Symfony\AI\Mate\Discovery\CapabilityCollector;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Display detailed information about a specific MCP tool.
+ *
+ * @phpstan-import-type Capabilities from CapabilityCollector
+ *
+ * @phpstan-type ToolData array{
+ *     name: string,
+ *     description: string|null,
+ *     handler: string,
+ *     input_schema: array<string, mixed>|null,
+ *     extension: string
+ * }
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('mcp:tools:inspect', 'Display detailed information about a specific MCP tool')]
+class ToolsInspectCommand extends Command
+{
+    private CapabilityCollector $collector;
+
+    /**
+     * @var array<string, array{dirs: string[], includes: string[]}>
+     */
+    private array $extensions;
+
+    public function __construct(
+        LoggerInterface $logger,
+        private ContainerInterface $container,
+    ) {
+        parent::__construct(self::getDefaultName());
+
+        $rootDir = $container->getParameter('mate.root_dir');
+        \assert(\is_string($rootDir));
+
+        $extensions = $this->container->getParameter('mate.extensions') ?? [];
+        \assert(\is_array($extensions));
+        $this->extensions = $extensions;
+
+        $disabledFeatures = $this->container->getParameter('mate.disabled_features') ?? [];
+        \assert(\is_array($disabledFeatures));
+
+        $this->collector = new CapabilityCollector($rootDir, $extensions, $disabledFeatures, $logger);
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'mcp:tools:inspect';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Display detailed information about a specific MCP tool';
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('tool-name', InputArgument::REQUIRED, 'Name of the tool to inspect')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (text, json)', 'text')
+            ->setHelp(<<<'HELP'
+The <info>%command.name%</info> command displays detailed information about a specific MCP tool including its full JSON schema.
+
+<info>Usage Examples:</info>
+
+  <comment># Inspect a tool</comment>
+  %command.full_name% php-version
+
+  <comment># JSON output for scripting</comment>
+  %command.full_name% php-version --format=json
+
+  <comment># Inspect extension tool</comment>
+  %command.full_name% search-logs
+
+  <comment># For a list of all available tools, use:</comment>
+  bin/mate.php mcp:tools:list
+HELP
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $toolName = $input->getArgument('tool-name');
+        \assert(\is_string($toolName));
+
+        $allTools = [];
+        foreach ($this->extensions as $extensionName => $extension) {
+            $capabilities = $this->collector->collectCapabilities($extensionName, $extension);
+            foreach ($capabilities['tools'] as $name => $toolData) {
+                $allTools[$name] = array_merge($toolData, ['extension' => $extensionName]);
+            }
+        }
+
+        if (!isset($allTools[$toolName])) {
+            $io->error(\sprintf('Tool "%s" not found', $toolName));
+            $io->note('Use "bin/mate.php mcp:tools:list" to see all available tools');
+
+            return Command::FAILURE;
+        }
+
+        $toolData = $allTools[$toolName];
+
+        $format = $input->getOption('format');
+        \assert(\is_string($format));
+
+        if ('json' === $format) {
+            $this->outputJson($toolData, $output);
+
+            return Command::SUCCESS;
+        }
+
+        $this->outputText($toolData, $io);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param ToolData $toolData
+     */
+    private function outputText(array $toolData, SymfonyStyle $io): void
+    {
+        $io->title($toolData['name']);
+
+        $io->definitionList(
+            ['Description' => $toolData['description'] ?? '<comment>N/A</comment>'],
+            ['Handler' => $toolData['handler']],
+            ['Extension' => $toolData['extension']],
+        );
+
+        if (null !== $toolData['input_schema']) {
+            $io->section('Input Schema');
+            $io->text(json_encode($toolData['input_schema'], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+            return;
+        }
+
+        $io->section('Input Schema');
+        $io->text('<comment>No input schema defined</comment>');
+    }
+
+    /**
+     * @param ToolData $toolData
+     */
+    private function outputJson(array $toolData, OutputInterface $output): void
+    {
+        $output->writeln(json_encode($toolData, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/src/mate/src/Command/ToolsListCommand.php
+++ b/src/mate/src/Command/ToolsListCommand.php
@@ -208,7 +208,7 @@ HELP
             return;
         }
 
-        $table = new Table($output = $io);
+        $table = new Table($io);
         $table->setHeaders(['Tool Name', 'Description', 'Handler', 'Extension']);
 
         foreach ($tools as $toolName => $toolData) {

--- a/src/mate/tests/Command/ToolsInspectCommandTest.php
+++ b/src/mate/tests/Command/ToolsInspectCommandTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Command\ToolsInspectCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ToolsInspectCommandTest extends TestCase
+{
+    public function testExecuteInspectsExistingTool()
+    {
+        $rootDir = __DIR__.'/../..';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ]);
+
+        $command = new ToolsInspectCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['tool-name' => 'php-version']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('php-version', $output);
+        $this->assertStringContainsString('Description', $output);
+        $this->assertStringContainsString('Handler', $output);
+        $this->assertStringContainsString('Extension', $output);
+        $this->assertStringContainsString('Input Schema', $output);
+    }
+
+    public function testExecuteWithJsonFormat()
+    {
+        $rootDir = __DIR__.'/../..';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ]);
+
+        $command = new ToolsInspectCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['tool-name' => 'php-version', '--format' => 'json']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $json = json_decode($output, true);
+        $this->assertIsArray($json);
+        $this->assertArrayHasKey('name', $json);
+        $this->assertArrayHasKey('description', $json);
+        $this->assertArrayHasKey('handler', $json);
+        $this->assertArrayHasKey('input_schema', $json);
+        $this->assertArrayHasKey('extension', $json);
+        $this->assertSame('php-version', $json['name']);
+    }
+
+    public function testExecuteWithInvalidToolName()
+    {
+        $rootDir = __DIR__.'/../..';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ]);
+
+        $command = new ToolsInspectCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['tool-name' => 'non-existent-tool']);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Tool "non-existent-tool" not found', $output);
+        $this->assertStringContainsString('mcp:tools:list', $output);
+    }
+
+    public function testTextOutputFormatDisplaysFullInformation()
+    {
+        $rootDir = __DIR__.'/../..';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ]);
+
+        $command = new ToolsInspectCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['tool-name' => 'php-version', '--format' => 'text']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('php-version', $output);
+        $this->assertStringContainsString('Description', $output);
+        $this->assertStringContainsString('Handler', $output);
+        $this->assertStringContainsString('Extension', $output);
+        $this->assertStringContainsString('Input Schema', $output);
+        $this->assertStringContainsString('_custom', $output);
+    }
+
+    public function testJsonOutputContainsAllFields()
+    {
+        $rootDir = __DIR__.'/../..';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ]);
+
+        $command = new ToolsInspectCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['tool-name' => 'operating-system', '--format' => 'json']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $json = json_decode($output, true);
+        $this->assertIsArray($json);
+        $this->assertSame('operating-system', $json['name']);
+        $this->assertIsString($json['handler']);
+        $this->assertSame('_custom', $json['extension']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | N/A
| License       | MIT

### Summary

Display comprehensive information about specific MCP tools including full JSON schema.

Features:
- Accept tool name as required argument
- Display tool metadata: name, description, handler, extension
- Show full JSON schema for tool parameters
- Support text (default) and JSON output formats
- Error handling for non-existent tools