### PR TITLE
[Store] Make `Indexer` stateless by moving source to `index()` parameter

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,39 @@
+UPGRADE FROM 0.3 to 0.4
+=======================
+
+AI Bundle
+---------
+
+ * An indexer configured with a `source`, now wraps the indexer with a `ConfiguredIndexer` decorator. This is
+   transparent - the configured source is still used by default, but can be overridden by passing a source to `index()`.
+
+Store
+-----
+
+ * The `Indexer` class is now stateless. The `$source` constructor parameter and `withSource()` method have been removed.
+   Source is now passed directly to the `index()` method:
+
+   ```diff
+   -$indexer = new Indexer($loader, $vectorizer, $store, '/path/to/source');
+   -$indexer->index();
+   +$indexer = new Indexer($loader, $vectorizer, $store);
+   +$indexer->index('/path/to/source');
+   ```
+
+ * The `IndexerInterface::withSource()` method has been removed. Use the `$source` parameter of `index()` instead:
+
+   ```diff
+   -$indexer->withSource('/new/source')->index();
+   +$indexer->index('/new/source');
+   ```
+
+ * The `Indexer` constructor parameter order has changed. Filters and transformers have shifted positions:
+
+   ```diff
+   -new Indexer($loader, $vectorizer, $store, $source, $filters, $transformers, $logger);
+   +new Indexer($loader, $vectorizer, $store, $filters, $transformers, $logger);
+   ```
+
 UPGRADE FROM 0.2 to 0.3
 =======================
 

--- a/examples/indexer/index-file-loader.php
+++ b/examples/indexer/index-file-loader.php
@@ -26,18 +26,17 @@ $indexer = new Indexer(
     loader: new TextFileLoader(),
     vectorizer: $vectorizer,
     store: $store,
-    source: [
-        dirname(__DIR__, 2).'/fixtures/movies/gladiator.md',
-        dirname(__DIR__, 2).'/fixtures/movies/inception.md',
-        dirname(__DIR__, 2).'/fixtures/movies/jurassic-park.md',
-    ],
     transformers: [
         new TextReplaceTransformer(search: '## Plot', replace: '## Synopsis'),
         new TextSplitTransformer(chunkSize: 500, overlap: 100),
     ],
 );
 
-$indexer->index();
+$indexer->index([
+    dirname(__DIR__, 2).'/fixtures/movies/gladiator.md',
+    dirname(__DIR__, 2).'/fixtures/movies/inception.md',
+    dirname(__DIR__, 2).'/fixtures/movies/jurassic-park.md',
+]);
 
 $vector = $vectorizer->vectorize('Roman gladiator revenge');
 $results = $store->query($vector);

