### PR TITLE
[Store] Make loader optional in Indexer when passing documents directly

### DIFF
--- a/examples/indexer/index-direct-documents.php
+++ b/examples/indexer/index-direct-documents.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\Transformer\TextSplitTransformer;
+use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Indexer;
+use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\Component\Uid\Uuid;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+$store = new InMemoryStore();
+$vectorizer = new Vectorizer($platform, 'text-embedding-3-small');
+
+// Create documents that we want to index
+$documents = [
+    new TextDocument(
+        Uuid::v4(),
+        'Artificial Intelligence is transforming the way we work and live. Machine learning algorithms can now process vast amounts of data and make predictions with remarkable accuracy.',
+        new Metadata(['title' => 'AI Revolution'])
+    ),
+    new TextDocument(
+        Uuid::v4(),
+        'Climate change is one of the most pressing challenges of our time. Renewable energy sources like solar and wind power are becoming increasingly important for a sustainable future.',
+        new Metadata(['title' => 'Climate Action'])
+    ),
+];
+
+// Create indexer WITHOUT a loader - documents will be passed directly
+$indexer = new Indexer(
+    vectorizer: $vectorizer,
+    store: $store,
+    transformers: [
+        new TextSplitTransformer(chunkSize: 100, overlap: 20),
+    ],
+);
+
+// Index documents directly - no loader needed
+$indexer->index($documents);
+
+// Query the store
+$vector = $vectorizer->vectorize('machine learning artificial intelligence');
+$results = $store->query($vector);
+
+output()->writeln('<info>Direct Document Indexing Example</info>');
+output()->writeln('Indexed '.count($documents).' documents directly without using a loader.');
+output()->writeln('');
+output()->writeln('Query results for "machine learning artificial intelligence":');
+foreach ($results as $i => $document) {
+    output()->writeln(sprintf('  %d. %s...', $i + 1, substr($document->id, 0, 40)));
+}

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Add `StoreInterface::remove()` method
  * [BC BREAK] Make `Indexer` stateless - removed `$source` constructor parameter and `withSource()` method
  * Add `ConfiguredIndexer` decorator for pre-configuring default sources
+ * [BC BREAK] Reorder `Indexer` constructor parameters and make `$loader` optional
+ * Add support for passing documents directly to `Indexer::index()` without requiring a loader
 
 0.3
 ---

--- a/src/store/src/Indexer.php
+++ b/src/store/src/Indexer.php
@@ -18,6 +18,7 @@ use Symfony\AI\Store\Document\FilterInterface;
 use Symfony\AI\Store\Document\LoaderInterface;
 use Symfony\AI\Store\Document\TransformerInterface;
 use Symfony\AI\Store\Document\VectorizerInterface;
+use Symfony\AI\Store\Exception\RuntimeException;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -30,28 +31,21 @@ class Indexer implements IndexerInterface
      * @param TransformerInterface[] $transformers Transformers to mutate documents after filtering (chunking, cleaning, etc.)
      */
     public function __construct(
-        private LoaderInterface $loader,
         private VectorizerInterface $vectorizer,
         private StoreInterface $store,
+        private ?LoaderInterface $loader = null,
         private array $filters = [],
         private array $transformers = [],
         private LoggerInterface $logger = new NullLogger(),
     ) {
     }
 
