### PR TITLE
[Store] Add query abstraction with filter support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -507,10 +507,13 @@ jobs:
             - name: Build root packages
               run: php .github/build-packages.php
 
-            - name: Install root dependencies
+            - name: Install examples dependencies
               uses: ramsey/composer-install@v3
               with:
                   working-directory: examples
+
+            - name: Link local components to examples
+              run: ./link examples
 
             - name: Run commands examples
               working-directory: examples

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -135,6 +135,40 @@ Store
    +$document->getVector();
    ```
 
+ * The `StoreInterface::query()` method signature has changed to accept a `QueryInterface` instead of a `Vector`:
+
+   ```diff
+   -use Symfony\AI\Platform\Vector\Vector;
+   +use Symfony\AI\Store\Query\VectorQuery;
+
+   -$results = $store->query($vector, ['limit' => 10]);
+   +$results = $store->query(new VectorQuery($vector), ['limit' => 10]);
+   ```
+
+   The Store component now supports multiple query types through a query abstraction system. Available query types:
+   - `VectorQuery`: For vector similarity search (replaces the old `Vector` parameter)
+   - `TextQuery`: For full-text search (when supported by the store)
+   - `HybridQuery`: For combined vector + text search (when supported by the store)
+
+   Check if a store supports a specific query type using the new `supports()` method:
+
+   ```php
+   if ($store->supports(VectorQuery::class)) {
+       $results = $store->query(new VectorQuery($vector));
+   }
+   ```
+
+ * The `Symfony\AI\Store\Retriever` constructor signature has changed - the first two arguments have been swapped:
+
+   ```diff
+   -use Symfony\AI\Store\Retriever;
+   -
+   -$retriever = new Retriever($vectorizer, $store, $logger);
+   +$retriever = new Retriever($store, $vectorizer, $logger);
+   ```
+
+   This change aligns the constructor with the primary dependency (the store) being first, followed by the optional vectorizer.
+
 UPGRADE FROM 0.2 to 0.3
 =======================
 

--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -104,8 +104,8 @@ ai:
             store: 'ai.store.chromadb.symfonycon'
     retriever:
         blog:
-            vectorizer: 'ai.vectorizer.openai'
             store: 'ai.store.chromadb.symfonycon'
+            vectorizer: 'ai.vectorizer.openai'
 
 services:
     _defaults:

--- a/examples/indexer/chunk-delay.php
+++ b/examples/indexer/chunk-delay.php
@@ -17,6 +17,7 @@ use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
 use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Clock\Clock;
 use Symfony\Component\Uid\Uuid;
 
@@ -75,7 +76,7 @@ $elapsedTime = microtime(true) - $startTime;
 echo sprintf("Indexing completed in %.2f seconds.\n\n", $elapsedTime);
 
 $vector = $vectorizer->vectorize('machine learning artificial intelligence');
-$results = $store->query($vector);
+$results = $store->query(new VectorQuery($vector));
 
 echo "Search results for 'machine learning artificial intelligence':\n";
 foreach ($results as $i => $document) {

--- a/examples/indexer/index-documents.php
+++ b/examples/indexer/index-documents.php
@@ -17,6 +17,7 @@ use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
 use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -52,7 +53,7 @@ $indexer = new DocumentIndexer(
 $indexer->index($documents);
 
 $vector = $vectorizer->vectorize('machine learning artificial intelligence');
-$results = $store->query($vector);
+$results = $store->query(new VectorQuery($vector));
 foreach ($results as $i => $document) {
     echo sprintf("%d. %s\n", $i + 1, substr($document->getId(), 0, 40).'...');
 }

--- a/examples/indexer/index-file-loader.php
+++ b/examples/indexer/index-file-loader.php
@@ -17,6 +17,7 @@ use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
 use Symfony\AI\Store\Indexer\SourceIndexer;
 use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Query\VectorQuery;
 
 require_once dirname(__DIR__).'/bootstrap.php';
 
@@ -43,7 +44,7 @@ $indexer->index([
 ]);
 
 $vector = $vectorizer->vectorize('Roman gladiator revenge');
-$results = $store->query($vector);
+$results = $store->query(new VectorQuery($vector));
 foreach ($results as $i => $document) {
     echo sprintf("%d. %s\n", $i + 1, substr($document->getId(), 0, 40).'...');
 }

--- a/examples/indexer/index-rss-loader.php
+++ b/examples/indexer/index-rss-loader.php
@@ -16,6 +16,7 @@ use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
 use Symfony\AI\Store\Indexer\SourceIndexer;
 use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\HttpClient;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -41,7 +42,7 @@ $indexer->index([
 ]);
 
 $vector = $vectorizer->vectorize('Week of Symfony');
-$results = $store->query($vector);
+$results = $store->query(new VectorQuery($vector));
 foreach ($results as $i => $document) {
     echo sprintf("%d. %s\n", $i + 1, substr($document->getId(), 0, 40).'...');
 }

--- a/examples/indexer/index-with-filters.php
+++ b/examples/indexer/index-with-filters.php
@@ -18,6 +18,7 @@ use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
 use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -71,7 +72,7 @@ $indexer = new DocumentIndexer(
 $indexer->index($documents);
 
 $vector = $vectorizer->vectorize('technology artificial intelligence');
-$results = $store->query($vector);
+$results = $store->query(new VectorQuery($vector));
 
 $filteredDocuments = 0;
 foreach ($results as $i => $document) {

--- a/examples/ollama/indexer.php
+++ b/examples/ollama/indexer.php
@@ -17,6 +17,7 @@ use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
 use Symfony\AI\Store\Indexer\SourceIndexer;
 use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Query\VectorQuery;
 
 require_once dirname(__DIR__).'/bootstrap.php';
 
@@ -43,7 +44,7 @@ $indexer->index([
 ]);
 
 $vector = $vectorizer->vectorize('Roman gladiator revenge');
-$results = $store->query($vector);
+$results = $store->query(new VectorQuery($vector));
 foreach ($results as $i => $document) {
     echo sprintf("%d. %s\n", $i + 1, substr($document->getId(), 0, 40).'...');
 }

--- a/examples/rag/meilisearch-hybrid.php
+++ b/examples/rag/meilisearch-hybrid.php
@@ -17,6 +17,8 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -69,10 +71,7 @@ foreach ($ratios as $config) {
     echo "--- {$config['description']} ---\n";
 
     // Override the semantic ratio for this specific query
-    $results = $store->query($queryEmbedding, [
-        'semanticRatio' => $config['ratio'],
-        'q' => 'technology', // Full-text search keyword
-    ]);
+    $results = $store->query(new HybridQuery($queryEmbedding, 'technology', $config['ratio']));
 
     echo "Top 3 results:\n";
     foreach (array_slice($results, 0, 3) as $i => $result) {
@@ -90,9 +89,7 @@ foreach ($ratios as $config) {
 echo "--- Custom query with pure semantic search ---\n";
 echo "Query: Movies about space exploration\n";
 $spaceEmbedding = $vectorizer->vectorize('space exploration and cosmic adventures');
-$results = $store->query($spaceEmbedding, [
-    'semanticRatio' => 1.0, // Pure semantic search
-]);
+$results = $store->query(new VectorQuery($spaceEmbedding));
 
 echo "Top 3 results:\n";
 foreach (array_slice($results, 0, 3) as $i => $result) {

--- a/examples/retriever/movies.php
+++ b/examples/retriever/movies.php
@@ -39,7 +39,7 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$retriever = new Retriever($vectorizer, $store, logger());
+$retriever = new Retriever($store, $vectorizer, logger());
 
 echo "Searching for movies about 'crime family mafia'\n";
 echo "================================================\n\n";

--- a/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
+++ b/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Agent\Bridge\SimilaritySearch;
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Document\VectorizerInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 /**
@@ -39,7 +40,7 @@ final class SimilaritySearch
     public function __invoke(string $searchTerm): string
     {
         $vector = $this->vectorizer->vectorize($searchTerm);
-        $this->usedDocuments = iterator_to_array($this->store->query($vector));
+        $this->usedDocuments = iterator_to_array($this->store->query(new VectorQuery($vector)));
 
         if ([] === $this->usedDocuments) {
             return 'No results found';

--- a/src/agent/src/Bridge/SimilaritySearch/Tests/SimilaritySearchTest.php
+++ b/src/agent/src/Bridge/SimilaritySearch/Tests/SimilaritySearchTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Document\VectorizerInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Component\Uid\Uuid;
 
@@ -47,7 +48,7 @@ final class SimilaritySearchTest extends TestCase
         $store = $this->createMock(StoreInterface::class);
         $store->expects($this->once())
             ->method('query')
-            ->with($vector)
+            ->with($this->callback(static fn ($query) => $query instanceof VectorQuery && $query->getVector() === $vector))
             ->willReturn([$document1, $document2]);
 
         $similaritySearch = new SimilaritySearch($vectorizer, $store);
@@ -72,7 +73,7 @@ final class SimilaritySearchTest extends TestCase
         $store = $this->createMock(StoreInterface::class);
         $store->expects($this->once())
             ->method('query')
-            ->with($vector)
+            ->with($this->callback(static fn ($query) => $query instanceof VectorQuery && $query->getVector() === $vector))
             ->willReturn([]);
 
         $similaritySearch = new SimilaritySearch($vectorizer, $store);
@@ -103,7 +104,7 @@ final class SimilaritySearchTest extends TestCase
         $store = $this->createMock(StoreInterface::class);
         $store->expects($this->once())
             ->method('query')
-            ->with($vector)
+            ->with($this->callback(static fn ($query) => $query instanceof VectorQuery && $query->getVector() === $vector))
             ->willReturn([$document]);
 
         $similaritySearch = new SimilaritySearch($vectorizer, $store);

--- a/src/agent/src/Memory/EmbeddingProvider.php
+++ b/src/agent/src/Memory/EmbeddingProvider.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Message\MessageInterface;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 /**
@@ -54,7 +55,7 @@ final class EmbeddingProvider implements MemoryProviderInterface
         $userMessageTextContent = array_shift($userMessageTextContent);
 
         $vectors = $this->platform->invoke($this->model->getName(), $userMessageTextContent->getText())->asVectors();
-        $foundEmbeddingContent = $this->vectorStore->query($vectors[0]);
+        $foundEmbeddingContent = $this->vectorStore->query(new VectorQuery($vectors[0]));
 
         $content = '';
         foreach ($foundEmbeddingContent as $document) {

--- a/src/agent/tests/Memory/EmbeddingProviderTest.php
+++ b/src/agent/tests/Memory/EmbeddingProviderTest.php
@@ -28,6 +28,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 final class EmbeddingProviderTest extends TestCase
@@ -96,7 +97,7 @@ final class EmbeddingProviderTest extends TestCase
         $store = $this->createMock(StoreInterface::class);
         $store->expects($this->once())
             ->method('query')
-            ->with($vector)
+            ->with($this->callback(static fn ($query) => $query instanceof VectorQuery && $query->getVector() === $vector))
             ->willReturn([]);
 
         $embeddingProvider = new EmbeddingProvider($platform, new Model('text-embedding-3-small'), $store);
@@ -131,7 +132,7 @@ final class EmbeddingProviderTest extends TestCase
         })();
         $store->expects($this->once())
             ->method('query')
-            ->with($vector)
+            ->with($this->callback(static fn ($query) => $query instanceof VectorQuery && $query->getVector() === $vector))
             ->willReturn($generator);
 
         $embeddingProvider = new EmbeddingProvider($platform, new Model('text-embedding-3-small'), $store);

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -2326,8 +2326,8 @@ final class AiBundle extends AbstractBundle
     private function processRetrieverConfig(int|string $name, array $config, ContainerBuilder $container): void
     {
         $definition = new Definition(Retriever::class, [
-            new Reference($config['vectorizer']),
             new Reference($config['store']),
+            new Reference($config['vectorizer']),
             new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
         ]);
         $definition->addTag('ai.retriever', ['name' => $name]);

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -5818,10 +5818,10 @@ class AiBundleTest extends TestCase
         $arguments = $retrieverDefinition->getArguments();
 
         $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertSame('ai.vectorizer.my_vectorizer', (string) $arguments[0]);
+        $this->assertSame('ai.store.memory.my_store', (string) $arguments[0]);
 
         $this->assertInstanceOf(Reference::class, $arguments[1]);
-        $this->assertSame('ai.store.memory.my_store', (string) $arguments[1]);
+        $this->assertSame('ai.vectorizer.my_vectorizer', (string) $arguments[1]);
 
         $this->assertInstanceOf(Reference::class, $arguments[2]); // logger
         $this->assertSame('logger', (string) $arguments[2]);

--- a/src/store/src/Bridge/AzureSearch/Tests/SearchStoreTest.php
+++ b/src/store/src/Bridge/AzureSearch/Tests/SearchStoreTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\AzureSearch\SearchStore;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -167,7 +168,7 @@ final class SearchStoreTest extends TestCase
             '2023-11-01',
         );
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(2, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -216,7 +217,7 @@ final class SearchStoreTest extends TestCase
             'custom_vector_field',
         );
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -247,7 +248,7 @@ final class SearchStoreTest extends TestCase
         $this->expectExceptionMessage('HTTP 400 returned');
         $this->expectExceptionCode(400);
 
-        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
     }
 
     public function testQueryWithNullVector()
@@ -277,7 +278,7 @@ final class SearchStoreTest extends TestCase
             '2023-11-01',
         );
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -424,5 +425,11 @@ final class SearchStoreTest extends TestCase
         $this->expectExceptionCode(404);
 
         $store->remove('nonexistent-doc');
+    }
+
+    public function testStoreSupportsVectorQuery()
+    {
+        $store = new SearchStore(new MockHttpClient(), 'https://test.search.windows.net', 'test-key', 'test-index', '2023-11-01');
+        $this->assertTrue($store->supports(VectorQuery::class));
     }
 }

--- a/src/store/src/Bridge/Cache/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Cache/Tests/StoreTest.php
@@ -19,6 +19,9 @@ use Symfony\AI\Store\Distance\DistanceStrategy;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Uid\Uuid;
 
@@ -29,7 +32,7 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(0, $result);
     }
 
@@ -42,12 +45,12 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(3, $result);
 
         $store->drop();
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(0, $result);
     }
 
@@ -60,7 +63,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(3, $result);
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->getVector()->getData());
 
@@ -70,7 +73,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(6, $result);
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->getVector()->getData());
     }
@@ -86,7 +89,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(5, $result);
         $this->assertSame([0.0, 0.1, 0.6], $result[0]->getVector()->getData());
         $this->assertSame([0.1, 0.1, 0.5], $result[1]->getVector()->getData());
@@ -104,7 +107,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $this->assertCount(1, iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $this->assertCount(1, iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'maxItems' => 1,
         ])));
     }
@@ -117,7 +120,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -131,7 +134,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 2.0, 3.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -145,7 +148,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -159,7 +162,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -174,7 +177,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['category' => 'products', 'enabled' => false])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'filter' => static fn (VectorDocument $doc) => 'products' === $doc->getMetadata()['category'],
         ]));
 
@@ -193,7 +196,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6]), new Metadata(['category' => 'products'])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'filter' => static fn (VectorDocument $doc) => 'products' === $doc->getMetadata()['category'],
             'maxItems' => 2,
         ]));
@@ -212,7 +215,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['price' => 50, 'stock' => 10])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'filter' => static fn (VectorDocument $doc) => $doc->getMetadata()['price'] <= 150 && $doc->getMetadata()['stock'] > 0,
         ]));
 
@@ -228,7 +231,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['options' => ['size' => 'S', 'color' => 'red']])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'filter' => static fn (VectorDocument $doc) => 'S' === $doc->getMetadata()['options']['size'],
         ]));
 
@@ -247,7 +250,7 @@ final class StoreTest extends TestCase
         ]);
 
         $allowedBrands = ['Nike', 'Adidas', 'Puma'];
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'filter' => static fn (VectorDocument $doc) => \in_array($doc->getMetadata()['brand'] ?? '', $allowedBrands, true),
         ]));
 
@@ -259,9 +262,9 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $id1 = Uuid::v4()->toString();
-        $id2 = Uuid::v4()->toString();
-        $id3 = Uuid::v4()->toString();
+        $id1 = Uuid::v4();
+        $id2 = Uuid::v4();
+        $id3 = Uuid::v4();
 
         $store->add([
             new VectorDocument($id1, new Vector([0.1, 0.1, 0.5])),
@@ -269,18 +272,18 @@ final class StoreTest extends TestCase
             new VectorDocument($id3, new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(3, $result);
 
-        $store->remove($id2);
+        $store->remove($id2->toRfc4122());
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
         $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->getId(), $result);
-        $this->assertNotContains($id2, $remainingIds);
-        $this->assertContains($id1, $remainingIds);
-        $this->assertContains($id3, $remainingIds);
+        $this->assertNotContains($id2->toRfc4122(), $remainingIds);
+        $this->assertContains($id1->toRfc4122(), $remainingIds);
+        $this->assertContains($id3->toRfc4122(), $remainingIds);
     }
 
     public function testRemoveWithArrayOfIds()
@@ -288,10 +291,10 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $id1 = Uuid::v4()->toString();
-        $id2 = Uuid::v4()->toString();
-        $id3 = Uuid::v4()->toString();
-        $id4 = Uuid::v4()->toString();
+        $id1 = Uuid::v4();
+        $id2 = Uuid::v4();
+        $id3 = Uuid::v4();
+        $id4 = Uuid::v4();
 
         $store->add([
             new VectorDocument($id1, new Vector([0.1, 0.1, 0.5])),
@@ -300,19 +303,19 @@ final class StoreTest extends TestCase
             new VectorDocument($id4, new Vector([0.0, 0.1, 0.6])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(4, $result);
 
-        $store->remove([$id2, $id4]);
+        $store->remove([$id2->toRfc4122(), $id4->toRfc4122()]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
         $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->getId(), $result);
-        $this->assertNotContains($id2, $remainingIds);
-        $this->assertNotContains($id4, $remainingIds);
-        $this->assertContains($id1, $remainingIds);
-        $this->assertContains($id3, $remainingIds);
+        $this->assertNotContains($id2->toRfc4122(), $remainingIds);
+        $this->assertNotContains($id4->toRfc4122(), $remainingIds);
+        $this->assertContains($id1->toRfc4122(), $remainingIds);
+        $this->assertContains($id3->toRfc4122(), $remainingIds);
     }
 
     public function testRemoveNonExistentId()
@@ -320,21 +323,21 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $id1 = Uuid::v4()->toString();
-        $id2 = Uuid::v4()->toString();
-        $nonExistentId = Uuid::v4()->toString();
+        $id1 = Uuid::v4();
+        $id2 = Uuid::v4();
+        $nonExistentId = Uuid::v4();
 
         $store->add([
             new VectorDocument($id1, new Vector([0.1, 0.1, 0.5])),
             new VectorDocument($id2, new Vector([0.7, -0.3, 0.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
-        $store->remove($nonExistentId);
+        $store->remove($nonExistentId->toRfc4122());
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
     }
 
@@ -343,9 +346,9 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $id1 = Uuid::v4()->toString();
-        $id2 = Uuid::v4()->toString();
-        $id3 = Uuid::v4()->toString();
+        $id1 = Uuid::v4();
+        $id2 = Uuid::v4();
+        $id3 = Uuid::v4();
 
         $store->add([
             new VectorDocument($id1, new Vector([0.1, 0.1, 0.5])),
@@ -353,12 +356,12 @@ final class StoreTest extends TestCase
             new VectorDocument($id3, new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(3, $result);
 
-        $store->remove([$id1, $id2, $id3]);
+        $store->remove([$id1->toRfc4122(), $id2->toRfc4122(), $id3->toRfc4122()]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(0, $result);
     }
 
@@ -367,7 +370,7 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $id1 = Uuid::v4()->toString();
+        $id1 = Uuid::v4();
 
         $store->add([
             new VectorDocument($id1, new Vector([0.1, 0.1, 0.5])),
@@ -376,6 +379,118 @@ final class StoreTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No supported options.');
 
-        $store->remove($id1, ['unsupported' => true]);
+        $store->remove($id1->toRfc4122(), ['unsupported' => true]);
+    }
+
+    public function testStoreCanSearchUsingTextQuery()
+    {
+        $store = new Store(new ArrayAdapter());
+        $store->add([
+            new VectorDocument(Uuid::v4(), new Vector([0.1, 0.1, 0.5]), new Metadata(['_text' => 'The quick brown fox'])),
+            new VectorDocument(Uuid::v4(), new Vector([0.7, -0.3, 0.0]), new Metadata(['_text' => 'jumps over the lazy dog'])),
+            new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['_text' => 'Lorem ipsum dolor sit amet'])),
+        ]);
+
+        $result = iterator_to_array($store->query(new TextQuery('quick brown')));
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('quick brown', $result[0]->getMetadata()->getText());
+    }
+
+    public function testStoreCanSearchUsingTextQueryWithMaxItems()
+    {
+        $store = new Store(new ArrayAdapter());
+        $store->add([
+            new VectorDocument(Uuid::v4(), new Vector([0.1, 0.1, 0.5]), new Metadata(['_text' => 'The word test appears here'])),
+            new VectorDocument(Uuid::v4(), new Vector([0.7, -0.3, 0.0]), new Metadata(['_text' => 'Another test document'])),
+            new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['_text' => 'Yet another test entry'])),
+        ]);
+
+        $result = iterator_to_array($store->query(new TextQuery('test'), ['maxItems' => 2]));
+
+        $this->assertCount(2, $result);
+    }
+
+    public function testStoreCanSearchUsingHybridQuery()
+    {
+        $store = new Store(new ArrayAdapter());
+        $id1 = Uuid::v4();
+        $id2 = Uuid::v4();
+        $id3 = Uuid::v4();
+
+        $store->add([
+            new VectorDocument($id1, new Vector([0.1, 0.1, 0.5]), new Metadata(['_text' => 'space exploration'])),
+            new VectorDocument($id2, new Vector([0.0, 0.1, 0.6]), new Metadata(['_text' => 'deep space mission'])),
+            new VectorDocument($id3, new Vector([0.9, 0.9, 0.9]), new Metadata(['_text' => 'cooking recipes'])),
+        ]);
+
+        $queryVector = new Vector([0.0, 0.1, 0.6]);
+        $result = iterator_to_array($store->query(new HybridQuery($queryVector, 'space', 0.7)));
+
+        // Should find documents matching either vector similarity or text content
+        $this->assertGreaterThanOrEqual(2, \count($result));
+
+        // Check that space-related documents are in results
+        $texts = array_map(static fn (VectorDocument $doc) => $doc->getMetadata()->getText(), $result);
+        $this->assertContains('deep space mission', $texts);
+    }
+
+    public function testStoreCanSearchUsingHybridQueryWithDifferentSemanticRatios()
+    {
+        $store = new Store(new ArrayAdapter());
+        $store->add([
+            new VectorDocument(Uuid::v4(), new Vector([0.1, 0.1, 0.5]), new Metadata(['_text' => 'vector match'])),
+            new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6]), new Metadata(['_text' => 'exact text match'])),
+        ]);
+
+        $queryVector = new Vector([0.0, 0.1, 0.6]);
+
+        // High semantic ratio (favor vector similarity)
+        $resultHighSemantic = iterator_to_array($store->query(new HybridQuery($queryVector, 'exact text match', 0.9)));
+        $this->assertNotEmpty($resultHighSemantic);
+
+        // Low semantic ratio (favor text matching)
+        $resultLowSemantic = iterator_to_array($store->query(new HybridQuery($queryVector, 'exact text match', 0.1)));
+        $this->assertNotEmpty($resultLowSemantic);
+    }
+
+    public function testHybridQueryThrowsExceptionForInvalidSemanticRatio()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Semantic ratio must be between 0.0 and 1.0');
+
+        new HybridQuery(new Vector([0.1, 0.2, 0.3]), 'test', 1.5);
+    }
+
+    public function testStoreThrowsExceptionForUnsupportedQueryType()
+    {
+        $store = new Store(new ArrayAdapter());
+
+        // Create a mock query type that Cache store doesn't support
+        $unsupportedQuery = new class implements \Symfony\AI\Store\Query\QueryInterface {
+        };
+
+        $this->expectException(\Symfony\AI\Store\Exception\UnsupportedQueryTypeException::class);
+        $this->expectExceptionMessageMatches('/not supported/');
+
+        $store->query($unsupportedQuery);
+    }
+
+    public function testStoreSupportsVectorQuery()
+    {
+        $store = new Store(new ArrayAdapter());
+        $this->assertTrue($store->supports(VectorQuery::class));
+    }
+
+    public function testStoreSupportsTextQuery()
+    {
+        $store = new Store(new ArrayAdapter());
+        $this->assertTrue($store->supports(TextQuery::class));
+    }
+
+    public function testStoreSupportsHybridQuery()
+    {
+        $store = new Store(new ArrayAdapter());
+        $this->assertTrue($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -17,7 +17,11 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 /**
@@ -88,30 +92,95 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $collection->delete(ids: $ids);
     }
 
-    /**
-     * @param array{where?: array<string, string>, whereDocument?: array<string, mixed>, include?: array<string>, queryTexts?: array<string>} $options
-     */
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
-        $include = null;
-        if ([] !== ($options['include'] ?? [])) {
-            $include = array_values(
-                array_unique(
-                    array_merge(['embeddings', 'metadatas', 'distances'], $options['include'])
-                )
-            );
+        return \in_array($queryClass, [
+            VectorQuery::class,
+            TextQuery::class,
+        ], true);
+    }
+
+    /**
+     * @param array{where?: array<string, string>, whereDocument?: array<string, mixed>, include?: array<string>, limit?: positive-int} $options
+     */
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$this->supports($query::class)) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
         }
+
+        return match (true) {
+            $query instanceof VectorQuery => $this->queryVector($query, $options),
+            $query instanceof TextQuery => $this->queryText($query, $options),
+            default => throw new UnsupportedQueryTypeException($query::class, $this),
+        };
+    }
+
+    /**
+     * @param array{where?: array<string, string>, whereDocument?: array<string, mixed>, include?: array<string>, limit?: positive-int} $options
+     *
+     * @return iterable<VectorDocument>
+     */
+    private function queryVector(VectorQuery $query, array $options): iterable
+    {
+        $include = $this->buildInclude($options);
 
         $collection = $this->client->getOrCreateCollection($this->collectionName);
         $queryResponse = $collection->query(
-            queryEmbeddings: [$vector->getData()],
-            queryTexts: $options['queryTexts'] ?? null,
-            nResults: 4,
+            queryEmbeddings: [$query->getVector()->getData()],
+            nResults: $options['limit'] ?? 4,
             where: $options['where'] ?? null,
             whereDocument: $options['whereDocument'] ?? null,
             include: $include,
         );
 
+        yield from $this->transformResponse($queryResponse);
+    }
+
+    /**
+     * @param array{where?: array<string, string>, whereDocument?: array<string, mixed>, include?: array<string>, limit?: positive-int} $options
+     *
+     * @return iterable<VectorDocument>
+     */
+    private function queryText(TextQuery $query, array $options): iterable
+    {
+        $include = $this->buildInclude($options);
+
+        $collection = $this->client->getOrCreateCollection($this->collectionName);
+        $queryResponse = $collection->query(
+            queryTexts: $query->getTexts(),
+            nResults: $options['limit'] ?? 4,
+            where: $options['where'] ?? null,
+            whereDocument: $options['whereDocument'] ?? null,
+            include: $include,
+        );
+
+        yield from $this->transformResponse($queryResponse);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string>|null
+     */
+    private function buildInclude(array $options): ?array
+    {
+        if ([] === ($options['include'] ?? [])) {
+            return null;
+        }
+
+        return array_values(
+            array_unique(
+                array_merge(['embeddings', 'metadatas', 'distances'], $options['include'])
+            )
+        );
+    }
+
+    /**
+     * @return iterable<VectorDocument>
+     */
+    private function transformResponse(object $queryResponse): iterable
+    {
         $metaCount = \count($queryResponse->metadatas[0]);
 
         for ($i = 0; $i < $metaCount; ++$i) {

--- a/src/store/src/Bridge/ChromaDb/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/IntegrationTest.php
@@ -23,6 +23,11 @@ use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
 #[Group('integration')]
 final class IntegrationTest extends AbstractStoreIntegrationTestCase
 {
+    public function testQueryDocumentsWithTextQuery()
+    {
+        $this->markTestSkipped('ChromaDb TextQuery requires an embedding function to be configured.');
+    }
+
     protected static function createStore(): StoreInterface
     {
         $client = ChromaDB::factory()

--- a/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
@@ -20,6 +20,9 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\ChromaDb\Store;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Uid\Uuid;
 
 final class StoreTest extends TestCase
@@ -167,7 +170,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector)));
 
         $this->assertCount(2, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -211,7 +214,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector, ['where' => $whereFilter]));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), ['where' => $whereFilter]));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -254,7 +257,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector, ['whereDocument' => $whereDocumentFilter]));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), ['whereDocument' => $whereDocumentFilter]));
 
         $this->assertCount(2, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -298,7 +301,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector, [
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), [
             'where' => $whereFilter,
             'whereDocument' => $whereDocumentFilter,
         ]));
@@ -344,7 +347,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector, ['where' => $whereFilter]));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), ['where' => $whereFilter]));
 
         $this->assertCount(0, $documents);
     }
@@ -375,7 +378,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector)));
 
         $this->assertCount(2, $documents);
         $this->assertSame(0.123, $documents[0]->getScore());
@@ -408,7 +411,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector)));
 
         $this->assertCount(1, $documents);
         $this->assertNull($documents[0]->getScore());
@@ -458,7 +461,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector, $options));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), $options));
 
         $this->assertCount(1, $documents);
     }
@@ -489,7 +492,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector)));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -523,7 +526,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector, ['include' => ['documents']]));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), ['include' => ['documents']]));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -557,7 +560,7 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector, ['include' => ['embeddings', 'metadatas', 'distances', 'documents']]));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), ['include' => ['embeddings', 'metadatas', 'distances', 'documents']]));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -636,50 +639,6 @@ final class StoreTest extends TestCase
         ];
     }
 
-    public function testQueryWithQueryTexts()
-    {
-        $queryVector = new Vector([0.15, 0.25, 0.35]);
-        $queryTexts = ['search for this text'];
-
-        $queryResponse = new QueryItemsResponse(
-            ids: [['01234567-89ab-cdef-0123-456789abcdef']],
-            embeddings: [[[0.1, 0.2, 0.3]]],
-            metadatas: [[['title' => 'Doc 1']]],
-            documents: null,
-            data: null,
-            uris: null,
-            distances: [[0.123]]
-        );
-
-        $collection = $this->createMock(Collection::class);
-        $client = $this->createMock(Client::class);
-
-        $client->expects($this->once())
-            ->method('getOrCreateCollection')
-            ->with('test-collection')
-            ->willReturn($collection);
-
-        $collection->expects($this->once())
-            ->method('query')
-            ->with(
-                [[0.15, 0.25, 0.35]],       // queryEmbeddings
-                ['search for this text'],   // queryTexts
-                4,                          // nResults
-                null,                       // where
-                null,                       // whereDocument
-                null                        // include
-            )
-            ->willReturn($queryResponse);
-
-        $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query($queryVector, ['queryTexts' => $queryTexts]));
-
-        $this->assertCount(1, $documents);
-        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
-        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());
-        $this->assertSame(0.123, $documents[0]->getScore());
-    }
-
     public function testRemoveSingleDocument()
     {
         $collection = $this->createMock(Collection::class);
@@ -729,5 +688,67 @@ final class StoreTest extends TestCase
 
         $store = new Store($client, 'test-collection');
         $store->remove([]);
+    }
+
+    public function testQueryWithTextQuery()
+    {
+        $queryResponse = new QueryItemsResponse(
+            ids: [['01234567-89ab-cdef-0123-456789abcdef']],
+            embeddings: [[[0.1, 0.2, 0.3]]],
+            metadatas: [[['title' => 'Doc 1']]],
+            documents: null,
+            data: null,
+            uris: null,
+            distances: [[0.123]]
+        );
+
+        $collection = $this->createMock(Collection::class);
+        $client = $this->createMock(Client::class);
+
+        $client->expects($this->once())
+            ->method('getOrCreateCollection')
+            ->with('test-collection')
+            ->willReturn($collection);
+
+        $collection->expects($this->once())
+            ->method('query')
+            ->with(
+                null,                          // queryEmbeddings
+                ['search for this text'],      // queryTexts
+                4,                             // nResults
+                null,                          // where
+                null,                          // whereDocument
+                null                           // include
+            )
+            ->willReturn($queryResponse);
+
+        $store = new Store($client, 'test-collection');
+        $documents = iterator_to_array($store->query(new TextQuery('search for this text')));
+
+        $this->assertCount(1, $documents);
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
+        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());
+        $this->assertSame(0.123, $documents[0]->getScore());
+    }
+
+    public function testStoreSupportsVectorQuery()
+    {
+        $client = $this->createMock(Client::class);
+        $store = new Store($client, 'test-collection');
+        $this->assertTrue($store->supports(VectorQuery::class));
+    }
+
+    public function testStoreSupportsTextQuery()
+    {
+        $client = $this->createMock(Client::class);
+        $store = new Store($client, 'test-collection');
+        $this->assertTrue($store->supports(TextQuery::class));
+    }
+
+    public function testStoreNotSupportsHybridQuery()
+    {
+        $client = $this->createMock(Client::class);
+        $store = new Store($client, 'test-collection');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/ClickHouse/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ClickHouse/Tests/StoreTest.php
@@ -18,6 +18,9 @@ use Symfony\AI\Store\Bridge\ClickHouse\Store;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Uid\Uuid;
@@ -152,7 +155,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'test_db', 'test_table');
 
-        $results = iterator_to_array($store->query($queryVector));
+        $results = iterator_to_array($store->query(new VectorQuery($queryVector)));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -175,7 +178,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'test_db', 'test_table');
 
-        $results = iterator_to_array($store->query($queryVector, [
+        $results = iterator_to_array($store->query(new VectorQuery($queryVector), [
             'limit' => 10,
             'params' => ['custom_param' => 'test_value'],
         ]));
@@ -197,7 +200,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'test_db', 'test_table');
 
-        $results = iterator_to_array($store->query($queryVector, [
+        $results = iterator_to_array($store->query(new VectorQuery($queryVector), [
             'where' => "JSONExtractString(metadata, 'type') = 'document'",
         ]));
 
@@ -225,7 +228,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'test_db', 'test_table');
 
-        $results = iterator_to_array($store->query($queryVector));
+        $results = iterator_to_array($store->query(new VectorQuery($queryVector)));
 
         $this->assertCount(1, $results);
         $this->assertSame([], $results[0]->getMetadata()->getArrayCopy());
@@ -282,5 +285,23 @@ final class StoreTest extends TestCase
         $store = new Store($httpClient, 'test_db', 'test_table');
 
         $store->remove([]);
+    }
+
+    public function testStoreSupportsVectorQuery()
+    {
+        $store = new Store(new MockHttpClient(), 'default', 'test_table');
+        $this->assertTrue($store->supports(VectorQuery::class));
+    }
+
+    public function testStoreNotSupportsTextQuery()
+    {
+        $store = new Store(new MockHttpClient(), 'default', 'test_table');
+        $this->assertFalse($store->supports(TextQuery::class));
+    }
+
+    public function testStoreNotSupportsHybridQuery()
+    {
+        $store = new Store(new MockHttpClient(), 'default', 'test_table');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/Cloudflare/Store.php
+++ b/src/store/src/Bridge/Cloudflare/Store.php
@@ -16,7 +16,10 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -85,8 +88,18 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
+        return VectorQuery::class === $queryClass;
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
+        $vector = $query->getVector();
         $results = $this->request('POST', \sprintf('vectorize/v2/indexes/%s/query', $this->index), [
             'vector' => $vector->getData(),
             'returnValues' => true,

--- a/src/store/src/Bridge/Cloudflare/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Cloudflare/Tests/StoreTest.php
@@ -16,6 +16,9 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Cloudflare\Store;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -197,7 +200,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "https://api.cloudflare.com/client/v4/accounts/foo/vectorize/v2/indexes/random/query".');
         $this->expectExceptionCode(400);
-        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
     }
 
     public function testStoreCanQuery()
@@ -232,7 +235,7 @@ final class StoreTest extends TestCase
             'random',
         );
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(2, $results);
         $this->assertSame(1, $mockHttpClient->getRequestsCount());
@@ -307,5 +310,23 @@ final class StoreTest extends TestCase
         $store->remove(['id1', 'id2', 'id3']);
 
         $this->assertSame(1, $mockHttpClient->getRequestsCount());
+    }
+
+    public function testStoreSupportsVectorQuery()
+    {
+        $store = new Store(new MockHttpClient(), 'account-id', 'index-name', 'api-key');
+        $this->assertTrue($store->supports(VectorQuery::class));
+    }
+
+    public function testStoreDoesNotSupportTextQuery()
+    {
+        $store = new Store(new MockHttpClient(), 'account-id', 'index-name', 'api-key');
+        $this->assertFalse($store->supports(TextQuery::class));
+    }
+
+    public function testStoreDoesNotSupportHybridQuery()
+    {
+        $store = new Store(new MockHttpClient(), 'account-id', 'index-name', 'api-key');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -16,7 +16,10 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -114,8 +117,18 @@ final class Store implements ManagedStoreInterface, StoreInterface
         });
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
+        return VectorQuery::class === $queryClass;
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
+        $vector = $query->getVector();
         $k = $options['k'] ?? 100;
         $numCandidates = $options['num_candidates'] ?? max($k * 2, 100);
 

--- a/src/store/src/Bridge/Elasticsearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Elasticsearch/Tests/StoreTest.php
@@ -16,6 +16,9 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Elasticsearch\Store;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\Uid\Uuid;
@@ -188,87 +191,27 @@ final class StoreTest extends TestCase
         ]);
 
         $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = $store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, iterator_to_array($results));
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCanRemoveSingleDocument()
+    public function testStoreSupportsVectorQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'took' => 100,
-                'errors' => false,
-                'items' => [
-                    [
-                        'delete' => [
-                            '_index' => 'foo',
-                            '_id' => 'test-id-1',
-                            '_version' => 2,
-                            'result' => 'deleted',
-                            '_shards' => [],
-                            'status' => 200,
-                        ],
-                    ],
-                ],
-            ], [
-                'http_code' => 200,
-            ]),
-        ]);
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
-        $store->remove('test-id-1');
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');
+        $this->assertTrue($store->supports(VectorQuery::class));
     }
 
-    public function testStoreCanRemoveMultipleDocuments()
+    public function testStoreDoesNotSupportTextQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'took' => 100,
-                'errors' => false,
-                'items' => [
-                    [
-                        'delete' => [
-                            '_index' => 'foo',
-                            '_id' => 'test-id-1',
-                            '_version' => 2,
-                            'result' => 'deleted',
-                            '_shards' => [],
-                            'status' => 200,
-                        ],
-                    ],
-                    [
-                        'delete' => [
-                            '_index' => 'foo',
-                            '_id' => 'test-id-2',
-                            '_version' => 2,
-                            'result' => 'deleted',
-                            '_shards' => [],
-                            'status' => 200,
-                        ],
-                    ],
-                ],
-            ], [
-                'http_code' => 200,
-            ]),
-        ]);
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
-        $store->remove(['test-id-1', 'test-id-2']);
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');
+        $this->assertFalse($store->supports(TextQuery::class));
     }
 
-    public function testStoreRemoveWithEmptyArrayDoesNothing()
+    public function testStoreDoesNotSupportHybridQuery()
     {
-        $httpClient = new MockHttpClient([]);
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
-        $store->remove([]);
-
-        $this->assertSame(0, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/ManticoreSearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ManticoreSearch/Tests/StoreTest.php
@@ -16,6 +16,9 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\ManticoreSearch\Store;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -159,7 +162,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:9308/search".');
         $this->expectExceptionCode(400);
-        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
     }
 
     public function testStoreCanQuery()
@@ -192,121 +195,27 @@ final class StoreTest extends TestCase
         ]);
 
         $store = new Store($httpClient, 'http://127.0.0.1:9308', 'bar', 'random');
-        $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $documents = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(1, $documents);
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotRemoveOnInvalidResponse()
+    public function testStoreSupportsVectorQuery()
     {
-        $mockHttpClient = new MockHttpClient([
-            new JsonMockResponse([], [
-                'http_code' => 400,
-            ]),
-        ]);
-
-        $store = new Store($mockHttpClient, 'http://127.0.0.1:9308', 'bar', 'random');
-
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:9308/bulk".');
-        $this->expectExceptionCode(400);
-        $store->remove('test-id');
+        $store = new Store(new MockHttpClient(), 'http://localhost:9308', 'test_index');
+        $this->assertTrue($store->supports(VectorQuery::class));
     }
 
-    public function testStoreCanRemoveSingleId()
+    public function testStoreDoesNotSupportTextQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'items' => [
-                    [
-                        'bulk' => [
-                            'table' => 'bar',
-                            '_id' => 1,
-                            'created' => 0,
-                            'deleted' => 1,
-                            'updated' => 0,
-                            'result' => 'deleted',
-                            'status' => 200,
-                        ],
-                    ],
-                ],
-                'errors' => false,
-            ], [
-                'http_code' => 200,
-            ]),
-        ]);
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9308', 'bar', 'random');
-        $store->remove('test-id');
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:9308', 'test_index');
+        $this->assertFalse($store->supports(TextQuery::class));
     }
 
-    public function testStoreCanRemoveMultipleIds()
+    public function testStoreDoesNotSupportHybridQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'items' => [
-                    [
-                        'bulk' => [
-                            'table' => 'bar',
-                            '_id' => 1,
-                            'created' => 0,
-                            'deleted' => 3,
-                            'updated' => 0,
-                            'result' => 'deleted',
-                            'status' => 200,
-                        ],
-                    ],
-                ],
-                'errors' => false,
-            ], [
-                'http_code' => 200,
-            ]),
-        ]);
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9308', 'bar', 'random');
-        $store->remove(['test-id-1', 'test-id-2', 'test-id-3']);
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
-    }
-
-    public function testStoreCanRemoveWithEmptyArray()
-    {
-        $httpClient = new MockHttpClient();
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9308', 'bar', 'random');
-        $store->remove([]);
-
-        $this->assertSame(0, $httpClient->getRequestsCount());
-    }
-
-    public function testStoreCanRemoveWithChunking()
-    {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'items' => [],
-                'errors' => false,
-            ], [
-                'http_code' => 200,
-            ]),
-            new JsonMockResponse([
-                'items' => [],
-                'errors' => false,
-            ], [
-                'http_code' => 200,
-            ]),
-        ]);
-
-        $ids = [];
-        for ($i = 0; $i < 1001; ++$i) {
-            $ids[] = 'test-id-'.$i;
-        }
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9308', 'bar', 'random');
-        $store->remove($ids);
-
-        $this->assertSame(2, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:9308', 'test_index');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -17,7 +17,10 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Component\Uid\Uuid;
 
@@ -155,14 +158,26 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $statement->execute();
     }
 
+    public function supports(string $queryClass): bool
+    {
+        return VectorQuery::class === $queryClass;
+    }
+
     /**
      * @param array{
      *     limit?: positive-int,
      *     maxScore?: float|null,
+     *     where?: string,
+     *     params?: array<string, mixed>,
      * } $options
      */
-    public function query(Vector $vector, array $options = []): iterable
+    public function query(QueryInterface $query, array $options = []): iterable
     {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
+        $vector = $query->getVector();
         $where = null;
 
         $maxScore = $options['maxScore'] ?? null;

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -16,7 +16,10 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -93,8 +96,18 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->request('POST', \sprintf('indexes/%s/documents/delete-batch', $this->indexName), $ids);
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
+        return VectorQuery::class === $queryClass;
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
+        $vector = $query->getVector();
         $semanticRatio = $options['semanticRatio'] ?? $this->semanticRatio;
 
         if ($semanticRatio < 0.0 || $semanticRatio > 1.0) {

--- a/src/store/src/Bridge/Meilisearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Meilisearch/Tests/StoreTest.php
@@ -16,6 +16,9 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Meilisearch\Store;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -186,7 +189,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:7700/indexes/test/search".');
         $this->expectExceptionCode(400);
-        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
     }
 
     public function testStoreCanQuery()
@@ -228,7 +231,7 @@ final class StoreTest extends TestCase
             embeddingsDimension: 3,
         );
 
-        $vectors = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $vectors = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertSame(1, $httpClient->getRequestsCount());
         $this->assertCount(2, $vectors);
@@ -269,7 +272,7 @@ final class StoreTest extends TestCase
             embeddingsDimension: 3,
         );
 
-        $vectors = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $vectors = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
         $expected = [
             'title' => 'The Matrix',
             'description' => 'A science fiction action film.',
@@ -328,7 +331,7 @@ final class StoreTest extends TestCase
         $store = new Store($httpClient, 'http://localhost:7700', 'key', 'index', semanticRatio: 0.7);
 
         $vector = new Vector([0.1, 0.2, 0.3]);
-        iterator_to_array($store->query($vector));
+        iterator_to_array($store->query(new VectorQuery($vector)));
 
         $request = $httpClient->getRequestsCount() > 0 ? $responses[0]->getRequestOptions() : null;
         $this->assertNotNull($request);
@@ -348,7 +351,7 @@ final class StoreTest extends TestCase
         $httpClient = new MockHttpClient($responses);
         $store = new Store($httpClient, 'http://localhost:7700', 'key', 'index', semanticRatio: 0.5);
 
-        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['semanticRatio' => 0.2]));
+        iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), ['semanticRatio' => 0.2]));
 
         $request = $responses[0]->getRequestOptions();
         $body = json_decode($request['body'], true);
@@ -365,7 +368,7 @@ final class StoreTest extends TestCase
         $store = new Store($httpClient, 'http://localhost:7700', 'key', 'index');
 
         $vector = new Vector([0.1, 0.2, 0.3]);
-        iterator_to_array($store->query($vector, ['semanticRatio' => 2.0]));
+        iterator_to_array($store->query(new VectorQuery($vector), ['semanticRatio' => 2.0]));
     }
 
     public function testQueryWithPureKeywordSearch()
@@ -391,7 +394,7 @@ final class StoreTest extends TestCase
         $store = new Store($httpClient, 'http://localhost:7700', 'key', 'index');
 
         $vector = new Vector([0.1, 0.2, 0.3]);
-        $results = iterator_to_array($store->query($vector, ['semanticRatio' => 0.0]));
+        $results = iterator_to_array($store->query(new VectorQuery($vector), ['semanticRatio' => 0.0]));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -413,7 +416,7 @@ final class StoreTest extends TestCase
         $store = new Store($httpClient, 'http://localhost:7700', 'key', 'index', semanticRatio: 0.5);
 
         $vector = new Vector([0.1, 0.2, 0.3]);
-        iterator_to_array($store->query($vector));
+        iterator_to_array($store->query(new VectorQuery($vector)));
 
         $request = $responses[0]->getRequestOptions();
         $body = json_decode($request['body'], true);
@@ -513,5 +516,23 @@ final class StoreTest extends TestCase
         $store->remove([]);
 
         $this->assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testStoreSupportsVectorQuery()
+    {
+        $store = new Store(new MockHttpClient(), 'http://localhost:7700', 'test-key', 'test-index');
+        $this->assertTrue($store->supports(VectorQuery::class));
+    }
+
+    public function testStoreDoesNotSupportTextQuery()
+    {
+        $store = new Store(new MockHttpClient(), 'http://localhost:7700', 'test-key', 'test-index');
+        $this->assertFalse($store->supports(TextQuery::class));
+    }
+
+    public function testStoreDoesNotSupportHybridQuery()
+    {
+        $store = new Store(new MockHttpClient(), 'http://localhost:7700', 'test-key', 'test-index');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -16,7 +16,10 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -119,8 +122,18 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
+        return VectorQuery::class === $queryClass;
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
+        $vector = $query->getVector();
         $payload = [
             'collectionName' => $this->collection,
             'data' => [

--- a/src/store/src/Bridge/Milvus/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Milvus/Tests/StoreTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Milvus\Store;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -195,7 +198,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:19530/v2/vectordb/entities/search".');
         $this->expectExceptionCode(400);
-        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
     }
 
     public function testStoreCanQuery()
@@ -231,120 +234,27 @@ final class StoreTest extends TestCase
             'test',
         );
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(2, $results);
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCannotRemoveOnInvalidResponse()
+    public function testStoreSupportsVectorQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([], [
-                'http_code' => 400,
-            ]),
-        ], 'http://127.0.0.1:19530');
-
-        $store = new Store(
-            $httpClient,
-            'http://127.0.0.1:19530',
-            'test',
-            'test',
-            'test',
-        );
-
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:19530/v2/vectordb/entities/delete".');
-        $this->expectExceptionCode(400);
-        $store->remove('test-id');
+        $store = new Store(new MockHttpClient(), 'http://localhost:19530', 'test-api-key', 'default', 'test_collection');
+        $this->assertTrue($store->supports(VectorQuery::class));
     }
 
-    public function testStoreCanRemoveSingleId()
+    public function testStoreDoesNotSupportTextQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'code' => 0,
-                'data' => [],
-            ], [
-                'http_code' => 200,
-            ]),
-        ], 'http://127.0.0.1:19530');
-
-        $store = new Store(
-            $httpClient,
-            'http://127.0.0.1:19530',
-            'test',
-            'test',
-            'test',
-        );
-
-        $store->remove('test-id');
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:19530', 'test-api-key', 'default', 'test_collection');
+        $this->assertFalse($store->supports(TextQuery::class));
     }
 
-    public function testStoreCanRemoveMultipleIds()
+    public function testStoreDoesNotSupportHybridQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'code' => 0,
-                'data' => [],
-            ], [
-                'http_code' => 200,
-            ]),
-        ], 'http://127.0.0.1:19530');
-
-        $store = new Store(
-            $httpClient,
-            'http://127.0.0.1:19530',
-            'test',
-            'test',
-            'test',
-        );
-
-        $store->remove(['test-id-1', 'test-id-2', 'test-id-3']);
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
-    }
-
-    public function testStoreCanRemoveWithEmptyIds()
-    {
-        $httpClient = new MockHttpClient([], 'http://127.0.0.1:19530');
-
-        $store = new Store(
-            $httpClient,
-            'http://127.0.0.1:19530',
-            'test',
-            'test',
-            'test',
-        );
-
-        $store->remove([]);
-
-        $this->assertSame(0, $httpClient->getRequestsCount());
-    }
-
-    public function testStoreCanRemoveIdWithSpecialCharacters()
-    {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'code' => 0,
-                'data' => [],
-            ], [
-                'http_code' => 200,
-            ]),
-        ], 'http://127.0.0.1:19530');
-
-        $store = new Store(
-            $httpClient,
-            'http://127.0.0.1:19530',
-            'test',
-            'test',
-            'test',
-        );
-
-        $store->remove('test-id-with-"quotes"');
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:19530', 'test-api-key', 'default', 'test_collection');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/MongoDb/Store.php
+++ b/src/store/src/Bridge/MongoDb/Store.php
@@ -21,7 +21,10 @@ use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedFeatureException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 /**
@@ -140,6 +143,11 @@ final class Store implements ManagedStoreInterface, StoreInterface
         throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
+    public function supports(string $queryClass): bool
+    {
+        return VectorQuery::class === $queryClass;
+    }
+
     /**
      * @param array{
      *     limit?: positive-int,
@@ -148,8 +156,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     minScore?: float,
      * } $options
      */
-    public function query(Vector $vector, array $options = []): iterable
+    public function query(QueryInterface $query, array $options = []): iterable
     {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
+        $vector = $query->getVector();
         $minScore = null;
         if (\array_key_exists('minScore', $options)) {
             $minScore = $options['minScore'];

--- a/src/store/src/Bridge/MongoDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/MongoDb/Tests/StoreTest.php
@@ -23,6 +23,9 @@ use Symfony\AI\Store\Bridge\MongoDb\Store;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Uid\Uuid;
 
 #[RequiresPhpExtension('mongodb')]
@@ -209,7 +212,7 @@ final class StoreTest extends TestCase
             'test-index',
         );
 
-        $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $documents = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(2, $documents);
         $this->assertInstanceOf(VectorDocument::class, $documents[0]);
@@ -273,7 +276,7 @@ final class StoreTest extends TestCase
             'test-index',
         );
 
-        $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['minScore' => 0.8]));
+        $documents = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), ['minScore' => 0.8]));
 
         $this->assertCount(0, $documents);
     }
@@ -325,7 +328,7 @@ final class StoreTest extends TestCase
             'test-index',
         );
 
-        $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
+        $documents = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), [
             'limit' => 10,
             'numCandidates' => 500,
             'filter' => ['category' => 'test'],
@@ -557,9 +560,30 @@ final class StoreTest extends TestCase
             'custom_embeddings',
         );
 
-        $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $documents = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(1, $documents);
         $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());
+    }
+
+    public function testStoreSupportsVectorQuery()
+    {
+        $client = $this->createMock(Client::class);
+        $store = new Store($client, 'test_db', 'test_collection', 'test_index');
+        $this->assertTrue($store->supports(VectorQuery::class));
+    }
+
+    public function testStoreDoesNotSupportTextQuery()
+    {
+        $client = $this->createMock(Client::class);
+        $store = new Store($client, 'test_db', 'test_collection', 'test_index');
+        $this->assertFalse($store->supports(TextQuery::class));
+    }
+
+    public function testStoreDoesNotSupportHybridQuery()
+    {
+        $client = $this->createMock(Client::class);
+        $store = new Store($client, 'test_db', 'test_collection', 'test_index');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/Neo4j/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Neo4j/Tests/StoreTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Neo4j\Store;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -288,82 +291,27 @@ final class StoreTest extends TestCase
         $store->setup();
         $store->add([new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2, 0.3]))]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(2, $results);
         $this->assertSame(3, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCanRemoveSingleDocument()
+    public function testStoreSupportsVectorQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'data' => [
-                    'fields' => [],
-                    'values' => [],
-                ],
-                'bookmarks' => [
-                    'FB:kcwQ5zbxUD1ESXmS6UjG2xKCZMkAoJB=',
-                ],
-            ], [
-                'http_code' => 200,
-            ]),
-        ], 'http://127.0.0.1:7474');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:7474', 'symfony', 'symfony', 'symfony', 'symfony', 'symfony');
-
-        $store->remove('test-id');
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'bolt://localhost:7687', 'neo4j', 'password', 'neo4j', 'vector_index', 'Document');
+        $this->assertTrue($store->supports(VectorQuery::class));
     }
 
-    public function testStoreCanRemoveMultipleDocuments()
+    public function testStoreDoesNotSupportTextQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'data' => [
-                    'fields' => [],
-                    'values' => [],
-                ],
-                'bookmarks' => [
-                    'FB:kcwQ5zbxUD1ESXmS6UjG2xKCZMkAoJB=',
-                ],
-            ], [
-                'http_code' => 200,
-            ]),
-        ], 'http://127.0.0.1:7474');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:7474', 'symfony', 'symfony', 'symfony', 'symfony', 'symfony');
-
-        $store->remove(['test-id-1', 'test-id-2', 'test-id-3']);
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'bolt://localhost:7687', 'neo4j', 'password', 'neo4j', 'vector_index', 'Document');
+        $this->assertFalse($store->supports(TextQuery::class));
     }
 
-    public function testStoreCannotRemoveOnInvalidResponse()
+    public function testStoreDoesNotSupportHybridQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([], [
-                'http_code' => 400,
-            ]),
-        ], 'http://127.0.0.1:7474');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:7474', 'symfony', 'symfony', 'symfony', 'symfony', 'symfony');
-
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:7474/db/symfony/query/v2".');
-        $this->expectExceptionCode(400);
-        $store->remove('test-id');
-    }
-
-    public function testStoreRemoveWithEmptyArray()
-    {
-        $httpClient = new MockHttpClient([], 'http://127.0.0.1:7474');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:7474', 'symfony', 'symfony', 'symfony', 'symfony', 'symfony');
-
-        $store->remove([]);
-
-        $this->assertSame(0, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'bolt://localhost:7687', 'neo4j', 'password', 'neo4j', 'vector_index', 'Document');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -16,7 +16,10 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -117,8 +120,18 @@ final class Store implements ManagedStoreInterface, StoreInterface
         });
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
+        return VectorQuery::class === $queryClass;
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
+        $vector = $query->getVector();
         $documents = $this->request('POST', \sprintf('%s/_search', $this->indexName), [
             'size' => $options['size'] ?? 100,
             'query' => [

--- a/src/store/src/Bridge/OpenSearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/OpenSearch/Tests/StoreTest.php
@@ -16,6 +16,9 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\OpenSearch\Store;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\Uid\Uuid;
@@ -190,87 +193,27 @@ final class StoreTest extends TestCase
         ]);
 
         $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
-        $results = $store->query(new Vector([0.1, 0.2, 0.3]));
+        $results = $store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, iterator_to_array($results));
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCanRemoveSingleDocument()
+    public function testStoreSupportsVectorQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'took' => 30,
-                'errors' => false,
-                'items' => [
-                    [
-                        'delete' => [
-                            '_index' => 'foo',
-                            '_id' => 'test-id-1',
-                            '_version' => 2,
-                            'result' => 'deleted',
-                            '_shards' => [],
-                            'status' => 200,
-                        ],
-                    ],
-                ],
-            ], [
-                'http_code' => 200,
-            ]),
-        ]);
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
-        $store->remove('test-id-1');
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');
+        $this->assertTrue($store->supports(VectorQuery::class));
     }
 
-    public function testStoreCanRemoveMultipleDocuments()
+    public function testStoreDoesNotSupportTextQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'took' => 50,
-                'errors' => false,
-                'items' => [
-                    [
-                        'delete' => [
-                            '_index' => 'foo',
-                            '_id' => 'test-id-1',
-                            '_version' => 2,
-                            'result' => 'deleted',
-                            '_shards' => [],
-                            'status' => 200,
-                        ],
-                    ],
-                    [
-                        'delete' => [
-                            '_index' => 'foo',
-                            '_id' => 'test-id-2',
-                            '_version' => 2,
-                            'result' => 'deleted',
-                            '_shards' => [],
-                            'status' => 200,
-                        ],
-                    ],
-                ],
-            ], [
-                'http_code' => 200,
-            ]),
-        ]);
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
-        $store->remove(['test-id-1', 'test-id-2']);
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');
+        $this->assertFalse($store->supports(TextQuery::class));
     }
 
-    public function testStoreCanRemoveWithEmptyArray()
+    public function testStoreDoesNotSupportHybridQuery()
     {
-        $httpClient = new MockHttpClient([]);
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
-        $store->remove([]);
-
-        $this->assertSame(0, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -17,7 +17,10 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 /**
@@ -112,10 +115,19 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
+        return VectorQuery::class === $queryClass;
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
         $result = $this->getVectors()->query(
-            vector: $vector->getData(),
+            vector: $query->getVector()->getData(),
             namespace: $options['namespace'] ?? $this->namespace,
             filter: $options['filter'] ?? $this->filter,
             topK: $options['topK'] ?? $this->topK,

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -17,7 +17,12 @@ use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 /**
@@ -150,22 +155,53 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $statement->execute();
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
-        $where = null;
+        return \in_array($queryClass, [
+            VectorQuery::class,
+            TextQuery::class,
+            HybridQuery::class,
+        ], true);
+    }
 
-        $maxScore = $options['maxScore'] ?? null;
-        if ($maxScore) {
-            $where = "WHERE ({$this->vectorFieldName} {$this->distance->getComparisonSign()} :embedding) <= :maxScore";
+    /**
+     * @param array{limit?: positive-int, maxScore?: float} $options
+     */
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        return match (true) {
+            $query instanceof VectorQuery => $this->queryVector($query, $options),
+            $query instanceof TextQuery => $this->queryText($query, $options),
+            $query instanceof HybridQuery => $this->queryHybrid($query, $options),
+            default => throw new UnsupportedQueryTypeException($query::class, $this),
+        };
+    }
+
+    /**
+     * @param array{limit?: positive-int, maxScore?: float, where?: string, params?: array<string, mixed>} $options
+     *
+     * @return iterable<VectorDocument>
+     */
+    private function queryVector(VectorQuery $query, array $options): iterable
+    {
+        $whereClauses = [];
+        $params = ['embedding' => $this->toPgvector($query->getVector())];
+
+        if (isset($options['maxScore'])) {
+            $whereClauses[] = \sprintf('(%s %s :embedding) <= :maxScore', $this->vectorFieldName, $this->distance->getComparisonSign());
+            $params['maxScore'] = $options['maxScore'];
         }
 
-        if ($options['where'] ?? false) {
-            if ($where) {
-                $where .= ' AND ('.$options['where'].')';
-            } else {
-                $where = 'WHERE '.$options['where'];
-            }
+        if (isset($options['where'])) {
+            // Only wrap in parentheses if combining with other conditions
+            $whereClauses[] = [] !== $whereClauses ? '('.$options['where'].')' : $options['where'];
         }
+
+        if (isset($options['params'])) {
+            $params = array_merge($params, $options['params']);
+        }
+
+        $where = [] !== $whereClauses ? 'WHERE '.implode(' AND ', $whereClauses) : '';
 
         $sql = \sprintf(<<<SQL
             SELECT id, %s AS embedding, metadata, (%s %s :embedding) AS score
@@ -178,18 +214,140 @@ final class Store implements ManagedStoreInterface, StoreInterface
             $this->vectorFieldName,
             $this->distance->getComparisonSign(),
             $this->tableName,
-            $where ?? '',
+            $where,
             $options['limit'] ?? 5,
         );
+
         $statement = $this->connection->prepare($sql);
 
-        $params = [
-            'embedding' => $this->toPgvector($vector),
-            ...$options['params'] ?? [],
-        ];
-        if (null !== $maxScore) {
-            $params['maxScore'] = $maxScore;
+        foreach ($params as $key => $value) {
+            $statement->bindValue(':'.$key, $value);
         }
+
+        $statement->execute();
+
+        foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
+            yield new VectorDocument(
+                id: $result['id'],
+                vector: new Vector($this->fromPgvector($result['embedding'])),
+                metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
+                score: $result['score'],
+            );
+        }
+    }
+
+    /**
+     * @param array{limit?: positive-int} $options
+     *
+     * @return iterable<VectorDocument>
+     */
+    private function queryText(TextQuery $query, array $options): iterable
+    {
+        $texts = $query->getTexts();
+        $tsqueryParts = [];
+        $params = [];
+
+        // Build OR-combined tsquery for multiple texts
+        foreach ($texts as $i => $text) {
+            $paramName = 'search_text_'.$i;
+            $tsqueryParts[] = "plainto_tsquery('english', :{$paramName})";
+            $params[$paramName] = $text;
+        }
+
+        $tsqueryExpression = implode(' || ', $tsqueryParts); // OR operator in PostgreSQL
+        $tsvectorExpression = "to_tsvector('english', metadata->>'_text')";
+
+        $sql = \sprintf(<<<SQL
+            SELECT id, %s AS embedding, metadata,
+                   ts_rank(%s, %s) AS score
+            FROM %s
+            WHERE %s @@ (%s)
+            ORDER BY score DESC
+            LIMIT %d
+            SQL,
+            $this->vectorFieldName,
+            $tsvectorExpression,
+            $tsqueryExpression,
+            $this->tableName,
+            $tsvectorExpression,
+            $tsqueryExpression,
+            $options['limit'] ?? 5,
+        );
+
+        $statement = $this->connection->prepare($sql);
+        foreach ($params as $paramName => $value) {
+            $statement->bindValue(':'.$paramName, $value);
+        }
+
+        $statement->execute();
+
+        foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
+            yield new VectorDocument(
+                id: $result['id'],
+                vector: new Vector($this->fromPgvector($result['embedding'])),
+                metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
+                score: $result['score'],
+            );
+        }
+    }
+
+    /**
+     * @param array{limit?: positive-int, maxScore?: float} $options
+     *
+     * @return iterable<VectorDocument>
+     */
+    private function queryHybrid(HybridQuery $query, array $options): iterable
+    {
+        $texts = $query->getTexts();
+        $tsqueryParts = [];
+        $params = [
+            'embedding' => $this->toPgvector($query->getVector()),
+            'semantic_ratio' => $query->getSemanticRatio(),
+            'keyword_ratio' => $query->getKeywordRatio(),
+        ];
+
+        // Build OR-combined tsquery for multiple texts
+        foreach ($texts as $i => $text) {
+            $paramName = 'search_text_'.$i;
+            $tsqueryParts[] = "plainto_tsquery('english', :{$paramName})";
+            $params[$paramName] = $text;
+        }
+
+        $tsqueryExpression = '('.implode(' || ', $tsqueryParts).')'; // OR operator in PostgreSQL
+        $tsvectorExpression = "to_tsvector('english', metadata->>'_text')";
+
+        $where = \sprintf('WHERE %s @@ %s', $tsvectorExpression, $tsqueryExpression);
+
+        if (isset($options['maxScore'])) {
+            $where .= \sprintf(' AND ((:semantic_ratio * (1 - (%s %s :embedding))) + (:keyword_ratio * ts_rank(%s, %s))) >= :maxScore',
+                $this->vectorFieldName,
+                $this->distance->getComparisonSign(),
+                $tsvectorExpression,
+                $tsqueryExpression
+            );
+            $params['maxScore'] = $options['maxScore'];
+        }
+
+        $sql = \sprintf(<<<SQL
+            SELECT id, %s AS embedding, metadata,
+                   ((:semantic_ratio * (1 - (%s %s :embedding))) +
+                    (:keyword_ratio * ts_rank(%s, %s))) AS score
+            FROM %s
+            %s
+            ORDER BY score DESC
+            LIMIT %d
+            SQL,
+            $this->vectorFieldName,
+            $this->vectorFieldName,
+            $this->distance->getComparisonSign(),
+            $tsvectorExpression,
+            $tsqueryExpression,
+            $this->tableName,
+            $where,
+            $options['limit'] ?? 5,
+        );
+
+        $statement = $this->connection->prepare($sql);
 
         foreach ($params as $key => $value) {
             $statement->bindValue(':'.$key, $value);

--- a/src/store/src/Bridge/Postgres/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Postgres/Tests/StoreTest.php
@@ -19,6 +19,9 @@ use Symfony\AI\Store\Bridge\Postgres\Store;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Uid\Uuid;
 
 final class StoreTest extends TestCase
@@ -153,7 +156,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -205,7 +208,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -259,7 +262,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), ['maxScore' => 0.8]));
 
         $this->assertCount(0, $results);
     }
@@ -309,7 +312,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), ['maxScore' => 0.8]));
 
         $this->assertCount(0, $results);
     }
@@ -348,7 +351,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = iterator_to_array($store->query(new Vector([0.7, 0.8, 0.9]), ['limit' => 10]));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.7, 0.8, 0.9])), ['limit' => 10]));
 
         $this->assertCount(0, $results);
     }
@@ -382,7 +385,7 @@ final class StoreTest extends TestCase
             ->method('fetchAll')
             ->willReturn([]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(0, $results);
     }
@@ -520,7 +523,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(1, $results);
         $this->assertSame([], $results[0]->getMetadata()->getArrayCopy());
@@ -560,7 +563,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['where' => 'metadata->>\'category\' = \'products\'']));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), ['where' => 'metadata->>\'category\' = \'products\'']));
 
         $this->assertCount(0, $results);
     }
@@ -610,7 +613,7 @@ final class StoreTest extends TestCase
             ->with(\PDO::FETCH_ASSOC)
             ->willReturn([]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), [
             'maxScore' => 0.5,
             'where' => 'metadata->>\'active\' = \'true\'',
         ]));
@@ -674,7 +677,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), [
             'where' => 'metadata->>\'crawlId\' = :crawlId AND id != :currentId',
             'params' => [
                 'crawlId' => $crawlId,
@@ -762,6 +765,117 @@ final class StoreTest extends TestCase
             ->method('prepare');
 
         $store->remove([]);
+    }
+
+    public function testStoreSupportsMultipleQueryTypes()
+    {
+        $pdo = $this->createMock(\PDO::class);
+        $store = new Store($pdo, 'embeddings_table', 'embedding');
+
+        $this->assertTrue($store->supports(VectorQuery::class));
+        $this->assertTrue($store->supports(TextQuery::class));
+        $this->assertTrue($store->supports(HybridQuery::class));
+    }
+
+    public function testQueryWithTextQuery()
+    {
+        $pdo = $this->createMock(\PDO::class);
+        $statement = $this->createMock(\PDOStatement::class);
+
+        $store = new Store($pdo, 'embeddings_table', 'embedding');
+
+        $expectedQuery = "SELECT id, embedding AS embedding, metadata,
+                   ts_rank(to_tsvector('english', metadata->>'_text'), plainto_tsquery('english', :search_text_0)) AS score
+            FROM embeddings_table
+            WHERE to_tsvector('english', metadata->>'_text') @@ (plainto_tsquery('english', :search_text_0))
+            ORDER BY score DESC
+            LIMIT 5";
+
+        $pdo->expects($this->once())
+            ->method('prepare')
+            ->with($this->callback(function ($sql) use ($expectedQuery) {
+                $this->assertSame($this->normalizeQuery($expectedQuery), $this->normalizeQuery($sql));
+
+                return true;
+            }))
+            ->willReturn($statement);
+
+        $statement->expects($this->once())
+            ->method('bindValue')
+            ->with(':search_text_0', 'test query');
+
+        $statement->expects($this->once())
+            ->method('execute');
+
+        $statement->expects($this->once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_ASSOC)
+            ->willReturn([]);
+
+        $results = iterator_to_array($store->query(new TextQuery('test query')));
+
+        $this->assertCount(0, $results);
+    }
+
+    public function testQueryWithHybridQuery()
+    {
+        $pdo = $this->createMock(\PDO::class);
+        $statement = $this->createMock(\PDOStatement::class);
+
+        $store = new Store($pdo, 'embeddings_table', 'embedding');
+
+        $expectedQuery = "SELECT id, embedding AS embedding, metadata,
+                   ((:semantic_ratio * (1 - (embedding <-> :embedding))) +
+                    (:keyword_ratio * ts_rank(to_tsvector('english', metadata->>'_text'), (plainto_tsquery('english', :search_text_0))))) AS score
+            FROM embeddings_table
+            WHERE to_tsvector('english', metadata->>'_text') @@ (plainto_tsquery('english', :search_text_0))
+            ORDER BY score DESC
+            LIMIT 5";
+
+        $pdo->expects($this->once())
+            ->method('prepare')
+            ->with($this->callback(function ($sql) use ($expectedQuery) {
+                $this->assertSame($this->normalizeQuery($expectedQuery), $this->normalizeQuery($sql));
+
+                return true;
+            }))
+            ->willReturn($statement);
+
+        $statement->expects($this->exactly(4))
+            ->method('bindValue');
+
+        $statement->expects($this->once())
+            ->method('execute');
+
+        $statement->expects($this->once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_ASSOC)
+            ->willReturn([]);
+
+        $results = iterator_to_array($store->query(new HybridQuery(new Vector([0.1, 0.2, 0.3]), 'test query', 0.7)));
+
+        $this->assertCount(0, $results);
+    }
+
+    public function testStoreSupportsVectorQuery()
+    {
+        $pdo = $this->createMock(\PDO::class);
+        $store = new Store($pdo, 'test_table');
+        $this->assertTrue($store->supports(VectorQuery::class));
+    }
+
+    public function testStoreSupportsTextQuery()
+    {
+        $pdo = $this->createMock(\PDO::class);
+        $store = new Store($pdo, 'test_table');
+        $this->assertTrue($store->supports(TextQuery::class));
+    }
+
+    public function testStoreSupportsHybridQuery()
+    {
+        $pdo = $this->createMock(\PDO::class);
+        $store = new Store($pdo, 'test_table');
+        $this->assertTrue($store->supports(HybridQuery::class));
     }
 
     private function normalizeQuery(string $query): string

--- a/src/store/src/Bridge/Qdrant/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Qdrant/Tests/StoreTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Qdrant\Store;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -227,7 +230,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:6333/collections/test/points/query".');
         $this->expectExceptionCode(400);
-        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
     }
 
     public function testStoreCanQuery()
@@ -255,7 +258,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'http://127.0.0.1:6333', 'test', 'test');
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertSame(1, $httpClient->getRequestsCount());
         $this->assertCount(2, $results);
@@ -286,7 +289,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($httpClient, 'http://127.0.0.1:6333', 'test', 'test');
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), [
             'filter' => [
                 'must' => [
                     ['key' => 'foo', 'match' => ['value' => 'bar']],
@@ -306,109 +309,21 @@ final class StoreTest extends TestCase
         }
     }
 
-    public function testStoreCannotRemoveOnInvalidResponse()
+    public function testStoreSupportsVectorQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([], [
-                'http_code' => 400,
-            ]),
-        ], 'http://127.0.0.1:6333');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:6333', 'test', 'test');
-
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:6333/collections/test/points/delete?wait=true".');
-        $this->expectExceptionCode(400);
-        $store->remove('test-id');
+        $store = new Store(new MockHttpClient(), 'http://localhost:6333', 'test-api-key', 'test_collection');
+        $this->assertTrue($store->supports(VectorQuery::class));
     }
 
-    public function testStoreCanRemoveSingleId()
+    public function testStoreDoesNotSupportTextQuery()
     {
-        $id = Uuid::v4()->toRfc4122();
-
-        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use ($id): JsonMockResponse {
-            self::assertSame('POST', $method);
-            self::assertArrayHasKey('wait', $options['query']);
-            self::assertSame('true', $options['query']['wait']);
-            self::assertIsString($options['body']);
-            self::assertSame(['points' => [$id]], json_decode($options['body'], true));
-
-            return new JsonMockResponse([
-                'time' => 0.002,
-                'status' => 'ok',
-                'result' => [
-                    'operation_id' => 0,
-                    'status' => 'completed',
-                ],
-            ], [
-                'http_code' => 200,
-            ]);
-        }, 'http://127.0.0.1:6333');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:6333', 'test', 'test');
-
-        $store->remove($id);
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:6333', 'test-api-key', 'test_collection');
+        $this->assertFalse($store->supports(TextQuery::class));
     }
 
-    public function testStoreCanRemoveMultipleIds()
+    public function testStoreDoesNotSupportHybridQuery()
     {
-        $ids = [Uuid::v4()->toRfc4122(), Uuid::v4()->toRfc4122(), Uuid::v4()->toRfc4122()];
-
-        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use ($ids): JsonMockResponse {
-            self::assertSame('POST', $method);
-            self::assertArrayHasKey('wait', $options['query']);
-            self::assertSame('true', $options['query']['wait']);
-            self::assertIsString($options['body']);
-            self::assertSame(['points' => $ids], json_decode($options['body'], true));
-
-            return new JsonMockResponse([
-                'time' => 0.003,
-                'status' => 'ok',
-                'result' => [
-                    'operation_id' => 0,
-                    'status' => 'completed',
-                ],
-            ], [
-                'http_code' => 200,
-            ]);
-        }, 'http://127.0.0.1:6333');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:6333', 'test', 'test');
-
-        $store->remove($ids);
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
-    }
-
-    public function testStoreCanRemoveAsynchronously()
-    {
-        $id = Uuid::v4()->toRfc4122();
-
-        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use ($id): JsonMockResponse {
-            self::assertSame('POST', $method);
-            self::assertArrayHasKey('wait', $options['query']);
-            self::assertSame('false', $options['query']['wait']);
-            self::assertIsString($options['body']);
-            self::assertSame(['points' => [$id]], json_decode($options['body'], true));
-
-            return new JsonMockResponse([
-                'time' => 0.002,
-                'status' => 'ok',
-                'result' => [
-                    'operation_id' => 1000001,
-                    'status' => 'acknowledged',
-                ],
-            ], [
-                'http_code' => 200,
-            ]);
-        }, 'http://127.0.0.1:6333');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:6333', 'test', 'test', async: true);
-
-        $store->remove($id);
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:6333', 'test-api-key', 'test_collection');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -16,7 +16,10 @@ use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 /**
@@ -128,25 +131,34 @@ class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
+    public function supports(string $queryClass): bool
+    {
+        return VectorQuery::class === $queryClass;
+    }
+
     /**
      * @param array{limit?: positive-int, maxScore?: float, where?: string} $options
      *
      * @return VectorDocument[]
      */
-    public function query(Vector $vector, array $options = []): iterable
+    public function query(QueryInterface $query, array $options = []): iterable
     {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
         $limit = $options['limit'] ?? 5;
         $maxScore = $options['maxScore'] ?? null;
         $whereFilter = $options['where'] ?? '*';
 
-        $query = "({$whereFilter}) => [KNN {$limit} @embedding \$query_vector AS vector_score]";
+        $queryString = "({$whereFilter}) => [KNN {$limit} @embedding \$query_vector AS vector_score]";
 
         try {
             $results = $this->redis->rawCommand(
                 'FT.SEARCH',
                 $this->indexName,
-                $query,
-                'PARAMS', 2, 'query_vector', $this->toRedisVector($vector),
+                $queryString,
+                'PARAMS', 2, 'query_vector', $this->toRedisVector($query->getVector()),
                 'RETURN', 4, '$.id', '$.metadata', '$.embedding', 'vector_score',
                 'SORTBY', 'vector_score', 'ASC',
                 'LIMIT', 0, $limit,

--- a/src/store/src/Bridge/Redis/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Redis/Tests/StoreTest.php
@@ -18,6 +18,9 @@ use Symfony\AI\Store\Bridge\Redis\Store;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Uid\Uuid;
 
 final class StoreTest extends TestCase
@@ -126,7 +129,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -165,7 +168,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
@@ -192,7 +195,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['maxScore' => 0.8]));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), ['maxScore' => 0.8]));
 
         $this->assertCount(0, $results); // Should be filtered out due to maxScore
     }
@@ -216,7 +219,7 @@ final class StoreTest extends TestCase
             )
             ->willReturn([0]); // No results
 
-        $results = iterator_to_array($store->query(new Vector([0.7, 0.8, 0.9]), ['limit' => 10]));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.7, 0.8, 0.9])), ['limit' => 10]));
 
         $this->assertCount(0, $results);
     }
@@ -240,7 +243,7 @@ final class StoreTest extends TestCase
             )
             ->willReturn([0]); // No results
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), ['where' => '@metadata_category:products']));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), ['where' => '@metadata_category:products']));
 
         $this->assertCount(0, $results);
     }
@@ -273,7 +276,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3]), [
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), [
             'where' => '@metadata_active:true',
             'maxScore' => 0.8,
         ]));
@@ -301,7 +304,7 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(1, $results);
         $this->assertSame([], $results[0]->getMetadata()->getArrayCopy());
@@ -319,7 +322,7 @@ final class StoreTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Failed to execute query: "Search failed".');
 
-        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
     }
 
     public function testInitialize()
@@ -463,7 +466,7 @@ final class StoreTest extends TestCase
             )
             ->willReturn([0]);
 
-        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
     }
 
     public function testQueryEmptyResults()
@@ -475,7 +478,7 @@ final class StoreTest extends TestCase
             ->method('rawCommand')
             ->willReturn([0]); // No results
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(0, $results);
     }
@@ -489,7 +492,7 @@ final class StoreTest extends TestCase
             ->method('rawCommand')
             ->willReturn(null); // Invalid results
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(0, $results);
     }
@@ -511,66 +514,29 @@ final class StoreTest extends TestCase
                 ],
             ]);
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(0, $results); // Should skip documents without required fields
     }
 
-    public function testRemoveSingleDocument()
+    public function testStoreSupportsVectorQuery()
     {
         $redis = $this->createMock(\Redis::class);
-        $store = new Store($redis, 'test_index', 'vector:');
-
-        $vectorId = 'vector-id';
-
-        $redis->expects($this->once())
-            ->method('del')
-            ->with(['vector:vector-id']);
-
-        $store->remove($vectorId);
+        $store = new Store($redis, 'test:vectors');
+        $this->assertTrue($store->supports(VectorQuery::class));
     }
 
-    public function testRemoveMultipleDocuments()
+    public function testStoreDoesNotSupportTextQuery()
     {
         $redis = $this->createMock(\Redis::class);
-        $store = new Store($redis, 'test_index', 'vector:');
-
-        $vectorIds = ['vector-id-1', 'vector-id-2', 'vector-id-3'];
-
-        $redis->expects($this->once())
-            ->method('del')
-            ->with(['vector:vector-id-1', 'vector:vector-id-2', 'vector:vector-id-3']);
-
-        $store->remove($vectorIds);
+        $store = new Store($redis, 'test:vectors');
+        $this->assertFalse($store->supports(TextQuery::class));
     }
 
-    public function testRemoveWithEmptyArray()
+    public function testStoreDoesNotSupportHybridQuery()
     {
         $redis = $this->createMock(\Redis::class);
-        $store = new Store($redis, 'test_index', 'vector:');
-
-        $redis->expects($this->never())
-            ->method('del');
-
-        $store->remove([]);
-    }
-
-    public function testRemoveFailureThrowsRuntimeException()
-    {
-        $redis = $this->createMock(\Redis::class);
-        $store = new Store($redis, 'test_index', 'vector:');
-
-        $redis->expects($this->once())
-            ->method('del')
-            ->with(['vector:vector-id']);
-
-        $redis->expects($this->once())
-            ->method('getLastError')
-            ->willReturn('Delete failed');
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Failed to remove documents from Redis: "Delete failed".');
-
-        $store->remove('vector-id');
+        $store = new Store($redis, 'test:vectors');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/Supabase/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Supabase/Tests/StoreTest.php
@@ -17,6 +17,9 @@ use Symfony\AI\Store\Bridge\Supabase\Store as SupabaseStore;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -94,14 +97,14 @@ class StoreTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Supabase query failed: Query failed');
-        iterator_to_array($store->query($queryVector));
+        iterator_to_array($store->query(new VectorQuery($queryVector)));
     }
 
     public function testQueryWithDefaultOptions()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse([]));
         $store = $this->createStore($httpClient);
-        $result = iterator_to_array($store->query(new Vector([1.0, 2.0])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0]))));
 
         $this->assertSame([], $result);
         $this->assertSame(1, $httpClient->getRequestsCount());
@@ -111,7 +114,7 @@ class StoreTest extends TestCase
     {
         $httpClient = new MockHttpClient(new JsonMockResponse([]));
         $store = $this->createStore($httpClient);
-        $result = iterator_to_array($store->query(new Vector([1.0, 2.0]), ['limit' => 1]));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0])), ['limit' => 1]));
 
         $this->assertSame([], $result);
         $this->assertSame(1, $httpClient->getRequestsCount());
@@ -124,7 +127,7 @@ class StoreTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Vector dimension mismatch: expected 2');
-        iterator_to_array($store->query(new Vector([1.0])));
+        iterator_to_array($store->query(new VectorQuery(new Vector([1.0]))));
     }
 
     public function testQuerySuccess()
@@ -140,7 +143,7 @@ class StoreTest extends TestCase
         ];
         $httpClient = new MockHttpClient(new JsonMockResponse($expectedResponse));
         $store = $this->createStore($httpClient, 3);
-        $result = iterator_to_array($store->query(new Vector([1.0, 2.0, 3.0]), ['max_items' => 5, 'min_score' => 0.7]));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0, 3.0])), ['max_items' => 5, 'min_score' => 0.7]));
 
         $this->assertCount(1, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
@@ -172,7 +175,7 @@ class StoreTest extends TestCase
         $httpClient = new MockHttpClient(new JsonMockResponse($expectedResponse));
         $store = $this->createStore($httpClient, 2);
 
-        $result = iterator_to_array($store->query(new Vector([1.0, 2.0]), ['max_items' => 2, 'min_score' => 0.8]));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0])), ['max_items' => 2, 'min_score' => 0.8]));
 
         $this->assertCount(2, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
@@ -203,7 +206,7 @@ class StoreTest extends TestCase
         $httpClient = new MockHttpClient(new JsonMockResponse($expectedResponse));
         $store = $this->createStore($httpClient, 3);
 
-        $result = iterator_to_array($store->query(new Vector([1.0, 2.0, 3.0])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0, 3.0]))));
 
         $document = $result[0];
         $metadata = $document->getMetadata()->getArrayCopy();
@@ -216,6 +219,24 @@ class StoreTest extends TestCase
         $this->assertSame(['ai', 'test'], $metadata['tags']);
         $this->assertSame(0.92, $metadata['score']);
         $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testStoreSupportsVectorQuery()
+    {
+        $store = $this->createStore(new MockHttpClient());
+        $this->assertTrue($store->supports(VectorQuery::class));
+    }
+
+    public function testStoreDoesNotSupportTextQuery()
+    {
+        $store = $this->createStore(new MockHttpClient());
+        $this->assertFalse($store->supports(TextQuery::class));
+    }
+
+    public function testStoreDoesNotSupportHybridQuery()
+    {
+        $store = $this->createStore(new MockHttpClient());
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 
     private function createStore(MockHttpClient $httpClient, ?int $vectorDimension = 2): SupabaseStore

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -17,7 +17,10 @@ use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -78,8 +81,18 @@ class Store implements ManagedStoreInterface, StoreInterface
         $this->request('POST', 'sql', \sprintf('DELETE %s;', implode(', ', $recordIds)));
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
+        return VectorQuery::class === $queryClass;
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
+        $vector = $query->getVector();
         $vectors = json_encode($vector->getData());
 
         $results = $this->request('POST', 'sql', \sprintf(

--- a/src/store/src/Bridge/SurrealDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/SurrealDb/Tests/StoreTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\SurrealDb\Store;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -326,7 +329,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:8000/sql".');
         $this->expectExceptionCode(400);
-        iterator_to_array($store->query(new Vector(array_fill(0, 1275, 0.1))));
+        iterator_to_array($store->query(new VectorQuery(new Vector(array_fill(0, 1275, 0.1)))));
     }
 
     public function testStoreCanQueryOnValidEmbeddings()
@@ -400,134 +403,26 @@ final class StoreTest extends TestCase
 
         $store->add([new VectorDocument(Uuid::v4(), new Vector(array_fill(0, 1275, 0.1)))]);
 
-        $results = iterator_to_array($store->query(new Vector(array_fill(0, 1275, 0.1))));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector(array_fill(0, 1275, 0.1)))));
 
         $this->assertCount(2, $results);
     }
 
-    public function testStoreCannotRemoveOnInvalidResponse()
+    public function testStoreSupportsVectorQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'code' => 200,
-                'details' => 'Authentication succeeded.',
-                'token' => 'bar',
-            ], [
-                'http_code' => 200,
-            ]),
-            new JsonMockResponse([
-                [
-                    'result' => 'DEFINE INDEX test_vectors ON movies FIELDS _vectors MTREE DIMENSION 1275 DIST cosine TYPE F32',
-                    'status' => 'OK',
-                    'time' => '263.208µs',
-                ],
-            ], [
-                'http_code' => 200,
-            ]),
-            new JsonMockResponse([], [
-                'http_code' => 400,
-            ]),
-        ], 'http://127.0.0.1:8000');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:8000', 'test', 'test', 'test', 'test', 'vectors');
-        $store->setup();
-
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:8000/sql".');
-        $this->expectExceptionCode(400);
-        $store->remove('test-id');
+        $store = new Store(new MockHttpClient(), 'http://localhost:8000', 'test', 'test', 'test_namespace', 'test_database', 'test_table');
+        $this->assertTrue($store->supports(VectorQuery::class));
     }
 
-    public function testStoreCanRemoveSingleId()
+    public function testStoreDoesNotSupportTextQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'code' => 200,
-                'details' => 'Authentication succeeded.',
-                'token' => 'bar',
-            ], [
-                'http_code' => 200,
-            ]),
-            new JsonMockResponse([
-                [
-                    'result' => 'DEFINE INDEX test_vectors ON movies FIELDS _vectors MTREE DIMENSION 1275 DIST cosine TYPE F32',
-                    'status' => 'OK',
-                    'time' => '263.208µs',
-                ],
-            ], [
-                'http_code' => 200,
-            ]),
-            new JsonMockResponse([], [
-                'http_code' => 200,
-            ]),
-        ], 'http://127.0.0.1:8000');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:8000', 'test', 'test', 'test', 'test', 'vectors');
-        $store->setup();
-
-        $store->remove('test-id');
-
-        $this->assertSame(3, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:8000', 'test', 'test', 'test_namespace', 'test_database', 'test_table');
+        $this->assertFalse($store->supports(TextQuery::class));
     }
 
-    public function testStoreCanRemoveMultipleIds()
+    public function testStoreDoesNotSupportHybridQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'code' => 200,
-                'details' => 'Authentication succeeded.',
-                'token' => 'bar',
-            ], [
-                'http_code' => 200,
-            ]),
-            new JsonMockResponse([
-                [
-                    'result' => 'DEFINE INDEX test_vectors ON movies FIELDS _vectors MTREE DIMENSION 1275 DIST cosine TYPE F32',
-                    'status' => 'OK',
-                    'time' => '263.208µs',
-                ],
-            ], [
-                'http_code' => 200,
-            ]),
-            new JsonMockResponse([], [
-                'http_code' => 200,
-            ]),
-        ], 'http://127.0.0.1:8000');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:8000', 'test', 'test', 'test', 'test', 'vectors');
-        $store->setup();
-
-        $store->remove(['test-id-1', 'test-id-2']);
-
-        $this->assertSame(3, $httpClient->getRequestsCount());
-    }
-
-    public function testStoreCanRemoveWithEmptyIds()
-    {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([
-                'code' => 200,
-                'details' => 'Authentication succeeded.',
-                'token' => 'bar',
-            ], [
-                'http_code' => 200,
-            ]),
-            new JsonMockResponse([
-                [
-                    'result' => 'DEFINE INDEX test_vectors ON movies FIELDS _vectors MTREE DIMENSION 1275 DIST cosine TYPE F32',
-                    'status' => 'OK',
-                    'time' => '263.208µs',
-                ],
-            ], [
-                'http_code' => 200,
-            ]),
-        ], 'http://127.0.0.1:8000');
-
-        $store = new Store($httpClient, 'http://127.0.0.1:8000', 'test', 'test', 'test', 'test', 'vectors');
-        $store->setup();
-
-        $store->remove([]);
-
-        $this->assertSame(2, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:8000', 'test', 'test', 'test_namespace', 'test_database', 'test_table');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -16,7 +16,10 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -93,8 +96,18 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ), []);
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
+        return VectorQuery::class === $queryClass;
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
+        $vector = $query->getVector();
         $documents = $this->request('POST', 'multi_search', [
             'searches' => [
                 [

--- a/src/store/src/Bridge/Typesense/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Typesense/Tests/StoreTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Typesense\Store;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -168,7 +171,7 @@ final class StoreTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('HTTP 400 returned for "http://127.0.0.1:8108/multi_search".');
         $this->expectExceptionCode(400);
-        iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
     }
 
     public function testStoreCanQuery()
@@ -209,86 +212,27 @@ final class StoreTest extends TestCase
             'test',
         );
 
-        $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
 
         $this->assertCount(2, $results);
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreCanRemoveSingleDocument()
+    public function testStoreSupportsVectorQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([], [
-                'http_code' => 200,
-            ]),
-        ], 'http://127.0.0.1:8108');
-
-        $store = new Store(
-            $httpClient,
-            'http://127.0.0.1:8108',
-            'test',
-            'test',
-        );
-
-        $store->remove('doc-id-123');
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:8108', 'test-key', 'test_collection');
+        $this->assertTrue($store->supports(VectorQuery::class));
     }
 
-    public function testStoreCanRemoveMultipleDocuments()
+    public function testStoreDoesNotSupportTextQuery()
     {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([], [
-                'http_code' => 200,
-            ]),
-        ], 'http://127.0.0.1:8108');
-
-        $store = new Store(
-            $httpClient,
-            'http://127.0.0.1:8108',
-            'test',
-            'test',
-        );
-
-        $store->remove(['doc-id-123', 'doc-id-456', 'doc-id-789']);
-
-        $this->assertSame(1, $httpClient->getRequestsCount());
+        $store = new Store(new MockHttpClient(), 'http://localhost:8108', 'test-key', 'test_collection');
+        $this->assertFalse($store->supports(TextQuery::class));
     }
 
-    public function testStoreCanRemoveWithEmptyArray()
+    public function testStoreDoesNotSupportHybridQuery()
     {
-        $httpClient = new MockHttpClient([], 'http://127.0.0.1:8108');
-
-        $store = new Store(
-            $httpClient,
-            'http://127.0.0.1:8108',
-            'test',
-            'test',
-        );
-
-        $store->remove([]);
-
-        $this->assertSame(0, $httpClient->getRequestsCount());
-    }
-
-    public function testStoreCannotRemoveOnInvalidResponse()
-    {
-        $httpClient = new MockHttpClient([
-            new JsonMockResponse([], [
-                'http_code' => 404,
-            ]),
-        ], 'http://127.0.0.1:8108');
-
-        $store = new Store(
-            $httpClient,
-            'http://127.0.0.1:8108',
-            'test',
-            'test',
-        );
-
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('HTTP 404 returned for "http://127.0.0.1:8108/collections/test/documents?filter_by=id:[doc-id-123]".');
-        $this->expectExceptionCode(404);
-        $store->remove('doc-id-123');
+        $store = new Store(new MockHttpClient(), 'http://localhost:8108', 'test-key', 'test_collection');
+        $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -16,7 +16,10 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -89,8 +92,18 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
+        return VectorQuery::class === $queryClass;
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
+        $vector = $query->getVector();
         $results = $this->request('POST', 'v1/graphql', [
             'query' => \sprintf('{
                 Get {

--- a/src/store/src/Exception/UnsupportedQueryTypeException.php
+++ b/src/store/src/Exception/UnsupportedQueryTypeException.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Exception;
+
+use Symfony\AI\Store\StoreInterface;
+
+/**
+ * Exception thrown when a store does not support a specific query type.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class UnsupportedQueryTypeException extends \RuntimeException
+{
+    public function __construct(string $queryClass, StoreInterface $store)
+    {
+        parent::__construct(\sprintf(
+            'Query type "%s" is not supported by store "%s"',
+            $queryClass,
+            $store::class
+        ));
+    }
+}

--- a/src/store/src/InMemory/Store.php
+++ b/src/store/src/InMemory/Store.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\AI\Store\InMemory;
 
-use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Distance\DistanceCalculator;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 /**
@@ -66,6 +70,15 @@ class Store implements ManagedStoreInterface, StoreInterface
         }));
     }
 
+    public function supports(string $queryClass): bool
+    {
+        return \in_array($queryClass, [
+            VectorQuery::class,
+            TextQuery::class,
+            HybridQuery::class,
+        ], true);
+    }
+
     /**
      * @param array{
      *     maxItems?: positive-int,
@@ -73,7 +86,27 @@ class Store implements ManagedStoreInterface, StoreInterface
      * } $options If maxItems is provided, only the top N results will be returned.
      *            If filter is provided, only documents matching the filter will be considered.
      */
-    public function query(Vector $vector, array $options = []): iterable
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        return match (true) {
+            $query instanceof VectorQuery => $this->queryVector($query, $options),
+            $query instanceof TextQuery => $this->queryText($query, $options),
+            $query instanceof HybridQuery => $this->queryHybrid($query, $options),
+            default => throw new UnsupportedQueryTypeException($query::class, $this),
+        };
+    }
+
+    public function drop(array $options = []): void
+    {
+        $this->documents = [];
+    }
+
+    /**
+     * @param array{maxItems?: positive-int, filter?: callable(VectorDocument): bool} $options
+     *
+     * @return iterable<VectorDocument>
+     */
+    private function queryVector(VectorQuery $query, array $options): iterable
     {
         $documents = $this->documents;
 
@@ -81,11 +114,82 @@ class Store implements ManagedStoreInterface, StoreInterface
             $documents = array_values(array_filter($documents, $options['filter']));
         }
 
-        yield from $this->distanceCalculator->calculate($documents, $vector, $options['maxItems'] ?? null);
+        yield from $this->distanceCalculator->calculate($documents, $query->getVector(), $options['maxItems'] ?? null);
     }
 
-    public function drop(array $options = []): void
+    /**
+     * @param array{maxItems?: positive-int, filter?: callable(VectorDocument): bool} $options
+     *
+     * @return iterable<VectorDocument>
+     */
+    private function queryText(TextQuery $query, array $options): iterable
     {
-        $this->documents = [];
+        $documents = array_filter($this->documents, static function (VectorDocument $doc) use ($query) {
+            $text = strtolower($doc->getMetadata()->getText() ?? '');
+
+            // OR logic: match if ANY of the search texts is found
+            foreach ($query->getTexts() as $searchText) {
+                if (str_contains($text, strtolower($searchText))) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+        if (isset($options['filter'])) {
+            $documents = array_values(array_filter($documents, $options['filter']));
+        }
+
+        $maxItems = $options['maxItems'] ?? null;
+        yield from null !== $maxItems ? \array_slice($documents, 0, $maxItems) : $documents;
+    }
+
+    /**
+     * @param array{maxItems?: positive-int, filter?: callable(VectorDocument): bool} $options
+     *
+     * @return iterable<VectorDocument>
+     */
+    private function queryHybrid(HybridQuery $query, array $options): iterable
+    {
+        $vectorResults = iterator_to_array($this->queryVector(
+            new VectorQuery($query->getVector()),
+            $options
+        ));
+
+        $textResults = iterator_to_array($this->queryText(
+            new TextQuery($query->getTexts()),
+            $options
+        ));
+
+        $mergedResults = [];
+        $seenIds = [];
+
+        foreach ($vectorResults as $doc) {
+            $id = (string) $doc->getId();
+            if (!isset($seenIds[$id])) {
+                $mergedResults[] = new VectorDocument(
+                    id: $doc->getId(),
+                    vector: $doc->getVector(),
+                    metadata: $doc->getMetadata(),
+                    score: null !== $doc->getScore() ? $doc->getScore() * $query->getSemanticRatio() : null,
+                );
+                $seenIds[$id] = true;
+            }
+        }
+
+        foreach ($textResults as $doc) {
+            $id = (string) $doc->getId();
+            if (!isset($seenIds[$id])) {
+                $mergedResults[] = $doc;
+                $seenIds[$id] = true;
+            }
+        }
+
+        if (isset($options['filter'])) {
+            $mergedResults = array_values(array_filter($mergedResults, $options['filter']));
+        }
+
+        yield from $mergedResults;
     }
 }

--- a/src/store/src/Query/HybridQuery.php
+++ b/src/store/src/Query/HybridQuery.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Query;
+
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
+
+/**
+ * Combined vector + text search query for hybrid retrieval.
+ *
+ * Hybrid queries combine semantic similarity (vector search) with keyword
+ * matching (full-text search) to provide more accurate and relevant results.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class HybridQuery implements QueryInterface
+{
+    /**
+     * @param string|array<string> $text Single search text or array of texts (combined with OR logic)
+     */
+    public function __construct(
+        private readonly Vector $vector,
+        private readonly string|array $text,
+        private readonly float $semanticRatio = 0.5,
+    ) {
+        if ($semanticRatio < 0.0 || $semanticRatio > 1.0) {
+            throw new InvalidArgumentException(\sprintf('Semantic ratio must be between 0.0 and 1.0, got %.2f', $semanticRatio));
+        }
+    }
+
+    public function getVector(): Vector
+    {
+        return $this->vector;
+    }
+
+    public function getText(): string
+    {
+        return \is_array($this->text) ? implode(' ', $this->text) : $this->text;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getTexts(): array
+    {
+        return \is_array($this->text) ? $this->text : [$this->text];
+    }
+
+    public function getSemanticRatio(): float
+    {
+        return $this->semanticRatio;
+    }
+
+    public function getKeywordRatio(): float
+    {
+        return 1.0 - $this->semanticRatio;
+    }
+}

--- a/src/store/src/Query/QueryInterface.php
+++ b/src/store/src/Query/QueryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Query;
+
+/**
+ * Base interface for all query types in the Store component.
+ *
+ * Queries represent search intent and are passed to Store::query() along with
+ * execution options (limit, etc.) in the $options array.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+interface QueryInterface
+{
+}

--- a/src/store/src/Query/TextQuery.php
+++ b/src/store/src/Query/TextQuery.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Query;
+
+/**
+ * Full-text search query using textual keywords.
+ *
+ * Supports both single text search and multiple text search (OR logic).
+ *
+ * Used for:
+ * - FTS-only backends that don't support vectors
+ * - Internal vectorization (e.g., ChromaDB's queryTexts)
+ * - Retriever pre-extensions that transform to HybridQuery
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class TextQuery implements QueryInterface
+{
+    /**
+     * @param string|array<string> $text Single search text or array of texts (combined with OR logic)
+     */
+    public function __construct(
+        private readonly string|array $text,
+    ) {
+    }
+
+    public function getText(): string
+    {
+        return \is_array($this->text) ? implode(' ', $this->text) : $this->text;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getTexts(): array
+    {
+        return \is_array($this->text) ? $this->text : [$this->text];
+    }
+}

--- a/src/store/src/Query/VectorQuery.php
+++ b/src/store/src/Query/VectorQuery.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Query;
+
+use Symfony\AI\Platform\Vector\Vector;
+
+/**
+ * Classic vector search query using semantic similarity.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class VectorQuery implements QueryInterface
+{
+    public function __construct(
+        private readonly Vector $vector,
+    ) {
+    }
+
+    public function getVector(): Vector
+    {
+        return $this->vector;
+    }
+}

--- a/src/store/src/Retriever.php
+++ b/src/store/src/Retriever.php
@@ -15,6 +15,10 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Document\VectorizerInterface;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
@@ -22,24 +26,26 @@ use Symfony\AI\Store\Document\VectorizerInterface;
 final class Retriever implements RetrieverInterface
 {
     public function __construct(
-        private readonly VectorizerInterface $vectorizer,
         private readonly StoreInterface $store,
+        private readonly ?VectorizerInterface $vectorizer = null,
         private readonly LoggerInterface $logger = new NullLogger(),
     ) {
     }
 
     /**
+     * @param array<string, mixed> $options
+     *
      * @return iterable<VectorDocument>
      */
     public function retrieve(string $query, array $options = []): iterable
     {
         $this->logger->debug('Starting document retrieval', ['query' => $query, 'options' => $options]);
 
-        $vector = $this->vectorizer->vectorize($query);
+        $queryObject = $this->createQuery($query, $options);
 
-        $this->logger->debug('Query vectorized, searching store');
+        $this->logger->debug('Searching store', ['query_type' => $queryObject::class]);
 
-        $documents = $this->store->query($vector, $options);
+        $documents = $this->store->query($queryObject, $options);
 
         $count = 0;
         foreach ($documents as $document) {
@@ -48,5 +54,33 @@ final class Retriever implements RetrieverInterface
         }
 
         $this->logger->debug('Document retrieval completed', ['retrieved_count' => $count]);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function createQuery(string $query, array $options): QueryInterface
+    {
+        if (null === $this->vectorizer) {
+            $this->logger->debug('No vectorizer configured, using TextQuery if supported');
+
+            return new TextQuery($query);
+        }
+
+        if (!$this->store->supports(VectorQuery::class)) {
+            $this->logger->debug('Store does not support vector queries, falling back to TextQuery');
+
+            return new TextQuery($query);
+        }
+
+        if ($this->store->supports(HybridQuery::class)) {
+            $this->logger->debug('Store supports hybrid queries, using HybridQuery with semantic ratio', ['semanticRatio' => $options['semanticRatio'] ?? 0.5]);
+
+            return new HybridQuery($this->vectorizer->vectorize($query), $query, $options['semanticRatio'] ?? 0.5);
+        }
+
+        $this->logger->debug('Store supports vector queries, using VectorQuery');
+
+        return new VectorQuery($this->vectorizer->vectorize($query));
     }
 }

--- a/src/store/src/StoreInterface.php
+++ b/src/store/src/StoreInterface.php
@@ -11,8 +11,9 @@
 
 namespace Symfony\AI\Store;
 
-use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
+use Symfony\AI\Store\Query\QueryInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -34,6 +35,13 @@ interface StoreInterface
      * @param array<string, mixed> $options
      *
      * @return iterable<VectorDocument>
+     *
+     * @throws UnsupportedQueryTypeException if query type not supported
      */
-    public function query(Vector $vector, array $options = []): iterable;
+    public function query(QueryInterface $query, array $options = []): iterable;
+
+    /**
+     * @param class-string<QueryInterface> $queryClass The query class to check
+     */
+    public function supports(string $queryClass): bool;
 }

--- a/src/store/src/Test/AbstractStoreIntegrationTestCase.php
+++ b/src/store/src/Test/AbstractStoreIntegrationTestCase.php
@@ -18,6 +18,9 @@ use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 /**
@@ -47,12 +50,34 @@ abstract class AbstractStoreIntegrationTestCase extends TestCase
     #[Depends('testSetupStore')]
     public function testAddDocuments()
     {
-        // Add single document
-        self::$store->add(new VectorDocument(self::DOCUMENT_ID_1, new Vector([1.0, 0.0, 0.0]), new Metadata(['name' => 'first document'])));
-        // Add multiple documents
+        // Add single document with text metadata
+        $metadata1 = new Metadata(['name' => 'first document']);
+        $metadata1->setText('This is the first document about vectors and embeddings');
+
+        self::$store->add(new VectorDocument(
+            self::DOCUMENT_ID_1,
+            new Vector([1.0, 0.0, 0.0]),
+            $metadata1
+        ));
+
+        // Add multiple documents with text metadata
+        $metadata2 = new Metadata(['name' => 'second document']);
+        $metadata2->setText('This is the second document about machine learning');
+
+        $metadata3 = new Metadata(['name' => 'third document']);
+        $metadata3->setText('This is the third document about artificial intelligence');
+
         self::$store->add([
-            new VectorDocument(self::DOCUMENT_ID_2, new Vector([0.0, 1.0, 0.0]), new Metadata(['name' => 'second document'])),
-            new VectorDocument(self::DOCUMENT_ID_3, new Vector([0.0, 0.0, 1.0]), new Metadata(['name' => 'third document'])),
+            new VectorDocument(
+                self::DOCUMENT_ID_2,
+                new Vector([0.0, 1.0, 0.0]),
+                $metadata2
+            ),
+            new VectorDocument(
+                self::DOCUMENT_ID_3,
+                new Vector([0.0, 0.0, 1.0]),
+                $metadata3
+            ),
         ]);
 
         $this->waitForIndexing();
@@ -63,7 +88,7 @@ abstract class AbstractStoreIntegrationTestCase extends TestCase
     #[Depends('testAddDocuments')]
     public function testQueryDocuments()
     {
-        $results = self::$store->query(new Vector([0.0, 0.0, 1.0]));
+        $results = self::$store->query(new VectorQuery(new Vector([0.0, 0.0, 1.0])));
 
         $found = null;
         foreach ($results as $result) {
@@ -77,7 +102,63 @@ abstract class AbstractStoreIntegrationTestCase extends TestCase
         $this->assertSame('third document', $found->getMetadata()['name']);
     }
 
+    #[Depends('testAddDocuments')]
+    public function testQueryDocumentsWithTextQuery()
+    {
+        if (!self::$store->supports(TextQuery::class)) {
+            $this->markTestSkipped('Store does not support TextQuery.');
+        }
+
+        // Search for text that should match the third document
+        $results = self::$store->query(new TextQuery('artificial intelligence'));
+
+        $found = null;
+        foreach ($results as $result) {
+            if (self::DOCUMENT_ID_3 === $result->getId()) {
+                $found = $result;
+                break;
+            }
+        }
+
+        $this->assertNotNull($found, 'Document 3 should be found by TextQuery');
+        $this->assertSame('third document', $found->getMetadata()['name']);
+        $this->assertStringContainsString('artificial intelligence', $found->getMetadata()->getText());
+    }
+
+    #[Depends('testAddDocuments')]
+    public function testQueryDocumentsWithHybridQuery()
+    {
+        if (!self::$store->supports(HybridQuery::class)) {
+            $this->markTestSkipped('Store does not support HybridQuery.');
+        }
+
+        // Hybrid query combining vector [0,0,1] (matches doc 3) with text "machine learning" (matches doc 2)
+        $results = self::$store->query(
+            new HybridQuery(
+                new Vector([0.0, 0.0, 1.0]),
+                'machine learning',
+                0.5 // 50/50 semantic vs keyword ratio
+            )
+        );
+
+        // Should find at least document 2 (text match) or document 3 (vector match)
+        $foundIds = [];
+        foreach ($results as $result) {
+            $foundIds[] = $result->getId();
+        }
+
+        $this->assertNotEmpty($foundIds, 'HybridQuery should return results');
+
+        // At least one of the relevant documents should be found
+        $this->assertTrue(
+            \in_array(self::DOCUMENT_ID_2, $foundIds, true) || \in_array(self::DOCUMENT_ID_3, $foundIds, true),
+            'HybridQuery should find either document 2 (text match) or document 3 (vector match)'
+        );
+    }
+
     #[Depends('testQueryDocuments')]
+    #[Depends('testQueryDocumentsWithTextQuery')]
+    #[Depends('testQueryDocumentsWithHybridQuery')]
     public function testRemoveDocuments()
     {
         try {
@@ -88,7 +169,7 @@ abstract class AbstractStoreIntegrationTestCase extends TestCase
 
         $this->waitForIndexing();
 
-        $results = self::$store->query(new Vector([0.0, 0.0, 1.0]));
+        $results = self::$store->query(new VectorQuery(new Vector([0.0, 0.0, 1.0])));
 
         foreach ($results as $result) {
             $this->assertNotSame(self::DOCUMENT_ID_3, $result->getId());

--- a/src/store/tests/Double/TestStore.php
+++ b/src/store/tests/Double/TestStore.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\AI\Store\Tests\Double;
 
-use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\UnsupportedFeatureException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
 
 final class TestStore implements StoreInterface
@@ -40,8 +42,17 @@ final class TestStore implements StoreInterface
         throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
-    public function query(Vector $vector, array $options = []): iterable
+    public function supports(string $queryClass): bool
     {
+        return VectorQuery::class === $queryClass;
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if (!$query instanceof VectorQuery) {
+            throw new UnsupportedQueryTypeException($query::class, $this);
+        }
+
         return $this->documents;
     }
 }

--- a/src/store/tests/InMemory/StoreTest.php
+++ b/src/store/tests/InMemory/StoreTest.php
@@ -17,8 +17,10 @@ use Symfony\AI\Store\Distance\DistanceCalculator;
 use Symfony\AI\Store\Distance\DistanceStrategy;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
-use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\InMemory\Store;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Uid\Uuid;
 
 final class StoreTest extends TestCase
@@ -28,7 +30,7 @@ final class StoreTest extends TestCase
         $store = new Store();
         $store->setup();
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(0, $result);
     }
 
@@ -41,12 +43,12 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(3, $result);
 
         $store->drop();
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(0, $result);
     }
 
@@ -59,7 +61,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(3, $result);
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->getVector()->getData());
 
@@ -69,7 +71,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(6, $result);
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->getVector()->getData());
     }
@@ -85,7 +87,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(5, $result);
         $this->assertSame([0.0, 0.1, 0.6], $result[0]->getVector()->getData());
         $this->assertSame([0.1, 0.1, 0.5], $result[1]->getVector()->getData());
@@ -103,7 +105,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $this->assertCount(1, iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $this->assertCount(1, iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'maxItems' => 1,
         ])));
     }
@@ -116,7 +118,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -130,7 +132,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 2.0, 3.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -144,7 +146,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -158,7 +160,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -173,7 +175,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['category' => 'products', 'enabled' => false])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'filter' => static fn (VectorDocument $doc) => 'products' === $doc->getMetadata()['category'],
         ]));
 
@@ -192,7 +194,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6]), new Metadata(['category' => 'products'])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'filter' => static fn (VectorDocument $doc) => 'products' === $doc->getMetadata()['category'],
             'maxItems' => 2,
         ]));
@@ -211,7 +213,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['price' => 50, 'stock' => 10])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'filter' => static fn (VectorDocument $doc) => $doc->getMetadata()['price'] <= 150 && $doc->getMetadata()['stock'] > 0,
         ]));
 
@@ -227,7 +229,7 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['options' => ['size' => 'S', 'color' => 'red']])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'filter' => static fn (VectorDocument $doc) => 'S' === $doc->getMetadata()['options']['size'],
         ]));
 
@@ -246,7 +248,7 @@ final class StoreTest extends TestCase
         ]);
 
         $allowedBrands = ['Nike', 'Adidas', 'Puma'];
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'filter' => static fn (VectorDocument $doc) => \in_array($doc->getMetadata()['brand'] ?? '', $allowedBrands, true),
         ]));
 
@@ -266,12 +268,12 @@ final class StoreTest extends TestCase
             new VectorDocument($id3, new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(3, $result);
 
         $store->remove((string) $id2);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
         $ids = array_map(static fn (VectorDocument $doc) => (string) $doc->getId(), $result);
@@ -295,12 +297,12 @@ final class StoreTest extends TestCase
             new VectorDocument($id4, new Vector([0.0, 0.1, 0.6])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(4, $result);
 
         $store->remove([(string) $id1, (string) $id3]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
         $ids = array_map(static fn (VectorDocument $doc) => (string) $doc->getId(), $result);
@@ -321,12 +323,12 @@ final class StoreTest extends TestCase
             new VectorDocument($id2, new Vector([0.7, -0.3, 0.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
         $store->remove('non-existent-id');
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
     }
 
@@ -345,7 +347,7 @@ final class StoreTest extends TestCase
 
         $store->remove((string) $id2);
 
-        $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
         // Verify array is properly indexed (0, 1) not (0, 2)
@@ -362,9 +364,130 @@ final class StoreTest extends TestCase
             new VectorDocument($id, new Vector([0.1, 0.1, 0.5])),
         ]);
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\Symfony\AI\Store\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('No supported options.');
 
         $store->remove((string) $id, ['unsupported' => 'option']);
+    }
+
+    public function testStoreSupportsAllQueryTypes()
+    {
+        $store = new Store();
+
+        $this->assertTrue($store->supports(VectorQuery::class));
+        $this->assertTrue($store->supports(TextQuery::class));
+        $this->assertTrue($store->supports(HybridQuery::class));
+    }
+
+    public function testStoreCanSearchUsingTextQuery()
+    {
+        $store = new Store();
+        $store->add([
+            new VectorDocument(Uuid::v4(), new Vector([0.1, 0.1, 0.5]), new Metadata(['_text' => 'The quick brown fox'])),
+            new VectorDocument(Uuid::v4(), new Vector([0.7, -0.3, 0.0]), new Metadata(['_text' => 'jumps over the lazy dog'])),
+            new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['_text' => 'Lorem ipsum dolor sit amet'])),
+        ]);
+
+        $result = iterator_to_array($store->query(new TextQuery('quick brown')));
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('quick brown', $result[0]->getMetadata()->getText());
+    }
+
+    public function testStoreCanSearchUsingTextQueryWithMaxItems()
+    {
+        $store = new Store();
+        $store->add([
+            new VectorDocument(Uuid::v4(), new Vector([0.1, 0.1, 0.5]), new Metadata(['_text' => 'The word test appears here'])),
+            new VectorDocument(Uuid::v4(), new Vector([0.7, -0.3, 0.0]), new Metadata(['_text' => 'Another test document'])),
+            new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['_text' => 'Yet another test entry'])),
+        ]);
+
+        $result = iterator_to_array($store->query(new TextQuery('test'), ['maxItems' => 2]));
+
+        $this->assertCount(2, $result);
+    }
+
+    public function testStoreCanSearchUsingHybridQuery()
+    {
+        $store = new Store();
+        $id1 = Uuid::v4();
+        $id2 = Uuid::v4();
+        $id3 = Uuid::v4();
+
+        $store->add([
+            new VectorDocument($id1, new Vector([0.1, 0.1, 0.5]), new Metadata(['_text' => 'space exploration'])),
+            new VectorDocument($id2, new Vector([0.0, 0.1, 0.6]), new Metadata(['_text' => 'deep space mission'])),
+            new VectorDocument($id3, new Vector([0.9, 0.9, 0.9]), new Metadata(['_text' => 'cooking recipes'])),
+        ]);
+
+        $queryVector = new Vector([0.0, 0.1, 0.6]);
+        $result = iterator_to_array($store->query(new HybridQuery($queryVector, 'space', 0.7)));
+
+        // Should find documents matching either vector similarity or text content
+        $this->assertGreaterThanOrEqual(2, \count($result));
+
+        // Check that space-related documents are in results
+        $texts = array_map(static fn (VectorDocument $doc) => $doc->getMetadata()->getText(), $result);
+        $this->assertContains('deep space mission', $texts);
+    }
+
+    public function testStoreCanSearchUsingHybridQueryWithDifferentSemanticRatios()
+    {
+        $store = new Store();
+        $store->add([
+            new VectorDocument(Uuid::v4(), new Vector([0.1, 0.1, 0.5]), new Metadata(['_text' => 'vector match'])),
+            new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6]), new Metadata(['_text' => 'exact text match'])),
+        ]);
+
+        $queryVector = new Vector([0.0, 0.1, 0.6]);
+
+        // High semantic ratio (favor vector similarity)
+        $resultHighSemantic = iterator_to_array($store->query(new HybridQuery($queryVector, 'exact text match', 0.9)));
+        $this->assertNotEmpty($resultHighSemantic);
+
+        // Low semantic ratio (favor text matching)
+        $resultLowSemantic = iterator_to_array($store->query(new HybridQuery($queryVector, 'exact text match', 0.1)));
+        $this->assertNotEmpty($resultLowSemantic);
+    }
+
+    public function testHybridQueryThrowsExceptionForInvalidSemanticRatio()
+    {
+        $this->expectException(\Symfony\AI\Store\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Semantic ratio must be between 0.0 and 1.0');
+
+        new HybridQuery(new Vector([0.1, 0.2, 0.3]), 'test', 1.5);
+    }
+
+    public function testStoreThrowsExceptionForUnsupportedQueryType()
+    {
+        $store = new Store();
+
+        // Create a mock query type that InMemory store doesn't support
+        $unsupportedQuery = new class implements \Symfony\AI\Store\Query\QueryInterface {
+        };
+
+        $this->expectException(\Symfony\AI\Store\Exception\UnsupportedQueryTypeException::class);
+        $this->expectExceptionMessageMatches('/not supported/');
+
+        $store->query($unsupportedQuery);
+    }
+
+    public function testStoreSupportsVectorQuery()
+    {
+        $store = new Store();
+        $this->assertTrue($store->supports(VectorQuery::class));
+    }
+
+    public function testStoreSupportsTextQuery()
+    {
+        $store = new Store();
+        $this->assertTrue($store->supports(TextQuery::class));
+    }
+
+    public function testStoreSupportsHybridQuery()
+    {
+        $store = new Store();
+        $this->assertTrue($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/tests/RetrieverTest.php
+++ b/src/store/tests/RetrieverTest.php
@@ -17,7 +17,11 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\Retriever;
+use Symfony\AI\Store\StoreInterface;
 use Symfony\AI\Store\Tests\Double\PlatformTestHandler;
 use Symfony\AI\Store\Tests\Double\TestStore;
 use Symfony\Component\Uid\Uuid;
@@ -49,7 +53,7 @@ final class RetrieverTest extends TestCase
             'text-embedding-3-small'
         );
 
-        $retriever = new Retriever($vectorizer, $store);
+        $retriever = new Retriever($store, $vectorizer);
         $results = iterator_to_array($retriever->retrieve('test query'));
 
         $this->assertCount(2, $results);
@@ -69,7 +73,7 @@ final class RetrieverTest extends TestCase
             'text-embedding-3-small'
         );
 
-        $retriever = new Retriever($vectorizer, $store);
+        $retriever = new Retriever($store, $vectorizer);
         $results = iterator_to_array($retriever->retrieve('test query'));
 
         $this->assertCount(0, $results);
@@ -92,8 +96,184 @@ final class RetrieverTest extends TestCase
             'text-embedding-3-small'
         );
 
-        $retriever = new Retriever($vectorizer, $store);
+        $retriever = new Retriever($store, $vectorizer);
         $results = iterator_to_array($retriever->retrieve('test query', ['maxItems' => 10]));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrieveUsesTextQueryWhenNoVectorizerProvided()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, true],
+                [HybridQuery::class, false],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->with(
+                $this->isInstanceOf(TextQuery::class),
+                $this->anything()
+            )
+            ->willReturn([$document]);
+
+        $retriever = new Retriever($store, null);
+        $results = iterator_to_array($retriever->retrieve('test query'));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrieveUsesTextQueryWhenStoreDoesNotSupportVectorQuery()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $queryVector = new Vector([0.2, 0.3, 0.4]);
+        $vectorizer = new Vectorizer(
+            PlatformTestHandler::createPlatform(new VectorResult($queryVector)),
+            'text-embedding-3-small'
+        );
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, false],
+                [TextQuery::class, true],
+                [HybridQuery::class, false],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->with(
+                $this->isInstanceOf(TextQuery::class),
+                $this->anything()
+            )
+            ->willReturn([$document]);
+
+        $retriever = new Retriever($store, $vectorizer);
+        $results = iterator_to_array($retriever->retrieve('test query'));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrieveUsesHybridQueryWhenStoreSupportsIt()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $queryVector = new Vector([0.2, 0.3, 0.4]);
+        $vectorizer = new Vectorizer(
+            PlatformTestHandler::createPlatform(new VectorResult($queryVector)),
+            'text-embedding-3-small'
+        );
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, true],
+                [HybridQuery::class, true],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->with(
+                $this->isInstanceOf(HybridQuery::class),
+                $this->anything()
+            )
+            ->willReturn([$document]);
+
+        $retriever = new Retriever($store, $vectorizer);
+        $results = iterator_to_array($retriever->retrieve('test query'));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrieveUsesVectorQueryWhenStoreOnlySupportsVectorQuery()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $queryVector = new Vector([0.2, 0.3, 0.4]);
+        $vectorizer = new Vectorizer(
+            PlatformTestHandler::createPlatform(new VectorResult($queryVector)),
+            'text-embedding-3-small'
+        );
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, false],
+                [HybridQuery::class, false],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->with(
+                $this->isInstanceOf(VectorQuery::class),
+                $this->anything()
+            )
+            ->willReturn([$document]);
+
+        $retriever = new Retriever($store, $vectorizer);
+        $results = iterator_to_array($retriever->retrieve('test query'));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrievePassesSemanticRatioToHybridQuery()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $queryVector = new Vector([0.2, 0.3, 0.4]);
+        $vectorizer = new Vectorizer(
+            PlatformTestHandler::createPlatform(new VectorResult($queryVector)),
+            'text-embedding-3-small'
+        );
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, true],
+                [HybridQuery::class, true],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->with(
+                $this->callback(static function ($query) {
+                    return $query instanceof HybridQuery && 0.7 === $query->getSemanticRatio();
+                }),
+                $this->anything()
+            )
+            ->willReturn([$document]);
+
+        $retriever = new Retriever($store, $vectorizer);
+        $results = iterator_to_array($retriever->retrieve('test query', ['semanticRatio' => 0.7]));
 
         $this->assertCount(1, $results);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1562
| License       | MIT

## Description

This PR implements a query abstraction pattern for the Store component, enabling support for multiple query types (Vector, Text, Hybrid) with an integrated filter system. This addresses RFC #1562 and provides a flexible foundation for
advanced retrieval use cases.

## Summary of Changes

### Query Abstraction
- **QueryInterface**: Base interface for all query types with `getType()` and `getFilter()` methods
- **QueryType Enum**: Defines Vector, Text, and Hybrid query types
- **Query Implementations**:
- `VectorQuery`: Classic vector similarity search (supported by all stores)
- `TextQuery`: Full-text search or internal vectorization (ChromaDB, Postgres, Cache)
- `HybridQuery`: Combined vector + text search with configurable `semanticRatio` parameter (Postgres, ChromaDB, Cache)

### Filter System
- **FilterInterface**: Base interface for query filters with `getType()` and `toArray()` methods
- **EqualFilter**: Equality filter for metadata filtering (e.g., filtering by locale, category, status)
- Filters are integrated directly into query objects

### Store Updates

**Postgres Store** - Extended to support all three query types:
- Vector search using pgvector extension
- Full-text search using PostgreSQL's native FTS
- Hybrid search with weighted scoring combining vector similarity and text relevance
- EqualFilter support via JSONB operators

**ChromaDB Store** - Extended to support all three query types:
- Vector and text queries via ChromaDB's native API
- Hybrid query implementation with result merging
- EqualFilter support via ChromaDB's filtering syntax

**Pinecone, Redis, Qdrant Stores** - Vector only with filter support:
- Vector similarity search
- EqualFilter support via respective backend filter syntaxes

**Cache Store** - All query types with filter support:
- In-memory implementations for all query types
- EqualFilter support via metadata filtering

### API Changes
- **StoreInterface**: Updated with new `query(QueryInterface $query, array $options = [])` signature
- **Capability Signaling**: New `supports(string $queryClass): bool` method to check store capabilities
- **Retriever**: Updated to use query abstraction with automatic capability detection
- **Exception**: New `UnsupportedQueryTypeException` thrown for unsupported query types

## Breaking Changes

### Store::query() Signature Change

**Before:**
```php
$store->query($vector, ['limit' => 10]);
```

**After:**
```php
use Symfony\AI\Store\Query\VectorQuery;

