### PR TITLE
[Demo] Lower store dependency for demo

### DIFF
--- a/demo/composer.json
+++ b/demo/composer.json
@@ -15,7 +15,7 @@
         "symfony/ai-agent": "^0.2",
         "symfony/ai-bundle": "^0.2",
         "symfony/ai-chat": "^0.2",
-        "symfony/ai-chroma-db-store": "^0.3",
+        "symfony/ai-chroma-db-store": "^0.2",
         "symfony/ai-clock-tool": "^0.2",
         "symfony/ai-hugging-face-platform": "^0.2",
         "symfony/ai-open-ai-platform": "^0.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Follows #1397, but for the demo the bump is actually not needed - still works with ^0.2 fine