### PR TITLE
Use old full FQCN for removed `StreamResult` class in `UPGRADE.md`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@ UPGRADE FROM 0.2 to 0.3
 Agent
 -----
 
-  * The `StreamResult` class has been removed in favor of a `StreamListener`. Checks should now target
+  * The `Symfony\AI\Agent\Toolbox\StreamResult` class has been removed in favor of a `StreamListener`. Checks should now target
     `Symfony\AI\Platform\Result\StreamResult` instead.
 
 UPGRADE FROM 0.1 to 0.2


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT
