### PR TITLE
[Mate] Add mcp:tools:call command for tool execution via JSON input

### DIFF
--- a/demo/mate/config.php
+++ b/demo/mate/config.php
@@ -18,5 +18,5 @@ return static function (ContainerConfigurator $container): void {
     $container->services()
         ->set(SymfonyAiFeaturesTool::class)
         ->arg('$projectDir', param('mate.root_dir'))
-        ->tag('mcp.capability');
+        ->public();
 };

--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -431,6 +431,36 @@ Commands
         # JSON output for scripting
         $ vendor/bin/mate mcp:tools:inspect php-version --format=json
 
+``mate mcp:tools:call``
+    Execute MCP tools via JSON input parameters. This command allows you to test and
+    debug tools by executing them directly from the command line.
+
+    **Arguments:**
+
+    ``tool-name``
+        Name of the tool to execute (required)
+
+    ``json-input``
+        JSON object with tool parameters (required)
+
+    **Options:**
+
+    ``--format=FORMAT``
+        Output format: ``pretty`` (default) or ``json``
+
+    **Examples:**
+
+    .. code-block:: terminal
+
+        # Execute tool with empty parameters
+        $ vendor/bin/mate mcp:tools:call php-version '{}'
+
+        # Execute tool with parameters
+        $ vendor/bin/mate mcp:tools:call search-logs '{"query": "error", "level": "error"}'
+
+        # JSON output format
+        $ vendor/bin/mate mcp:tools:call php-version '{}' --format=json
+
 Security
 --------
 

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add support for `extension: false` flag in `extra.ai-mate` composer.json configuration to exclude packages from being discovered as extensions
  * Add `ToolsInspectCommand` to inspect a specific tool
  * Add `ToolsListCommand` to list all available tools
+ * Add `ToolsCallCommand` to call a specific tool with input
 
 0.2
 ---

--- a/src/mate/CLAUDE.md
+++ b/src/mate/CLAUDE.md
@@ -54,6 +54,10 @@ bin/mate mcp:tools:list --filter="search*"  # Filter tools by name pattern
 bin/mate mcp:tools:list --format=json       # Output in JSON format
 bin/mate mcp:tools:inspect php-version      # Inspect specific tool with schema
 bin/mate mcp:tools:inspect php-version --format=json  # Output in JSON format
