### PR TITLE
[Mate][Symfony][Monolog] Add TOON format encoding for MCP tool responses

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add Codex wrapper generation (`bin/codex`, `bin/codex.bat`) to `mate init`
  * Add AGENT instruction artifact materialization to `mate discover` (`mate/AGENT_INSTRUCTIONS.md` and managed `AGENTS.md` block)
  * Merge `php-version`, `operating-system`, `operating-system-family`, and `php-extensions` tools into a single `server-info` tool
+ * Add optional TOON format encoding for MCP tool responses to reduce token consumption (install `helgesverre/toon` to enable)
 
 0.3
 ---

--- a/src/mate/CLAUDE.md
+++ b/src/mate/CLAUDE.md
@@ -52,12 +52,12 @@ bin/mate debug:extensions        # Show extension discovery and loading status
 bin/mate mcp:tools:list          # List all available MCP tools
 bin/mate mcp:tools:list --filter="search*"  # Filter tools by name pattern
 bin/mate mcp:tools:list --format=json       # Output in JSON format
-bin/mate mcp:tools:inspect php-version      # Inspect specific tool with schema
-bin/mate mcp:tools:inspect php-version --format=json  # Output in JSON format
+bin/mate mcp:tools:inspect server-info      # Inspect specific tool with schema
+bin/mate mcp:tools:inspect server-info --format=json  # Output in JSON format
 
 # Tool execution
