### PR TITLE
[Agent] Support limiting iteration loop when tool calling

### DIFF
--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -58,7 +58,9 @@ Tools
 -----
 
 To integrate LLMs with your application, Symfony AI supports tool calling out of the box. Tools are services that can be
-called by the LLM to provide additional features or process data.
+called by the LLM to provide additional features or process data. The LLM is capable of making an arbitrary number of
+tool calls. To control token costs or prevent infinite loops, you can limit the number of tool calls by using the
+`maxToolCalls` parameter of the :class:`Symfony\\AI\\Agent\\Toolbox\\AgentProcessor`.
 
 Tool calling can be enabled by registering the processors in the agent::
 

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * [BC BREAK] Drop toolboxes `StreamResult` in favor of `StreamListener` on top of Platform's `StreamResult`
  * [BC BREAK] Rename `SourceMap` to `SourceCollection`, its methods from `getSources()` to `all()` and `addSource()` to `add()`
  * [BC BREAK] Third Argument of `ToolResult::__construct()` now expects `SourceCollection` instead of `array<int, Source>`
+ * Add `maxToolCalls` parameter to `AgentProcessor` to limit tool calling iterations and prevent infinite loops
 
 0.2
 ---

--- a/src/agent/src/Exception/MaxIterationsExceededException.php
+++ b/src/agent/src/Exception/MaxIterationsExceededException.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Exception;
+
+/**
+ * Exception thrown when the maximum number of tool calling iterations is exceeded.
+ *
+ * @author Tim Lochmüller <tim@fruit-lab.de>
+ */
+final class MaxIterationsExceededException extends RuntimeException
+{
+    public function __construct(int $maxToolCalls, ?\Throwable $previous = null)
+    {
+        parent::__construct(
+            \sprintf('Maximum number of tool calling iterations (%d) exceeded.', $maxToolCalls),
+            0,
+            $previous
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1376
| License       | MIT

Count the iterations in the AgentProcessor to limit the tool calls in the iteration. Default value is 50. Add information to CHANGELOG.md and UPGRADE.md
