### PR TITLE
[Platform] Add support for object instances in structured output

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -494,6 +494,7 @@ Code Examples
 
 * `Structured Output with PHP class`_
 * `Structured Output with array`_
+* `Populating existing objects`_
 
 Server Tools
 ------------
@@ -748,6 +749,7 @@ Code Examples
 .. _`Embeddings with Mistral`: https://github.com/symfony/ai/blob/main/examples/mistral/embeddings.php
 .. _`Structured Output with PHP class`: https://github.com/symfony/ai/blob/main/examples/openai/structured-output-math.php
 .. _`Structured Output with array`: https://github.com/symfony/ai/blob/main/examples/openai/structured-output-clock.php
+.. _`Populating existing objects`: https://github.com/symfony/ai/blob/main/examples/platform/structured-output-populate-object.php
 .. _`Parallel GPT Calls`: https://github.com/symfony/ai/blob/main/examples/misc/parallel-chat-gpt.php
 .. _`Parallel Embeddings Calls`: https://github.com/symfony/ai/blob/main/examples/misc/parallel-embeddings.php
 .. _`LM Studio`: https://lmstudio.ai/

--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -12,6 +12,7 @@ Getting Started Guides
 
     chatbot-with-memory
     rag-implementation
+    structured-output-object-instances
 
 Memory & Context Management
 ---------------------------
@@ -22,3 +23,8 @@ Retrieval Augmented Generation
 ------------------------------
 
 * :doc:`rag-implementation` - Implement complete RAG systems with vector stores and semantic search
+
+Structured Output
+-----------------
+
+* :doc:`structured-output-object-instances` - Populate existing object instances with AI-generated data

--- a/docs/cookbook/structured-output-object-instances.rst
+++ b/docs/cookbook/structured-output-object-instances.rst
@@ -1,0 +1,75 @@
+Using Object Instances with Structured Output
+=============================================
+
+Pass object instances to ``response_format`` to populate missing fields while preserving
+existing values. Use ``template_vars`` to provide object context to the AI model.
+
+Basic Example
+-------------
+
+.. code-block:: php
+
+    use Symfony\AI\Platform\Message\Message;
+    use Symfony\AI\Platform\Message\MessageBag;
+    use Symfony\AI\Platform\Message\Template;
+
+    $city = new City(name: 'Berlin');
+
+    $messages = new MessageBag(
+        Message::ofUser(Template::string('Research missing data for: {city.name}'))
+    );
+
+    $result = $platform->invoke($model, $messages, [
+        'template_vars' => ['city' => $city],
+        'response_format' => $city,
+    ]);
+
+    // Same instance returned with populated fields
+    assert($city === $result->asObject());
+
+Use Cases
+---------
+
+**Enriching database records**
+    Populate missing fields from partial database data.
+
+**Updating incomplete records**
+    Generate AI content for null fields in existing objects.
+
+**Progressive data collection**
+    Build data incrementally across multiple AI calls using the same object instance.
+
+Configuration
+-------------
+
+Register ``TemplateRendererListener`` with a normalizer::
+
+    use Symfony\AI\Platform\EventListener\TemplateRendererListener;
+    use Symfony\AI\Platform\Message\TemplateRenderer\StringTemplateRenderer;
+    use Symfony\AI\Platform\Message\TemplateRenderer\TemplateRendererRegistry;
+    use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+    $normalizer = new ObjectNormalizer();
+    $registry = new TemplateRendererRegistry([new StringTemplateRenderer()]);
+    $dispatcher->addSubscriber(new TemplateRendererListener($registry, $normalizer));
+    $dispatcher->addSubscriber(new PlatformSubscriber());
+
+Normalization Options
+---------------------
+
+Control object normalization with ``template_options['normalizer_context']``::
+
+    $result = $platform->invoke($model, $messages, [
+        'template_vars' => ['product' => $product],
+        'template_options' => [
+            'normalizer_context' => [
+                'groups' => ['public'],
+            ],
+        ],
+        'response_format' => $product,
+    ]);
+
+Related Documentation
+---------------------
+
+* :doc:`../components/platform` - Platform component documentation

