### PR TITLE
[Store][Weaviate] Add collection existence check before creation

### DIFF
--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -40,6 +40,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
             throw new InvalidArgumentException('No supported options.');
         }
 
+        if ($this->collectionExists()) {
+            return;
+        }
+
         $this->request('POST', 'v1/schema', [
             'class' => $this->collection,
         ]);
@@ -147,5 +151,22 @@ final class Store implements ManagedStoreInterface, StoreInterface
             : new Vector($data['vector']);
 
         return new VectorDocument($id, $vector, new Metadata(json_decode($data['_metadata'], true)));
+    }
+
+    private function collectionExists(): bool
+    {
+        $response = $this->request('GET', 'v1/schema', []);
+
+        if (!isset($response['classes'])) {
+            return false;
+        }
+
+        foreach ($response['classes'] as $class) {
+            if (0 === strcasecmp($class['class'], $this->collection)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/store/src/Bridge/Weaviate/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Weaviate/Tests/StoreTest.php
@@ -69,7 +69,60 @@ final class StoreTest extends TestCase
     {
         $httpClient = new MockHttpClient([
             new JsonMockResponse([
+                'classes' => [],
+            ], [
+                'http_code' => 200,
+            ]),
+            new JsonMockResponse([
                 'class' => 'test',
+            ], [
+                'http_code' => 200,
+            ]),
+        ], 'http://127.0.0.1:8080');
+
+        $store = new Store(
+            $httpClient,
+            'http://127.0.0.1:8080',
+            'test',
+            'test',
+        );
+
+        $store->setup();
+
+        $this->assertSame(2, $httpClient->getRequestsCount());
+    }
+
+    public function testStoreSetupSkipsWhenCollectionExists()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'classes' => [
+                    ['class' => 'test'],
+                ],
+            ], [
+                'http_code' => 200,
+            ]),
+        ], 'http://127.0.0.1:8080');
+
+        $store = new Store(
+            $httpClient,
+            'http://127.0.0.1:8080',
+            'test',
+            'test',
+        );
+
+        $store->setup();
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testStoreSetupSkipsWhenCollectionExistsCaseInsensitive()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'classes' => [
+                    ['class' => 'Test'],
+                ],
             ], [
                 'http_code' => 200,
             ]),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

Added a collection existence check so multiple setups with the same collection name don't crash. Used the schema list API since the GET call was case-sensitive. 
Saw that some of the other bridges already had this functionality.

Skip collection creation if it already exists, using case-insensitive matching via the schema API.