+
+# Tool execution
+bin/mate mcp:tools:call php-version '{}'    # Execute tool with parameters
+bin/mate mcp:tools:call php-version '{}' --format=json    # JSON output format
 ```
 
 ## Architecture
@@ -65,7 +69,7 @@ bin/mate mcp:tools:inspect php-version --format=json  # Output in JSON format
 - **FilteredDiscoveryLoader**: Loads MCP capabilities with feature filtering
 
 ### Key Directories
-- `src/Command/`: CLI commands (serve, init, discover, clear-cache, debug:capabilities, debug:extensions, mcp:tools:list, mcp:tools:inspect)
+- `src/Command/`: CLI commands (serve, init, discover, clear-cache, debug:capabilities, debug:extensions, mcp:tools:list, mcp:tools:inspect, mcp:tools:call)
 - `src/Container/`: DI container management
 - `src/Discovery/`: Extension discovery system
 - `src/Capability/`: Built-in MCP tools

--- a/src/mate/src/App.php
+++ b/src/mate/src/App.php
@@ -21,6 +21,7 @@ use Symfony\AI\Mate\Command\DiscoverCommand;
 use Symfony\AI\Mate\Command\InitCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
 use Symfony\AI\Mate\Command\StopCommand;
+use Symfony\AI\Mate\Command\ToolsCallCommand;
 use Symfony\AI\Mate\Command\ToolsInspectCommand;
 use Symfony\AI\Mate\Command\ToolsListCommand;
 use Symfony\AI\Mate\Exception\UnsupportedVersionException;
@@ -59,6 +60,7 @@ final class App
         self::addCommand($application, new ClearCacheCommand($cacheDir));
         self::addCommand($application, new ToolsListCommand($logger, $container));
         self::addCommand($application, new ToolsInspectCommand($logger, $container));
+        self::addCommand($application, new ToolsCallCommand($logger, $container));
 
         if (\defined('SIGUSR1') && class_exists(RunnerControl::class)) {
             $application->getSignalRegistry()->register(\SIGUSR1, function () {

--- a/src/mate/src/Command/Session/CliSession.php
+++ b/src/mate/src/Command/Session/CliSession.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command\Session;
+
+use Mcp\Server\Session\InMemorySessionStore;
+use Mcp\Server\Session\SessionInterface;
+use Mcp\Server\Session\SessionStoreInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CLI-specific session implementation for tool execution.
+ *
+ * Provides minimal session state for RequestContext injection.
+ * Does not support pending requests or responses (throws error on sampling).
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class CliSession implements SessionInterface
+{
+    private Uuid $id;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $data = [];
+    private SessionStoreInterface $store;
+
+    public function __construct()
+    {
+        $this->id = Uuid::v4();
+
+        $this->data = [
+            '_mcp.pending_requests' => [],
+            '_mcp.responses' => [],
+            '_mcp.outgoing_queue' => [],
+            '_mcp.active_request_meta' => null,
+        ];
+
+        $this->store = new InMemorySessionStore();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function save(): bool
+    {
+        return true;
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->data[$key] ?? $default;
+    }
+
+    public function set(string $key, mixed $value, bool $overwrite = true): void
+    {
+        if ($overwrite || !isset($this->data[$key])) {
+            $this->data[$key] = $value;
+        }
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->data[$key]);
+    }
+
+    public function forget(string $key): void
+    {
+        unset($this->data[$key]);
+    }
+
+    public function clear(): void
+    {
+        $this->data = [];
+    }
+
+    public function pull(string $key, mixed $default = null): mixed
+    {
+        $value = $this->get($key, $default);
+        $this->forget($key);
+
+        return $value;
+    }
+
+    public function all(): array
+    {
+        return $this->data;
+    }
+
+    public function hydrate(array $attributes): void
+    {
+        $this->data = $attributes;
+    }
+
+    public function getStore(): SessionStoreInterface
+    {
+        return $this->store;
+    }
+
+    /**
+     * @return array{id: string, data: array<string, mixed>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id->toString(),
+            'data' => $this->data,
+        ];
+    }
+}

--- a/src/mate/src/Command/ToolsCallCommand.php
+++ b/src/mate/src/Command/ToolsCallCommand.php
@@ -1,0 +1,224 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command;
+
+use Mcp\Capability\Discovery\Discoverer;
+use Mcp\Capability\Registry;
+use Mcp\Capability\Registry\ReferenceHandler;
+use Mcp\Exception\ToolNotFoundException;
+use Mcp\Schema\Request\CallToolRequest;
+use Psr\Log\LoggerInterface;
+use Symfony\AI\Mate\Command\Session\CliSession;
+use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Execute MCP tools via JSON input.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('mcp:tools:call', 'Execute MCP tools via JSON input')]
+class ToolsCallCommand extends Command
+{
+    private Registry $registry;
+    private ReferenceHandler $referenceHandler;
+
+    public function __construct(
+        LoggerInterface $logger,
+        private ContainerInterface $container,
+    ) {
+        parent::__construct(self::getDefaultName());
+
+        $rootDir = $container->getParameter('mate.root_dir');
+        \assert(\is_string($rootDir));
+
+        $extensions = $this->container->getParameter('mate.extensions') ?? [];
+        \assert(\is_array($extensions));
+
+        $disabledFeatures = $this->container->getParameter('mate.disabled_features') ?? [];
+        \assert(\is_array($disabledFeatures));
+
+        $loader = new FilteredDiscoveryLoader(
+            basePath: $rootDir,
+            extensions: $extensions,
+            disabledFeatures: $disabledFeatures,
+            discoverer: new Discoverer($logger),
+            logger: $logger
+        );
+
+        $this->registry = new Registry(null, $logger);
+        $loader->load($this->registry);
+
+        $this->referenceHandler = new ReferenceHandler($container);
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'mcp:tools:call';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Execute MCP tools via JSON input';
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('tool-name', InputArgument::REQUIRED, 'Name of the tool to execute')
+            ->addArgument('json-input', InputArgument::REQUIRED, 'JSON object with tool parameters')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (json, pretty)', 'pretty')
+            ->setHelp(<<<'HELP'
+The <info>%command.name%</info> command executes MCP tools with JSON input parameters.
+
+<info>Usage Examples:</info>
+
+  <comment># Execute a tool with parameters</comment>
+  %command.full_name% search-logs '{"query": "error", "level": "error"}'
+
+  <comment># Execute tool with empty parameters</comment>
+  %command.full_name% php-version '{}'
+
+  <comment># JSON output format</comment>
+  %command.full_name% php-version '{}' --format=json
+
+  <comment># For a list of available tools, use:</comment>
+  bin/mate.php mcp:tools:list
+
+  <comment># For detailed tool information and schema, use:</comment>
+  bin/mate.php mcp:tools:inspect <tool-name>
+HELP
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $verbose = $output->isVerbose();
+
+        $toolName = $input->getArgument('tool-name');
+        \assert(\is_string($toolName));
+
+        $jsonInput = $input->getArgument('json-input');
+        \assert(\is_string($jsonInput));
+
+        $params = json_decode($jsonInput, true);
+        if (\JSON_ERROR_NONE !== json_last_error()) {
+            $io->error(\sprintf('Invalid JSON: %s', json_last_error_msg()));
+
+            return Command::FAILURE;
+        }
+
+        if (!\is_array($params)) {
+            $io->error('JSON input must be an object');
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $tool = $this->registry->getTool($toolName);
+        } catch (ToolNotFoundException $e) {
+            $io->error(\sprintf('Tool "%s" not found', $toolName));
+            $io->note('Use "bin/mate.php mcp:tools:list" to see all available tools');
+
+            return Command::FAILURE;
+        }
+
+        $session = new CliSession();
+        $request = new CallToolRequest(
+            name: $toolName,
+            arguments: $params
+        );
+
+        $arguments = $params;
+        $arguments['_session'] = $session;
+        $arguments['_request'] = $request;
+
+        $format = $input->getOption('format');
+        \assert(\is_string($format));
+
+        if ('pretty' === $format) {
+            $io->title(\sprintf('Executing Tool: %s', $toolName));
+            if ($tool->tool->description) {
+                $io->text($tool->tool->description);
+            }
+            $io->newLine();
+        }
+
+        try {
+            $result = $this->referenceHandler->handle($tool, $arguments);
+        } catch (\Throwable $e) {
+            if ($verbose) {
+                $io->error(\sprintf('Error: %s', $e->getMessage()));
+                $io->text($e->getTraceAsString());
+            } else {
+                $io->error(\sprintf('Error: %s', $e->getMessage()));
+            }
+
+            return Command::FAILURE;
+        }
+
+        if ('json' === $format) {
+            $output->writeln(json_encode($result, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        } else {
+            $io->section('Result');
+            $this->renderPretty($result, $io);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function renderPretty(mixed $result, SymfonyStyle $io): void
+    {
+        if (\is_array($result)) {
+            if (array_is_list($result)) {
+                foreach ($result as $item) {
+                    $io->text($this->formatValue($item));
+                }
+            } else {
+                $io->definitionList(...array_map(fn ($key, $value) => [$key => $this->formatValue($value)], array_keys($result), $result));
+            }
+        } elseif (\is_string($result)) {
+            $io->text($result);
+        } elseif (\is_bool($result)) {
+            $io->text($result ? 'true' : 'false');
+        } elseif (null === $result) {
+            $io->text('<comment>null</comment>');
+        } else {
+            $io->text((string) $result);
+        }
+    }
+
+    private function formatValue(mixed $value): string
+    {
+        if (\is_array($value)) {
+            return json_encode($value, \JSON_UNESCAPED_SLASHES);
+        }
+
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (null === $value) {
+            return 'null';
+        }
+
+        return (string) $value;
+    }
+}

--- a/src/mate/tests/Command/ToolsCallCommandTest.php
+++ b/src/mate/tests/Command/ToolsCallCommandTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Capability\ServerInfo;
+use Symfony\AI\Mate\Command\ToolsCallCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ToolsCallCommandTest extends TestCase
+{
+    public function testExecuteCallsToolSuccessfully()
+    {
+        $container = $this->createContainer();
+
+        $command = new ToolsCallCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'tool-name' => 'php-version',
+            'json-input' => '{}',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Executing Tool: php-version', $output);
+        $this->assertStringContainsString('Result', $output);
+        $this->assertStringContainsString(\PHP_VERSION, $output);
+    }
+
+    public function testExecuteWithJsonFormat()
+    {
+        $container = $this->createContainer();
+
+        $command = new ToolsCallCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'tool-name' => 'php-version',
+            'json-input' => '{}',
+            '--format' => 'json',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        // JSON format should not include decorative headers
+        $this->assertStringNotContainsString('Executing Tool:', $output);
+        $this->assertStringNotContainsString('Result', $output);
+
+        $result = json_decode($output, true);
+        $this->assertIsString($result);
+        $this->assertSame(\PHP_VERSION, $result);
+    }
+
+    public function testExecuteWithInvalidToolName()
+    {
+        $container = $this->createContainer();
+
+        $command = new ToolsCallCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'tool-name' => 'non-existent-tool',
+            'json-input' => '{}',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Tool "non-existent-tool" not found', $output);
+    }
+
+    public function testExecuteWithInvalidJson()
+    {
+        $container = $this->createContainer();
+
+        $command = new ToolsCallCommand(new NullLogger(), $container);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'tool-name' => 'php-version',
+            'json-input' => '{invalid json}',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Invalid JSON', $output);
+    }
+
+    private function createContainer(): ContainerBuilder
+    {
+        $rootDir = __DIR__.'/../..';
+        $container = new ContainerBuilder();
+        $container->setParameter('mate.root_dir', $rootDir);
+        $container->setParameter('mate.enabled_extensions', []);
+        $container->setParameter('mate.disabled_features', []);
+        $container->setParameter('mate.extensions', [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ]);
+
+        // Register ServerInfo service for tool execution
+        $container->set(ServerInfo::class, new ServerInfo());
+
+        return $container;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | N/A
| License       | MIT

## Summary

This PR adds a new `mcp:tools:call` command that enables executing MCP tools directly from the command line with JSON input parameters. This complements the existing `mcp:tools:list` and `mcp:tools:inspect` commands, providing a complete CLI workflow for tool discovery, inspection, and execution.

## Features

- Execute MCP tools with JSON parameter input
- Automatic JSON schema validation against tool input schemas
- Two output formats:
  - **Pretty format** (default): Human-readable output with clear headers, descriptions, and formatted results
  - **JSON format**: Machine-parseable output for scripting and automation
- Comprehensive error handling for invalid tools, malformed JSON, and schema validation failures
- Clear execution headers showing tool name, description, and extension

## Usage Examples

### Execute tool with parameters
```bash
$ vendor/bin/mate mcp:tools:call monolog-search '{"term": "about"}'

