### PR TITLE
[Mate] Add agent-instructions support for MCP extensions

### DIFF
--- a/docs/components/mate/creating-extensions.rst
+++ b/docs/components/mate/creating-extensions.rst
@@ -20,7 +20,8 @@ Quick Start
         },
         "extra": {
             "ai-mate": {
-                "scan-dirs": ["src", "lib"]
+                "scan-dirs": ["src", "lib"],
+                "instructions": "INSTRUCTIONS.md"
             }
         }
     }
@@ -132,6 +133,57 @@ Service Includes
 - Array of service configuration file paths
 - Standard Symfony DI configuration format (PHP files)
 - Supports environment variables via ``%env()%``
+
+Agent Instructions
+~~~~~~~~~~~~~~~~~~
+
+``extra.ai-mate.instructions`` (optional)
+
+- Path to a markdown file containing instructions for AI agents
+- Relative to package root
+- Conventionally named ``INSTRUCTIONS.md``
+- Content is aggregated and provided to AI assistants during MCP handshake
+
+Example configuration:
+
+.. code-block:: json
+
+    {
+        "extra": {
+            "ai-mate": {
+                "scan-dirs": ["src"],
+                "instructions": "INSTRUCTIONS.md"
+            }
+        }
+    }
+
+Writing Effective Agent Instructions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Agent instructions help AI assistants understand when and how to use your extension's tools.
+A good ``INSTRUCTIONS.md`` file should:
+
+1. **Map CLI commands to MCP tools** - Show what tools replace common CLI operations
+2. **Highlight benefits** - Explain why the MCP tools are better than alternatives
+3. **Be concise** - AI assistants have context limits; focus on essential guidance
+
+Example ``INSTRUCTIONS.md``:
+
+.. code-block:: markdown
+
+    ## My Extension
+
+    Use MCP tools instead of CLI for better results:
+
+    | Instead of...              | Use                    |
+    |----------------------------|------------------------|
+    | `my-cli command`           | `my-tool`              |
+    | `my-cli search "term"`     | `my-search` with term  |
+
+    ### Benefits
+    - Structured output that AI can parse
+    - Better error handling and context
+    - Integrated with project configuration
 
 Security
 ~~~~~~~~
@@ -265,5 +317,34 @@ If dependencies aren't being injected:
                }
            }
        }
+
+Agent Instructions Not Loading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your agent instructions aren't being provided to AI assistants:
+
+1. **Verify the file exists** at the path specified in ``composer.json``
+
+2. **Check the path is correct** - must be relative to package root:
+
+   .. code-block:: json
+
+       {
+           "extra": {
+               "ai-mate": {
+                   "instructions": "INSTRUCTIONS.md"
+               }
+           }
+       }
+
+3. **Ensure the file is readable** and contains valid markdown
+
+4. **Use debug command** to verify discovery:
+
+   .. code-block:: terminal
+
+       $ vendor/bin/mate debug:extensions
+
+   Look for ``instructions`` field in the output.
 
 For general server issues and debugging tips, see the :doc:`troubleshooting` guide.

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.3
 ---
 
+ * Add support for `instructions` field in extension composer.json to provide AI agent guidance
  * Add support for `extension: false` flag in `extra.ai-mate` composer.json configuration to exclude packages from being discovered as extensions
  * Add `ToolsInspectCommand` to inspect a specific tool
  * Add `ToolsListCommand` to list all available tools

