### PR TITLE
 Add `LICENSE` year validation for new bridge files

### DIFF
--- a/.github/scripts/validate-bridge-files.sh
+++ b/.github/scripts/validate-bridge-files.sh
@@ -36,6 +36,7 @@ REQUIRED_FILES=(
 )
 
 ERRORS=0
+CURRENT_YEAR=$(date +%Y)
 
 echo "Validating ${BRIDGE_TYPE} bridges have required files (${BRIDGE_PATH})..."
 echo ""
@@ -57,16 +58,39 @@ for bridge_dir in ${BRIDGE_PATH}/; do
         fi
     done
 
+    # Check newly added LICENSE files have correct first line
+    license_file="${bridge_dir}LICENSE"
+    if [[ -f "$license_file" ]]; then
+        # Determine base ref for comparison (PR base branch or default branch)
+        if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+            BASE_REF="origin/${GITHUB_BASE_REF}"
+        else
+            BASE_REF="origin/main"
+        fi
+
+        # Check if LICENSE file is newly added (not in base branch)
+        # Use git show which works with shallow clones if base is fetched
+        if ! git show "${BASE_REF}:${license_file}" &>/dev/null; then
+            expected_first_line="Copyright (c) ${CURRENT_YEAR}-present Fabien Potencier"
+            actual_first_line=$(head -n 1 "$license_file")
+            if [[ "$actual_first_line" != "$expected_first_line" ]]; then
+                echo "::error file=${license_file}::${BRIDGE_TYPE} bridge '$bridge_name' LICENSE file first line must be '${expected_first_line}'"
+                bridge_errors=$((bridge_errors + 1))
+                ERRORS=$((ERRORS + 1))
+            fi
+        fi
+    fi
+
     if [[ $bridge_errors -eq 0 ]]; then
-        echo "✓ $bridge_name: all required files present"
+        echo "✓ $bridge_name: all required files present and valid"
     fi
 done
 
 if [[ $ERRORS -gt 0 ]]; then
     echo ""
-    echo "::error::Found $ERRORS missing required file(s) in ${BRIDGE_TYPE} bridges"
+    echo "::error::Found $ERRORS validation error(s) in ${BRIDGE_TYPE} bridges"
     exit 1
 fi
 
 echo ""
-echo "All ${BRIDGE_TYPE} bridges have required files!"
+echo "All ${BRIDGE_TYPE} bridges have required files and valid content!"

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -34,6 +34,9 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
 
+            - name: Fetch base branch for LICENSE validation
+              run: git fetch origin ${{ github.base_ref || 'main' }} --depth=1
+
             - name: Validate store bridge naming conventions
               run: .github/scripts/validate-bridge-naming.sh store store src/ai-bundle/config/options.php
 
@@ -52,6 +55,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v6
+
+            - name: Fetch base branch for LICENSE validation
+              run: git fetch origin ${{ github.base_ref || 'main' }} --depth=1
 
             - name: Validate tool bridge naming conventions
               run: .github/scripts/validate-bridge-naming.sh tool agent
@@ -72,6 +78,9 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
 
+            - name: Fetch base branch for LICENSE validation
+              run: git fetch origin ${{ github.base_ref || 'main' }} --depth=1
+
             - name: Validate message store bridge naming conventions
               run: .github/scripts/validate-bridge-naming.sh message-store chat
 
@@ -91,6 +100,9 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
 
+            - name: Fetch base branch for LICENSE validation
+              run: git fetch origin ${{ github.base_ref || 'main' }} --depth=1
+
             - name: Validate platform bridge naming conventions
               run: .github/scripts/validate-bridge-naming.sh platform platform
 
@@ -109,6 +121,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v6
+
+            - name: Fetch base branch for LICENSE validation
+              run: git fetch origin ${{ github.base_ref || 'main' }} --depth=1
 
             - name: Validate Mate bridge naming conventions
               run: .github/scripts/validate-bridge-naming.sh mate-extension mate


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Validate that newly added LICENSE files have the correct first line format: "Copyright (c) {YEAR}-present Fabien Potencier" where YEAR is the current year. Existing and modified LICENSE files are not affected by this check.