### PR TITLE
[AI Bundle] Add `DocumentIndexer` support when no loader is configured

### DIFF
--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `chats` data from `DataCollector` to the `data_collector.html.twig` template
  * [BC BREAK] Rename service ID prefix `ai.toolbox.{agent}.agent_wrapper.` to `ai.toolbox.{agent}.subagent.`
+ * Add support for `DocumentIndexer` when no loader is configured for an indexer
 
 0.2
 ---

--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -471,7 +471,7 @@ return static function (DefinitionConfigurator $configurator): void {
                     ->children()
                         ->stringNode('loader')
                             ->info('Service name of loader')
-                            ->isRequired()
+                            ->defaultNull()
                         ->end()
                         ->variableNode('source')
                             ->info('Source identifier (file path, URL, etc.) or array of sources')

--- a/src/store/src/Command/IndexCommand.php
+++ b/src/store/src/Command/IndexCommand.php
@@ -12,6 +12,8 @@
 namespace Symfony\AI\Store\Command;
 
 use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\Indexer\ConfiguredSourceIndexer;
+use Symfony\AI\Store\Indexer\SourceIndexer;
 use Symfony\AI\Store\IndexerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -87,6 +89,10 @@ EOF
         }
 
         $indexerService = $this->indexers->get($indexer);
+
+        if (!$indexerService instanceof SourceIndexer && !$indexerService instanceof ConfiguredSourceIndexer) {
+            throw new RuntimeException(\sprintf('The "%s" indexer is not a SourceIndexer. This command only works with indexers that have a loader configured.', $indexer));
+        }
 
         $io->title(\sprintf('Indexing documents using "%s" indexer', $indexer));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

This PR adds support for configuring an indexer without a loader. When no `loader` option is specified, a `DocumentIndexer` is created instead of a `SourceIndexer`.

This is useful when you want to index documents directly without loading them from a source (file path, URL, etc.).

## Configuration

```yaml
ai:
    indexer:
        my_indexer:
            # No loader configured - creates a DocumentIndexer
            vectorizer: my_vectorizer
            store: ai.store.memory.my_store
```

## Usage

```php
$indexer->index(new TextDocument('id', 'content'));
$indexer->index([$document1, $document2]);
```

## The Three Indexer Types

| Configuration | Resulting Class |
|--------------|-----------------|
| `loader` + `source` | `ConfiguredSourceIndexer` wrapping `SourceIndexer` |
| `loader` only | `SourceIndexer` |
| Neither | `DocumentIndexer` |

🤖 Generated with [Claude Code](https://claude.ai/code)