### PR TITLE
[Agent] Enforce pipeline installs PR-specific platform component

### DIFF
--- a/src/agent/src/Bridge/Brave/composer.json
+++ b/src/agent/src/Bridge/Brave/composer.json
@@ -33,7 +33,8 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5.46"
+        "phpunit/phpunit": "^11.5.46",
+        "symfony/ai-platform": "^0.2"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/agent/src/Bridge/Clock/composer.json
+++ b/src/agent/src/Bridge/Clock/composer.json
@@ -34,7 +34,8 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5.46"
+        "phpunit/phpunit": "^11.5.46",
+        "symfony/ai-platform": "^0.2"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/agent/src/Bridge/Firecrawl/composer.json
+++ b/src/agent/src/Bridge/Firecrawl/composer.json
@@ -33,7 +33,8 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5.46"
+        "phpunit/phpunit": "^11.5.46",
+        "symfony/ai-platform": "^0.2"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/agent/src/Bridge/Scraper/composer.json
+++ b/src/agent/src/Bridge/Scraper/composer.json
@@ -37,7 +37,8 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5.46"
+        "phpunit/phpunit": "^11.5.46",
+        "symfony/ai-platform": "^0.2"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/agent/src/Bridge/SerpApi/composer.json
+++ b/src/agent/src/Bridge/SerpApi/composer.json
@@ -29,7 +29,8 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5.46"
+        "phpunit/phpunit": "^11.5.46",
+        "symfony/ai-platform": "^0.2"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/agent/src/Bridge/Tavily/composer.json
+++ b/src/agent/src/Bridge/Tavily/composer.json
@@ -33,7 +33,8 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5.46"
+        "phpunit/phpunit": "^11.5.46",
+        "symfony/ai-platform": "^0.2"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/agent/src/Bridge/Wikipedia/composer.json
+++ b/src/agent/src/Bridge/Wikipedia/composer.json
@@ -33,7 +33,8 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5.46"
+        "phpunit/phpunit": "^11.5.46",
+        "symfony/ai-platform": "^0.2"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Prepares for #1415.

Since the pipeline script `build-packages.php` only registers path repos for packages that are listed in `require` or `require-dev`, this is a short cut for making sure bridges are tested also with the Platform component of the PR itself.

(Better solution would be to rewrite the `build-packages.php` to work with a `composer.lock`, but that requires bigger pipeline changes, there's no `composer.lock` without running `composer update` first)