### PR TITLE
[Agent] Introduce capabilities

### DIFF
--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -922,6 +922,129 @@ The attribute :class:`Symfony\\AI\\AiBundle\\Security\\Attribute\\IsGrantedTool`
 times. If multiple attributes apply to one tool call, a logical AND is used and all access
 decisions have to grant access.
 
+Capabilities
+------------
+
+An agent need tools to interact with its ecosystem and perform actions like creating/reading files, obtaining current time and more,
+apart from tools, agents also requires extra configuration, especially at runtime where user actions can determine next steps (in workflows and so on).
+
+To interact with the agent configuration at runtime and add extra behavior, capabilities can be used.
+
+Configuration
+^^^^^^^^^^^^^
+
+To use capabilities and allow them to be executed, class implementing :class:`Symfony\\AI\\Agent\\Capability\\CapabilityHandlerInterface`
+must be defined and added to the agent configuration.
+
+.. code-block:: yaml
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            # ...
+        agent:
+            platform: 'ai.platform.anthropic'
+            model: 'claude-3-7-sonnet'
+            capabilities:
+                enabled: true
+                handlers:
+                    - 'Symfony\AI\Agent\Capability\DelayCapabilityHandler' # Allow to apply delay to agent responses
+
+Creating Custom Capability
+--------------------------
+
+Custom capability can be registered by either implementing :class:`Symfony\\AI\\Agent\\Capability\\InputCapabilityInterface`
+or :class:`Symfony\\AI\\Agent\\Capability\\OutputCapabilityInterface`::
+
+    namespace App\Capability;
+
+    use Symfony\AI\Agent\Capability\InputCapabilityInterface;
+
+    final class NotificationCapability implements OutputCapabilityInterface
+    {
+        public function __construct(
+            public readonly string $message,
+        ) {
+        }
+    }
+
+Once the capability is created, create a handler by implementing :class:`Symfony\\AI\\Agent\\Capability\\CapabilityHandlerInterface`::
+
+    namespace App\Agent\Capability;
+
+    use App\Capability\NotificationCapability;
+    use Symfony\AI\Agent\AgentInterface;
+    use Symfony\AI\Agent\Capability\CapabilityHandlerInterface;
+    use Symfony\AI\Agent\Capability\InputCapabilityInterface;
+    use Symfony\AI\Agent\Capability\OutputCapabilityInterface;
+    use Symfony\AI\Platform\Message\MessageBag;
+    use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+    final class NotificationCapabilityHandler implements CapabilityHandlerInterface
+    {
+        public function __construct(
+            private readonly NotifierInterface $notifier,
+        ) {
+        }
+
+        public function handle(AgentInterface $agent, MessageBag $messages, array $options, InputCapabilityInterface|OutputCapabilityInterface $capability): void
+        {
+            // ...
+        }
+
+        public function support(InputCapabilityInterface|OutputCapabilityInterface $capability): bool
+        {
+            return $capability instanceof NotificationCapability;
+        }
+    }
+
+To use the capability, inject the :class:`Symfony\\AI\\Agent\\Agent` service and use the `call` method::
+
+    use App\Capability\NotificationCapability;
+    use Symfony\AI\Agent\AgentInterface;
+    use Symfony\AI\Platform\Message\Message;
+    use Symfony\AI\Platform\Message\MessageBag;
+
+    final readonly class MyService
+    {
+        public function __construct(
+            private AgentInterface $agent,
+        ) {
+        }
+
+        public function submit(string $message): string
+        {
+            $messages = new MessageBag(
+                Message::forSystem('Speak like a pirate.'),
+                Message::ofUser($message),
+            );
+
+            return $this->agent->call($messages, policies: [
+                new NotificationCapability(...),
+            ]);
+        }
+    }
+
+Register Capability Handlers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, all services implementing the :class:`Symfony\\AI\\Agent\\Capability\\CapabilityHandlerInterface` interface
+are automatically configured as capability handlers, to enable them, use the `handlers` option in agent definition:
+
+.. code-block:: yaml
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            # ...
+        agent:
+            platform: 'ai.platform.anthropic'
+            model: 'claude-3-7-sonnet'
+            capabilities:
+                enabled: true
+                handlers:
+                    - 'App\Agent\Capability\NotificationCapabilityHandler'
+
 Token Usage Tracking
 --------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,6 +99,10 @@ Key Features
 **Testing Tools**
     Mock agents and platforms for reliable testing without external API calls.
 
+**Agent Capabilities**
+    Define custom capabilities for agents to perform specific tasks, such as context compression,
+    guardrails usage, content validation, speech support and more.
+
 Documentation
 -------------
 

--- a/examples/misc/agent-with-delay-capability.php
+++ b/examples/misc/agent-with-delay-capability.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Capability\CapabilityHandlerRegistry;
+use Symfony\AI\Agent\Capability\DelayCapabilityHandler;
+use Symfony\AI\Agent\Capability\InputDelayCapability;
+use Symfony\AI\Agent\InputProcessor\CapabilityProcessor;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+
+$agent = new Agent($platform, 'gpt-4o-mini', inputProcessors: [
+    new CapabilityProcessor(new CapabilityHandlerRegistry([
+        new DelayCapabilityHandler(),
+    ])),
+]);
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant.'),
+    Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
+);
+
+$result = $agent->call($messages, capabilities: [
+    new InputDelayCapability(rand(1, 5)),
+]);
+
+echo $result->getContent().\PHP_EOL;

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * [BC BREAK] Change AgentProcessor `keepToolMessages` to `excludeToolMessages` and default behaviour to preserve tool messages
  * Add `MetaDataAwareTrait` to `MockResponse`, the metadata will also be set on the returned `TextResult` when calling the `toResult` function
  * Add `HasSourcesTrait` to `Symfony\AI\Agent\Toolbox\Tool\Subagent`
+ * Add custom policies for agents
 
 0.3
 ---

--- a/src/agent/composer.json
+++ b/src/agent/composer.json
@@ -45,7 +45,8 @@
         "symfony/ai-store": "^0.6",
         "symfony/event-dispatcher": "^7.3|^8.0",
         "symfony/translation": "^7.3|^8.0",
-        "symfony/translation-contracts": "^3.6"
+        "symfony/translation-contracts": "^3.6",
+        "symfony/validator": "^7.3|^8.0"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/agent/phpunit.xml.dist
+++ b/src/agent/phpunit.xml.dist
@@ -4,7 +4,7 @@
          bootstrap="vendor/autoload.php"
          cacheDirectory=".phpunit.cache"
          colors="true"
-         executionOrder="depends,defects"
+         executionOrder="random"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true">

