### PR TITLE
[Store] Introduce integration tests for stores

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -125,7 +125,70 @@ jobs:
                   dependency-versions: ${{ matrix.dependency-version }}
 
             - name: Run PHPUnit
-              run: cd src/${{ matrix.bridge.component }}/src/Bridge/${{ matrix.bridge.bridge }} && vendor/bin/phpunit
+              run: cd src/${{ matrix.bridge.component }}/src/Bridge/${{ matrix.bridge.bridge }} && vendor/bin/phpunit --exclude-group integration
+
+    store-bridges-integration:
+        name: Integration / Store / ${{ matrix.bridge }}
+        needs: matrix
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                bridge:
+                    - ChromaDb
+                    - ClickHouse
+                    - Elasticsearch
+                    - ManticoreSearch
+                    - MariaDb
+                    - Meilisearch
+                    - Milvus
+                    - Neo4j
+                    - OpenSearch
+                    - Postgres
+                    - Qdrant
+                    - Redis
+                    - Weaviate
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.4'
+                  tools: flex
+                  extensions: ${{ env.REQUIRED_PHP_EXTENSIONS }}
+
+            - name: Install root dependencies
+              uses: ramsey/composer-install@v3
+
+            - name: Build packages
+              run: php .github/build-packages.php
+
+            # Remove root vendor and bridge vendor to avoid circular symlinks when installing bridge dependencies
+            - name: Clean vendor folders
+              run: rm -rf vendor src/store/src/Bridge/${{ matrix.bridge }}/vendor
+
+            - name: Install dependencies
+              uses: ramsey/composer-install@v3
+              with:
+                  working-directory: src/store/src/Bridge/${{ matrix.bridge }}
+
+            - name: Start Docker services
+              working-directory: src/store/src/Bridge/${{ matrix.bridge }}
+              run: docker compose up -d --wait
+
+            - name: Wait for services to be ready
+              run: sleep 15
+
+            - name: Run integration tests
+              run: cd src/store/src/Bridge/${{ matrix.bridge }} && vendor/bin/phpunit --group integration
+
+            - name: Stop Docker services
+              if: always()
+              working-directory: src/store/src/Bridge/${{ matrix.bridge }}
+              run: docker compose down
 
     message-store-bridges:
         name: Unit / Message Store / ${{ matrix.bridge.bridge }} / PHP ${{ matrix.php-version }}${{ matrix.dependency-version == 'lowest' && ' / lowest' || '' }}

--- a/src/store/src/Bridge/ChromaDb/CHANGELOG.md
+++ b/src/store/src/Bridge/ChromaDb/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `remove` method
+ * Add support for store management methods `setup` and `drop`
 
 0.1
 ---

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -12,20 +12,41 @@
 namespace Symfony\AI\Store\Bridge\ChromaDb;
 
 use Codewithkyrian\ChromaDB\Client;
+use Codewithkyrian\ChromaDB\Exceptions\ChromaException;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class Store implements StoreInterface
+final class Store implements ManagedStoreInterface, StoreInterface
 {
     public function __construct(
         private readonly Client $client,
         private readonly string $collectionName,
     ) {
+    }
+
+    public function setup(array $options = []): void
+    {
+        try {
+            $this->client->createCollection($this->collectionName);
+        } catch (ChromaException $e) {
+            throw new RuntimeException(\sprintf('Could not create collection "%s".', $this->collectionName), previous: $e);
+        }
+    }
+
+    public function drop(array $options = []): void
+    {
+        try {
+            $this->client->deleteCollection($this->collectionName);
+        } catch (ChromaException $e) {
+            throw new RuntimeException(\sprintf('Could not delete collection "%s".', $this->collectionName), previous: $e);
+        }
     }
 
     public function add(VectorDocument|array $documents): void

--- a/src/store/src/Bridge/ChromaDb/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/IntegrationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\ChromaDb\Tests;
+
+use Codewithkyrian\ChromaDB\ChromaDB;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\ChromaDb\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        $client = ChromaDB::factory()
+            ->withHost('http://127.0.0.1')
+            ->withPort(8000)
+            ->connect();
+
+        return new Store($client, 'test_collection');
+    }
+}

--- a/src/store/src/Bridge/ChromaDb/compose.yaml
+++ b/src/store/src/Bridge/ChromaDb/compose.yaml
@@ -1,0 +1,9 @@
+services:
+    chromadb:
+        image: chromadb/chroma:0.6.3
+        environment:
+            IS_PERSISTENT: TRUE
+            PERSIST_DIRECTORY: /chroma/chroma
+            ANONYMIZED_TELEMETRY: false
+        ports:
+            - '8000:8000'