--- a/src/mate/src/Agent/AgentInstructionsAggregator.php
+++ b/src/mate/src/Agent/AgentInstructionsAggregator.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Agent;
+
+use Psr\Log\LoggerInterface;
+use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
+
+/**
+ * Aggregates agent instructions from all installed extensions.
+ *
+ * Each extension can provide an INSTRUCTIONS.md file with instructions for AI agents,
+ * typically documenting CLI → MCP tool mappings, benefits, and usage modes.
+ *
+ * These instructions are injected via the MCP protocol's `instructions` field
+ * during the server handshake, allowing agents to understand how to best use
+ * the available MCP tools.
+ *
+ * @phpstan-import-type ExtensionData from ComposerExtensionDiscovery
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class AgentInstructionsAggregator
+{
+    /**
+     * @param array<string, ExtensionData> $extensions
+     */
+    public function __construct(
+        private string $rootDir,
+        private array $extensions,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function aggregate(): ?string
+    {
+        $extensionInstructions = [];
+
+        foreach ($this->extensions as $packageName => $data) {
+            if ('_custom' === $packageName) {
+                $content = $this->loadRootProjectInstructions($data);
+            } else {
+                $content = $this->loadExtensionInstructions($packageName, $data);
+            }
+
+            if (null !== $content) {
+                $extensionInstructions[$packageName] = $content;
+            }
+        }
+
+        if ([] === $extensionInstructions) {
+            return null;
+        }
+
+        $sections = [$this->getGlobalHeader()];
+        foreach ($extensionInstructions as $content) {
+            $sections[] = $content;
+        }
+
+        return implode("\n\n---\n\n", $sections);
+    }
+
+    /**
+     * @param ExtensionData $data
+     */
+    private function loadExtensionInstructions(string $packageName, array $data): ?string
+    {
+        $instructionsPath = $data['instructions'] ?? null;
+
+        if (null === $instructionsPath) {
+            return null;
+        }
+
+        $fullPath = $this->rootDir.'/vendor/'.$packageName.'/'.ltrim($instructionsPath, '/');
+
+        return $this->readInstructionsFile($fullPath, $packageName);
+    }
+
+    /**
+     * @param ExtensionData $data
+     */
+    private function loadRootProjectInstructions(array $data): ?string
+    {
+        $instructionsPath = $data['instructions'] ?? null;
+
+        if (null === $instructionsPath) {
+            return null;
+        }
+
+        $fullPath = $this->rootDir.'/'.ltrim($instructionsPath, '/');
+
+        return $this->readInstructionsFile($fullPath, 'root project');
+    }
+
+    private function readInstructionsFile(string $path, string $source): ?string
+    {
+        if (!file_exists($path)) {
+            $this->logger->warning('Agent instructions file not found', [
+                'source' => $source,
+                'path' => $path,
+            ]);
+
+            return null;
+        }
+
+        $content = file_get_contents($path);
+        if (false === $content) {
+            $this->logger->warning('Failed to read agent instructions file', [
+                'source' => $source,
+                'path' => $path,
+                'error' => error_get_last()['message'] ?? 'Unknown error',
+            ]);
+
+            return null;
+        }
+
+        $content = trim($content);
+        if ('' === $content) {
+            $this->logger->debug('Empty agent instructions file', [
+                'source' => $source,
+                'path' => $path,
+            ]);
+
+            return null;
+        }
+
+        $this->logger->debug('Loaded agent instructions', [
+            'source' => $source,
+            'path' => $path,
+            'length' => \strlen($content),
+        ]);
+
+        return $content;
+    }
+
+    private function getGlobalHeader(): string
+    {
+        return <<<'MD'
+            # AI Mate Agent Instructions
+
+            This MCP server provides specialized tools for PHP development.
+            The following extensions are installed and provide MCP tools that you should
+            prefer over running CLI commands directly.
+            MD;
+    }
+}

--- a/src/mate/src/Bridge/Monolog/CHANGELOG.md
+++ b/src/mate/src/Bridge/Monolog/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.3
+---
+
+ * Add `INSTRUCTIONS.md` with AI agent guidance for log analysis tools
+
 0.1
 ---
 

--- a/src/mate/src/Bridge/Monolog/INSTRUCTIONS.md
+++ b/src/mate/src/Bridge/Monolog/INSTRUCTIONS.md
@@ -1,0 +1,15 @@
+## Monolog Bridge
+
+Use MCP tools instead of CLI for log analysis:
+
+| Instead of...                     | Use                                |
+|-----------------------------------|------------------------------------|
+| `tail -f var/log/dev.log`         | `monolog-tail`                     |
+| `grep "error" var/log/*.log`      | `monolog-search` with term "error" |
+| `grep -E "pattern" var/log/*.log` | `monolog-search-regex`             |
+
+### Benefits
+
+- Structured output with parsed log entries
+- Multi-file search across all logs at once
+- Filter by environment, level, or channel

--- a/src/mate/src/Bridge/Monolog/composer.json
+++ b/src/mate/src/Bridge/Monolog/composer.json
@@ -65,7 +65,8 @@
             ],
             "includes": [
                 "config/config.php"
-            ]
+            ],
+            "instructions": "INSTRUCTIONS.md"
         }
     }
 }

--- a/src/mate/src/Bridge/Symfony/CHANGELOG.md
+++ b/src/mate/src/Bridge/Symfony/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.3
+---
+
+ * Add `INSTRUCTIONS.md` with AI agent guidance for container introspection tools
+
 0.1
 ---
 

--- a/src/mate/src/Bridge/Symfony/INSTRUCTIONS.md
+++ b/src/mate/src/Bridge/Symfony/INSTRUCTIONS.md
@@ -1,0 +1,13 @@
+## Symfony Bridge
+
+Use MCP tools instead of CLI for container introspection:
+
+| Instead of...                  | Use                 |
+|--------------------------------|---------------------|
+| `bin/console debug:container`  | `symfony-services`  |
+
+### Benefits
+
+- Direct access to compiled container
+- Environment-aware (auto-detects dev/test/prod)
+- Structured service ID → class mapping

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -65,7 +65,8 @@
             ],
             "includes": [
                 "config/config.php"
-            ]
+            ],
+            "instructions": "INSTRUCTIONS.md"
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | N/A
| License       | MIT

## Summary

Add support for `instructions` field in MCP extension `composer.json`, allowing extensions to provide `INSTRUCTIONS.md` files with guidance for AI assistants.

## Motivation

AI assistants using MCP tools benefit from understanding when and how to use specific tools. This feature allows extension authors to provide structured guidance that gets aggregated and delivered during the MCP handshake, helping AI
assistants make better tool choices.

## Usage

Extensions can add an `INSTRUCTIONS.md` file and reference it in `composer.json`:

```json
{
    "extra": {
        "ai-mate": {
            "scan-dirs": ["src"],
            "instructions": "INSTRUCTIONS.md"
        }
    }
}
```

Example INSTRUCTIONS.md:

```md
## My Extension

Use MCP tools instead of CLI:

| Instead of...       | Use        |
|---------------------|------------|
| `my-cli command`    | `my-tool`  |

### Benefits
- Structured output that AI can parse
- Better error handling and context
```