--- a/examples/indexer/index-inmemory-loader.php
+++ b/examples/indexer/index-inmemory-loader.php
@@ -42,7 +42,6 @@ $indexer = new Indexer(
     loader: new InMemoryLoader($documents),
     vectorizer: $vectorizer,
     store: $store,
-    source: null,
     transformers: [
         new TextSplitTransformer(chunkSize: 100, overlap: 20),
     ],

--- a/examples/indexer/index-rss-loader.php
+++ b/examples/indexer/index-rss-loader.php
@@ -26,16 +26,15 @@ $indexer = new Indexer(
     loader: new RssFeedLoader(HttpClient::create()),
     vectorizer: $vectorizer,
     store: $store,
-    source: [
-        'https://feeds.feedburner.com/symfony/blog',
-        'https://www.tagesschau.de/index~rss2.xml',
-    ],
     transformers: [
         new TextSplitTransformer(chunkSize: 500, overlap: 100),
     ],
 );
 
-$indexer->index();
+$indexer->index([
+    'https://feeds.feedburner.com/symfony/blog',
+    'https://www.tagesschau.de/index~rss2.xml',
+]);
 
 $vector = $vectorizer->vectorize('Week of Symfony');
 $results = $store->query($vector);

--- a/examples/indexer/index-with-filters.php
+++ b/examples/indexer/index-with-filters.php
@@ -60,7 +60,6 @@ $indexer = new Indexer(
     loader: new InMemoryLoader($documents),
     vectorizer: $vectorizer,
     store: $store,
-    source: null,
     filters: $filters,
     transformers: [
         new TextTrimTransformer(),

--- a/examples/memory/mariadb.php
+++ b/examples/memory/mariadb.php
@@ -58,7 +58,7 @@ $store->setup();
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, $embeddings = 'text-embedding-3-small');
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 // Execute a chat call that is utilizing the memory
 $embeddingsModel = $platform->getModelCatalog()->getModel($embeddings);

--- a/examples/ollama/indexer.php
+++ b/examples/ollama/indexer.php
@@ -26,18 +26,17 @@ $indexer = new Indexer(
     loader: new TextFileLoader(),
     vectorizer: $vectorizer,
     store: $store,
-    source: [
-        dirname(__DIR__, 2).'/fixtures/movies/gladiator.md',
-        dirname(__DIR__, 2).'/fixtures/movies/inception.md',
-        dirname(__DIR__, 2).'/fixtures/movies/jurassic-park.md',
-    ],
     transformers: [
         new TextReplaceTransformer(search: '## Plot', replace: '## Synopsis'),
         new TextSplitTransformer(chunkSize: 500, overlap: 100),
     ],
 );
 
-$indexer->index();
+$indexer->index([
+    dirname(__DIR__, 2).'/fixtures/movies/gladiator.md',
+    dirname(__DIR__, 2).'/fixtures/movies/inception.md',
+    dirname(__DIR__, 2).'/fixtures/movies/jurassic-park.md',
+]);
 
 $vector = $vectorizer->vectorize('Roman gladiator revenge');
 $results = $store->query($vector);

--- a/examples/ollama/rag.php
+++ b/examples/ollama/rag.php
@@ -44,7 +44,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create(env('OLLAMA_HOST_URL'), http_client());
 $vectorizer = new Vectorizer($platform, env('OLLAMA_EMBEDDINGS'), logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/cache.php
+++ b/examples/rag/cache.php
@@ -45,7 +45,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/chromadb.php
+++ b/examples/rag/chromadb.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/clickhouse.php
+++ b/examples/rag/clickhouse.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/cloudflare.php
+++ b/examples/rag/cloudflare.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/elasticsearch.php
+++ b/examples/rag/elasticsearch.php
@@ -51,7 +51,7 @@ $store->setup();
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/in-memory.php
+++ b/examples/rag/in-memory.php
@@ -44,7 +44,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/manticore.php
+++ b/examples/rag/manticore.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/mariadb-gemini.php
+++ b/examples/rag/mariadb-gemini.php
@@ -54,7 +54,7 @@ $platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
 $model = 'gemini-embedding-exp-03-07?dimensions=768&task_type=SEMANTIC_SIMILARITY';
 $vectorizer = new Vectorizer($platform, $model, logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/mariadb-openai.php
+++ b/examples/rag/mariadb-openai.php
@@ -53,7 +53,7 @@ $store->setup();
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/meilisearch-hybrid.php
+++ b/examples/rag/meilisearch-hybrid.php
@@ -51,7 +51,7 @@ $store->setup();
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 // Create a query embedding
 $queryText = 'futuristic technology and artificial intelligence';

--- a/examples/rag/meilisearch.php
+++ b/examples/rag/meilisearch.php
@@ -52,7 +52,7 @@ $store->setup();
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/milvus.php
+++ b/examples/rag/milvus.php
@@ -53,7 +53,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/mongodb.php
+++ b/examples/rag/mongodb.php
@@ -51,7 +51,7 @@ foreach (Movies::all() as $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'));
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 // initialize the index
 $store->setup();

--- a/examples/rag/neo4j.php
+++ b/examples/rag/neo4j.php
@@ -55,7 +55,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/opensearch.php
+++ b/examples/rag/opensearch.php
@@ -51,7 +51,7 @@ $store->setup();
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/pinecone.php
+++ b/examples/rag/pinecone.php
@@ -45,7 +45,7 @@ foreach (Movies::all() as $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/postgres.php
+++ b/examples/rag/postgres.php
@@ -52,7 +52,7 @@ $store->setup();
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/qdrant.php
+++ b/examples/rag/qdrant.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/redis.php
+++ b/examples/rag/redis.php
@@ -54,7 +54,7 @@ $store->setup(['vector_size' => 1536]);
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/surrealdb.php
+++ b/examples/rag/surrealdb.php
@@ -55,7 +55,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create($_SERVER['OPENAI_API_KEY']);
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/typesense.php
+++ b/examples/rag/typesense.php
@@ -52,7 +52,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/rag/weaviate.php
+++ b/examples/rag/weaviate.php
@@ -53,7 +53,7 @@ foreach (Movies::all() as $i => $movie) {
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new Indexer(new InMemoryLoader($documents), $vectorizer, $store, logger: logger());
-$indexer->index($documents);
+$indexer->index();
 
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());

--- a/examples/retriever/basic.php
+++ b/examples/retriever/basic.php
@@ -28,16 +28,15 @@ $indexer = new Indexer(
     loader: new TextFileLoader(),
     vectorizer: $vectorizer,
     store: $store,
-    source: [
-        dirname(__DIR__, 2).'/fixtures/movies/gladiator.md',
-        dirname(__DIR__, 2).'/fixtures/movies/inception.md',
-        dirname(__DIR__, 2).'/fixtures/movies/jurassic-park.md',
-    ],
     transformers: [
         new TextSplitTransformer(chunkSize: 500, overlap: 100),
     ],
 );
-$indexer->index();
+$indexer->index([
+    dirname(__DIR__, 2).'/fixtures/movies/gladiator.md',
+    dirname(__DIR__, 2).'/fixtures/movies/inception.md',
+    dirname(__DIR__, 2).'/fixtures/movies/jurassic-park.md',
+]);
 
 $retriever = new Retriever(
     vectorizer: $vectorizer,

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add `StoreInterface::remove()` method
+ * [BC BREAK] Make `Indexer` stateless - removed `$source` constructor parameter and `withSource()` method
+ * Add `ConfiguredIndexer` decorator for pre-configuring default sources
 
 0.3
 ---

--- a/src/store/src/Command/IndexCommand.php
+++ b/src/store/src/Command/IndexCommand.php
@@ -88,14 +88,10 @@ EOF
 
         $indexerService = $this->indexers->get($indexer);
 
-        if (null !== $source) {
-            $indexerService = $indexerService->withSource($source);
-        }
-
         $io->title(\sprintf('Indexing documents using "%s" indexer', $indexer));
 
         try {
-            $indexerService->index([]);
+            $indexerService->index($source);
 
             $io->success(\sprintf('Documents indexed successfully using "%s" indexer.', $indexer));
         } catch (\Exception $e) {

--- a/src/store/src/ConfiguredIndexer.php
+++ b/src/store/src/ConfiguredIndexer.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store;
+
+/**
+ * Decorator that wraps an IndexerInterface with a pre-configured default source.
+ *
+ * This is useful for bundle configuration where the source is defined in YAML/PHP config
+ * but can still be overridden at runtime by passing a source to index().
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ConfiguredIndexer implements IndexerInterface
+{
+    /**
+     * @param string|array<string>|null $defaultSource Default source to use when none is provided to index()
+     */
+    public function __construct(
+        private IndexerInterface $indexer,
+        private string|array|null $defaultSource = null,
+    ) {
+    }
+
+    public function index(string|array|null $source = null, array $options = []): void
+    {
+        $this->indexer->index($source ?? $this->defaultSource, $options);
+    }
+}

--- a/src/store/src/IndexerInterface.php
+++ b/src/store/src/IndexerInterface.php
@@ -21,14 +21,8 @@ interface IndexerInterface
     /**
      * Process sources through the complete document pipeline: load → transform → vectorize → store.
      *
+     * @param string|array<string>|null                                        $source  Source identifier (file path, URL, etc.) or array of sources
      * @param array{chunk_size?: int, platform_options?: array<string, mixed>} $options Processing options
      */
-    public function index(array $options = []): void;
-
-    /**
-     * Create a new instance with a different source.
-     *
-     * @param string|array<string> $source Source identifier (file path, URL, etc.) or array of sources
-     */
-    public function withSource(string|array $source): self;
+    public function index(string|array|null $source = null, array $options = []): void;
 }

--- a/src/store/tests/ConfiguredIndexerTest.php
+++ b/src/store/tests/ConfiguredIndexerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\ConfiguredIndexer;
+use Symfony\AI\Store\Document\Loader\InMemoryLoader;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Indexer;
+use Symfony\AI\Store\Tests\Double\PlatformTestHandler;
+use Symfony\AI\Store\Tests\Double\TestStore;
+use Symfony\Component\Uid\Uuid;
+
+final class ConfiguredIndexerTest extends TestCase
+{
+    public function testIndexUsesDefaultSourceWhenNoneProvided()
+    {
+        $document = new TextDocument(Uuid::v4(), 'Test content');
+        $vector = new Vector([0.1, 0.2, 0.3]);
+        $loader = new InMemoryLoader([$document]);
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), 'text-embedding-3-small');
+
+        $innerIndexer = new Indexer($loader, $vectorizer, $store = new TestStore());
+        $configuredIndexer = new ConfiguredIndexer($innerIndexer, 'default-source');
+
+        // When calling index() without source, it should use the default source
+        $configuredIndexer->index();
+
+        $this->assertCount(1, $store->documents);
+    }
+
+    public function testIndexOverridesDefaultSourceWhenProvided()
+    {
+        $document = new TextDocument(Uuid::v4(), 'Test content');
+        $vector = new Vector([0.1, 0.2, 0.3]);
+        $loader = new InMemoryLoader([$document]);
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), 'text-embedding-3-small');
+
+        $innerIndexer = new Indexer($loader, $vectorizer, $store = new TestStore());
+        $configuredIndexer = new ConfiguredIndexer($innerIndexer, 'default-source');
+
+        // When calling index() with a source, it should override the default
+        $configuredIndexer->index('override-source');
+
+        $this->assertCount(1, $store->documents);
+    }
+
+    public function testIndexWithNullDefaultSource()
+    {
+        $document = new TextDocument(Uuid::v4(), 'Test content');
+        $vector = new Vector([0.1, 0.2, 0.3]);
+        $loader = new InMemoryLoader([$document]);
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), 'text-embedding-3-small');
+
+        $innerIndexer = new Indexer($loader, $vectorizer, $store = new TestStore());
+        $configuredIndexer = new ConfiguredIndexer($innerIndexer, null);
+
+        // When no default source is set and none provided, it should work
+        $configuredIndexer->index();
+
+        $this->assertCount(1, $store->documents);
+    }
+
+    public function testIndexWithArrayDefaultSource()
+    {
+        $document1 = new TextDocument(Uuid::v4(), 'Document 1');
+        $document2 = new TextDocument(Uuid::v4(), 'Document 2');
+        $vector1 = new Vector([0.1, 0.2, 0.3]);
+        $vector2 = new Vector([0.4, 0.5, 0.6]);
+        $vector3 = new Vector([0.7, 0.8, 0.9]);
+        $vector4 = new Vector([1.0, 1.1, 1.2]);
+        $loader = new InMemoryLoader([$document1, $document2]);
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector1, $vector2, $vector3, $vector4)), 'text-embedding-3-small');
+
+        $innerIndexer = new Indexer($loader, $vectorizer, $store = new TestStore());
+        $configuredIndexer = new ConfiguredIndexer($innerIndexer, ['source1', 'source2']);
+
+        // When default source is an array, it should be used
+        $configuredIndexer->index();
+
+        // InMemoryLoader ignores source, so 2 sources * 2 docs = 4 docs
+        $this->assertCount(4, $store->documents);
+    }
+
+    public function testIndexPassesOptionsToInnerIndexer()
+    {
+        $documents = [];
+        for ($i = 0; $i < 100; ++$i) {
+            $documents[] = new TextDocument(Uuid::v4(), 'Document '.$i, new Metadata(['index' => $i]));
+        }
+
+        $vectors = [];
+        for ($i = 0; $i < 100; ++$i) {
+            $vectors[] = new Vector([0.1 * $i, 0.2 * $i, 0.3 * $i]);
+        }
+
+        $loader = new InMemoryLoader($documents);
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult(...$vectors)), 'text-embedding-3-small');
+
+        $innerIndexer = new Indexer($loader, $vectorizer, $store = new TestStore());
+        $configuredIndexer = new ConfiguredIndexer($innerIndexer, 'default-source');
+
+        // Pass custom chunk_size option
+        $configuredIndexer->index(null, ['chunk_size' => 10]);
+
+        $this->assertCount(100, $store->documents);
+        // With chunk_size 10 and 100 documents, there should be 10 add calls
+        $this->assertSame(10, $store->addCalls);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #911 ; fix #875
| License       | MIT