--- a/src/store/src/Bridge/ChromaDb/composer.json
+++ b/src/store/src/Bridge/ChromaDb/composer.json
@@ -32,6 +32,7 @@
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {
+        "nyholm/psr7": "^1.8",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -77,8 +77,8 @@ class Store implements ManagedStoreInterface, StoreInterface
             return;
         }
 
-        $this->execute('POST', 'ALTER TABLE {{ table }} DELETE WHERE id IN {ids:Array(String)}', [
-            'ids' => $ids,
+        $this->execute('POST', 'DELETE FROM {{ table }} WHERE id IN {ids:Array(UUID)}', [
+            'ids' => "['".implode("','", $ids)."']",
         ]);
     }
 

--- a/src/store/src/Bridge/ClickHouse/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/ClickHouse/Tests/IntegrationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\ClickHouse\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\ClickHouse\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        return new Store(
+            HttpClient::createForBaseUri('http://symfony:symfony@127.0.0.1:8123'),
+            'symfony',
+            'test_embedding',
+        );
+    }
+}

--- a/src/store/src/Bridge/ClickHouse/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ClickHouse/Tests/StoreTest.php
@@ -233,14 +233,15 @@ final class StoreTest extends TestCase
 
     public function testRemoveSingleDocument()
     {
-        $id = Uuid::v4()->toRfc4122();
+        $id = 'a0d23a85-abfb-4696-a652-73a83b46710b';
 
-        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use ($id) {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
             $this->assertSame('POST', $method);
             $this->assertStringContainsString('?', $url); // Check that URL has query parameters
-            $expectedSql = 'ALTER TABLE test_table DELETE WHERE id IN {ids:Array(String)}';
+            $expectedSql = 'DELETE FROM test_table WHERE id IN {ids:Array(UUID)}';
             $this->assertSame($expectedSql, $options['query']['query']);
-            $this->assertSame([$id], $options['query']['param_ids']);
+            $expectedId = "['a0d23a85-abfb-4696-a652-73a83b46710b']";
+            $this->assertSame($expectedId, $options['query']['param_ids']);
 
             return new MockResponse('', ['http_code' => 200]);
         });
@@ -252,15 +253,16 @@ final class StoreTest extends TestCase
 
     public function testRemoveMultipleDocuments()
     {
-        $id1 = Uuid::v4()->toRfc4122();
-        $id2 = Uuid::v4()->toRfc4122();
+        $id1 = '93c1d46a-2a30-4466-a28b-8e92e935a29b';
+        $id2 = 'f5667ae9-e0f1-4fa0-ab16-37e0136680ca';
+        $expectedIds = "['93c1d46a-2a30-4466-a28b-8e92e935a29b','f5667ae9-e0f1-4fa0-ab16-37e0136680ca']";
 
-        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use ($id1, $id2) {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use ($expectedIds) {
             $this->assertSame('POST', $method);
             $this->assertStringContainsString('?', $url); // Check that URL has query parameters
-            $expectedSql = 'ALTER TABLE test_table DELETE WHERE id IN {ids:Array(String)}';
+            $expectedSql = 'DELETE FROM test_table WHERE id IN {ids:Array(UUID)}';
             $this->assertSame($expectedSql, $options['query']['query']);
-            $this->assertSame([$id1, $id2], $options['query']['param_ids']);
+            $this->assertSame($expectedIds, $options['query']['param_ids']);
 
             return new MockResponse('', ['http_code' => 200]);
         });

--- a/src/store/src/Bridge/ClickHouse/compose.yaml
+++ b/src/store/src/Bridge/ClickHouse/compose.yaml
@@ -1,0 +1,9 @@
+services:
+    clickhouse:
+        image: clickhouse/clickhouse-server
+        environment:
+            CLICKHOUSE_DB: 'symfony'
+            CLICKHOUSE_USER: 'symfony'
+            CLICKHOUSE_PASSWORD: 'symfony'
+        ports:
+            - '8123:8123'

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Component\Uid\Uuid;
@@ -93,7 +93,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     public function query(Vector $vector, array $options = []): iterable

--- a/src/store/src/Bridge/Elasticsearch/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Elasticsearch/Tests/IntegrationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Elasticsearch\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\Elasticsearch\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        return new Store(
+            HttpClient::create(),
+            'http://127.0.0.1:9200',
+            'test_index',
+            dimensions: 3,
+        );
+    }
+
+    protected function waitForIndexing(): void
+    {
+        HttpClient::create()->request('POST', 'http://127.0.0.1:9200/_refresh');
+        usleep(500_000);
+    }
+}

