### PR TITLE
[Agent] ToolCallArgumentResolver use and implement interface

### DIFF
--- a/src/agent/src/Toolbox/ToolCallArgumentResolver.php
+++ b/src/agent/src/Toolbox/ToolCallArgumentResolver.php
@@ -25,7 +25,7 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 /**
  * @author Valtteri R <valtzu@gmail.com>
  */
-final class ToolCallArgumentResolver
+final class ToolCallArgumentResolver implements ToolCallArgumentResolverInterface
 {
     private readonly TypeResolver $typeResolver;
 

--- a/src/agent/src/Toolbox/ToolCallArgumentResolverInterface.php
+++ b/src/agent/src/Toolbox/ToolCallArgumentResolverInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Agent\Toolbox;
 
+use Symfony\AI\Agent\Toolbox\Exception\ToolException;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tool\Tool;
 
@@ -21,6 +22,8 @@ interface ToolCallArgumentResolverInterface
 {
     /**
      * @return array<string, mixed>
+     *
+     * @throws ToolException When it is not possible to resolve the tool arguments
      */
-    public function resolveArguments(object $tool, Tool $metadata, ToolCall $toolCall): array;
+    public function resolveArguments(Tool $metadata, ToolCall $toolCall): array;
 }

--- a/src/agent/src/Toolbox/Toolbox.php
+++ b/src/agent/src/Toolbox/Toolbox.php
@@ -51,7 +51,7 @@ final class Toolbox implements ToolboxInterface
     public function __construct(
         iterable $tools,
         private readonly ToolFactoryInterface $toolFactory = new ReflectionToolFactory(),
-        private readonly ToolCallArgumentResolver $argumentResolver = new ToolCallArgumentResolver(),
+        private readonly ToolCallArgumentResolverInterface $argumentResolver = new ToolCallArgumentResolver(),
         private readonly LoggerInterface $logger = new NullLogger(),
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Docs?         | no
| Issues        | no
| License       | MIT

Hi, I'am currently trying to build a toolbox where the tools are defined in a database table and not as dedicated PHP class with attributes. Therefor I need to provide a custom `ToolFactory` and `ToolCallArgumentResolver`. Currently the `ToolCallArgumentResolver` has no interface but there is an interface `ToolCallArgumentResolverInterface` which is not used, this PR implements this interface to the `ToolCallArgumentResolver` so that it is possible to provide a custom implementation to the `Toolbox`. Let me know if I'am missing anything here, and thanks for this project!
