### PR TITLE
[AI Bundle] add `ResetInterface` to prevent memory leaks

### DIFF
--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * [BC BREAK] Rename service ID prefix `ai.toolbox.{agent}.agent_wrapper.` to `ai.toolbox.{agent}.subagent.`
  * Add support for `DocumentIndexer` when no loader is configured for an indexer
  * [BC BREAK] The `host_url` configuration key for `Ollama` has been renamed `endpoint`
+ * Add `ResetInterface` support to `TraceableChat`, `TraceableMessageStore`, `TraceablePlatform` and `TraceableToolbox` to clear collected data between requests
 
 0.2
 ---

--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -25,6 +25,7 @@
         "symfony/console": "^7.3|^8.0",
         "symfony/dependency-injection": "^7.3|^8.0",
         "symfony/framework-bundle": "^7.3|^8.0",
+        "symfony/service-contracts": "^2.5|^3",
         "symfony/string": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -185,7 +185,8 @@ final class AiBundle extends AbstractBundle
                 $traceablePlatformDefinition = (new Definition(TraceablePlatform::class))
                     ->setDecoratedService($platform, priority: -1024)
                     ->setArguments([new Reference('.inner')])
-                    ->addTag('ai.traceable_platform');
+                    ->addTag('ai.traceable_platform')
+                    ->addTag('kernel.reset', ['method' => 'reset']);
                 $suffix = u($platform)->after('ai.platform.')->toString();
                 $builder->setDefinition('ai.traceable_platform.'.$suffix, $traceablePlatformDefinition);
             }
@@ -262,7 +263,8 @@ final class AiBundle extends AbstractBundle
                         new Reference('.inner'),
                         new Reference(ClockInterface::class),
                     ])
-                    ->addTag('ai.traceable_message_store');
+                    ->addTag('ai.traceable_message_store')
+                    ->addTag('kernel.reset', ['method' => 'reset']);
                 $suffix = u($messageStore)->afterLast('.')->toString();
                 $builder->setDefinition('ai.traceable_message_store.'.$suffix, $traceableMessageStoreDefinition);
             }
@@ -297,7 +299,8 @@ final class AiBundle extends AbstractBundle
                         new Reference('.inner'),
                         new Reference(ClockInterface::class),
                     ])
-                    ->addTag('ai.traceable_chat');
+                    ->addTag('ai.traceable_chat')
+                    ->addTag('kernel.reset', ['method' => 'reset']);
                 $suffix = u($chat)->afterLast('.')->toString();
                 $builder->setDefinition('ai.traceable_chat.'.$suffix, $traceableChatDefinition);
             }
@@ -1150,7 +1153,8 @@ final class AiBundle extends AbstractBundle
                     ->setClass(TraceableToolbox::class)
                     ->setArguments([new Reference('.inner')])
                     ->setDecoratedService('ai.toolbox.'.$name, priority: -1024)
-                    ->addTag('ai.traceable_toolbox');
+                    ->addTag('ai.traceable_toolbox')
+                    ->addTag('kernel.reset', ['method' => 'reset']);
                 $container->setDefinition('ai.traceable_toolbox.'.$name, $traceableToolboxDefinition);
             }
 
@@ -1537,11 +1541,9 @@ final class AiBundle extends AbstractBundle
 
                 $definition = new Definition(InMemoryStore::class);
                 $definition
-                    ->setLazy(true)
                     ->setArguments($arguments)
-                    ->addTag('proxy', ['interface' => StoreInterface::class])
-                    ->addTag('proxy', ['interface' => ManagedStoreInterface::class])
-                    ->addTag('ai.store');
+                    ->addTag('ai.store')
+                    ->addTag('kernel.reset', ['method' => 'reset']);
 
                 $container->setDefinition('ai.store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.store.'.$type.'.'.$name, StoreInterface::class, $name);
@@ -2089,11 +2091,9 @@ final class AiBundle extends AbstractBundle
             foreach ($messageStores as $name => $messageStore) {
                 $definition = new Definition(InMemoryMessageStore::class);
                 $definition
-                    ->setLazy(true)
                     ->setArgument(0, $messageStore['identifier'])
-                    ->addTag('proxy', ['interface' => MessageStoreInterface::class])
-                    ->addTag('proxy', ['interface' => ManagedMessageStoreInterface::class])
-                    ->addTag('ai.message_store');
+                    ->addTag('ai.message_store')
+                    ->addTag('kernel.reset', ['method' => 'reset']);
 
                 $container->setDefinition('ai.message_store.'.$type.'.'.$name, $definition);
                 $container->registerAliasForArgument('ai.message_store.'.$type.'.'.$name, MessageStoreInterface::class, $name);

--- a/src/ai-bundle/src/Profiler/TraceableChat.php
+++ b/src/ai-bundle/src/Profiler/TraceableChat.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
@@ -27,7 +28,7 @@ use Symfony\Component\Clock\ClockInterface;
  *      saved_at: \DateTimeImmutable,
  *  }
  */