--- a/src/store/src/Bridge/Elasticsearch/compose.yaml
+++ b/src/store/src/Bridge/Elasticsearch/compose.yaml
@@ -1,0 +1,22 @@
+services:
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:9.2.2
+        environment:
+            discovery.type: 'single-node'
+            xpack.security.enabled: false
+            ES_JAVA_OPTS: '-Xms512m -Xmx512m'
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        healthcheck:
+            test: ['CMD', 'curl', '-f', 'http://127.0.0.1:9200/_cluster/health']
+            interval: 30s
+            start_period: 120s
+            timeout: 20s
+            retries: 3
+        ports:
+            - '9200:9200'

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -88,7 +88,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     public function query(Vector $vector, array $options = []): iterable

--- a/src/store/src/Bridge/ManticoreSearch/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/ManticoreSearch/Tests/IntegrationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\ManticoreSearch\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\ManticoreSearch\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        return new Store(
+            HttpClient::create(),
+            'http://127.0.0.1:9308',
+            'test_collection',
+            dimensions: 3,
+        );
+    }
+}

--- a/src/store/src/Bridge/ManticoreSearch/compose.yaml
+++ b/src/store/src/Bridge/ManticoreSearch/compose.yaml
@@ -1,0 +1,13 @@
+services:
+    manticore:
+        image: manticoresearch/manticore
+        ulimits:
+            nproc: 65535
+            nofile:
+                soft: 65535
+                hard: 65535
+            memlock:
+                soft: -1
+                hard: -1
+        ports:
+            - '9308:9308'

--- a/src/store/src/Bridge/MariaDb/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/MariaDb/Tests/IntegrationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\MariaDb\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\MariaDb\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        $pdo = new \PDO('mysql:host=127.0.0.1;port=3306;dbname=test_database', 'root', '');
+
+        return new Store($pdo, 'test_vectors', 'test_vector_idx', 'embedding');
+    }
+
+    protected static function getSetupOptions(): array
+    {
+        return ['dimensions' => 3];
+    }
+}

--- a/src/store/src/Bridge/MariaDb/compose.yaml
+++ b/src/store/src/Bridge/MariaDb/compose.yaml
@@ -1,0 +1,8 @@
+services:
+    mariadb:
+        image: mariadb:11.7
+        environment:
+            MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
+            MARIADB_DATABASE: test_database
+        ports:
+            - '3306:3306'

--- a/src/store/src/Bridge/Meilisearch/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Meilisearch/Tests/IntegrationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Meilisearch\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\Meilisearch\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        return new Store(
+            HttpClient::create(),
+            'http://127.0.0.1:7700',
+            'changeMe',
+            'test_index',
+            embeddingsDimension: 3,
+        );
+    }
+
+    protected function waitForIndexing(): void
+    {
+        sleep(2);
+    }
+}

--- a/src/store/src/Bridge/Meilisearch/compose.yaml
+++ b/src/store/src/Bridge/Meilisearch/compose.yaml
@@ -1,0 +1,8 @@
+services:
+    meilisearch:
+        image: getmeili/meilisearch:v1.19
+        environment:
+            MEILI_MASTER_KEY: 'changeMe'
+            MEILI_EXPERIMENTAL_VECTOR_STORE: 'true'
+        ports:
+            - '7700:7700'

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -106,7 +106,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     public function query(Vector $vector, array $options = []): iterable

--- a/src/store/src/Bridge/Milvus/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Milvus/Tests/IntegrationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Milvus\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\Milvus\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        return new Store(
+            HttpClient::create(),
+            'http://127.0.0.1:19530',
+            '',
+            'test_database',
+            'test_collection',
+            dimensions: 3,
+        );
+    }
+
+    protected static function getSetupOptions(): array
+    {
+        return ['forceDatabaseCreation' => true];
+    }
+
+    protected function waitForIndexing(): void
+    {
+        sleep(2);
+    }
+}

