### PR TITLE
[Agent] Fix propagation of tokens on tool calls again

### DIFF
--- a/src/agent/src/Toolbox/StreamListener.php
+++ b/src/agent/src/Toolbox/StreamListener.php
@@ -12,9 +12,12 @@
 namespace Symfony\AI\Agent\Toolbox;
 
 use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Metadata\Metadata;
 use Symfony\AI\Platform\Result\Stream\AbstractStreamListener;
 use Symfony\AI\Platform\Result\Stream\ChunkEvent;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsageAggregation;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
 
 /**
  * @author Denis Zunke <denis.zunke@gmail.com>
@@ -54,9 +57,9 @@ final class StreamListener extends AbstractStreamListener
             return;
         }
 
-        $event->setChunk(
-            ($this->handleToolCallsCallback)($chunk, Message::ofAssistant($this->buffer))->getContent()
-        );
+        $result = ($this->handleToolCallsCallback)($chunk, Message::ofAssistant($this->buffer));
+        $this->propagateMetadata($result->getMetadata(), $event->getResult()->getMetadata());
+        $event->setChunk($result->getContent());
 
         $this->toolHandled = true;
     }
@@ -65,5 +68,17 @@ final class StreamListener extends AbstractStreamListener
     {
         $this->buffer = '';
         $this->toolHandled = false;
+    }
+
+    private function propagateMetadata(Metadata $source, Metadata $target): void
+    {
+        foreach ($source->all() as $key => $value) {
+            if ('token_usage' === $key && $target->get('token_usage') instanceof TokenUsageInterface && $value instanceof TokenUsageInterface) {
+                $target->add('token_usage', new TokenUsageAggregation([$target->get('token_usage'), $value]));
+                continue;
+            }
+
+            $target->add($key, $value);
+        }
     }
 }

--- a/src/agent/tests/Toolbox/AgentProcessorTest.php
+++ b/src/agent/tests/Toolbox/AgentProcessorTest.php
@@ -239,8 +239,7 @@ class AgentProcessorTest extends TestCase
 
     public function testSourcesEndUpInResultMetadataWithStreaming()
     {
-        $this->markTestSkipped('Broken with #1394 - to be fixed in a follow-up.');
-        $toolCall = new ToolCall('call_1234', 'tool_sources', ['arg1' => 'value1']); /** @phpstan-ignore deadCode.unreachable */
+        $toolCall = new ToolCall('call_1234', 'tool_sources', ['arg1' => 'value1']);
         $source1 = new Source('Relevant Article 1', 'http://example.com/article1', 'Content of article about the topic');
         $source2 = new Source('Relevant Article 2', 'http://example.com/article2', 'More content of article about the topic');
         $toolbox = $this->createMock(ToolboxInterface::class);
@@ -288,8 +287,7 @@ class AgentProcessorTest extends TestCase
 
     public function testMetadataGetsPropagatedInStreamingWithToolCalls()
     {
-        $this->markTestSkipped('Broken with #1394 - to be fixed in a follow-up.');
-        $toolCall = new ToolCall('call_meta_1', 'tool_meta', ['foo' => 'bar']); /** @phpstan-ignore deadCode.unreachable */
+        $toolCall = new ToolCall('call_meta_1', 'tool_meta', ['foo' => 'bar']);
         $toolbox = $this->createMock(ToolboxInterface::class);
         $toolbox
             ->expects($this->once())
@@ -332,8 +330,7 @@ class AgentProcessorTest extends TestCase
 
     public function testUsageMetadataGetsPropagatedInStreaming()
     {
-        $this->markTestSkipped('Broken with #1394 - to be fixed in a follow-up.');
-        $toolCall = new ToolCall('call_meta_1', 'tool_meta', ['foo' => 'bar']); /** @phpstan-ignore deadCode.unreachable */
+        $toolCall = new ToolCall('call_meta_1', 'tool_meta', ['foo' => 'bar']);
         $toolbox = $this->createMock(ToolboxInterface::class);
         $toolbox
             ->expects($this->once())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #...
| License       | MIT

Follows #1394 

And it's only the tests green - but still not fully working again => see `php openai/toolcall-stream.php -vv`