### PR TITLE
[Platform][ElevenLabs] Support `voice_settings` options

### DIFF
--- a/src/platform/src/Bridge/ElevenLabs/CHANGELOG.md
+++ b/src/platform/src/Bridge/ElevenLabs/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.3
+---
+
+ * Add support for using API options, e.g. voice_settings
+
 0.1
 ---
 

--- a/src/platform/src/Bridge/ElevenLabs/ElevenLabsClient.php
+++ b/src/platform/src/Bridge/ElevenLabs/ElevenLabsClient.php
@@ -93,6 +93,8 @@ final class ElevenLabsClient implements ModelClientInterface
             ? \sprintf('%s/text-to-speech/%s/stream', $this->hostUrl, $voice)
             : \sprintf('%s/text-to-speech/%s', $this->hostUrl, $voice);
 
+        unset($options['voice'], $options['stream']);
+
         return new RawHttpResult($this->httpClient->request('POST', $url, [
             'headers' => [
                 'xi-api-key' => $this->apiKey,
@@ -100,6 +102,7 @@ final class ElevenLabsClient implements ModelClientInterface
             'json' => [
                 'text' => $payload['text'],
                 'model_id' => $model->getName(),
+                ...$options,
             ],
         ]));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

### This PR adds support for passing voice_settings options to the ElevenLabs Text-to-Speech API.

Previously, the agent only forwarded the required text and model_id fields when performing a TTS request. ElevenLabs also supports optional voice_settings (e.g. stability, similarity boost, style, etc.), but there was no way to provide them through the agent.

This change conditionally includes voice_settings in the request payload when the option is provided, while preserving the existing behavior when it is not.

### Changes

Add optional voice_settings to the JSON payload of the Text-to-Speech request

Keep backward compatibility by only sending voice_settings when explicitly defined

### Example
```php
$result = $this->platform->invoke('eleven_flash_v2_5', ['text' => $text], [
    'voice' => 'my-voice-id',
    'voice_settings' => [
        'stability' => 0.5,
        'use_speaker_boost' => 1,
        'similarity_boost' => 0.7,
        'style' => 0.2,
        'speed' => 1.2,
    ],
]);
```