### PR TITLE
[AI Bundle] Add `chats` data from `DataCollector` to the `data_collector.html.twig` template

### DIFF
--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.4
+---
+
+ * Add `chats` data from `DataCollector` to the `data_collector.html.twig` template 
+
 0.2
 ---
 

--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -32,6 +32,10 @@
                     <b class="label">Tool Calls</b>
                     <span class="sf-toolbar-status">{{ collector.toolCalls|length }}</span>
                 </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Chats sent</b>
+                    <span class="sf-toolbar-status">{{ collector.chats|length }}</span>
+                </div>
             </div>
         {% endset %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no ( I think is not necessary )
| Issues        | Fix #1532
| License       | MIT

This PR shows the number of chats sent in the `WebProfiler`. This information was collected previously, but was never displayed in the profiler.