### PR TITLE
[Platform] Add Load Balanced Platform

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -161,6 +161,10 @@ deptrac:
       collectors:
         - type: classLike
           value: Symfony\\AI\\Platform\\Bridge\\LmStudio\\.*
+    - name: LoadBalancedPlatform
+      collectors:
+        - type: classLike
+          value: Symfony\\AI\\Platform\\Bridge\\LoadBalanced\\.*
     - name: MetaPlatform
       collectors:
         - type: classLike
@@ -389,6 +393,8 @@ deptrac:
     LmStudioPlatform:
       - PlatformComponent
       - GenericPlatform
+    LoadBalancedPlatform:
+      - PlatformComponent
     MetaPlatform:
       - PlatformComponent
     MistralPlatform:

--- a/splitsh.json
+++ b/splitsh.json
@@ -56,6 +56,7 @@
         "ai-generic-platform": "src/platform/src/Bridge/Generic",
         "ai-hugging-face-platform": "src/platform/src/Bridge/HuggingFace",
         "ai-lm-studio-platform": "src/platform/src/Bridge/LmStudio",
+        "ai-load-balanced-platform": "src/platform/src/Bridge/LoadBalanced",
         "ai-meta-platform": "src/platform/src/Bridge/Meta",
         "ai-mistral-platform": "src/platform/src/Bridge/Mistral",
         "ai-ollama-platform": "src/platform/src/Bridge/Ollama",

--- a/src/platform/src/Bridge/LoadBalanced/.gitattributes
+++ b/src/platform/src/Bridge/LoadBalanced/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/platform/src/Bridge/LoadBalanced/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/platform/src/Bridge/LoadBalanced/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/ai
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/platform/src/Bridge/LoadBalanced/.github/workflows/close-pull-request.yml
+++ b/src/platform/src/Bridge/LoadBalanced/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/ai
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/platform/src/Bridge/LoadBalanced/.gitignore
+++ b/src/platform/src/Bridge/LoadBalanced/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+phpunit.xml
+.phpunit.result.cache

--- a/src/platform/src/Bridge/LoadBalanced/CHANGELOG.md
+++ b/src/platform/src/Bridge/LoadBalanced/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+0.6
+---
+
+ * Add the bridge