--- a/src/agent/src/AgentInterface.php
+++ b/src/agent/src/AgentInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Capability\InputCapabilityInterface;
+use Symfony\AI\Agent\Capability\OutputCapabilityInterface;
 use Symfony\AI\Agent\Exception\ExceptionInterface;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -21,11 +23,12 @@ use Symfony\AI\Platform\Result\ResultInterface;
 interface AgentInterface
 {
     /**
-     * @param array<string, mixed> $options
+     * @param array<string, mixed>                                   $options
+     * @param InputCapabilityInterface[]|OutputCapabilityInterface[] $capabilities
      *
      * @throws ExceptionInterface When the agent encounters an error (e.g., unsupported model capabilities, invalid arguments, network failures, or processor errors)
      */
-    public function call(MessageBag $messages, array $options = []): ResultInterface;
+    public function call(MessageBag $messages, array $options = [], array $capabilities = []): ResultInterface;
 
     /**
      * Get the agent's name, which can be used for debugging or multi-agent configuration.

--- a/src/agent/src/Capability/CapabilityHandlerInterface.php
+++ b/src/agent/src/Capability/CapabilityHandlerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Platform\Message\MessageBag;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+interface CapabilityHandlerInterface
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function handle(AgentInterface $agent, MessageBag $messages, array $options, InputCapabilityInterface|OutputCapabilityInterface $capability): void;
+
+    public function support(InputCapabilityInterface|OutputCapabilityInterface $capability): bool;
+}

--- a/src/agent/src/Capability/CapabilityHandlerRegistry.php
+++ b/src/agent/src/Capability/CapabilityHandlerRegistry.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+use Symfony\AI\Agent\Exception\InvalidArgumentException;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class CapabilityHandlerRegistry implements CapabilityHandlerRegistryInterface
+{
+    /**
+     * @param CapabilityHandlerInterface[] $handlers
+     */
+    public function __construct(
+        private readonly iterable $handlers = [],
+    ) {
+    }
+
+    public function get(InputCapabilityInterface|OutputCapabilityInterface $capability): CapabilityHandlerInterface
+    {
+        foreach ($this->handlers as $handler) {
+            if (!$handler->support($capability)) {
+                continue;
+            }
+
+            return $handler;
+        }
+
+        throw new InvalidArgumentException(\sprintf('No capability handler found for the "%s" capability.', $capability::class));
+    }
+}

--- a/src/agent/src/Capability/CapabilityHandlerRegistryInterface.php
+++ b/src/agent/src/Capability/CapabilityHandlerRegistryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+interface CapabilityHandlerRegistryInterface
+{
+    public function get(InputCapabilityInterface|OutputCapabilityInterface $capability): CapabilityHandlerInterface;
+}

--- a/src/agent/src/Capability/DelayCapabilityHandler.php
+++ b/src/agent/src/Capability/DelayCapabilityHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\MonotonicClock;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class DelayCapabilityHandler implements CapabilityHandlerInterface
+{
+    public function __construct(
+        private readonly ClockInterface $clock = new MonotonicClock(),
+    ) {
+    }
+
+    /**
+     * @param InputDelayCapability|OutputDelayCapability $capability
+     */
+    public function handle(AgentInterface $agent, MessageBag $messages, array $options, InputCapabilityInterface|OutputCapabilityInterface $capability): void
+    {
+        $this->clock->sleep($capability->getDelay());
+    }
+
+    public function support(InputCapabilityInterface|OutputCapabilityInterface $capability): bool
+    {
+        return $capability instanceof InputDelayCapability || $capability instanceof OutputDelayCapability;
+    }
+}

--- a/src/agent/src/Capability/DelayCapabilityTrait.php
+++ b/src/agent/src/Capability/DelayCapabilityTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+use Symfony\Component\Clock\Clock;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+trait DelayCapabilityTrait
+{
+    /**
+     * @param int $delay The delay in milliseconds
+     */
+    public function __construct(
+        private readonly int $delay,
+    ) {
+    }
+
+    public function getDelay(): int
+    {
+        return $this->delay;
+    }
+
+    public static function delayFor(\DateInterval $interval): static
+    {
+        $now = Clock::get()->withTimeZone(new \DateTimeZone('UTC'))->now();
+        $end = $now->add($interval);
+
+        return new static(($end->getTimestamp() - $now->getTimestamp()) * 1000);
+    }
+
+    public static function delayUntil(\DateTimeInterface $dateTime): static
+    {
+        return new static(($dateTime->getTimestamp() - Clock::get()->now()->getTimestamp()) * 1000);
+    }
+}

--- a/src/agent/src/Capability/InputCapabilityInterface.php
+++ b/src/agent/src/Capability/InputCapabilityInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+interface InputCapabilityInterface
+{
+}

--- a/src/agent/src/Capability/InputDelayCapability.php
+++ b/src/agent/src/Capability/InputDelayCapability.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class InputDelayCapability implements InputCapabilityInterface
+{
+    use DelayCapabilityTrait;
+}

--- a/src/agent/src/Capability/OutputCapabilityInterface.php
+++ b/src/agent/src/Capability/OutputCapabilityInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+interface OutputCapabilityInterface
+{
+}

--- a/src/agent/src/Capability/OutputDelayCapability.php
+++ b/src/agent/src/Capability/OutputDelayCapability.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class OutputDelayCapability implements OutputCapabilityInterface
+{
+    use DelayCapabilityTrait;
+}

--- a/src/agent/src/Capability/ValidationCapabilityHandler.php
+++ b/src/agent/src/Capability/ValidationCapabilityHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Exception\InvalidArgumentException;
+use Symfony\AI\Agent\Exception\ValidationFailedException;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\MessageInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class ValidationCapabilityHandler implements CapabilityHandlerInterface
+{
+    public function __construct(
+        private readonly ValidatorInterface $validator,
+    ) {
+    }
+
+    /**
+     * @param ValidationGroupInputCapability|ValidationGroupOutputCapability $capability
+     */
+    public function handle(AgentInterface $agent, MessageBag $messages, array $options, InputCapabilityInterface|OutputCapabilityInterface $capability): void
+    {
+        $message = match (true) {
+            $capability instanceof ValidationGroupInputCapability => $messages->getUserMessage(),
+            $capability instanceof ValidationGroupOutputCapability => $messages->getAssistantMessage(),
+            default => throw new InvalidArgumentException(\sprintf('The "%s" capability handler requires either a "%s" or a "%s".', self::class, ValidationGroupInputCapability::class, ValidationGroupOutputCapability::class)),
+        };
+
+        if (!$message instanceof MessageInterface) {
+            throw new InvalidArgumentException(\sprintf('The "%s" capability handler requires either a user message or an assistant message.', self::class));
+        }
+
+        $violations = $this->validator->validate($message->getContent(), groups: $capability->getGroups());
+        if (0 === \count($violations)) {
+            return;
+        }
+
+        throw new ValidationFailedException($message, $violations);
+    }
+
+    public function support(InputCapabilityInterface|OutputCapabilityInterface $capability): bool
+    {
+        return $capability instanceof ValidationGroupInputCapability || $capability instanceof ValidationGroupOutputCapability;
+    }
+}

--- a/src/agent/src/Capability/ValidationGroupInputCapability.php
+++ b/src/agent/src/Capability/ValidationGroupInputCapability.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+use Symfony\Component\Validator\Constraints\GroupSequence;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class ValidationGroupInputCapability implements InputCapabilityInterface
+{
+    /**
+     * @param string[]|GroupSequence $groups
+     */
+    public function __construct(
+        private readonly array|GroupSequence $groups,
+    ) {
+    }
+
+    /** @return string[]|GroupSequence */
+    public function getGroups(): array|GroupSequence
+    {
+        return $this->groups;
+    }
+}

--- a/src/agent/src/Capability/ValidationGroupOutputCapability.php
+++ b/src/agent/src/Capability/ValidationGroupOutputCapability.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Capability;
+
+use Symfony\Component\Validator\Constraints\GroupSequence;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class ValidationGroupOutputCapability implements InputCapabilityInterface
+{
+    /**
+     * @param string[]|GroupSequence $groups
+     */
+    public function __construct(
+        private readonly array|GroupSequence $groups,
+    ) {
+    }
+
+    /** @return string[]|GroupSequence */
+    public function getGroups(): array|GroupSequence
+    {
+        return $this->groups;
+    }
+}

