### PR TITLE
[Platform] Add support for DiscriminatorMap on single polymorphic interface parameters

### DIFF
--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -271,6 +271,17 @@ arguments did not pass validation. When using the AI Bundle, the event listener 
 
 See `Tool Call Argument Validation`_ for a complete example.
 
+Polymorphic Parameters with DiscriminatorMap
+............................................
+
+For complex tool parameters that can be one of multiple types, use the ``DiscriminatorMap`` attribute from Symfony Serializer.
+This generates a JSON Schema with ``anyOf`` to properly describe all possible implementations. The ``typeProperty`` defines
+which field identifies the type, and the Symfony Serializer will automatically deserialize to the correct implementation
+class based on this discriminator field.
+
+See the `toolcall-polymorphic-interface.php <https://github.com/symfony/ai/blob/main/examples/agent/toolcall-polymorphic-interface.php>`_
+example for a complete working implementation.
+
 Third-Party Tools
 ~~~~~~~~~~~~~~~~~
 

--- a/examples/agent/toolcall-nested-objects.php
+++ b/examples/agent/toolcall-nested-objects.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Agent\Toolbox\ToolCallArgumentResolver;
+use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory as AnthropicPlatformFactory;
+use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory as GeminiPlatformFactory;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory as OpenAiPlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\ShippingOrder\ShippingOrder;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+/*
+ * This example demonstrates that the ToolCallArgumentResolver supports nested
+ * objects, backed enums, datetime, arrays of objects, and type resolution via PHP docblocks.
+ */
+
+#[AsTool('create_shipping_order', 'Create a shipping order with items to ship to an address', method: 'create')]
+final class ShippingTool
+{
+    /**
+     * @param ShippingOrder $order The shipping order to create
+     */
+    public function create(ShippingOrder $order): string
+    {
+        dump($order);
+
+        return 'Shipping order created.';
+    }
+}
+
+$platforms = [
+    'claude-sonnet-4-5-20250929' => AnthropicPlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client()),
+    'gpt-5-mini' => OpenAiPlatformFactory::create(env('OPENAI_API_KEY'), httpClient: http_client()),
+    'gemini-2.5-flash' => GeminiPlatformFactory::create(env('GEMINI_API_KEY'), httpClient: http_client()),
+];
+
+foreach ($platforms as $model => $platform) {
+    $shippingTool = new ShippingTool();
+    $toolbox = new Toolbox(tools: [$shippingTool]);
+    $processor = new AgentProcessor(toolbox: $toolbox);
+    $agent = new Agent($platform, $model, [$processor], [$processor]);
+
+    echo "\n=== Testing with model: $model ===\n\n";
+
+    $messages = new MessageBag(
+        Message::forSystem('You are a shipping assistant. Help users create shipping orders.'),
+        Message::ofUser('Create an express shipping order for John Doe at 123 Main St, Springfield, 62701 to be delivered by 2026-03-15 with 2 items: 3x Widget ($9.99 each) and 1x Gadget ($24.99)'),
+    );
+
+    $result = $agent->call($messages);
+
+    echo $result->getContent().\PHP_EOL;
+}

