### PR TITLE
 Update examples to use GPT-5.x models

### DIFF
--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -7,7 +7,7 @@ ai:
     agent:
         blog:
             platform: 'ai.platform.openai'
-            model: 'gpt-4o-mini'
+            model: 'gpt-5-mini'
             tools:
                 - 'Symfony\AI\Agent\Bridge\SimilaritySearch\SimilaritySearch'
                 - service: 'clock'
@@ -18,24 +18,24 @@ ai:
                 service: 'App\Blog\SymfonyVersionsMemory'
         stream:
             platform: 'ai.platform.openai'
-            model: 'gpt-4o-mini'
+            model: 'gpt-5-mini'
             prompt:
                 file: '%kernel.project_dir%/prompts/stream-chat.txt'
             tools: false
         youtube:
             platform: 'ai.platform.openai'
-            model: 'gpt-4o-mini'
+            model: 'gpt-5-mini'
             tools: false
         recipe:
             platform: 'ai.platform.openai'
-            model: 'gpt-4o-mini'
+            model: 'gpt-5-mini'
             prompt:
                 text: 'You are a helpful cooking assistant. Provide detailed recipes based on user requests.'
             tools: false
         wikipedia:
             platform: 'ai.platform.openai'
             model:
-                name: 'gpt-4o-mini'
+                name: 'gpt-5-mini'
                 options:
                     temperature: 0.5
             prompt:
@@ -46,7 +46,7 @@ ai:
             include_sources: true
         speech:
             platform: 'ai.platform.openai'
-            model: 'gpt-4o-mini?temperature=1.0'
+            model: 'gpt-5-mini?temperature=1.0'
             prompt: |
                 You are a friendly, positive and energetic voice assistant. You can engage in light discussions, ask
                 questions, and do general small-talk. If asked about the Symfony Framework or their community events,
@@ -64,17 +64,17 @@ ai:
         # Multi-agent setup
         orchestrator:
             platform: 'ai.platform.openai'
-            model: 'gpt-4o-mini'
+            model: 'gpt-5-mini'
             prompt: 'You are an intelligent agent orchestrator that routes user questions to specialized agents.'
             tools: false
         technical:
             platform: 'ai.platform.openai'
-            model: 'gpt-4o-mini'
+            model: 'gpt-5-mini'
             prompt: 'You are a technical support specialist. Help users resolve bugs, problems, and technical errors.'
             tools: false
         fallback:
             platform: 'ai.platform.openai'
-            model: 'gpt-4o-mini'
+            model: 'gpt-5-mini'
             prompt: 'You are a helpful general assistant. Assist users with any questions or tasks they may have.'
             tools: false
     multi_agent:

--- a/demo/src/Video/TwigComponent.php
+++ b/demo/src/Video/TwigComponent.php
@@ -58,7 +58,7 @@ final class TwigComponent
             Message::ofUser($this->instruction, Image::fromDataUrl($this->image))
         );
 
