### PR TITLE
 Use generic PlatformFactory for generic based factories

### DIFF
--- a/src/platform/src/Bridge/AiMlApi/PlatformFactory.php
+++ b/src/platform/src/Bridge/AiMlApi/PlatformFactory.php
@@ -12,8 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\AiMlApi;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Symfony\AI\Platform\Bridge\Generic\Completions;
-use Symfony\AI\Platform\Bridge\Generic\Embeddings;
+use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Platform;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -30,18 +29,13 @@ class PlatformFactory
         string $baseUrl = 'https://api.aimlapi.com',
         ?EventDispatcherInterface $eventDispatcher = null,
     ): Platform {
-        return new Platform(
-            [
-                new Completions\ModelClient($httpClient, $baseUrl, $apiKey),
-                new Embeddings\ModelClient($httpClient, $baseUrl, $apiKey),
-            ],
-            [
-                new Embeddings\ResultConverter(),
-                new Completions\ResultConverter(),
-            ],
-            new ModelCatalog(),
-            $contract,
-            $eventDispatcher,
+        return GenericPlatformFactory::create(
+            baseUrl: $baseUrl,
+            apiKey: $apiKey,
+            httpClient: $httpClient,
+            modelCatalog: new ModelCatalog(),
+            contract: $contract,
+            eventDispatcher: $eventDispatcher,
         );
     }
 }

--- a/src/platform/src/Bridge/Albert/PlatformFactory.php
+++ b/src/platform/src/Bridge/Albert/PlatformFactory.php
@@ -12,9 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Albert;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Symfony\AI\Platform\Bridge\Generic\Completions;
-use Symfony\AI\Platform\Bridge\Generic\Embeddings;
-use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
@@ -48,15 +46,14 @@ final class PlatformFactory
 
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
-        return new Platform(
-            [
-                new Completions\ModelClient($httpClient, $baseUrl, $apiKey, '/chat/completions'),
-                new Embeddings\ModelClient($httpClient, $baseUrl, $apiKey, '/embeddings'),
-            ],
-            [new Completions\ResultConverter(), new Embeddings\ResultConverter()],
-            $modelCatalog,
-            Contract::create(),
-            $eventDispatcher,
+        return GenericPlatformFactory::create(
+            baseUrl: $baseUrl,
+            apiKey: $apiKey,
+            httpClient: $httpClient,
+            modelCatalog: $modelCatalog,
+            eventDispatcher: $eventDispatcher,
+            completionsPath: '/chat/completions',
+            embeddingsPath: '/embeddings',
         );
     }
 }

--- a/src/platform/src/Bridge/LmStudio/PlatformFactory.php
+++ b/src/platform/src/Bridge/LmStudio/PlatformFactory.php
@@ -12,8 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\LmStudio;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Symfony\AI\Platform\Bridge\Generic\Completions;
-use Symfony\AI\Platform\Bridge\Generic\Embeddings;
+use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
@@ -34,18 +33,12 @@ class PlatformFactory
     ): Platform {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
-        return new Platform(
-            [
-                new Completions\ModelClient($httpClient, $baseUrl),
-                new Embeddings\ModelClient($httpClient, $baseUrl),
-            ],
-            [
-                new Embeddings\ResultConverter(),
-                new Completions\ResultConverter(),
-            ],
-            $modelCatalog,
-            $contract ?? Contract::create(),
-            $eventDispatcher,
+        return GenericPlatformFactory::create(
+            baseUrl: $baseUrl,
+            httpClient: $httpClient,
+            modelCatalog: $modelCatalog,
+            contract: $contract,
+            eventDispatcher: $eventDispatcher,
         );
     }
 }

--- a/src/platform/src/Bridge/OpenRouter/PlatformFactory.php
+++ b/src/platform/src/Bridge/OpenRouter/PlatformFactory.php
@@ -12,8 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\OpenRouter;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Symfony\AI\Platform\Bridge\Generic\Completions;
-use Symfony\AI\Platform\Bridge\Generic\Embeddings;
+use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
@@ -34,15 +33,13 @@ final class PlatformFactory
     ): Platform {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
-        return new Platform(
-            [
-                new Embeddings\ModelClient($httpClient, 'https://openrouter.ai', $apiKey, '/api/v1/embeddings'),
-                new Completions\ModelClient($httpClient, 'https://openrouter.ai', $apiKey, '/api/v1/chat/completions'),
-            ],
-            [new Embeddings\ResultConverter(), new Completions\ResultConverter()],
-            $modelCatalog,
-            $contract ?? Contract::create(),
-            $eventDispatcher,
+        return GenericPlatformFactory::create(
+            baseUrl: 'https://openrouter.ai/api',
+            apiKey: $apiKey,
+            httpClient: $httpClient,
+            modelCatalog: $modelCatalog,
+            contract: $contract,
+            eventDispatcher: $eventDispatcher,
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

- Used central PlatformFactory of the generic package in the "simple packages" that based on the generic
- Drop `Contract::create()` fallback (Platform create also the default contract itself as fallback)