--- a/src/agent/src/Exception/ValidationFailedException.php
+++ b/src/agent/src/Exception/ValidationFailedException.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Exception;
+
+use Symfony\AI\Platform\Message\MessageInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class ValidationFailedException extends RuntimeException
+{
+    public function __construct(
+        private readonly MessageInterface $violatingMessage,
+        private readonly ConstraintViolationListInterface $violations,
+    ) {
+        parent::__construct();
+    }
+
+    public function getViolatingMessage(): MessageInterface
+    {
+        return $this->violatingMessage;
+    }
+
+    public function getViolations(): ConstraintViolationListInterface
+    {
+        return $this->violations;
+    }
+}

--- a/src/agent/src/Input.php
+++ b/src/agent/src/Input.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Capability\InputCapabilityInterface;
 use Symfony\AI\Platform\Message\MessageBag;
 
 /**
@@ -19,12 +20,14 @@ use Symfony\AI\Platform\Message\MessageBag;
 final class Input
 {
     /**
-     * @param array<string, mixed> $options
+     * @param array<string, mixed>       $options
+     * @param InputCapabilityInterface[] $capabilities
      */
     public function __construct(
         private string $model,
         private MessageBag $messageBag,
         private array $options = [],
+        private readonly iterable $capabilities = [],
     ) {
     }
 
@@ -62,5 +65,13 @@ final class Input
     public function setOptions(array $options): void
     {
         $this->options = $options;
+    }
+
+    /**
+     * @return InputCapabilityInterface[]
+     */
+    public function getCapabilities(): iterable
+    {
+        return $this->capabilities;
     }
 }

--- a/src/agent/src/InputProcessor/CapabilityProcessor.php
+++ b/src/agent/src/InputProcessor/CapabilityProcessor.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\InputProcessor;
+
+use Symfony\AI\Agent\AgentAwareTrait;
+use Symfony\AI\Agent\Capability\CapabilityHandlerRegistryInterface;
+use Symfony\AI\Agent\Input;
+use Symfony\AI\Agent\InputProcessorInterface;
+use Symfony\AI\Agent\Output;
+use Symfony\AI\Agent\OutputProcessorInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class CapabilityProcessor implements InputProcessorInterface, OutputProcessorInterface
+{
+    use AgentAwareTrait;
+
+    public function __construct(
+        private readonly CapabilityHandlerRegistryInterface $policyHandlerRegistry,
+    ) {
+    }
+
+    public function processInput(Input $input): void
+    {
+        $inputCapabilities = $input->getCapabilities();
+
+        if ([] === $inputCapabilities) {
+            return;
+        }
+
+        foreach ($inputCapabilities as $capability) {
+            $handler = $this->policyHandlerRegistry->get($capability);
+
+            $handler->handle($this->agent, $input->getMessageBag(), $input->getOptions(), $capability);
+        }
+    }
+
+    public function processOutput(Output $output): void
+    {
+        $outputCapabilities = $output->getCapabilities();
+
+        if ([] === $outputCapabilities) {
+            return;
+        }
+
+        foreach ($outputCapabilities as $capability) {
+            $handler = $this->policyHandlerRegistry->get($capability);
+
+            $handler->handle($this->agent, $output->getMessageBag(), $output->getOptions(), $capability);
+        }
+    }
+}

--- a/src/agent/src/MockAgent.php
+++ b/src/agent/src/MockAgent.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Capability\InputCapabilityInterface;
+use Symfony\AI\Agent\Capability\OutputCapabilityInterface;
 use Symfony\AI\Agent\Exception\LogicException;
 use Symfony\AI\Agent\Exception\OutOfBoundsException;
 use Symfony\AI\Agent\Exception\RuntimeException;
@@ -54,9 +56,10 @@ final class MockAgent implements AgentInterface
     }
 
     /**
-     * @param array<string, mixed> $options
+     * @param array<string, mixed>                                   $options
+     * @param InputCapabilityInterface[]|OutputCapabilityInterface[] $capabilities
      */
-    public function call(MessageBag $messages, array $options = []): ResultInterface
+    public function call(MessageBag $messages, array $options = [], array $capabilities = []): ResultInterface
     {
         $lastMessage = $messages->getMessages()[\count($messages->getMessages()) - 1];
         $content = '';
@@ -77,7 +80,7 @@ final class MockAgent implements AgentInterface
 
         // Handle callable responses (similar to MockHttpClient)
         if (\is_callable($response)) {
-            $response = $response($messages, $options, $content);
+            $response = $response($messages, $options, $content, $capabilities);
         }
 
         // Convert response to ResultInterface
@@ -96,6 +99,7 @@ final class MockAgent implements AgentInterface
             'options' => $options,
             'input' => $content,
             'response' => $responseText,
+            'capabilities' => $capabilities,
         ];
 
         return $result;

--- a/src/agent/src/Output.php
+++ b/src/agent/src/Output.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Capability\OutputCapabilityInterface;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Result\ResultInterface;
 
@@ -20,13 +21,15 @@ use Symfony\AI\Platform\Result\ResultInterface;
 final class Output
 {
     /**
-     * @param array<string, mixed> $options
+     * @param array<string, mixed>        $options
+     * @param OutputCapabilityInterface[] $capabilities
      */
     public function __construct(
         private readonly string $model,
         private ResultInterface $result,
         private readonly MessageBag $messageBag,
         private readonly array $options = [],
+        private readonly array $capabilities = [],
     ) {
     }
 
@@ -56,5 +59,13 @@ final class Output
     public function getOptions(): array
     {
         return $this->options;
+    }
+
+    /**
+     * @return OutputCapabilityInterface[]
+     */
+    public function getCapabilities(): array
+    {
+        return $this->capabilities;
     }
 }

--- a/src/agent/tests/Capability/CapabilityHandlerRegistryTest.php
+++ b/src/agent/tests/Capability/CapabilityHandlerRegistryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Capability;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Capability\CapabilityHandlerRegistry;
+use Symfony\AI\Agent\Capability\DelayCapabilityHandler;
+use Symfony\AI\Agent\Capability\InputDelayCapability;
+use Symfony\AI\Agent\Exception\InvalidArgumentException;
+
+final class CapabilityHandlerRegistryTest extends TestCase
+{
+    public function testRegistryCannotReturnMissingHandler()
+    {
+        $registry = new CapabilityHandlerRegistry();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No capability handler found for the "Symfony\AI\Agent\Capability\InputDelayCapability" capability.');
+        $this->expectExceptionCode(0);
+        $registry->get(new InputDelayCapability(60));
+    }
+
+    public function testRegistryCanReturnHandler()
+    {
+        $registry = new CapabilityHandlerRegistry([
+            new DelayCapabilityHandler(),
+        ]);
+
+        $this->assertInstanceOf(DelayCapabilityHandler::class, $registry->get(new InputDelayCapability(60)));
+    }
+}

