### PR TITLE
[Platform][DeepSeek] Add missing bundle configuration

### DIFF
--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -35,6 +35,7 @@ return static function (DefinitionConfigurator $configurator): void {
                     ->append($import('platform/cartesia'))
                     ->append($import('platform/cerebras'))
                     ->append($import('platform/decart'))
+                    ->append($import('platform/deepseek'))
                     ->append($import('platform/dockermodelrunner'))
                     ->append($import('platform/elevenlabs'))
                     ->append($import('platform/failover'))

--- a/src/ai-bundle/config/platform/deepseek.php
+++ b/src/ai-bundle/config/platform/deepseek.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition\Configurator;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+return (new ArrayNodeDefinition('deepseek'))
+    ->children()
+        ->stringNode('api_key')->isRequired()->end()
+        ->stringNode('http_client')
+            ->defaultValue('http_client')
+            ->info('Service ID of the HTTP client to use')
+        ->end()
+    ->end();

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -4105,6 +4105,57 @@ class AiBundleTest extends TestCase
         $this->assertSame('ai.platform.contract.perplexity', (string) $arguments[3]);
     }
 
+    public function testDeepSeekPlatformConfiguration()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'deepseek' => [
+                        'api_key' => 'sk-deepseek-test-key',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.deepseek'));
+
+        $definition = $container->getDefinition('ai.platform.deepseek');
+        $arguments = $definition->getArguments();
+
+        $this->assertCount(5, $arguments);
+        $this->assertSame('sk-deepseek-test-key', $arguments[0]);
+        $this->assertInstanceOf(Reference::class, $arguments[1]);
+        $this->assertSame('http_client', (string) $arguments[1]);
+        $this->assertInstanceOf(Reference::class, $arguments[2]);
+        $this->assertSame('ai.platform.model_catalog.deepseek', (string) $arguments[2]);
+        $this->assertNull($arguments[3]);
+        $this->assertInstanceOf(Reference::class, $arguments[4]);
+        $this->assertSame('event_dispatcher', (string) $arguments[4]);
+    }
+
+    #[TestDox('DeepSeek platform uses custom http_client when configured')]
+    public function testDeepSeekPlatformUsesCustomHttpClient()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'deepseek' => [
+                        'api_key' => 'sk-deepseek-test-key',
+                        'http_client' => 'my_custom_http_client',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.deepseek'));
+
+        $definition = $container->getDefinition('ai.platform.deepseek');
+        $arguments = $definition->getArguments();
+
+        $this->assertInstanceOf(Reference::class, $arguments[1]);
+        $this->assertSame('my_custom_http_client', (string) $arguments[1]);
+    }
+
     public function testTransformersPhpConfiguration()
     {
         $container = $this->buildContainer([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1525
| License       | MIT

The DeepSeek platform was registered in `AiBundle.php` and `services.php` but the required configuration file was missing. This caused a configuration error when users tried to configure the `deepseek` platform in their Symfony application.

### What was missing

1. Configuration file `src/ai-bundle/config/platform/deepseek.php`
2. Import of the configuration in `src/ai-bundle/config/options.php`

### Error before fix

```
Unrecognized option "deepseek" under "ai.platform". Available options are "albert", "anthropic", ...
```

### After fix

Users can now configure the DeepSeek platform like any other platform:

```yaml
ai:
    platform:
        deepseek:
            api_key: '%env(DEEPSEEK_API_KEY)%'
```

Friendly ping @ephp