### PR TITLE
[Store][MariaDB] Fix for invalid parameter number

### DIFF
--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -115,7 +115,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
                 <<<'SQL'
                     INSERT INTO %1$s (id, metadata, `%2$s`)
                     VALUES (:id, :metadata, VEC_FromText(:vector))
-                    ON DUPLICATE KEY UPDATE metadata = :metadata, `%2$s` = VEC_FromText(:vector)
+                    ON DUPLICATE KEY UPDATE metadata = :metadata2, `%2$s` = VEC_FromText(:vector2)
                     SQL,
                 $this->tableName,
                 $this->vectorFieldName,
@@ -126,6 +126,8 @@ final class Store implements ManagedStoreInterface, StoreInterface
             $statement->bindValue(':id', $document->getId());
             $statement->bindValue(':metadata', json_encode($document->getMetadata()->getArrayCopy()));
             $statement->bindValue(':vector', json_encode($document->getVector()->getData()));
+            $statement->bindValue(':metadata2', json_encode($document->getMetadata()->getArrayCopy()));
+            $statement->bindValue(':vector2', json_encode($document->getVector()->getData()));
 
             $statement->execute();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | No issue
| License       | MIT

When storing the documents in the MariaDB Store Bridge, the 'metadata' and 'vector' parameter names are bound 2 times, which isn't allowed and results in a 'SQLSTATE[HY093]: Invalid parameter number on PDO Statement' error. This fixes it.