--- a/src/agent/tests/Capability/DelayCapabilityHandlerTest.php
+++ b/src/agent/tests/Capability/DelayCapabilityHandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Capability;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Capability\DelayCapabilityHandler;
+use Symfony\AI\Agent\Capability\InputCapabilityInterface;
+use Symfony\AI\Agent\Capability\InputDelayCapability;
+use Symfony\AI\Agent\Capability\OutputDelayCapability;
+use Symfony\AI\Agent\MockAgent;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\Component\Clock\MockClock;
+
+final class DelayCapabilityHandlerTest extends TestCase
+{
+    public function testHandlerSupport()
+    {
+        $handler = new DelayCapabilityHandler();
+
+        $this->assertFalse($handler->support(new class implements InputCapabilityInterface {}));
+        $this->assertTrue($handler->support(new InputDelayCapability(1)));
+        $this->assertTrue($handler->support(new OutputDelayCapability(1)));
+    }
+
+    public function testHandlerCanHandleInputDelay()
+    {
+        $clock = new MockClock('01-01-2020 10:00:00');
+
+        $handler = new DelayCapabilityHandler($clock);
+
+        $handler->handle(new MockAgent(), new MessageBag(), [], new InputDelayCapability(10));
+
+        $this->assertSame('2020-01-01 10:00:10', $clock->now()->format('Y-m-d H:i:s'));
+    }
+
+    public function testHandlerCanHandleOutputDelay()
+    {
+        $clock = new MockClock('01-01-2020 10:00:00');
+
+        $handler = new DelayCapabilityHandler($clock);
+
+        $handler->handle(new MockAgent(), new MessageBag(), [], new OutputDelayCapability(10));
+
+        $this->assertSame('2020-01-01 10:00:10', $clock->now()->format('Y-m-d H:i:s'));
+    }
+}

--- a/src/agent/tests/Capability/InputDelayCapabilityTest.php
+++ b/src/agent/tests/Capability/InputDelayCapabilityTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Capability;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Capability\InputDelayCapability;
+
+final class InputDelayCapabilityTest extends TestCase
+{
+    public function testDelayFor()
+    {
+        $stamp = InputDelayCapability::delayFor(\DateInterval::createFromDateString('30 seconds'));
+        $this->assertSame(30000, $stamp->getDelay());
+        $stamp = InputDelayCapability::delayFor(\DateInterval::createFromDateString('30 minutes'));
+        $this->assertSame(1800000, $stamp->getDelay());
+        $stamp = InputDelayCapability::delayFor(\DateInterval::createFromDateString('30 hours'));
+        $this->assertSame(108000000, $stamp->getDelay());
+
+        $stamp = InputDelayCapability::delayFor(\DateInterval::createFromDateString('-5 seconds'));
+        $this->assertSame(-5000, $stamp->getDelay());
+    }
+
+    public function testDelayUntil()
+    {
+        $stamp = InputDelayCapability::delayUntil(new \DateTimeImmutable('+30 seconds'));
+        $this->assertSame(30000, $stamp->getDelay());
+
+        $stamp = InputDelayCapability::delayUntil(new \DateTimeImmutable('-5 seconds'));
+        $this->assertSame(-5000, $stamp->getDelay());
+    }
+}

--- a/src/agent/tests/Capability/OutputDelayCapabilityTest.php
+++ b/src/agent/tests/Capability/OutputDelayCapabilityTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Capability;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Capability\InputDelayCapability;
+
+final class OutputDelayCapabilityTest extends TestCase
+{
+    public function testDelayFor()
+    {
+        $stamp = InputDelayCapability::delayFor(\DateInterval::createFromDateString('30 seconds'));
+        $this->assertSame(30000, $stamp->getDelay());
+        $stamp = InputDelayCapability::delayFor(\DateInterval::createFromDateString('30 minutes'));
+        $this->assertSame(1800000, $stamp->getDelay());
+        $stamp = InputDelayCapability::delayFor(\DateInterval::createFromDateString('30 hours'));
+        $this->assertSame(108000000, $stamp->getDelay());
+
+        $stamp = InputDelayCapability::delayFor(\DateInterval::createFromDateString('-5 seconds'));
+        $this->assertSame(-5000, $stamp->getDelay());
+    }
+
+    public function testDelayUntil()
+    {
+        $stamp = InputDelayCapability::delayUntil(new \DateTimeImmutable('+30 seconds'));
+        $this->assertSame(30000, $stamp->getDelay());
+
+        $stamp = InputDelayCapability::delayUntil(new \DateTimeImmutable('-5 seconds'));
+        $this->assertSame(-5000, $stamp->getDelay());
+    }
+}

--- a/src/agent/tests/Capability/ValidationCapabilityHandlerTest.php
+++ b/src/agent/tests/Capability/ValidationCapabilityHandlerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Capability;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Capability\InputCapabilityInterface;
+use Symfony\AI\Agent\Capability\InputDelayCapability;
+use Symfony\AI\Agent\Capability\OutputDelayCapability;
+use Symfony\AI\Agent\Capability\ValidationCapabilityHandler;
+use Symfony\AI\Agent\Capability\ValidationGroupInputCapability;
+use Symfony\AI\Agent\Capability\ValidationGroupOutputCapability;
+use Symfony\AI\Agent\Exception\InvalidArgumentException;
+use Symfony\AI\Agent\Exception\ValidationFailedException;
+use Symfony\AI\Agent\MockAgent;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class ValidationCapabilityHandlerTest extends TestCase
+{
+    public function testHandlerSupport()
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+
+        $handler = new ValidationCapabilityHandler($validator);
+
+        $this->assertFalse($handler->support(new class implements InputCapabilityInterface {}));
+        $this->assertFalse($handler->support(new InputDelayCapability(1)));
+        $this->assertFalse($handler->support(new OutputDelayCapability(1)));
+        $this->assertTrue($handler->support(new ValidationGroupInputCapability(['foo'])));
+        $this->assertTrue($handler->support(new ValidationGroupOutputCapability(['bar'])));
+    }
+
+    public function testHandlerCannotHandleMessageBagWithoutUserMessage()
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->never())->method('validate');
+
+        $handler = new ValidationCapabilityHandler($validator);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The "%s" capability handler requires either a user message or an assistant message.', ValidationCapabilityHandler::class));
+        $this->expectExceptionCode(0);
+        $handler->handle(new MockAgent(), new MessageBag(), [], new ValidationGroupInputCapability(['foo']));
+    }
+
+    public function testHandlerCanHandleMessageBagWithUserMessageAndWithoutViolations()
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())->method('validate')->willReturn(new ConstraintViolationList());
+
+        $handler = new ValidationCapabilityHandler($validator);
+        $handler->handle(new MockAgent(), new MessageBag(Message::ofUser('Hello there')), [], new ValidationGroupInputCapability(['foo']));
+    }
+
+    public function testHandlerCanHandleMessageBagWithUserMessageAndViolations()
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())->method('validate')->willReturn(new ConstraintViolationList([
+            new ConstraintViolation('foo', 'bar', [], '', '', '', 0, null),
+        ]));
+
+        $handler = new ValidationCapabilityHandler($validator);
+
+        $this->expectException(ValidationFailedException::class);
+        $this->expectExceptionCode(0);
+        $handler->handle(new MockAgent(), new MessageBag(Message::ofUser('Hello there')), [], new ValidationGroupInputCapability(['foo']));
+    }
+
+    public function testHandlerCannotHandleMessageBagWithoutAssistantMessage()
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->never())->method('validate');
+
+        $handler = new ValidationCapabilityHandler($validator);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The "%s" capability handler requires either a user message or an assistant message.', ValidationCapabilityHandler::class));
+        $this->expectExceptionCode(0);
+        $handler->handle(new MockAgent(), new MessageBag(), [], new ValidationGroupOutputCapability(['bar']));
+    }
+
+    public function testHandlerCanHandleMessageBagWithAssistantMessageMessageAndWithoutViolations()
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())->method('validate')->willReturn(new ConstraintViolationList());
+
+        $handler = new ValidationCapabilityHandler($validator);
+        $handler->handle(new MockAgent(), new MessageBag(Message::ofAssistant('Hello there')), [], new ValidationGroupOutputCapability(['foo']));
+    }
+
+    public function testHandlerCanHandleMessageBagWithAssistantMessageMessageAndViolations()
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())->method('validate')->willReturn(new ConstraintViolationList([
+            new ConstraintViolation('foo', 'bar', [], '', '', '', 0, null),
+        ]));
+
+        $handler = new ValidationCapabilityHandler($validator);
+
+        $this->expectException(ValidationFailedException::class);
+        $this->expectExceptionCode(0);
+        $handler->handle(new MockAgent(), new MessageBag(Message::ofAssistant('Hello there')), [], new ValidationGroupOutputCapability(['foo']));
+    }
+}

