### PR TITLE
[AI Bundle] Fix ResultNormalizer parse-time import causing fatal error

### DIFF
--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -30,7 +30,6 @@ use Symfony\AI\Platform\Bridge\Anthropic\Contract\AnthropicContract;
 use Symfony\AI\Platform\Bridge\Anthropic\ModelCatalog as AnthropicModelCatalog;
 use Symfony\AI\Platform\Bridge\Azure\OpenAi\ModelCatalog as AzureOpenAiModelCatalog;
 use Symfony\AI\Platform\Bridge\Bedrock\ModelCatalog as BedrockModelCatalog;
-use Symfony\AI\Platform\Bridge\Cache\ResultNormalizer;
 use Symfony\AI\Platform\Bridge\Cartesia\ModelCatalog as CartesiaModelCatalog;
 use Symfony\AI\Platform\Bridge\Cerebras\ModelCatalog as CerebrasModelCatalog;
 use Symfony\AI\Platform\Bridge\Decart\ModelCatalog as DecartModelCatalog;
@@ -223,12 +222,6 @@ return static function (ContainerConfigurator $container): void {
 
         // serializer
         ->set('ai.chat.message_bag.normalizer', MessageNormalizer::class)
-            ->tag('serializer.normalizer')
-
-        ->set('ai.platform.cache.result_normalizer', ResultNormalizer::class)
-            ->args([
-                service('serializer.normalizer.object'),
-            ])
             ->tag('serializer.normalizer')
 
         // commands

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -56,6 +56,7 @@ use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory as AnthropicPlatformFac
 use Symfony\AI\Platform\Bridge\Azure\OpenAi\PlatformFactory as AzureOpenAiPlatformFactory;
 use Symfony\AI\Platform\Bridge\Bedrock\PlatformFactory as BedrockFactory;
 use Symfony\AI\Platform\Bridge\Cache\CachePlatform;
+use Symfony\AI\Platform\Bridge\Cache\ResultNormalizer;
 use Symfony\AI\Platform\Bridge\Cartesia\PlatformFactory as CartesiaPlatformFactory;
 use Symfony\AI\Platform\Bridge\Cerebras\PlatformFactory as CerebrasPlatformFactory;
 use Symfony\AI\Platform\Bridge\Decart\PlatformFactory as DecartPlatformFactory;
@@ -541,8 +542,13 @@ final class AiBundle extends AbstractBundle
 
             return;
         }
-        if (!ContainerBuilder::willBeAvailable('symfony/ai-cache-platform', CachePlatform::class, ['symfony/ai-bundle'])) {
-            $container->removeDefinition('ai.platform.cache.result_normalizer');
+
+        if (ContainerBuilder::willBeAvailable('symfony/ai-cache-platform', CachePlatform::class, ['symfony/ai-bundle'])) {
+            $container->register('ai.platform.cache.result_normalizer', ResultNormalizer::class)
+                ->setArguments([
+                    new Reference('serializer.normalizer.object'),
+                ])
+                ->addTag('serializer.normalizer');
         }
 
         if ('cartesia' === $type) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | N/A
| License       | MIT

## Summary

When the symfony/ai-cache-platform bridge package is not installed, the parse-time import of ResultNormalizer in services.php causes a fatal error before the container build phase can remove it.

This fix moves the service registration from parse-time configuration (services.php) to runtime conditional registration (AiBundle.php), using a string class name to avoid class loading at parse time.

The service is now only registered when ContainerBuilder::willBeAvailable() confirms the cache platform bridge is present, following the same pattern used for other optional bridge integrations.
