### PR TITLE
[Platform] Change `TokenUsageAggregation::__construct` from variadic to array

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,16 @@ Agent
   * The `Symfony\AI\Agent\Toolbox\StreamResult` class has been removed in favor of a `StreamListener`. Checks should now target
     `Symfony\AI\Platform\Result\StreamResult` instead.
 
+Platform
+--------
+
+ * The `TokenUsageAggregation::__construct()` method signature has changed from variadic to accept an array of `TokenUsageInterface`
+
+   ```diff
+   -$aggregation = new TokenUsageAggregation($usage1, $usage2);
+   +$aggregation = new TokenUsageAggregation([$usage1, $usage2]);
+   ```
+
 UPGRADE FROM 0.1 to 0.2
 =======================
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `StreamListenerInterface` to hook into response streams
+ * [BC BREAK] Change `TokenUsageAggregation::__construct()` from variadic to array
 
 0.2
 ---

--- a/src/platform/src/TokenUsage/TokenUsageAggregation.php
+++ b/src/platform/src/TokenUsage/TokenUsageAggregation.php
@@ -17,14 +17,11 @@ namespace Symfony\AI\Platform\TokenUsage;
 final class TokenUsageAggregation implements TokenUsageInterface
 {
     /**
-     * @var TokenUsageInterface[]
+     * @param TokenUsageInterface[] $tokenUsages
      */
-    private readonly array $tokenUsages;
-
     public function __construct(
-        TokenUsageInterface ...$tokenUsages,
+        private readonly array $tokenUsages,
     ) {
-        $this->tokenUsages = $tokenUsages;
     }
 
     public function getPromptTokens(): ?int

--- a/src/platform/tests/Metadata/TokenUsageAggregationTest.php
+++ b/src/platform/tests/Metadata/TokenUsageAggregationTest.php
@@ -41,7 +41,7 @@ class TokenUsageAggregationTest extends TestCase
             remainingTokensMonth: 900,
             totalTokens: 21
         );
-        $aggregation = new TokenUsageAggregation($usage1, $usage2);
+        $aggregation = new TokenUsageAggregation([$usage1, $usage2]);
 
         $this->assertSame(15, $aggregation->getPromptTokens());
         $this->assertSame(30, $aggregation->getCompletionTokens());
@@ -58,7 +58,7 @@ class TokenUsageAggregationTest extends TestCase
     {
         $usage1 = new TokenUsage(promptTokens: null, completionTokens: null, remainingTokens: null, totalTokens: null);
         $usage2 = new TokenUsage(promptTokens: 5, completionTokens: 10, remainingTokens: 25, totalTokens: 21);
-        $aggregation = new TokenUsageAggregation($usage1, $usage2);
+        $aggregation = new TokenUsageAggregation([$usage1, $usage2]);
 
         $this->assertSame(5, $aggregation->getPromptTokens());
         $this->assertSame(10, $aggregation->getCompletionTokens());
@@ -70,7 +70,7 @@ class TokenUsageAggregationTest extends TestCase
     {
         $usage1 = new TokenUsage();
         $usage2 = new TokenUsage();
-        $aggregation = new TokenUsageAggregation($usage1, $usage2);
+        $aggregation = new TokenUsageAggregation([$usage1, $usage2]);
 
         $this->assertNull($aggregation->getPromptTokens());
         $this->assertNull($aggregation->getCompletionTokens());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Extracted from #1396
| License       | MIT

This change improves BC handling for future modifications by accepting an array of TokenUsageInterface instead of variadic arguments.
