### PR TITLE
[Agent][Chat] Add `metadata` to `AssistantMessage`

### DIFF
--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * [BC BREAK] Rename `Symfony\AI\Agent\Toolbox\Tool\Agent` to `Symfony\AI\Agent\Toolbox\Tool\Subagent`
+ * Add `MetaDataAwareTrait` to `MockResponse`, the metadata will also be set on the returned `TextResult` when calling the `toResult` function
 
 0.3
 ---

--- a/src/agent/src/MockResponse.php
+++ b/src/agent/src/MockResponse.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Platform\Metadata\MetadataAwareTrait;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
 
@@ -24,6 +25,8 @@ use Symfony\AI\Platform\Result\TextResult;
  */
 final class MockResponse
 {
+    use MetadataAwareTrait;
+
     public function __construct(
         private readonly string $content = '',
     ) {
@@ -31,7 +34,10 @@ final class MockResponse
 
     public function toResult(): ResultInterface
     {
-        return new TextResult($this->content);
+        $result = new TextResult($this->content);
+        $result->getMetadata()->merge($this->getMetadata());
+
+        return $result;
     }
 
     public function getContent(): string

--- a/src/agent/tests/MockResponseTest.php
+++ b/src/agent/tests/MockResponseTest.php
@@ -34,10 +34,13 @@ final class MockResponseTest extends TestCase
     public function testToResult()
     {
         $response = new MockResponse('Response content');
+        $response->getMetadata()->add('sources', ['https://example.com']);
+
         $result = $response->toResult();
 
         $this->assertInstanceOf(TextResult::class, $result);
         $this->assertSame('Response content', $result->getContent());
+        $this->assertEquals($response->getMetadata(), $result->getMetadata());
     }
 
     public function testCreate()

--- a/src/chat/CHANGELOG.md
+++ b/src/chat/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 ---
 
  * Add the component
+ * Add `metadata` from `TextResult` to `AssistantMessage`

--- a/src/chat/src/Chat.php
+++ b/src/chat/src/Chat.php
@@ -45,6 +45,7 @@ final class Chat implements ChatInterface
         \assert($result instanceof TextResult);
 
         $assistantMessage = Message::ofAssistant($result->getContent());
+        $assistantMessage->getMetadata()->merge($result->getMetadata());
         $messages->add($assistantMessage);
 
         $this->store->save($messages);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1558
| License       | MIT


This PR adds the sources of a TextResult to the metadata of the AssistantMessage within the [Chat](https://github.com/symfony/ai-chat) component.