### PR TITLE
[Agent] Add `HasSourcesTrait` to `Subagent`

### DIFF
--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * [BC BREAK] Rename `Symfony\AI\Agent\Toolbox\Tool\Agent` to `Symfony\AI\Agent\Toolbox\Tool\Subagent`
  * Add `MetaDataAwareTrait` to `MockResponse`, the metadata will also be set on the returned `TextResult` when calling the `toResult` function
+ * Add `HasSourcesTrait` to `Symfony\AI\Agent\Toolbox\Tool\Subagent`
 
 0.3
 ---

--- a/src/agent/src/Toolbox/Tool/Subagent.php
+++ b/src/agent/src/Toolbox/Tool/Subagent.php
@@ -12,6 +12,8 @@
 namespace Symfony\AI\Agent\Toolbox\Tool;
 
 use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Toolbox\Source\HasSourcesInterface;
+use Symfony\AI\Agent\Toolbox\Source\HasSourcesTrait;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Result\TextResult;
@@ -19,8 +21,10 @@ use Symfony\AI\Platform\Result\TextResult;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class Subagent
+final class Subagent implements HasSourcesInterface
 {
+    use HasSourcesTrait;
+
     public function __construct(
         private readonly AgentInterface $agent,
     ) {
@@ -34,6 +38,10 @@ final class Subagent
         $result = $this->agent->call(new MessageBag(Message::ofUser($message)));
 
         \assert($result instanceof TextResult);
+
+        foreach ($result->getMetadata()->get('sources', []) as $source) {
+            $this->addSource($source);
+        }
 
         return $result->getContent();
     }

--- a/src/agent/tests/Toolbox/Tool/SubagentTest.php
+++ b/src/agent/tests/Toolbox/Tool/SubagentTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Toolbox\Tool;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\MockAgent;
+use Symfony\AI\Agent\MockResponse;
+use Symfony\AI\Agent\Toolbox\Source\Source;
+use Symfony\AI\Agent\Toolbox\Tool\Subagent;
+
+final class SubagentTest extends TestCase
+{
+    private MockAgent $agent;
+    private Subagent $subagent;
+
+    protected function setUp(): void
+    {
+        $this->agent = new MockAgent();
+        $this->subagent = new Subagent($this->agent);
+    }
+
+    public function testItCallsAgentAndReturnsContent()
+    {
+        $sources = [
+            new Source('doc1', 'ref1', 'content1'),
+            new Source('doc2', 'ref2', 'content2'),
+        ];
+
+        $response = new MockResponse($responseContent = 'It will be sunny today!');
+        $response->getMetadata()->add('sources', $sources);
+
+        $this->agent->addResponse($userPrompt = 'What is the weather?', $response);
+
+        $result = ($this->subagent)($userPrompt);
+
+        $this->assertSame($responseContent, $result);
+        $this->assertSame($sources, $this->subagent->getSourceCollection()->all());
+
+        $this->agent->assertCallCount(1);
+        $this->agent->assertCalledWith($userPrompt);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1574 
| License       | MIT


This PR adds the sources of the TextResult to the [Subagent](https://github.com/symfony/ai-agent/blob/main/src/Toolbox/Tool/Subagent.php) class. This way the sources do not get lost when using an agent as a tool.