--- a/src/agent/tests/InputProcessor/CapabilityProcessorTest.php
+++ b/src/agent/tests/InputProcessor/CapabilityProcessorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\InputProcessor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Capability\CapabilityHandlerRegistry;
+use Symfony\AI\Agent\Capability\DelayCapabilityHandler;
+use Symfony\AI\Agent\Capability\InputDelayCapability;
+use Symfony\AI\Agent\Capability\OutputDelayCapability;
+use Symfony\AI\Agent\Exception\InvalidArgumentException;
+use Symfony\AI\Agent\Input;
+use Symfony\AI\Agent\InputProcessor\CapabilityProcessor;
+use Symfony\AI\Agent\MockAgent;
+use Symfony\AI\Agent\Output;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\Component\Clock\MockClock;
+
+final class CapabilityProcessorTest extends TestCase
+{
+    public function testProcessorCannotProcessInputWithoutHandlers()
+    {
+        $processor = new CapabilityProcessor(new CapabilityHandlerRegistry([]));
+        $processor->setAgent(new MockAgent());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No capability handler found for the "Symfony\AI\Agent\Capability\InputDelayCapability" capability.');
+        $this->expectExceptionCode(0);
+        $processor->processInput(new Input('foo', new MessageBag(
+            Message::ofUser('Hello there'),
+        ), capabilities: [
+            new InputDelayCapability(10),
+        ]));
+    }
+
+    public function testProcessorCanProcessInput()
+    {
+        $clock = new MockClock('2020-01-01 10:00:00');
+
+        $processor = new CapabilityProcessor(new CapabilityHandlerRegistry([
+            new DelayCapabilityHandler($clock),
+        ]));
+        $processor->setAgent(new MockAgent());
+
+        $processor->processInput(new Input('foo', new MessageBag(
+            Message::ofUser('Hello there'),
+        ), capabilities: [
+            new InputDelayCapability(10),
+        ]));
+
+        $this->assertSame('2020-01-01 10:00:10', $clock->now()->format('Y-m-d H:i:s'));
+    }
+
+    public function testProcessorCannotProcessOutputWithoutHandlers()
+    {
+        $processor = new CapabilityProcessor(new CapabilityHandlerRegistry([]));
+        $processor->setAgent(new MockAgent());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No capability handler found for the "Symfony\AI\Agent\Capability\OutputDelayCapability" capability.');
+        $this->expectExceptionCode(0);
+        $processor->processOutput(new Output('foo', new TextResult('foo'), new MessageBag(
+            Message::ofUser('Hello there'),
+        ), capabilities: [
+            new OutputDelayCapability(10),
+        ]));
+    }
+
+    public function testProcessorCanProcessOutput()
+    {
+        $clock = new MockClock('2020-01-01 10:00:00');
+
+        $processor = new CapabilityProcessor(new CapabilityHandlerRegistry([
+            new DelayCapabilityHandler($clock),
+        ]));
+        $processor->setAgent(new MockAgent());
+
+        $processor->processOutput(new Output('foo', new TextResult('foo'), new MessageBag(
+            Message::ofUser('Hello there'),
+        ), capabilities: [
+            new OutputDelayCapability(10),
+        ]));
+
+        $this->assertSame('2020-01-01 10:00:10', $clock->now()->format('Y-m-d H:i:s'));
+    }
+}

--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -266,12 +266,10 @@ return static function (DefinitionConfigurator $configurator): void {
                             ->treatNullLike(['enabled' => true])
                             ->beforeNormalization()
                                 ->ifArray()
-                                ->then(static function (array $v): array {
-                                    return [
-                                        'enabled' => $v['enabled'] ?? true,
-                                        'services' => $v['services'] ?? $v,
-                                    ];
-                                })
+                                ->then(static fn (array $v): array => [
+                                    'enabled' => $v['enabled'] ?? true,
+                                    'services' => $v['services'] ?? $v,
+                                ])
                             ->end()
                             ->children()
                                 ->booleanNode('enabled')->defaultTrue()->end()
@@ -286,13 +284,40 @@ return static function (DefinitionConfigurator $configurator): void {
                                         ->end()
                                         ->beforeNormalization()
                                             ->ifString()
-                                            ->then(static function (string $v) {
-                                                return ['service' => $v];
-                                            })
+                                            ->then(static fn (string $v): array => ['service' => $v])
                                         ->end()
                                         ->validate()
-                                            ->ifTrue(static fn ($v) => !(empty($v['agent']) xor empty($v['service'])))
+                                            ->ifTrue(static fn (array $v): bool => !(empty($v['agent']) xor empty($v['service'])))
                                             ->thenInvalid('Either "agent" or "service" must be configured, and never both.')
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('capabilities')
+                            ->addDefaultsIfNotSet()
+                            ->treatFalseLike(['enabled' => false])
+                            ->treatTrueLike(['enabled' => true])
+                            ->treatNullLike(['enabled' => true])
+                            ->beforeNormalization()
+                                ->ifArray()
+                                ->then(static fn (array $v): array => [
+                                    'enabled' => $v['enabled'] ?? true,
+                                    'handlers' => $v['handlers'] ?? $v,
+                                ])
+                            ->end()
+                            ->children()
+                                ->booleanNode('enabled')->defaultTrue()->end()
+                                ->arrayNode('handlers')
+                                    ->arrayPrototype()
+                                        ->children()
+                                            ->stringNode('service')->cannotBeEmpty()->end()
+                                        ->end()
+                                        ->beforeNormalization()
+                                            ->ifString()
+                                            ->then(static fn (string $v): array => [
+                                                'service' => $v,
+                                            ])
                                         ->end()
                                     ->end()
                                 ->end()

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -254,6 +254,7 @@ return static function (ContainerConfigurator $container): void {
                 tagged_iterator('ai.traceable_chat'),
                 tagged_iterator('ai.traceable_agent'),
                 tagged_iterator('ai.traceable_store'),
+                tagged_iterator('ai.traceable_capability_handler'),
             ])
             ->tag('data_collector', ['id' => 'ai'])
 

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -19,6 +19,12 @@ use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Agent\Attribute\AsInputProcessor;
 use Symfony\AI\Agent\Attribute\AsOutputProcessor;
+use Symfony\AI\Agent\Capability\CapabilityHandlerInterface;
+use Symfony\AI\Agent\Capability\CapabilityHandlerRegistry;
+use Symfony\AI\Agent\Capability\CapabilityHandlerRegistryInterface;
+use Symfony\AI\Agent\Capability\InputCapabilityInterface;
+use Symfony\AI\Agent\Capability\OutputCapabilityInterface;
+use Symfony\AI\Agent\InputProcessor\CapabilityProcessor;
 use Symfony\AI\Agent\InputProcessor\SystemPromptInputProcessor;
 use Symfony\AI\Agent\InputProcessorInterface;
 use Symfony\AI\Agent\Memory\MemoryInputProcessor;
@@ -328,6 +334,12 @@ final class AiBundle extends AbstractBundle
                 ->addTag('ai.agent.input_processor', ['tagged_by' => 'interface']);
             $builder->registerForAutoconfiguration(OutputProcessorInterface::class)
                 ->addTag('ai.agent.output_processor', ['tagged_by' => 'interface']);
+            $builder->registerForAutoconfiguration(CapabilityHandlerInterface::class)
+                ->addTag('ai.agent.capability_handler', ['tagged_by' => 'interface']);
+            $builder->registerForAutoconfiguration(InputCapabilityInterface::class)
+                ->addResourceTag('ai.agent.input_capability');
+            $builder->registerForAutoconfiguration(OutputCapabilityInterface::class)
+                ->addResourceTag('ai.agent.output_capability');
         }
 
         $builder->registerForAutoconfiguration(ModelClientInterface::class)
