### PR TITLE
[Store] Replace public properties by private+getters for BC promise

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -97,6 +97,19 @@ Store
 
  * The `Symfony\AI\Store\Document\EmbeddableDocumentInterface::getId()` can only return `string` or `int` types now.
 
+ * Properties of `Symfony\AI\Store\Document\VectorDocument` and `Symfony\AI\Store\Document\Loader\Rss\RssItem` have been changed to private, use getters instead of public properties:
+
+   ```diff
+   -$document->id;
+   -$document->metadata;
+   -$document->score;
+   -$document->vector;
+   +$document->getId();
+   +$document->getMetadata();
+   +$document->getScore();
+   +$document->getVector();
+   ```
+
 UPGRADE FROM 0.2 to 0.3
 =======================
 

--- a/examples/document/vectorizing-text-documents.php
+++ b/examples/document/vectorizing-text-documents.php
@@ -28,4 +28,4 @@ $textDocuments = [
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-large');
 $vectorDocuments = $vectorizer->vectorize($textDocuments);
 
-dump(array_map(static fn (VectorDocument $document) => $document->vector->getDimensions(), $vectorDocuments));
+dump(array_map(static fn (VectorDocument $document) => $document->getVector()->getDimensions(), $vectorDocuments));

--- a/examples/indexer/chunk-delay.php
+++ b/examples/indexer/chunk-delay.php
@@ -79,5 +79,5 @@ $results = $store->query($vector);
 
 echo "Search results for 'machine learning artificial intelligence':\n";
 foreach ($results as $i => $document) {
-    echo sprintf("%d. %s\n", $i + 1, substr($document->id, 0, 40).'...');
+    echo sprintf("%d. %s\n", $i + 1, substr($document->getId(), 0, 40).'...');
 }

--- a/examples/indexer/index-documents.php
+++ b/examples/indexer/index-documents.php
@@ -54,5 +54,5 @@ $indexer->index($documents);
 $vector = $vectorizer->vectorize('machine learning artificial intelligence');
 $results = $store->query($vector);
 foreach ($results as $i => $document) {
-    echo sprintf("%d. %s\n", $i + 1, substr($document->id, 0, 40).'...');
+    echo sprintf("%d. %s\n", $i + 1, substr($document->getId(), 0, 40).'...');
 }

--- a/examples/indexer/index-file-loader.php
+++ b/examples/indexer/index-file-loader.php
@@ -45,5 +45,5 @@ $indexer->index([
 $vector = $vectorizer->vectorize('Roman gladiator revenge');
 $results = $store->query($vector);
 foreach ($results as $i => $document) {
-    echo sprintf("%d. %s\n", $i + 1, substr($document->id, 0, 40).'...');
+    echo sprintf("%d. %s\n", $i + 1, substr($document->getId(), 0, 40).'...');
 }

--- a/examples/indexer/index-rss-loader.php
+++ b/examples/indexer/index-rss-loader.php
@@ -43,5 +43,5 @@ $indexer->index([
 $vector = $vectorizer->vectorize('Week of Symfony');
 $results = $store->query($vector);
 foreach ($results as $i => $document) {
-    echo sprintf("%d. %s\n", $i + 1, substr($document->id, 0, 40).'...');
+    echo sprintf("%d. %s\n", $i + 1, substr($document->getId(), 0, 40).'...');
 }

--- a/examples/indexer/index-with-filters.php
+++ b/examples/indexer/index-with-filters.php
@@ -75,11 +75,11 @@ $results = $store->query($vector);
 
 $filteredDocuments = 0;
 foreach ($results as $i => $document) {
-    $title = $document->metadata['title'] ?? 'Unknown';
-    $category = $document->metadata['category'] ?? 'Unknown';
+    $title = $document->getMetadata()['title'] ?? 'Unknown';
+    $category = $document->getMetadata()['category'] ?? 'Unknown';
     echo sprintf("%d. %s [%s]\n", $i + 1, $title, $category);
-    echo sprintf("   Content: %s\n", substr($document->metadata->getText() ?? 'No content', 0, 80).'...');
-    echo sprintf("   ID: %s\n\n", substr($document->id, 0, 8).'...');
+    echo sprintf("   Content: %s\n", substr($document->getMetadata()->getText() ?? 'No content', 0, 80).'...');
+    echo sprintf("   ID: %s\n\n", substr($document->getId(), 0, 8).'...');
     ++$filteredDocuments;
 }
 

--- a/examples/ollama/indexer.php
+++ b/examples/ollama/indexer.php
@@ -45,5 +45,5 @@ $indexer->index([
 $vector = $vectorizer->vectorize('Roman gladiator revenge');
 $results = $store->query($vector);
 foreach ($results as $i => $document) {
-    echo sprintf("%d. %s\n", $i + 1, substr($document->id, 0, 40).'...');
+    echo sprintf("%d. %s\n", $i + 1, substr($document->getId(), 0, 40).'...');
 }

--- a/examples/retriever/basic.php
+++ b/examples/retriever/basic.php
@@ -51,7 +51,7 @@ echo "Searching for: 'Roman gladiator revenge'\n\n";
 $results = $retriever->retrieve('Roman gladiator revenge', ['maxItems' => 1]);
 
 foreach ($results as $i => $document) {
-    echo sprintf("%d. Document ID: %s\n", $i + 1, $document->id);
-    echo sprintf("   Score: %s\n", $document->score ?? 'n/a');
-    echo sprintf("   Source: %s\n\n", $document->metadata->getSource() ?? 'unknown');
+    echo sprintf("%d. Document ID: %s\n", $i + 1, $document->getId());
+    echo sprintf("   Score: %s\n", $document->getScore() ?? 'n/a');
+    echo sprintf("   Source: %s\n\n", $document->getMetadata()->getSource() ?? 'unknown');
 }

--- a/examples/retriever/movies.php
+++ b/examples/retriever/movies.php
@@ -47,9 +47,9 @@ echo "================================================\n\n";
 $results = $retriever->retrieve('crime family mafia');
 
 foreach ($results as $i => $document) {
-    $title = $document->metadata['title'];
-    $director = $document->metadata['director'];
-    $score = $document->score;
+    $title = $document->getMetadata()['title'];
+    $director = $document->getMetadata()['director'];
+    $score = $document->getScore();
 
     echo sprintf("%d. %s (Director: %s)\n", $i + 1, $title, $director);
     echo sprintf("   Score: %.4f\n\n", $score ?? 0);

--- a/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
+++ b/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
@@ -47,7 +47,7 @@ final class SimilaritySearch
 
         $result = 'Found documents with following information:'.\PHP_EOL;
         foreach ($this->usedDocuments as $document) {
-            $result .= json_encode($document->metadata);
+            $result .= json_encode($document->getMetadata());
         }
 
         return $result;

--- a/src/agent/src/Memory/EmbeddingProvider.php
+++ b/src/agent/src/Memory/EmbeddingProvider.php
@@ -58,7 +58,7 @@ final class EmbeddingProvider implements MemoryProviderInterface
 
         $content = '';
         foreach ($foundEmbeddingContent as $document) {
-            $content .= json_encode($document->metadata);
+            $content .= json_encode($document->getMetadata());
         }
 
         if ('' === $content) {

--- a/src/agent/tests/Memory/EmbeddingProviderTest.php
+++ b/src/agent/tests/Memory/EmbeddingProviderTest.php
@@ -24,7 +24,10 @@ use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\StoreInterface;
 
 final class EmbeddingProviderTest extends TestCase
@@ -123,8 +126,8 @@ final class EmbeddingProviderTest extends TestCase
 
         $store = $this->createMock(StoreInterface::class);
         $generator = (static function () {
-            yield (object) ['metadata' => ['fact' => 'The sky is blue']];
-            yield (object) ['metadata' => ['fact' => 'Water is wet']];
+            yield new VectorDocument(123, new NullVector(), new Metadata(['fact' => 'The sky is blue']));
+            yield new VectorDocument(234, new NullVector(), new Metadata(['fact' => 'Water is wet']));
         })();
         $store->expects($this->once())
             ->method('query')

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * [BC BREAK] Change `IndexerInterface::index()` signature - input parameter is no longer nullable
  * [BC BREAK] Remove `Uuid` as possible type for `TextDocument::id` and `VectorDocument::id`, use `string` or `int` instead
  * [BC BREAK] `Symfony\AI\Store\Document\EmbeddableDocumentInterface::getId()` now returns `string|int` instead of `mixed`
+ * [BC BREAK] Reduce visibility of `VectorDocument` and `RssItem` properties to `private` and add getters
 
 0.3
 ---

--- a/src/store/src/Bridge/AzureSearch/SearchStore.php
+++ b/src/store/src/Bridge/AzureSearch/SearchStore.php
@@ -103,9 +103,9 @@ final class SearchStore implements StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return array_merge([
-            'id' => $document->id,
-            $this->vectorFieldName => $document->vector->getData(),
-        ], $document->metadata->getArrayCopy());
+            'id' => $document->getId(),
+            $this->vectorFieldName => $document->getVector()->getData(),
+        ], $document->getMetadata()->getArrayCopy());
     }
 
     /**

--- a/src/store/src/Bridge/AzureSearch/Tests/SearchStoreTest.php
+++ b/src/store/src/Bridge/AzureSearch/Tests/SearchStoreTest.php
@@ -172,10 +172,10 @@ final class SearchStoreTest extends TestCase
         $this->assertCount(2, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
         $this->assertInstanceOf(VectorDocument::class, $results[1]);
-        $this->assertEquals($uuid1, $results[0]->id);
-        $this->assertEquals($uuid2, $results[1]->id);
-        $this->assertSame('First Document', $results[0]->metadata['title']);
-        $this->assertSame('Second Document', $results[1]->metadata['title']);
+        $this->assertEquals($uuid1, $results[0]->getId());
+        $this->assertEquals($uuid2, $results[1]->getId());
+        $this->assertSame('First Document', $results[0]->getMetadata()['title']);
+        $this->assertSame('Second Document', $results[1]->getMetadata()['title']);
     }
 
     public function testQueryWithCustomVectorFieldName()
@@ -281,7 +281,7 @@ final class SearchStoreTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
-        $this->assertInstanceOf(NullVector::class, $results[0]->vector);
+        $this->assertInstanceOf(NullVector::class, $results[0]->getVector());
     }
 
     public function testRemoveWithSingleId()

--- a/src/store/src/Bridge/Cache/Store.php
+++ b/src/store/src/Bridge/Cache/Store.php
@@ -55,9 +55,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $existingVectors = $this->cache->get($this->cacheKey, static fn (): array => []);
 
         $newVectors = array_map(static fn (VectorDocument $document): array => [
-            'id' => $document->id,
-            'vector' => $document->vector->getData(),
-            'metadata' => $document->metadata->getArrayCopy(),
+            'id' => $document->getId(),
+            'vector' => $document->getVector()->getData(),
+            'metadata' => $document->getMetadata()->getArrayCopy(),
         ], $documents);
 
         $cacheItem = $this->cache->getItem($this->cacheKey);

--- a/src/store/src/Bridge/Cache/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Cache/Tests/StoreTest.php
@@ -62,7 +62,7 @@ final class StoreTest extends TestCase
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(3, $result);
-        $this->assertSame([0.1, 0.1, 0.5], $result[0]->vector->getData());
+        $this->assertSame([0.1, 0.1, 0.5], $result[0]->getVector()->getData());
 
         $store->add([
             new VectorDocument(Uuid::v4(), new Vector([0.1, 0.1, 0.5])),
@@ -72,7 +72,7 @@ final class StoreTest extends TestCase
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(6, $result);
-        $this->assertSame([0.1, 0.1, 0.5], $result[0]->vector->getData());
+        $this->assertSame([0.1, 0.1, 0.5], $result[0]->getVector()->getData());
     }
 
     public function testStoreCanSearchUsingCosineDistanceAndReturnCorrectOrder()
@@ -88,11 +88,11 @@ final class StoreTest extends TestCase
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(5, $result);
-        $this->assertSame([0.0, 0.1, 0.6], $result[0]->vector->getData());
-        $this->assertSame([0.1, 0.1, 0.5], $result[1]->vector->getData());
-        $this->assertSame([0.3, 0.1, 0.6], $result[2]->vector->getData());
-        $this->assertSame([0.3, 0.7, 0.1], $result[3]->vector->getData());
-        $this->assertSame([0.7, -0.3, 0.0], $result[4]->vector->getData());
+        $this->assertSame([0.0, 0.1, 0.6], $result[0]->getVector()->getData());
+        $this->assertSame([0.1, 0.1, 0.5], $result[1]->getVector()->getData());
+        $this->assertSame([0.3, 0.1, 0.6], $result[2]->getVector()->getData());
+        $this->assertSame([0.3, 0.7, 0.1], $result[3]->getVector()->getData());
+        $this->assertSame([0.7, -0.3, 0.0], $result[4]->getVector()->getData());
     }
 
     public function testStoreCanSearchUsingCosineDistanceWithMaxItems()
@@ -120,7 +120,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
-        $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
+        $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
     }
 
     public function testStoreCanSearchUsingEuclideanDistance()
@@ -134,7 +134,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
-        $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
+        $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
     }
 
     public function testStoreCanSearchUsingManhattanDistance()
@@ -148,7 +148,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
-        $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
+        $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
     }
 
     public function testStoreCanSearchUsingChebyshevDistance()
@@ -162,7 +162,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([1.2, 2.3, 3.4])));
 
         $this->assertCount(2, $result);
-        $this->assertSame([1.0, 2.0, 3.0], $result[0]->vector->getData());
+        $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
     }
 
     public function testStoreCanSearchWithFilter()
@@ -175,12 +175,12 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
-            'filter' => static fn (VectorDocument $doc) => 'products' === $doc->metadata['category'],
+            'filter' => static fn (VectorDocument $doc) => 'products' === $doc->getMetadata()['category'],
         ]));
 
         $this->assertCount(2, $result);
-        $this->assertSame('products', $result[0]->metadata['category']);
-        $this->assertSame('products', $result[1]->metadata['category']);
+        $this->assertSame('products', $result[0]->getMetadata()['category']);
+        $this->assertSame('products', $result[1]->getMetadata()['category']);
     }
 
     public function testStoreCanSearchWithFilterAndMaxItems()
@@ -194,13 +194,13 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
-            'filter' => static fn (VectorDocument $doc) => 'products' === $doc->metadata['category'],
+            'filter' => static fn (VectorDocument $doc) => 'products' === $doc->getMetadata()['category'],
             'maxItems' => 2,
         ]));
 
         $this->assertCount(2, $result);
-        $this->assertSame('products', $result[0]->metadata['category']);
-        $this->assertSame('products', $result[1]->metadata['category']);
+        $this->assertSame('products', $result[0]->getMetadata()['category']);
+        $this->assertSame('products', $result[1]->getMetadata()['category']);
     }
 
     public function testStoreCanSearchWithComplexFilter()
@@ -213,7 +213,7 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
-            'filter' => static fn (VectorDocument $doc) => $doc->metadata['price'] <= 150 && $doc->metadata['stock'] > 0,
+            'filter' => static fn (VectorDocument $doc) => $doc->getMetadata()['price'] <= 150 && $doc->getMetadata()['stock'] > 0,
         ]));
 
         $this->assertCount(2, $result);
@@ -229,12 +229,12 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
-            'filter' => static fn (VectorDocument $doc) => 'S' === $doc->metadata['options']['size'],
+            'filter' => static fn (VectorDocument $doc) => 'S' === $doc->getMetadata()['options']['size'],
         ]));
 
         $this->assertCount(2, $result);
-        $this->assertSame('S', $result[0]->metadata['options']['size']);
-        $this->assertSame('S', $result[1]->metadata['options']['size']);
+        $this->assertSame('S', $result[0]->getMetadata()['options']['size']);
+        $this->assertSame('S', $result[1]->getMetadata()['options']['size']);
     }
 
     public function testStoreCanSearchWithInArrayFilter()
@@ -248,7 +248,7 @@ final class StoreTest extends TestCase
 
         $allowedBrands = ['Nike', 'Adidas', 'Puma'];
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6]), [
-            'filter' => static fn (VectorDocument $doc) => \in_array($doc->metadata['brand'] ?? '', $allowedBrands, true),
+            'filter' => static fn (VectorDocument $doc) => \in_array($doc->getMetadata()['brand'] ?? '', $allowedBrands, true),
         ]));
 
         $this->assertCount(2, $result);
@@ -277,7 +277,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(2, $result);
 
-        $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->id, $result);
+        $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->getId(), $result);
         $this->assertNotContains($id2, $remainingIds);
         $this->assertContains($id1, $remainingIds);
         $this->assertContains($id3, $remainingIds);
@@ -308,7 +308,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([0.0, 0.1, 0.6])));
         $this->assertCount(2, $result);
 
-        $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->id, $result);
+        $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->getId(), $result);
         $this->assertNotContains($id2, $remainingIds);
         $this->assertNotContains($id4, $remainingIds);
         $this->assertContains($id1, $remainingIds);

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -39,10 +39,10 @@ final class Store implements StoreInterface
         $metadata = [];
         $originalDocuments = [];
         foreach ($documents as $document) {
-            $ids[] = (string) $document->id;
-            $vectors[] = $document->vector->getData();
-            $metadataCopy = $document->metadata->getArrayCopy();
-            $originalDocuments[] = $document->metadata->getText() ?? '';
+            $ids[] = (string) $document->getId();
+            $vectors[] = $document->getVector()->getData();
+            $metadataCopy = $document->getMetadata()->getArrayCopy();
+            $originalDocuments[] = $document->getMetadata()->getText() ?? '';
             unset($metadataCopy[Metadata::KEY_TEXT]);
             $metadata[] = $metadataCopy;
         }

--- a/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
@@ -170,9 +170,9 @@ final class StoreTest extends TestCase
         $documents = iterator_to_array($store->query($queryVector));
 
         $this->assertCount(2, $documents);
-        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
-        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->vector->getData());
-        $this->assertSame(['title' => 'Doc 1'], $documents[0]->metadata->getArrayCopy());
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
+        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());
+        $this->assertSame(['title' => 'Doc 1'], $documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryWithWhereFilter()
@@ -214,8 +214,8 @@ final class StoreTest extends TestCase
         $documents = iterator_to_array($store->query($queryVector, ['where' => $whereFilter]));
 
         $this->assertCount(1, $documents);
-        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
-        $this->assertSame(['title' => 'Tech Doc', 'category' => 'technology'], $documents[0]->metadata->getArrayCopy());
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
+        $this->assertSame(['title' => 'Tech Doc', 'category' => 'technology'], $documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryWithWhereDocumentFilter()
@@ -257,8 +257,8 @@ final class StoreTest extends TestCase
         $documents = iterator_to_array($store->query($queryVector, ['whereDocument' => $whereDocumentFilter]));
 
         $this->assertCount(2, $documents);
-        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
-        $this->assertSame('fedcba98-7654-3210-fedc-ba9876543210', (string) $documents[1]->id);
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
+        $this->assertSame('fedcba98-7654-3210-fedc-ba9876543210', (string) $documents[1]->getId());
     }
 
     public function testQueryWithBothFilters()
@@ -304,8 +304,8 @@ final class StoreTest extends TestCase
         ]));
 
         $this->assertCount(1, $documents);
-        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
-        $this->assertSame(['title' => 'AI Neural Networks', 'category' => 'AI', 'status' => 'published'], $documents[0]->metadata->getArrayCopy());
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
+        $this->assertSame(['title' => 'AI Neural Networks', 'category' => 'AI', 'status' => 'published'], $documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryWithEmptyResults()
@@ -378,8 +378,8 @@ final class StoreTest extends TestCase
         $documents = iterator_to_array($store->query($queryVector));
 
         $this->assertCount(2, $documents);
-        $this->assertSame(0.123, $documents[0]->score);
-        $this->assertSame(0.456, $documents[1]->score);
+        $this->assertSame(0.123, $documents[0]->getScore());
+        $this->assertSame(0.456, $documents[1]->getScore());
     }
 
     public function testQueryReturnsNullScoreWhenDistancesNotAvailable()
@@ -411,7 +411,7 @@ final class StoreTest extends TestCase
         $documents = iterator_to_array($store->query($queryVector));
 
         $this->assertCount(1, $documents);
-        $this->assertNull($documents[0]->score);
+        $this->assertNull($documents[0]->getScore());
     }
 
     /**
@@ -492,9 +492,9 @@ final class StoreTest extends TestCase
         $documents = iterator_to_array($store->query($queryVector));
 
         $this->assertCount(1, $documents);
-        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
-        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->vector->getData());
-        $this->assertSame(['title' => 'Doc 1'], $documents[0]->metadata->getArrayCopy());
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
+        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());
+        $this->assertSame(['title' => 'Doc 1'], $documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryReturnsMetadatasEmbeddingsDistanceWithOnlyDocuments()
@@ -526,9 +526,9 @@ final class StoreTest extends TestCase
         $documents = iterator_to_array($store->query($queryVector, ['include' => ['documents']]));
 
         $this->assertCount(1, $documents);
-        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
-        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->vector->getData());
-        $this->assertSame(['title' => 'Doc 1', '_text' => 'Document content here'], $documents[0]->metadata->getArrayCopy());
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
+        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());
+        $this->assertSame(['title' => 'Doc 1', '_text' => 'Document content here'], $documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryReturnsMetadatasEmbeddingsDistanceWithAll()
@@ -560,9 +560,9 @@ final class StoreTest extends TestCase
         $documents = iterator_to_array($store->query($queryVector, ['include' => ['embeddings', 'metadatas', 'distances', 'documents']]));
 
         $this->assertCount(1, $documents);
-        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
-        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->vector->getData());
-        $this->assertSame(['title' => 'Doc 1', '_text' => 'Document content here'], $documents[0]->metadata->getArrayCopy());
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
+        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());
+        $this->assertSame(['title' => 'Doc 1', '_text' => 'Document content here'], $documents[0]->getMetadata()->getArrayCopy());
     }
 
     /**
@@ -675,9 +675,9 @@ final class StoreTest extends TestCase
         $documents = iterator_to_array($store->query($queryVector, ['queryTexts' => $queryTexts]));
 
         $this->assertCount(1, $documents);
-        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->id);
-        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->vector->getData());
-        $this->assertSame(0.123, $documents[0]->score);
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
+        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());
+        $this->assertSame(0.123, $documents[0]->getScore());
     }
 
     public function testRemoveSingleDocument()

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -127,9 +127,9 @@ class Store implements ManagedStoreInterface, StoreInterface
     protected function formatVectorDocument(VectorDocument $document): array
     {
         return [
-            'id' => $document->id,
-            'metadata' => json_encode($document->metadata->getArrayCopy(), \JSON_THROW_ON_ERROR),
-            'embedding' => $document->vector->getData(),
+            'id' => $document->getId(),
+            'metadata' => json_encode($document->getMetadata()->getArrayCopy(), \JSON_THROW_ON_ERROR),
+            'embedding' => $document->getVector()->getData(),
         ];
     }
 

--- a/src/store/src/Bridge/ClickHouse/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ClickHouse/Tests/StoreTest.php
@@ -156,8 +156,8 @@ final class StoreTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
-        $this->assertSame(0.95, $results[0]->score);
-        $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
+        $this->assertSame(0.95, $results[0]->getScore());
+        $this->assertSame(['title' => 'Test Document'], $results[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryWithOptions()
@@ -228,7 +228,7 @@ final class StoreTest extends TestCase
         $results = iterator_to_array($store->query($queryVector));
 
         $this->assertCount(1, $results);
-        $this->assertSame([], $results[0]->metadata->getArrayCopy());
+        $this->assertSame([], $results[0]->getMetadata()->getArrayCopy());
     }
 
     public function testRemoveSingleDocument()

--- a/src/store/src/Bridge/Cloudflare/Store.php
+++ b/src/store/src/Bridge/Cloudflare/Store.php
@@ -134,9 +134,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return [
-            'id' => $document->id,
-            'values' => $document->vector->getData(),
-            'metadata' => $document->metadata->getArrayCopy(),
+            'id' => $document->getId(),
+            'values' => $document->getVector()->getData(),
+            'metadata' => $document->getMetadata()->getArrayCopy(),
         ];
     }
 

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -75,13 +75,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $documentToIndex = fn (VectorDocument $document): array => [
             'index' => [
                 '_index' => $this->indexName,
-                '_id' => $document->id,
+                '_id' => $document->getId(),
             ],
         ];
 
         $documentToPayload = fn (VectorDocument $document): array => [
-            $this->vectorsField => $document->vector->getData(),
-            'metadata' => json_encode($document->metadata->getArrayCopy()),
+            $this->vectorsField => $document->getVector()->getData(),
+            'metadata' => json_encode($document->getMetadata()->getArrayCopy()),
         ];
 
         $this->request('POST', '_bulk', static function () use ($documents, $documentToIndex, $documentToPayload) {

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -70,9 +70,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
                     'table' => $this->table,
                     'id' => random_int(0, \PHP_INT_MAX),
                     'doc' => [
-                        'uuid' => $document->id,
-                        $this->field => $document->vector->getData(),
-                        'metadata' => json_encode($document->metadata->getArrayCopy()),
+                        'uuid' => $document->getId(),
+                        $this->field => $document->getVector()->getData(),
+                        'metadata' => json_encode($document->getMetadata()->getArrayCopy()),
                     ],
                 ],
             ],

--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -120,9 +120,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
 
         foreach ($documents as $document) {
-            $statement->bindValue(':id', $document->id);
-            $statement->bindValue(':metadata', json_encode($document->metadata->getArrayCopy()));
-            $statement->bindValue(':vector', json_encode($document->vector->getData()));
+            $statement->bindValue(':id', $document->getId());
+            $statement->bindValue(':metadata', json_encode($document->getMetadata()->getArrayCopy()));
+            $statement->bindValue(':vector', json_encode($document->getVector()->getData()));
 
             $statement->execute();
         }

--- a/src/store/src/Bridge/MariaDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/MariaDb/Tests/StoreTest.php
@@ -64,8 +64,8 @@ final class StoreTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
-        $this->assertSame(0.85, $results[0]->score);
-        $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
+        $this->assertSame(0.85, $results[0]->getScore());
+        $this->assertSame(['title' => 'Test Document'], $results[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryWithoutMaxScore()
@@ -112,7 +112,7 @@ final class StoreTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
-        $this->assertSame(0.95, $results[0]->score);
+        $this->assertSame(0.95, $results[0]->getScore());
     }
 
     public function testQueryWithCustomLimit()
@@ -284,9 +284,9 @@ final class StoreTest extends TestCase
         ]));
 
         $this->assertCount(1, $results);
-        $this->assertSame(0.85, $results[0]->score);
-        $this->assertSame($crawlId, $results[0]->metadata['crawlId']);
-        $this->assertSame('https://example.com', $results[0]->metadata['url']);
+        $this->assertSame(0.85, $results[0]->getScore());
+        $this->assertSame($crawlId, $results[0]->getMetadata()['crawlId']);
+        $this->assertSame('https://example.com', $results[0]->getMetadata()['url']);
     }
 
     public function testItCanDrop()

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -146,14 +146,14 @@ final class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return array_merge([
-            'id' => $document->id,
+            'id' => $document->getId(),
             $this->vectorFieldName => [
                 $this->embedder => [
-                    'embeddings' => $document->vector->getData(),
+                    'embeddings' => $document->getVector()->getData(),
                     'regenerate' => false,
                 ],
             ],
-        ], $document->metadata->getArrayCopy());
+        ], $document->getMetadata()->getArrayCopy());
     }
 
     /**

--- a/src/store/src/Bridge/Meilisearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Meilisearch/Tests/StoreTest.php
@@ -234,8 +234,8 @@ final class StoreTest extends TestCase
         $this->assertCount(2, $vectors);
         $this->assertInstanceOf(VectorDocument::class, $vectors[0]);
         $this->assertInstanceOf(VectorDocument::class, $vectors[1]);
-        $this->assertSame(0.95, $vectors[0]->score);
-        $this->assertSame(0.85, $vectors[1]->score);
+        $this->assertSame(0.95, $vectors[0]->getScore());
+        $this->assertSame(0.85, $vectors[1]->getScore());
     }
 
     public function testMetadataWithoutIDRankingandVector()
@@ -275,7 +275,7 @@ final class StoreTest extends TestCase
             'description' => 'A science fiction action film.',
         ];
 
-        $this->assertSame($expected, $vectors[0]->metadata->getArrayCopy());
+        $this->assertSame($expected, $vectors[0]->getMetadata()->getArrayCopy());
     }
 
     public function testConstructorWithValidSemanticRatio()

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -160,9 +160,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return [
-            'id' => $document->id,
-            '_metadata' => json_encode($document->metadata->getArrayCopy()),
-            $this->vectorFieldName => $document->vector->getData(),
+            'id' => $document->getId(),
+            '_metadata' => json_encode($document->getMetadata()->getArrayCopy()),
+            $this->vectorFieldName => $document->getVector()->getData(),
         ];
     }
 

--- a/src/store/src/Bridge/MongoDb/Store.php
+++ b/src/store/src/Bridge/MongoDb/Store.php
@@ -113,10 +113,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         foreach ($documents as $document) {
             $operation = [
-                ['_id' => (string) $document->id],
+                ['_id' => (string) $document->getId()],
                 array_filter([
-                    'metadata' => $document->metadata->getArrayCopy(),
-                    $this->vectorFieldName => $document->vector->getData(),
+                    'metadata' => $document->getMetadata()->getArrayCopy(),
+                    $this->vectorFieldName => $document->getVector()->getData(),
                 ]),
                 ['upsert' => true], // insert if not exists
             ];

--- a/src/store/src/Bridge/MongoDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/MongoDb/Tests/StoreTest.php
@@ -214,12 +214,12 @@ final class StoreTest extends TestCase
         $this->assertCount(2, $documents);
         $this->assertInstanceOf(VectorDocument::class, $documents[0]);
         $this->assertInstanceOf(VectorDocument::class, $documents[1]);
-        $this->assertEquals($uuid1->toString(), $documents[0]->id);
-        $this->assertEquals($uuid2->toString(), $documents[1]->id);
-        $this->assertSame(0.95, $documents[0]->score);
-        $this->assertSame(0.85, $documents[1]->score);
-        $this->assertSame('First Document', $documents[0]->metadata['title']);
-        $this->assertSame('Second Document', $documents[1]->metadata['title']);
+        $this->assertEquals($uuid1->toString(), $documents[0]->getId());
+        $this->assertEquals($uuid2->toString(), $documents[1]->getId());
+        $this->assertSame(0.95, $documents[0]->getScore());
+        $this->assertSame(0.85, $documents[1]->getScore());
+        $this->assertSame('First Document', $documents[0]->getMetadata()['title']);
+        $this->assertSame('Second Document', $documents[1]->getMetadata()['title']);
     }
 
     public function testQueryWithMinScore()
@@ -560,6 +560,6 @@ final class StoreTest extends TestCase
         $documents = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $documents);
-        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->vector->getData());
+        $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());
     }
 }

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -61,9 +61,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
             $this->request('POST', \sprintf('db/%s/query/v2', $this->databaseName), [
                 'statement' => \sprintf('CREATE (n:%s {id: $id, metadata: $metadata, %s: $embeddings}) RETURN n', $this->nodeName, $this->embeddingsField),
                 'parameters' => [
-                    'id' => $document->id,
-                    'metadata' => json_encode($document->metadata->getArrayCopy()),
-                    'embeddings' => $document->vector->getData(),
+                    'id' => $document->getId(),
+                    'metadata' => json_encode($document->getMetadata()->getArrayCopy()),
+                    'embeddings' => $document->getVector()->getData(),
                 ],
             ]);
         }

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -80,13 +80,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $documentToIndex = fn (VectorDocument $document): array => [
             'index' => [
                 '_index' => $this->indexName,
-                '_id' => $document->id,
+                '_id' => $document->getId(),
             ],
         ];
 
         $documentToPayload = fn (VectorDocument $document): array => [
-            $this->vectorsField => $document->vector->getData(),
-            'metadata' => json_encode($document->metadata->getArrayCopy()),
+            $this->vectorsField => $document->getVector()->getData(),
+            'metadata' => json_encode($document->getMetadata()->getArrayCopy()),
         ];
 
         $this->request('POST', '_bulk', static function () use ($documents, $documentToIndex, $documentToPayload) {

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -71,9 +71,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $vectors = [];
         foreach ($documents as $document) {
             $vectors[] = [
-                'id' => (string) $document->id,
-                'values' => $document->vector->getData(),
-                'metadata' => $document->metadata->getArrayCopy(),
+                'id' => (string) $document->getId(),
+                'values' => $document->getVector()->getData(),
+                'metadata' => $document->getMetadata()->getArrayCopy(),
             ];
         }
 

--- a/src/store/src/Bridge/Pinecone/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Pinecone/Tests/StoreTest.php
@@ -265,12 +265,12 @@ final class StoreTest extends TestCase
         $this->assertCount(2, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
         $this->assertInstanceOf(VectorDocument::class, $results[1]);
-        $this->assertEquals($uuid1, $results[0]->id);
-        $this->assertEquals($uuid2, $results[1]->id);
-        $this->assertSame(0.95, $results[0]->score);
-        $this->assertSame(0.85, $results[1]->score);
-        $this->assertSame('First Document', $results[0]->metadata['title']);
-        $this->assertSame('Second Document', $results[1]->metadata['title']);
+        $this->assertEquals($uuid1, $results[0]->getId());
+        $this->assertEquals($uuid2, $results[1]->getId());
+        $this->assertSame(0.95, $results[0]->getScore());
+        $this->assertSame(0.85, $results[1]->getScore());
+        $this->assertSame('First Document', $results[0]->getMetadata()['title']);
+        $this->assertSame('Second Document', $results[1]->getMetadata()['title']);
     }
 
     public function testQueryWithNamespaceAndFilter()

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -120,9 +120,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
 
         foreach ($documents as $document) {
-            $statement->bindValue(':id', $document->id);
-            $statement->bindValue(':metadata', json_encode($document->metadata->getArrayCopy(), \JSON_THROW_ON_ERROR));
-            $statement->bindValue(':vector', $this->toPgvector($document->vector));
+            $statement->bindValue(':id', $document->getId());
+            $statement->bindValue(':metadata', json_encode($document->getMetadata()->getArrayCopy(), \JSON_THROW_ON_ERROR));
+            $statement->bindValue(':vector', $this->toPgvector($document->getVector()));
 
             $statement->execute();
         }

--- a/src/store/src/Bridge/Postgres/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Postgres/Tests/StoreTest.php
@@ -157,9 +157,9 @@ final class StoreTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
-        $this->assertEquals($uuid, $results[0]->id);
-        $this->assertSame(0.95, $results[0]->score);
-        $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
+        $this->assertEquals($uuid, $results[0]->getId());
+        $this->assertSame(0.95, $results[0]->getScore());
+        $this->assertSame(['title' => 'Test Document'], $results[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryChangedDistanceMethodWithoutMaxScore()
@@ -209,9 +209,9 @@ final class StoreTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
-        $this->assertEquals($uuid, $results[0]->id);
-        $this->assertSame(0.95, $results[0]->score);
-        $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
+        $this->assertEquals($uuid, $results[0]->getId());
+        $this->assertSame(0.95, $results[0]->getScore());
+        $this->assertSame(['title' => 'Test Document'], $results[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryWithMaxScore()
@@ -523,7 +523,7 @@ final class StoreTest extends TestCase
         $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $results);
-        $this->assertSame([], $results[0]->metadata->getArrayCopy());
+        $this->assertSame([], $results[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryWithCustomWhereExpression()
@@ -683,9 +683,9 @@ final class StoreTest extends TestCase
         ]));
 
         $this->assertCount(1, $results);
-        $this->assertSame(0.85, $results[0]->score);
-        $this->assertSame($crawlId, $results[0]->metadata['crawlId']);
-        $this->assertSame('https://example.com', $results[0]->metadata['url']);
+        $this->assertSame(0.85, $results[0]->getScore());
+        $this->assertSame($crawlId, $results[0]->getMetadata()['crawlId']);
+        $this->assertSame('https://example.com', $results[0]->getMetadata()['url']);
     }
 
     public function testRemoveSingleDocument()

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -144,9 +144,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return [
-            'id' => $document->id,
-            'vector' => $document->vector->getData(),
-            'payload' => $document->metadata->getArrayCopy(),
+            'id' => $document->getId(),
+            'vector' => $document->getVector()->getData(),
+            'payload' => $document->getMetadata()->getArrayCopy(),
         ];
     }
 

--- a/src/store/src/Bridge/Qdrant/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Qdrant/Tests/StoreTest.php
@@ -164,9 +164,9 @@ final class StoreTest extends TestCase
                 'result' => [
                     'points' => [
                         [
-                            'id' => (string) $document->id,
-                            'payload' => (array) $document->metadata,
-                            'vector' => $document->vector->getData(),
+                            'id' => (string) $document->getId(),
+                            'payload' => (array) $document->getMetadata(),
+                            'vector' => $document->getVector()->getData(),
                         ],
                     ],
                 ],
@@ -298,9 +298,9 @@ final class StoreTest extends TestCase
         $this->assertCount(2, $results);
 
         foreach ($results as $result) {
-            $this->assertArrayHasKey('foo', $result->metadata);
+            $this->assertArrayHasKey('foo', $result->getMetadata());
             $this->assertTrue(
-                'bar' === $result->metadata['foo'] || (\is_array($result->metadata['foo']) && \in_array('bar', $result->metadata['foo'], true)),
+                'bar' === $result->getMetadata()['foo'] || (\is_array($result->getMetadata()['foo']) && \in_array('bar', $result->getMetadata()['foo'], true)),
                 "Value should be 'bar' or an array containing 'bar'"
             );
         }

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -89,11 +89,11 @@ class Store implements ManagedStoreInterface, StoreInterface
         $pipeline = $this->redis->multi(\Redis::PIPELINE);
 
         foreach ($documents as $document) {
-            $key = $this->keyPrefix.$document->id;
+            $key = $this->keyPrefix.$document->getId();
             $data = [
-                'id' => $document->id,
-                'metadata' => $document->metadata->getArrayCopy(),
-                'embedding' => $document->vector->getData(),
+                'id' => $document->getId(),
+                'metadata' => $document->getMetadata()->getArrayCopy(),
+                'embedding' => $document->getVector()->getData(),
             ];
 
             $pipeline->rawCommand('JSON.SET', $key, '$', json_encode($data, \JSON_THROW_ON_ERROR));

--- a/src/store/src/Bridge/Redis/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Redis/Tests/StoreTest.php
@@ -130,9 +130,9 @@ final class StoreTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
-        $this->assertEquals($uuid, $results[0]->id);
-        $this->assertSame(0.95, $results[0]->score);
-        $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
+        $this->assertEquals($uuid, $results[0]->getId());
+        $this->assertSame(0.95, $results[0]->getScore());
+        $this->assertSame(['title' => 'Test Document'], $results[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryChangedDistanceMethodWithoutMaxScore()
@@ -169,9 +169,9 @@ final class StoreTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
-        $this->assertEquals($uuid, $results[0]->id);
-        $this->assertSame(0.95, $results[0]->score);
-        $this->assertSame(['title' => 'Test Document'], $results[0]->metadata->getArrayCopy());
+        $this->assertEquals($uuid, $results[0]->getId());
+        $this->assertSame(0.95, $results[0]->getScore());
+        $this->assertSame(['title' => 'Test Document'], $results[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryWithMaxScore()
@@ -304,7 +304,7 @@ final class StoreTest extends TestCase
         $results = iterator_to_array($store->query(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(1, $results);
-        $this->assertSame([], $results[0]->metadata->getArrayCopy());
+        $this->assertSame([], $results[0]->getMetadata()->getArrayCopy());
     }
 
     public function testQueryFailureThrowsRuntimeException()

--- a/src/store/src/Bridge/Supabase/Store.php
+++ b/src/store/src/Bridge/Supabase/Store.php
@@ -59,14 +59,14 @@ final class Store implements StoreInterface
         $rows = [];
 
         foreach ($documents as $document) {
-            if (\count($document->vector->getData()) !== $this->vectorDimension) {
+            if (\count($document->getVector()->getData()) !== $this->vectorDimension) {
                 continue;
             }
 
             $rows[] = [
-                'id' => $document->id,
-                $this->vectorFieldName => $document->vector->getData(),
-                'metadata' => $document->metadata->getArrayCopy(),
+                'id' => $document->getId(),
+                $this->vectorFieldName => $document->getVector()->getData(),
+                'metadata' => $document->getMetadata()->getArrayCopy(),
             ];
         }
 

--- a/src/store/src/Bridge/Supabase/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Supabase/Tests/StoreTest.php
@@ -144,10 +144,10 @@ class StoreTest extends TestCase
 
         $this->assertCount(1, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
-        $this->assertSame($uuid, $result[0]->id);
-        $this->assertSame([0.5, 0.6, 0.7], $result[0]->vector->getData());
-        $this->assertSame(['category' => 'test'], $result[0]->metadata->getArrayCopy());
-        $this->assertSame(0.85, $result[0]->score);
+        $this->assertSame($uuid, $result[0]->getId());
+        $this->assertSame([0.5, 0.6, 0.7], $result[0]->getVector()->getData());
+        $this->assertSame(['category' => 'test'], $result[0]->getMetadata()->getArrayCopy());
+        $this->assertSame(0.85, $result[0]->getScore());
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
@@ -176,15 +176,15 @@ class StoreTest extends TestCase
 
         $this->assertCount(2, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
-        $this->assertSame($uuid1, $result[0]->id);
-        $this->assertSame([0.1, 0.2], $result[0]->vector->getData());
-        $this->assertSame(0.95, $result[0]->score);
-        $this->assertSame(['type' => 'first'], $result[0]->metadata->getArrayCopy());
+        $this->assertSame($uuid1, $result[0]->getId());
+        $this->assertSame([0.1, 0.2], $result[0]->getVector()->getData());
+        $this->assertSame(0.95, $result[0]->getScore());
+        $this->assertSame(['type' => 'first'], $result[0]->getMetadata()->getArrayCopy());
         $this->assertInstanceOf(VectorDocument::class, $result[1]);
-        $this->assertSame($uuid2, $result[1]->id);
-        $this->assertSame([0.3, 0.4], $result[1]->vector->getData());
-        $this->assertSame(0.85, $result[1]->score);
-        $this->assertSame(['type' => 'second'], $result[1]->metadata->getArrayCopy());
+        $this->assertSame($uuid2, $result[1]->getId());
+        $this->assertSame([0.3, 0.4], $result[1]->getVector()->getData());
+        $this->assertSame(0.85, $result[1]->getScore());
+        $this->assertSame(['type' => 'second'], $result[1]->getMetadata()->getArrayCopy());
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
@@ -206,12 +206,12 @@ class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new Vector([1.0, 2.0, 3.0])));
 
         $document = $result[0];
-        $metadata = $document->metadata->getArrayCopy();
+        $metadata = $document->getMetadata()->getArrayCopy();
         $this->assertCount(1, $result);
         $this->assertInstanceOf(VectorDocument::class, $document);
-        $this->assertSame($uuid, $document->id);
-        $this->assertSame([0.1, 0.2, 0.3, 0.4], $document->vector->getData());
-        $this->assertSame(0.92, $document->score);
+        $this->assertSame($uuid, $document->getId());
+        $this->assertSame([0.1, 0.2, 0.3, 0.4], $document->getVector()->getData());
+        $this->assertSame(0.92, $document->getScore());
         $this->assertSame('Test Document', $metadata['title']);
         $this->assertSame(['ai', 'test'], $metadata['tags']);
         $this->assertSame(0.92, $metadata['score']);

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -136,10 +136,10 @@ class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return [
-            'id' => $document->id,
-            $this->vectorFieldName => $document->vector->getData(),
-            '_metadata' => array_merge($document->metadata->getArrayCopy(), [
-                '_id' => $document->id,
+            'id' => $document->getId(),
+            $this->vectorFieldName => $document->getVector()->getData(),
+            '_metadata' => array_merge($document->getMetadata()->getArrayCopy(), [
+                '_id' => $document->getId(),
             ]),
         ];
     }

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -124,9 +124,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
     private function convertToIndexableArray(VectorDocument $document): array
     {
         return [
-            'id' => $document->id,
-            $this->vectorFieldName => $document->vector->getData(),
-            'metadata' => json_encode($document->metadata->getArrayCopy()),
+            'id' => $document->getId(),
+            $this->vectorFieldName => $document->getVector()->getData(),
+            'metadata' => json_encode($document->getMetadata()->getArrayCopy()),
         ];
     }
 

--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -125,12 +125,12 @@ final class Store implements ManagedStoreInterface, StoreInterface
     {
         return [
             'class' => $this->collection,
-            'id' => $document->id,
-            'vector' => $document->vector->getData(),
+            'id' => $document->getId(),
+            'vector' => $document->getVector()->getData(),
             'properties' => [
-                'uuid' => $document->id,
-                'vector' => $document->vector->getData(),
-                '_metadata' => json_encode($document->metadata->getArrayCopy()),
+                'uuid' => $document->getId(),
+                'vector' => $document->getVector()->getData(),
+                '_metadata' => json_encode($document->getMetadata()->getArrayCopy()),
             ],
         ];
     }

--- a/src/store/src/Command/RetrieveCommand.php
+++ b/src/store/src/Command/RetrieveCommand.php
@@ -56,17 +56,17 @@ final class RetrieveCommand extends Command
             ->addArgument('query', InputArgument::OPTIONAL, 'Search query')
             ->addOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Maximum number of results to return', '10')
             ->setHelp(<<<'EOF'
-The <info>%command.name%</info> command retrieves documents from a store using the specified retriever.
+                The <info>%command.name%</info> command retrieves documents from a store using the specified retriever.
 
-Basic usage:
-    <info>php %command.full_name% blog "search query"</info>
+                Basic usage:
+                    <info>php %command.full_name% blog "search query"</info>
 
-Interactive mode (prompts for query):
-    <info>php %command.full_name% blog</info>
+                Interactive mode (prompts for query):
+                    <info>php %command.full_name% blog</info>
 
-Limit results:
-    <info>php %command.full_name% blog "search query" --limit=5</info>
-EOF
+                Limit results:
+                    <info>php %command.full_name% blog "search query" --limit=5</info>
+                EOF
             )
         ;
     }
@@ -106,16 +106,16 @@ EOF
                 $io->section(\sprintf('Result #%d', $count));
 
                 $tableData = [
-                    ['ID', (string) $document->id],
-                    ['Score', $document->score ?? 'n/a'],
+                    ['ID', (string) $document->getId()],
+                    ['Score', $document->getScore() ?? 'n/a'],
                 ];
 
-                if ($document->metadata->hasSource()) {
-                    $tableData[] = ['Source', $document->metadata->getSource()];
+                if ($document->getMetadata()->hasSource()) {
+                    $tableData[] = ['Source', $document->getMetadata()->getSource()];
                 }
 
-                if ($document->metadata->hasText()) {
-                    $text = $document->metadata->getText();
+                if ($document->getMetadata()->hasText()) {
+                    $text = $document->getMetadata()->getText();
                     if (\strlen($text) > 200) {
                         $text = substr($text, 0, 200).'...';
                     }

--- a/src/store/src/Distance/DistanceCalculator.php
+++ b/src/store/src/Distance/DistanceCalculator.php
@@ -70,7 +70,7 @@ final class DistanceCalculator
 
     private function cosineSimilarity(VectorDocument $embedding, Vector $against): float
     {
-        $currentEmbeddingVectors = $embedding->vector->getData();
+        $currentEmbeddingVectors = $embedding->getVector()->getData();
 
         $dotProduct = array_sum(array: array_map(
             static fn (float $a, float $b): float => $a * $b,
@@ -102,7 +102,7 @@ final class DistanceCalculator
     {
         return sqrt(array_sum(array_map(
             static fn (float $a, float $b): float => ($a - $b) ** 2,
-            $embedding->vector->getData(),
+            $embedding->getVector()->getData(),
             $against->getData(),
         )));
     }
@@ -111,7 +111,7 @@ final class DistanceCalculator
     {
         return array_sum(array_map(
             static fn (float $a, float $b): float => abs($a - $b),
-            $embedding->vector->getData(),
+            $embedding->getVector()->getData(),
             $against->getData(),
         ));
     }
@@ -120,7 +120,7 @@ final class DistanceCalculator
     {
         $embeddingsAsPower = array_map(
             static fn (float $currentValue, float $againstValue): float => abs($currentValue - $againstValue),
-            $embedding->vector->getData(),
+            $embedding->getVector()->getData(),
             $against->getData(),
         );
 

--- a/src/store/src/Document/Loader/Rss/RssItem.php
+++ b/src/store/src/Document/Loader/Rss/RssItem.php
@@ -19,26 +19,26 @@ use Symfony\Component\Uid\Uuid;
 final class RssItem
 {
     public function __construct(
-        public readonly Uuid $id,
-        public readonly string $title,
-        public readonly string $link,
-        public readonly \DateTimeImmutable $date,
-        public readonly string $description,
-        public readonly ?string $author,
-        public readonly ?string $content,
+        private readonly Uuid $id,
+        private readonly string $title,
+        private readonly string $link,
+        private readonly \DateTimeImmutable $date,
+        private readonly string $description,
+        private readonly ?string $author,
+        private readonly ?string $content,
     ) {
     }
 
     public function toString(): string
     {
-        return trim(<<<EOD
-Title: {$this->title}
-Date: {$this->date->format('Y-m-d H:i')}
-Link: {$this->link}
-Description: {$this->description}
+        return <<<EOD
+            Title: {$this->title}
+            Date: {$this->date->format('Y-m-d H:i')}
+            Link: {$this->link}
+            Description: {$this->description}
 
-{$this->content}
-EOD);
+            {$this->content}
+            EOD;
     }
 
     /**

--- a/src/store/src/Document/VectorDocument.php
+++ b/src/store/src/Document/VectorDocument.php
@@ -19,10 +19,10 @@ use Symfony\AI\Platform\Vector\VectorInterface;
 final class VectorDocument
 {
     public function __construct(
-        public readonly int|string $id,
-        public readonly VectorInterface $vector,
-        public readonly Metadata $metadata = new Metadata(),
-        public readonly ?float $score = null,
+        private readonly int|string $id,
+        private readonly VectorInterface $vector,
+        private readonly Metadata $metadata = new Metadata(),
+        private readonly ?float $score = null,
     ) {
     }
 
@@ -37,5 +37,25 @@ final class VectorDocument
             metadata: $this->metadata,
             score: $score,
         );
+    }
+
+    public function getId(): int|string
+    {
+        return $this->id;
+    }
+
+    public function getVector(): VectorInterface
+    {
+        return $this->vector;
+    }
+
+    public function getMetadata(): Metadata
+    {
+        return $this->metadata;
+    }
+
+    public function getScore(): ?float
+    {
+        return $this->score;
     }
 }

--- a/src/store/src/InMemory/Store.php
+++ b/src/store/src/InMemory/Store.php
@@ -62,7 +62,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         }
 
         $this->documents = array_values(array_filter($this->documents, static function (VectorDocument $document) use ($ids): bool {
-            return !\in_array((string) $document->id, $ids, true);
+            return !\in_array((string) $document->getId(), $ids, true);
         }));
     }
 

--- a/src/store/tests/Distance/DistanceCalculatorTest.php
+++ b/src/store/tests/Distance/DistanceCalculatorTest.php
@@ -53,7 +53,7 @@ final class DistanceCalculatorTest extends TestCase
         $this->assertCount(\count($expectedOrder), $result);
 
         foreach ($expectedOrder as $position => $expectedIndex) {
-            $metadata = $result[$position]->metadata;
+            $metadata = $result[$position]->getMetadata();
             $this->assertSame($expectedIndex, $metadata['index']);
         }
     }
@@ -123,7 +123,7 @@ final class DistanceCalculatorTest extends TestCase
         // d: [1.0, 1.0] -> sqrt(2) ≈ 1.414
         // e: [0.5, 0.5] -> sqrt(0.5) ≈ 0.707
 
-        $ids = array_map(static fn ($doc) => $doc->metadata['id'], $result);
+        $ids = array_map(static fn ($doc) => $doc->getMetadata()['id'], $result);
         $this->assertSame(['a', 'e', 'b'], $ids); // a is closest, then e, then b/c (same distance)
     }
 
@@ -158,12 +158,12 @@ final class DistanceCalculatorTest extends TestCase
         $result = $calculator->calculate([$orthogonalDoc, $parallelDoc], $queryVector);
 
         // Parallel vector should be first (smaller angular distance)
-        $this->assertEquals($parallelDoc->id, $result[0]->id);
-        $this->assertEquals($parallelDoc->vector, $result[0]->vector);
-        $this->assertNotNull($result[0]->score);
-        $this->assertEquals($orthogonalDoc->id, $result[1]->id);
-        $this->assertEquals($orthogonalDoc->vector, $result[1]->vector);
-        $this->assertNotNull($result[1]->score);
+        $this->assertEquals($parallelDoc->getId(), $result[0]->getId());
+        $this->assertEquals($parallelDoc->getVector(), $result[0]->getVector());
+        $this->assertNotNull($result[0]->getScore());
+        $this->assertEquals($orthogonalDoc->getId(), $result[1]->getId());
+        $this->assertEquals($orthogonalDoc->getVector(), $result[1]->getVector());
+        $this->assertNotNull($result[1]->getScore());
     }
 
     #[TestDox('Calculates Chebyshev distance using maximum absolute difference')]
@@ -180,12 +180,12 @@ final class DistanceCalculatorTest extends TestCase
         $result = $calculator->calculate([$doc1, $doc2, $doc3], $queryVector);
 
         // doc1 should be first (distance 0), doc2 second (max diff 0.5), doc3 last (max diff 3.0)
-        $this->assertEquals($doc1->id, $result[0]->id);
-        $this->assertNotNull($result[0]->score);
-        $this->assertEquals($doc2->id, $result[1]->id);
-        $this->assertNotNull($result[1]->score);
-        $this->assertEquals($doc3->id, $result[2]->id);
-        $this->assertNotNull($result[2]->score);
+        $this->assertEquals($doc1->getId(), $result[0]->getId());
+        $this->assertNotNull($result[0]->getScore());
+        $this->assertEquals($doc2->getId(), $result[1]->getId());
+        $this->assertNotNull($result[1]->getScore());
+        $this->assertEquals($doc3->getId(), $result[2]->getId());
+        $this->assertNotNull($result[2]->getScore());
     }
 
     #[TestDox('Returns empty array when no documents are provided')]
@@ -208,9 +208,9 @@ final class DistanceCalculatorTest extends TestCase
         $result = $calculator->calculate([$doc], new Vector([0.0, 0.0, 0.0]));
 
         $this->assertCount(1, $result);
-        $this->assertEquals($doc->id, $result[0]->id);
-        $this->assertEquals($doc->vector, $result[0]->vector);
-        $this->assertNotNull($result[0]->score);
+        $this->assertEquals($doc->getId(), $result[0]->getId());
+        $this->assertEquals($doc->getVector(), $result[0]->getVector());
+        $this->assertNotNull($result[0]->getScore());
     }
 
     #[TestDox('Handles high-dimensional vectors correctly')]
@@ -231,10 +231,10 @@ final class DistanceCalculatorTest extends TestCase
         $result = $calculator->calculate([$doc1, $doc2], $queryVector);
 
         // doc1 should be closer to query vector (0.15 is closer to 0.1 than to 0.2)
-        $this->assertEquals($doc1->id, $result[0]->id);
-        $this->assertNotNull($result[0]->score);
-        $this->assertEquals($doc2->id, $result[1]->id);
-        $this->assertNotNull($result[1]->score);
+        $this->assertEquals($doc1->getId(), $result[0]->getId());
+        $this->assertNotNull($result[0]->getScore());
+        $this->assertEquals($doc2->getId(), $result[1]->getId());
+        $this->assertNotNull($result[1]->getScore());
     }
 
     #[TestDox('Handles negative vector components correctly')]
@@ -251,8 +251,8 @@ final class DistanceCalculatorTest extends TestCase
         $result = $calculator->calculate([$doc1, $doc2, $doc3], $queryVector);
 
         // doc1 should be first (identical to query)
-        $this->assertEquals($doc1->id, $result[0]->id);
-        $this->assertNotNull($result[0]->score);
+        $this->assertEquals($doc1->getId(), $result[0]->getId());
+        $this->assertNotNull($result[0]->getScore());
     }
 
     #[TestDox('Returns all documents when maxItems exceeds document count')]
@@ -283,8 +283,8 @@ final class DistanceCalculatorTest extends TestCase
         $result = $calculator->calculate([$doc1, $doc2, $doc3], $queryVector);
 
         // doc3 has smallest Manhattan distance (2.0), then doc1 and doc2 (both 4.0)
-        $this->assertEquals($doc3->id, $result[0]->id);
-        $this->assertNotNull($result[0]->score);
+        $this->assertEquals($doc3->getId(), $result[0]->getId());
+        $this->assertNotNull($result[0]->getScore());
     }
 
     #[TestDox('Uses cosine distance as default strategy')]

--- a/src/store/tests/Document/VectorDocumentTest.php
+++ b/src/store/tests/Document/VectorDocumentTest.php
@@ -31,7 +31,7 @@ final class VectorDocumentTest extends TestCase
     {
         $document = new VectorDocument($id, new NullVector());
 
-        $this->assertSame($id, $document->id);
+        $this->assertSame($id, $document->getId());
     }
 
     public static function constructorIdDataProvider(): iterable
@@ -48,11 +48,11 @@ final class VectorDocumentTest extends TestCase
 
         $document = new VectorDocument($id, $vector);
 
-        $this->assertSame($id, $document->id);
-        $this->assertSame($vector, $document->vector);
-        $this->assertInstanceOf(Metadata::class, $document->metadata);
-        $this->assertCount(0, $document->metadata);
-        $this->assertNull($document->score);
+        $this->assertSame($id, $document->getId());
+        $this->assertSame($vector, $document->getVector());
+        $this->assertInstanceOf(Metadata::class, $document->getMetadata());
+        $this->assertCount(0, $document->getMetadata());
+        $this->assertNull($document->getScore());
     }
 
     #[TestDox('Creates document with metadata')]
@@ -64,10 +64,10 @@ final class VectorDocumentTest extends TestCase
 
         $document = new VectorDocument($id, $vector, $metadata);
 
-        $this->assertSame($id, $document->id);
-        $this->assertSame($vector, $document->vector);
-        $this->assertSame($metadata, $document->metadata);
-        $this->assertSame(['source' => 'test.txt', 'author' => 'John Doe'], $document->metadata->getArrayCopy());
+        $this->assertSame($id, $document->getId());
+        $this->assertSame($vector, $document->getVector());
+        $this->assertSame($metadata, $document->getMetadata());
+        $this->assertSame(['source' => 'test.txt', 'author' => 'John Doe'], $document->getMetadata()->getArrayCopy());
     }
 
     #[TestDox('Creates document with all parameters including score')]
@@ -80,10 +80,10 @@ final class VectorDocumentTest extends TestCase
 
         $document = new VectorDocument($id, $vector, $metadata, $score);
 
-        $this->assertSame($id, $document->id);
-        $this->assertSame($vector, $document->vector);
-        $this->assertSame($metadata, $document->metadata);
-        $this->assertSame($score, $document->score);
+        $this->assertSame($id, $document->getId());
+        $this->assertSame($vector, $document->getVector());
+        $this->assertSame($metadata, $document->getMetadata());
+        $this->assertSame($score, $document->getScore());
     }
 
     #[TestWith([null])]
@@ -100,7 +100,7 @@ final class VectorDocumentTest extends TestCase
 
         $document = new VectorDocument(Uuid::v4()->toString(), $vector, new Metadata(), $score);
 
-        $this->assertSame($score, $document->score);
+        $this->assertSame($score, $document->getScore());
     }
 
     #[TestDox('Handles metadata with special keys')]
@@ -116,14 +116,14 @@ final class VectorDocumentTest extends TestCase
 
         $document = new VectorDocument(Uuid::v4()->toString(), $vector, $metadata);
 
-        $this->assertSame($metadata, $document->metadata);
-        $this->assertTrue($document->metadata->hasParentId());
-        $this->assertSame('parent-123', $document->metadata->getParentId());
-        $this->assertTrue($document->metadata->hasText());
-        $this->assertSame('Additional text information', $document->metadata->getText());
-        $this->assertTrue($document->metadata->hasSource());
-        $this->assertSame('document.pdf', $document->metadata->getSource());
-        $this->assertSame('custom_value', $document->metadata['custom_field']);
+        $this->assertSame($metadata, $document->getMetadata());
+        $this->assertTrue($document->getMetadata()->hasParentId());
+        $this->assertSame('parent-123', $document->getMetadata()->getParentId());
+        $this->assertTrue($document->getMetadata()->hasText());
+        $this->assertSame('Additional text information', $document->getMetadata()->getText());
+        $this->assertTrue($document->getMetadata()->hasSource());
+        $this->assertSame('document.pdf', $document->getMetadata()->getSource());
+        $this->assertSame('custom_value', $document->getMetadata()['custom_field']);
     }
 
     #[TestDox('Handles complex nested metadata structures')]
@@ -144,12 +144,12 @@ final class VectorDocumentTest extends TestCase
 
         $document = new VectorDocument(Uuid::v4()->toString(), $vector, $metadata);
 
-        $this->assertSame($metadata, $document->metadata);
-        $this->assertSame('Complex Document', $document->metadata['title']);
-        $this->assertSame(['ai', 'ml', 'vectors'], $document->metadata['tags']);
-        $this->assertSame(['level1' => ['level2' => 'deep value']], $document->metadata['nested']);
-        $this->assertSame(1234567890, $document->metadata['timestamp']);
-        $this->assertTrue($document->metadata['active']);
+        $this->assertSame($metadata, $document->getMetadata());
+        $this->assertSame('Complex Document', $document->getMetadata()['title']);
+        $this->assertSame(['ai', 'ml', 'vectors'], $document->getMetadata()['tags']);
+        $this->assertSame(['level1' => ['level2' => 'deep value']], $document->getMetadata()['nested']);
+        $this->assertSame(1234567890, $document->getMetadata()['timestamp']);
+        $this->assertTrue($document->getMetadata()['active']);
     }
 
     #[TestDox('Verifies vector interface methods are accessible')]
@@ -159,8 +159,8 @@ final class VectorDocumentTest extends TestCase
 
         $document = new VectorDocument(Uuid::v4()->toString(), $vector);
 
-        $this->assertSame([0.1, 0.2, 0.3], $document->vector->getData());
-        $this->assertSame(3, $document->vector->getDimensions());
+        $this->assertSame([0.1, 0.2, 0.3], $document->getVector()->getData());
+        $this->assertSame(3, $document->getVector()->getDimensions());
     }
 
     #[TestDox('Multiple documents can share the same metadata instance')]
@@ -174,9 +174,9 @@ final class VectorDocumentTest extends TestCase
         $document2 = new VectorDocument(Uuid::v4()->toString(), $vector2, $metadata);
 
         // Both documents share the same metadata instance
-        $this->assertSame($metadata, $document1->metadata);
-        $this->assertSame($metadata, $document2->metadata);
-        $this->assertSame($document1->metadata, $document2->metadata);
+        $this->assertSame($metadata, $document1->getMetadata());
+        $this->assertSame($metadata, $document2->getMetadata());
+        $this->assertSame($document1->getMetadata(), $document2->getMetadata());
     }
 
     #[TestDox('Documents with same values are equal but not identical')]
@@ -194,9 +194,9 @@ final class VectorDocumentTest extends TestCase
         $this->assertNotSame($document1, $document2);
 
         // But properties should be the same
-        $this->assertSame($document1->id, $document2->id);
-        $this->assertSame($document1->vector, $document2->vector);
-        $this->assertSame($document1->metadata, $document2->metadata);
-        $this->assertSame($document1->score, $document2->score);
+        $this->assertSame($document1->getId(), $document2->getId());
+        $this->assertSame($document1->getVector(), $document2->getVector());
+        $this->assertSame($document1->getMetadata(), $document2->getMetadata());
+        $this->assertSame($document1->getScore(), $document2->getScore());
     }
 }

--- a/src/store/tests/Document/VectorizerTest.php
+++ b/src/store/tests/Document/VectorizerTest.php
@@ -72,9 +72,9 @@ final class VectorizerTest extends TestCase
 
         foreach ($vectorDocuments as $i => $vectorDoc) {
             $this->assertInstanceOf(VectorDocument::class, $vectorDoc);
-            $this->assertSame($documents[$i]->getId(), $vectorDoc->id);
-            $this->assertEquals($vectors[$i], $vectorDoc->vector);
-            $this->assertSame($documents[$i]->getMetadata(), $vectorDoc->metadata);
+            $this->assertSame($documents[$i]->getId(), $vectorDoc->getId());
+            $this->assertEquals($vectors[$i], $vectorDoc->getVector());
+            $this->assertSame($documents[$i]->getMetadata(), $vectorDoc->getMetadata());
         }
     }
 
@@ -89,9 +89,9 @@ final class VectorizerTest extends TestCase
 
         $this->assertCount(1, $vectorDocuments);
         $this->assertInstanceOf(VectorDocument::class, $vectorDocuments[0]);
-        $this->assertSame($document->getId(), $vectorDocuments[0]->id);
-        $this->assertEquals($vector, $vectorDocuments[0]->vector);
-        $this->assertSame($document->getMetadata(), $vectorDocuments[0]->metadata);
+        $this->assertSame($document->getId(), $vectorDocuments[0]->getId());
+        $this->assertEquals($vector, $vectorDocuments[0]->getVector());
+        $this->assertSame($document->getMetadata(), $vectorDocuments[0]->getMetadata());
     }
 
     public function testVectorizeEmptyDocumentsArray()
@@ -123,10 +123,10 @@ final class VectorizerTest extends TestCase
         $vectorDocuments = $vectorizer->vectorize($documents);
 
         $this->assertCount(2, $vectorDocuments);
-        $this->assertSame($metadata1, $vectorDocuments[0]->metadata);
-        $this->assertSame($metadata2, $vectorDocuments[1]->metadata);
-        $this->assertSame(['source' => 'file1.txt', 'author' => 'Alice', 'tags' => ['important']], $vectorDocuments[0]->metadata->getArrayCopy());
-        $this->assertSame(['source' => 'file2.txt', 'author' => 'Bob', 'version' => 2], $vectorDocuments[1]->metadata->getArrayCopy());
+        $this->assertSame($metadata1, $vectorDocuments[0]->getMetadata());
+        $this->assertSame($metadata2, $vectorDocuments[1]->getMetadata());
+        $this->assertSame(['source' => 'file1.txt', 'author' => 'Alice', 'tags' => ['important']], $vectorDocuments[0]->getMetadata()->getArrayCopy());
+        $this->assertSame(['source' => 'file2.txt', 'author' => 'Bob', 'version' => 2], $vectorDocuments[1]->getMetadata()->getArrayCopy());
     }
 
     public function testVectorizeDocumentsPreservesDocumentIds()
@@ -152,9 +152,9 @@ final class VectorizerTest extends TestCase
         $vectorDocuments = $vectorizer->vectorize($documents);
 
         $this->assertCount(3, $vectorDocuments);
-        $this->assertSame($id1, $vectorDocuments[0]->id);
-        $this->assertSame($id2, $vectorDocuments[1]->id);
-        $this->assertSame($id3, $vectorDocuments[2]->id);
+        $this->assertSame($id1, $vectorDocuments[0]->getId());
+        $this->assertSame($id2, $vectorDocuments[1]->getId());
+        $this->assertSame($id3, $vectorDocuments[2]->getId());
     }
 
     #[DataProvider('provideDocumentCounts')]
@@ -182,10 +182,10 @@ final class VectorizerTest extends TestCase
 
         foreach ($vectorDocuments as $i => $vectorDoc) {
             $this->assertInstanceOf(VectorDocument::class, $vectorDoc);
-            $this->assertSame($documents[$i]->getId(), $vectorDoc->id);
-            $this->assertEquals($vectors[$i], $vectorDoc->vector);
-            $this->assertSame($documents[$i]->getMetadata(), $vectorDoc->metadata);
-            $this->assertSame(['index' => $i], $vectorDoc->metadata->getArrayCopy());
+            $this->assertSame($documents[$i]->getId(), $vectorDoc->getId());
+            $this->assertEquals($vectors[$i], $vectorDoc->getVector());
+            $this->assertSame($documents[$i]->getMetadata(), $vectorDoc->getMetadata());
+            $this->assertSame(['index' => $i], $vectorDoc->getMetadata()->getArrayCopy());
         }
     }
 
@@ -216,7 +216,7 @@ final class VectorizerTest extends TestCase
         $vectorDocuments = $vectorizer->vectorize([$document]);
 
         $this->assertCount(1, $vectorDocuments);
-        $this->assertEquals($vector, $vectorDocuments[0]->vector);
+        $this->assertEquals($vector, $vectorDocuments[0]->getVector());
     }
 
     public function testVectorizeDocumentsWithSpecialCharacters()
@@ -240,8 +240,8 @@ final class VectorizerTest extends TestCase
         $this->assertCount(3, $vectorDocuments);
 
         foreach ($vectorDocuments as $i => $vectorDoc) {
-            $this->assertSame($documents[$i]->getId(), $vectorDoc->id);
-            $this->assertEquals($vectors[$i], $vectorDoc->vector);
+            $this->assertSame($documents[$i]->getId(), $vectorDoc->getId());
+            $this->assertEquals($vectors[$i], $vectorDoc->getVector());
         }
     }
 
@@ -276,8 +276,8 @@ final class VectorizerTest extends TestCase
         $vectorDocuments = $vectorizer->vectorize($documents);
 
         $this->assertCount(2, $vectorDocuments);
-        $this->assertEquals($vectors[0], $vectorDocuments[0]->vector);
-        $this->assertEquals($vectors[1], $vectorDocuments[1]->vector);
+        $this->assertEquals($vectors[0], $vectorDocuments[0]->getVector());
+        $this->assertEquals($vectors[1], $vectorDocuments[1]->getVector());
     }
 
     public function testVectorizeString()
@@ -453,7 +453,7 @@ final class VectorizerTest extends TestCase
         $result = $vectorizer->vectorize($documents, $options);
 
         $this->assertCount(1, $result);
-        $this->assertEquals($vector, $result[0]->vector);
+        $this->assertEquals($vector, $result[0]->getVector());
     }
 
     public function testVectorizeTextDocumentsWithEmptyOptions()
@@ -471,7 +471,7 @@ final class VectorizerTest extends TestCase
         $result = $vectorizer->vectorize($documents);
 
         $this->assertCount(1, $result);
-        $this->assertEquals($vector, $result[0]->vector);
+        $this->assertEquals($vector, $result[0]->getVector());
     }
 
     public function testVectorizeStringPassesOptionsToInvoke()
@@ -550,7 +550,7 @@ final class VectorizerTest extends TestCase
         $result = $vectorizer->vectorize($documents, $options);
 
         $this->assertCount(2, $result);
-        $this->assertEquals($vectors[0], $result[0]->vector);
-        $this->assertEquals($vectors[1], $result[1]->vector);
+        $this->assertEquals($vectors[0], $result[0]->getVector());
+        $this->assertEquals($vectors[1], $result[1]->getVector());
     }
 }

--- a/src/store/tests/Indexer/DocumentIndexerTest.php
+++ b/src/store/tests/Indexer/DocumentIndexerTest.php
@@ -39,8 +39,8 @@ final class DocumentIndexerTest extends TestCase
 
         $this->assertCount(1, $store->documents);
         $this->assertInstanceOf(VectorDocument::class, $store->documents[0]);
-        $this->assertSame($id, $store->documents[0]->id);
-        $this->assertSame($vector, $store->documents[0]->vector);
+        $this->assertSame($id, $store->documents[0]->getId());
+        $this->assertSame($vector, $store->documents[0]->getVector());
     }
 
     public function testIndexEmptyDocumentList()
@@ -68,9 +68,9 @@ final class DocumentIndexerTest extends TestCase
         $this->assertSame(1, $store->addCalls);
         $this->assertCount(1, $store->documents);
         $this->assertInstanceOf(VectorDocument::class, $store->documents[0]);
-        $this->assertSame($id, $store->documents[0]->id);
-        $this->assertSame($vector, $store->documents[0]->vector);
-        $this->assertSame(['key' => 'value'], $store->documents[0]->metadata->getArrayCopy());
+        $this->assertSame($id, $store->documents[0]->getId());
+        $this->assertSame($vector, $store->documents[0]->getVector());
+        $this->assertSame(['key' => 'value'], $store->documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testIndexMultipleDocuments()

--- a/src/store/tests/Indexer/DocumentProcessorTest.php
+++ b/src/store/tests/Indexer/DocumentProcessorTest.php
@@ -38,8 +38,8 @@ final class DocumentProcessorTest extends TestCase
         $processor->process([$document]);
 
         $this->assertCount(1, $store->documents);
-        $this->assertSame($id, $store->documents[0]->id);
-        $this->assertSame($vector, $store->documents[0]->vector);
+        $this->assertSame($id, $store->documents[0]->getId());
+        $this->assertSame($vector, $store->documents[0]->getVector());
     }
 
     public function testProcessEmptyDocumentList()
@@ -64,9 +64,9 @@ final class DocumentProcessorTest extends TestCase
 
         $this->assertSame(1, $store->addCalls);
         $this->assertCount(1, $store->documents);
-        $this->assertSame($id, $store->documents[0]->id);
-        $this->assertSame($vector, $store->documents[0]->vector);
-        $this->assertSame(['key' => 'value'], $store->documents[0]->metadata->getArrayCopy());
+        $this->assertSame($id, $store->documents[0]->getId());
+        $this->assertSame($vector, $store->documents[0]->getVector());
+        $this->assertSame(['key' => 'value'], $store->documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testProcessMultipleDocuments()
@@ -157,10 +157,10 @@ final class DocumentProcessorTest extends TestCase
 
         // Should have 2 documents (filtered out "Week of Symfony"), and transformation should have occurred
         $this->assertCount(2, $store->documents);
-        $this->assertTrue($store->documents[0]->metadata['transformed']);
-        $this->assertTrue($store->documents[1]->metadata['transformed']);
-        $this->assertSame('Regular blog post', $store->documents[0]->metadata['original_content']);
-        $this->assertSame('Good content', $store->documents[1]->metadata['original_content']);
+        $this->assertTrue($store->documents[0]->getMetadata()['transformed']);
+        $this->assertTrue($store->documents[1]->getMetadata()['transformed']);
+        $this->assertSame('Regular blog post', $store->documents[0]->getMetadata()['original_content']);
+        $this->assertSame('Good content', $store->documents[1]->getMetadata()['original_content']);
     }
 
     public function testProcessWithFiltersAndTransformersAppliesBoth()
@@ -205,7 +205,7 @@ final class DocumentProcessorTest extends TestCase
 
         // Both remaining documents should be transformed
         foreach ($store->documents as $document) {
-            $this->assertTrue($document->metadata['transformed']);
+            $this->assertTrue($document->getMetadata()['transformed']);
         }
     }
 

--- a/src/store/tests/Indexer/SourceIndexerTest.php
+++ b/src/store/tests/Indexer/SourceIndexerTest.php
@@ -41,8 +41,8 @@ final class SourceIndexerTest extends TestCase
 
         $this->assertCount(1, $store->documents);
         $this->assertInstanceOf(VectorDocument::class, $store->documents[0]);
-        $this->assertSame($id, $store->documents[0]->id);
-        $this->assertSame($vector, $store->documents[0]->vector);
+        $this->assertSame($id, $store->documents[0]->getId());
+        $this->assertSame($vector, $store->documents[0]->getVector());
     }
 
     public function testIndexEmptyDocumentList()
@@ -72,9 +72,9 @@ final class SourceIndexerTest extends TestCase
         $this->assertSame(1, $store->addCalls);
         $this->assertCount(1, $store->documents);
         $this->assertInstanceOf(VectorDocument::class, $store->documents[0]);
-        $this->assertSame($id, $store->documents[0]->id);
-        $this->assertSame($vector, $store->documents[0]->vector);
-        $this->assertSame(['key' => 'value'], $store->documents[0]->metadata->getArrayCopy());
+        $this->assertSame($id, $store->documents[0]->getId());
+        $this->assertSame($vector, $store->documents[0]->getVector());
+        $this->assertSame(['key' => 'value'], $store->documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testIndexWithSource()

--- a/src/store/tests/RetrieverTest.php
+++ b/src/store/tests/RetrieverTest.php
@@ -55,8 +55,8 @@ final class RetrieverTest extends TestCase
         $this->assertCount(2, $results);
         $this->assertInstanceOf(VectorDocument::class, $results[0]);
         $this->assertInstanceOf(VectorDocument::class, $results[1]);
-        $this->assertSame('Document 1', $results[0]->metadata['title']);
-        $this->assertSame('Document 2', $results[1]->metadata['title']);
+        $this->assertSame('Document 1', $results[0]->getMetadata()['title']);
+        $this->assertSame('Document 2', $results[1]->getMetadata()['title']);
     }
 
     public function testRetrieveWithEmptyStore()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Addressing BC promise issues with public properties with `VectorDocument` and `RssItem`