## Summary

- Make `Indexer` stateless by removing `$sources` property and `$source` constructor parameter
- Add `$source` parameter to `index()` method instead of storing it in the constructor
- Remove `withSource()` method from `IndexerInterface`
- Add `ConfiguredIndexer` decorator for bundle configuration backward compatibility

## Motivation

The `Indexer` was a stateful service due to the `$sources` member being stored in the constructor. Stateful services are generally a bad practice in Symfony applications. The source is only used as input for the `LoaderInterface`, which already accepts it as a parameter.

## Changes

**Store Component:**
- `IndexerInterface`: Removed `withSource()`, added `$source` parameter to `index()`
- `Indexer`: Removed `$sources` property and constructor parameter, now stateless
- `ConfiguredIndexer`: New decorator that holds default source for bundle config
- `IndexCommand`: Passes source directly to `index()` instead of `withSource()`

**AI Bundle:**
- When `source` is configured in YAML, wraps indexer with `ConfiguredIndexer`
- Inner indexer registered as `ai.indexer.<name>.inner` when source is present

## Test plan

- [x] All existing `IndexerTest` tests updated and passing
- [x] New `ConfiguredIndexerTest` with tests for the decorator
- [x] All `AiBundleTest` indexer tests updated and passing
- [x] PHP-CS-Fixer applied

🤖 Generated with [Claude Code](https://claude.ai/claude-code)