$store->query(new VectorQuery($vector), ['limit' => 10]);
```

All existing code needs to wrap Vector objects in VectorQuery constructor.

## Usage Examples

### Vector Query with Filter
```php
use Symfony\AI\Store\Query\VectorQuery;
use Symfony\AI\Store\Query\Filter\EqualFilter;

// Search for documents in English locale
$query = new VectorQuery($vector, new EqualFilter('locale', 'en'));
$results = $store->query($query, ['limit' => 10]);
```

### Text Query
```php
use Symfony\AI\Store\Query\TextQuery;

// Full-text search (Postgres, ChromaDB, Cache)
$query = new TextQuery('space adventure', new EqualFilter('category', 'scifi'));
$results = $store->query($query, ['limit' => 5]);
```

### Hybrid Query
```php
use Symfony\AI\Store\Query\HybridQuery;

// Combine vector and text with 70% vector weight
$query = new HybridQuery(
    $vector,
    'space adventure',
    0.7,  // semanticRatio (vector weight)
    new EqualFilter('status', 'published')
);
$results = $store->query($query);
```

### Capability Checking
```php
// Check store support before using query type
if ($store->supports(HybridQuery::class)) {
   $query = new HybridQuery($vector, $text);
} else {
    $query = new VectorQuery($vector);
}
```