### PR TITLE
[Mate] Refactor command registration to use service container

### DIFF
--- a/demo/mate/config.php
+++ b/demo/mate/config.php
@@ -16,7 +16,12 @@ return static function (ContainerConfigurator $container): void {
     ;
 
     $container->services()
+        ->defaults()
+            ->autowire()
+            ->autoconfigure()
+
         ->set(SymfonyAiFeaturesTool::class)
-        ->arg('$projectDir', param('mate.root_dir'))
-        ->public();
+            ->arg('$projectDir', param('mate.root_dir'))
+            ->public()
+    ;
 };

--- a/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
+++ b/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
@@ -31,7 +31,7 @@ final class LogSearchTool
     }
 
     /**
-     * @phpstan-return list<LogEntryArray>
+     * @phpstan-return array{entries: list<LogEntryArray>}
      */
     #[McpTool('monolog-search', 'Search log entries by text term with optional level, channel, environment, and date filters')]
     public function search(
@@ -52,11 +52,11 @@ final class LogSearchTool
             limit: $limit,
         );
 
-        return $this->collectResults($criteria, $environment);
+        return ['entries' => $this->collectResults($criteria, $environment)];
     }
 
     /**
-     * @phpstan-return list<LogEntryArray>
+     * @phpstan-return array{entries: list<LogEntryArray>}
      */
     #[McpTool('monolog-search-regex', 'Search log entries using a regex pattern')]
     public function searchRegex(
@@ -78,11 +78,11 @@ final class LogSearchTool
             limit: $limit,
         );
 
-        return $this->collectResults($criteria, $environment);
+        return ['entries' => $this->collectResults($criteria, $environment)];
     }
 
     /**
-     * @phpstan-return list<LogEntryArray>
+     * @phpstan-return array{entries: list<LogEntryArray>}
      */
     #[McpTool('monolog-context-search', 'Search logs by context field value')]
     public function searchContext(
@@ -99,27 +99,27 @@ final class LogSearchTool
             limit: $limit,
         );
 
-        return $this->collectResults($criteria, $environment);
+        return ['entries' => $this->collectResults($criteria, $environment)];
     }
 
     /**
-     * @phpstan-return list<LogEntryArray>
+     * @phpstan-return array{entries: list<LogEntryArray>}
      */
     #[McpTool('monolog-tail', 'Get the last N log entries')]
     public function tail(int $lines = 50, ?string $level = null, ?string $environment = null): array
     {
         $entries = $this->reader->tail($lines, $level, $environment);
 
-        return array_values(array_map(static fn ($entry) => $entry->toArray(), $entries));
+        return ['entries' => array_values(array_map(static fn ($entry) => $entry->toArray(), $entries))];
     }
 
     /**
-     * @return array<int, array{
+     * @return array{files: array<int, array{
      *     name: string,
      *     path: string,
      *     size: int,
      *     modified: string
-     * }>
+     * }>}
      */
     #[McpTool('monolog-list-files', 'List available log files, optionally filtered by environment')]
     public function listFiles(?string $environment = null): array
@@ -138,22 +138,22 @@ final class LogSearchTool
             ];
         }
 
-        return $result;
+        return ['files' => $result];
     }
 
     /**
-     * @return string[]
+     * @return array{channels: string[]}
      */
     #[McpTool('monolog-list-channels', 'List all log channels found in log files')]
     public function listChannels(): array
     {
-        return $this->reader->getUniqueChannels();
+        return ['channels' => $this->reader->getUniqueChannels()];
     }
 
     /**
      * Get log entries by level (e.g., all ERROR logs).
      *
-     * @phpstan-return list<LogEntryArray>
+     * @phpstan-return array{entries: list<LogEntryArray>}
      */
     #[McpTool('monolog-by-level', 'Get log entries filtered by level (DEBUG, INFO, WARNING, ERROR, etc.)')]
     public function byLevel(string $level, ?string $environment = null, int $limit = 100): array
@@ -163,7 +163,7 @@ final class LogSearchTool
             limit: $limit,
         );
 