--- a/examples/platform/structured-output-populate-object.php
+++ b/examples/platform/structured-output-populate-object.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\EventListener\TemplateRendererListener;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\Template;
+use Symfony\AI\Platform\Message\TemplateRenderer\StringTemplateRenderer;
+use Symfony\AI\Platform\Message\TemplateRenderer\TemplateRendererRegistry;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\City;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$dispatcher = new EventDispatcher();
+$dispatcher->addSubscriber(new PlatformSubscriber());
+
+$normalizer = new ObjectNormalizer();
+$registry = new TemplateRendererRegistry([new StringTemplateRenderer()]);
+$dispatcher->addSubscriber(new TemplateRendererListener($registry, $normalizer));
+
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client(), eventDispatcher: $dispatcher);
+
+$city = new City(name: 'Berlin');
+
+echo "Initial object state:\n";
+dump($city);
+
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant that provides information about cities.'),
+    Message::ofUser(Template::string('Please research the missing data attributes for this city: {city.name}')),
+);
+
+$result = $platform->invoke('gpt-4o-mini', $messages, [
+    'template_vars' => ['city' => $city],
+    'response_format' => $city,
+]);
+
+echo "\nPopulated object state:\n";
+dump($result->asObject());
+
+echo "\nObject identity preserved: ";
+dump($city === $result->asObject());

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for object serialization in template variables via `template_vars` option
+ * Add support for populating existing object instances in structured output via `response_format` option
 
 0.3
 ---

--- a/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
+++ b/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
@@ -27,6 +27,7 @@ use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\City;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\MathReasoning;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\MathReasoningWithAttributes;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType\ListItemAge;
@@ -281,5 +282,181 @@ final class PlatformSubscriberTest extends TestCase
         $processor->processResult($event);
 
         $this->assertSame($result, $event->getDeferredResult()->getResult());