-bin/mate mcp:tools:call php-version '{}'    # Execute tool with parameters
-bin/mate mcp:tools:call php-version '{}' --format=json    # JSON output format
+bin/mate mcp:tools:call server-info '{}'    # Execute tool with parameters
+bin/mate mcp:tools:call server-info '{}' --format=json    # JSON output format
 ```
 
 ## Architecture
@@ -78,14 +78,11 @@ bin/mate mcp:tools:call php-version '{}' --format=json    # JSON output format
 ### Bridges
 The component includes embedded bridge packages:
 
-**Symfony Bridge** (`src/Bridge/Symfony/`):
-- `ServiceTool`: Symfony container introspection
-- `ContainerProvider`: Parses compiled container XML
+**Symfony Bridge** (`src/Bridge/Symfony/`): Symfony container introspection and profiler access
+**Monolog Bridge** (`src/Bridge/Monolog/`): Log search and analysis
 
-**Monolog Bridge** (`src/Bridge/Monolog/`):
-- `LogSearchTool`: Log search and analysis
-- `LogParser`: Parses JSON and standard Monolog formats
-- `LogReader`: Reads and filters log files
+### Agent Instructions Materialization
+Running `bin/mate discover` generates `mate/AGENT_INSTRUCTIONS.md` with extension-specific instructions and maintains a managed block in `AGENTS.md` with a summary of installed extensions. AI agents should read these files to learn about available MCP tools rather than relying on hardcoded tool lists.
 
 ### Configuration
 - `mate/extensions.php`: Enable/disable extensions

--- a/src/mate/composer.json
+++ b/src/mate/composer.json
@@ -39,6 +39,9 @@
         "symfony/ai-mate-composer-plugin": "self.version",
         "symfony/finder": "^5.4|^6.4|^7.3|^8.0"
     },
+    "suggest": {
+        "helgesverre/toon": "Required for TOON format encoding to reduce token consumption in tool responses"
+    },
     "require-dev": {
         "ext-simplexml": "*",
         "helgesverre/toon": "^3.1",

--- a/src/mate/src/Bridge/Monolog/CHANGELOG.md
+++ b/src/mate/src/Bridge/Monolog/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Merge `monolog-search-regex` into `monolog-search` via a `regex` parameter
  * Remove `monolog-by-level` tool (use `monolog-search` with `level` filter instead)
  * Add `@param` docblocks to all tool methods for AI-readable parameter descriptions
+ * Add optional TOON format encoding for `LogSearchTool` methods to reduce token consumption
 
 0.3
 ---

--- a/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
+++ b/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
@@ -12,14 +12,12 @@
 namespace Symfony\AI\Mate\Bridge\Monolog\Capability;
 
 use Mcp\Capability\Attribute\McpTool;
-use Symfony\AI\Mate\Bridge\Monolog\Model\LogEntry;
 use Symfony\AI\Mate\Bridge\Monolog\Model\SearchCriteria;
 use Symfony\AI\Mate\Bridge\Monolog\Service\LogReader;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
 
 /**
  * MCP tools for searching and analyzing Monolog log files.
- *
- * @phpstan-import-type LogEntryArray from LogEntry
  *
  * @author Johannes Wachter <johannes@sulu.io>
  */
@@ -39,8 +37,6 @@ final class LogSearchTool
      * @param string|null $from        Start date filter, any PHP-parseable date string (e.g. 2024-01-01, -1 hour, yesterday)
      * @param string|null $to          End date filter, any PHP-parseable date string
      * @param int         $limit       Maximum number of entries to return
-     *
-     * @phpstan-return array{entries: list<LogEntryArray>}
      */
     #[McpTool('monolog-search', 'Search log entries by text or regex pattern. Supports filtering by log level, channel, environment, and date range. Use empty string for term to match all entries when using filters only.')]
     public function search(
@@ -52,7 +48,7 @@ final class LogSearchTool
         ?string $from = null,
         ?string $to = null,
         int $limit = 100,
-    ): array {
+    ): string {
         if ($regex) {
             $pattern = $term;
             if (!str_starts_with($pattern, '/') && !str_starts_with($pattern, '#')) {
@@ -78,7 +74,7 @@ final class LogSearchTool
             );
         }
 
-        return ['entries' => $this->collectResults($criteria, $environment)];
+        return ResponseEncoder::encode(['entries' => $this->collectResults($criteria, $environment)]);
     }
 
     /**
@@ -87,8 +83,6 @@ final class LogSearchTool
      * @param string|null $level       Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
      * @param string|null $environment Filter by Symfony environment (e.g. dev, prod, test)
      * @param int         $limit       Maximum number of entries to return
-     *
-     * @phpstan-return array{entries: list<LogEntryArray>}
      */
     #[McpTool('monolog-context-search', 'Search log entries by structured context data. Finds entries where a specific context key contains the given value.')]
     public function searchContext(
@@ -97,7 +91,7 @@ final class LogSearchTool
         ?string $level = null,
         ?string $environment = null,
         int $limit = 100,
-    ): array {
+    ): string {
         $criteria = new SearchCriteria(
             level: $level,
             contextKey: $key,
@@ -105,31 +99,27 @@ final class LogSearchTool
             limit: $limit,
         );
 
-        return ['entries' => $this->collectResults($criteria, $environment)];
+        return ResponseEncoder::encode(['entries' => $this->collectResults($criteria, $environment)]);
     }
 
     /**
      * @param int         $lines       Number of most recent log entries to return
      * @param string|null $level       Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
      * @param string|null $environment Filter by Symfony environment (e.g. dev, prod, test)
-     *
-     * @phpstan-return array{entries: list<LogEntryArray>}
      */
     #[McpTool('monolog-tail', 'Get the most recent log entries. Reads from the end of log files, optionally filtered by level and environment.')]
-    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null): array
+    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null): string
     {
         $entries = $this->reader->tail($lines, $level, $environment);
 
-        return ['entries' => array_values(array_map(static fn ($entry) => $entry->toArray(), $entries))];
+        return ResponseEncoder::encode(['entries' => array_values(array_map(static fn ($entry) => $entry->toArray(), $entries))]);
     }
 
     /**
      * @param string|null $environment Filter log files by Symfony environment (e.g. dev, prod, test)
-     *
-     * @return array{files: array<int, array{name: string, path: string, size: int, modified: string}>}
      */
     #[McpTool('monolog-list-files', 'List available log files with metadata (name, path, size, last modified). Use to discover which logs exist before searching.')]
-    public function listFiles(?string $environment = null): array
+    public function listFiles(?string $environment = null): string
     {
         $files = null !== $environment
             ? $this->reader->getLogFilesForEnvironment($environment)
@@ -145,20 +135,17 @@ final class LogSearchTool
             ];
         }
 
-        return ['files' => $result];
+        return ResponseEncoder::encode(['files' => $result]);
     }
 
-    /**
-     * @return array{channels: string[]}
-     */
     #[McpTool('monolog-list-channels', 'List all unique Monolog channel names found across log files (e.g. app, security, doctrine).')]
-    public function listChannels(): array
+    public function listChannels(): string
     {
-        return ['channels' => $this->reader->getUniqueChannels()];
+        return ResponseEncoder::encode(['channels' => $this->reader->getUniqueChannels()]);
     }
 
     /**
-     * @phpstan-return list<LogEntryArray>
+     * @return list<array<string, mixed>>
      */
     private function collectResults(SearchCriteria $criteria, ?string $environment = null): array
     {

--- a/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Mate\Bridge\Monolog\Tests\Capability;
 
+use HelgeSverre\Toon\DecodeOptions;
+use HelgeSverre\Toon\Toon;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Mate\Bridge\Monolog\Capability\LogSearchTool;
 use Symfony\AI\Mate\Bridge\Monolog\Service\LogParser;
@@ -34,7 +36,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchByTextTerm()
     {
-        $result = $this->tool->search('logged in');
+        $result = Toon::decode($this->tool->search('logged in'));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);
@@ -44,7 +46,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchByTextTermReturnsEmptyWhenNotFound()
     {
-        $result = $this->tool->search('nonexistent search term xyz');
+        $result = Toon::decode($this->tool->search('nonexistent search term xyz'), DecodeOptions::lenient());
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertEmpty($result['entries']);
@@ -52,7 +54,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchByLevel()
     {
-        $result = $this->tool->search('', level: 'ERROR');
+        $result = Toon::decode($this->tool->search('', level: 'ERROR'));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);
@@ -64,7 +66,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchByChannel()
     {
-        $result = $this->tool->search('', channel: 'security');
+        $result = Toon::decode($this->tool->search('', channel: 'security'));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);
@@ -74,15 +76,9 @@ final class LogSearchToolTest extends TestCase
         }
     }
 
-    public function testSearchByEnvironment()
-    {
-        // Skip this test as the bridge test fixtures don't have environment-specific files
-        $this->markTestSkipped('Environment-specific search not supported in bridge test fixtures');
-    }
-
     public function testSearchWithLimit()
     {
-        $result = $this->tool->search('', limit: 2);
+        $result = Toon::decode($this->tool->search('', limit: 2));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertLessThanOrEqual(2, \count($result['entries']));
@@ -90,7 +86,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchRegex()
     {
-        $result = $this->tool->search('Database.*failed', regex: true);
+        $result = Toon::decode($this->tool->search('Database.*failed', regex: true));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);
@@ -99,7 +95,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchRegexWithDelimiters()
     {
-        $result = $this->tool->search('/User.*logged/i', regex: true);
+        $result = Toon::decode($this->tool->search('/User.*logged/i', regex: true));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);
@@ -107,7 +103,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchRegexByLevel()
     {
-        $result = $this->tool->search('.*', regex: true, level: 'WARNING');
+        $result = Toon::decode($this->tool->search('.*', regex: true, level: 'WARNING'));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);
@@ -119,7 +115,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchContext()
     {
-        $result = $this->tool->searchContext('user_id', '123');
+        $result = Toon::decode($this->tool->searchContext('user_id', '123'));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);
@@ -129,7 +125,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchContextReturnsEmptyWhenKeyNotFound()
     {
-        $result = $this->tool->searchContext('nonexistent_key', 'value');
+        $result = Toon::decode($this->tool->searchContext('nonexistent_key', 'value'), DecodeOptions::lenient());
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertEmpty($result['entries']);
@@ -137,7 +133,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchContextByLevel()
     {
-        $result = $this->tool->searchContext('error', 'Connection', level: 'ERROR');
+        $result = Toon::decode($this->tool->searchContext('error', 'Connection', level: 'ERROR'));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);
@@ -145,7 +141,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testTail()
     {
-        $result = $this->tool->tail(10);
+        $result = Toon::decode($this->tool->tail(10));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);
@@ -154,7 +150,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testTailWithLevel()
     {
-        $result = $this->tool->tail(10, level: 'INFO');
+        $result = Toon::decode($this->tool->tail(10, level: 'INFO'));
 
         $this->assertArrayHasKey('entries', $result);
         foreach ($result['entries'] as $entry) {
@@ -162,15 +158,9 @@ final class LogSearchToolTest extends TestCase
         }
     }
 
-    public function testTailWithEnvironment()
-    {
-        // Skip this test as the bridge test fixtures don't have environment-specific files
-        $this->markTestSkipped('Environment-specific tail not supported in bridge test fixtures');
-    }
-
     public function testListFiles()
     {
-        $result = $this->tool->listFiles();
+        $result = Toon::decode($this->tool->listFiles());
 
         $this->assertArrayHasKey('files', $result);
         $this->assertNotEmpty($result['files']);
@@ -183,15 +173,9 @@ final class LogSearchToolTest extends TestCase
         }
     }
 
-    public function testListFilesForEnvironment()
-    {
-        // Skip this test as the bridge test fixtures don't have environment-specific files
-        $this->markTestSkipped('Environment-specific file listing not supported in bridge test fixtures');
-    }
-
     public function testListChannels()
     {
-        $result = $this->tool->listChannels();
+        $result = Toon::decode($this->tool->listChannels());
 
         $this->assertArrayHasKey('channels', $result);
         $this->assertNotEmpty($result['channels']);
@@ -201,7 +185,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testByLevel()
     {
-        $result = $this->tool->search('', level: 'INFO');
+        $result = Toon::decode($this->tool->search('', level: 'INFO'));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);
@@ -213,7 +197,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testByLevelWithLimit()
     {
-        $result = $this->tool->search('', level: 'INFO', limit: 1);
+        $result = Toon::decode($this->tool->search('', level: 'INFO', limit: 1));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertLessThanOrEqual(1, \count($result['entries']));
@@ -221,7 +205,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchReturnsLogEntryArrayStructure()
     {
-        $result = $this->tool->search('logged');
+        $result = Toon::decode($this->tool->search('logged'));
 
         $this->assertArrayHasKey('entries', $result);
         $this->assertNotEmpty($result['entries']);

--- a/src/mate/src/Bridge/Monolog/composer.json
+++ b/src/mate/src/Bridge/Monolog/composer.json
@@ -27,10 +27,11 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/ai-mate": "^0.6",
-        "monolog/monolog": "^2.0|^3.0"
+        "monolog/monolog": "^2.0|^3.0",
+        "symfony/ai-mate": "^0.6"
     },
     "require-dev": {
+        "helgesverre/toon": "^3.1",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",

--- a/src/mate/src/Bridge/Symfony/CHANGELOG.md
+++ b/src/mate/src/Bridge/Symfony/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `@param` docblocks to all tool methods for AI-readable parameter descriptions
  * Add automatic detection of compiled container XML for kernels with custom class names
  * Add `DoctrineCollectorFormatter` to expose Doctrine DBAL query data (query count, execution times, SQL, duplicate detection) to AI via the profiler
+ * Add optional TOON format encoding for `ServiceTool`, `ProfilerTool`, and `ProfilerResourceTemplate` to reduce token consumption
 
 0.6
 ---

--- a/src/mate/src/Bridge/Symfony/Capability/ProfilerResourceTemplate.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ProfilerResourceTemplate.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Mate\Bridge\Symfony\Capability;
 
 use Mcp\Capability\Attribute\McpResourceTemplate;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
 
 /**
  * MCP resource templates for accessing Symfony profiler data.
@@ -46,8 +47,8 @@ final class ProfilerResourceTemplate
         if (null === $profileData) {
             return [
                 'uri' => "symfony-profiler://profile/{$token}",
-                'mimeType' => 'application/json',
-                'text' => json_encode(['error' => 'Profile not found'], \JSON_PRETTY_PRINT) ?: '{}',
+                'mimeType' => 'text/plain',
+                'text' => ResponseEncoder::encode(['error' => 'Profile not found']),
             ];
         }
 
@@ -79,8 +80,8 @@ final class ProfilerResourceTemplate
 
         return [
             'uri' => "symfony-profiler://profile/{$token}",
-            'mimeType' => 'application/json',
-            'text' => json_encode($data, \JSON_PRETTY_PRINT) ?: '{}',
+            'mimeType' => 'text/plain',
+            'text' => ResponseEncoder::encode($data),
         ];
     }
 
@@ -99,14 +100,14 @@ final class ProfilerResourceTemplate
 
             return [
                 'uri' => "symfony-profiler://profile/{$token}/{$collector}",
-                'mimeType' => 'application/json',
-                'text' => json_encode($data, \JSON_PRETTY_PRINT) ?: '{}',
+                'mimeType' => 'text/plain',
+                'text' => ResponseEncoder::encode($data),
             ];
         } catch (\Throwable $e) {
             return [
                 'uri' => "symfony-profiler://profile/{$token}/{$collector}",
-                'mimeType' => 'application/json',
-                'text' => json_encode(['error' => $e->getMessage()]) ?: '{}',
+                'mimeType' => 'text/plain',
+                'text' => ResponseEncoder::encode(['error' => $e->getMessage()]),
             ];
         }
     }

--- a/src/mate/src/Bridge/Symfony/Capability/ProfilerTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ProfilerTool.php
@@ -14,14 +14,13 @@ namespace Symfony\AI\Mate\Bridge\Symfony\Capability;
 use Mcp\Capability\Attribute\McpTool;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Model\ProfileIndex;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
 use Symfony\AI\Mate\Exception\InvalidArgumentException;
 
 /**
  * MCP tools for accessing Symfony profiler data.
  *
  * @author Johannes Wachter <johannes@sulu.io>
- *
- * @phpstan-import-type ProfileIndexData from ProfileIndex
  */
 final class ProfilerTool
 {
@@ -39,8 +38,6 @@ final class ProfilerTool
      * @param string|null $context    Filter by Symfony kernel context
      * @param string|null $from       Start date filter for profile creation time
      * @param string|null $to         End date filter for profile creation time
-     *
-     * @return array{profiles: list<ProfileIndexData>}
      */
     #[McpTool('symfony-profiler-list', 'List and filter Symfony profiler profiles by HTTP method, URL, IP, status code, date range, or context. Profiles are sorted by most recent first, so limit=1 returns the latest profile. Returns summary data with resource_uri for fetching full details via the resource template.')]
     public function listProfiles(
@@ -52,7 +49,7 @@ final class ProfilerTool
         ?string $context = null,
         ?string $from = null,
         ?string $to = null,
-    ): array {
+    ): string {
         $criteria = [
             'context' => $context,
             'method' => $method,
@@ -65,21 +62,19 @@ final class ProfilerTool
 
         $profiles = $this->dataProvider->searchProfiles(array_filter($criteria), $limit);
 
-        return [
+        return ResponseEncoder::encode([
             'profiles' => array_values(array_map(
                 static fn (ProfileIndex $profile): array => $profile->toArray(),
                 $profiles,
             )),
-        ];
+        ]);
     }
 
     /**
      * @param string $token The unique profiler token identifying the profile
-     *
-     * @return ProfileIndexData
      */
     #[McpTool('symfony-profiler-get', 'Get a specific profiler profile by its token. Returns detailed profile data including available collectors and resource_uri for accessing collector-specific data.')]
-    public function getProfile(string $token): array
+    public function getProfile(string $token): string
     {
         $profileData = $this->dataProvider->findProfile($token);
 
@@ -104,6 +99,6 @@ final class ProfilerTool
             $data['context'] = $profileData->context;
         }
 
-        return $data;
+        return ResponseEncoder::encode($data);
     }
 }

--- a/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Mate\Bridge\Symfony\Capability;
 use Mcp\Capability\Attribute\McpTool;
 use Symfony\AI\Mate\Bridge\Symfony\Model\Container;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -28,15 +29,13 @@ class ServiceTool
 
     /**
      * @param string|null $query Filter services by ID or class name (case-insensitive partial match)
-     *
-     * @return array<string, class-string|null>
      */
     #[McpTool('symfony-services', 'Search Symfony dependency injection container services. Optionally filter by service ID or class name. Returns a map of service IDs to their class names.')]
-    public function getServices(?string $query = null): array
+    public function getServices(?string $query = null): string
     {
         $container = $this->readContainer();
         if (null === $container) {
-            return [];
+            return ResponseEncoder::encode([]);
         }
 
         $output = [];
@@ -51,7 +50,7 @@ class ServiceTool
             $output[$service->id] = $service->class;
         }
 
-        return $output;
+        return ResponseEncoder::encode($output);
     }
 
     private function readContainer(): ?Container

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ProfilerResourceTemplateTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ProfilerResourceTemplateTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Capability;
 
+use HelgeSverre\Toon\Toon;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ProfilerResourceTemplate;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
@@ -41,14 +42,14 @@ final class ProfilerResourceTemplateTest extends TestCase
         $this->assertArrayHasKey('mimeType', $resource);
         $this->assertArrayHasKey('text', $resource);
         $this->assertSame('symfony-profiler://profile/abc123', $resource['uri']);
-        $this->assertSame('application/json', $resource['mimeType']);
+        $this->assertSame('text/plain', $resource['mimeType']);
     }
 
     public function testGetProfileResourceIncludesMetadata()
     {
         $resource = $this->template->getProfileResource('abc123');
 
-        $data = json_decode($resource['text'], true);
+        $data = Toon::decode($resource['text']);
         $this->assertIsArray($data);
 
         $this->assertArrayHasKey('token', $data);
@@ -64,7 +65,7 @@ final class ProfilerResourceTemplateTest extends TestCase
     {
         $resource = $this->template->getProfileResource('abc123');
 
-        $data = json_decode($resource['text'], true);
+        $data = Toon::decode($resource['text']);
         $this->assertIsArray($data);
 
         $this->assertArrayHasKey('collectors', $data);
@@ -83,7 +84,7 @@ final class ProfilerResourceTemplateTest extends TestCase
     {
         $resource = $this->template->getProfileResource('nonexistent');
 
-        $data = json_decode($resource['text'], true);
+        $data = Toon::decode($resource['text']);
         $this->assertIsArray($data);
 
         $this->assertArrayHasKey('error', $data);
@@ -100,11 +101,11 @@ final class ProfilerResourceTemplateTest extends TestCase
         $this->assertSame('symfony-profiler://profile/abc123/request', $resource['uri']);
     }
 
-    public function testGetCollectorResourceReturnsJsonContent()
+    public function testGetCollectorResourceReturnsToonContent()
     {
         $resource = $this->template->getCollectorResource('abc123', 'request');
 
-        $data = json_decode($resource['text'], true);
+        $data = Toon::decode($resource['text']);
 
         $this->assertIsArray($data);
         $this->assertArrayHasKey('name', $data);
@@ -129,7 +130,7 @@ final class ProfilerResourceTemplateTest extends TestCase
         $resource = $this->template->getCollectorResource('nonexistent', 'request');
 
         $this->assertArrayHasKey('text', $resource);
-        $data = json_decode($resource['text'], true);
+        $data = Toon::decode($resource['text']);
         $this->assertIsArray($data);
         $this->assertArrayHasKey('error', $data);
     }

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ProfilerToolTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ProfilerToolTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Capability;
 
+use HelgeSverre\Toon\Toon;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ProfilerTool;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
@@ -35,7 +36,7 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesReturnsAllProfiles()
     {
-        $result = $this->tool->listProfiles();
+        $result = Toon::decode($this->tool->listProfiles());
 
         $this->assertArrayHasKey('profiles', $result);
         $profiles = $result['profiles'];
@@ -47,7 +48,7 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesWithLimit()
     {
-        $result = $this->tool->listProfiles(limit: 2);
+        $result = Toon::decode($this->tool->listProfiles(limit: 2));
 
         $this->assertArrayHasKey('profiles', $result);
         $this->assertCount(2, $result['profiles']);
@@ -55,7 +56,7 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesFilterByMethod()
     {
-        $result = $this->tool->listProfiles(method: 'POST');
+        $result = Toon::decode($this->tool->listProfiles(method: 'POST'));
 
         $this->assertArrayHasKey('profiles', $result);
         $profiles = $result['profiles'];
@@ -65,7 +66,7 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesFilterByStatusCode()
     {
-        $result = $this->tool->listProfiles(statusCode: 404);
+        $result = Toon::decode($this->tool->listProfiles(statusCode: 404));
 
         $this->assertArrayHasKey('profiles', $result);
         $profiles = $result['profiles'];
@@ -75,7 +76,7 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesFilterByUrl()
     {
-        $result = $this->tool->listProfiles(url: 'users');
+        $result = Toon::decode($this->tool->listProfiles(url: 'users'));
 
         $this->assertArrayHasKey('profiles', $result);
         $this->assertCount(2, $result['profiles']);
@@ -83,7 +84,7 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesFilterByIp()
     {
-        $result = $this->tool->listProfiles(ip: '127.0.0.1');
+        $result = Toon::decode($this->tool->listProfiles(ip: '127.0.0.1'));
 
         $this->assertArrayHasKey('profiles', $result);
         $this->assertCount(2, $result['profiles']);
@@ -91,7 +92,7 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesFilterByRoute()
     {
-        $result = $this->tool->listProfiles(url: '/api/users');
+        $result = Toon::decode($this->tool->listProfiles(url: '/api/users'));
 
         $this->assertArrayHasKey('profiles', $result);
         $this->assertCount(2, $result['profiles']);
@@ -99,7 +100,7 @@ final class ProfilerToolTest extends TestCase
 
     public function testGetProfileReturnsProfileWithResourceUri()
     {
-        $profile = $this->tool->getProfile('abc123');
+        $profile = Toon::decode($this->tool->getProfile('abc123'));
 
         $this->assertArrayHasKey('token', $profile);
         $this->assertArrayHasKey('resource_uri', $profile);
@@ -117,7 +118,7 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesIncludesResourceUri()
     {
-        $result = $this->tool->listProfiles();
+        $result = Toon::decode($this->tool->listProfiles());
 
         $this->assertArrayHasKey('profiles', $result);
         $profiles = $result['profiles'];
@@ -134,7 +135,7 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesReturnsIntegerKeys()
     {
-        $result = $this->tool->listProfiles();
+        $result = Toon::decode($this->tool->listProfiles());
 
         $this->assertArrayHasKey('profiles', $result);
         $keys = array_keys($result['profiles']);

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Capability;
 
+use HelgeSverre\Toon\DecodeOptions;
+use HelgeSverre\Toon\Toon;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ServiceTool;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
@@ -32,7 +34,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $services = $tool->getServices();
+        $services = Toon::decode($tool->getServices());
 
         $this->assertArrayHasKey('cache.app', $services);
         $this->assertArrayHasKey('logger', $services);
@@ -48,7 +50,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool('/non/existent/directory', $provider);
 
-        $services = $tool->getServices();
+        $services = Toon::decode($tool->getServices(), DecodeOptions::lenient());
 
         $this->assertEmpty($services);
     }
@@ -58,7 +60,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $services = $tool->getServices();
+        $services = Toon::decode($tool->getServices());
 
         $this->assertArrayHasKey('event_dispatcher', $services);
         $this->assertSame('Symfony\Component\EventDispatcher\EventDispatcher', $services['event_dispatcher']);
@@ -69,7 +71,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $services = $tool->getServices();
+        $services = Toon::decode($tool->getServices());
 
         $this->assertArrayHasKey('cache.app', $services);
         $this->assertArrayHasKey('logger', $services);
@@ -80,7 +82,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $services = $tool->getServices();
+        $services = Toon::decode($tool->getServices());
 
         // my_service is an alias to cache.app
         $this->assertArrayHasKey('my_service', $services);
@@ -92,7 +94,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $services = $tool->getServices();
+        $services = Toon::decode($tool->getServices());
 
         // .service_locator.abc123 should be accessible without the leading dot
         $this->assertArrayHasKey('service_locator.abc123', $services);
@@ -103,7 +105,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $services = $tool->getServices();
+        $services = Toon::decode($tool->getServices());
 
         $this->assertArrayHasKey('router', $services);
         $this->assertSame('Symfony\Component\Routing\Router', $services['router']);
@@ -114,7 +116,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $services = $tool->getServices('cache');
+        $services = Toon::decode($tool->getServices('cache'));
 
         $this->assertArrayHasKey('cache.app', $services);
         $this->assertArrayNotHasKey('logger', $services);
@@ -126,7 +128,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $services = $tool->getServices('NullLogger');
+        $services = Toon::decode($tool->getServices('NullLogger'));
 
         $this->assertArrayHasKey('logger', $services);
         $this->assertArrayNotHasKey('cache.app', $services);
@@ -137,7 +139,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $services = $tool->getServices('CACHE');
+        $services = Toon::decode($tool->getServices('CACHE'));
 
         $this->assertArrayHasKey('cache.app', $services);
     }
@@ -147,8 +149,8 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $allServices = $tool->getServices();
-        $emptyQueryServices = $tool->getServices('');
+        $allServices = Toon::decode($tool->getServices());
+        $emptyQueryServices = Toon::decode($tool->getServices(''));
 
         $this->assertSame($allServices, $emptyQueryServices);
     }
@@ -158,7 +160,7 @@ final class ServiceToolTest extends TestCase
         $provider = new ContainerProvider();
         $tool = new ServiceTool($this->fixturesDir, $provider);
 
-        $services = $tool->getServices('nonexistent_service_xyz');
+        $services = Toon::decode($tool->getServices('nonexistent_service_xyz'), DecodeOptions::lenient());
 
         $this->assertEmpty($services);
     }
@@ -185,7 +187,7 @@ XML;
             $provider = new ContainerProvider();
             $tool = new ServiceTool($tempDir, $provider);
 
-            $services = $tool->getServices();
+            $services = Toon::decode($tool->getServices());
 
             $this->assertArrayHasKey('custom.service', $services);
             $this->assertSame('Custom\ServiceClass', $services['custom.service']);

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -33,6 +33,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.13|^3.0",
+        "helgesverre/toon": "^3.1",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",

--- a/src/mate/src/Capability/ServerInfo.php
+++ b/src/mate/src/Capability/ServerInfo.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Mate\Capability;
 
 use Mcp\Capability\Attribute\McpTool;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
 
 /**
  * @author Johannes Wachter <johannes@sulu.io>
@@ -19,17 +20,14 @@ use Mcp\Capability\Attribute\McpTool;
  */
 class ServerInfo
 {
-    /**
-     * @return array{php_version: string, operating_system: string, operating_system_family: string, extensions: list<string>}
-     */
     #[McpTool('server-info', 'Get PHP runtime environment details: version, OS, OS family, and loaded extensions')]
-    public function getInfo(): array
+    public function getInfo(): string
     {
-        return [
+        return ResponseEncoder::encode([
             'php_version' => \PHP_VERSION,
             'operating_system' => \PHP_OS,
             'operating_system_family' => \PHP_OS_FAMILY,
             'extensions' => get_loaded_extensions(),
-        ];
+        ]);
     }
 }

--- a/src/mate/src/Command/ToolsCallCommand.php
+++ b/src/mate/src/Command/ToolsCallCommand.php
@@ -18,6 +18,7 @@ use Mcp\Exception\ToolNotFoundException;
 use Mcp\Schema\Request\CallToolRequest;
 use Symfony\AI\Mate\Command\Session\CliSession;
 use Symfony\AI\Mate\Command\Trait\EnsuresToonFormatAvailabilityTrait;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
 use Symfony\AI\Mate\Service\RegistryProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -160,6 +161,10 @@ HELP
             }
 
             return Command::FAILURE;
+        }
+
+        if (\is_string($result)) {
+            $result = ResponseEncoder::decode($result);
         }
 
         if ('json' === $format) {

--- a/src/mate/src/Encoding/ResponseEncoder.php
+++ b/src/mate/src/Encoding/ResponseEncoder.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Encoding;
+
+use HelgeSverre\Toon\Toon;
+
+/**
+ * Encodes data for MCP tool responses.
+ *
+ * Uses TOON (Token-Oriented Object Notation) format when the helgesverre/toon
+ * package is installed, falling back to JSON otherwise.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResponseEncoder
+{
+    /**
+     * Encodes data for MCP tool responses using TOON if available, JSON otherwise.
+     */
+    public static function encode(mixed $data): string
+    {
+        if (class_exists(Toon::class)) {
+            return Toon::encode($data);
+        }
+
+        return json_encode($data, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * Decodes a previously encoded response back to structured data.
+     *
+     * Tries TOON decoding first (if available), then JSON.
+     */
+    public static function decode(string $data): mixed
+    {
+        if (class_exists(Toon::class)) {
+            return Toon::decode($data);
+        }
+
+        return json_decode($data, true, 512, \JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | N/A
| License       | MIT

> **Note:** This PR is based on #1806 and should be merged after it.

### Summary

Add optional TOON (Token-Oriented Object Notation) format encoding for MCP tool responses to reduce token consumption when communicating with LLMs.

Introduces a `ResponseEncoder` utility that uses the `helgesverre/toon` package when installed, falling back to JSON otherwise. This keeps the dependency **optional** (moved to `suggest`/`require-dev`) as discussed in #1805.

### Updated tools
- `ServerInfo::getInfo()`
- `LogSearchTool`: `search`, `searchContext`, `tail`, `listFiles`, `listChannels`
- `ServiceTool::getServices()`
- `ProfilerTool`: `listProfiles`, `getProfile`
- `ProfilerResourceTemplate`: `getProfileResource`, `getCollectorResource`

### Key design decision

Based on review feedback from #1805, `helgesverre/toon` is **not** a hard dependency:
- Moved to `suggest` in `symfony/ai-mate` and to `require-dev` in bridge packages
- New `ResponseEncoder::encode()` checks `class_exists(Toon::class)` and falls back to `json_encode()`
- When toon is installed, tools benefit from reduced token consumption; when it's not, JSON works fine