### PR TITLE
[Agent][Platform] Restrict phpdocumentor/reflection-docblock to ^5.4

### DIFF
--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=8.2",
         "ext-fileinfo": "*",
-        "phpdocumentor/reflection-docblock": "^5.4|^6.0",
+        "phpdocumentor/reflection-docblock": "^5.4",
         "phpstan/phpdoc-parser": "^2.1",
         "psr/log": "^3.0",
         "symfony/ai-platform": "^0.2",

--- a/src/platform/composer.json
+++ b/src/platform/composer.json
@@ -49,7 +49,7 @@
         "php": ">=8.2",
         "ext-fileinfo": "*",
         "oskarstark/enum-helper": "^1.5",
-        "phpdocumentor/reflection-docblock": "^5.4|^6.0",
+        "phpdocumentor/reflection-docblock": "^5.4",
         "phpstan/phpdoc-parser": "^2.1",
         "psr/log": "^3.0",
         "symfony/clock": "^7.3|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Follows https://github.com/symfony/symfony/pull/63126
| License       | MIT

This fixes our CI for now