### PR TITLE
[Store] Expose chunk size and delay via construct to actually override via container

### DIFF
--- a/src/store/src/Document/Transformer/ChunkDelayTransformer.php
+++ b/src/store/src/Document/Transformer/ChunkDelayTransformer.php
@@ -27,6 +27,8 @@ final class ChunkDelayTransformer implements TransformerInterface
 
     public function __construct(
         private readonly ClockInterface $clock,
+        private readonly int $chunkSize = 50,
+        private readonly int $delay = 10,
     ) {
     }
 
@@ -35,8 +37,8 @@ final class ChunkDelayTransformer implements TransformerInterface
      */
     public function transform(iterable $documents, array $options = []): iterable
     {
-        $chunkSize = $options[self::OPTION_CHUNK_SIZE] ?? 50;
-        $delay = $options[self::OPTION_DELAY] ?? 10;
+        $chunkSize = $options[self::OPTION_CHUNK_SIZE] ?? $this->chunkSize;
+        $delay = $options[self::OPTION_DELAY] ?? $this->delay;
 
         $counter = 0;
         foreach ($documents as $document) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

It's not possible to use this transformer currently with indexer because the options are not exposed via constructor.