+    }
+
+    public function testProcessInputWithObjectInstance()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));
+        $city = new City(name: 'Berlin');
+        $event = new InvocationEvent(new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]), new MessageBag(), [
+            'response_format' => $city,
+        ]);
+
+        $processor->processInput($event);
+
+        $this->assertSame(['response_format' => ['some' => 'format']], $event->getOptions());
+    }
+
+    public function testProcessOutputWithObjectInstance()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));
+
+        $city = new City(name: 'Berlin');
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+        $invocationEvent = new InvocationEvent($model, new MessageBag(), ['response_format' => $city]);
+        $processor->processInput($invocationEvent);
+
+        $converter = new PlainConverter(new TextResult('{"name": "Berlin", "population": 3500000, "country": "Germany", "mayor": "Kai Wegner"}'));
+        $deferred = new DeferredResult($converter, new InMemoryRawResult());
+        $resultEvent = new ResultEvent($model, $deferred, $invocationEvent->getOptions());
+
+        $processor->processResult($resultEvent);
+
+        $deferredResult = $resultEvent->getDeferredResult();
+        $this->assertInstanceOf(ObjectResult::class, $deferredResult->getResult());
+        $result = $deferredResult->asObject();
+        $this->assertInstanceOf(City::class, $result);
+        $this->assertSame($city, $result);
+        $this->assertSame('Berlin', $result->name);
+        $this->assertSame(3500000, $result->population);
+        $this->assertSame('Germany', $result->country);
+        $this->assertSame('Kai Wegner', $result->mayor);
+    }
+
+    public function testObjectInstancePreservesExistingValues()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));
+
+        $city = new City(name: 'Berlin', country: 'Germany');
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+        $invocationEvent = new InvocationEvent($model, new MessageBag(), ['response_format' => $city]);
+        $processor->processInput($invocationEvent);
+
+        $converter = new PlainConverter(new TextResult('{"population": 3500000, "mayor": "Kai Wegner"}'));
+        $deferred = new DeferredResult($converter, new InMemoryRawResult());
+        $resultEvent = new ResultEvent($model, $deferred, $invocationEvent->getOptions());
+
+        $processor->processResult($resultEvent);
+
+        $result = $resultEvent->getDeferredResult()->asObject();
+        $this->assertSame($city, $result);
+        $this->assertSame('Berlin', $result->name);
+        $this->assertSame('Germany', $result->country);
+        $this->assertSame(3500000, $result->population);
+        $this->assertSame('Kai Wegner', $result->mayor);
+    }
+
+    public function testObjectInstanceThrowsExceptionWithStreaming()
+    {
+        $this->expectException(\Symfony\AI\Platform\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Streamed responses are not supported for structured output.');
+
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory());
+
+        $city = new City(name: 'Berlin');
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+        $event = new InvocationEvent($model, new MessageBag(), [
+            'response_format' => $city,
+            'stream' => true,
+        ]);
+
+        $processor->processInput($event);
+    }
+
+    public function testProcessInputIgnoresNonObjectNonClassString()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory());
+
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+        $event = new InvocationEvent($model, new MessageBag(), [
+            'response_format' => 'invalid-class-name',
+        ]);
+
+        $processor->processInput($event);
+
+        $this->assertSame(['response_format' => 'invalid-class-name'], $event->getOptions());
+    }
+
+    public function testProcessInputIgnoresNonStructuredOutputResponseFormats()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory());
+
+        $model = new Model('dalle-2');
+        $event = new InvocationEvent($model, new MessageBag(), [
+            'response_format' => 'url',
+        ]);
+
+        $processor->processInput($event);
+
+        $this->assertSame(['response_format' => 'url'], $event->getOptions());
+    }
+
+    public function testObjectToPopulateIsResetAfterProcessResult()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));
+
+        $city1 = new City(name: 'Berlin');
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+        $invocationEvent1 = new InvocationEvent($model, new MessageBag(), ['response_format' => $city1]);
+        $processor->processInput($invocationEvent1);
+
+        $converter = new PlainConverter(new TextResult('{"name": "Berlin", "population": 3500000}'));
+        $deferred = new DeferredResult($converter, new InMemoryRawResult());
+        $resultEvent1 = new ResultEvent($model, $deferred, $invocationEvent1->getOptions());
+        $processor->processResult($resultEvent1);
+
+        $invocationEvent2 = new InvocationEvent($model, new MessageBag(), ['response_format' => City::class]);
+        $processor->processInput($invocationEvent2);
+
+        $converter2 = new PlainConverter(new TextResult('{"name": "Paris", "population": 2161000}'));
+        $deferred2 = new DeferredResult($converter2, new InMemoryRawResult());
+        $resultEvent2 = new ResultEvent($model, $deferred2, $invocationEvent2->getOptions());
+        $processor->processResult($resultEvent2);
+
+        $result2 = $resultEvent2->getDeferredResult()->asObject();
+
+        $this->assertInstanceOf(City::class, $result2);
+        $this->assertNotSame($city1, $result2);
+        $this->assertSame('Paris', $result2->name);
+    }
+
+    public function testMultipleObjectInstancesInSequenceAreHandledCorrectly()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));
+
+        $city1 = new City(name: 'Berlin');
+        $city2 = new City(name: 'Paris');
+
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+
+        // First invocation
+        $invocationEvent1 = new InvocationEvent($model, new MessageBag(), ['response_format' => $city1]);
+        $processor->processInput($invocationEvent1);
+        $this->assertSame(['response_format' => ['some' => 'format']], $invocationEvent1->getOptions());
+
+        $converter1 = new PlainConverter(new TextResult('{"name": "Berlin", "population": 3500000}'));
+        $deferred1 = new DeferredResult($converter1, new InMemoryRawResult());
+        $resultEvent1 = new ResultEvent($model, $deferred1, $invocationEvent1->getOptions());
+        $processor->processResult($resultEvent1);
+
+        $result1 = $resultEvent1->getDeferredResult()->asObject();
+        $this->assertSame($city1, $result1);
+
+        // Second invocation with different object
+        $invocationEvent2 = new InvocationEvent($model, new MessageBag(), ['response_format' => $city2]);
+        $processor->processInput($invocationEvent2);
+
+        $converter2 = new PlainConverter(new TextResult('{"name": "Paris", "population": 2161000}'));
+        $deferred2 = new DeferredResult($converter2, new InMemoryRawResult());
+        $resultEvent2 = new ResultEvent($model, $deferred2, $invocationEvent2->getOptions());
+        $processor->processResult($resultEvent2);
+
+        $result2 = $resultEvent2->getDeferredResult()->asObject();
+        $this->assertSame($city2, $result2);
+
+        $this->assertSame('Berlin', $city1->name);
+        $this->assertSame(3500000, $city1->population);
+        $this->assertSame('Paris', $city2->name);
+        $this->assertSame(2161000, $city2->population);
     }
 }