--- a/examples/agent/toolcall-polymorphic-interface.php
+++ b/examples/agent/toolcall-polymorphic-interface.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory as AnthropicPlatformFactory;
+use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory as GeminiPlatformFactory;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory as OpenAiPlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType\Filterable;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType\OrderFilter;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType\PurchaseContractFilter;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platforms = [
+    'claude-sonnet-4-5-20250929' => AnthropicPlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client()),
+    'gpt-5-mini' => OpenAiPlatformFactory::create(env('OPENAI_API_KEY'), httpClient: http_client()),
+    'gemini-2.5-flash' => GeminiPlatformFactory::create(env('GEMINI_API_KEY'), httpClient: http_client()),
+];
+
+foreach ($platforms as $model => $platform) {
+    $toolbox = new Toolbox(tools: [new SearchTool()]);
+    $processor = new AgentProcessor(toolbox: $toolbox);
+    $agent = new Agent($platform, $model, [$processor], [$processor]);
+
+    echo "\n=== Testing with model: $model ===\n\n";
+
+    $systemMsg = Message::forSystem('You are a helpful search assistant. Help users search for different resources.');
+    $userMsg = 'Search for order number ORD-12345 with user responsible John Doe';
+    $messages = new MessageBag(
+        $systemMsg,
+        Message::ofUser($userMsg)
+    );
+
+    $result = $agent->call($messages);
+
+    echo $userMsg." : \n".$result->getContent().\PHP_EOL.\PHP_EOL;
+
+    $userMsg = 'Search for purchase contract number PC-67890 with subsidiary Acme Corp';
+    $messages = new MessageBag(
+        $systemMsg,
+        Message::ofUser($userMsg),
+    );
+
+    $result = $agent->call($messages);
+
+    echo $userMsg." : \n".$result->getContent().\PHP_EOL;
+}
+
+// Tool that uses polymorphic interface as parameter
+#[AsTool('search', 'Search various resources based on filter criteria', method: 'search')]
+final class SearchTool
+{
+    /**
+     * @param Filterable $filter The filter to use for search (order or purchase_contract)
+     */
+    public function search(Filterable $filter): string
+    {
+        return match (true) {
+            $filter instanceof OrderFilter => sprintf(
+                'Searching for order: %s (User: %s) Found 1 result.',
+                $filter->number ?? 'N/A',
+                $filter->userResponsible ?? 'N/A'
+            ),
+            $filter instanceof PurchaseContractFilter => sprintf(
+                'Searching for purchase contract: %s (Subsidiary: %s) Found 1 result.',
+                $filter->contractNumber ?? 'N/A',
+                $filter->subsidiary ?? 'N/A'
+            ),
+            default => 'Unknown filter type',
+        };
+    }
+}

--- a/examples/platform/structured-output-nested-objects.php
+++ b/examples/platform/structured-output-nested-objects.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory as AnthropicPlatformFactory;
+use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory as GeminiPlatformFactory;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory as OpenAiPlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\ShippingOrder\ShippingOrder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+/*
+ * This example demonstrates structured output with nested objects, backed enums,
+ * datetime, and arrays of objects resolved via PHP docblocks.
+ */
+
+$dispatcher = new EventDispatcher();
+$dispatcher->addSubscriber(new PlatformSubscriber());
+
+$platforms = [
+    'claude-sonnet-4-5-20250929' => AnthropicPlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client(), eventDispatcher: $dispatcher),
+    'gpt-5-mini' => OpenAiPlatformFactory::create(env('OPENAI_API_KEY'), http_client(), eventDispatcher: $dispatcher),
+    'gemini-2.5-flash' => GeminiPlatformFactory::create(env('GEMINI_API_KEY'), httpClient: http_client(), eventDispatcher: $dispatcher),
+];
+
+foreach ($platforms as $model => $platform) {
+    echo "\n=== Testing with model: $model ===\n\n";
+
+    $messages = new MessageBag(
+        Message::forSystem('You are a shipping assistant. Create shipping orders based on user requests.'),
+        Message::ofUser('Create an express shipping order for John Doe at 123 Main St, Springfield, 62701 to be delivered by 2026-03-15 with 2 items: 3x Widget ($9.99 each) and 1x Gadget ($24.99)'),
+    );
+
+    $result = $platform->invoke($model, $messages, ['response_format' => ShippingOrder::class]);
+
+    $order = $result->asObject();
+    assert($order instanceof ShippingOrder);
+    dump($order);
+}

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * [BC BREAK] Replace variadic constructor parameters with array parameters in `VectorResult`, `ToolCallResult`, `RerankingResult`, `ToolCallComplete`, and `ImageResult` (OpenAI DallE bridge)
  * [BC BREAK] Rename `#[With]` attribute to `#[Schema]` and `WithAttributeDescriber` to `SchemaAttributeDescriber`
  * Add `ref` property to `#[Schema]` attribute to allow providing schema as file
