### PR TITLE
[Mate] Consolidate profiler documentation into Symfony bridge

### DIFF
--- a/src/mate/README.md
+++ b/src/mate/README.md
@@ -15,7 +15,8 @@ https://github.com/symfony/ai to create issues or submit pull requests.
 
 ## Resources
 
- * [Contributing](https://symfony.com/doc/current/contributing/index.html)
- * [Report issues](https://github.com/symfony/ai/issues) and
-   [send Pull Requests](https://github.com/symfony/ai/pulls)
-   in the [main Symfony AI repository](https://github.com/symfony/ai)
+- [Documentation](https://symfony.com/doc/current/ai/components/mate.html)
+- [Report issues](https://github.com/symfony/ai/issues) and
+  [send Pull Requests](https://github.com/symfony/ai/pulls)
+  in the [main Symfony AI repository](https://github.com/symfony/ai)
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | N/A
| License       | MIT

## Summary

- Remove incorrect 'Profiler Bridge' section (symfony/ai-profiler-mate-extension does not exist)
- Add profiler tools and resources to Symfony Bridge section as optional features
- Profiler functionality is part of symfony/ai-symfony-mate-extension, not a separate package
- Update mate README.md with documentation link and proper formatting
- Update formatting to match other component READMEs (use dashes, add docs link)

The profiler tools (symfony-profiler-list, symfony-profiler-latest, symfony-profiler-search, symfony-profiler-get) and resources (symfony-profiler://profile/{token}) are now correctly documented as optional features of the Symfony bridge that activate when symfony/http-kernel is installed.
