### PR TITLE
[Platform] Allow response_format option without class-string

### DIFF
--- a/src/platform/src/StructuredOutput/PlatformSubscriber.php
+++ b/src/platform/src/StructuredOutput/PlatformSubscriber.php
@@ -58,16 +58,16 @@ final class PlatformSubscriber implements EventSubscriberInterface
             return;
         }
 
+        if (!class_exists($options[self::RESPONSE_FORMAT])) {
+            return;
+        }
+
         if (true === ($options['stream'] ?? false)) {
             throw new InvalidArgumentException('Streamed responses are not supported for structured output.');
         }
 
         if (!$event->getModel()->supports(Capability::OUTPUT_STRUCTURED)) {
             throw MissingModelSupportException::forStructuredOutput($event->getModel());
-        }
-
-        if (!class_exists($options[self::RESPONSE_FORMAT])) {
-            throw new InvalidArgumentException(\sprintf('The specified response format class "%s" does not exist.', $options[self::RESPONSE_FORMAT]));
         }
 
         $this->outputType = $options[self::RESPONSE_FORMAT];

--- a/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
+++ b/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
@@ -62,6 +62,18 @@ final class PlatformSubscriberTest extends TestCase
         $this->assertSame([], $event->getOptions());
     }
 
+    public function testWithResponseFormatForNonLlmModel()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory());
+
+        $model = new Model('dalle-2');
+        $event = new InvocationEvent($model, 'some input text', ['response_format' => 'url']);
+
+        $processor->processInput($event);
+
+        $this->assertSame(['response_format' => 'url'], $event->getOptions());
+    }
+
     public function testProcessInputThrowsExceptionWhenLlmDoesNotSupportStructuredOutput()
     {
         $this->expectException(MissingModelSupportException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | 
| Issues        | Fix #1367
| License       | MIT

Should fix dall-e issues - decided for this solution this time bc it feels we'll run into it again, see whisper before.
cc @tito10047