Executing Tool: monolog-search
==============================

 Search log entries by text term with optional level, channel, environment, and date filters
 Extension: symfony/ai-monolog-mate-extension

Result
------

 {"datetime":"2026-01-16T18:28:19+00:00","channel":"console","level":"CRITICAL","message":"Error thrown while running command \"about --profiler\". Message: \"The \"--profiler\" option does not exist.\"","context":{...},"source_file":"dev.log","line_number":21}
 {"datetime":"2026-01-16T18:28:19+00:00","channel":"console","level":"DEBUG","message":"Command \"about --profiler\" exited with code \"1\"","context":{...},"source_file":"dev.log","line_number":22}
```

### Execute tool with empty parameters

```bash
$ vendor/bin/mate mcp:tools:call php-version "{}"

Executing Tool: php-version
===========================

 Get the version of PHP
 Extension: symfony/ai-mate

Result
------

 8.4.15

JSON output format

$ vendor/bin/mate mcp:tools:call php-version '{}' --format=json
"8.4.15"
```

## Implementation Details

- Reuses the same capability collection system as mcp:tools:list and mcp:tools:inspect
- Properly handles schema default values for optional parameters
- Resolves tool handlers from the Symfony DI container
- Supports both ClassName::method and ClassName (for __invoke) handler formats
- Includes comprehensive test coverage (5 test cases)