-        $result = $this->platform->invoke('gpt-4o-mini', $messageBag, [
+        $result = $this->platform->invoke('gpt-5-mini', $messageBag, [
             'max_output_tokens' => 100,
         ]);
 

--- a/examples/azure/chat-gpt.php
+++ b/examples/azure/chat-gpt.php
@@ -26,6 +26,6 @@ $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$result = $platform->invoke('gpt-4o-mini', $messages);
+$result = $platform->invoke('gpt-5-mini', $messages);
 
 echo $result->asText().\PHP_EOL;

--- a/examples/chat/persistent-chat-cache.php
+++ b/examples/chat/persistent-chat-cache.php
@@ -24,7 +24,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $store = new CacheStore(new ArrayAdapter(), 'chat');
 $store->setup();
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $chat = new Chat($agent, $store);
 
 $messages = new MessageBag(

--- a/examples/chat/persistent-chat-cloudflare.php
+++ b/examples/chat/persistent-chat-cloudflare.php
@@ -28,7 +28,7 @@ $store = new MessageStore(
 );
 $store->setup();
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $chat = new Chat($agent, $store);
 
 $messages = new MessageBag(

--- a/examples/chat/persistent-chat-doctrine-dbal.php
+++ b/examples/chat/persistent-chat-doctrine-dbal.php
@@ -26,7 +26,7 @@ $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' =
 $store = new DoctrineDbalMessageStore('symfony', $connection);
 $store->setup();
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $chat = new Chat($agent, $store);
 
 $messages = new MessageBag(

--- a/examples/chat/persistent-chat-meilisearch.php
+++ b/examples/chat/persistent-chat-meilisearch.php
@@ -24,7 +24,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $store = new MessageStore(http_client(), env('MEILISEARCH_HOST'), env('MEILISEARCH_API_KEY'), new MonotonicClock());
 $store->setup();
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $chat = new Chat($agent, $store);
 
 $messages = new MessageBag(

--- a/examples/chat/persistent-chat-mongodb.php
+++ b/examples/chat/persistent-chat-mongodb.php
@@ -28,7 +28,7 @@ $store = new MessageStore(
 );
 $store->setup();
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $chat = new Chat($agent, $store);
 
 $messages = new MessageBag(

--- a/examples/chat/persistent-chat-pogocache.php
+++ b/examples/chat/persistent-chat-pogocache.php
@@ -23,7 +23,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $store = new MessageStore(http_client(), env('POGOCACHE_HOST'), env('POGOCACHE_PASSWORD'));
 $store->setup();
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $chat = new Chat($agent, $store);
 
 $messages = new MessageBag(

--- a/examples/chat/persistent-chat-redis.php
+++ b/examples/chat/persistent-chat-redis.php
@@ -28,7 +28,7 @@ $redis = new Redis([
 $store = new MessageStore($redis, 'symfony');
 $store->setup();
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $chat = new Chat($agent, $store);
 
 $messages = new MessageBag(

--- a/examples/chat/persistent-chat-session.php
+++ b/examples/chat/persistent-chat-session.php
@@ -33,7 +33,7 @@ $requestStack->push($request);
 $store = new MessageStore($requestStack, 'chat');
 $store->setup();
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $chat = new Chat($agent, $store);
 
 $messages = new MessageBag(

--- a/examples/chat/persistent-chat-surrealdb.php
+++ b/examples/chat/persistent-chat-surrealdb.php
@@ -31,7 +31,7 @@ $store = new MessageStore(
     table: 'chat',
 );
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $chat = new Chat($agent, $store);
 
 $messages = new MessageBag(

--- a/examples/chat/persistent-chat.php
+++ b/examples/chat/persistent-chat.php
@@ -20,7 +20,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $chat = new Chat($agent, new InMemoryStore());
 
 $messages = new MessageBag(

--- a/examples/memory/mariadb.php
+++ b/examples/memory/mariadb.php
@@ -65,7 +65,7 @@ $embeddingsModel = $platform->getModelCatalog()->getModel($embeddings);
 $embeddingsMemory = new EmbeddingProvider($platform, $embeddingsModel, $store);
 $memoryProcessor = new MemoryInputProcessor([$embeddingsMemory]);
 
-$agent = new Agent($platform, 'gpt-4o-mini', [$memoryProcessor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$memoryProcessor]);
 $messages = new MessageBag(Message::ofUser('Have we discussed about my friend John in the past? If yes, what did we talk about?'));
 $result = $agent->call($messages);
 

--- a/examples/memory/static.php
+++ b/examples/memory/static.php
@@ -30,7 +30,7 @@ $personalFacts = new StaticMemoryProvider(
 );
 $memoryProcessor = new MemoryInputProcessor([$personalFacts]);
 
-$agent = new Agent($platform, 'gpt-4o-mini', [$systemPromptProcessor, $memoryProcessor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$systemPromptProcessor, $memoryProcessor]);
 $messages = new MessageBag(Message::ofUser('What do we do today?'));
 $result = $agent->call($messages);
 

--- a/examples/misc/agent-with-cache.php
+++ b/examples/misc/agent-with-cache.php
@@ -22,7 +22,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
 
-$agent = new Agent($cachedPlatform, 'gpt-4o-mini');
+$agent = new Agent($cachedPlatform, 'gpt-5-mini');
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),

--- a/examples/misc/agent-with-external-cache.php
+++ b/examples/misc/agent-with-external-cache.php
@@ -24,7 +24,7 @@ $cachedPlatform = new CachePlatform($platform, cache: new RedisTagAwareAdapter(n
     'port' => 6379,
 ])));
 
-$agent = new Agent($cachedPlatform, 'gpt-4o-mini');
+$agent = new Agent($cachedPlatform, 'gpt-5-mini');
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),

--- a/examples/misc/chat-system-prompt.php
+++ b/examples/misc/chat-system-prompt.php
@@ -21,7 +21,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
 $processor = new SystemPromptInputProcessor('You are Yoda and write like he speaks. But short.');
 
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor]);
 $messages = new MessageBag(Message::ofUser('What is the meaning of life?'));
 $result = $agent->call($messages);
 

--- a/examples/misc/failover-platform.php
+++ b/examples/misc/failover-platform.php
@@ -27,13 +27,13 @@ $rateLimiter = new RateLimiterFactory([
     'limit' => 1,
 ], new InMemoryStorage());
 
-// # Ollama will fail as 'gpt-4o' is not available in the catalog
+// # Ollama will fail as 'gpt-5.2' is not available in the catalog
 $platform = new FailoverPlatform([
     OllamaPlatformFactory::create(env('OLLAMA_HOST_URL'), http_client()),
     OpenAiPlatformFactory::create(env('OPENAI_API_KEY'), http_client()),
 ], $rateLimiter);
 
-$result = $platform->invoke('gpt-4o', new MessageBag(
+$result = $platform->invoke('gpt-5.2', new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
 ));

--- a/examples/misc/parallel-chat-gpt.php
+++ b/examples/misc/parallel-chat-gpt.php
@@ -25,7 +25,7 @@ echo 'Initiating parallel calls to GPT on platform ...'.\PHP_EOL;
 $results = [];
 foreach (range('A', 'D') as $letter) {
     echo ' - Request for the letter '.$letter.' initiated.'.\PHP_EOL;
-    $results[] = $platform->invoke('gpt-4o-mini', $messages->with(Message::ofUser($letter)));
+    $results[] = $platform->invoke('gpt-5-mini', $messages->with(Message::ofUser($letter)));
 }
 
 echo 'Waiting for the responses ...'.\PHP_EOL;

--- a/examples/misc/prompt-json-file.php
+++ b/examples/misc/prompt-json-file.php
@@ -24,7 +24,7 @@ $platform = PlatformFactory::create($_ENV['OPENAI_API_KEY'], http_client());
 $promptFile = File::fromFile(dirname(__DIR__, 2).'/fixtures/prompts/code-reviewer.json');
 $systemPromptProcessor = new SystemPromptInputProcessor($promptFile);
 
-$agent = new Agent($platform, 'gpt-4o-mini', [$systemPromptProcessor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$systemPromptProcessor]);
 $messages = new MessageBag(Message::ofUser('Review this code: function add($a, $b) { return $a + $b; }'));
 $result = $agent->call($messages);
 

--- a/examples/misc/prompt-text-file.php
+++ b/examples/misc/prompt-text-file.php
@@ -24,7 +24,7 @@ $platform = PlatformFactory::create($_ENV['OPENAI_API_KEY'], http_client());
 $promptFile = File::fromFile(dirname(__DIR__, 2).'/fixtures/prompts/helpful-assistant.txt');
 $systemPromptProcessor = new SystemPromptInputProcessor($promptFile);
 
-$agent = new Agent($platform, 'gpt-4o-mini', [$systemPromptProcessor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$systemPromptProcessor]);
 $messages = new MessageBag(Message::ofUser('Can you explain what dependency injection is?'));
 $result = $agent->call($messages);
 

--- a/examples/multi-agent/orchestrator.php
+++ b/examples/multi-agent/orchestrator.php
@@ -28,7 +28,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client(), eventD
 // Create orchestrator agent for routing decisions
 $orchestrator = new Agent(
     $platform,
-    'gpt-4o-mini',
+    'gpt-5-mini',
     [new SystemPromptInputProcessor('You are an intelligent agent orchestrator that routes user questions to specialized agents.')],
 );
 
@@ -43,7 +43,7 @@ $technical = new Agent(
 // Create general agent for handling any other questions
 $fallback = new Agent(
     $platform,
-    'gpt-4o-mini',
+    'gpt-5-mini',
     [new SystemPromptInputProcessor('You are a helpful general assistant. Assist users with any questions or tasks they may have. You should never ever answer technical question.')],
     name: 'fallback',
 );

--- a/examples/openai/agent-as-tool.php
+++ b/examples/openai/agent-as-tool.php
@@ -27,7 +27,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
 // Create a specialized agent for mathematical calculations
 $mathSystemPrompt = new SystemPromptInputProcessor('You are a mathematical calculator. When given a math problem, solve it and return only the numerical result with a brief explanation.');
-$mathAgent = new Agent($platform, 'gpt-4o', [$mathSystemPrompt]);
+$mathAgent = new Agent($platform, 'gpt-5.2', [$mathSystemPrompt]);
 
 // Wrap the math agent as a tool
 $mathTool = new AgentTool($mathAgent);
@@ -49,7 +49,7 @@ $chainFactory = new ChainFactory([
 // Create the main agent with the math agent as a tool
 $toolbox = new Toolbox([$mathTool], toolFactory: $chainFactory, logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 // Ask a question that requires mathematical calculation
 $messages = new MessageBag(Message::ofUser('I have 15 apples and I want to share them equally among 4 friends. How many apples does each friend get and how many are left over?'));

--- a/examples/openai/agent-stream-sources.php
+++ b/examples/openai/agent-stream-sources.php
@@ -27,7 +27,7 @@ $clock = new Clock(new SymfonyClock());
 $tavily = new Tavily(http_client(), env('TAVILY_API_KEY'));
 $toolbox = new Toolbox([$clock, $tavily], logger: logger());
 $processor = new AgentProcessor($toolbox, includeSources: true);
-$agent = new Agent($platform, 'gpt-4o', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5.2', [$processor], [$processor]);
 
 $prompt = <<<PROMPT
     Summarize the latest game of the Dallas Cowboys. When and where was it? Who was the opponent, what was the result,

--- a/examples/openai/chat.php
+++ b/examples/openai/chat.php
@@ -21,7 +21,7 @@ $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),
 );
-$result = $platform->invoke('gpt-4o-mini', $messages, [
+$result = $platform->invoke('gpt-5-mini', $messages, [
     'max_output_tokens' => 500, // specific options just for this call
 ]);
 

--- a/examples/openai/image-input-binary.php
+++ b/examples/openai/image-input-binary.php
@@ -25,6 +25,6 @@ $messages = new MessageBag(
         Image::fromFile(dirname(__DIR__, 2).'/fixtures/image.jpg'),
     ),
 );
-$result = $platform->invoke('gpt-4o-mini', $messages);
+$result = $platform->invoke('gpt-5-mini', $messages);
 
 echo $result->asText().\PHP_EOL;

--- a/examples/openai/image-input-url.php
+++ b/examples/openai/image-input-url.php
@@ -25,6 +25,6 @@ $messages = new MessageBag(
         new ImageUrl('https://christopher-hertel.de/images/projects/llmchain.png'),
     ),
 );
-$result = $platform->invoke('gpt-4o-mini', $messages);
+$result = $platform->invoke('gpt-5-mini', $messages);
 
 echo $result->asText().\PHP_EOL;

--- a/examples/openai/pdf-input-binary.php
+++ b/examples/openai/pdf-input-binary.php
@@ -24,6 +24,6 @@ $messages = new MessageBag(
         Document::fromFile(dirname(__DIR__, 2).'/fixtures/document.pdf'),
     ),
 );
-$result = $platform->invoke('gpt-4o-mini', $messages);
+$result = $platform->invoke('gpt-5-mini', $messages);
 
 echo $result->asText().\PHP_EOL;

--- a/examples/openai/stream-token-metadata.php
+++ b/examples/openai/stream-token-metadata.php
@@ -18,7 +18,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/openai/stream.php
+++ b/examples/openai/stream.php
@@ -21,7 +21,7 @@ $messages = new MessageBag(
     Message::forSystem('You are a thoughtful philosopher.'),
     Message::ofUser('What is the purpose of an ant?'),
 );
-$result = $platform->invoke('gpt-4o-mini', $messages, [
+$result = $platform->invoke('gpt-5-mini', $messages, [
     'stream' => true, // enable streaming of response text
 ]);
 

--- a/examples/openai/structured-output-clock.php
+++ b/examples/openai/structured-output-clock.php
@@ -30,7 +30,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client(), eventD
 $clock = new Clock(new SymfonyClock());
 $toolbox = new Toolbox([$clock], logger: logger());
 $toolProcessor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$toolProcessor], [$toolProcessor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$toolProcessor], [$toolProcessor]);
 
 $messages = new MessageBag(Message::ofUser('What date and time is it?'));
 $result = $agent->call($messages, ['response_format' => [

--- a/examples/openai/structured-output-list-of-polymorphic-items.php
+++ b/examples/openai/structured-output-list-of-polymorphic-items.php
@@ -26,6 +26,6 @@ $messages = new MessageBag(
     Message::forSystem('You are a persona data collector! Return all the data you can gather from the user input.'),
     Message::ofUser('Hi! My name is John Doe, I am 30 years old and I live in Paris.'),
 );
-$result = $platform->invoke('gpt-4o-mini', $messages, ['response_format' => ListOfPolymorphicTypesDto::class]);
+$result = $platform->invoke('gpt-5-mini', $messages, ['response_format' => ListOfPolymorphicTypesDto::class]);
 
 dump($result->asObject());

--- a/examples/openai/structured-output-math.php
+++ b/examples/openai/structured-output-math.php
@@ -27,6 +27,6 @@ $messages = new MessageBag(
     Message::ofUser('how can I solve 8x + 7 = -23'),
 );
 
-$result = $platform->invoke('gpt-4o-mini', $messages, ['response_format' => MathReasoning::class]);
+$result = $platform->invoke('gpt-5-mini', $messages, ['response_format' => MathReasoning::class]);
 
 dump($result->asObject());

--- a/examples/openai/structured-output-union-types.php
+++ b/examples/openai/structured-output-union-types.php
@@ -29,6 +29,6 @@ $messages = new MessageBag(
     PROMPT),
     Message::ofUser('What is the current time?'),
 );
-$result = $platform->invoke('gpt-4o-mini', $messages, ['response_format' => UnionTypeDto::class]);
+$result = $platform->invoke('gpt-5-mini', $messages, ['response_format' => UnionTypeDto::class]);
 
 dump($result->asObject());

--- a/examples/openai/token-metadata.php
+++ b/examples/openai/token-metadata.php
@@ -18,7 +18,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
-$agent = new Agent($platform, 'gpt-4o-mini');
+$agent = new Agent($platform, 'gpt-5-mini');
 $messages = new MessageBag(
     Message::forSystem('You are a pirate and you write funny.'),
     Message::ofUser('What is the Symfony framework?'),

--- a/examples/openai/toolcall-stream.php
+++ b/examples/openai/toolcall-stream.php
@@ -24,7 +24,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $wikipedia = new Wikipedia(http_client());
 $toolbox = new Toolbox([$wikipedia], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 $messages = new MessageBag(Message::ofUser(<<<TXT
         First, define unicorn in 30 words.
         Then lookup at Wikipedia what the irish history looks like in 2 sentences.

--- a/examples/openai/toolcall.php
+++ b/examples/openai/toolcall.php
@@ -24,7 +24,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $transcriber = new YoutubeTranscriber(http_client());
 $toolbox = new Toolbox([$transcriber], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(Message::ofUser('Please summarize this video for me: https://www.youtube.com/watch?v=6uXW-ulpj0s'));
 $result = $agent->call($messages);

--- a/examples/openrouter/structured-output-math.php
+++ b/examples/openrouter/structured-output-math.php
@@ -27,6 +27,6 @@ $messages = new MessageBag(
     Message::ofUser('how can I solve 8x + 7 = -23'),
 );
 
-$result = $platform->invoke('openai/gpt-4o-mini', $messages, ['response_format' => MathReasoning::class]);
+$result = $platform->invoke('openai/gpt-5-mini', $messages, ['response_format' => MathReasoning::class]);
 
 dump($result->asObject());

--- a/examples/platform/template/mixed-content.php
+++ b/examples/platform/template/mixed-content.php
@@ -37,7 +37,7 @@ $messages = new MessageBag(
     Message::ofUser('I need help with', Template::string(' {task}'))
 );
 
-$result = $platform->invoke('gpt-4o-mini', $messages, [
+$result = $platform->invoke('gpt-5-mini', $messages, [
     'template_vars' => ['task' => 'debugging'],
 ]);
 

--- a/examples/platform/template/multiple-messages.php
+++ b/examples/platform/template/multiple-messages.php
@@ -40,7 +40,7 @@ $messages = new MessageBag(
     Message::ofUser($userTemplate)
 );
 
-$result = $platform->invoke('gpt-4o-mini', $messages, [
+$result = $platform->invoke('gpt-5-mini', $messages, [
     'template_vars' => [
         'domain' => 'math',
         'operation' => '2 + 2',

--- a/examples/platform/template/system-message.php
+++ b/examples/platform/template/system-message.php
@@ -38,7 +38,7 @@ $messages = new MessageBag(
     Message::ofUser('What is PHP?')
 );
 
-$result = $platform->invoke('gpt-4o-mini', $messages, [
+$result = $platform->invoke('gpt-5-mini', $messages, [
     'template_vars' => ['domain' => 'programming'],
 ]);
 

--- a/examples/platform/template/user-message.php
+++ b/examples/platform/template/user-message.php
@@ -37,7 +37,7 @@ $messages = new MessageBag(
     Message::ofUser(Template::string('Tell me about {topic}'))
 );
 
-$result = $platform->invoke('gpt-4o-mini', $messages, [
+$result = $platform->invoke('gpt-5-mini', $messages, [
     'template_vars' => ['topic' => 'PHP'],
 ]);
 

--- a/examples/rag/cache.php
+++ b/examples/rag/cache.php
@@ -50,7 +50,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/chromadb.php
+++ b/examples/rag/chromadb.php
@@ -57,7 +57,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/clickhouse.php
+++ b/examples/rag/clickhouse.php
@@ -57,7 +57,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/cloudflare.php
+++ b/examples/rag/cloudflare.php
@@ -57,7 +57,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/elasticsearch.php
+++ b/examples/rag/elasticsearch.php
@@ -56,7 +56,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/in-memory.php
+++ b/examples/rag/in-memory.php
@@ -49,7 +49,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/manticore.php
+++ b/examples/rag/manticore.php
@@ -57,7 +57,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/mariadb-openai.php
+++ b/examples/rag/mariadb-openai.php
@@ -58,7 +58,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/meilisearch.php
+++ b/examples/rag/meilisearch.php
@@ -57,7 +57,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/milvus.php
+++ b/examples/rag/milvus.php
@@ -58,7 +58,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/mongodb.php
+++ b/examples/rag/mongodb.php
@@ -59,7 +59,7 @@ $store->setup();
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/neo4j.php
+++ b/examples/rag/neo4j.php
@@ -60,7 +60,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/opensearch.php
+++ b/examples/rag/opensearch.php
@@ -56,7 +56,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/pinecone.php
+++ b/examples/rag/pinecone.php
@@ -50,7 +50,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/postgres.php
+++ b/examples/rag/postgres.php
@@ -57,7 +57,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/qdrant.php
+++ b/examples/rag/qdrant.php
@@ -57,7 +57,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/redis.php
+++ b/examples/rag/redis.php
@@ -59,7 +59,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/surrealdb.php
+++ b/examples/rag/surrealdb.php
@@ -60,7 +60,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/typesense.php
+++ b/examples/rag/typesense.php
@@ -57,7 +57,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/rag/weaviate.php
+++ b/examples/rag/weaviate.php
@@ -57,7 +57,7 @@ $indexer->index($documents);
 $similaritySearch = new SimilaritySearch($vectorizer, $store);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('Please answer all user questions only using SimilaritySearch function.'),

--- a/examples/toolbox/brave.php
+++ b/examples/toolbox/brave.php
@@ -29,7 +29,7 @@ $clock = new Clock(new SymfonyClock());
 $crawler = new Scraper(http_client());
 $toolbox = new Toolbox([$brave, $clock, $crawler], logger: logger());
 $processor = new AgentProcessor($toolbox, includeSources: true);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $prompt = <<<PROMPT
     Summarize the latest game of the Dallas Cowboys. When and where was it? Who was the opponent, what was the result,

--- a/examples/toolbox/clock.php
+++ b/examples/toolbox/clock.php
@@ -26,7 +26,7 @@ $metadataFactory = (new MemoryToolFactory())
     ->addTool(Clock::class, 'clock', 'Get the current date and time', 'now');
 $toolbox = new Toolbox([new Clock()], $metadataFactory, logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(Message::ofUser('What date and time is it?'));
 $result = $agent->call($messages);

--- a/examples/toolbox/firecrawl-crawl.php
+++ b/examples/toolbox/firecrawl-crawl.php
@@ -30,7 +30,7 @@ $firecrawl = new Firecrawl(
 $toolbox = new Toolbox([$firecrawl], logger: logger());
 $toolProcessor = new AgentProcessor($toolbox);
 
-$agent = new Agent($platform, 'gpt-4o-mini', inputProcessors: [$toolProcessor], outputProcessors: [$toolProcessor]);
+$agent = new Agent($platform, 'gpt-5-mini', inputProcessors: [$toolProcessor], outputProcessors: [$toolProcessor]);
 
 $messages = new MessageBag(Message::ofUser('Crawl the following URL: https://symfony.com/doc/current/setup.html then resume it in less than 200 words.'));
 $result = $agent->call($messages);

--- a/examples/toolbox/firecrawl-map.php
+++ b/examples/toolbox/firecrawl-map.php
@@ -30,7 +30,7 @@ $firecrawl = new Firecrawl(
 $toolbox = new Toolbox([$firecrawl], logger: logger());
 $toolProcessor = new AgentProcessor($toolbox);
 
-$agent = new Agent($platform, 'gpt-4o-mini', inputProcessors: [$toolProcessor], outputProcessors: [$toolProcessor]);
+$agent = new Agent($platform, 'gpt-5-mini', inputProcessors: [$toolProcessor], outputProcessors: [$toolProcessor]);
 
 $messages = new MessageBag(Message::ofUser('Retrieve all the links from https://symfony.com then list only the ones related to the Messenger component.'));
 $result = $agent->call($messages);

--- a/examples/toolbox/firecrawl-scrape.php
+++ b/examples/toolbox/firecrawl-scrape.php
@@ -30,7 +30,7 @@ $firecrawl = new Firecrawl(
 $toolbox = new Toolbox([$firecrawl], logger: logger());
 $toolProcessor = new AgentProcessor($toolbox);
 
-$agent = new Agent($platform, 'gpt-4o-mini', inputProcessors: [$toolProcessor], outputProcessors: [$toolProcessor]);
+$agent = new Agent($platform, 'gpt-5-mini', inputProcessors: [$toolProcessor], outputProcessors: [$toolProcessor]);
 
 $messages = new MessageBag(Message::ofUser('Scrape the following URL: https://symfony.com/doc/current/setup.html then resume it in less than 200 words.'));
 $result = $agent->call($messages);

--- a/examples/toolbox/mapbox-geocode.php
+++ b/examples/toolbox/mapbox-geocode.php
@@ -24,7 +24,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $mapbox = new Mapbox(http_client(), env('MAPBOX_ACCESS_TOKEN'));
 $toolbox = new Toolbox([$mapbox], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(Message::ofUser('What are the coordinates of Brandenburg Gate in Berlin?'));
 $result = $agent->call($messages);

--- a/examples/toolbox/mapbox-reverse-geocode.php
+++ b/examples/toolbox/mapbox-reverse-geocode.php
@@ -24,7 +24,7 @@ $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 $mapbox = new Mapbox(http_client(), env('MAPBOX_ACCESS_TOKEN'));
 $toolbox = new Toolbox([$mapbox], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 $messages = new MessageBag(Message::ofUser('What address is at coordinates longitude -73.985131, latitude 40.758895?'));
 $result = $agent->call($messages);

--- a/examples/toolbox/serpapi.php
+++ b/examples/toolbox/serpapi.php
@@ -29,7 +29,7 @@ $crawler = new Scraper(http_client());
 $serpApi = new SerpApi(http_client(), env('SERP_API_KEY'));
 $toolbox = new Toolbox([$clock, $crawler, $serpApi], logger: logger());
 $processor = new AgentProcessor($toolbox, includeSources: true);
-$agent = new Agent($platform, 'gpt-4o', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5.2', [$processor], [$processor]);
 
 $prompt = <<<PROMPT
     Summarize the latest game of the Dallas Cowboys. When and where was it? Who was the opponent, what was the result,

--- a/examples/toolbox/tavily.php
+++ b/examples/toolbox/tavily.php
@@ -27,7 +27,7 @@ $clock = new Clock(new SymfonyClock());
 $tavily = new Tavily(http_client(), env('TAVILY_API_KEY'));
 $toolbox = new Toolbox([$clock, $tavily], logger: logger());
 $processor = new AgentProcessor($toolbox, includeSources: true);
-$agent = new Agent($platform, 'gpt-4o', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5.2', [$processor], [$processor]);
 
 $prompt = <<<PROMPT
     Summarize the latest game of the Dallas Cowboys. When and where was it? Who was the opponent, what was the result,

--- a/examples/toolbox/weather-event.php
+++ b/examples/toolbox/weather-event.php
@@ -28,7 +28,7 @@ $openMeteo = new OpenMeteo(http_client());
 $toolbox = new Toolbox([$openMeteo], logger: logger());
 $eventDispatcher = new EventDispatcher();
 $processor = new AgentProcessor($toolbox, eventDispatcher: $eventDispatcher);
-$agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
 // Add tool call result listener to enforce chain exits direct with structured response for weather tools
 $eventDispatcher->addListener(ToolCallsExecuted::class, static function (ToolCallsExecuted $event): void {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

OpenAI is retiring GPT-4o, GPT-4.1, GPT-4.1 mini, and o4-mini on **February 13, 2026**.
GPT-5.2 is now the default model in ChatGPT.

This PR updates all examples and demo configurations to use:
- `gpt-5-mini` instead of `gpt-4o-mini`
- `gpt-5.2` instead of `gpt-4o`

The model catalog already includes GPT-5.x models, so this change only affects example code and demo configs.

See: https://help.openai.com/en/articles/6825453-chatgpt-release-notes