@@ -1227,6 +1239,35 @@ final class AiBundle extends AbstractBundle
                 ->addTag('ai.agent.input_processor', ['agent' => $agentId, 'priority' => -40]);
 
             $container->setDefinition('ai.agent.'.$name.'.memory_input_processor', $memoryInputProcessorDefinition);
+        }
+
+        // CAPABILITIES
+        if ($config['capabilities']['enabled']) {
+            if ([] !== $config['capabilities']['handlers']) {
+                $capabilityHandlerRegistryDefinition = (new Definition(CapabilityHandlerRegistry::class))
+                    ->setLazy(true)
+                    ->setArgument(0, array_map(
+                        static fn (array $handler): Reference => new Reference($handler['service']),
+                        $config['capabilities']['handlers'],
+                    ))
+                    ->addTag('proxy', ['interface' => CapabilityHandlerRegistryInterface::class])
+                ;
+
+                $container->setDefinition('ai.agent.capability_handler_registry', $capabilityHandlerRegistryDefinition);
+
+                $capabilityProcessorDefinition = (new Definition(CapabilityProcessor::class))
+                    ->setLazy(true)
+                    ->setArguments([
+                        new Reference('ai.agent.capability_handler_registry'),
+                    ])
+                    ->addTag('proxy', ['interface' => InputProcessorInterface::class])
+                    ->addTag('proxy', ['interface' => OutputProcessorInterface::class])
+                    ->addTag('ai.agent.input_processor')
+                    ->addTag('ai.agent.output_processor')
+                ;
+
+                $container->setDefinition('ai.agent.capability_processor', $capabilityProcessorDefinition);
+            }
         }
 
         $agentDefinition

--- a/src/ai-bundle/src/DependencyInjection/DebugCompilerPass.php
+++ b/src/ai-bundle/src/DependencyInjection/DebugCompilerPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\AiBundle\DependencyInjection;
 
 use Symfony\AI\AiBundle\Profiler\TraceableAgent;
+use Symfony\AI\AiBundle\Profiler\TraceableCapabilityHandler;
 use Symfony\AI\AiBundle\Profiler\TraceableChat;
 use Symfony\AI\AiBundle\Profiler\TraceableMessageStore;
 use Symfony\AI\AiBundle\Profiler\TraceablePlatform;
@@ -97,6 +98,16 @@ final class DebugCompilerPass implements CompilerPassInterface
                 ->addTag('kernel.reset', ['method' => 'reset']);
             $suffix = u($store)->afterLast('.')->toString();
             $container->setDefinition('ai.traceable_store.'.$suffix, $traceableStoreDefinition);
+        }
+
+        foreach (array_keys($container->findTaggedServiceIds('ai.capability_handler')) as $capabilityHandler) {
+            $traceableCapabilityHandlerDefinition = (new Definition(TraceableCapabilityHandler::class))
+                ->setDecoratedService($capabilityHandler, priority: -1024)
+                ->setArguments([new Reference('.inner')])
+                ->addTag('ai.traceable_capability_handler')
+                ->addTag('kernel.reset', ['method' => 'reset']);
+            $suffix = u($capabilityHandler)->afterLast('.')->toString();
+            $container->setDefinition('ai.traceable_capability_handler.'.$suffix, $traceableCapabilityHandlerDefinition);
         }
     }
 }

--- a/src/ai-bundle/src/Profiler/TraceableAgent.php
+++ b/src/ai-bundle/src/Profiler/TraceableAgent.php
@@ -12,6 +12,8 @@
 namespace Symfony\AI\AiBundle\Profiler;
 
 use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Capability\InputCapabilityInterface;
+use Symfony\AI\Agent\Capability\OutputCapabilityInterface;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\Component\Clock\ClockInterface;
@@ -24,6 +26,7 @@ use Symfony\Contracts\Service\ResetInterface;
  * @phpstan-type AgentData array{
  *     messages: MessageBag,
  *     options: array<string, mixed>,
+ *     capabilities: InputCapabilityInterface[]|OutputCapabilityInterface[],
  *     called_at: \DateTimeImmutable,
  * }
  */
@@ -40,15 +43,16 @@ final class TraceableAgent implements AgentInterface, ResetInterface
     ) {
     }
 
-    public function call(MessageBag $messages, array $options = []): ResultInterface
+    public function call(MessageBag $messages, array $options = [], array $capabilities = []): ResultInterface
     {
         $this->calls[] = [
             'messages' => $messages,
             'options' => $options,
+            'capabilities' => $capabilities,
             'called_at' => $this->clock->now(),
         ];
 
-        return $this->agent->call($messages, $options);
+        return $this->agent->call($messages, $options, $capabilities);
     }
 
     public function getName(): string

--- a/src/ai-bundle/src/Profiler/TraceableCapabilityHandler.php
+++ b/src/ai-bundle/src/Profiler/TraceableCapabilityHandler.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\AiBundle\Profiler;
+
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Capability\CapabilityHandlerInterface;
+use Symfony\AI\Agent\Capability\InputCapabilityInterface;
+use Symfony\AI\Agent\Capability\OutputCapabilityInterface;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\MonotonicClock;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ *
+ * @phpstan-type CapabilityHandlerData array{
+ *    method: string,
+ *    agent: AgentInterface,
+ *    messages?: MessageBag,
+ *    options?: array<string, mixed>,
+ *    capability: string,
+ *    handled_at?: \DateTimeImmutable,
+ *    checked_at?: \DateTimeImmutable,
+ * }
+ */
+final class TraceableCapabilityHandler implements CapabilityHandlerInterface, ResetInterface
+{
+    /**
+     * @var CapabilityHandlerData[]
+     */
+    public array $calls = [];
+
+    public function __construct(
+        private readonly CapabilityHandlerInterface $policyHandler,
+        private readonly ClockInterface $clock = new MonotonicClock(),
+    ) {
+    }
+
+    public function handle(AgentInterface $agent, MessageBag $messages, array $options, InputCapabilityInterface|OutputCapabilityInterface $capability): void
+    {
+        $this->calls[] = [
+            'method' => 'handle',
+            'agent' => $agent,
+            'messages' => $messages,
+            'options' => $options,
+            'capability' => $capability::class,
+            'handled_at' => $this->clock->now(),
+        ];
+
+        $this->policyHandler->handle($agent, $messages, $options, $capability);
+    }
+
+    public function support(InputCapabilityInterface|OutputCapabilityInterface $capability): bool
+    {
+        $this->calls[] = [
+            'method' => 'support',
+            'capability' => $capability::class,
+            'checked_at' => $this->clock->now(),
+        ];
+
+        return $this->policyHandler->support($capability);
+    }
+
+    public function reset(): void
+    {
+        $this->calls = [];
+    }
+}

