### PR TITLE
[Platform] Add missing EMBEDDINGS capability to embedding models

### DIFF
--- a/src/platform/src/Bridge/AiMlApi/ModelCatalog.php
+++ b/src/platform/src/Bridge/AiMlApi/ModelCatalog.php
@@ -1025,67 +1025,67 @@ final class ModelCatalog extends AbstractModelCatalog
             // Embedding models
             'text-embedding-3-small' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'text-embedding-3-large' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'text-embedding-ada-002' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'togethercomputer/m2-bert-80M-32k-retrieval' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'BAAI/bge-base-en-v1.5' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'BAAI/bge-large-en-v1.' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-large-2-instruct' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-finance-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-multilingual-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-law-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-code-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-large-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'textembedding-gecko@003' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'textembedding-gecko-multilingual@001' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'text-multilingual-embedding-002' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
         ];
 

--- a/src/platform/src/Bridge/AiMlApi/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/AiMlApi/Tests/ModelCatalogTest.php
@@ -149,22 +149,22 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'zhipu/glm-4.5' => ['zhipu/glm-4.5', CompletionsModel::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING]];
 
         // Embedding models
-        yield 'text-embedding-3-small' => ['text-embedding-3-small', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'text-embedding-3-large' => ['text-embedding-3-large', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'text-embedding-ada-002' => ['text-embedding-ada-002', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'togethercomputer/m2-bert-80M-32k-retrieval' => ['togethercomputer/m2-bert-80M-32k-retrieval', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'BAAI/bge-base-en-v1.5' => ['BAAI/bge-base-en-v1.5', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'BAAI/bge-large-en-v1.' => ['BAAI/bge-large-en-v1.', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-large-2-instruct' => ['voyage-large-2-instruct', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-finance-2' => ['voyage-finance-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-multilingual-2' => ['voyage-multilingual-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-law-2' => ['voyage-law-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-code-2' => ['voyage-code-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-large-2' => ['voyage-large-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-2' => ['voyage-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'textembedding-gecko@003' => ['textembedding-gecko@003', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'textembedding-gecko-multilingual@001' => ['textembedding-gecko-multilingual@001', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
-        yield 'text-multilingual-embedding-002' => ['text-multilingual-embedding-002', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE]];
+        yield 'text-embedding-3-small' => ['text-embedding-3-small', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'text-embedding-3-large' => ['text-embedding-3-large', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'text-embedding-ada-002' => ['text-embedding-ada-002', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'togethercomputer/m2-bert-80M-32k-retrieval' => ['togethercomputer/m2-bert-80M-32k-retrieval', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'BAAI/bge-base-en-v1.5' => ['BAAI/bge-base-en-v1.5', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'BAAI/bge-large-en-v1.' => ['BAAI/bge-large-en-v1.', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-large-2-instruct' => ['voyage-large-2-instruct', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-finance-2' => ['voyage-finance-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-multilingual-2' => ['voyage-multilingual-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-law-2' => ['voyage-law-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-code-2' => ['voyage-code-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-large-2' => ['voyage-large-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-2' => ['voyage-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'textembedding-gecko@003' => ['textembedding-gecko@003', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'textembedding-gecko-multilingual@001' => ['textembedding-gecko-multilingual@001', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'text-multilingual-embedding-002' => ['text-multilingual-embedding-002', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/Albert/ModelCatalog.php
+++ b/src/platform/src/Bridge/Albert/ModelCatalog.php
@@ -54,7 +54,7 @@ final class ModelCatalog extends AbstractModelCatalog
             ],
             'openweight-embeddings' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_TEXT],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
         ];
 

--- a/src/platform/src/Bridge/Albert/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Albert/Tests/ModelCatalogTest.php
@@ -28,7 +28,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'openweight-small' => ['openweight-small', CompletionsModel::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
         yield 'openweight-medium' => ['openweight-medium', CompletionsModel::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
         yield 'openweight-large' => ['openweight-large', CompletionsModel::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
-        yield 'openweight-embeddings' => ['openweight-embeddings', EmbeddingsModel::class, [Capability::INPUT_TEXT]];
+        yield 'openweight-embeddings' => ['openweight-embeddings', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/DockerModelRunner/ModelCatalog.php
+++ b/src/platform/src/Bridge/DockerModelRunner/ModelCatalog.php
@@ -143,24 +143,28 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => Embeddings::class,
                 'capabilities' => [
                     Capability::INPUT_TEXT,
+                    Capability::EMBEDDINGS,
                 ],
             ],
             'ai/mxbai-embed-large' => [
                 'class' => Embeddings::class,
                 'capabilities' => [
                     Capability::INPUT_TEXT,
+                    Capability::EMBEDDINGS,
                 ],
             ],
             'ai/embeddinggemma' => [
                 'class' => Embeddings::class,
                 'capabilities' => [
                     Capability::INPUT_TEXT,
+                    Capability::EMBEDDINGS,
                 ],
             ],
             'ai/granite-embedding-multilingual' => [
                 'class' => Embeddings::class,
                 'capabilities' => [
                     Capability::INPUT_TEXT,
+                    Capability::EMBEDDINGS,
                 ],
             ],
         ];

--- a/src/platform/src/Bridge/DockerModelRunner/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Tests/ModelCatalogTest.php
@@ -44,10 +44,10 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'ai/smollm3' => ['ai/smollm3', Completions::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]];
 
         // Embeddings models
-        yield 'ai/nomic-embed-text-v1.5' => ['ai/nomic-embed-text-v1.5', Embeddings::class, [Capability::INPUT_TEXT]];
-        yield 'ai/mxbai-embed-large' => ['ai/mxbai-embed-large', Embeddings::class, [Capability::INPUT_TEXT]];
-        yield 'ai/embeddinggemma' => ['ai/embeddinggemma', Embeddings::class, [Capability::INPUT_TEXT]];
-        yield 'ai/granite-embedding-multilingual' => ['ai/granite-embedding-multilingual', Embeddings::class, [Capability::INPUT_TEXT]];
+        yield 'ai/nomic-embed-text-v1.5' => ['ai/nomic-embed-text-v1.5', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'ai/mxbai-embed-large' => ['ai/mxbai-embed-large', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'ai/embeddinggemma' => ['ai/embeddinggemma', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'ai/granite-embedding-multilingual' => ['ai/granite-embedding-multilingual', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/Gemini/ModelCatalog.php
+++ b/src/platform/src/Bridge/Gemini/ModelCatalog.php
@@ -164,15 +164,15 @@ final class ModelCatalog extends AbstractModelCatalog
             ],
             'gemini-embedding-exp-03-07' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'text-embedding-004' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'embedding-001' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
         ];
 

--- a/src/platform/src/Bridge/Gemini/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/ModelCatalogTest.php
@@ -33,9 +33,9 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'gemini-2.0-flash-lite-preview-02-05' => ['gemini-2.0-flash-lite-preview-02-05', Gemini::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::INPUT_AUDIO, Capability::INPUT_PDF, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING]];
         yield 'gemini-2.0-flash-thinking-exp-01-21' => ['gemini-2.0-flash-thinking-exp-01-21', Gemini::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::INPUT_AUDIO, Capability::INPUT_PDF, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING]];
         yield 'gemini-1.5-flash' => ['gemini-1.5-flash', Gemini::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::INPUT_AUDIO, Capability::INPUT_PDF, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING]];
-        yield 'gemini-embedding-exp-03-07' => ['gemini-embedding-exp-03-07', Embeddings::class, [Capability::INPUT_MULTIPLE]];
-        yield 'text-embedding-004' => ['text-embedding-004', Embeddings::class, [Capability::INPUT_MULTIPLE]];
-        yield 'embedding-001' => ['embedding-001', Embeddings::class, [Capability::INPUT_MULTIPLE]];
+        yield 'gemini-embedding-exp-03-07' => ['gemini-embedding-exp-03-07', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'text-embedding-004' => ['text-embedding-004', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'embedding-001' => ['embedding-001', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/Mistral/ModelCatalog.php
+++ b/src/platform/src/Bridge/Mistral/ModelCatalog.php
@@ -182,7 +182,7 @@ final class ModelCatalog extends AbstractModelCatalog
             ],
             'mistral-embed' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
         ];
 

--- a/src/platform/src/Bridge/Mistral/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/ModelCatalogTest.php
@@ -39,7 +39,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'pixstral-12b-latest' => ['pixstral-12b-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::INPUT_IMAGE, Capability::TOOL_CALLING]];
         yield 'voxtral-small-latest' => ['voxtral-small-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::INPUT_AUDIO, Capability::TOOL_CALLING]];
         yield 'voxtral-mini-latest' => ['voxtral-mini-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::INPUT_AUDIO, Capability::TOOL_CALLING]];
-        yield 'mistral-embed' => ['mistral-embed', Embeddings::class, [Capability::INPUT_MULTIPLE]];
+        yield 'mistral-embed' => ['mistral-embed', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/OpenAi/ModelCatalog.php
+++ b/src/platform/src/Bridge/OpenAi/ModelCatalog.php
@@ -242,15 +242,15 @@ final class ModelCatalog extends AbstractModelCatalog
             ],
             'text-embedding-ada-002' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_TEXT],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'text-embedding-3-large' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_TEXT],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'text-embedding-3-small' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_TEXT],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'tts-1' => [
                 'class' => TextToSpeech::class,

--- a/src/platform/src/Bridge/OpenAi/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/ModelCatalogTest.php
@@ -49,9 +49,9 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'gpt-5-nano' => ['gpt-5-nano', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF, Capability::OUTPUT_STRUCTURED]];
 
         // Embedding models
-        yield 'text-embedding-ada-002' => ['text-embedding-ada-002', Embeddings::class, [Capability::INPUT_TEXT]];
-        yield 'text-embedding-3-large' => ['text-embedding-3-large', Embeddings::class, [Capability::INPUT_TEXT]];
-        yield 'text-embedding-3-small' => ['text-embedding-3-small', Embeddings::class, [Capability::INPUT_TEXT]];
+        yield 'text-embedding-ada-002' => ['text-embedding-ada-002', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'text-embedding-3-large' => ['text-embedding-3-large', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'text-embedding-3-small' => ['text-embedding-3-small', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
 
         // Text-to-speech models
         yield 'tts-1' => ['tts-1', TextToSpeech::class, [Capability::INPUT_TEXT, Capability::OUTPUT_AUDIO]];

--- a/src/platform/src/Bridge/Scaleway/ModelCatalog.php
+++ b/src/platform/src/Bridge/Scaleway/ModelCatalog.php
@@ -138,7 +138,7 @@ final class ModelCatalog extends AbstractModelCatalog
             ],
             'bge-multilingual-gemma2' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_TEXT],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
         ];
 

--- a/src/platform/src/Bridge/Scaleway/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/ModelCatalogTest.php
@@ -39,7 +39,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'qwen3-235b-a22b-instruct-2507' => ['qwen3-235b-a22b-instruct-2507', Scaleway::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::OUTPUT_STRUCTURED]];
 
         // Embedding models
-        yield 'bge-multilingual-gemma2' => ['bge-multilingual-gemma2', Embeddings::class, [Capability::INPUT_TEXT]];
+        yield 'bge-multilingual-gemma2' => ['bge-multilingual-gemma2', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/VertexAi/ModelCatalog.php
+++ b/src/platform/src/Bridge/VertexAi/ModelCatalog.php
@@ -113,6 +113,7 @@ final class ModelCatalog extends AbstractModelCatalog
                 'capabilities' => [
                     Capability::INPUT_TEXT,
                     Capability::INPUT_MULTIPLE,
+                    Capability::EMBEDDINGS,
                 ],
             ],
             'text-embedding-005' => [
@@ -120,6 +121,7 @@ final class ModelCatalog extends AbstractModelCatalog
                 'capabilities' => [
                     Capability::INPUT_TEXT,
                     Capability::INPUT_MULTIPLE,
+                    Capability::EMBEDDINGS,
                 ],
             ],
             'text-multilingual-embedding-002' => [
@@ -127,6 +129,7 @@ final class ModelCatalog extends AbstractModelCatalog
                 'capabilities' => [
                     Capability::INPUT_TEXT,
                     Capability::INPUT_MULTIPLE,
+                    Capability::EMBEDDINGS,
                 ],
             ],
         ];

--- a/src/platform/src/Bridge/VertexAi/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/ModelCatalogTest.php
@@ -33,9 +33,9 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'gemini-2.0-flash-lite' => ['gemini-2.0-flash-lite', GeminiModel::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::INPUT_AUDIO, Capability::INPUT_PDF, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING]];
 
         // Embeddings models
-        yield 'gemini-embedding-001' => ['gemini-embedding-001', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE]];
-        yield 'text-embedding-005' => ['text-embedding-005', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE]];
-        yield 'text-multilingual-embedding-002' => ['text-multilingual-embedding-002', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE]];
+        yield 'gemini-embedding-001' => ['gemini-embedding-001', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'text-embedding-005' => ['text-embedding-005', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'text-multilingual-embedding-002' => ['text-multilingual-embedding-002', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/Voyage/ModelCatalog.php
+++ b/src/platform/src/Bridge/Voyage/ModelCatalog.php
@@ -24,49 +24,50 @@ final class ModelCatalog extends AbstractModelCatalog
         $defaultModels = [
             'voyage-3.5' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-3.5-lite' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-3' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-3-lite' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-3-large' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-finance-2' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-multilingual-2' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-law-2' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-code-3' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-code-2' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE],
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'voyage-multimodal-3' => [
                 'class' => Voyage::class,
                 'capabilities' => [
                     Capability::INPUT_MULTIPLE,
                     Capability::INPUT_MULTIMODAL,
+                    Capability::EMBEDDINGS,
                 ],
             ],
         ];

--- a/src/platform/src/Bridge/Voyage/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Voyage/Tests/ModelCatalogTest.php
@@ -21,17 +21,17 @@ final class ModelCatalogTest extends ModelCatalogTestCase
 {
     public static function modelsProvider(): iterable
     {
-        yield 'voyage-3.5' => ['voyage-3.5', Voyage::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-3.5-lite' => ['voyage-3.5-lite', Voyage::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-3' => ['voyage-3', Voyage::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-3-lite' => ['voyage-3-lite', Voyage::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-3-large' => ['voyage-3-large', Voyage::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-finance-2' => ['voyage-finance-2', Voyage::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-multilingual-2' => ['voyage-multilingual-2', Voyage::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-law-2' => ['voyage-law-2', Voyage::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-code-3' => ['voyage-code-3', Voyage::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-code-2' => ['voyage-code-2', Voyage::class, [Capability::INPUT_MULTIPLE]];
-        yield 'voyage-multimodal-3' => ['voyage-multimodal-3', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::INPUT_MULTIMODAL]];
+        yield 'voyage-3.5' => ['voyage-3.5', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-3.5-lite' => ['voyage-3.5-lite', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-3' => ['voyage-3', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-3-lite' => ['voyage-3-lite', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-3-large' => ['voyage-3-large', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-finance-2' => ['voyage-finance-2', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-multilingual-2' => ['voyage-multilingual-2', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-law-2' => ['voyage-law-2', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-code-3' => ['voyage-code-3', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-code-2' => ['voyage-code-2', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'voyage-multimodal-3' => ['voyage-multimodal-3', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::INPUT_MULTIMODAL, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #1529  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

                                                                                                                                 
  ## Description                                                                                                                  
                                                                                                                                  
  This PR fixes embedding models missing the `Capability::EMBEDDINGS` enum in their capabilities array across multiple bridge `ModelCatalog` classes.                                                                                                         
                                                                                                                                  
  ### Problem                                                                                                                     
                                                                                                                                  
  The `Capability::EMBEDDINGS` enum exists in `src/platform/src/Capability.php`, but embedding models in various `ModelCatalog`  classes only had `INPUT_TEXT` or `INPUT_MULTIPLE` capabilities defined. 
  This caused `$model->supports(Capability::EMBEDDINGS)` to incorrectly return `false` for embedding models.                                                                             
                                                                                                                                  
  ```php                                                                                                                          
  $catalog = new \Symfony\AI\Platform\Bridge\OpenAi\ModelCatalog();                                                               
  $model = $catalog->getModel('text-embedding-3-large');                                                                          
                                                                                                                                  
  $model->supports(Capability::EMBEDDINGS); // Expected: true, Actual: false    