### PR TITLE
[Store] Allow `id` to be `int|string|Uuid` for `VectorDocument` and `TextDocument`

### DIFF
--- a/demo/composer.json
+++ b/demo/composer.json
@@ -15,7 +15,7 @@
         "symfony/ai-agent": "^0.2",
         "symfony/ai-bundle": "^0.2",
         "symfony/ai-chat": "^0.2",
-        "symfony/ai-chroma-db-store": "^0.2",
+        "symfony/ai-chroma-db-store": "^0.3",
         "symfony/ai-clock-tool": "^0.2",
         "symfony/ai-hugging-face-platform": "^0.2",
         "symfony/ai-open-ai-platform": "^0.2",

--- a/docs/cookbook/rag-implementation.rst
+++ b/docs/cookbook/rag-implementation.rst
@@ -203,7 +203,7 @@ Document Loading Strategies
     $articles = $articleRepository->findAll();
     $documents = array_map(
         fn($article) => new TextDocument(
-            id: Uuid::fromString($article->getId()),
+            id: $article->getId(),
             content: $article->getTitle().PHP_EOL.$article->getContent(),
             metadata: new Metadata(['author' => $article->getAuthor()])
         ),

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.3
+---
+
+ * Add support for more types (`int`, `string`) on `VectorDocument` and `TextDocument`
+ * [BC BREAK] Store Bridges don't auto-cast the document `$id` property to `uuid` anymore
+
 0.2
 ---
 

--- a/src/store/src/Bridge/AzureSearch/SearchStore.php
+++ b/src/store/src/Bridge/AzureSearch/SearchStore.php
@@ -16,7 +16,6 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -95,7 +94,7 @@ final class SearchStore implements StoreInterface
     private function convertToVectorDocument(array $data): VectorDocument
     {
         return new VectorDocument(
-            id: Uuid::fromString($data['id']),
+            id: $data['id'],
             vector: !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
                 ? new NullVector()
                 : new Vector($data[$this->vectorFieldName]),

--- a/src/store/src/Bridge/AzureSearch/composer.json
+++ b/src/store/src/Bridge/AzureSearch/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/Cache/Store.php
+++ b/src/store/src/Bridge/Cache/Store.php
@@ -19,7 +19,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\Cache\CacheInterface;
 
 /**
@@ -83,7 +82,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $documents = $this->cache->get($this->cacheKey, static fn (): array => []);
 
         $vectorDocuments = array_map(static fn (array $document): VectorDocument => new VectorDocument(
-            id: Uuid::fromString($document['id']),
+            id: $document['id'],
             vector: new Vector($document['vector']),
             metadata: new Metadata($document['metadata']),
         ), $documents);

--- a/src/store/src/Bridge/Cache/composer.json
+++ b/src/store/src/Bridge/Cache/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/cache": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -16,7 +16,6 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -87,7 +86,7 @@ final class Store implements StoreInterface
             }
 
             yield new VectorDocument(
-                id: Uuid::fromString($queryResponse->ids[0][$i]),
+                id: $queryResponse->ids[0][$i],
                 vector: new Vector($queryResponse->embeddings[0][$i]),
                 metadata: $metaData,
                 score: $queryResponse->distances[0][$i] ?? null,

--- a/src/store/src/Bridge/ChromaDb/composer.json
+++ b/src/store/src/Bridge/ChromaDb/composer.json
@@ -28,7 +28,7 @@
         "php": ">=8.2",
         "codewithkyrian/chromadb-php": "^1.0",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -99,7 +98,7 @@ class Store implements ManagedStoreInterface, StoreInterface
 
         foreach ($results as $result) {
             yield new VectorDocument(
-                id: Uuid::fromString($result['id']),
+                id: $result['id'],
                 vector: new Vector($result['embedding']),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],

--- a/src/store/src/Bridge/ClickHouse/composer.json
+++ b/src/store/src/Bridge/ClickHouse/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/Cloudflare/Store.php
+++ b/src/store/src/Bridge/Cloudflare/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -142,7 +141,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             : new Vector($data['values']);
 
         return new VectorDocument(
-            id: Uuid::fromString($id),
+            id: $id,
             vector: $vector,
             metadata: new Metadata($data['metadata']),
             score: $data['score'] ?? null

--- a/src/store/src/Bridge/Cloudflare/composer.json
+++ b/src/store/src/Bridge/Cloudflare/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/Elasticsearch/composer.json
+++ b/src/store/src/Bridge/Elasticsearch/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -154,7 +153,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             : new Vector($payload[$this->field]);
 
         return new VectorDocument(
-            id: Uuid::fromString($payload['uuid']),
+            id: $payload['uuid'],
             vector: $vector,
             metadata: new Metadata($payload['metadata'] ?? []),
             score: $data['_knn_dist'] ?? null

--- a/src/store/src/Bridge/ManticoreSearch/composer.json
+++ b/src/store/src/Bridge/ManticoreSearch/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/MariaDb/composer.json
+++ b/src/store/src/Bridge/MariaDb/composer.json
@@ -28,7 +28,7 @@
         "php": ">=8.2",
         "ext-pdo": "*",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -134,7 +133,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return array_merge([
-            'id' => $document->id->toRfc4122(),
+            'id' => $document->id,
             $this->vectorFieldName => [
                 $this->embedder => [
                     'embeddings' => $document->vector->getData(),
@@ -158,6 +157,6 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         unset($data['id'], $data[$this->vectorFieldName], $data['_rankingScore']);
 
-        return new VectorDocument(Uuid::fromString($id), $vector, new Metadata($data), $score);
+        return new VectorDocument($id, $vector, new Metadata($data), $score);
     }
 }

--- a/src/store/src/Bridge/Meilisearch/composer.json
+++ b/src/store/src/Bridge/Meilisearch/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -155,7 +154,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return [
-            'id' => $document->id->toRfc4122(),
+            'id' => $document->id,
             '_metadata' => json_encode($document->metadata->getArrayCopy()),
             $this->vectorFieldName => $document->vector->getData(),
         ];
@@ -174,6 +173,6 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $score = $data['distance'] ?? null;
 
-        return new VectorDocument(Uuid::fromString($id), $vector, new Metadata(json_decode($data['_metadata'], true)), $score);
+        return new VectorDocument($id, $vector, new Metadata(json_decode($data['_metadata'], true)), $score);
     }
 }

--- a/src/store/src/Bridge/Milvus/composer.json
+++ b/src/store/src/Bridge/Milvus/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/MongoDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/MongoDb/Tests/StoreTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Store\Bridge\MongoDb\Tests;
 
-use MongoDB\BSON\Binary;
 use MongoDB\Client;
 use MongoDB\Collection;
 use MongoDB\Driver\CursorInterface;
@@ -40,12 +39,12 @@ final class StoreTest extends TestCase
             ->willReturn($collection);
 
         $uuid = Uuid::v4();
-        $expectedBinary = new Binary($uuid->toBinary(), Binary::TYPE_UUID);
+        $expectedId = $uuid->toString();
 
         $collection->expects($this->once())
             ->method('replaceOne')
             ->with(
-                ['_id' => $expectedBinary],
+                ['_id' => $expectedId],
                 [
                     'metadata' => ['title' => 'Test Document'],
                     'vector' => [0.1, 0.2, 0.3],
@@ -111,7 +110,7 @@ final class StoreTest extends TestCase
             ->with([
                 [
                     'replaceOne' => [
-                        ['_id' => new Binary($uuid1->toBinary(), Binary::TYPE_UUID)],
+                        ['_id' => $uuid1->toString()],
                         [
                             'vector' => [0.1, 0.2, 0.3],
                         ],
@@ -120,7 +119,7 @@ final class StoreTest extends TestCase
                 ],
                 [
                     'replaceOne' => [
-                        ['_id' => new Binary($uuid2->toBinary(), Binary::TYPE_UUID)],
+                        ['_id' => $uuid2->toString()],
                         [
                             'metadata' => ['title' => 'Test'],
                             'vector' => [0.4, 0.5, 0.6],
@@ -160,13 +159,13 @@ final class StoreTest extends TestCase
 
         $results = [
             [
-                '_id' => new Binary($uuid1->toBinary(), Binary::TYPE_UUID),
+                '_id' => $uuid1->toString(),
                 'vector' => [0.1, 0.2, 0.3],
                 'metadata' => ['title' => 'First Document'],
                 'score' => 0.95,
             ],
             [
-                '_id' => new Binary($uuid2->toBinary(), Binary::TYPE_UUID),
+                '_id' => $uuid2->toString(),
                 'vector' => [0.4, 0.5, 0.6],
                 'metadata' => ['title' => 'Second Document'],
                 'score' => 0.85,
@@ -215,8 +214,8 @@ final class StoreTest extends TestCase
         $this->assertCount(2, $documents);
         $this->assertInstanceOf(VectorDocument::class, $documents[0]);
         $this->assertInstanceOf(VectorDocument::class, $documents[1]);
-        $this->assertEquals($uuid1, $documents[0]->id);
-        $this->assertEquals($uuid2, $documents[1]->id);
+        $this->assertEquals($uuid1->toString(), $documents[0]->id);
+        $this->assertEquals($uuid2->toString(), $documents[1]->id);
         $this->assertSame(0.95, $documents[0]->score);
         $this->assertSame(0.85, $documents[1]->score);
         $this->assertSame('First Document', $documents[0]->metadata['title']);
@@ -511,7 +510,7 @@ final class StoreTest extends TestCase
 
         $results = [
             [
-                '_id' => new Binary($uuid->toBinary(), Binary::TYPE_UUID),
+                '_id' => $uuid->toString(),
                 'custom_embeddings' => [0.1, 0.2, 0.3],
                 'metadata' => ['title' => 'Document'],
                 'score' => 0.95,

--- a/src/store/src/Bridge/MongoDb/composer.json
+++ b/src/store/src/Bridge/MongoDb/composer.json
@@ -30,7 +30,7 @@
         "mongodb/mongodb": "^1.21|^2.0",
         "psr/log": "^3.0",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -121,7 +120,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             : new Vector($payload['properties'][$this->embeddingsField]);
 
         return new VectorDocument(
-            id: Uuid::fromString($id),
+            id: $id,
             vector: $vector,
             metadata: new Metadata(json_decode($payload['properties']['metadata'], true)),
             score: $data[1] ?? null

--- a/src/store/src/Bridge/Neo4j/composer.json
+++ b/src/store/src/Bridge/Neo4j/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -80,7 +79,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $documentToIndex = fn (VectorDocument $document): array => [
             'index' => [
                 '_index' => $this->indexName,
-                '_id' => $document->id->toRfc4122(),
+                '_id' => $document->id,
             ],
         ];
 
@@ -157,6 +156,6 @@ final class Store implements ManagedStoreInterface, StoreInterface
             ? new NullVector()
             : new Vector($document['_source'][$this->vectorsField]);
 
-        return new VectorDocument(Uuid::fromString($id), $vector, new Metadata(json_decode($document['_source']['metadata'], true)), $document['_score'] ?? null);
+        return new VectorDocument($id, $vector, new Metadata(json_decode($document['_source']['metadata'], true)), $document['_score'] ?? null);
     }
 }

--- a/src/store/src/Bridge/OpenSearch/composer.json
+++ b/src/store/src/Bridge/OpenSearch/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -19,7 +19,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -97,7 +96,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         foreach ($result->json()['matches'] as $match) {
             yield new VectorDocument(
-                id: Uuid::fromString($match['id']),
+                id: $match['id'],
                 vector: new Vector($match['values']),
                 metadata: new Metadata($match['metadata']),
                 score: $match['score'],

--- a/src/store/src/Bridge/Pinecone/composer.json
+++ b/src/store/src/Bridge/Pinecone/composer.json
@@ -28,7 +28,7 @@
         "php": ">=8.2",
         "probots-io/pinecone-php": "^1.0",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -19,7 +19,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 
 /**
  * Requires PostgreSQL with pgvector extension.
@@ -178,7 +177,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
             yield new VectorDocument(
-                id: Uuid::fromString($result['id']),
+                id: $result['id'],
                 vector: new Vector($this->fromPgvector($result['embedding'])),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],

--- a/src/store/src/Bridge/Postgres/composer.json
+++ b/src/store/src/Bridge/Postgres/composer.json
@@ -31,7 +31,7 @@
         "ext-pdo": "*",
         "oskarstark/enum-helper": "^1.5",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -157,7 +156,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             : new Vector($data['vector']);
 
         return new VectorDocument(
-            id: Uuid::fromString($id),
+            id: $id,
             vector: $vector,
             metadata: new Metadata($data['payload']),
             score: $data['score'] ?? null

--- a/src/store/src/Bridge/Qdrant/composer.json
+++ b/src/store/src/Bridge/Qdrant/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
@@ -171,7 +170,7 @@ class Store implements ManagedStoreInterface, StoreInterface
             }
 
             yield new VectorDocument(
-                id: Uuid::fromString($data['$.id']),
+                id: $data['$.id'],
                 vector: new Vector($data['$.embedding'] ?? []),
                 metadata: new Metadata($data['$.metadata'] ?? []),
                 score: $score,

--- a/src/store/src/Bridge/Redis/composer.json
+++ b/src/store/src/Bridge/Redis/composer.json
@@ -29,7 +29,7 @@
         "ext-redis": "*",
         "oskarstark/enum-helper": "^1.5",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/store/src/Bridge/Supabase/Store.php
+++ b/src/store/src/Bridge/Supabase/Store.php
@@ -17,7 +17,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -141,7 +140,7 @@ final class Store implements StoreInterface
             $metadata = \is_array($record['metadata']) ? $record['metadata'] : json_decode($record['metadata'], true, 512, \JSON_THROW_ON_ERROR);
 
             yield new VectorDocument(
-                id: Uuid::fromString($record['id']),
+                id: $record['id'],
                 vector: new Vector($embedding),
                 metadata: new Metadata($metadata),
                 score: (float) $record['score'],

--- a/src/store/src/Bridge/Supabase/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Supabase/Tests/StoreTest.php
@@ -144,7 +144,7 @@ class StoreTest extends TestCase
 
         $this->assertCount(1, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
-        $this->assertTrue($uuid->equals($result[0]->id));
+        $this->assertSame($uuid->toRfc4122(), $result[0]->id);
         $this->assertSame([0.5, 0.6, 0.7], $result[0]->vector->getData());
         $this->assertSame(['category' => 'test'], $result[0]->metadata->getArrayCopy());
         $this->assertSame(0.85, $result[0]->score);
@@ -176,12 +176,12 @@ class StoreTest extends TestCase
 
         $this->assertCount(2, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
-        $this->assertTrue($uuid1->equals($result[0]->id));
+        $this->assertSame($uuid1->toRfc4122(), $result[0]->id);
         $this->assertSame([0.1, 0.2], $result[0]->vector->getData());
         $this->assertSame(0.95, $result[0]->score);
         $this->assertSame(['type' => 'first'], $result[0]->metadata->getArrayCopy());
         $this->assertInstanceOf(VectorDocument::class, $result[1]);
-        $this->assertTrue($uuid2->equals($result[1]->id));
+        $this->assertSame($uuid2->toRfc4122(), $result[1]->id);
         $this->assertSame([0.3, 0.4], $result[1]->vector->getData());
         $this->assertSame(0.85, $result[1]->score);
         $this->assertSame(['type' => 'second'], $result[1]->metadata->getArrayCopy());
@@ -209,7 +209,7 @@ class StoreTest extends TestCase
         $metadata = $document->metadata->getArrayCopy();
         $this->assertCount(1, $result);
         $this->assertInstanceOf(VectorDocument::class, $document);
-        $this->assertTrue($uuid->equals($document->id));
+        $this->assertSame($uuid->toRfc4122(), $document->id);
         $this->assertSame([0.1, 0.2, 0.3, 0.4], $document->vector->getData());
         $this->assertSame(0.92, $document->score);
         $this->assertSame('Test Document', $metadata['title']);

--- a/src/store/src/Bridge/Supabase/composer.json
+++ b/src/store/src/Bridge/Supabase/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -19,7 +19,6 @@ use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -153,7 +152,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         unset($data['_metadata']['_id']);
 
         return new VectorDocument(
-            id: Uuid::fromString($id),
+            id: $id,
             vector: $vector,
             metadata: new Metadata($data['_metadata']),
         );

--- a/src/store/src/Bridge/SurrealDb/composer.json
+++ b/src/store/src/Bridge/SurrealDb/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -119,7 +118,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return [
-            'id' => $document->id->toRfc4122(),
+            'id' => $document->id,
             $this->vectorFieldName => $document->vector->getData(),
             'metadata' => json_encode($document->metadata->getArrayCopy()),
         ];
@@ -140,6 +139,6 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $score = $data['vector_distance'] ?? null;
 
-        return new VectorDocument(Uuid::fromString($id), $vector, new Metadata(json_decode($document['metadata'], true)), $score);
+        return new VectorDocument($id, $vector, new Metadata(json_decode($document['metadata'], true)), $score);
     }
 }

--- a/src/store/src/Bridge/Typesense/composer.json
+++ b/src/store/src/Bridge/Typesense/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -18,7 +18,6 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -120,10 +119,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
     {
         return [
             'class' => $this->collection,
-            'id' => $document->id->toRfc4122(),
+            'id' => $document->id,
             'vector' => $document->vector->getData(),
             'properties' => [
-                'uuid' => $document->id->toRfc4122(),
+                'uuid' => $document->id,
                 'vector' => $document->vector->getData(),
                 '_metadata' => json_encode($document->metadata->getArrayCopy()),
             ],
@@ -141,6 +140,6 @@ final class Store implements ManagedStoreInterface, StoreInterface
             ? new NullVector()
             : new Vector($data['vector']);
 
-        return new VectorDocument(Uuid::fromString($id), $vector, new Metadata(json_decode($data['_metadata'], true)));
+        return new VectorDocument($id, $vector, new Metadata(json_decode($data['_metadata'], true)));
     }
 }

--- a/src/store/src/Bridge/Weaviate/composer.json
+++ b/src/store/src/Bridge/Weaviate/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.2",
-        "symfony/ai-store": "^0.2",
+        "symfony/ai-store": "^0.3",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },

--- a/src/store/src/Document/TextDocument.php
+++ b/src/store/src/Document/TextDocument.php
@@ -20,7 +20,7 @@ use Symfony\Component\Uid\Uuid;
 final class TextDocument implements EmbeddableDocumentInterface
 {
     public function __construct(
-        private readonly Uuid $id,
+        private readonly int|string|Uuid $id,
         private readonly string $content,
         private readonly Metadata $metadata = new Metadata(),
     ) {
@@ -34,7 +34,7 @@ final class TextDocument implements EmbeddableDocumentInterface
         return new self($this->id, $content, $this->metadata);
     }
 
-    public function getId(): Uuid
+    public function getId(): int|string|Uuid
     {
         return $this->id;
     }

--- a/src/store/src/Document/VectorDocument.php
+++ b/src/store/src/Document/VectorDocument.php
@@ -20,7 +20,7 @@ use Symfony\Component\Uid\Uuid;
 final class VectorDocument
 {
     public function __construct(
-        public readonly Uuid $id,
+        public readonly int|string|Uuid $id,
         public readonly VectorInterface $vector,
         public readonly Metadata $metadata = new Metadata(),
         public readonly ?float $score = null,

--- a/src/store/tests/Document/TextDocumentTest.php
+++ b/src/store/tests/Document/TextDocumentTest.php
@@ -22,6 +22,21 @@ use Symfony\Component\Uid\Uuid;
 
 final class TextDocumentTest extends TestCase
 {
+    #[DataProvider('constructorIdDataProvider')]
+    public function testConstructorIdSupportsManyTypes(int|string|Uuid $id)
+    {
+        $document = new TextDocument($id, 'content');
+
+        $this->assertSame($id, $document->getId());
+    }
+
+    public static function constructorIdDataProvider(): iterable
+    {
+        yield 'int' => [1];
+        yield 'string' => ['id'];
+        yield 'uuid' => [Uuid::v4()];
+    }
+
     #[TestDox('Creates document with valid content and metadata')]
     public function testConstructorWithValidContent()
     {

--- a/src/store/tests/Document/VectorDocumentTest.php
+++ b/src/store/tests/Document/VectorDocumentTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
@@ -25,6 +26,21 @@ use Symfony\Component\Uid\Uuid;
  */
 final class VectorDocumentTest extends TestCase
 {
+    #[DataProvider('constructorIdDataProvider')]
+    public function testConstructorIdSupportsManyTypes(int|string|Uuid $id)
+    {
+        $document = new VectorDocument($id, new NullVector());
+
+        $this->assertSame($id, $document->id);
+    }
+
+    public static function constructorIdDataProvider(): iterable
+    {
+        yield 'int' => [1];
+        yield 'string' => ['id'];
+        yield 'uuid' => [Uuid::v4()];
+    }
+
     #[TestDox('Creates document with required parameters only')]
     public function testConstructorWithRequiredParameters()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no 
| Issues        | Fix #857
| License       | MIT

This PR is a duplicate of #867 but with a clean commit history