--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -40,6 +40,14 @@
                     <b class="label">Stores used</b>
                     <span class="sf-toolbar-status">{{ collector.stores|length }}</span>
                 </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Agents used</b>
+                    <span class="sf-toolbar-status">{{ collector.agents|length }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Capabilities calls</b>
+                    <span class="sf-toolbar-status">{{ collector.capabilityHandlers|length }}</span>
+                </div>
             </div>
         {% endset %}
 

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -21,11 +21,17 @@ use PHPUnit\Framework\TestCase;
 use Probots\Pinecone\Client as PineconeClient;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Capability\CapabilityHandlerRegistry;
+use Symfony\AI\Agent\Capability\CapabilityHandlerRegistryInterface;
+use Symfony\AI\Agent\InputProcessor\CapabilityProcessor;
+use Symfony\AI\Agent\InputProcessorInterface;
 use Symfony\AI\Agent\Memory\MemoryInputProcessor;
 use Symfony\AI\Agent\Memory\StaticMemoryProvider;
 use Symfony\AI\Agent\MultiAgent\Handoff;
 use Symfony\AI\Agent\MultiAgent\MultiAgent;
+use Symfony\AI\Agent\OutputProcessorInterface;
 use Symfony\AI\AiBundle\AiBundle;
 use Symfony\AI\AiBundle\DependencyInjection\DebugCompilerPass;
 use Symfony\AI\AiBundle\Exception\InvalidArgumentException;
@@ -7765,6 +7771,124 @@ class AiBundleTest extends TestCase
         $this->assertNull($definition->getArgument(3));
     }
 