-final class TraceableChat implements ChatInterface
+final class TraceableChat implements ChatInterface, ResetInterface
 {
     /**
      * @var array<int, array{
@@ -65,5 +66,13 @@ final class TraceableChat implements ChatInterface
         ];
 
         return $this->chat->submit($message);
+    }
+
+    public function reset(): void
+    {
+        if ($this->chat instanceof ResetInterface) {
+            $this->chat->reset();
+        }
+        $this->calls = [];
     }
 }

--- a/src/ai-bundle/src/Profiler/TraceableMessageStore.php
+++ b/src/ai-bundle/src/Profiler/TraceableMessageStore.php
@@ -15,6 +15,7 @@ use Symfony\AI\Chat\ManagedStoreInterface;
 use Symfony\AI\Chat\MessageStoreInterface;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
@@ -24,7 +25,7 @@ use Symfony\Component\Clock\ClockInterface;
  *      saved_at: \DateTimeImmutable,
  *  }
  */
-final class TraceableMessageStore implements ManagedStoreInterface, MessageStoreInterface
+final class TraceableMessageStore implements ManagedStoreInterface, MessageStoreInterface, ResetInterface
 {
     /**
      * @var MessageStoreData[]
@@ -68,5 +69,13 @@ final class TraceableMessageStore implements ManagedStoreInterface, MessageStore
         }
 
         $this->messageStore->drop();
+    }
+
+    public function reset(): void
+    {
+        if ($this->messageStore instanceof ResetInterface) {
+            $this->messageStore->reset();
+        }
+        $this->calls = [];
     }
 }

--- a/src/ai-bundle/src/Profiler/TraceablePlatform.php
+++ b/src/ai-bundle/src/Profiler/TraceablePlatform.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -30,7 +31,7 @@ use Symfony\AI\Platform\Result\StreamResult;
  *     result: DeferredResult,
  * }
  */
-final class TraceablePlatform implements PlatformInterface
+final class TraceablePlatform implements PlatformInterface, ResetInterface
 {
     /**
      * @var PlatformCallData[]
@@ -72,6 +73,12 @@ final class TraceablePlatform implements PlatformInterface
     public function getModelCatalog(): ModelCatalogInterface
     {
         return $this->platform->getModelCatalog();
+    }
+
+    public function reset(): void
+    {
+        $this->calls = [];
+        $this->resultCache = new \WeakMap();
     }
 
     private function createTraceableStreamResult(DeferredResult $originalStream): StreamResult

--- a/src/ai-bundle/src/Profiler/TraceableToolbox.php
+++ b/src/ai-bundle/src/Profiler/TraceableToolbox.php
@@ -14,11 +14,12 @@ namespace Symfony\AI\AiBundle\Profiler;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
 use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class TraceableToolbox implements ToolboxInterface
+final class TraceableToolbox implements ToolboxInterface, ResetInterface
 {
     /**
      * @var ToolResult[]
@@ -38,5 +39,10 @@ final class TraceableToolbox implements ToolboxInterface
     public function execute(ToolCall $toolCall): ToolResult
     {
         return $this->calls[] = $this->toolbox->execute($toolCall);
+    }
+
+    public function reset(): void
+    {
+        $this->calls = [];
     }
 }

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -1535,17 +1535,14 @@ class AiBundleTest extends TestCase
         $definition = $container->getDefinition('ai.store.memory.my_memory_store_with_custom_strategy');
         $this->assertSame(InMemoryStore::class, $definition->getClass());
 
-        $this->assertTrue($definition->isLazy());
+        $this->assertFalse($definition->isLazy());
         $this->assertCount(1, $definition->getArguments());
         $this->assertInstanceOf(Definition::class, $definition->getArgument(0));
         $this->assertSame(DistanceCalculator::class, $definition->getArgument(0)->getClass());
 
-        $this->assertTrue($definition->hasTag('proxy'));
-        $this->assertSame([
-            ['interface' => StoreInterface::class],
-            ['interface' => ManagedStoreInterface::class],
-        ], $definition->getTag('proxy'));
+        $this->assertFalse($definition->hasTag('proxy'));
         $this->assertTrue($definition->hasTag('ai.store'));
+        $this->assertTrue($definition->hasTag('kernel.reset'));
 
         $this->assertTrue($container->hasAlias('.'.StoreInterface::class.' $my_memory_store_with_custom_strategy'));
         $this->assertTrue($container->hasAlias(StoreInterface::class.' $myMemoryStoreWithCustomStrategy'));
@@ -1574,17 +1571,14 @@ class AiBundleTest extends TestCase
         $definition = $container->getDefinition('ai.store.memory.my_memory_store_with_custom_strategy');
         $this->assertSame(InMemoryStore::class, $definition->getClass());
 
-        $this->assertTrue($definition->isLazy());
+        $this->assertFalse($definition->isLazy());
         $this->assertCount(1, $definition->getArguments());
         $this->assertInstanceOf(Reference::class, $definition->getArgument(0));
         $this->assertSame('ai.store.distance_calculator.my_memory_store_with_custom_strategy', (string) $definition->getArgument(0));
 
-        $this->assertTrue($definition->hasTag('proxy'));
-        $this->assertSame([
-            ['interface' => StoreInterface::class],
-            ['interface' => ManagedStoreInterface::class],
-        ], $definition->getTag('proxy'));
+        $this->assertFalse($definition->hasTag('proxy'));
         $this->assertTrue($definition->hasTag('ai.store'));
+        $this->assertTrue($definition->hasTag('kernel.reset'));
 
         $this->assertTrue($container->hasAlias('.'.StoreInterface::class.' $my_memory_store_with_custom_strategy'));
         $this->assertTrue($container->hasAlias(StoreInterface::class.' $myMemoryStoreWithCustomStrategy'));
@@ -6906,14 +6900,12 @@ class AiBundleTest extends TestCase
 
         $definition = $container->getDefinition('ai.message_store.memory.custom');
 
-        $this->assertTrue($definition->isLazy());
+        $this->assertFalse($definition->isLazy());
         $this->assertSame('foo', $definition->getArgument(0));
 
-        $this->assertSame([
-            ['interface' => MessageStoreInterface::class],
-            ['interface' => ManagedMessageStoreInterface::class],
-        ], $definition->getTag('proxy'));
+        $this->assertFalse($definition->hasTag('proxy'));
         $this->assertTrue($definition->hasTag('ai.message_store'));
+        $this->assertTrue($definition->hasTag('kernel.reset'));
     }
 
     public function testMongoDbMessageStoreIsConfigured()

--- a/src/ai-bundle/tests/Profiler/TraceableChatTest.php
+++ b/src/ai-bundle/tests/Profiler/TraceableChatTest.php
@@ -60,4 +60,17 @@ final class TraceableChatTest extends TestCase
         $this->assertInstanceOf(UserMessage::class, $traceableChat->calls[1]['message']);
         $this->assertInstanceOf(\DateTimeImmutable::class, $traceableChat->calls[1]['saved_at']);
     }
+
+    public function testResetClearsCalls()
+    {
+        $agent = $this->createStub(AgentInterface::class);
+        $chat = new Chat($agent, new InMemoryStore());
+        $traceableChat = new TraceableChat($chat, new MonotonicClock());
+
+        $traceableChat->initiate(new MessageBag());
+        $this->assertCount(1, $traceableChat->calls);
+
+        $traceableChat->reset();
+        $this->assertCount(0, $traceableChat->calls);
+    }
 }

--- a/src/ai-bundle/tests/Profiler/TraceableMessageStoreTest.php
+++ b/src/ai-bundle/tests/Profiler/TraceableMessageStoreTest.php
@@ -42,4 +42,16 @@ final class TraceableMessageStoreTest extends TestCase
         $this->assertCount(1, $calls[0]['bag']);
         $this->assertInstanceOf(\DateTimeImmutable::class, $calls[0]['saved_at']);
     }
+
+    public function testResetClearsCalls()
+    {
+        $messageStore = new InMemoryStore();
+        $traceableMessageStore = new TraceableMessageStore($messageStore, new MonotonicClock());
+
+        $traceableMessageStore->save(new MessageBag());
+        $this->assertCount(1, $traceableMessageStore->calls);
+
+        $traceableMessageStore->reset();
+        $this->assertCount(0, $traceableMessageStore->calls);
+    }
 }

--- a/src/ai-bundle/tests/Profiler/TraceablePlatformTest.php
+++ b/src/ai-bundle/tests/Profiler/TraceablePlatformTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\AiBundle\Tests\Profiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\AiBundle\Profiler\TraceablePlatform;
+use Symfony\AI\Platform\PlainConverter;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+
+final class TraceablePlatformTest extends TestCase
+{
+    public function testResetClearsCallsAndResultCache()
+    {
+        $platform = $this->createStub(PlatformInterface::class);
+        $traceablePlatform = new TraceablePlatform($platform);
+        $result = new TextResult('Assistant response');
+
+        $platform->method('invoke')->willReturn(new DeferredResult(new PlainConverter($result), $this->createStub(RawResultInterface::class)));
+
+        $traceablePlatform->invoke('gpt-4o', 'Hello');
+        $this->assertCount(1, $traceablePlatform->calls);
+        $this->assertSame('gpt-4o', $traceablePlatform->calls[0]['model']);
+        $this->assertSame('Hello', $traceablePlatform->calls[0]['input']);
+
+        $oldCache = $traceablePlatform->resultCache;
+
+        $traceablePlatform->reset();
+
+        $this->assertCount(0, $traceablePlatform->calls);
+        $this->assertNotSame($oldCache, $traceablePlatform->resultCache);
+        $this->assertInstanceOf(\WeakMap::class, $traceablePlatform->resultCache);
+    }
+}

--- a/src/ai-bundle/tests/Profiler/TraceableToolboxTest.php
+++ b/src/ai-bundle/tests/Profiler/TraceableToolboxTest.php
@@ -47,6 +47,18 @@ final class TraceableToolboxTest extends TestCase
         $this->assertSame('tool_result', $traceableToolbox->calls[0]->getResult());
     }
 
+    public function testResetClearsCalls()
+    {
+        $toolbox = $this->createToolbox([]);
+        $traceableToolbox = new TraceableToolbox($toolbox);
+
+        $traceableToolbox->execute(new ToolCall('foo', '__invoke'));
+        $this->assertCount(1, $traceableToolbox->calls);
+
+        $traceableToolbox->reset();
+        $this->assertCount(0, $traceableToolbox->calls);
+    }
+
     /**
      * @param Tool[] $tools
      */

--- a/src/chat/CHANGELOG.md
+++ b/src/chat/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.4
+---
+
+ * Add `ResetInterface` support to in-memory store
+
 0.1
 ---
 

--- a/src/chat/composer.json
+++ b/src/chat/composer.json
@@ -26,7 +26,8 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-agent": "^0.3",
-        "symfony/ai-platform": "^0.3"
+        "symfony/ai-platform": "^0.3",
+        "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",

--- a/src/chat/src/InMemory/Store.php
+++ b/src/chat/src/InMemory/Store.php
@@ -14,11 +14,12 @@ namespace Symfony\AI\Chat\InMemory;
 use Symfony\AI\Chat\ManagedStoreInterface;
 use Symfony\AI\Chat\MessageStoreInterface;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class Store implements ManagedStoreInterface, MessageStoreInterface
+final class Store implements ManagedStoreInterface, MessageStoreInterface, ResetInterface
 {
     /**
      * @var MessageBag[]
@@ -48,5 +49,10 @@ final class Store implements ManagedStoreInterface, MessageStoreInterface
     public function drop(): void
     {
         $this->messages[$this->identifier] = new MessageBag();
+    }
+
+    public function reset(): void
+    {
+        $this->messages = [];
     }
 }

--- a/src/chat/tests/InMemory/StoreTest.php
+++ b/src/chat/tests/InMemory/StoreTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Chat\Tests\InMemory;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Chat\InMemory\Store;
+use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
@@ -101,5 +102,19 @@ final class StoreTest extends TestCase
 
         $messages = $store->load();
         $this->assertInstanceOf(MessageBag::class, $messages);
+    }
+
+    public function testResetClearsMessages()
+    {
+        $store = new Store();
+        $store->setup();
+        $store->save(new MessageBag(new UserMessage(new Text('Hello'))));
+        $store->save(new MessageBag(new UserMessage(new Text('Hello')), new AssistantMessage('Hi')));
+
+        $this->assertCount(2, $store->load());
+
+        $store->reset();
+
+        $this->assertCount(0, $store->load());
     }
 }

--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.4
+---
+
+ * Add `ResetInterface` support to `TraceableRegistry` to clear collected data between requests
+
 0.3
 ---
 

--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -23,7 +23,8 @@
         "symfony/http-foundation": "^7.3|^8.0",
         "symfony/http-kernel": "^7.3|^8.0",
         "symfony/psr-http-message-bridge": "^7.3|^8.0",
-        "symfony/routing": "^7.3|^8.0"
+        "symfony/routing": "^7.3|^8.0",
+        "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -76,7 +76,8 @@ final class McpBundle extends AbstractBundle
             $traceableRegistry = (new Definition('mcp.traceable_registry'))
                 ->setClass(TraceableRegistry::class)
                 ->setArguments([new Reference('.inner')])
-                ->setDecoratedService('mcp.registry');
+                ->setDecoratedService('mcp.registry')
+                ->addTag('kernel.reset', ['method' => 'reset']);
             $builder->setDefinition('mcp.traceable_registry', $traceableRegistry);
 
             $dataCollector = (new Definition(DataCollector::class))

--- a/src/mcp-bundle/src/Profiler/TraceableRegistry.php
+++ b/src/mcp-bundle/src/Profiler/TraceableRegistry.php
@@ -22,13 +22,14 @@ use Mcp\Schema\Prompt;
 use Mcp\Schema\Resource;
 use Mcp\Schema\ResourceTemplate;
 use Mcp\Schema\Tool;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Decorator for Registry that provides access to capabilities for the profiler.
  *
  * @author Camille Islasse <guiziweb@gmail.com>
  */
-final class TraceableRegistry implements RegistryInterface
+final class TraceableRegistry implements RegistryInterface, ResetInterface
 {
     public function __construct(
         private readonly RegistryInterface $registry,
@@ -136,5 +137,10 @@ final class TraceableRegistry implements RegistryInterface
     public function getPrompt(string $name): PromptReference
     {
         return $this->registry->getPrompt($name);
+    }
+
+    public function reset(): void
+    {
+        $this->clear();
     }
 }

--- a/src/mcp-bundle/tests/Profiler/TraceableRegistryTest.php
+++ b/src/mcp-bundle/tests/Profiler/TraceableRegistryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\Profiler;
+
+use Mcp\Capability\RegistryInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\Profiler\TraceableRegistry;
+
+final class TraceableRegistryTest extends TestCase
+{
+    public function testResetCallsClear()
+    {
+        $registry = $this->createMock(RegistryInterface::class);
+        $registry->expects($this->once())->method('clear');
+
+        $traceableRegistry = new TraceableRegistry($registry);
+        $traceableRegistry->reset();
+    }
+}

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * [BC BREAK] Reduce visibility of `VectorDocument` and `RssItem` properties to `private` and add getters
  * Add `MarkdownLoader`
  * Add `JsonFileLoader`
+ * Add `ResetInterface` support to in-memory store
 
 0.3
 ---

--- a/src/store/composer.json
+++ b/src/store/composer.json
@@ -46,6 +46,7 @@
         "symfony/clock": "^7.3|^8.0",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/polyfill-php83": "^1.32",
+        "symfony/service-contracts": "^2.5|^3",
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/store/src/InMemory/Store.php
+++ b/src/store/src/InMemory/Store.php
@@ -21,11 +21,12 @@ use Symfony\AI\Store\Query\QueryInterface;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-class Store implements ManagedStoreInterface, StoreInterface
+class Store implements ManagedStoreInterface, StoreInterface, ResetInterface
 {
     /**
      * @var VectorDocument[]
@@ -99,6 +100,11 @@ class Store implements ManagedStoreInterface, StoreInterface
     public function drop(array $options = []): void
     {
         $this->documents = [];
+    }
+
+    public function reset(): void
+    {
+        $this->drop();
     }
 
     /**

--- a/src/store/tests/InMemory/StoreTest.php
+++ b/src/store/tests/InMemory/StoreTest.php
@@ -490,4 +490,17 @@ final class StoreTest extends TestCase
         $store = new Store();
         $this->assertTrue($store->supports(HybridQuery::class));
     }
+
+    public function testResetClearsDocuments()
+    {
+        $store = new Store();
+        $store->add(new VectorDocument('1', new Vector([1.0, 2.0])));
+        $store->add(new VectorDocument('2', new Vector([3.0, 4.0])));
+
+        $this->assertCount(2, iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0])))));
+
+        $store->reset();
+
+        $this->assertCount(0, iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0])))));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1531 
| License       | MIT

This PR introduces the `ResetInterface` and `reset` tags to the tracers and in memory stores. These changes help optimize memory usage by preventing unnecessary memory increases with each request. Additionally, they ensure that erroneous information is no longer displayed in the profiler, improving accuracy and performance monitoring.