--- a/src/platform/tests/StructuredOutput/ResultConverterTest.php
+++ b/src/platform/tests/StructuredOutput/ResultConverterTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\StructuredOutput;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\PlainConverter;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\StructuredOutput\ResultConverter;
+use Symfony\AI\Platform\StructuredOutput\Serializer;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\City;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\SomeStructure;
+
+final class ResultConverterTest extends TestCase
+{
+    public function testConvertWithoutOutputType()
+    {
+        $innerConverter = new PlainConverter(new TextResult('{"key": "value"}'));
+        $converter = new ResultConverter($innerConverter, new Serializer());
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(ObjectResult::class, $result);
+        $this->assertIsArray($result->getContent());
+        $this->assertSame(['key' => 'value'], $result->getContent());
+    }
+
+    public function testConvertWithOutputType()
+    {
+        $innerConverter = new PlainConverter(new TextResult('{"some": "data"}'));
+        $converter = new ResultConverter($innerConverter, new Serializer(), SomeStructure::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(ObjectResult::class, $result);
+        $this->assertInstanceOf(SomeStructure::class, $result->getContent());
+        $this->assertSame('data', $result->getContent()->some);
+    }
+
+    public function testConvertWithObjectToPopulate()
+    {
+        $city = new City(name: 'Berlin');
+        $innerConverter = new PlainConverter(new TextResult('{"name": "Berlin", "population": 3500000, "country": "Germany", "mayor": "Kai Wegner"}'));
+        $converter = new ResultConverter($innerConverter, new Serializer(), City::class, $city);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(ObjectResult::class, $result);
+        $populatedCity = $result->getContent();
+
+        $this->assertSame($city, $populatedCity);
+        $this->assertSame('Berlin', $populatedCity->name);
+        $this->assertSame(3500000, $populatedCity->population);
+        $this->assertSame('Germany', $populatedCity->country);
+        $this->assertSame('Kai Wegner', $populatedCity->mayor);
+    }
+
+    public function testConvertWithObjectToPopulatePreservesExistingValues()
+    {
+        $city = new City(name: 'Paris', country: 'France');
+        $innerConverter = new PlainConverter(new TextResult('{"population": 2161000, "mayor": "Anne Hidalgo"}'));
+        $converter = new ResultConverter($innerConverter, new Serializer(), City::class, $city);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $populatedCity = $result->getContent();
+
+        $this->assertInstanceOf(City::class, $populatedCity);
+        $this->assertSame($city, $populatedCity);
+        $this->assertSame('Paris', $populatedCity->name);
+        $this->assertSame('France', $populatedCity->country);
+
+        $this->assertSame(2161000, $populatedCity->population);
+        $this->assertSame('Anne Hidalgo', $populatedCity->mayor);
+    }
+
+    public function testConvertWithNullObjectToPopulateCreatesNewInstance()
+    {
+        $innerConverter = new PlainConverter(new TextResult('{"name": "Tokyo", "population": 13960000}'));
+        $converter = new ResultConverter($innerConverter, new Serializer(), City::class, null);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $city = $result->getContent();
+
+        $this->assertInstanceOf(City::class, $city);
+        $this->assertSame('Tokyo', $city->name);
+        $this->assertSame(13960000, $city->population);
+    }
+
+    public function testConvertSupportsAllModels()
+    {
+        $innerConverter = new PlainConverter(new TextResult('{}'));
+        $converter = new ResultConverter($innerConverter, new Serializer());
+
+        $this->assertTrue($converter->supports(new Model('any-model')));
+        $this->assertTrue($converter->supports(new Model('gpt-4')));
+    }
+
+    public function testConvertReturnsNonTextResultUnchanged()
+    {
+        $objectResult = new ObjectResult(['data' => 'test']);
+        $innerConverter = new PlainConverter($objectResult);
+        $converter = new ResultConverter($innerConverter, new Serializer(), City::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertSame($objectResult, $result);
+    }
+
+    public function testConvertPreservesMetadataFromInnerResult()
+    {
+        $textResult = new TextResult('{"some": "data"}');
+        $textResult->getMetadata()->add('test_key', 'test_value');
+
+        $innerConverter = new PlainConverter($textResult);
+        $converter = new ResultConverter($innerConverter, new Serializer(), SomeStructure::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertTrue($result->getMetadata()->has('test_key'));
+        $this->assertSame('test_value', $result->getMetadata()->get('test_key'));
+    }
+
+    public function testConvertSetsRawResultOnObjectResult()
+    {
+        $innerConverter = new PlainConverter(new TextResult('{"some": "data"}'));
+        $converter = new ResultConverter($innerConverter, new Serializer(), SomeStructure::class);
+
+        $rawResult = new InMemoryRawResult();
+        $result = $converter->convert($rawResult);
+
+        $this->assertSame($rawResult, $result->getRawResult());
+    }
+
+    public function testGetTokenUsageExtractorDelegatesToInnerConverter()
+    {
+        $innerConverter = new PlainConverter(new TextResult('{}'));
+        $converter = new ResultConverter($innerConverter, new Serializer());
+
+        $extractor = $converter->getTokenUsageExtractor();
+
+        $this->assertNull($extractor);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1545
| License       | MIT

### Summary

This change implements support for object instances in structured output workflows:

1. **Object instances in response_format option**
   - PlatformSubscriber now accepts both class-string and object instances
   - Uses Symfony Serializer's OBJECT_TO_POPULATE context
   - Preserves object identity (same instance returned)
   - Allows AI to populate missing data in partially-instantiated objects

2. **Object instances in template variables**
   - TemplateRendererListener normalizes objects in `template_vars` using NormalizerInterface
   - Normalized objects are flattened for dot notation access in templates (e.g., `{city.name}`)
   - Supports custom normalizer context via `template_options['normalizer_context']`
   - StringTemplateRenderer supports nested array access with dot notation

3. **Template rendering enhancements**
   - Nested arrays are automatically flattened with dot notation
   - Null values are converted to empty strings
   - Deep nesting supported (e.g., `{level1.level2.level3}`)

Usage example:
```php
$city = new City(name: 'Berlin'); // Partial object

$messages = new MessageBag(
    Message::forSystem('You are a helpful assistant.'),
    Message::ofUser(Template::string('Research missing data for: {city.name}')),
);

$result = $platform->invoke($model, $messages, [
    'template_vars' => ['city' => $city],
    'template_options' => [
        'normalizer_context' => ['groups' => ['api']], // Optional
    ],
    'response_format' => $city, // Returns same instance with fields populated
]);

Fixes #1545