--- a/src/platform/src/Bridge/LoadBalanced/Exception/CapacityExhaustedException.php
+++ b/src/platform/src/Bridge/LoadBalanced/Exception/CapacityExhaustedException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Exception;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+
+/**
+ * Thrown when no platform has available capacity to handle a request.
+ *
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+class CapacityExhaustedException extends RuntimeException
+{
+}

--- a/src/platform/src/Bridge/LoadBalanced/LICENSE
+++ b/src/platform/src/Bridge/LoadBalanced/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/platform/src/Bridge/LoadBalanced/LoadBalancedPlatform.php
+++ b/src/platform/src/Bridge/LoadBalanced/LoadBalancedPlatform.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced;
+
+use Symfony\AI\Platform\Bridge\LoadBalanced\Exception\CapacityExhaustedException;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Strategy\PlatformSelectionStrategy;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+
+/**
+ * A platform that load balances requests across multiple platforms.
+ *
+ * Platforms are selected based on the configured strategy and their
+ * available capacity (rate limits, concurrency limits, etc.).
+ *
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+final class LoadBalancedPlatform implements PlatformInterface
+{
+    /**
+     * @var array<PlatformCapacity>
+     */
+    private readonly array $platforms;
+
+    /**
+     * @param iterable<PlatformCapacity> $platforms
+     */
+    public function __construct(
+        iterable $platforms,
+        private readonly PlatformSelectionStrategy $strategy,
+    ) {
+        $platformsArray = $platforms instanceof \Traversable ? iterator_to_array($platforms) : $platforms;
+
+        if ([] === $platformsArray) {
+            throw new InvalidArgumentException(\sprintf('"%s" must have at least one platform configured.', self::class));
+        }
+
+        $this->platforms = $platformsArray;
+    }
+
+    public function invoke(string $model, object|array|string $input, array $options = []): DeferredResult
+    {
+        return $this->execute(
+            static fn (PlatformCapacity $capacity): DeferredResult => $capacity->platform->invoke($capacity->model ?? $model, $input, $options),
+        );
+    }
+
+    public function getModelCatalog(): ModelCatalogInterface
+    {
+        return $this->execute(
+            static fn (PlatformCapacity $capacity): ModelCatalogInterface => $capacity->platform->getModelCatalog()
+        );
+    }
+
+    private function execute(\Closure $operation): DeferredResult|ModelCatalogInterface
+    {
+        foreach ($this->strategy->order($this->platforms) as $entry) {
+            if (!$entry->capacityProvider->tryAcquire()) {
+                continue;
+            }
+
+            try {
+                $result = $operation($entry);
+            } catch (\Throwable $throwable) {
+                $entry->capacityProvider->release();
+
+                throw $throwable;
+            }
+
+            if (!$result instanceof DeferredResult) {
+                $entry->capacityProvider->release();
+
+                return $result;
+            }
+
+            $result->onResolved(static function () use ($entry): void {
+                $entry->capacityProvider->release();
+            });
+
+            return $result;
+        }
+
+        throw new CapacityExhaustedException('All platforms have exhausted their capacity.');
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/PlatformCapacity.php
+++ b/src/platform/src/Bridge/LoadBalanced/PlatformCapacity.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced;
+
+use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\CapacityProvider;
+use Symfony\AI\Platform\PlatformInterface;
+
+/**
+ * Pairs a platform with its capacity provider for load balancing.
+ *
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+final class PlatformCapacity
+{
+    public function __construct(
+        public readonly PlatformInterface $platform,
+        public readonly CapacityProvider $capacityProvider,
+        public readonly ?string $model = null,
+    ) {
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/Provider/CapacityProvider.php
+++ b/src/platform/src/Bridge/LoadBalanced/Provider/CapacityProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Provider;
+
+/**
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+interface CapacityProvider
+{
+    public function tryAcquire(): bool;
+
+    public function release(): void;
+}

--- a/src/platform/src/Bridge/LoadBalanced/Provider/CompositeCapacityProvider.php
+++ b/src/platform/src/Bridge/LoadBalanced/Provider/CompositeCapacityProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Provider;
+
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\Semaphore\SemaphoreInterface;
+
+/**
+ * A composite capacity provider that combines rate limiting and concurrency limiting.
+ *
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+final class CompositeCapacityProvider implements CapacityProvider
+{
+    public function __construct(
+        private readonly SemaphoreInterface $semaphore,
+        private readonly LimiterInterface $limiter,
+    ) {
+    }
+
+    public function tryAcquire(): bool
+    {
+        if (!$this->semaphore->acquire()) {
+            return false;
+        }
+
+        if (!$this->limiter->consume()->isAccepted()) {
+            $this->semaphore->release();
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public function release(): void
+    {
+        $this->semaphore->release();
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/Provider/ConcurrencyLimitedProvider.php
+++ b/src/platform/src/Bridge/LoadBalanced/Provider/ConcurrencyLimitedProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Provider;
+
+use Symfony\Component\Semaphore\SemaphoreInterface;
+
+/**
+ * A capacity provider that limits concurrency using semaphore.
+ *
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+final class ConcurrencyLimitedProvider implements CapacityProvider
+{
+    public function __construct(
+        private readonly SemaphoreInterface $semaphore,
+    ) {
+    }
+
+    public function tryAcquire(): bool
+    {
+        return $this->semaphore->acquire();
+    }
+
+    public function release(): void
+    {
+        $this->semaphore->release();
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/Provider/NoLimitCapacityProvider.php
+++ b/src/platform/src/Bridge/LoadBalanced/Provider/NoLimitCapacityProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Provider;
+
+/**
+ * A capacity provider with no restrictions - always allows acquisition.
+ *
+ * Use this for platforms that don't need rate limiting or concurrency control.
+ *
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+final class NoLimitCapacityProvider implements CapacityProvider
+{
+    public function tryAcquire(): bool
+    {
+        return true;
+    }
+
+    public function release(): void
+    {
+        // no-op
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/Provider/RateLimitedCapacityProvider.php
+++ b/src/platform/src/Bridge/LoadBalanced/Provider/RateLimitedCapacityProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Provider;
+
+use Symfony\Component\RateLimiter\LimiterInterface;
+
+/**
+ * A capacity provider that limits usage with a rate limiter.
+ *
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+final class RateLimitedCapacityProvider implements CapacityProvider
+{
+    public function __construct(
+        private readonly LimiterInterface $limiter,
+    ) {
+    }
+
+    public function tryAcquire(): bool
+    {
+        return $this->limiter->consume()->isAccepted();
+    }
+
+    public function release(): void
+    {
+        // no-op
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/README.md
+++ b/src/platform/src/Bridge/LoadBalanced/README.md
@@ -1,0 +1,12 @@
+Load Balanced Platform
+======================
+
+Load balanced platform bridge for Symfony AI.
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/ai/issues) and
+   [send Pull Requests](https://github.com/symfony/ai/pulls)
+   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/platform/src/Bridge/LoadBalanced/Strategy/PlatformSelectionStrategy.php
+++ b/src/platform/src/Bridge/LoadBalanced/Strategy/PlatformSelectionStrategy.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Strategy;
+
+use Symfony\AI\Platform\Bridge\LoadBalanced\PlatformCapacity;
+
+/**
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+interface PlatformSelectionStrategy
+{
+    /**
+     * Orders the platforms for selection priority.
+     *
+     * @param array<PlatformCapacity> $platforms
+     *
+     * @return iterable<PlatformCapacity>
+     */
+    public function order(array $platforms): iterable;
+}