-    public function index(string|array|null $source = null, array $options = []): void
+    public function index(string|array|EmbeddableDocumentInterface|null $source = null, array $options = []): void
     {
-        $sources = null === $source ? [null] : (array) $source;
-
-        $this->logger->debug('Starting document processing', ['sources' => $sources, 'options' => $options]);
-
-        $documents = [];
-        foreach ($sources as $singleSource) {
-            $documents = array_merge($documents, $this->loadSource($singleSource));
-        }
+        $documents = $this->resolveDocuments($source);
 
         if ([] === $documents) {
-            $this->logger->debug('No documents to process', ['sources' => $sources]);
+            $this->logger->debug('No documents to process');
 
             return;
         }
@@ -85,10 +79,98 @@ class Indexer implements IndexerInterface
     }
 
     /**
+     * Resolve the source parameter into an array of documents.
+     *
+     * @param string|array<string>|EmbeddableDocumentInterface|array<EmbeddableDocumentInterface>|null $source
+     *
+     * @return EmbeddableDocumentInterface[]
+     */
+    private function resolveDocuments(string|array|EmbeddableDocumentInterface|null $source): array
+    {
+        // Direct document(s) passed - no loader needed
+        if ($source instanceof EmbeddableDocumentInterface) {
+            $this->logger->debug('Processing single document directly');
+
+            return [$source];
+        }
+
+        // Check if array contains documents or sources (or is empty)
+        if (\is_array($source)) {
+            // Empty array - no documents to process, no loader needed
+            if ([] === $source) {
+                $this->logger->debug('Empty document array provided');
+
+                return [];
+            }
+
+            $firstElement = reset($source);
+            if ($firstElement instanceof EmbeddableDocumentInterface) {
+                $this->logger->debug('Processing document array directly', ['count' => \count($source)]);
+
+                return $this->filterDocuments($source);
+            }
+
+            // Array contains strings - will be processed by the loader below
+            // We know $firstElement is string here since it's not EmbeddableDocumentInterface
+            \assert(\is_string($firstElement));
+            $stringSources = array_filter($source, 'is_string');
+
+            return $this->loadFromSources($stringSources);
+        }
+
+        // Source string or null - loader is required
+        return $this->loadFromSources(null === $source ? [null] : [$source]);
+    }
+
+    /**
+     * Filter array to only include EmbeddableDocumentInterface instances.
+     *
+     * @param array<mixed> $source
+     *
+     * @return EmbeddableDocumentInterface[]
+     */
+    private function filterDocuments(array $source): array
+    {
+        $documents = [];
+        foreach ($source as $item) {
+            if ($item instanceof EmbeddableDocumentInterface) {
+                $documents[] = $item;
+            }
+        }
+
+        return $documents;
+    }
+
+    /**
+     * Load documents from source strings using the loader.
+     *
+     * @param array<string|null> $sources
+     *
+     * @return EmbeddableDocumentInterface[]
+     */
+    private function loadFromSources(array $sources): array
+    {
+        if (null === $this->loader) {
+            throw new RuntimeException('A loader is required when indexing from sources. Either provide a loader in the constructor or pass documents directly.');
+        }
+
+        $this->logger->debug('Loading documents from sources', ['sources' => $sources]);
+
+        $documents = [];
+        foreach ($sources as $singleSource) {
+            $documents = array_merge($documents, $this->loadSource($singleSource));
+        }
+
+        return $documents;
+    }
+
+    /**
      * @return EmbeddableDocumentInterface[]
      */
     private function loadSource(?string $source): array
     {
+        \assert(null !== $this->loader);
+
         $documents = [];
         foreach ($this->loader->load($source) as $document) {
             $documents[] = $document;

--- a/src/store/src/IndexerInterface.php
+++ b/src/store/src/IndexerInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Store;
 
+use Symfony\AI\Store\Document\EmbeddableDocumentInterface;
+
 /**
  * Handles the complete document processing pipeline: load → transform → vectorize → store.
  *
@@ -19,10 +21,12 @@ namespace Symfony\AI\Store;
 interface IndexerInterface
 {
     /**
-     * Process sources through the complete document pipeline: load → transform → vectorize → store.
+     * Process sources or documents through the complete document pipeline: (load →) filter → transform → vectorize → store.
      *
-     * @param string|array<string>|null                                        $source  Source identifier (file path, URL, etc.) or array of sources
-     * @param array{chunk_size?: int, platform_options?: array<string, mixed>} $options Processing options
+     * When passing documents directly, the loader is bypassed.
+     *
+     * @param string|array<string>|EmbeddableDocumentInterface|array<EmbeddableDocumentInterface>|null $source  Source identifier (file path, URL, etc.), array of sources, or document(s) to index directly
+     * @param array{chunk_size?: int, platform_options?: array<string, mixed>}                         $options Processing options
      */
-    public function index(string|array|null $source = null, array $options = []): void;
+    public function index(string|array|EmbeddableDocumentInterface|null $source = null, array $options = []): void;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

## Summary

Allow callers to pass `TextDocument` or `TextDocument[]` directly to `Indexer::index()`, bypassing the loader. This is useful when documents are already available in memory and don't need to be loaded from an external source.

### Changes

- Reorder `Indexer` constructor: `(vectorizer, store, loader?, filters, transformers, logger)`
- Make `$loader` parameter optional (nullable)
- Accept `EmbeddableDocumentInterface|array<EmbeddableDocumentInterface>` in `index()` method
- Throw `RuntimeException` when using source strings without a configured loader
- Add example demonstrating direct document indexing

### Usage

```php
// Without loader - passing documents directly
$indexer = new Indexer($vectorizer, $store);
$indexer->index($textDocument);
$indexer->index([$document1, $document2]);

// With loader (existing behavior, using named parameters)
$indexer = new Indexer(
    vectorizer: $vectorizer,
    store: $store,
    loader: $loader,
);
$indexer->index('path/to/file.txt');
```

## Test plan

- [x] All existing Indexer tests pass
- [x] New tests for direct document indexing
- [x] New tests for error handling when loader is missing
- [x] PHP syntax validation on all examples

🤖 Generated with [Claude Code](https://claude.ai/claude-code)