+ * Add support for `DiscriminatorMap` and `DateTimeImmutable` for structured output and tool calls
 
 0.7
 ---

--- a/src/platform/src/Contract/JsonSchema/Describer/SerializerDescriber.php
+++ b/src/platform/src/Contract/JsonSchema/Describer/SerializerDescriber.php
@@ -58,15 +58,11 @@ final class SerializerDescriber implements ObjectDescriberInterface, ObjectDescr
 
         $discriminatorMapping = $classMetadata->getClassDiscriminatorMapping();
         if ($discriminatorMapping) {
-            $type = $schema['type'] ??= 'object';
             $typeProperty = $discriminatorMapping->getTypeProperty();
             foreach ($discriminatorMapping->getTypesMapping() as $discriminatorValue => $discriminatorClass) {
                 $subSchema = &$schema['anyOf'][];
                 $this->describer->describeObject(new ObjectSubject($discriminatorClass, new \ReflectionClass($discriminatorClass)), $subSchema);
-                $subSchema['properties'][$typeProperty]['const'] = $discriminatorValue;
-                if ($type === ($subSchema['type'] ?? null)) {
-                    unset($subSchema['type']);
-                }
+                $subSchema['properties'][$typeProperty]['enum'] = [$discriminatorValue];
             }
         }
 