-        return $this->collectResults($criteria, $environment);
+        return ['entries' => $this->collectResults($criteria, $environment)];
     }
 
     /**

--- a/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
@@ -34,38 +34,42 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchByTextTerm()
     {
-        $results = $this->tool->search('logged in');
+        $result = $this->tool->search('logged in');
 
-        $this->assertNotEmpty($results);
-        $this->assertCount(1, $results);
-        $this->assertStringContainsString('User logged in', $results[0]['message']);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
+        $this->assertCount(1, $result['entries']);
+        $this->assertStringContainsString('User logged in', $result['entries'][0]['message']);
     }
 
     public function testSearchByTextTermReturnsEmptyWhenNotFound()
     {
-        $results = $this->tool->search('nonexistent search term xyz');
+        $result = $this->tool->search('nonexistent search term xyz');
 
-        $this->assertEmpty($results);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertEmpty($result['entries']);
     }
 
     public function testSearchByLevel()
     {
-        $results = $this->tool->search('', level: 'ERROR');
+        $result = $this->tool->search('', level: 'ERROR');
 
-        $this->assertNotEmpty($results);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
 
-        foreach ($results as $entry) {
+        foreach ($result['entries'] as $entry) {
             $this->assertSame('ERROR', $entry['level']);
         }
     }
 
     public function testSearchByChannel()
     {
-        $results = $this->tool->search('', channel: 'security');
+        $result = $this->tool->search('', channel: 'security');
 
-        $this->assertNotEmpty($results);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
 
-        foreach ($results as $entry) {
+        foreach ($result['entries'] as $entry) {
             $this->assertSame('security', $entry['channel']);
         }
     }
@@ -78,73 +82,82 @@ final class LogSearchToolTest extends TestCase
 
     public function testSearchWithLimit()
     {
-        $results = $this->tool->search('', limit: 2);
+        $result = $this->tool->search('', limit: 2);
 
-        $this->assertLessThanOrEqual(2, \count($results));
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertLessThanOrEqual(2, \count($result['entries']));
     }
 
     public function testSearchRegex()
     {
-        $results = $this->tool->searchRegex('Database.*failed');
+        $result = $this->tool->searchRegex('Database.*failed');
 
-        $this->assertNotEmpty($results);
-        $this->assertStringContainsString('Database connection failed', $results[0]['message']);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
+        $this->assertStringContainsString('Database connection failed', $result['entries'][0]['message']);
     }
 
     public function testSearchRegexWithDelimiters()
     {
-        $results = $this->tool->searchRegex('/User.*logged/i');
+        $result = $this->tool->searchRegex('/User.*logged/i');
 
-        $this->assertNotEmpty($results);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
     }
 
     public function testSearchRegexByLevel()
     {
-        $results = $this->tool->searchRegex('.*', level: 'WARNING');
+        $result = $this->tool->searchRegex('.*', level: 'WARNING');
 
-        $this->assertNotEmpty($results);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
 
-        foreach ($results as $entry) {
+        foreach ($result['entries'] as $entry) {
             $this->assertSame('WARNING', $entry['level']);
         }
     }
 
     public function testSearchContext()
     {
-        $results = $this->tool->searchContext('user_id', '123');
+        $result = $this->tool->searchContext('user_id', '123');
 
-        $this->assertNotEmpty($results);
-        $this->assertArrayHasKey('user_id', $results[0]['context']);
-        $this->assertSame(123, $results[0]['context']['user_id']);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
+        $this->assertArrayHasKey('user_id', $result['entries'][0]['context']);
+        $this->assertSame(123, $result['entries'][0]['context']['user_id']);
     }
 
     public function testSearchContextReturnsEmptyWhenKeyNotFound()
     {
-        $results = $this->tool->searchContext('nonexistent_key', 'value');
+        $result = $this->tool->searchContext('nonexistent_key', 'value');
 
-        $this->assertEmpty($results);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertEmpty($result['entries']);
     }
 
     public function testSearchContextByLevel()
     {
-        $results = $this->tool->searchContext('error', 'Connection', level: 'ERROR');
+        $result = $this->tool->searchContext('error', 'Connection', level: 'ERROR');
 
-        $this->assertNotEmpty($results);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
     }
 
     public function testTail()
     {
-        $results = $this->tool->tail(10);
+        $result = $this->tool->tail(10);
 
-        $this->assertNotEmpty($results);
-        $this->assertLessThanOrEqual(10, \count($results));
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
+        $this->assertLessThanOrEqual(10, \count($result['entries']));
     }
 
     public function testTailWithLevel()
     {
-        $results = $this->tool->tail(10, level: 'INFO');
+        $result = $this->tool->tail(10, level: 'INFO');
 
-        foreach ($results as $entry) {
+        $this->assertArrayHasKey('entries', $result);
+        foreach ($result['entries'] as $entry) {
             $this->assertSame('INFO', $entry['level']);
         }
     }
@@ -157,11 +170,12 @@ final class LogSearchToolTest extends TestCase
 
     public function testListFiles()
     {
-        $results = $this->tool->listFiles();
+        $result = $this->tool->listFiles();
 
-        $this->assertNotEmpty($results);
+        $this->assertArrayHasKey('files', $result);
+        $this->assertNotEmpty($result['files']);
 
-        foreach ($results as $file) {
+        foreach ($result['files'] as $file) {
             $this->assertArrayHasKey('name', $file);
             $this->assertArrayHasKey('path', $file);
             $this->assertArrayHasKey('size', $file);
@@ -177,20 +191,22 @@ final class LogSearchToolTest extends TestCase
 
     public function testListChannels()
     {
-        $results = $this->tool->listChannels();
+        $result = $this->tool->listChannels();
 
-        $this->assertNotEmpty($results);
-        $this->assertContains('app', $results);
-        $this->assertContains('security', $results);
+        $this->assertArrayHasKey('channels', $result);
+        $this->assertNotEmpty($result['channels']);
+        $this->assertContains('app', $result['channels']);
+        $this->assertContains('security', $result['channels']);
     }
 
     public function testByLevel()
     {
-        $results = $this->tool->byLevel('INFO');
+        $result = $this->tool->byLevel('INFO');
 
-        $this->assertNotEmpty($results);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
 
-        foreach ($results as $entry) {
+        foreach ($result['entries'] as $entry) {
             $this->assertSame('INFO', $entry['level']);
         }
     }
@@ -203,18 +219,20 @@ final class LogSearchToolTest extends TestCase
 
     public function testByLevelWithLimit()
     {
-        $results = $this->tool->byLevel('INFO', limit: 1);
+        $result = $this->tool->byLevel('INFO', limit: 1);
 
-        $this->assertLessThanOrEqual(1, \count($results));
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertLessThanOrEqual(1, \count($result['entries']));
     }
 
     public function testSearchReturnsLogEntryArrayStructure()
     {
-        $results = $this->tool->search('logged');
+        $result = $this->tool->search('logged');
 
-        $this->assertNotEmpty($results);
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
 
-        $entry = $results[0];
+        $entry = $result['entries'][0];
         $this->assertArrayHasKey('datetime', $entry);
         $this->assertArrayHasKey('channel', $entry);
         $this->assertArrayHasKey('level', $entry);

--- a/src/mate/src/Capability/ServerInfo.php
+++ b/src/mate/src/Capability/ServerInfo.php
@@ -38,11 +38,11 @@ class ServerInfo
     }
 
     /**
-     * @return string[]
+     * @return array{extensions: string[]}
      */
     #[McpTool('php-extensions', 'Get a list of PHP extensions')]
     public function extensions(): array
     {
-        return get_loaded_extensions();
+        return ['extensions' => get_loaded_extensions()];
     }
 }

