### PR TITLE
[Platform] Move StructuredOutputSerializer to feature namespace

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,6 +26,7 @@ Platform
      * Run `composer require symfony/ai-cache-platform`
      * Change `Symfony\AI\Platform\CachedPlatform` namespace usages to `Symfony\AI\Platform\Bridge\Cache\CachePlatform`
      * The `ttl` option can be used in the configuration
+ * Adopt usage of class `Symfony\AI\Platform\Serializer\StructuredOuputSerializer` to `Symfony\AI\Platform\StructuredOutput\Serializer`
 
 UPGRADE FROM 0.1 to 0.2
 =======================

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -65,10 +65,10 @@ use Symfony\AI\Platform\Message\TemplateRenderer\ExpressionLanguageTemplateRende
 use Symfony\AI\Platform\Message\TemplateRenderer\StringTemplateRenderer;
 use Symfony\AI\Platform\Message\TemplateRenderer\TemplateRendererRegistry;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
-use Symfony\AI\Platform\Serializer\StructuredOutputSerializer;
 use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
 use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactory;
 use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactoryInterface;
+use Symfony\AI\Platform\StructuredOutput\Serializer as StructuredOutputSerializer;
 use Symfony\AI\Store\Command\DropStoreCommand;
 use Symfony\AI\Store\Command\IndexCommand;
 use Symfony\AI\Store\Command\RetrieveCommand;

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * [BC BREAK] `CachedPlatform` has been renamed `CachePlatform` and moved as a bridge, please require `symfony/ai-cache-platform` and use `Symfony\AI\Platform\Bridge\Cache\CachePlatform`
  * [BC BREAK] `Metadata::merge()` method signature has changed to accept `Metadata` instead of array
  * [BC BREAK] Behavior of `Metadata::add()` has changed to merge existing keys instead of overwriting them
+ * [BC BREAK] Move `Symfony\AI\Platform\Serializer\StructuredOutputSerializer` to `Symfony\AI\Platform\StructuredOutput\Serializer`
 
 0.2
 ---

--- a/src/platform/src/StructuredOutput/PlatformSubscriber.php
+++ b/src/platform/src/StructuredOutput/PlatformSubscriber.php
@@ -17,7 +17,6 @@ use Symfony\AI\Platform\Event\ResultEvent;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Exception\MissingModelSupportException;
 use Symfony\AI\Platform\Result\DeferredResult;
-use Symfony\AI\Platform\Serializer\StructuredOutputSerializer;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -36,7 +35,7 @@ final class PlatformSubscriber implements EventSubscriberInterface
         private readonly ResponseFormatFactoryInterface $responseFormatFactory = new ResponseFormatFactory(),
         ?SerializerInterface $serializer = null,
     ) {
-        $this->serializer = $serializer ?? new StructuredOutputSerializer();
+        $this->serializer = $serializer ?? new Serializer();
     }
 
     public static function getSubscribedEvents(): array

--- a/src/platform/src/StructuredOutput/Serializer.php
+++ b/src/platform/src/StructuredOutput/Serializer.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Serializer;
+namespace Symfony\AI\Platform\StructuredOutput;
 
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
@@ -21,9 +21,9 @@ use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
-use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Serializer as BaseSerializer;
 
-class StructuredOutputSerializer extends Serializer
+class Serializer extends BaseSerializer
 {
     /*
      * Custom serializer made to deserialize StructuredOutput.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

We have that feature namespace, let's use it.