--- a/src/platform/src/Bridge/LoadBalanced/Strategy/RandomStrategy.php
+++ b/src/platform/src/Bridge/LoadBalanced/Strategy/RandomStrategy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Strategy;
+
+use Symfony\AI\Platform\Bridge\LoadBalanced\PlatformCapacity;
+
+/**
+ * Randomises the platform selection order.
+ *
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+final class RandomStrategy implements PlatformSelectionStrategy
+{
+    /**
+     * @param array<PlatformCapacity> $platforms
+     */
+    public function order(array $platforms): iterable
+    {
+        shuffle($platforms);
+
+        return $platforms;
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/Tests/LoadBalancedPlatformTest.php
+++ b/src/platform/src/Bridge/LoadBalanced/Tests/LoadBalancedPlatformTest.php
@@ -1,0 +1,251 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Exception\CapacityExhaustedException;
+use Symfony\AI\Platform\Bridge\LoadBalanced\LoadBalancedPlatform;
+use Symfony\AI\Platform\Bridge\LoadBalanced\PlatformCapacity;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\ConcurrencyLimitedProvider;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\NoLimitCapacityProvider;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\RateLimitedCapacityProvider;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Strategy\PlatformSelectionStrategy;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Strategy\RandomStrategy;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\Test\InMemoryPlatform;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Symfony\Component\Semaphore\SemaphoreInterface;
+
+class LoadBalancedPlatformTest extends TestCase
+{
+    public function testThrowsWhenNoPlatformsConfigured()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new LoadBalancedPlatform([], new RandomStrategy());
+    }
+
+    public function testThrowsWhenAllPlatformsExhausted()
+    {
+        $limiter = $this->createRateLimiter(1)->create('test');
+        $limiter->consume();
+
+        $loadBalancedPlatform = new LoadBalancedPlatform([
+            new PlatformCapacity(
+                $this->createMock(PlatformInterface::class),
+                new RateLimitedCapacityProvider($limiter),
+            ),
+        ], new RandomStrategy());
+
+        $this->expectException(CapacityExhaustedException::class);
+        $this->expectExceptionMessage('All platforms have exhausted their capacity.');
+
+        $loadBalancedPlatform->invoke('model', 'foo');
+    }
+
+    public function testInvokesPlatformWhenCapacityAvailable()
+    {
+        $loadBalancedPlatform = new LoadBalancedPlatform([
+            new PlatformCapacity(
+                new InMemoryPlatform(static fn (): string => 'foo'),
+                new NoLimitCapacityProvider(),
+            ),
+        ], new RandomStrategy());
+
+        $result = $loadBalancedPlatform->invoke('gpt-4', 'input');
+
+        $this->assertSame('foo', $result->asText());
+    }
+
+    public function testGetsModelCatalogFromPlatform()
+    {
+        $catalog = $this->createMock(ModelCatalogInterface::class);
+        $platform = $this->createMock(PlatformInterface::class);
+
+        $platform
+            ->expects($this->once())
+            ->method('getModelCatalog')
+            ->willReturn($catalog);
+
+        $loadBalancedPlatform = new LoadBalancedPlatform([
+            new PlatformCapacity(
+                $platform,
+                new NoLimitCapacityProvider(),
+            ),
+        ], new RandomStrategy());
+
+        $this->assertSame($catalog, $loadBalancedPlatform->getModelCatalog());
+    }
+
+    public function testUsesPlatformSpecificModelWhenProvided()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+
+        $platform
+            ->expects($this->once())
+            ->method('invoke')
+            ->with('claude-sonnet-4', 'input')
+            ->willReturn($this->createDeferredResult());
+
+        $loadBalancedPlatform = new LoadBalancedPlatform([
+            new PlatformCapacity(
+                $platform,
+                new NoLimitCapacityProvider(),
+                model: 'claude-sonnet-4',
+            ),
+        ], new RandomStrategy());
+
+        $loadBalancedPlatform->invoke('gpt-4', 'input');
+    }
+
+    public function testFallsBackToInvokeModelWhenPlatformModelNotProvided()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+
+        $platform
+            ->expects($this->once())
+            ->method('invoke')
+            ->with('gpt-4', 'input')
+            ->willReturn($this->createDeferredResult());
+
+        $loadBalancedPlatform = new LoadBalancedPlatform([
+            new PlatformCapacity(
+                $platform,
+                new NoLimitCapacityProvider(),
+            ),
+        ], new RandomStrategy());
+
+        $loadBalancedPlatform->invoke('gpt-4', 'input');
+    }
+
+    public function testSkipsExhaustedPlatform()
+    {
+        $exhaustedLimiter = $this->createRateLimiter(1)->create('exhausted');
+        $exhaustedLimiter->consume();
+
+        $exhaustedPlatform = $this->createMock(PlatformInterface::class);
+        $exhaustedPlatform
+            ->expects($this->never())
+            ->method('invoke');
+
+        $availablePlatform = $this->createMock(PlatformInterface::class);
+        $availablePlatform
+            ->expects($this->once())
+            ->method('invoke')
+            ->willReturn($this->createDeferredResult());
+
+        $strategy = new class implements PlatformSelectionStrategy {
+            public function order(array $platforms): iterable
+            {
+                return $platforms;
+            }
+        };
+
+        $platform = new LoadBalancedPlatform([
+            new PlatformCapacity($exhaustedPlatform, new RateLimitedCapacityProvider($exhaustedLimiter)),
+            new PlatformCapacity($availablePlatform, new NoLimitCapacityProvider()),
+        ], $strategy);
+
+        $platform->invoke('model', 'input');
+    }
+
+    public function testReleasesConcurrencyTokenAfterDeferredResultResolves()
+    {
+        $releaseCounter = new \ArrayObject(['count' => 0]);
+        $semaphore = $this->createSemaphore($releaseCounter);
+
+        $loadBalancedPlatform = new LoadBalancedPlatform([
+            new PlatformCapacity(
+                new InMemoryPlatform(static fn (): string => 'foo'),
+                new ConcurrencyLimitedProvider($semaphore),
+            ),
+        ], new RandomStrategy());
+
+        $deferredResult = $loadBalancedPlatform->invoke('model', 'input');
+
+        $this->assertSame(0, (int) $releaseCounter['count']);
+        $this->assertSame('foo', $deferredResult->asText());
+        $this->assertSame(1, (int) $releaseCounter['count']);
+    }
+
+    public function testReleasesConcurrencyTokenAfterStreamStopsEarly()
+    {
+        $releaseCounter = new \ArrayObject(['count' => 0]);
+        $semaphore = $this->createSemaphore($releaseCounter);
+
+        $loadBalancedPlatform = new LoadBalancedPlatform([
+            new PlatformCapacity(
+                new InMemoryPlatform(static fn (): StreamResult => new StreamResult((static function (): \Generator {
+                    yield 'chunk1';
+                    yield 'chunk2';
+                })())),
+                new ConcurrencyLimitedProvider($semaphore),
+            ),
+        ], new RandomStrategy());
+
+        $stream = $loadBalancedPlatform->invoke('model', 'input')->asStream();
+        $this->assertTrue($stream->valid());
+        $this->assertSame('chunk1', $stream->current());
+        $this->assertSame(0, (int) $releaseCounter['count']);
+
+        unset($stream);
+        gc_collect_cycles();
+
+        $this->assertSame(1, (int) $releaseCounter['count']);
+    }
+
+    private function createDeferredResult(): DeferredResult
+    {
+        return new DeferredResult(
+            $this->createMock(ResultConverterInterface::class),
+            $this->createMock(RawResultInterface::class),
+        );
+    }
+
+    private function createRateLimiter(int $limit): RateLimiterFactory
+    {
+        return new RateLimiterFactory([
+            'policy' => 'fixed_window',
+            'interval' => '1 minute',
+            'limit' => $limit,
+            'id' => 'test',
+        ], new InMemoryStorage());
+    }
+
+    /**
+     * @param \ArrayObject<string, int> $releaseCounter
+     */
+    private function createSemaphore(\ArrayObject $releaseCounter): SemaphoreInterface
+    {
+        $semaphore = $this->createMock(SemaphoreInterface::class);
+        $semaphore
+            ->expects($this->once())
+            ->method('acquire')
+            ->willReturn(true);
+
+        $semaphore
+            ->expects($this->once())
+            ->method('release')
+            ->willReturnCallback(static function () use ($releaseCounter): void {
+                ++$releaseCounter['count'];
+            });
+
+        return $semaphore;
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/Tests/Provider/CompositeCapacityProviderTest.php
+++ b/src/platform/src/Bridge/LoadBalanced/Tests/Provider/CompositeCapacityProviderTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\CompositeCapacityProvider;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\Semaphore\SemaphoreInterface;
+
+class CompositeCapacityProviderTest extends TestCase
+{
+    public function testTryAcquireFailsWhenSemaphoreIsUnavailable()
+    {
+        $mockSemaphore = $this->createMock(SemaphoreInterface::class);
+
+        $mockSemaphore
+            ->expects($this->once())
+            ->method('acquire')
+            ->willReturn(false);
+
+        $composite = new CompositeCapacityProvider(
+            $mockSemaphore,
+            $this->createMock(LimiterInterface::class)
+        );
+
+        $this->assertFalse($composite->tryAcquire());
+    }
+
+    public function testTryAcquireFailsWhenLimiterHasReachedCapacity()
+    {
+        $mockSemaphore = $this->createMock(SemaphoreInterface::class);
+        $mockLimiter = $this->createMock(LimiterInterface::class);
+        $mockRateLimit = $this->createMock(RateLimit::class);
+
+        $mockSemaphore
+            ->expects($this->once())
+            ->method('acquire')
+            ->willReturn(true);
+
+        $mockLimiter
+            ->expects($this->once())
+            ->method('consume')
+            ->willReturn($mockRateLimit);
+
+        $mockRateLimit
+            ->expects($this->once())
+            ->method('isAccepted')
+            ->willReturn(false);
+
+        $composite = new CompositeCapacityProvider(
+            $mockSemaphore,
+            $mockLimiter
+        );
+
+        $this->assertFalse($composite->tryAcquire());
+    }
+
+    public function testTryAcquireSucceedsWhenSemaphoreAndLimiterAreAvailable()
+    {
+        $mockSemaphore = $this->createMock(SemaphoreInterface::class);
+        $mockLimiter = $this->createMock(LimiterInterface::class);
+        $mockRateLimit = $this->createMock(RateLimit::class);
+
+        $mockSemaphore
+            ->expects($this->once())
+            ->method('acquire')
+            ->willReturn(true);
+
+        $mockLimiter
+            ->expects($this->once())
+            ->method('consume')
+            ->willReturn($mockRateLimit);
+
+        $mockRateLimit
+            ->expects($this->once())
+            ->method('isAccepted')
+            ->willReturn(true);
+
+        $composite = new CompositeCapacityProvider(
+            $mockSemaphore,
+            $mockLimiter
+        );
+
+        $this->assertTrue($composite->tryAcquire());
+    }
+
+    public function testReleaseCallsSemaphoreRelease()
+    {
+        $mockSemaphore = $this->createMock(SemaphoreInterface::class);
+
+        $composite = new CompositeCapacityProvider(
+            $mockSemaphore,
+            $this->createMock(LimiterInterface::class)
+        );
+
+        $mockSemaphore
+            ->expects($this->once())
+            ->method('release');
+
+        $composite->release();
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/Tests/Provider/ConcurrencyLimitedProviderTest.php
+++ b/src/platform/src/Bridge/LoadBalanced/Tests/Provider/ConcurrencyLimitedProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\ConcurrencyLimitedProvider;
+use Symfony\Component\Semaphore\SemaphoreInterface;
+
+class ConcurrencyLimitedProviderTest extends TestCase
+{
+    public function testTryAcquireCallsSemaphoreAcquire()
+    {
+        $mockSemaphore = $this->createMock(SemaphoreInterface::class);
+
+        $composite = new ConcurrencyLimitedProvider($mockSemaphore);
+
+        $mockSemaphore
+            ->expects($this->once())
+            ->method('acquire');
+
+        $composite->tryAcquire();
+    }
+
+    public function testReleaseCallsSemaphoreRelease()
+    {
+        $mockSemaphore = $this->createMock(SemaphoreInterface::class);
+
+        $composite = new ConcurrencyLimitedProvider($mockSemaphore);
+
+        $mockSemaphore
+            ->expects($this->once())
+            ->method('release');
+
+        $composite->release();
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/Tests/Provider/RateLimitedCapacityProviderTest.php
+++ b/src/platform/src/Bridge/LoadBalanced/Tests/Provider/RateLimitedCapacityProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\RateLimitedCapacityProvider;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+
+class RateLimitedCapacityProviderTest extends TestCase
+{
+    public function testTryAcquireCallsLimiterConsume()
+    {
+        $mockLimiter = $this->createMock(LimiterInterface::class);
+        $mockRateLimit = $this->createMock(RateLimit::class);
+
+        $mockLimiter
+            ->expects($this->once())
+            ->method('consume')
+            ->willReturn($mockRateLimit);
+
+        $mockRateLimit
+            ->expects($this->once())
+            ->method('isAccepted');
+
+        $capacityProvider = new RateLimitedCapacityProvider($mockLimiter);
+
+        $this->assertFalse($capacityProvider->tryAcquire());
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/Tests/Strategy/RandomStrategyTest.php
+++ b/src/platform/src/Bridge/LoadBalanced/Tests/Strategy/RandomStrategyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\LoadBalanced\Tests\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\LoadBalanced\PlatformCapacity;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\NoLimitCapacityProvider;
+use Symfony\AI\Platform\Bridge\LoadBalanced\Strategy\RandomStrategy;
+use Symfony\AI\Platform\PlatformInterface;
+
+class RandomStrategyTest extends TestCase
+{
+    public function testRandomStrategy()
+    {
+        $platforms = [
+            new PlatformCapacity($this->createMock(PlatformInterface::class), new NoLimitCapacityProvider()),
+            new PlatformCapacity($this->createMock(PlatformInterface::class), new NoLimitCapacityProvider()),
+            new PlatformCapacity($this->createMock(PlatformInterface::class), new NoLimitCapacityProvider()),
+        ];
+
+        $strategy = new RandomStrategy();
+        $result = iterator_to_array($strategy->order($platforms));
+
+        $this->assertCount(3, $result);
+        $this->assertEqualsCanonicalizing($platforms, $result);
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/composer.json
+++ b/src/platform/src/Bridge/LoadBalanced/composer.json
@@ -1,0 +1,60 @@
+{
+    "name": "symfony/ai-load-balanced-platform",
+    "description": "Load balanced platform bridge for Symfony AI",
+    "license": "MIT",
+    "type": "symfony-ai-platform",
+    "keywords": [
+        "ai",
+        "bridge",
+        "platform"
+    ],
+    "authors": [
+        {
+            "name": "Christopher Hertel",
+            "email": "mail@christopher-hertel.de"
+        },
+        {
+            "name": "Oskar Stark",
+            "email": "oskarstark@googlemail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/ai-platform": "^0.6",
+        "symfony/rate-limiter": "^7.3|^8.0",
+        "symfony/semaphore": "^7.3|^8.0"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.5.53"
+    },
+    "autoload": {
+        "psr-4": {
+            "Symfony\\AI\\Platform\\Bridge\\LoadBalanced\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\AI\\PHPStan\\": "../../../../../.phpstan/",
+            "Symfony\\AI\\Platform\\Bridge\\LoadBalanced\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "0.6.x-dev"
+        },
+        "thanks": {
+            "name": "symfony/ai",
+            "url": "https://github.com/symfony/ai"
+        }
+    }
+}

--- a/src/platform/src/Bridge/LoadBalanced/phpstan.dist.neon
+++ b/src/platform/src/Bridge/LoadBalanced/phpstan.dist.neon
@@ -1,0 +1,29 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../../../../../.phpstan/extension.neon
+
+parameters:
+    level: 6
+    paths:
+        - .
+        - Tests/
+    excludePaths:
+        - vendor/
+    treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+            reportUnmatched: false
+        -
+            message: '#^Call to( static)? method PHPUnit\\Framework\\Assert::.* will always evaluate to true\.$#'
+            reportUnmatched: false
+        -
+            identifier: 'symfonyAi.forbidNativeException'
+            path: Tests/*
+            reportUnmatched: false
+
+services:
+    - # Conditionally enabled by bleeding edge in phpstan/phpstan-phpunit 2.x
+        class: PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension
+        tags:
+            - phpstan.ignoreErrorExtension

--- a/src/platform/src/Bridge/LoadBalanced/phpunit.xml.dist
+++ b/src/platform/src/Bridge/LoadBalanced/phpunit.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         executionOrder="random"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony AI Load Balanced Platform Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| License       | MIT

This PR is a working proof-of-concept to gather feedback on the approach before I flesh it out further, add tests and documentation.

Adds a `LoadBalancedPlatform` that distributes requests across multiple platforms based on their available capacity.

## Use Case
I have multiple API keys across different providers (OpenAI, Anthropic, Bedrock) with varying rate limits and concurrency constraints. I want to fan out requests and have them distributed automatically whilst respecting each platform's limits.

More context: https://github.com/symfony/ai/issues/41#issuecomment-3794465762

## Design
Follows the same pattern as `FailoverPlatform`, but for capacity distribution rather than error recovery.

- `CapacityProvider` - abstracts capacity checking (rate limits, concurrency, or both)
- `PlatformCapacity` - pairs a platform with its capacity provider
- `PlatformSelectionStrategy`- determines platform ordering (random, round-robin, etc.)

## Open Questions

Model handling across providers
Currently the `$model` parameter is passed directly to whichever platform is selected. This works when balancing multiple keys for the same provider, but not when mixing providers (OpenAI/Anthropic/Bedrock) since model names differ.

Possible approaches:
1. Model-per-platform - PlatformCapacity specifies the model to use, request-level $model is ignored or used as a capability hint
2. Model mapping - translate a generic model name to provider-specific models
3. Document as a constraint - all configured platforms must support the requested model

Leaning towards option 1 for flexibility, but interested in feedback.

## Example usage 

```php
use Redis;
use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory as AnthropicPlatformFactory;
use Symfony\AI\Platform\Bridge\LoadBalanced\LoadBalancedPlatform;
use Symfony\AI\Platform\Bridge\LoadBalanced\PlatformCapacity;
use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\CompositeCapacityProvider;
use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\NoLimitCapacityProvider;
use Symfony\AI\Platform\Bridge\LoadBalanced\Provider\RateLimitedCapacityProvider;
use Symfony\AI\Platform\Bridge\LoadBalanced\Strategy\RandomStrategy;
use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory as OpenAiPlatformFactory;
use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory as BedrockPlatformFactory;
use Symfony\Component\RateLimiter\RateLimiterFactory;
use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
use Symfony\Component\Semaphore\SemaphoreFactory;
use Symfony\Component\Semaphore\Store\RedisStore;

// Create the underlying platforms
$openAi = OpenAiPlatformFactory::create('openai-api-key');
$anthropic = AnthropicPlatformFactory::create('anthropic-api-key');
$bedrock = BedrockPlatformFactory::create(...);

// Configure Semaphore factory for concurrency limits
$redis = new Redis();
$redis->connect('redis');
$semaphoreFactory = new SemaphoreFactory(new RedisStore($redis));

// Configure rate limiters
$sixtyPerMinuteLimit = new RateLimiterFactory([
    'policy' => 'fixed_window',
    'interval' => '1 minute',
    'limit' => 60,
], new InMemoryStorage());

$thirtyPerMinuteLimit = new RateLimiterFactory([
    'policy' => 'fixed_window',
    'interval' => '1 minute',
    'limit' => 30,
], new InMemoryStorage());

// Create the load balanced platform
$loadBalanced = new LoadBalancedPlatform([
    // 60 RPM
    new PlatformCapacity(
        $openAi,
        new RateLimitedCapacityProvider($sixtyPerMinuteLimit->create('openai')),
    ),
    // 30 RPM
    new PlatformCapacity(
        $anthropic,
        new RateLimitedCapacityProvider($thirtyPerMinuteLimit->create('anthropic')),
    ),
    // 60 RPM & 6 concurrent
    new PlatformCapacity(
        $bedrock,
        new CompositeCapacityProvider($semaphoreFactory->createSemaphore('bedrock', 6), $sixtyPerMinuteLimit->create('bedrock'))
    ),
], new RandomStrategy());

$result = $loadBalanced->invoke($model, $messages);
```

## Future Extensions
- `RoundRobinStrategy`, `PriorityStrategy`, `LeastConnectionsStrategy` etc
- Bundle configuration