--- a/src/platform/src/Contract/JsonSchema/Describer/TypeInfoDescriber.php
+++ b/src/platform/src/Contract/JsonSchema/Describer/TypeInfoDescriber.php
@@ -51,17 +51,8 @@ final class TypeInfoDescriber implements ObjectDescriberInterface, PropertyDescr
      */
     public function describeObject(ObjectSubject $subject, ?array &$schema): iterable
     {
-        $schema['type'] ??= 'object';
-        foreach (['anyOf', 'oneOf', 'allOf', 'not'] as $subSchemaKey) {
-            if (!\array_key_exists($subSchemaKey, $schema)) {
-                continue;
-            }
-
-            foreach ($schema[$subSchemaKey] as &$subSchema) {
-                if (\array_key_exists('type', $subSchema) && $subSchema['type'] === $schema['type']) {
-                    unset($subSchema['type']);
-                }
-            }
+        if (!isset($schema['anyOf']) && !isset($schema['oneOf']) && !isset($schema['allOf'])) {
+            $schema['type'] ??= 'object';
         }
 
         return [];

--- a/src/platform/src/StructuredOutput/Serializer.php
+++ b/src/platform/src/StructuredOutput/Serializer.php
@@ -20,6 +20,7 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer as BaseSerializer;
 
@@ -39,6 +40,7 @@ class Serializer extends BaseSerializer
         $propertyInfo = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
 
         $normalizers = [
+            new DateTimeNormalizer(),
             new BackedEnumNormalizer(),
             new ObjectNormalizer(
                 propertyTypeExtractor: $propertyInfo,

--- a/src/platform/tests/Contract/JsonSchema/Describer/SerializerDescriberTest.php
+++ b/src/platform/tests/Contract/JsonSchema/Describer/SerializerDescriberTest.php
@@ -41,13 +41,12 @@ final class SerializerDescriberTest extends TestCase
         $describer->describeObject(new ObjectSubject(ListItemDiscriminator::class, new \ReflectionClass(ListItemDiscriminator::class)), $schema);
 
         $expectedSchema = [
-            'type' => 'object',
             'anyOf' => [
                 [
                     'description' => ListItemName::class,
                     'properties' => [
                         'type' => [
-                            'const' => 'name',
+                            'enum' => ['name'],
                         ],
                     ],
                 ],
@@ -55,7 +54,7 @@ final class SerializerDescriberTest extends TestCase
                     'description' => ListItemAge::class,
                     'properties' => [
                         'type' => [
-                            'const' => 'age',
+                            'enum' => ['age'],
                         ],
                     ],
                 ],

--- a/src/platform/tests/Contract/JsonSchema/FactoryTest.php
+++ b/src/platform/tests/Contract/JsonSchema/FactoryTest.php
@@ -231,15 +231,15 @@ final class FactoryTest extends TestCase
                 'items' => [
                     'type' => 'array',
                     'items' => [
-                        'type' => 'object',
                         'anyOf' => [
                             [
+                                'type' => 'object',
                                 'properties' => [
                                     'name' => ['type' => 'string'],
                                     'type' => [
                                         'type' => 'string',
                                         'pattern' => '^name$',
-                                        'const' => 'name',
+                                        'enum' => ['name'],
                                     ],
                                 ],
                                 'required' => [
@@ -249,12 +249,13 @@ final class FactoryTest extends TestCase
                                 'additionalProperties' => false,
                             ],
                             [
+                                'type' => 'object',
                                 'properties' => [
                                     'age' => ['type' => 'integer'],
                                     'type' => [
                                         'type' => 'string',
                                         'pattern' => '^age$',
-                                        'const' => 'age',
+                                        'enum' => ['age'],
                                     ],
                                 ],
                                 'required' => [

--- a/src/platform/tests/Fixtures/StructuredOutput/PolymorphicType/Filterable.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/PolymorphicType/Filterable.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType;
+
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+
+#[DiscriminatorMap(
+    typeProperty: 'type',
+    mapping: [
+        'order' => OrderFilter::class,
+        'purchase_contract' => PurchaseContractFilter::class,
+    ]
+)]
+/**
+ * @property string $type
+ *
+ * With the PHP 8.4^ you can replace the property annotation with a property hook:
+ * public string $type {
+ *     get;
+ * }
+ */
+interface Filterable
+{
+}

--- a/src/platform/tests/Fixtures/StructuredOutput/PolymorphicType/OrderFilter.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/PolymorphicType/OrderFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType;
+
+final class OrderFilter implements Filterable
+{
+    public function __construct(
+        public string $type = 'order',
+        public ?string $number = null,
+        public ?string $userResponsible = null,
+        public ?\DateTimeImmutable $departureDate = null,
+    ) {
+    }
+}

--- a/src/platform/tests/Fixtures/StructuredOutput/PolymorphicType/PurchaseContractFilter.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/PolymorphicType/PurchaseContractFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType;
+
+final class PurchaseContractFilter implements Filterable
+{
+    public function __construct(
+        public string $type = 'purchase_contract',
+        public ?string $contractNumber = null,
+        public ?string $subsidiary = null,
+    ) {
+    }
+}

--- a/src/platform/tests/Fixtures/StructuredOutput/ShippingOrder/Address.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/ShippingOrder/Address.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\ShippingOrder;
+
+final class Address
+{
+    public function __construct(
+        public readonly string $street,
+        public readonly string $city,
+        public readonly string $zip,
+    ) {
+    }
+}

--- a/src/platform/tests/Fixtures/StructuredOutput/ShippingOrder/OrderItem.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/ShippingOrder/OrderItem.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\ShippingOrder;
+
+final class OrderItem
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $quantity,
+        public readonly float $price,
+    ) {
+    }
+}

--- a/src/platform/tests/Fixtures/StructuredOutput/ShippingOrder/ShippingOrder.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/ShippingOrder/ShippingOrder.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\ShippingOrder;
+
+class ShippingOrder
+{
+    public string $recipientName;
+    public ShippingPriority $priority;
+    public \DateTimeImmutable $deliverBy;
+
+    /** @var Address */
+    public $address;
+
+    /** @var OrderItem[] */
+    public array $items;
+}

--- a/src/platform/tests/Fixtures/StructuredOutput/ShippingOrder/ShippingPriority.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/ShippingOrder/ShippingPriority.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\ShippingOrder;
+
+enum ShippingPriority: string
+{
+    case Standard = 'standard';
+    case Express = 'express';
+    case Overnight = 'overnight';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1159
| License       | MIT

This PR extends JSON schema generation to support `DiscriminatorMap` on single interface parameters, not just arrays. The implementation generates a `oneOf` schema with all discriminator implementations, allowing LLMs to properly understand and use polymorphic tool parameters.

See `examples/anthropic/toolcall-polymorphic-interface.php` for a working example.