### PR TITLE
 fix: update phpdocumentor/reflection-docblock version constraint to support 6.0

### DIFF
--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=8.2",
         "ext-fileinfo": "*",
-        "phpdocumentor/reflection-docblock": "^5.4",
+        "phpdocumentor/reflection-docblock": "^5.4|^6.0",
         "phpstan/phpdoc-parser": "^2.1",
         "psr/log": "^3.0",
         "symfony/ai-platform": "^0.2",

--- a/src/platform/composer.json
+++ b/src/platform/composer.json
@@ -49,7 +49,7 @@
         "php": ">=8.2",
         "ext-fileinfo": "*",
         "oskarstark/enum-helper": "^1.5",
-        "phpdocumentor/reflection-docblock": "^5.4",
+        "phpdocumentor/reflection-docblock": "^5.4|^6.0",
         "phpstan/phpdoc-parser": "^2.1",
         "psr/log": "^3.0",
         "symfony/clock": "^7.3|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Allow phpdocumentor/reflection-docblock ^6.0 to be used.