### PR TITLE
[AI Bundle] Remove cache result normalizer if package is not available

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -538,6 +538,9 @@ final class AiBundle extends AbstractBundle
 
             return;
         }
+        if (!ContainerBuilder::willBeAvailable('symfony/ai-cache-platform', CachePlatform::class, ['symfony/ai-bundle'])) {
+            $container->removeDefinition('ai.platform.cache.result_normalizer');
+        }
 
         if ('cartesia' === $type) {
             if (!ContainerBuilder::willBeAvailable('symfony/ai-cartesia-platform', CartesiaPlatformFactory::class, ['symfony/ai-bundle'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1453
| License       | MIT

We need to remove it, when package is not available.