### PR TITLE
[Platform] Read discriminator mapping from serializer metadata

### DIFF
--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -156,6 +156,7 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('ai.platform.json_schema.description_parser'),
                 service('type_info.resolver')->nullOnInvalid(),
+                service('serializer.mapping.class_metadata_factory')->ignoreOnInvalid(),
             ])
         ->alias(ResponseFormatFactoryInterface::class, 'ai.platform.response_format_factory')
         ->set('ai.platform.structured_output_serializer', StructuredOutputSerializer::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (kinda)
| New feature?  | no
| Docs?         | no
| Issues        | Related to #559
| License       | MIT

The discriminator mapping introduced in #585 only supports mapping via attributes – I found it quite unexpected behavior. Let's use serializer metadata instead?