### PR TITLE
[Store] Remove UID as type from Documents ID

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -79,6 +79,24 @@ Store
    +$indexer->index('/new/source');
    ```
 
+ * The `Symfony\AI\Store\Document\TextDocument` and `Symfony\AI\Store\Document\VectorDocument` classes now only accept
+   `string` or `int` types for the `$id` property. The `Uuid` type has been removed and auto-casting to `uuid` in store
+   bridges has been removed as well:
+
+   ```diff
+    use Symfony\AI\Store\Document\TextDocument;
+    use Symfony\AI\Store\Document\VectorDocument;
+    use Symfony\Component\Uid\Uuid;
+
+    -$textDoc = new TextDocument(Uuid::v4(), 'content');
+    +$textDoc = new TextDocument(Uuid::v4()->toString(), 'content');
+
+    -$vectorDoc = new VectorDocument(Uuid::v4(), [0.1, ...]);
+    +$vectorDoc = new VectorDocument(Uuid::v4()->toString(), [0.1, ...]);
+    ```
+
+ * The `Symfony\AI\Store\Document\EmbeddableDocumentInterface::getId()` can only return `string` or `int` types now.
+
 UPGRADE FROM 0.2 to 0.3
 =======================
 

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGELOG
  * Add `ConfiguredSourceIndexer` decorator for pre-configuring default sources on `SourceIndexer`
  * [BC BREAK] Remove `Indexer` class - use `SourceIndexer` or `DocumentIndexer` instead
  * [BC BREAK] Change `IndexerInterface::index()` signature - input parameter is no longer nullable
+ * [BC BREAK] Remove `Uuid` as possible type for `TextDocument::id` and `VectorDocument::id`, use `string` or `int` instead
+ * [BC BREAK] `Symfony\AI\Store\Document\EmbeddableDocumentInterface::getId()` now returns `string|int` instead of `mixed`
 
 0.3
 ---

--- a/src/store/src/Bridge/AzureSearch/Tests/SearchStoreTest.php
+++ b/src/store/src/Bridge/AzureSearch/Tests/SearchStoreTest.php
@@ -135,20 +135,20 @@ final class SearchStoreTest extends TestCase
 
     public function testQueryReturnsDocuments()
     {
-        $uuid1 = Uuid::v4();
-        $uuid2 = Uuid::v4();
+        $uuid1 = Uuid::v4()->toString();
+        $uuid2 = Uuid::v4()->toString();
 
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
                 'value' => [
                     [
-                        'id' => $uuid1->toRfc4122(),
+                        'id' => $uuid1,
                         'vector' => [0.1, 0.2, 0.3],
                         '@search.score' => 0.95,
                         'title' => 'First Document',
                     ],
                     [
-                        'id' => $uuid2->toRfc4122(),
+                        'id' => $uuid2,
                         'vector' => [0.4, 0.5, 0.6],
                         '@search.score' => 0.85,
                         'title' => 'Second Document',

--- a/src/store/src/Bridge/Cache/Store.php
+++ b/src/store/src/Bridge/Cache/Store.php
@@ -55,7 +55,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $existingVectors = $this->cache->get($this->cacheKey, static fn (): array => []);
 
         $newVectors = array_map(static fn (VectorDocument $document): array => [
-            'id' => $document->id->toRfc4122(),
+            'id' => $document->id,
             'vector' => $document->vector->getData(),
             'metadata' => $document->metadata->getArrayCopy(),
         ], $documents);

--- a/src/store/src/Bridge/Cache/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Cache/Tests/StoreTest.php
@@ -259,9 +259,9 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $id1 = Uuid::v4();
-        $id2 = Uuid::v4();
-        $id3 = Uuid::v4();
+        $id1 = Uuid::v4()->toString();
+        $id2 = Uuid::v4()->toString();
+        $id3 = Uuid::v4()->toString();
 
         $store->add([
             new VectorDocument($id1, new Vector([0.1, 0.1, 0.5])),
@@ -272,15 +272,15 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(3, $result);
 
-        $store->remove($id2->toRfc4122());
+        $store->remove($id2);
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(2, $result);
 
         $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->id, $result);
-        $this->assertNotContains($id2->toRfc4122(), $remainingIds);
-        $this->assertContains($id1->toRfc4122(), $remainingIds);
-        $this->assertContains($id3->toRfc4122(), $remainingIds);
+        $this->assertNotContains($id2, $remainingIds);
+        $this->assertContains($id1, $remainingIds);
+        $this->assertContains($id3, $remainingIds);
     }
 
     public function testRemoveWithArrayOfIds()
@@ -288,10 +288,10 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $id1 = Uuid::v4();
-        $id2 = Uuid::v4();
-        $id3 = Uuid::v4();
-        $id4 = Uuid::v4();
+        $id1 = Uuid::v4()->toString();
+        $id2 = Uuid::v4()->toString();
+        $id3 = Uuid::v4()->toString();
+        $id4 = Uuid::v4()->toString();
 
         $store->add([
             new VectorDocument($id1, new Vector([0.1, 0.1, 0.5])),
@@ -303,16 +303,16 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(4, $result);
 
-        $store->remove([$id2->toRfc4122(), $id4->toRfc4122()]);
+        $store->remove([$id2, $id4]);
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(2, $result);
 
         $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->id, $result);
-        $this->assertNotContains($id2->toRfc4122(), $remainingIds);
-        $this->assertNotContains($id4->toRfc4122(), $remainingIds);
-        $this->assertContains($id1->toRfc4122(), $remainingIds);
-        $this->assertContains($id3->toRfc4122(), $remainingIds);
+        $this->assertNotContains($id2, $remainingIds);
+        $this->assertNotContains($id4, $remainingIds);
+        $this->assertContains($id1, $remainingIds);
+        $this->assertContains($id3, $remainingIds);
     }
 
     public function testRemoveNonExistentId()
@@ -320,9 +320,9 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $id1 = Uuid::v4();
-        $id2 = Uuid::v4();
-        $nonExistentId = Uuid::v4();
+        $id1 = Uuid::v4()->toString();
+        $id2 = Uuid::v4()->toString();
+        $nonExistentId = Uuid::v4()->toString();
 
         $store->add([
             new VectorDocument($id1, new Vector([0.1, 0.1, 0.5])),
@@ -332,7 +332,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(2, $result);
 
-        $store->remove($nonExistentId->toRfc4122());
+        $store->remove($nonExistentId);
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(2, $result);
@@ -343,9 +343,9 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $id1 = Uuid::v4();
-        $id2 = Uuid::v4();
-        $id3 = Uuid::v4();
+        $id1 = Uuid::v4()->toString();
+        $id2 = Uuid::v4()->toString();
+        $id3 = Uuid::v4()->toString();
 
         $store->add([
             new VectorDocument($id1, new Vector([0.1, 0.1, 0.5])),
@@ -356,7 +356,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(3, $result);
 
-        $store->remove([$id1->toRfc4122(), $id2->toRfc4122(), $id3->toRfc4122()]);
+        $store->remove([$id1, $id2, $id3]);
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(0, $result);
@@ -367,7 +367,7 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
         $store->setup();
 
-        $id1 = Uuid::v4();
+        $id1 = Uuid::v4()->toString();
 
         $store->add([
             new VectorDocument($id1, new Vector([0.1, 0.1, 0.5])),
@@ -376,6 +376,6 @@ final class StoreTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No supported options.');
 
-        $store->remove($id1->toRfc4122(), ['unsupported' => true]);
+        $store->remove($id1, ['unsupported' => true]);
     }
 }

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -127,7 +127,7 @@ class Store implements ManagedStoreInterface, StoreInterface
     protected function formatVectorDocument(VectorDocument $document): array
     {
         return [
-            'id' => $document->id->toRfc4122(),
+            'id' => $document->id,
             'metadata' => json_encode($document->metadata->getArrayCopy(), \JSON_THROW_ON_ERROR),
             'embedding' => $document->vector->getData(),
         ];

--- a/src/store/src/Bridge/ClickHouse/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ClickHouse/Tests/StoreTest.php
@@ -57,11 +57,11 @@ final class StoreTest extends TestCase
 
     public function testAddSingleDocument()
     {
-        $uuid = Uuid::v4();
+        $uuid = Uuid::v4()->toString();
         $document = new VectorDocument($uuid, new Vector([0.1, 0.2, 0.3]), new Metadata(['title' => 'Test Document']));
 
         $expectedJsonData = json_encode([
-            'id' => $uuid->toRfc4122(),
+            'id' => $uuid,
             'metadata' => json_encode(['title' => 'Test Document']),
             'embedding' => [0.1, 0.2, 0.3],
         ])."\n";
@@ -83,17 +83,17 @@ final class StoreTest extends TestCase
 
     public function testAddMultipleDocuments()
     {
-        $uuid1 = Uuid::v4();
-        $uuid2 = Uuid::v4();
+        $uuid1 = Uuid::v4()->toString();
+        $uuid2 = Uuid::v4()->toString();
         $document1 = new VectorDocument($uuid1, new Vector([0.1, 0.2, 0.3]));
         $document2 = new VectorDocument($uuid2, new Vector([0.4, 0.5, 0.6]), new Metadata(['title' => 'Second']));
 
         $expectedJsonData = json_encode([
-            'id' => $uuid1->toRfc4122(),
+            'id' => $uuid1,
             'metadata' => json_encode([]),
             'embedding' => [0.1, 0.2, 0.3],
         ])."\n".json_encode([
-            'id' => $uuid2->toRfc4122(),
+            'id' => $uuid2,
             'metadata' => json_encode(['title' => 'Second']),
             'embedding' => [0.4, 0.5, 0.6],
         ])."\n";
@@ -113,7 +113,7 @@ final class StoreTest extends TestCase
 
     public function testAddThrowsExceptionOnHttpError()
     {
-        $uuid = Uuid::v4();
+        $uuid = Uuid::v4()->toString();
         $document = new VectorDocument($uuid, new Vector([0.1, 0.2, 0.3]));
 
         $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) {
@@ -131,7 +131,6 @@ final class StoreTest extends TestCase
     public function testQuery()
     {
         $queryVector = new Vector([0.1, 0.2, 0.3]);
-        $uuid = Uuid::v4();
 
         $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
             $this->assertSame('GET', $method);
@@ -208,12 +207,11 @@ final class StoreTest extends TestCase
     public function testQueryWithNullMetadata()
     {
         $queryVector = new Vector([0.1, 0.2, 0.3]);
-        $uuid = Uuid::v4();
 
         $responseData = [
             'data' => [
                 [
-                    'id' => $uuid->toRfc4122(),
+                    'id' => Uuid::v4()->toString(),
                     'embedding' => [0.1, 0.2, 0.3],
                     'metadata' => null,
                     'score' => 0.95,
@@ -221,7 +219,7 @@ final class StoreTest extends TestCase
             ],
         ];
 
-        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use ($responseData) {
+        $httpClient = new MockHttpClient(static function () use ($responseData) {
             return new MockResponse(json_encode($responseData));
         });
 
@@ -235,8 +233,7 @@ final class StoreTest extends TestCase
 
     public function testRemoveSingleDocument()
     {
-        $uuid = Uuid::v4();
-        $id = $uuid->toRfc4122();
+        $id = Uuid::v4()->toRfc4122();
 
         $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use ($id) {
             $this->assertSame('POST', $method);
@@ -255,10 +252,8 @@ final class StoreTest extends TestCase
 
     public function testRemoveMultipleDocuments()
     {
-        $uuid1 = Uuid::v4();
-        $uuid2 = Uuid::v4();
-        $id1 = $uuid1->toRfc4122();
-        $id2 = $uuid2->toRfc4122();
+        $id1 = Uuid::v4()->toRfc4122();
+        $id2 = Uuid::v4()->toRfc4122();
 
         $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use ($id1, $id2) {
             $this->assertSame('POST', $method);

--- a/src/store/src/Bridge/Cloudflare/Store.php
+++ b/src/store/src/Bridge/Cloudflare/Store.php
@@ -134,7 +134,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return [
-            'id' => $document->id->toRfc4122(),
+            'id' => $document->id,
             'values' => $document->vector->getData(),
             'metadata' => $document->metadata->getArrayCopy(),
         ];

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -75,7 +75,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $documentToIndex = fn (VectorDocument $document): array => [
             'index' => [
                 '_index' => $this->indexName,
-                '_id' => $document->id->toRfc4122(),
+                '_id' => $document->id,
             ],
         ];
 

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -70,7 +70,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
                     'table' => $this->table,
                     'id' => random_int(0, \PHP_INT_MAX),
                     'doc' => [
-                        'uuid' => $document->id->toRfc4122(),
+                        'uuid' => $document->id,
                         $this->field => $document->vector->getData(),
                         'metadata' => json_encode($document->metadata->getArrayCopy()),
                     ],

--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -120,7 +120,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
 
         foreach ($documents as $document) {
-            $statement->bindValue(':id', $document->id->toRfc4122());
+            $statement->bindValue(':id', $document->id);
             $statement->bindValue(':metadata', json_encode($document->metadata->getArrayCopy()));
             $statement->bindValue(':vector', json_encode($document->vector->getData()));
 

--- a/src/store/src/Bridge/MariaDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/MariaDb/Tests/StoreTest.php
@@ -257,7 +257,6 @@ final class StoreTest extends TestCase
             }))
             ->willReturn($statement);
 
-        $uuid = Uuid::v4();
         $crawlId = '396af6fe-0dfd-47ed-b222-3dbcced3f38e';
 
         $statement->expects($this->once())
@@ -280,7 +279,7 @@ final class StoreTest extends TestCase
             'where' => 'metadata->>\'crawlId\' = :crawlId AND id != :currentId',
             'params' => [
                 'crawlId' => $crawlId,
-                'currentId' => $uuid->toRfc4122(),
+                'currentId' => Uuid::v4()->toRfc4122(),
             ],
         ]));
 

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -61,7 +61,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             $this->request('POST', \sprintf('db/%s/query/v2', $this->databaseName), [
                 'statement' => \sprintf('CREATE (n:%s {id: $id, metadata: $metadata, %s: $embeddings}) RETURN n', $this->nodeName, $this->embeddingsField),
                 'parameters' => [
-                    'id' => $document->id->toRfc4122(),
+                    'id' => $document->id,
                     'metadata' => json_encode($document->metadata->getArrayCopy()),
                     'embeddings' => $document->vector->getData(),
                 ],

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -120,7 +120,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
 
         foreach ($documents as $document) {
-            $statement->bindValue(':id', $document->id->toRfc4122());
+            $statement->bindValue(':id', $document->id);
             $statement->bindValue(':metadata', json_encode($document->metadata->getArrayCopy(), \JSON_THROW_ON_ERROR));
             $statement->bindValue(':vector', $this->toPgvector($document->vector));
 

--- a/src/store/src/Bridge/Postgres/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Postgres/Tests/StoreTest.php
@@ -43,7 +43,7 @@ final class StoreTest extends TestCase
             }))
             ->willReturn($statement);
 
-        $uuid = Uuid::v4();
+        $uuid = Uuid::v4()->toString();
 
         $statement->expects($this->exactly(3))
             ->method('bindValue')
@@ -52,7 +52,7 @@ final class StoreTest extends TestCase
                 ++$callCount;
 
                 match ($callCount) {
-                    1 => $this->assertSame([':id', $uuid->toRfc4122()], [$param, $value]),
+                    1 => $this->assertSame([':id', $uuid], [$param, $value]),
                     2 => $this->assertSame([':metadata', json_encode(['title' => 'Test Document'])], [$param, $value]),
                     3 => $this->assertSame([':vector', '[0.1,0.2,0.3]'], [$param, $value]),
                     default => $this->fail('Unexpected bindValue call'),
@@ -79,8 +79,8 @@ final class StoreTest extends TestCase
             ->method('prepare')
             ->willReturn($statement);
 
-        $uuid1 = Uuid::v4();
-        $uuid2 = Uuid::v4();
+        $uuid1 = Uuid::v4()->toString();
+        $uuid2 = Uuid::v4()->toString();
 
         $statement->expects($this->exactly(6))
             ->method('bindValue')
@@ -89,10 +89,10 @@ final class StoreTest extends TestCase
                 ++$callCount;
 
                 match ($callCount) {
-                    1 => $this->assertSame([':id', $uuid1->toRfc4122()], [$param, $value]),
+                    1 => $this->assertSame([':id', $uuid1], [$param, $value]),
                     2 => $this->assertSame([':metadata', '[]'], [$param, $value]),
                     3 => $this->assertSame([':vector', '[0.1,0.2,0.3]'], [$param, $value]),
-                    4 => $this->assertSame([':id', $uuid2->toRfc4122()], [$param, $value]),
+                    4 => $this->assertSame([':id', $uuid2], [$param, $value]),
                     5 => $this->assertSame([':metadata', json_encode(['title' => 'Second'])], [$param, $value]),
                     6 => $this->assertSame([':vector', '[0.4,0.5,0.6]'], [$param, $value]),
                     default => $this->fail('Unexpected bindValue call'),

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -144,7 +144,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return [
-            'id' => $document->id->toRfc4122(),
+            'id' => $document->id,
             'vector' => $document->vector->getData(),
             'payload' => $document->metadata->getArrayCopy(),
         ];

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -89,9 +89,9 @@ class Store implements ManagedStoreInterface, StoreInterface
         $pipeline = $this->redis->multi(\Redis::PIPELINE);
 
         foreach ($documents as $document) {
-            $key = $this->keyPrefix.$document->id->toRfc4122();
+            $key = $this->keyPrefix.$document->id;
             $data = [
-                'id' => $document->id->toRfc4122(),
+                'id' => $document->id,
                 'metadata' => $document->metadata->getArrayCopy(),
                 'embedding' => $document->vector->getData(),
             ];

--- a/src/store/src/Bridge/Redis/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Redis/Tests/StoreTest.php
@@ -34,10 +34,10 @@ final class StoreTest extends TestCase
             ->with(\Redis::PIPELINE)
             ->willReturn($pipeline);
 
-        $uuid = Uuid::v4();
-        $expectedKey = 'vector:'.$uuid->toRfc4122();
+        $uuid = Uuid::v4()->toString();
+        $expectedKey = 'vector:'.$uuid;
         $expectedData = [
-            'id' => $uuid->toRfc4122(),
+            'id' => $uuid,
             'metadata' => ['title' => 'Test Document'],
             'embedding' => [0.1, 0.2, 0.3],
         ];
@@ -101,7 +101,7 @@ final class StoreTest extends TestCase
         $redis = $this->createMock(\Redis::class);
         $store = new Store($redis, 'test_index', 'vector:');
 
-        $uuid = Uuid::v4();
+        $uuid = Uuid::v4()->toString();
 
         $redis->expects($this->once())
             ->method('rawCommand')
@@ -117,9 +117,9 @@ final class StoreTest extends TestCase
             )
             ->willReturn([
                 1, // number of results
-                'vector:'.$uuid->toRfc4122(), // document key
+                'vector:'.$uuid, // document key
                 [
-                    '$.id', $uuid->toRfc4122(),
+                    '$.id', $uuid,
                     '$.metadata', json_encode(['title' => 'Test Document']),
                     '$.embedding', json_encode([0.1, 0.2, 0.3]),
                     'vector_score', '0.95',
@@ -140,7 +140,7 @@ final class StoreTest extends TestCase
         $redis = $this->createMock(\Redis::class);
         $store = new Store($redis, 'test_index', 'vector:', Distance::L2);
 
-        $uuid = Uuid::v4();
+        $uuid = Uuid::v4()->toString();
 
         $redis->expects($this->once())
             ->method('rawCommand')
@@ -156,9 +156,9 @@ final class StoreTest extends TestCase
             )
             ->willReturn([
                 1,
-                'vector:'.$uuid->toRfc4122(),
+                'vector:'.$uuid,
                 [
-                    '$.id', $uuid->toRfc4122(),
+                    '$.id', $uuid,
                     '$.metadata', json_encode(['title' => 'Test Document']),
                     '$.embedding', json_encode([0.1, 0.2, 0.3]),
                     'vector_score', '0.95',

--- a/src/store/src/Bridge/Supabase/Store.php
+++ b/src/store/src/Bridge/Supabase/Store.php
@@ -64,7 +64,7 @@ final class Store implements StoreInterface
             }
 
             $rows[] = [
-                'id' => $document->id->toRfc4122(),
+                'id' => $document->id,
                 $this->vectorFieldName => $document->vector->getData(),
                 'metadata' => $document->metadata->getArrayCopy(),
             ];

--- a/src/store/src/Bridge/Supabase/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Supabase/Tests/StoreTest.php
@@ -129,10 +129,10 @@ class StoreTest extends TestCase
 
     public function testQuerySuccess()
     {
-        $uuid = Uuid::v4();
+        $uuid = Uuid::v4()->toString();
         $expectedResponse = [
             [
-                'id' => $uuid->toRfc4122(),
+                'id' => $uuid,
                 'embedding' => '[0.5, 0.6, 0.7]',
                 'metadata' => '{"category": "test"}',
                 'score' => 0.85,
@@ -144,7 +144,7 @@ class StoreTest extends TestCase
 
         $this->assertCount(1, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
-        $this->assertSame($uuid->toRfc4122(), $result[0]->id);
+        $this->assertSame($uuid, $result[0]->id);
         $this->assertSame([0.5, 0.6, 0.7], $result[0]->vector->getData());
         $this->assertSame(['category' => 'test'], $result[0]->metadata->getArrayCopy());
         $this->assertSame(0.85, $result[0]->score);
@@ -153,17 +153,17 @@ class StoreTest extends TestCase
 
     public function testQueryHandlesMultipleResultsAndMultipleOptions()
     {
-        $uuid1 = Uuid::v4();
-        $uuid2 = Uuid::v4();
+        $uuid1 = Uuid::v4()->toString();
+        $uuid2 = Uuid::v4()->toString();
         $expectedResponse = [
             [
-                'id' => $uuid1->toRfc4122(),
+                'id' => $uuid1,
                 'embedding' => '[0.1, 0.2]',
                 'metadata' => '{"type": "first"}',
                 'score' => 0.95,
             ],
             [
-                'id' => $uuid2->toRfc4122(),
+                'id' => $uuid2,
                 'embedding' => '[0.3, 0.4]',
                 'metadata' => '{"type": "second"}',
                 'score' => 0.85,
@@ -176,12 +176,12 @@ class StoreTest extends TestCase
 
         $this->assertCount(2, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
-        $this->assertSame($uuid1->toRfc4122(), $result[0]->id);
+        $this->assertSame($uuid1, $result[0]->id);
         $this->assertSame([0.1, 0.2], $result[0]->vector->getData());
         $this->assertSame(0.95, $result[0]->score);
         $this->assertSame(['type' => 'first'], $result[0]->metadata->getArrayCopy());
         $this->assertInstanceOf(VectorDocument::class, $result[1]);
-        $this->assertSame($uuid2->toRfc4122(), $result[1]->id);
+        $this->assertSame($uuid2, $result[1]->id);
         $this->assertSame([0.3, 0.4], $result[1]->vector->getData());
         $this->assertSame(0.85, $result[1]->score);
         $this->assertSame(['type' => 'second'], $result[1]->metadata->getArrayCopy());
@@ -191,10 +191,10 @@ class StoreTest extends TestCase
 
     public function testQueryParsesComplexMetadata()
     {
-        $uuid = Uuid::v4();
+        $uuid = Uuid::v4()->toString();
         $expectedResponse = [
             [
-                'id' => $uuid->toRfc4122(),
+                'id' => $uuid,
                 'embedding' => '[0.1, 0.2, 0.3, 0.4]',
                 'metadata' => '{"title": "Test Document", "tags": ["ai", "test"], "score": 0.92}',
                 'score' => 0.92,
@@ -209,7 +209,7 @@ class StoreTest extends TestCase
         $metadata = $document->metadata->getArrayCopy();
         $this->assertCount(1, $result);
         $this->assertInstanceOf(VectorDocument::class, $document);
-        $this->assertSame($uuid->toRfc4122(), $document->id);
+        $this->assertSame($uuid, $document->id);
         $this->assertSame([0.1, 0.2, 0.3, 0.4], $document->vector->getData());
         $this->assertSame(0.92, $document->score);
         $this->assertSame('Test Document', $metadata['title']);

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -136,10 +136,10 @@ class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return [
-            'id' => $document->id->toRfc4122(),
+            'id' => $document->id,
             $this->vectorFieldName => $document->vector->getData(),
             '_metadata' => array_merge($document->metadata->getArrayCopy(), [
-                '_id' => $document->id->toRfc4122(),
+                '_id' => $document->id,
             ]),
         ];
     }

--- a/src/store/src/Document/EmbeddableDocumentInterface.php
+++ b/src/store/src/Document/EmbeddableDocumentInterface.php
@@ -13,7 +13,7 @@ namespace Symfony\AI\Store\Document;
 
 interface EmbeddableDocumentInterface
 {
-    public function getId(): mixed;
+    public function getId(): int|string;
 
     public function getContent(): string|object;
 

--- a/src/store/src/Document/Loader/RssFeedLoader.php
+++ b/src/store/src/Document/Loader/RssFeedLoader.php
@@ -74,7 +74,7 @@ final class RssFeedLoader implements LoaderInterface
 
             $item = new RssItem($id, $node->filterXpath('//title')->text(), $link, new \DateTimeImmutable($node->filterXpath('//pubDate')->text()), $node->filterXpath('//description')->text(), $author, $content);
 
-            yield new TextDocument($id, $item->toString(), new Metadata([
+            yield new TextDocument($id->toString(), $item->toString(), new Metadata([
                 Metadata::KEY_SOURCE => $source,
                 ...$item->toArray(),
             ]));

--- a/src/store/src/Document/TextDocument.php
+++ b/src/store/src/Document/TextDocument.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Store\Document;
 
 use Symfony\AI\Store\Exception\InvalidArgumentException;
-use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -20,7 +19,7 @@ use Symfony\Component\Uid\Uuid;
 final class TextDocument implements EmbeddableDocumentInterface
 {
     public function __construct(
-        private readonly int|string|Uuid $id,
+        private readonly int|string $id,
         private readonly string $content,
         private readonly Metadata $metadata = new Metadata(),
     ) {
@@ -34,7 +33,7 @@ final class TextDocument implements EmbeddableDocumentInterface
         return new self($this->id, $content, $this->metadata);
     }
 
-    public function getId(): int|string|Uuid
+    public function getId(): int|string
     {
         return $this->id;
     }

--- a/src/store/src/Document/VectorDocument.php
+++ b/src/store/src/Document/VectorDocument.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Store\Document;
 
 use Symfony\AI\Platform\Vector\VectorInterface;
-use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -20,7 +19,7 @@ use Symfony\Component\Uid\Uuid;
 final class VectorDocument
 {
     public function __construct(
-        public readonly int|string|Uuid $id,
+        public readonly int|string $id,
         public readonly VectorInterface $vector,
         public readonly Metadata $metadata = new Metadata(),
         public readonly ?float $score = null,

--- a/src/store/tests/Document/Filter/TextContainsFilterTest.php
+++ b/src/store/tests/Document/Filter/TextContainsFilterTest.php
@@ -28,9 +28,9 @@ final class TextContainsFilterTest extends TestCase
     {
         $filter = new TextContainsFilter('Week of Symfony');
         $documents = [
-            new TextDocument(Uuid::v4(), 'This is a regular blog post'),
-            new TextDocument(Uuid::v4(), 'Week of Symfony - News roundup'),
-            new TextDocument(Uuid::v4(), 'Another regular post'),
+            new TextDocument(Uuid::v4()->toString(), 'This is a regular blog post'),
+            new TextDocument(Uuid::v4()->toString(), 'Week of Symfony - News roundup'),
+            new TextDocument(Uuid::v4()->toString(), 'Another regular post'),
         ];
 
         $result = iterator_to_array($filter->filter($documents));
@@ -44,9 +44,9 @@ final class TextContainsFilterTest extends TestCase
     {
         $filter = new TextContainsFilter('initial');
         $documents = [
-            new TextDocument(Uuid::v4(), 'Keep this document'),
-            new TextDocument(Uuid::v4(), 'Remove this SPAM content'),
-            new TextDocument(Uuid::v4(), 'Another good document'),
+            new TextDocument(Uuid::v4()->toString(), 'Keep this document'),
+            new TextDocument(Uuid::v4()->toString(), 'Remove this SPAM content'),
+            new TextDocument(Uuid::v4()->toString(), 'Another good document'),
         ];
 
         $result = iterator_to_array($filter->filter($documents, [
@@ -62,9 +62,9 @@ final class TextContainsFilterTest extends TestCase
     {
         $filter = new TextContainsFilter('Week of Symfony');
         $documents = [
-            new TextDocument(Uuid::v4(), 'Regular post'),
-            new TextDocument(Uuid::v4(), 'Week of Symfony news'),
-            new TextDocument(Uuid::v4(), 'Advertisement content'),
+            new TextDocument(Uuid::v4()->toString(), 'Regular post'),
+            new TextDocument(Uuid::v4()->toString(), 'Week of Symfony news'),
+            new TextDocument(Uuid::v4()->toString(), 'Advertisement content'),
         ];
 
         $result = iterator_to_array($filter->filter($documents, [
@@ -80,10 +80,10 @@ final class TextContainsFilterTest extends TestCase
     {
         $filter = new TextContainsFilter('SPAM', false);
         $documents = [
-            new TextDocument(Uuid::v4(), 'This contains spam'),
-            new TextDocument(Uuid::v4(), 'This contains SPAM'),
-            new TextDocument(Uuid::v4(), 'This contains Spam'),
-            new TextDocument(Uuid::v4(), 'Clean content'),
+            new TextDocument(Uuid::v4()->toString(), 'This contains spam'),
+            new TextDocument(Uuid::v4()->toString(), 'This contains SPAM'),
+            new TextDocument(Uuid::v4()->toString(), 'This contains Spam'),
+            new TextDocument(Uuid::v4()->toString(), 'Clean content'),
         ];
 
         $result = iterator_to_array($filter->filter($documents));
@@ -96,10 +96,10 @@ final class TextContainsFilterTest extends TestCase
     {
         $filter = new TextContainsFilter('SPAM', true);
         $documents = [
-            new TextDocument(Uuid::v4(), 'This contains spam'),
-            new TextDocument(Uuid::v4(), 'This contains SPAM'),
-            new TextDocument(Uuid::v4(), 'This contains Spam'),
-            new TextDocument(Uuid::v4(), 'Clean content'),
+            new TextDocument(Uuid::v4()->toString(), 'This contains spam'),
+            new TextDocument(Uuid::v4()->toString(), 'This contains SPAM'),
+            new TextDocument(Uuid::v4()->toString(), 'This contains Spam'),
+            new TextDocument(Uuid::v4()->toString(), 'Clean content'),
         ];
 
         $result = iterator_to_array($filter->filter($documents));
@@ -114,8 +114,8 @@ final class TextContainsFilterTest extends TestCase
     {
         $filter = new TextContainsFilter('test', false);
         $documents = [
-            new TextDocument(Uuid::v4(), 'This has Test'),
-            new TextDocument(Uuid::v4(), 'Clean content'),
+            new TextDocument(Uuid::v4()->toString(), 'This has Test'),
+            new TextDocument(Uuid::v4()->toString(), 'Clean content'),
         ];
 
         $result = iterator_to_array($filter->filter($documents, [
@@ -132,8 +132,8 @@ final class TextContainsFilterTest extends TestCase
         $metadata = new Metadata(['key' => 'value']);
         $filter = new TextContainsFilter('remove');
         $documents = [
-            new TextDocument(Uuid::v4(), 'keep this', $metadata),
-            new TextDocument(Uuid::v4(), 'remove this content'),
+            new TextDocument(Uuid::v4()->toString(), 'keep this', $metadata),
+            new TextDocument(Uuid::v4()->toString(), 'remove this content'),
         ];
 
         $result = iterator_to_array($filter->filter($documents));
@@ -145,11 +145,11 @@ final class TextContainsFilterTest extends TestCase
 
     public function testFilterPreservesDocumentId()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $filter = new TextContainsFilter('remove');
         $documents = [
             new TextDocument($id, 'keep this content'),
-            new TextDocument(Uuid::v4(), 'remove this content'),
+            new TextDocument(Uuid::v4()->toString(), 'remove this content'),
         ];
 
         $result = iterator_to_array($filter->filter($documents));
@@ -172,8 +172,8 @@ final class TextContainsFilterTest extends TestCase
     {
         $filter = new TextContainsFilter('nonexistent');
         $documents = [
-            new TextDocument(Uuid::v4(), 'First document'),
-            new TextDocument(Uuid::v4(), 'Second document'),
+            new TextDocument(Uuid::v4()->toString(), 'First document'),
+            new TextDocument(Uuid::v4()->toString(), 'Second document'),
         ];
 
         $result = iterator_to_array($filter->filter($documents));
@@ -187,8 +187,8 @@ final class TextContainsFilterTest extends TestCase
     {
         $filter = new TextContainsFilter('spam');
         $documents = [
-            new TextDocument(Uuid::v4(), 'This is spam content'),
-            new TextDocument(Uuid::v4(), 'More spam here'),
+            new TextDocument(Uuid::v4()->toString(), 'This is spam content'),
+            new TextDocument(Uuid::v4()->toString(), 'More spam here'),
         ];
 
         $result = iterator_to_array($filter->filter($documents));
@@ -200,9 +200,9 @@ final class TextContainsFilterTest extends TestCase
     {
         $filter = new TextContainsFilter('test');
         $documents = [
-            new TextDocument(Uuid::v4(), 'This is a test document'),
-            new TextDocument(Uuid::v4(), 'testing functionality'),
-            new TextDocument(Uuid::v4(), 'Clean content'),
+            new TextDocument(Uuid::v4()->toString(), 'This is a test document'),
+            new TextDocument(Uuid::v4()->toString(), 'testing functionality'),
+            new TextDocument(Uuid::v4()->toString(), 'Clean content'),
         ];
 
         $result = iterator_to_array($filter->filter($documents));
@@ -215,8 +215,8 @@ final class TextContainsFilterTest extends TestCase
     {
         $filter = new TextContainsFilter('TEST', true);
         $documents = [
-            new TextDocument(Uuid::v4(), 'This has test content'),
-            new TextDocument(Uuid::v4(), 'Clean content'),
+            new TextDocument(Uuid::v4()->toString(), 'This has test content'),
+            new TextDocument(Uuid::v4()->toString(), 'Clean content'),
         ];
 
         // Only provide needle option, should use constructor's case sensitivity

--- a/src/store/tests/Document/Loader/RssFeedLoaderTest.php
+++ b/src/store/tests/Document/Loader/RssFeedLoaderTest.php
@@ -125,7 +125,7 @@ XML;
 
         foreach ($result as $document) {
             $this->assertInstanceOf(TextDocument::class, $document);
-            $this->assertInstanceOf(Uuid::class, $document->getId());
+            $this->assertTrue(Uuid::isValid($document->getId()));
             $this->assertNotEmpty($document->getContent());
         }
     }

--- a/src/store/tests/Document/TextDocumentTest.php
+++ b/src/store/tests/Document/TextDocumentTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Uid\Uuid;
 final class TextDocumentTest extends TestCase
 {
     #[DataProvider('constructorIdDataProvider')]
-    public function testConstructorIdSupportsManyTypes(int|string|Uuid $id)
+    public function testConstructorIdSupportsManyTypes(int|string $id)
     {
         $document = new TextDocument($id, 'content');
 
@@ -34,13 +34,12 @@ final class TextDocumentTest extends TestCase
     {
         yield 'int' => [1];
         yield 'string' => ['id'];
-        yield 'uuid' => [Uuid::v4()];
     }
 
     #[TestDox('Creates document with valid content and metadata')]
     public function testConstructorWithValidContent()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $content = 'This is valid content';
         $metadata = new Metadata(['title' => 'Test Document']);
 
@@ -54,7 +53,7 @@ final class TextDocumentTest extends TestCase
     #[TestDox('Creates document with default empty metadata when not provided')]
     public function testConstructorWithDefaultMetadata()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $content = 'This is valid content';
 
         $document = new TextDocument($id, $content);
@@ -78,7 +77,7 @@ final class TextDocumentTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The content shall not be an empty string.');
 
-        new TextDocument(Uuid::v4(), $content);
+        new TextDocument(Uuid::v4()->toString(), $content);
     }
 
     #[TestWith(['Hello, World!'])]
@@ -96,7 +95,7 @@ final class TextDocumentTest extends TestCase
     #[TestDox('Accepts valid content')]
     public function testConstructorAcceptsValidContent(string $content)
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
 
         $document = new TextDocument($id, $content);
 
@@ -107,7 +106,7 @@ final class TextDocumentTest extends TestCase
     #[TestDox('Accepts very long text content')]
     public function testConstructorAcceptsVeryLongContent()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $content = str_repeat('Lorem ipsum dolor sit amet, ', 1000);
 
         $document = new TextDocument($id, $content);
@@ -119,7 +118,7 @@ final class TextDocumentTest extends TestCase
     #[TestDox('Properties are publicly accessible and readonly')]
     public function testReadonlyProperties()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $content = 'Test content';
         $metadata = new Metadata(['key' => 'value']);
 
@@ -133,7 +132,7 @@ final class TextDocumentTest extends TestCase
     #[TestDox('Metadata contents can be modified even though the property is readonly')]
     public function testMetadataCanBeModified()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $content = 'Test content';
         $metadata = new Metadata();
 
@@ -147,32 +146,10 @@ final class TextDocumentTest extends TestCase
         $this->assertSame('test.txt', $document->getMetadata()->getSource());
     }
 
-    #[DataProvider('uuidVersionProvider')]
-    #[TestDox('Accepts UUID version $version')]
-    public function testDifferentUuidVersions(string $version, Uuid $uuid)
-    {
-        $content = 'Test content';
-
-        $document = new TextDocument($uuid, $content);
-
-        $this->assertSame($uuid, $document->getId());
-        $this->assertSame($content, $document->getContent());
-    }
-
-    /**
-     * @return \Iterator<string, array{version: string, uuid: Uuid}>
-     */
-    public static function uuidVersionProvider(): \Iterator
-    {
-        yield 'UUID v4' => ['version' => '4', 'uuid' => Uuid::v4()];
-        yield 'UUID v6' => ['version' => '6', 'uuid' => Uuid::v6()];
-        yield 'UUID v7' => ['version' => '7', 'uuid' => Uuid::v7()];
-    }
-
     #[TestDox('Handles complex nested metadata with special keys')]
     public function testDocumentWithComplexMetadata()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $content = 'Document content';
         $metadata = new Metadata([
             'title' => 'Test Document',
@@ -216,8 +193,8 @@ final class TextDocumentTest extends TestCase
         $metadata1 = new Metadata(['source' => 'doc1.txt']);
         $metadata2 = new Metadata(['source' => 'doc2.txt']);
 
-        $document1 = new TextDocument(Uuid::v4(), $content, $metadata1);
-        $document2 = new TextDocument(Uuid::v4(), $content, $metadata2);
+        $document1 = new TextDocument(Uuid::v4()->toString(), $content, $metadata1);
+        $document2 = new TextDocument(Uuid::v4()->toString(), $content, $metadata2);
 
         $this->assertSame($content, $document1->getContent());
         $this->assertSame($content, $document2->getContent());
@@ -228,7 +205,7 @@ final class TextDocumentTest extends TestCase
     #[TestDox('Documents can have the same ID but different content')]
     public function testDocumentWithSameIdButDifferentContent()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
 
         $document1 = new TextDocument($id, 'Content 1');
         $document2 = new TextDocument($id, 'Content 2');
@@ -242,7 +219,7 @@ final class TextDocumentTest extends TestCase
     public function testTrimBehaviorValidation()
     {
         // Content with whitespace that is not purely whitespace should be valid
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $contentWithWhitespace = '  Valid content with spaces  ';
 
         $document = new TextDocument($id, $contentWithWhitespace);
@@ -257,13 +234,13 @@ final class TextDocumentTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The content shall not be an empty string.');
 
-        new TextDocument(Uuid::v4(), '   ');
+        new TextDocument(Uuid::v4()->toString(), '   ');
     }
 
     #[TestDox('withContent creates new instance with updated content')]
     public function testWithContent()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $originalContent = 'Original content';
         $newContent = 'Updated content';
         $metadata = new Metadata(['title' => 'Test Document']);
@@ -281,7 +258,7 @@ final class TextDocumentTest extends TestCase
     #[TestDox('withContent validates new content')]
     public function testWithContentValidatesContent()
     {
-        $document = new TextDocument(Uuid::v4(), 'Valid content');
+        $document = new TextDocument(Uuid::v4()->toString(), 'Valid content');
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The content shall not be an empty string.');

--- a/src/store/tests/Document/Transformer/TextReplaceTransformerTest.php
+++ b/src/store/tests/Document/Transformer/TextReplaceTransformerTest.php
@@ -26,7 +26,7 @@ final class TextReplaceTransformerTest extends TestCase
     public function testReplaceWithConstructorParameters()
     {
         $transformer = new TextReplaceTransformer('foo', 'bar');
-        $document = new TextDocument(Uuid::v4(), 'foo is foo');
+        $document = new TextDocument(Uuid::v4()->toString(), 'foo is foo');
 
         $result = iterator_to_array($transformer->transform([$document]));
 
@@ -37,7 +37,7 @@ final class TextReplaceTransformerTest extends TestCase
     public function testReplaceWithOptions()
     {
         $transformer = new TextReplaceTransformer('initial', 'value');
-        $document = new TextDocument(Uuid::v4(), 'hello world');
+        $document = new TextDocument(Uuid::v4()->toString(), 'hello world');
 
         $result = iterator_to_array($transformer->transform([$document], [
             TextReplaceTransformer::OPTION_SEARCH => 'hello',
@@ -51,7 +51,7 @@ final class TextReplaceTransformerTest extends TestCase
     public function testOptionsOverrideConstructorParameters()
     {
         $transformer = new TextReplaceTransformer('foo', 'bar');
-        $document = new TextDocument(Uuid::v4(), 'foo hello');
+        $document = new TextDocument(Uuid::v4()->toString(), 'foo hello');
 
         $result = iterator_to_array($transformer->transform([$document], [
             TextReplaceTransformer::OPTION_SEARCH => 'hello',
@@ -65,7 +65,7 @@ final class TextReplaceTransformerTest extends TestCase
     public function testReplaceMultipleOccurrences()
     {
         $transformer = new TextReplaceTransformer('a', 'b');
-        $document = new TextDocument(Uuid::v4(), 'a a a');
+        $document = new TextDocument(Uuid::v4()->toString(), 'a a a');
 
         $result = iterator_to_array($transformer->transform([$document]));
 
@@ -76,7 +76,7 @@ final class TextReplaceTransformerTest extends TestCase
     public function testReplaceWithEmptyString()
     {
         $transformer = new TextReplaceTransformer('remove', '');
-        $document = new TextDocument(Uuid::v4(), 'remove this word');
+        $document = new TextDocument(Uuid::v4()->toString(), 'remove this word');
 
         $result = iterator_to_array($transformer->transform([$document]));
 
@@ -88,7 +88,7 @@ final class TextReplaceTransformerTest extends TestCase
     {
         $metadata = new Metadata(['key' => 'value']);
         $transformer = new TextReplaceTransformer('old', 'new');
-        $document = new TextDocument(Uuid::v4(), 'old text', $metadata);
+        $document = new TextDocument(Uuid::v4()->toString(), 'old text', $metadata);
 
         $result = iterator_to_array($transformer->transform([$document]));
 
@@ -99,7 +99,7 @@ final class TextReplaceTransformerTest extends TestCase
 
     public function testReplacePreservesDocumentId()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $transformer = new TextReplaceTransformer('old', 'new');
         $document = new TextDocument($id, 'old text');
 
@@ -113,9 +113,9 @@ final class TextReplaceTransformerTest extends TestCase
     {
         $transformer = new TextReplaceTransformer('x', 'y');
         $documents = [
-            new TextDocument(Uuid::v4(), 'x marks the spot'),
-            new TextDocument(Uuid::v4(), 'find x here'),
-            new TextDocument(Uuid::v4(), 'no match'),
+            new TextDocument(Uuid::v4()->toString(), 'x marks the spot'),
+            new TextDocument(Uuid::v4()->toString(), 'find x here'),
+            new TextDocument(Uuid::v4()->toString(), 'no match'),
         ];
 
         $result = iterator_to_array($transformer->transform($documents));
@@ -129,7 +129,7 @@ final class TextReplaceTransformerTest extends TestCase
     public function testReplaceCaseSensitive()
     {
         $transformer = new TextReplaceTransformer('Hello', 'Goodbye');
-        $document = new TextDocument(Uuid::v4(), 'Hello hello HELLO');
+        $document = new TextDocument(Uuid::v4()->toString(), 'Hello hello HELLO');
 
         $result = iterator_to_array($transformer->transform([$document]));
 
@@ -140,7 +140,7 @@ final class TextReplaceTransformerTest extends TestCase
     public function testReplaceHandlesNoMatch()
     {
         $transformer = new TextReplaceTransformer('notfound', 'replacement');
-        $document = new TextDocument(Uuid::v4(), 'original text');
+        $document = new TextDocument(Uuid::v4()->toString(), 'original text');
 
         $result = iterator_to_array($transformer->transform([$document]));
 
@@ -159,7 +159,7 @@ final class TextReplaceTransformerTest extends TestCase
     public function testTransformThrowsExceptionWhenSearchEqualsReplaceInOptions()
     {
         $transformer = new TextReplaceTransformer('initial', 'value');
-        $document = new TextDocument(Uuid::v4(), 'text');
+        $document = new TextDocument(Uuid::v4()->toString(), 'text');
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Search and replace strings must be different.');
@@ -181,7 +181,7 @@ final class TextReplaceTransformerTest extends TestCase
     public function testPartialOptionsUseConstructorDefaults()
     {
         $transformer = new TextReplaceTransformer('default', 'replacement');
-        $document = new TextDocument(Uuid::v4(), 'default text');
+        $document = new TextDocument(Uuid::v4()->toString(), 'default text');
 
         // Only provide search option, should use constructor's replace value
         $result = iterator_to_array($transformer->transform([$document], [

--- a/src/store/tests/Document/Transformer/TextTrimTransformerTest.php
+++ b/src/store/tests/Document/Transformer/TextTrimTransformerTest.php
@@ -34,7 +34,7 @@ final class TextTrimTransformerTest extends TestCase
     public function testTrim(string $input, string $expected)
     {
         $transformer = new TextTrimTransformer();
-        $document = new TextDocument(Uuid::v4(), $input);
+        $document = new TextDocument(Uuid::v4()->toString(), $input);
 
         $result = iterator_to_array($transformer->transform([$document]));
 
@@ -49,16 +49,16 @@ final class TextTrimTransformerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The content shall not be an empty string.');
 
-        new TextDocument(Uuid::v4(), '   ');
+        new TextDocument(Uuid::v4()->toString(), '   ');
     }
 
     public function testTrimProcessesMultipleDocuments()
     {
         $transformer = new TextTrimTransformer();
         $documents = [
-            new TextDocument(Uuid::v4(), '  first  '),
-            new TextDocument(Uuid::v4(), '  second  '),
-            new TextDocument(Uuid::v4(), '  third  '),
+            new TextDocument(Uuid::v4()->toString(), '  first  '),
+            new TextDocument(Uuid::v4()->toString(), '  second  '),
+            new TextDocument(Uuid::v4()->toString(), '  third  '),
         ];
 
         $result = iterator_to_array($transformer->transform($documents));
@@ -73,7 +73,7 @@ final class TextTrimTransformerTest extends TestCase
     {
         $transformer = new TextTrimTransformer();
         $metadata = new Metadata(['key' => 'value']);
-        $document = new TextDocument(Uuid::v4(), '  text  ', $metadata);
+        $document = new TextDocument(Uuid::v4()->toString(), '  text  ', $metadata);
 
         $result = iterator_to_array($transformer->transform([$document]));
 
@@ -85,7 +85,7 @@ final class TextTrimTransformerTest extends TestCase
     public function testTrimPreservesDocumentId()
     {
         $transformer = new TextTrimTransformer();
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $document = new TextDocument($id, '  text  ');
 
         $result = iterator_to_array($transformer->transform([$document]));

--- a/src/store/tests/Document/VectorDocumentTest.php
+++ b/src/store/tests/Document/VectorDocumentTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\Uid\Uuid;
 final class VectorDocumentTest extends TestCase
 {
     #[DataProvider('constructorIdDataProvider')]
-    public function testConstructorIdSupportsManyTypes(int|string|Uuid $id)
+    public function testConstructorIdSupportsManyTypes(int|string $id)
     {
         $document = new VectorDocument($id, new NullVector());
 
@@ -38,13 +38,12 @@ final class VectorDocumentTest extends TestCase
     {
         yield 'int' => [1];
         yield 'string' => ['id'];
-        yield 'uuid' => [Uuid::v4()];
     }
 
     #[TestDox('Creates document with required parameters only')]
     public function testConstructorWithRequiredParameters()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $vector = new Vector([0.1, 0.2, 0.3]);
 
         $document = new VectorDocument($id, $vector);
@@ -59,7 +58,7 @@ final class VectorDocumentTest extends TestCase
     #[TestDox('Creates document with metadata')]
     public function testConstructorWithMetadata()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $vector = new Vector([0.1, 0.2, 0.3]);
         $metadata = new Metadata(['source' => 'test.txt', 'author' => 'John Doe']);
 
@@ -74,7 +73,7 @@ final class VectorDocumentTest extends TestCase
     #[TestDox('Creates document with all parameters including score')]
     public function testConstructorWithAllParameters()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $vector = new Vector([0.1, 0.2, 0.3]);
         $metadata = new Metadata(['title' => 'Test Document']);
         $score = 0.95;
@@ -97,10 +96,9 @@ final class VectorDocumentTest extends TestCase
     #[TestDox('Handles different score values: $score')]
     public function testConstructorWithDifferentScores(?float $score)
     {
-        $id = Uuid::v4();
         $vector = new Vector([0.1, 0.2, 0.3]);
 
-        $document = new VectorDocument($id, $vector, new Metadata(), $score);
+        $document = new VectorDocument(Uuid::v4()->toString(), $vector, new Metadata(), $score);
 
         $this->assertSame($score, $document->score);
     }
@@ -108,7 +106,6 @@ final class VectorDocumentTest extends TestCase
     #[TestDox('Handles metadata with special keys')]
     public function testMetadataWithSpecialKeys()
     {
-        $id = Uuid::v4();
         $vector = new Vector([0.1, 0.2, 0.3]);
         $metadata = new Metadata([
             Metadata::KEY_PARENT_ID => 'parent-123',
@@ -117,7 +114,7 @@ final class VectorDocumentTest extends TestCase
             'custom_field' => 'custom_value',
         ]);
 
-        $document = new VectorDocument($id, $vector, $metadata);
+        $document = new VectorDocument(Uuid::v4()->toString(), $vector, $metadata);
 
         $this->assertSame($metadata, $document->metadata);
         $this->assertTrue($document->metadata->hasParentId());
@@ -129,32 +126,9 @@ final class VectorDocumentTest extends TestCase
         $this->assertSame('custom_value', $document->metadata['custom_field']);
     }
 
-    #[DataProvider('uuidProvider')]
-    #[TestDox('Accepts different UUID versions')]
-    public function testWithDifferentUuidVersions(Uuid $uuid)
-    {
-        $vector = new Vector([0.1, 0.2, 0.3]);
-
-        $document = new VectorDocument($uuid, $vector);
-
-        $this->assertSame($uuid, $document->id);
-    }
-
-    /**
-     * @return \Iterator<string, array{uuid: Uuid}>
-     */
-    public static function uuidProvider(): \Iterator
-    {
-        yield 'UUID v1' => ['uuid' => Uuid::v1()];
-        yield 'UUID v4' => ['uuid' => Uuid::v4()];
-        yield 'UUID v6' => ['uuid' => Uuid::v6()];
-        yield 'UUID v7' => ['uuid' => Uuid::v7()];
-    }
-
     #[TestDox('Handles complex nested metadata structures')]
     public function testWithComplexMetadata()
     {
-        $id = Uuid::v4();
         $vector = new Vector([0.1, 0.2, 0.3]);
         $metadata = new Metadata([
             'title' => 'Complex Document',
@@ -168,7 +142,7 @@ final class VectorDocumentTest extends TestCase
             'active' => true,
         ]);
 
-        $document = new VectorDocument($id, $vector, $metadata);
+        $document = new VectorDocument(Uuid::v4()->toString(), $vector, $metadata);
 
         $this->assertSame($metadata, $document->metadata);
         $this->assertSame('Complex Document', $document->metadata['title']);
@@ -181,10 +155,9 @@ final class VectorDocumentTest extends TestCase
     #[TestDox('Verifies vector interface methods are accessible')]
     public function testVectorInterfaceInteraction()
     {
-        $id = Uuid::v4();
         $vector = new Vector([0.1, 0.2, 0.3]);
 
-        $document = new VectorDocument($id, $vector);
+        $document = new VectorDocument(Uuid::v4()->toString(), $vector);
 
         $this->assertSame([0.1, 0.2, 0.3], $document->vector->getData());
         $this->assertSame(3, $document->vector->getDimensions());
@@ -197,8 +170,8 @@ final class VectorDocumentTest extends TestCase
         $vector1 = new Vector([0.1, 0.2, 0.3]);
         $vector2 = new Vector([0.4, 0.5, 0.6]);
 
-        $document1 = new VectorDocument(Uuid::v4(), $vector1, $metadata);
-        $document2 = new VectorDocument(Uuid::v4(), $vector2, $metadata);
+        $document1 = new VectorDocument(Uuid::v4()->toString(), $vector1, $metadata);
+        $document2 = new VectorDocument(Uuid::v4()->toString(), $vector2, $metadata);
 
         // Both documents share the same metadata instance
         $this->assertSame($metadata, $document1->metadata);
@@ -209,7 +182,7 @@ final class VectorDocumentTest extends TestCase
     #[TestDox('Documents with same values are equal but not identical')]
     public function testDocumentEquality()
     {
-        $id = Uuid::v4();
+        $id = Uuid::v4()->toString();
         $vector = new Vector([0.1, 0.2, 0.3]);
         $metadata = new Metadata(['key' => 'value']);
         $score = 0.75;

--- a/src/store/tests/Document/VectorizerTest.php
+++ b/src/store/tests/Document/VectorizerTest.php
@@ -39,9 +39,9 @@ final class VectorizerTest extends TestCase
     public function testVectorizeDocumentsWithBatchSupport()
     {
         $documents = [
-            new TextDocument(Uuid::v4(), 'First document content', new Metadata(['source' => 'test1'])),
-            new TextDocument(Uuid::v4(), 'Second document content', new Metadata(['source' => 'test2'])),
-            new TextDocument(Uuid::v4(), 'Third document content', new Metadata(['source' => 'test3'])),
+            new TextDocument(Uuid::v4()->toString(), 'First document content', new Metadata(['source' => 'test1'])),
+            new TextDocument(Uuid::v4()->toString(), 'Second document content', new Metadata(['source' => 'test2'])),
+            new TextDocument(Uuid::v4()->toString(), 'Third document content', new Metadata(['source' => 'test3'])),
         ];
 
         $vectors = [
@@ -80,7 +80,7 @@ final class VectorizerTest extends TestCase
 
     public function testVectorizeDocumentsWithSingleDocument()
     {
-        $document = new TextDocument(Uuid::v4(), 'Single document content', new Metadata(['test' => 'value']));
+        $document = new TextDocument(Uuid::v4()->toString(), 'Single document content', new Metadata(['test' => 'value']));
         $vector = new Vector([0.1, 0.2, 0.3]);
 
         $platform = PlatformTestHandler::createPlatform(new VectorResult($vector));
@@ -109,8 +109,8 @@ final class VectorizerTest extends TestCase
         $metadata2 = new Metadata(['source' => 'file2.txt', 'author' => 'Bob', 'version' => 2]);
 
         $documents = [
-            new TextDocument(Uuid::v4(), 'Content 1', $metadata1),
-            new TextDocument(Uuid::v4(), 'Content 2', $metadata2),
+            new TextDocument(Uuid::v4()->toString(), 'Content 1', $metadata1),
+            new TextDocument(Uuid::v4()->toString(), 'Content 2', $metadata2),
         ];
 
         $vectors = [
@@ -131,9 +131,9 @@ final class VectorizerTest extends TestCase
 
     public function testVectorizeDocumentsPreservesDocumentIds()
     {
-        $id1 = Uuid::v4();
-        $id2 = Uuid::v4();
-        $id3 = Uuid::v4();
+        $id1 = Uuid::v4()->toString();
+        $id2 = Uuid::v4()->toString();
+        $id3 = Uuid::v4()->toString();
 
         $documents = [
             new TextDocument($id1, 'Document 1'),
@@ -165,7 +165,7 @@ final class VectorizerTest extends TestCase
 
         for ($i = 0; $i < $count; ++$i) {
             $documents[] = new TextDocument(
-                Uuid::v4(),
+                Uuid::v4()->toString(),
                 \sprintf('Document %d content', $i),
                 new Metadata(['index' => $i])
             );
@@ -202,7 +202,7 @@ final class VectorizerTest extends TestCase
 
     public function testVectorizeDocumentsWithLargeVectors()
     {
-        $document = new TextDocument(Uuid::v4(), 'Test content');
+        $document = new TextDocument(Uuid::v4()->toString(), 'Test content');
 
         // Create a large vector with 1536 dimensions (typical for OpenAI embeddings)
         $dimensions = [];
@@ -222,9 +222,9 @@ final class VectorizerTest extends TestCase
     public function testVectorizeDocumentsWithSpecialCharacters()
     {
         $documents = [
-            new TextDocument(Uuid::v4(), 'Document with "quotes" and special chars: @#$%'),
-            new TextDocument(Uuid::v4(), "Document with\nnewlines\nand\ttabs"),
-            new TextDocument(Uuid::v4(), 'Document with émojis 🚀 and ünïcödé'),
+            new TextDocument(Uuid::v4()->toString(), 'Document with "quotes" and special chars: @#$%'),
+            new TextDocument(Uuid::v4()->toString(), "Document with\nnewlines\nand\ttabs"),
+            new TextDocument(Uuid::v4()->toString(), 'Document with émojis 🚀 and ünïcödé'),
         ];
 
         $vectors = [
@@ -248,8 +248,8 @@ final class VectorizerTest extends TestCase
     public function testVectorizeDocumentsWithoutBatchSupportUsesNonBatchMode()
     {
         $documents = [
-            new TextDocument(Uuid::v4(), 'Document 1'),
-            new TextDocument(Uuid::v4(), 'Document 2'),
+            new TextDocument(Uuid::v4()->toString(), 'Document 1'),
+            new TextDocument(Uuid::v4()->toString(), 'Document 2'),
         ];
 
         $vectors = [
@@ -440,7 +440,7 @@ final class VectorizerTest extends TestCase
     public function testVectorizeTextDocumentsPassesOptionsToInvoke()
     {
         $documents = [
-            new TextDocument(Uuid::v4(), 'Test document', new Metadata(['source' => 'test'])),
+            new TextDocument(Uuid::v4()->toString(), 'Test document', new Metadata(['source' => 'test'])),
         ];
 
         $vector = new Vector([0.1, 0.2, 0.3]);
@@ -459,7 +459,7 @@ final class VectorizerTest extends TestCase
     public function testVectorizeTextDocumentsWithEmptyOptions()
     {
         $documents = [
-            new TextDocument(Uuid::v4(), 'Test document'),
+            new TextDocument(Uuid::v4()->toString(), 'Test document'),
         ];
 
         $vector = new Vector([0.1, 0.2, 0.3]);
@@ -520,8 +520,8 @@ final class VectorizerTest extends TestCase
     public function testVectorizeTextDocumentsWithoutBatchSupportPassesOptions()
     {
         $documents = [
-            new TextDocument(Uuid::v4(), 'Document 1'),
-            new TextDocument(Uuid::v4(), 'Document 2'),
+            new TextDocument(Uuid::v4()->toString(), 'Document 1'),
+            new TextDocument(Uuid::v4()->toString(), 'Document 2'),
         ];
 
         $vectors = [

--- a/src/store/tests/Indexer/DocumentIndexerTest.php
+++ b/src/store/tests/Indexer/DocumentIndexerTest.php
@@ -29,7 +29,7 @@ final class DocumentIndexerTest extends TestCase
 {
     public function testIndexSingleDocument()
     {
-        $document = new TextDocument($id = Uuid::v4(), 'Test content');
+        $document = new TextDocument($id = Uuid::v4()->toString(), 'Test content');
         $vector = new Vector([0.1, 0.2, 0.3]);
         $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), 'text-embedding-3-small');
 
@@ -57,7 +57,7 @@ final class DocumentIndexerTest extends TestCase
     public function testIndexDocumentWithMetadata()
     {
         $metadata = new Metadata(['key' => 'value']);
-        $document = new TextDocument($id = Uuid::v4(), 'Test content', $metadata);
+        $document = new TextDocument($id = Uuid::v4()->toString(), 'Test content', $metadata);
         $vector = new Vector([0.1, 0.2, 0.3]);
         $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), 'text-embedding-3-small');
 
@@ -75,8 +75,8 @@ final class DocumentIndexerTest extends TestCase
 
     public function testIndexMultipleDocuments()
     {
-        $document1 = new TextDocument(Uuid::v4(), 'Document 1');
-        $document2 = new TextDocument(Uuid::v4(), 'Document 2');
+        $document1 = new TextDocument(Uuid::v4()->toString(), 'Document 1');
+        $document2 = new TextDocument(Uuid::v4()->toString(), 'Document 2');
         $vector1 = new Vector([0.1, 0.2, 0.3]);
         $vector2 = new Vector([0.4, 0.5, 0.6]);
 

--- a/src/store/tests/Indexer/DocumentProcessorTest.php
+++ b/src/store/tests/Indexer/DocumentProcessorTest.php
@@ -30,7 +30,7 @@ final class DocumentProcessorTest extends TestCase
 {
     public function testProcessSingleDocument()
     {
-        $document = new TextDocument($id = Uuid::v4(), 'Test content');
+        $document = new TextDocument($id = Uuid::v4()->toString(), 'Test content');
         $vector = new Vector([0.1, 0.2, 0.3]);
         $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), 'text-embedding-3-small');
 
@@ -55,7 +55,7 @@ final class DocumentProcessorTest extends TestCase
     public function testProcessDocumentWithMetadata()
     {
         $metadata = new Metadata(['key' => 'value']);
-        $document = new TextDocument($id = Uuid::v4(), 'Test content', $metadata);
+        $document = new TextDocument($id = Uuid::v4()->toString(), 'Test content', $metadata);
         $vector = new Vector([0.1, 0.2, 0.3]);
         $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), 'text-embedding-3-small');
 
@@ -71,8 +71,8 @@ final class DocumentProcessorTest extends TestCase
 
     public function testProcessMultipleDocuments()
     {
-        $document1 = new TextDocument(Uuid::v4(), 'Document 1');
-        $document2 = new TextDocument(Uuid::v4(), 'Document 2');
+        $document1 = new TextDocument(Uuid::v4()->toString(), 'Document 1');
+        $document2 = new TextDocument(Uuid::v4()->toString(), 'Document 2');
         $vector1 = new Vector([0.1, 0.2, 0.3]);
         $vector2 = new Vector([0.4, 0.5, 0.6]);
 
@@ -87,9 +87,9 @@ final class DocumentProcessorTest extends TestCase
     public function testProcessWithTextContainsFilter()
     {
         $documents = [
-            new TextDocument(Uuid::v4(), 'Regular blog post'),
-            new TextDocument(Uuid::v4(), 'Week of Symfony news roundup'),
-            new TextDocument(Uuid::v4(), 'Another regular post'),
+            new TextDocument(Uuid::v4()->toString(), 'Regular blog post'),
+            new TextDocument(Uuid::v4()->toString(), 'Week of Symfony news roundup'),
+            new TextDocument(Uuid::v4()->toString(), 'Another regular post'),
         ];
         // Filter will remove the "Week of Symfony" document, leaving 2 documents
         $vector1 = new Vector([0.1, 0.2, 0.3]);
@@ -107,10 +107,10 @@ final class DocumentProcessorTest extends TestCase
     public function testProcessWithMultipleFilters()
     {
         $documents = [
-            new TextDocument(Uuid::v4(), 'Regular blog post'),
-            new TextDocument(Uuid::v4(), 'Week of Symfony news'),
-            new TextDocument(Uuid::v4(), 'SPAM content here'),
-            new TextDocument(Uuid::v4(), 'Good content'),
+            new TextDocument(Uuid::v4()->toString(), 'Regular blog post'),
+            new TextDocument(Uuid::v4()->toString(), 'Week of Symfony news'),
+            new TextDocument(Uuid::v4()->toString(), 'SPAM content here'),
+            new TextDocument(Uuid::v4()->toString(), 'Good content'),
         ];
         // Filters will remove "Week of Symfony" and "SPAM" documents, leaving 2 documents
         $vector1 = new Vector([0.1, 0.2, 0.3]);
@@ -131,9 +131,9 @@ final class DocumentProcessorTest extends TestCase
     public function testProcessWithFiltersAndTransformers()
     {
         $documents = [
-            new TextDocument(Uuid::v4(), 'Regular blog post'),
-            new TextDocument(Uuid::v4(), 'Week of Symfony news'),
-            new TextDocument(Uuid::v4(), 'Good content'),
+            new TextDocument(Uuid::v4()->toString(), 'Regular blog post'),
+            new TextDocument(Uuid::v4()->toString(), 'Week of Symfony news'),
+            new TextDocument(Uuid::v4()->toString(), 'Good content'),
         ];
         // Filter will remove "Week of Symfony" document, leaving 2 documents
         $vector1 = new Vector([0.1, 0.2, 0.3]);
@@ -166,9 +166,9 @@ final class DocumentProcessorTest extends TestCase
     public function testProcessWithFiltersAndTransformersAppliesBoth()
     {
         $documents = [
-            new TextDocument(Uuid::v4(), 'Keep this document'),
-            new TextDocument(Uuid::v4(), 'Remove this content'),  // Will be filtered out
-            new TextDocument(Uuid::v4(), 'Also keep this one'),
+            new TextDocument(Uuid::v4()->toString(), 'Keep this document'),
+            new TextDocument(Uuid::v4()->toString(), 'Remove this content'),  // Will be filtered out
+            new TextDocument(Uuid::v4()->toString(), 'Also keep this one'),
         ];
         // Filter will remove the "Remove" document, leaving 2 documents
         $vector1 = new Vector([0.1, 0.2, 0.3]);
@@ -211,7 +211,7 @@ final class DocumentProcessorTest extends TestCase
 
     public function testProcessWithNoFilters()
     {
-        $document = new TextDocument(Uuid::v4(), 'Test content');
+        $document = new TextDocument(Uuid::v4()->toString(), 'Test content');
         $vector = new Vector([0.1, 0.2, 0.3]);
         $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), 'text-embedding-3-small');
 
@@ -238,7 +238,7 @@ final class DocumentProcessorTest extends TestCase
         $documents = [];
         $vectors = [];
         for ($i = 0; $i < 100; ++$i) {
-            $documents[] = new TextDocument(Uuid::v4(), 'Document '.$i);
+            $documents[] = new TextDocument(Uuid::v4()->toString(), 'Document '.$i);
             $vectors[] = new Vector([0.1 * $i, 0.2 * $i, 0.3 * $i]);
         }
 
@@ -257,7 +257,7 @@ final class DocumentProcessorTest extends TestCase
         $documents = [];
         $vectors = [];
         for ($i = 0; $i < 100; ++$i) {
-            $documents[] = new TextDocument(Uuid::v4(), 'Document '.$i);
+            $documents[] = new TextDocument(Uuid::v4()->toString(), 'Document '.$i);
             $vectors[] = new Vector([0.1 * $i, 0.2 * $i, 0.3 * $i]);
         }
 

--- a/src/store/tests/Indexer/SourceIndexerTest.php
+++ b/src/store/tests/Indexer/SourceIndexerTest.php
@@ -30,7 +30,7 @@ final class SourceIndexerTest extends TestCase
 {
     public function testIndexSingleDocument()
     {
-        $document = new TextDocument($id = Uuid::v4(), 'Test content');
+        $document = new TextDocument($id = Uuid::v4()->toString(), 'Test content');
         $vector = new Vector([0.1, 0.2, 0.3]);
         $loader = new InMemoryLoader([$document]);
         $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), 'text-embedding-3-small');
@@ -60,7 +60,7 @@ final class SourceIndexerTest extends TestCase
     public function testIndexDocumentWithMetadata()
     {
         $metadata = new Metadata(['key' => 'value']);
-        $document = new TextDocument($id = Uuid::v4(), 'Test content', $metadata);
+        $document = new TextDocument($id = Uuid::v4()->toString(), 'Test content', $metadata);
         $vector = new Vector([0.1, 0.2, 0.3]);
         $loader = new InMemoryLoader([$document]);
         $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(new VectorResult($vector)), 'text-embedding-3-small');
@@ -79,7 +79,7 @@ final class SourceIndexerTest extends TestCase
 
     public function testIndexWithSource()
     {
-        $document1 = new TextDocument(Uuid::v4(), 'Document 1');
+        $document1 = new TextDocument(Uuid::v4()->toString(), 'Document 1');
         $vector = new Vector([0.1, 0.2, 0.3]);
 
         $loader = new InMemoryLoader([$document1]);
@@ -94,8 +94,8 @@ final class SourceIndexerTest extends TestCase
 
     public function testIndexWithSourceArray()
     {
-        $document1 = new TextDocument(Uuid::v4(), 'Document 1');
-        $document2 = new TextDocument(Uuid::v4(), 'Document 2');
+        $document1 = new TextDocument(Uuid::v4()->toString(), 'Document 1');
+        $document2 = new TextDocument(Uuid::v4()->toString(), 'Document 2');
         $vector1 = new Vector([0.1, 0.2, 0.3]);
         $vector2 = new Vector([0.4, 0.5, 0.6]);
         $vector3 = new Vector([0.7, 0.8, 0.9]);
@@ -128,7 +128,7 @@ final class SourceIndexerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('SourceIndexer expects a string or iterable of strings');
 
-        $indexer->index(new TextDocument(Uuid::v4(), 'Test content')); /* @phpstan-ignore argument.type */
+        $indexer->index(new TextDocument(Uuid::v4()->toString(), 'Test content')); /* @phpstan-ignore argument.type */
     }
 
     public function testIndexThrowsExceptionForNonStringInIterable()
@@ -142,6 +142,6 @@ final class SourceIndexerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('SourceIndexer expects sources to be strings');
 
-        $indexer->index([new TextDocument(Uuid::v4(), 'Test content')]); /* @phpstan-ignore argument.type */
+        $indexer->index([new TextDocument(Uuid::v4()->toString(), 'Test content')]); /* @phpstan-ignore argument.type */
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

This might be a bit controversial, but while working on #1563 I stumbled on a few store implementations strongly assuming that `id` is a `Uuid` even tho we opened it to `string|int|Uuid` with #1397 - and i still thinkg `int|string` is def needed here.