--- a/src/mate/src/Command/DebugCapabilitiesCommand.php
+++ b/src/mate/src/Command/DebugCapabilitiesCommand.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\AI\Mate\Command;
 
-use Mcp\Capability\Discovery\Discoverer;
-use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Discovery\CapabilityCollector;
 use Symfony\AI\Mate\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -21,7 +19,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Display all MCP capabilities grouped by extension.
@@ -36,31 +33,20 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 #[AsCommand('debug:capabilities', 'Display all MCP capabilities grouped by extension')]
 class DebugCapabilitiesCommand extends Command
 {
-    private CapabilityCollector $collector;
-
     /**
      * @var array<string, ExtensionData>
      */
     private array $extensions;
 
+    /**
+     * @param array<string, ExtensionData> $extensions
+     */
     public function __construct(
-        LoggerInterface $logger,
-        private ContainerInterface $container,
+        array $extensions,
+        private CapabilityCollector $collector,
     ) {
         parent::__construct(self::getDefaultName());
-
-        $rootDir = $container->getParameter('mate.root_dir');
-        \assert(\is_string($rootDir));
-
-        $extensions = $this->container->getParameter('mate.extensions') ?? [];
-        \assert(\is_array($extensions));
         $this->extensions = $extensions;
-
-        $disabledFeatures = $this->container->getParameter('mate.disabled_features') ?? [];
-        \assert(\is_array($disabledFeatures));
-
-        $discoverer = new Discoverer($logger);
-        $this->collector = new CapabilityCollector($rootDir, $extensions, $disabledFeatures, $discoverer, $logger);
     }
 
     public static function getDefaultName(): string

--- a/src/mate/src/Command/DiscoverCommand.php
+++ b/src/mate/src/Command/DiscoverCommand.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Mate\Command;
 
-use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -31,15 +30,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand('discover', 'Discover MCP bridges installed via Composer')]
 class DiscoverCommand extends Command
 {
-    private ComposerExtensionDiscovery $extensionDiscovery;
-
     public function __construct(
         private string $rootDir,
-        private LoggerInterface $logger,
+        private ComposerExtensionDiscovery $extensionDiscovery,
     ) {
         parent::__construct(self::getDefaultName());
-
-        $this->extensionDiscovery = new ComposerExtensionDiscovery($this->rootDir, $this->logger);
     }
 
     public static function getDefaultName(): string

--- a/src/mate/src/Command/ToolsCallCommand.php
+++ b/src/mate/src/Command/ToolsCallCommand.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Mate\Command;
 
-use Mcp\Capability\Discovery\Discoverer;
 use Mcp\Capability\Registry;
 use Mcp\Capability\Registry\ReferenceHandler;
 use Mcp\Exception\ToolNotFoundException;
@@ -40,27 +39,11 @@ class ToolsCallCommand extends Command
     private ReferenceHandler $referenceHandler;
 
     public function __construct(
+        FilteredDiscoveryLoader $loader,
+        ContainerInterface $container,
         LoggerInterface $logger,
-        private ContainerInterface $container,
     ) {
         parent::__construct(self::getDefaultName());
-
-        $rootDir = $container->getParameter('mate.root_dir');
-        \assert(\is_string($rootDir));
-
-        $extensions = $this->container->getParameter('mate.extensions') ?? [];
-        \assert(\is_array($extensions));
-
-        $disabledFeatures = $this->container->getParameter('mate.disabled_features') ?? [];
-        \assert(\is_array($disabledFeatures));
-
-        $loader = new FilteredDiscoveryLoader(
-            basePath: $rootDir,
-            extensions: $extensions,
-            disabledFeatures: $disabledFeatures,
-            discoverer: new Discoverer($logger),
-            logger: $logger
-        );
 
         $this->registry = new Registry(null, $logger);
         $loader->load($this->registry);

--- a/src/mate/src/Command/ToolsInspectCommand.php
+++ b/src/mate/src/Command/ToolsInspectCommand.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\AI\Mate\Command;
 
-use Mcp\Capability\Discovery\Discoverer;
-use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Discovery\CapabilityCollector;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -21,7 +19,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Display detailed information about a specific MCP tool.
@@ -41,30 +38,20 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 #[AsCommand('mcp:tools:inspect', 'Display detailed information about a specific MCP tool')]
 class ToolsInspectCommand extends Command
 {
-    private CapabilityCollector $collector;
-
     /**
      * @var array<string, array{dirs: string[], includes: string[]}>
      */
     private array $extensions;
 
+    /**
+     * @param array<string, array{dirs: string[], includes: string[]}> $extensions
+     */
     public function __construct(
-        LoggerInterface $logger,
-        private ContainerInterface $container,
+        array $extensions,
+        private CapabilityCollector $collector,
     ) {
         parent::__construct(self::getDefaultName());
-
-        $rootDir = $container->getParameter('mate.root_dir');
-        \assert(\is_string($rootDir));
-
-        $extensions = $this->container->getParameter('mate.extensions') ?? [];
-        \assert(\is_array($extensions));
         $this->extensions = $extensions;
-
-        $disabledFeatures = $this->container->getParameter('mate.disabled_features') ?? [];
-        \assert(\is_array($disabledFeatures));
-
-        $this->collector = new CapabilityCollector($rootDir, $extensions, $disabledFeatures, new Discoverer($logger), $logger);
     }
 
     public static function getDefaultName(): string

--- a/src/mate/src/Command/ToolsListCommand.php
+++ b/src/mate/src/Command/ToolsListCommand.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\AI\Mate\Command;
 
-use Mcp\Capability\Discovery\Discoverer;
-use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Discovery\CapabilityCollector;
 use Symfony\AI\Mate\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -22,7 +20,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Display available MCP tools with metadata.
@@ -42,31 +39,20 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 #[AsCommand('mcp:tools:list', 'Display available MCP tools with metadata')]
 class ToolsListCommand extends Command
 {
-    private CapabilityCollector $collector;
-
     /**
      * @var array<string, array{dirs: string[], includes: string[]}>
      */
     private array $extensions;
 
+    /**
+     * @param array<string, array{dirs: string[], includes: string[]}> $extensions
+     */
     public function __construct(
-        LoggerInterface $logger,
-        private ContainerInterface $container,
+        array $extensions,
+        private CapabilityCollector $collector,
     ) {
         parent::__construct(self::getDefaultName());
-
-        $rootDir = $container->getParameter('mate.root_dir');
-        \assert(\is_string($rootDir));
-
-        $extensions = $this->container->getParameter('mate.extensions') ?? [];
-        \assert(\is_array($extensions));
         $this->extensions = $extensions;
-
-        $disabledFeatures = $this->container->getParameter('mate.disabled_features') ?? [];
-        \assert(\is_array($disabledFeatures));
-
-        $discoverer = new Discoverer($logger);
-        $this->collector = new CapabilityCollector($rootDir, $extensions, $disabledFeatures, $discoverer, $logger);
     }
 
     public static function getDefaultName(): string

--- a/src/mate/src/Discovery/CapabilityCollector.php
+++ b/src/mate/src/Discovery/CapabilityCollector.php
@@ -11,11 +11,9 @@
 
 namespace Symfony\AI\Mate\Discovery;
 
-use Mcp\Capability\Discovery\DiscovererInterface;
 use Mcp\Capability\Registry\PromptReference;
 use Mcp\Capability\Registry\ResourceTemplateReference;
 use Mcp\Capability\Registry\ToolReference;
-use Psr\Log\LoggerInterface;
 
 /**
  * Collects MCP capabilities from discovered extensions.
@@ -52,28 +50,9 @@ use Psr\Log\LoggerInterface;
  */
 class CapabilityCollector
 {
-    private DiscovererInterface $discoverer;
-    private FilteredDiscoveryLoader $loader;
-
-    /**
-     * @param array<string, array{dirs: string[], includes: string[]}> $extensions
-     * @param array<string, array<string, array{enabled: bool}>>       $disabledFeatures
-     */
     public function __construct(
-        string $rootDir,
-        array $extensions,
-        array $disabledFeatures,
-        DiscovererInterface $discoverer,
-        private LoggerInterface $logger,
+        private FilteredDiscoveryLoader $loader,
     ) {
-        $this->discoverer = $discoverer;
-        $this->loader = new FilteredDiscoveryLoader(
-            $rootDir,
-            $extensions,
-            $disabledFeatures,
-            $this->discoverer,
-            $this->logger,
-        );
     }
 
     /**

--- a/src/mate/src/Discovery/FilteredDiscoveryLoader.php
+++ b/src/mate/src/Discovery/FilteredDiscoveryLoader.php
@@ -30,7 +30,7 @@ final class FilteredDiscoveryLoader implements LoaderInterface
      * @param array<string, array<string, array{enabled: bool}>>      $disabledFeatures
      */
     public function __construct(
-        private string $basePath,
+        private string $rootDir,
         private array $extensions,
         private array $disabledFeatures,
         private DiscovererInterface $discoverer,
@@ -72,7 +72,7 @@ final class FilteredDiscoveryLoader implements LoaderInterface
         $prompts = [];
         $resourceTemplates = [];
 
-        $discoveryState = $this->discoverer->discover($this->basePath, $extension['dirs']);
+        $discoveryState = $this->discoverer->discover($this->rootDir, $extension['dirs']);
 
         foreach ($discoveryState->getTools() as $name => $tool) {
             if (!$this->isFeatureAllowed($extensionName, $name)) {

--- a/src/mate/src/default.config.php
+++ b/src/mate/src/default.config.php
@@ -9,8 +9,25 @@
  * file that was distributed with this source code.
  */
 
+use Mcp\Capability\Discovery\Discoverer;
+use Mcp\Capability\Discovery\DiscovererInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\AI\Mate\Agent\AgentInstructionsAggregator;
+use Symfony\AI\Mate\Command\ClearCacheCommand;
+use Symfony\AI\Mate\Command\DebugCapabilitiesCommand;
+use Symfony\AI\Mate\Command\DebugExtensionsCommand;
+use Symfony\AI\Mate\Command\DiscoverCommand;
+use Symfony\AI\Mate\Command\InitCommand;
+use Symfony\AI\Mate\Command\ServeCommand;
+use Symfony\AI\Mate\Command\StopCommand;
+use Symfony\AI\Mate\Command\ToolsCallCommand;
+use Symfony\AI\Mate\Command\ToolsInspectCommand;
+use Symfony\AI\Mate\Command\ToolsListCommand;
+use Symfony\AI\Mate\Discovery\CapabilityCollector;
+use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
+use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
 use Symfony\AI\Mate\Service\Logger;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $container): void {
@@ -36,6 +53,13 @@ return static function (ContainerConfigurator $container): void {
         ->defaults()
             ->autowire()
             ->autoconfigure()
+            // Named argument binding for common parameters
+            ->bind('$rootDir', '%mate.root_dir%')
+            ->bind('$cacheDir', '%mate.cache_dir%')
+            ->bind('$extensions', '%mate.extensions%')
+            ->bind('$disabledFeatures', '%mate.disabled_features%')
+            ->bind('$enabledExtensions', '%mate.enabled_extensions%')
+            ->bind('$mcpProtocolVersion', '%mate.mcp_protocol_version%')
 
         ->set('_build.logger', Logger::class)
             ->private() // To be removed when we compile
@@ -49,5 +73,51 @@ return static function (ContainerConfigurator $container): void {
             ->arg('$fileLogEnabled', '%mate.debug_file_enabled%')
             ->arg('$debugEnabled', '%mate.debug_enabled%')
             ->alias(Logger::class, LoggerInterface::class)
+
+        // Container service for commands that need it
+        ->alias(ContainerInterface::class, 'service_container')
+
+        // Register discovery services
+        ->set(Discoverer::class)
+            ->alias(DiscovererInterface::class, Discoverer::class)
+
+        ->set(ComposerExtensionDiscovery::class)
+
+        ->set(FilteredDiscoveryLoader::class)
+
+        ->set(CapabilityCollector::class)
+
+        ->set(AgentInstructionsAggregator::class)
+
+        // Register all commands
+        ->set(InitCommand::class)
+            ->public()
+
+        ->set(ServeCommand::class)
+            ->public()
+
+        ->set(DiscoverCommand::class)
+            ->public()
+
+        ->set(StopCommand::class)
+            ->public()
+
+        ->set(DebugCapabilitiesCommand::class)
+            ->public()
+
+        ->set(DebugExtensionsCommand::class)
+            ->public()
+
+        ->set(ClearCacheCommand::class)
+            ->public()
+
+        ->set(ToolsListCommand::class)
+            ->public()
+
+        ->set(ToolsInspectCommand::class)
+            ->public()
+
+        ->set(ToolsCallCommand::class)
+            ->public()
     ;
 };

--- a/src/mate/tests/Command/DiscoverCommandTest.php
+++ b/src/mate/tests/Command/DiscoverCommandTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Mate\Tests\Command;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\AI\Mate\Command\DiscoverCommand;
+use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -37,7 +38,9 @@ final class DiscoverCommandTest extends TestCase
 
         try {
             $rootDir = $this->createConfiguration($this->fixturesDir.'/with-ai-mate-config', $tempDir);
-            $command = new DiscoverCommand($rootDir, new NullLogger());
+            $logger = new NullLogger();
+            $discoverer = new ComposerExtensionDiscovery($rootDir, $logger);
+            $command = new DiscoverCommand($rootDir, $discoverer);
             $tester = new CommandTester($command);
 
             $tester->execute([]);
@@ -79,7 +82,9 @@ PHP
             );
 
             $rootDir = $this->createConfiguration($this->fixturesDir.'/with-ai-mate-config', $tempDir);
-            $command = new DiscoverCommand($rootDir, new NullLogger());
+            $logger = new NullLogger();
+            $discoverer = new ComposerExtensionDiscovery($rootDir, $logger);
+            $command = new DiscoverCommand($rootDir, $discoverer);
             $tester = new CommandTester($command);
 
             $tester->execute([]);
@@ -111,7 +116,9 @@ PHP
             );
 
             $rootDir = $this->createConfiguration($this->fixturesDir.'/with-ai-mate-config', $tempDir);
-            $command = new DiscoverCommand($rootDir, new NullLogger());
+            $logger = new NullLogger();
+            $discoverer = new ComposerExtensionDiscovery($rootDir, $logger);
+            $command = new DiscoverCommand($rootDir, $discoverer);
             $tester = new CommandTester($command);
 
             $tester->execute([]);
@@ -134,7 +141,9 @@ PHP
 
         try {
             $rootDir = $this->createConfiguration($this->fixturesDir.'/without-ai-mate-config', $tempDir);
-            $command = new DiscoverCommand($rootDir, new NullLogger());
+            $logger = new NullLogger();
+            $discoverer = new ComposerExtensionDiscovery($rootDir, $logger);
+            $command = new DiscoverCommand($rootDir, $discoverer);
             $tester = new CommandTester($command);
 
             $tester->execute([]);

--- a/src/mate/tests/Discovery/CapabilityCollectorTest.php
+++ b/src/mate/tests/Discovery/CapabilityCollectorTest.php
@@ -15,6 +15,7 @@ use Mcp\Capability\Discovery\Discoverer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\AI\Mate\Discovery\CapabilityCollector;
+use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
 
 /**
  * @author Johannes Wachter <johannes@sulu.io>
@@ -30,14 +31,7 @@ final class CapabilityCollectorTest extends TestCase
 
     public function testCollectCapabilitiesReturnsStructure()
     {
-        $logger = new NullLogger();
-        $collector = new CapabilityCollector(
-            $this->fixturesDir.'/with-ai-mate-config',
-            [],
-            [],
-            new Discoverer($logger),
-            $logger
-        );
+        $collector = $this->createCollector($this->fixturesDir.'/with-ai-mate-config');
 
         $extension = [
             'dirs' => ['mate/src'],
@@ -54,14 +48,7 @@ final class CapabilityCollectorTest extends TestCase
 
     public function testCollectCapabilitiesWithEmptyDirectories()
     {
-        $logger = new NullLogger();
-        $collector = new CapabilityCollector(
-            $this->fixturesDir.'/with-ai-mate-config',
-            [],
-            [],
-            new Discoverer($logger),
-            $logger
-        );
+        $collector = $this->createCollector($this->fixturesDir.'/with-ai-mate-config');
 
         $extension = [
             'dirs' => ['mate/src'],
@@ -79,14 +66,7 @@ final class CapabilityCollectorTest extends TestCase
 
     public function testCollectCapabilitiesWithIncludes()
     {
-        $logger = new NullLogger();
-        $collector = new CapabilityCollector(
-            $this->fixturesDir.'/with-ai-mate-config',
-            [],
-            [],
-            new Discoverer($logger),
-            $logger
-        );
+        $collector = $this->createCollector($this->fixturesDir.'/with-ai-mate-config');
 
         $extension = [
             'dirs' => [],
@@ -103,14 +83,7 @@ final class CapabilityCollectorTest extends TestCase
 
     public function testCollectCapabilitiesFormatsTools()
     {
-        $logger = new NullLogger();
-        $collector = new CapabilityCollector(
-            $this->fixturesDir.'/with-ai-mate-config',
-            [],
-            [],
-            new Discoverer($logger),
-            $logger
-        );
+        $collector = $this->createCollector($this->fixturesDir.'/with-ai-mate-config');
 
         $extension = [
             'dirs' => ['mate/src'],
@@ -131,14 +104,7 @@ final class CapabilityCollectorTest extends TestCase
 
     public function testCollectCapabilitiesFormatsResources()
     {
-        $logger = new NullLogger();
-        $collector = new CapabilityCollector(
-            $this->fixturesDir.'/with-ai-mate-config',
-            [],
-            [],
-            new Discoverer($logger),
-            $logger
-        );
+        $collector = $this->createCollector($this->fixturesDir.'/with-ai-mate-config');
 
         $extension = [
             'dirs' => ['mate/src'],
@@ -160,14 +126,7 @@ final class CapabilityCollectorTest extends TestCase
 
     public function testCollectCapabilitiesFormatsPrompts()
     {
-        $logger = new NullLogger();
-        $collector = new CapabilityCollector(
-            $this->fixturesDir.'/with-ai-mate-config',
-            [],
-            [],
-            new Discoverer($logger),
-            $logger
-        );
+        $collector = $this->createCollector($this->fixturesDir.'/with-ai-mate-config');
 
         $extension = [
             'dirs' => ['mate/src'],
@@ -188,14 +147,7 @@ final class CapabilityCollectorTest extends TestCase
 
     public function testCollectCapabilitiesFormatsResourceTemplates()
     {
-        $logger = new NullLogger();
-        $collector = new CapabilityCollector(
-            $this->fixturesDir.'/with-ai-mate-config',
-            [],
-            [],
-            new Discoverer($logger),
-            $logger
-        );
+        $collector = $this->createCollector($this->fixturesDir.'/with-ai-mate-config');
 
         $extension = [
             'dirs' => ['mate/src'],
@@ -212,5 +164,18 @@ final class CapabilityCollectorTest extends TestCase
             $this->assertArrayHasKey('description', $template);
             $this->assertArrayHasKey('handler', $template);
         }
+    }
+
+    /**
+     * @param array<string, array{dirs: string[], includes: string[]}> $extensions
+     * @param array<string, array<string, array{enabled: bool}>>       $disabledFeatures
+     */
+    private function createCollector(string $rootDir, array $extensions = [], array $disabledFeatures = []): CapabilityCollector
+    {
+        $logger = new NullLogger();
+        $discoverer = new Discoverer($logger);
+        $loader = new FilteredDiscoveryLoader($rootDir, $extensions, $disabledFeatures, $discoverer, $logger);
+
+        return new CapabilityCollector($loader);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | N/A
| License       | MIT

## Summary

Refactored the Mate application to use dependency injection container with services for command registration instead of manual instantiation. This improves modularity and makes the application more maintainable.