--- a/src/store/src/Bridge/Milvus/compose.yaml
+++ b/src/store/src/Bridge/Milvus/compose.yaml
@@ -1,0 +1,48 @@
+services:
+    etcd:
+        image: quay.io/coreos/etcd:v3.5.18
+        environment:
+            ETCD_AUTO_COMPACTION_MODE: revision
+            ETCD_AUTO_COMPACTION_RETENTION: 1000
+            ETCD_QUOTA_BACKEND_BYTES: 4294967296
+            ETCD_SNAPSHOT_COUNT: 50000
+        command: etcd -advertise-client-urls=http://etcd:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+        healthcheck:
+            test: ['CMD', 'etcdctl', 'endpoint', 'health']
+            interval: 30s
+            timeout: 20s
+            retries: 3
+
+    minio:
+        image: minio/minio:RELEASE.2024-12-18T13-15-44Z
+        environment:
+            MINIO_ACCESS_KEY: minioadmin
+            MINIO_SECRET_KEY: minioadmin
+        command: minio server /minio_data --console-address ":9001"
+        healthcheck:
+            test: ['CMD', 'curl', '-f', 'http://localhost:9000/minio/health/live']
+            interval: 30s
+            timeout: 20s
+            retries: 3
+
+    milvus:
+        image: milvusdb/milvus:v2.6.0
+        command: ['milvus', 'run', 'standalone']
+        security_opt:
+            - seccomp:unconfined
+        environment:
+            ETCD_ENDPOINTS: etcd:2379
+            MINIO_ADDRESS: minio:9000
+            MQ_TYPE: woodpecker
+        healthcheck:
+            test: ['CMD', 'curl', '-f', 'http://localhost:9091/healthz']
+            interval: 30s
+            start_period: 90s
+            timeout: 20s
+            retries: 3
+        ports:
+            - '19530:19530'
+            - '9091:9091'
+        depends_on:
+            - etcd
+            - minio

--- a/src/store/src/Bridge/MongoDb/Store.php
+++ b/src/store/src/Bridge/MongoDb/Store.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 
@@ -64,6 +64,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         private readonly string $vectorFieldName = 'vector',
         private readonly bool $bulkWrite = false,
         private readonly LoggerInterface $logger = new NullLogger(),
+        private readonly int $embeddingsDimension = 1536,
     ) {
     }
 