+    public function testAgentCanEnableCapabilitiesHandlers()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'agent_without_capability_handlers' => [
+                        'model' => 'gpt-4',
+                        'capabilities' => [],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.agent.agent_without_capability_handlers'));
+        $this->assertFalse($container->hasDefinition('ai.agent.capability_handler_registry'));
+        $this->assertFalse($container->hasDefinition('ai.agent.capability_processor'));
+
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'agent_with_capability_handlers' => [
+                        'model' => 'gpt-4',
+                        'capabilities' => [
+                            'enabled' => true,
+                            'handlers' => [
+                                'default_capability_handler',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.agent.agent_with_capability_handlers'));
+        $this->assertTrue($container->hasDefinition('ai.agent.capability_handler_registry'));
+        $this->assertTrue($container->hasDefinition('ai.agent.capability_processor'));
+
+        $agentDefinition = $container->getDefinition('ai.agent.agent_with_capability_handlers');
+        $this->assertSame(Agent::class, $agentDefinition->getClass());
+
+        $capabilityHandlerRegistryDefinition = $container->getDefinition('ai.agent.capability_handler_registry');
+        $this->assertSame(CapabilityHandlerRegistry::class, $capabilityHandlerRegistryDefinition->getClass());
+        $this->assertTrue($capabilityHandlerRegistryDefinition->isLazy());
+        $this->assertCount(1, $capabilityHandlerRegistryDefinition->getArguments());
+        $this->assertEquals([
+            new Reference('default_capability_handler'),
+        ], $capabilityHandlerRegistryDefinition->getArgument(0));
+
+        $this->assertSame([
+            ['interface' => CapabilityHandlerRegistryInterface::class],
+        ], $capabilityHandlerRegistryDefinition->getTag('proxy'));
+
+        $capabilityProcessorDefinition = $container->getDefinition('ai.agent.capability_processor');
+        $this->assertSame(CapabilityProcessor::class, $capabilityProcessorDefinition->getClass());
+        $this->assertTrue($capabilityProcessorDefinition->isLazy());
+        $this->assertCount(1, $capabilityProcessorDefinition->getArguments());
+        $this->assertInstanceOf(Reference::class, $capabilityProcessorDefinition->getArgument(0));
+        $this->assertSame('ai.agent.capability_handler_registry', (string) $capabilityProcessorDefinition->getArgument(0));
+
+        $this->assertSame([
+            ['interface' => InputProcessorInterface::class],
+            ['interface' => OutputProcessorInterface::class],
+        ], $capabilityProcessorDefinition->getTag('proxy'));
+
+        $this->assertTrue($capabilityProcessorDefinition->hasTag('ai.agent.input_processor'));
+        $this->assertTrue($capabilityProcessorDefinition->hasTag('ai.agent.output_processor'));
+
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'agent_with_capability_handlers' => [
+                        'model' => 'gpt-4',
+                        'capabilities' => [
+                            'enabled' => true,
+                            'handlers' => [
+                                ['service' => 'new_capability_handler'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.agent.agent_with_capability_handlers'));
+        $this->assertTrue($container->hasDefinition('ai.agent.capability_handler_registry'));
+        $this->assertTrue($container->hasDefinition('ai.agent.capability_processor'));
+
+        $agentDefinition = $container->getDefinition('ai.agent.agent_with_capability_handlers');
+        $this->assertSame(Agent::class, $agentDefinition->getClass());
+
+        $capabilityHandlerRegistryDefinition = $container->getDefinition('ai.agent.capability_handler_registry');
+        $this->assertSame(CapabilityHandlerRegistry::class, $capabilityHandlerRegistryDefinition->getClass());
+        $this->assertTrue($capabilityHandlerRegistryDefinition->isLazy());
+        $this->assertCount(1, $capabilityHandlerRegistryDefinition->getArguments());
+        $this->assertEquals([
+            new Reference('new_capability_handler'),
+        ], $capabilityHandlerRegistryDefinition->getArgument(0));
+
+        $this->assertSame([
+            ['interface' => CapabilityHandlerRegistryInterface::class],
+        ], $capabilityHandlerRegistryDefinition->getTag('proxy'));
+
+        $capabilityProcessorDefinition = $container->getDefinition('ai.agent.capability_processor');
+        $this->assertSame(CapabilityProcessor::class, $capabilityProcessorDefinition->getClass());
+        $this->assertTrue($capabilityProcessorDefinition->isLazy());
+        $this->assertCount(1, $capabilityProcessorDefinition->getArguments());
+        $this->assertInstanceOf(Reference::class, $capabilityProcessorDefinition->getArgument(0));
+        $this->assertSame('ai.agent.capability_handler_registry', (string) $capabilityProcessorDefinition->getArgument(0));
+
+        $this->assertSame([
+            ['interface' => InputProcessorInterface::class],
+            ['interface' => OutputProcessorInterface::class],
+        ], $capabilityProcessorDefinition->getTag('proxy'));
+
+        $this->assertTrue($capabilityProcessorDefinition->hasTag('ai.agent.input_processor'));
+        $this->assertTrue($capabilityProcessorDefinition->hasTag('ai.agent.output_processor'));
+    }
+
     /**
      * @param array<string, mixed> $configuration
      */
@@ -7934,6 +8058,15 @@ class AiBundleTest extends TestCase
                     'another_agent' => [
                         'model' => 'claude-3-opus-20240229',
                         'prompt' => 'Be concise.',
+                    ],
+                    'another_agent_with_capability_handlers' => [
+                        'model' => 'gpt-4',
+                        'capabilities' => [
+                            'enabled' => true,
+                            'handlers' => [
+                                'default_capability_handler',
+                            ],
+                        ],
                     ],
                 ],
                 'store' => [

--- a/src/ai-bundle/tests/DependencyInjection/DebugCompilerPassTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/DebugCompilerPassTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\AiBundle\Tests\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\AiBundle\DependencyInjection\DebugCompilerPass;
 use Symfony\AI\AiBundle\Profiler\TraceableAgent;
+use Symfony\AI\AiBundle\Profiler\TraceableCapabilityHandler;
 use Symfony\AI\AiBundle\Profiler\TraceableChat;
 use Symfony\AI\AiBundle\Profiler\TraceableMessageStore;
 use Symfony\AI\AiBundle\Profiler\TraceablePlatform;
@@ -36,6 +37,7 @@ final class DebugCompilerPassTest extends TestCase
         $container->register('ai.toolbox.my_agent', \stdClass::class)->addTag('ai.toolbox');
         $container->register('ai.agent.my_agent', \stdClass::class)->addTag('ai.agent');
         $container->register('ai.store.store', \stdClass::class)->addTag('ai.store');
+        $container->register('ai.capability_handler.capability_handler', \stdClass::class)->addTag('ai.capability_handler');
 
         (new DebugCompilerPass())->process($container);
 
@@ -80,6 +82,13 @@ final class DebugCompilerPassTest extends TestCase
         $this->assertEquals([new Reference('.inner')], $traceableStore->getArguments());
         $this->assertTrue($traceableStore->hasTag('ai.traceable_store'));
         $this->assertSame([['method' => 'reset']], $traceableStore->getTag('kernel.reset'));
+
+        $traceableCapabilityHandler = $container->getDefinition('ai.traceable_capability_handler.capability_handler');
+        $this->assertSame(TraceableCapabilityHandler::class, $traceableCapabilityHandler->getClass());
+        $this->assertSame(['ai.capability_handler.capability_handler', null, -1024], $traceableCapabilityHandler->getDecoratedService());
+        $this->assertEquals([new Reference('.inner')], $traceableCapabilityHandler->getArguments());
+        $this->assertTrue($traceableCapabilityHandler->hasTag('ai.traceable_capability_handler'));
+        $this->assertSame([['method' => 'reset']], $traceableCapabilityHandler->getTag('kernel.reset'));
     }
 
     public function testProcessSkipsWhenDebugDisabled()
@@ -93,6 +102,7 @@ final class DebugCompilerPassTest extends TestCase
         $container->register('ai.toolbox.my_agent', \stdClass::class)->addTag('ai.toolbox');
         $container->register('ai.agent.my_agent', \stdClass::class)->addTag('ai.agent');
         $container->register('ai.store.store', \stdClass::class)->addTag('ai.store');
+        $container->register('ai.capability_handler.capability_handler', \stdClass::class)->addTag('ai.capability_handler');
 
         (new DebugCompilerPass())->process($container);
 
@@ -102,5 +112,6 @@ final class DebugCompilerPassTest extends TestCase
         $this->assertFalse($container->hasDefinition('ai.traceable_toolbox.my_agent'));
         $this->assertFalse($container->hasDefinition('ai.traceable_agent.my_agent'));
         $this->assertFalse($container->hasDefinition('ai.traceable_store.store'));
+        $this->assertFalse($container->hasDefinition('ai.traceable_capability_handler.capability_handler'));
     }
 }

--- a/src/ai-bundle/tests/Profiler/TraceableAgentTest.php
+++ b/src/ai-bundle/tests/Profiler/TraceableAgentTest.php
@@ -39,6 +39,7 @@ final class TraceableAgentTest extends TestCase
             [
                 'messages' => $messageBag,
                 'options' => [],
+                'capabilities' => [],
                 'called_at' => $clock->now(),
             ],
         ], $traceableAgent->calls);

--- a/src/ai-bundle/tests/Profiler/TraceableCapabilityHandlerTest.php
+++ b/src/ai-bundle/tests/Profiler/TraceableCapabilityHandlerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\AiBundle\Tests\Profiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Capability\DelayCapabilityHandler;
+use Symfony\AI\Agent\Capability\InputDelayCapability;
+use Symfony\AI\Agent\MockAgent;
+use Symfony\AI\AiBundle\Profiler\TraceableCapabilityHandler;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\Component\Clock\MockClock;
+
+final class TraceableCapabilityHandlerTest extends TestCase
+{
+    public function testDataAreCollected()
+    {
+        $clock = new MockClock('2020-01-01 10:00:00');
+
+        $agent = new MockAgent();
+        $traceableCapabilityHandler = new TraceableCapabilityHandler(new DelayCapabilityHandler(), $clock);
+
+        $bag = new MessageBag();
+
+        $traceableCapabilityHandler->support(new InputDelayCapability(10));
+        $traceableCapabilityHandler->handle($agent, $bag, [], new InputDelayCapability(10));
+
+        $this->assertCount(2, $traceableCapabilityHandler->calls);
+        $this->assertEquals([
+            'method' => 'support',
+            'capability' => InputDelayCapability::class,
+            'checked_at' => $clock->now(),
+        ], $traceableCapabilityHandler->calls[0]);
+        $this->assertEquals([
+            'method' => 'handle',
+            'agent' => $agent,
+            'messages' => $bag,
+            'options' => [],
+            'capability' => InputDelayCapability::class,
+            'handled_at' => $clock->now(),
+        ], $traceableCapabilityHandler->calls[1]);
+    }
+}

--- a/src/platform/src/Message/MessageBag.php
+++ b/src/platform/src/Message/MessageBag.php
@@ -78,6 +78,17 @@ class MessageBag implements \Countable, \IteratorAggregate
         return null;
     }
 
+    public function getAssistantMessage(): ?AssistantMessage
+    {
+        foreach ($this->messages as $message) {
+            if ($message instanceof AssistantMessage) {
+                return $message;
+            }
+        }
+
+        return null;
+    }
+
     public function with(MessageInterface $message): self
     {
         $messages = clone $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | --
| License       | MIT

This PR aims to introduce the support for "policies" at the `Agent` level, Policies are a way to enable/disable features in agents (think of it like stamps on `Messenger` messages` or "feature-flags").

This PR is an extension of a discussion with @chr-hertel last week about the refactoring of `Agent`, the main goal is to allow adding new features depending on the configuration of an agent and the enabled policies (for example, we might want to enable `SpeechPolicy` to add the support for Speech as implemented in #943, it can also help the introduction of `Evaluator` later and many more).

For now, two policies are implemented (for demo purpose and tests), the configuration is done and tested, same for the agent implementation.