@@ -81,7 +82,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
                 [
                     'fields' => array_merge([
                         [
-                            'numDimensions' => 1536,
+                            'numDimensions' => $this->embeddingsDimension,
                             'path' => $this->vectorFieldName,
                             'similarity' => 'euclidean',
                             'type' => 'vector',
@@ -136,7 +137,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     /**

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -71,7 +71,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     public function query(Vector $vector, array $options = []): iterable

--- a/src/store/src/Bridge/Neo4j/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Neo4j/Tests/IntegrationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Neo4j\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\Neo4j\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        return new Store(
+            HttpClient::create(),
+            'http://127.0.0.1:7474',
+            'neo4j',
+            'symfonyai',
+            'neo4j',
+            'test_vector_index',
+            'TestNode',
+            embeddingsDimension: 3,
+        );
+    }
+}

--- a/src/store/src/Bridge/Neo4j/compose.yaml
+++ b/src/store/src/Bridge/Neo4j/compose.yaml
@@ -1,0 +1,8 @@
+services:
+    neo4j:
+        image: neo4j
+        environment:
+            NEO4J_AUTH: 'neo4j/symfonyai'
+        ports:
+            - '7474:7474'
+            - '7687:7687'

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -98,7 +98,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     public function query(Vector $vector, array $options = []): iterable

--- a/src/store/src/Bridge/OpenSearch/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/OpenSearch/Tests/IntegrationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\OpenSearch\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\OpenSearch\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        return new Store(
+            HttpClient::create(),
+            'http://127.0.0.1:9200',
+            'test_index',
+            dimensions: 3,
+        );
+    }
+
+    protected function waitForIndexing(): void
+    {
+        HttpClient::create()->request('POST', 'http://127.0.0.1:9200/_refresh');
+        usleep(500_000);
+    }
+}

--- a/src/store/src/Bridge/OpenSearch/compose.yaml
+++ b/src/store/src/Bridge/OpenSearch/compose.yaml
@@ -1,0 +1,23 @@
+services:
+    opensearch:
+        image: opensearchproject/opensearch
+        environment:
+            discovery.type: 'single-node'
+            bootstrap.memory_lock: true
+            DISABLE_SECURITY_PLUGIN: true
+            OPENSEARCH_JAVA_OPTS: '-Xms512m -Xmx512m'
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        healthcheck:
+            test: ['CMD', 'curl', '-f', 'http://127.0.0.1:9200']
+            interval: 30s
+            start_period: 120s
+            timeout: 20s
+            retries: 3
+        ports:
+            - '9200:9200'

--- a/src/store/src/Bridge/Postgres/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Postgres/Tests/IntegrationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Postgres\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\Postgres\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        $pdo = new \PDO('pgsql:host=127.0.0.1;port=5432;dbname=test_database', 'postgres', 'postgres');
+
+        return new Store($pdo, 'test_vectors');
+    }
+
+    protected static function getSetupOptions(): array
+    {
+        return ['vector_size' => 3];
+    }
+}

--- a/src/store/src/Bridge/Postgres/compose.yaml
+++ b/src/store/src/Bridge/Postgres/compose.yaml
@@ -1,0 +1,9 @@
+services:
+    postgres:
+        image: pgvector/pgvector:0.8.0-pg17
+        environment:
+            POSTGRES_DB: test_database
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+        ports:
+            - '5432:5432'

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -75,7 +75,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     /**

--- a/src/store/src/Bridge/Qdrant/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Qdrant/Tests/IntegrationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Qdrant\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\Qdrant\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        return new Store(
+            HttpClient::create(),
+            'http://127.0.0.1:6333',
+            'changeMe',
+            'test_collection',
+            embeddingsDimension: 3,
+        );
+    }
+}

--- a/src/store/src/Bridge/Qdrant/compose.yaml
+++ b/src/store/src/Bridge/Qdrant/compose.yaml
@@ -1,0 +1,7 @@
+services:
+    qdrant:
+        image: qdrant/qdrant
+        environment:
+            QDRANT__SERVICE__API_KEY: 'changeMe'
+        ports:
+            - '6333:6333'

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -15,8 +15,8 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
-use Symfony\AI\Store\Exception\LogicException;
 use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 
@@ -109,7 +109,7 @@ class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     /**

--- a/src/store/src/Bridge/Redis/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Redis/Tests/IntegrationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Redis\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\Redis\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        $redis = new \Redis();
+        $redis->connect('127.0.0.1', 6379);
+
+        return new Store($redis, 'test_index');
+    }
+
+    protected static function getSetupOptions(): array
+    {
+        return ['vector_size' => 3];
+    }
+}

--- a/src/store/src/Bridge/Redis/compose.yaml
+++ b/src/store/src/Bridge/Redis/compose.yaml
@@ -1,0 +1,5 @@
+services:
+    redis:
+        image: redis:8.2.2-alpine
+        ports:
+            - '6379:6379'

--- a/src/store/src/Bridge/Supabase/Store.php
+++ b/src/store/src/Bridge/Supabase/Store.php
@@ -15,8 +15,8 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
 use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -95,7 +95,7 @@ final class Store implements StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     /**

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -16,8 +16,8 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
 use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -67,7 +67,7 @@ class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     public function query(Vector $vector, array $options = []): iterable

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -75,7 +75,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     public function query(Vector $vector, array $options = []): iterable

--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\AI\Store\Exception\LogicException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -65,7 +65,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     public function query(Vector $vector, array $options = []): iterable

--- a/src/store/src/Bridge/Weaviate/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Weaviate/Tests/IntegrationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Weaviate\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\Weaviate\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        return new Store(
+            HttpClient::create(),
+            'http://127.0.0.1:8080',
+            'symfony',
+            'TestCollection',
+        );
+    }
+}

--- a/src/store/src/Bridge/Weaviate/compose.yaml
+++ b/src/store/src/Bridge/Weaviate/compose.yaml
@@ -1,0 +1,16 @@
+services:
+    weaviate:
+        image: cr.weaviate.io/semitechnologies/weaviate:1.35.3
+        command: ['--host', '0.0.0.0', '--port', '8080', '--scheme', 'http']
+        environment:
+            QUERY_DEFAULTS_LIMIT: 25
+            AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'false'
+            AUTHENTICATION_APIKEY_ENABLED: 'true'
+            AUTHENTICATION_APIKEY_ALLOWED_KEYS: 'symfony'
+            AUTHENTICATION_APIKEY_USERS: 'symfony'
+            PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+            ENABLE_API_BASED_MODULES: 'true'
+            CLUSTER_HOSTNAME: 'node1'
+            RAFT_ENABLE_ONE_NODE_RECOVERY: 'true'
+        ports:
+            - '8080:8080'

--- a/src/store/src/Exception/UnsupportedFeatureException.php
+++ b/src/store/src/Exception/UnsupportedFeatureException.php
@@ -14,6 +14,6 @@ namespace Symfony\AI\Store\Exception;
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-class LogicException extends \LogicException implements ExceptionInterface
+class UnsupportedFeatureException extends \LogicException implements ExceptionInterface
 {
 }

--- a/src/store/src/Test/AbstractStoreIntegrationTestCase.php
+++ b/src/store/src/Test/AbstractStoreIntegrationTestCase.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Test;
+
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
+use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\StoreInterface;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+abstract class AbstractStoreIntegrationTestCase extends TestCase
+{
+    private const DOCUMENT_ID_1 = '367e550e-6c92-4f12-8a6b-3f3f1d5e8c9a';
+    private const DOCUMENT_ID_2 = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    private const DOCUMENT_ID_3 = '123e4567-e89b-12d3-a456-426614174000';
+
+    private static ?StoreInterface $store = null;
+
+    public function testSetupStore()
+    {
+        self::$store = static::createStore();
+
+        if (!self::$store instanceof ManagedStoreInterface) {
+            $this->markTestSkipped('Store does not implement ManagedStoreInterface.');
+        }
+
+        self::$store->setup(static::getSetupOptions());
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Depends('testSetupStore')]
+    public function testAddDocuments()
+    {
+        // Add single document
+        self::$store->add(new VectorDocument(self::DOCUMENT_ID_1, new Vector([1.0, 0.0, 0.0]), new Metadata(['name' => 'first document'])));
+        // Add multiple documents
+        self::$store->add([
+            new VectorDocument(self::DOCUMENT_ID_2, new Vector([0.0, 1.0, 0.0]), new Metadata(['name' => 'second document'])),
+            new VectorDocument(self::DOCUMENT_ID_3, new Vector([0.0, 0.0, 1.0]), new Metadata(['name' => 'third document'])),
+        ]);
+
+        $this->waitForIndexing();
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Depends('testAddDocuments')]
+    public function testQueryDocuments()
+    {
+        $results = self::$store->query(new Vector([0.0, 0.0, 1.0]));
+
+        $found = null;
+        foreach ($results as $result) {
+            if (self::DOCUMENT_ID_3 === $result->getId()) {
+                $found = $result;
+                break;
+            }
+        }
+
+        $this->assertNotNull($found);
+        $this->assertSame('third document', $found->getMetadata()['name']);
+    }
+
+    #[Depends('testQueryDocuments')]
+    public function testRemoveDocuments()
+    {
+        try {
+            self::$store->remove(self::DOCUMENT_ID_3);
+        } catch (UnsupportedFeatureException) {
+            $this->markTestSkipped('Store does not support remove().');
+        }
+
+        $this->waitForIndexing();
+
+        $results = self::$store->query(new Vector([0.0, 0.0, 1.0]));
+
+        foreach ($results as $result) {
+            $this->assertNotSame(self::DOCUMENT_ID_3, $result->getId());
+        }
+    }
+
+    #[Depends('testRemoveDocuments')]
+    public function testDropStore()
+    {
+        if (!self::$store instanceof ManagedStoreInterface) {
+            $this->markTestSkipped('Store does not implement ManagedStoreInterface.');
+        }
+
+        self::$store->drop();
+
+        $this->addToAssertionCount(1);
+    }
+
+    abstract protected static function createStore(): StoreInterface;
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function getSetupOptions(): array
+    {
+        return [];
+    }
+
+    protected function waitForIndexing(): void
+    {
+        // no-op by default, override in subclasses that need indexing time
+    }
+}

--- a/src/store/tests/Double/TestStore.php
+++ b/src/store/tests/Double/TestStore.php
@@ -13,7 +13,7 @@ namespace Symfony\AI\Store\Tests\Double;
 
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\VectorDocument;
-use Symfony\AI\Store\Exception\LogicException;
+use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\StoreInterface;
 
 final class TestStore implements StoreInterface
@@ -37,7 +37,7 @@ final class TestStore implements StoreInterface
 
     public function remove(string|array $ids, array $options = []): void
     {
-        throw new LogicException('Method not implemented yet.');
+        throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
     public function query(Vector $vector, array $options = []): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Want to tackle a few things here
* `examples/commands/store.php` is not an example, but integration tests
  back then we went for the synergy about the docker setup, but with that `remove` PR it gets a bit more important for tests
* store tests are by far the slowest in our pipeline since we bring up all the container together and run it sequentially
* bring in a store conformance test with a base integration test

Initially built by Claude