### PR TITLE
[Chat] Add support for streaming

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -40,6 +40,9 @@ Store
    +$retriever = new Retriever($store, $vectorizer, logger: $logger);
    ```
 
+ * The `ChatInterface` now has a `stream()` method. If you implement this interface,
+   you need to add this method to your implementation.
+
 UPGRADE FROM 0.5 to 0.6
 =======================
 

--- a/docs/components/chat.rst
+++ b/docs/components/chat.rst
@@ -30,6 +30,46 @@ with a ``Symfony\AI\Agent\AgentInterface`` and a ``Symfony\AI\Chat\MessageStoreI
 
     $chat->submit(Message::ofUser('Hello'));
 
+Streaming
+---------
+
+The Chat component supports streaming responses from the LLM in real-time
+using the :method:`Symfony\\AI\\Chat\\ChatInterface::stream` method. This returns
+a :class:`Generator` that yields text chunks as they are produced by the model::
+
+    use Symfony\AI\Agent\Agent;
+    use Symfony\AI\Chat\Chat;
+    use Symfony\AI\Chat\InMemory\Store as InMemoryStore;
+    use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+    use Symfony\AI\Platform\Message\Message;
+    use Symfony\AI\Platform\Message\MessageBag;
+
+    $platform = PlatformFactory::create($apiKey);
+
+    $agent = new Agent($platform, 'gpt-4o-mini');
+    $chat = new Chat($agent, new InMemoryStore());
+
+    $chat->initiate(new MessageBag(
+        Message::forSystem('You are a helpful assistant.'),
+    ));
+
+    foreach ($chat->stream(Message::ofUser('Tell me a story about the sun')) as $chunk) {
+        echo $chunk;
+    }
+
+Once the stream is fully consumed, the assistant message is automatically
+persisted to the message store along with the user message. This means the
+conversation history is kept up-to-date without any additional code.
+
+.. note::
+
+    Due to implementations limitations, using streaming with :class:`Symfony\\AI\\Chat\\Bridge\\Session\\MessageStore` is *not* recommended.
+
+Code Examples
+~~~~~~~~~~~~~
+
+* `Streaming Chat`_
+
 You can find more advanced usage in combination with an Agent using the store for long-term context:
 
 * `External services storage with Cache`_
@@ -131,6 +171,7 @@ store and ``bin/console ai:message-store:drop`` to clean up the message store:
     $ php bin/console ai:message-store:setup symfonycon
     $ php bin/console ai:message-store:drop symfonycon
 
+.. _`Streaming Chat`: https://github.com/symfony/ai/blob/main/examples/chat/stream-chat.php
 .. _`External services storage with Cache`: https://github.com/symfony/ai/blob/main/examples/chat/persistent-chat-cache.php
 .. _`Long-term context with Doctrine DBAL`: https://github.com/symfony/ai/blob/main/examples/chat/persistent-chat-doctrine-dbal.php
 .. _`Current session context storage with HttpFoundation session`: https://github.com/symfony/ai/blob/main/examples/chat/persistent-chat-session.php

--- a/examples/chat/stream-chat.php
+++ b/examples/chat/stream-chat.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Chat\Chat;
+use Symfony\AI\Chat\InMemory\Store as InMemoryStore;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+
+$agent = new Agent($platform, 'gpt-4o-mini');
+$chat = new Chat($agent, new InMemoryStore());
+
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant. You only answer with short sentences.'),
+);
+
+$chat->initiate($messages);
+$chat->submit(Message::ofUser('My name is Christopher.'));
+
+foreach ($chat->stream(Message::ofUser('Tell me a story about the sun')) as $chunk) {
+    echo $chunk;
+}
+echo \PHP_EOL;

--- a/src/agent/src/MockAgent.php
+++ b/src/agent/src/MockAgent.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\StreamResult;
 
 /**
  * A test-friendly agent implementation that doesn't make actual AI calls.
@@ -44,7 +45,7 @@ final class MockAgent implements AgentInterface
     private array $calls = [];
 
     /**
-     * @param array<string, string|MockResponse|\Closure> $responses Predefined responses for specific inputs
+     * @param array<string, string|MockResponse|StreamResult|\Closure> $responses Predefined responses for specific inputs
      */
     public function __construct(
         array $responses = [],
@@ -80,10 +81,12 @@ final class MockAgent implements AgentInterface
             $response = $response($messages, $options, $content);
         }
 
-        // Convert response to ResultInterface
-        $result = $response instanceof MockResponse
-            ? $response->toResult()
-            : MockResponse::create($response)->toResult();
+        $result = match (true) {
+            $response instanceof MockResponse => $response->toResult(),
+            \is_string($response) => MockResponse::create($response)->toResult(),
+            $response instanceof StreamResult => $response,
+            default => throw new RuntimeException(\sprintf('Invalid response type for input "%s".', $content)),
+        };
 
         $responseText = $response instanceof MockResponse
             ? $response->getContent()

--- a/src/ai-bundle/src/Profiler/TraceableChat.php
+++ b/src/ai-bundle/src/Profiler/TraceableChat.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\MonotonicClock;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -25,33 +26,30 @@ use Symfony\Contracts\Service\ResetInterface;
  *      action: string,
  *      bag?: MessageBag,
  *      message?: UserMessage,
- *      saved_at: \DateTimeImmutable,
+ *      submitted_at?: \DateTimeImmutable,
+ *      streamed_at?: \DateTimeImmutable,
+ *      initiated_at?: \DateTimeImmutable,
  *  }
  */
 final class TraceableChat implements ChatInterface, ResetInterface
 {
     /**
-     * @var array<int, array{
-     *     action: string,
-     *     bag?: MessageBag,
-     *     message?: UserMessage,
-     *     saved_at: \DateTimeImmutable,
-     * }>
+     * @var ChatData[]
      */
     public array $calls = [];
 
     public function __construct(
         private readonly ChatInterface $chat,
-        private readonly ClockInterface $clock,
+        private readonly ClockInterface $clock = new MonotonicClock(),
     ) {
     }
 
     public function initiate(MessageBag $messages): void
     {
         $this->calls[] = [
-            'action' => __FUNCTION__,
+            'action' => 'initiate',
             'bag' => $messages,
-            'saved_at' => $this->clock->now(),
+            'initiated_at' => $this->clock->now(),
         ];
 
         $this->chat->initiate($messages);
@@ -60,12 +58,23 @@ final class TraceableChat implements ChatInterface, ResetInterface
     public function submit(UserMessage $message): AssistantMessage
     {
         $this->calls[] = [
-            'action' => __FUNCTION__,
+            'action' => 'submit',
             'message' => $message,
-            'saved_at' => $this->clock->now(),
+            'submitted_at' => $this->clock->now(),
         ];
 
         return $this->chat->submit($message);
+    }
+
+    public function stream(UserMessage $message): \Generator
+    {
+        $this->calls[] = [
+            'action' => 'stream',
+            'message' => $message,
+            'streamed_at' => $this->clock->now(),
+        ];
+
+        return $this->chat->stream($message);
     }
 
     public function reset(): void
@@ -73,6 +82,7 @@ final class TraceableChat implements ChatInterface, ResetInterface
         if ($this->chat instanceof ResetInterface) {
             $this->chat->reset();
         }
+
         $this->calls = [];
     }
 }

--- a/src/ai-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/ai-bundle/tests/Profiler/DataCollectorTest.php
@@ -175,9 +175,9 @@ class DataCollectorTest extends TestCase
         $calls = $dataCollector->getChats();
 
         $this->assertArrayHasKey('message', $calls[0]);
-        $this->assertArrayHasKey('saved_at', $calls[0]);
+        $this->assertArrayHasKey('submitted_at', $calls[0]);
         $this->assertInstanceOf(UserMessage::class, $calls[0]['message']);
-        $this->assertInstanceOf(\DateTimeImmutable::class, $calls[0]['saved_at']);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $calls[0]['submitted_at']);
     }
 
     public function testGetNameReturnsShortName()

--- a/src/ai-bundle/tests/Profiler/TraceableChatTest.php
+++ b/src/ai-bundle/tests/Profiler/TraceableChatTest.php
@@ -13,23 +13,24 @@ namespace Symfony\AI\AiBundle\Tests\Profiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\MockAgent;
 use Symfony\AI\AiBundle\Profiler\TraceableChat;
 use Symfony\AI\Chat\Chat;
 use Symfony\AI\Chat\InMemory\Store as InMemoryStore;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
-use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\Clock\MonotonicClock;
 
 final class TraceableChatTest extends TestCase
 {
-    public function testInitializationMessageBagCanBeRetrieved()
+    public function testDataCanBeCollected()
     {
-        $agent = $this->createMock(AgentInterface::class);
-        $agent->expects($this->once())->method('call')->willReturn(new TextResult('foo'));
-
-        $chat = new Chat($agent, new InMemoryStore());
+        $chat = new Chat(new MockAgent([
+            'Hello World' => 'General Kenobi',
+            'Second Hello world' => 'General Kenobi',
+            'Third Hello world' => 'General Kenobi',
+        ]), new InMemoryStore());
 
         $traceableChat = new TraceableChat($chat, new MonotonicClock());
 
@@ -43,11 +44,11 @@ final class TraceableChatTest extends TestCase
 
         $this->assertArrayHasKey('action', $traceableChat->calls[0]);
         $this->assertArrayHasKey('bag', $traceableChat->calls[0]);
-        $this->assertArrayHasKey('saved_at', $traceableChat->calls[0]);
+        $this->assertArrayHasKey('initiated_at', $traceableChat->calls[0]);
         $this->assertSame('initiate', $traceableChat->calls[0]['action']);
         $this->assertInstanceOf(MessageBag::class, $traceableChat->calls[0]['bag']);
         $this->assertCount(1, $traceableChat->calls[0]['bag']);
-        $this->assertInstanceOf(\DateTimeImmutable::class, $traceableChat->calls[0]['saved_at']);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $traceableChat->calls[0]['initiated_at']);
 
         $traceableChat->submit(Message::ofUser('Second Hello world'));
 
@@ -55,10 +56,21 @@ final class TraceableChatTest extends TestCase
 
         $this->assertArrayHasKey('action', $traceableChat->calls[1]);
         $this->assertArrayHasKey('message', $traceableChat->calls[1]);
-        $this->assertArrayHasKey('saved_at', $traceableChat->calls[1]);
+        $this->assertArrayHasKey('submitted_at', $traceableChat->calls[1]);
         $this->assertSame('submit', $traceableChat->calls[1]['action']);
         $this->assertInstanceOf(UserMessage::class, $traceableChat->calls[1]['message']);
-        $this->assertInstanceOf(\DateTimeImmutable::class, $traceableChat->calls[1]['saved_at']);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $traceableChat->calls[1]['submitted_at']);
+
+        $traceableChat->stream(Message::ofUser('Third Hello world'));
+
+        $this->assertCount(3, $traceableChat->calls);
+
+        $this->assertArrayHasKey('action', $traceableChat->calls[2]);
+        $this->assertArrayHasKey('message', $traceableChat->calls[2]);
+        $this->assertArrayHasKey('streamed_at', $traceableChat->calls[2]);
+        $this->assertSame('stream', $traceableChat->calls[2]['action']);
+        $this->assertInstanceOf(UserMessage::class, $traceableChat->calls[2]['message']);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $traceableChat->calls[2]['streamed_at']);
     }
 
     public function testResetClearsCalls()

--- a/src/chat/CHANGELOG.md
+++ b/src/chat/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.7
+---
+
+ * Add `ChatInterface::stream()` method for real-time streaming support
+
 0.4
 ---
 

--- a/src/chat/src/Chat.php
+++ b/src/chat/src/Chat.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 
 /**
@@ -51,5 +52,19 @@ final class Chat implements ChatInterface
         $this->store->save($messages);
 
         return $assistantMessage;
+    }
+
+    public function stream(UserMessage $message): \Generator
+    {
+        $messages = $this->store->load();
+        $messages->add($message);
+
+        $result = $this->agent->call($messages, ['stream' => true]);
+
+        \assert($result instanceof StreamResult);
+
+        $result->addListener(new ChatStreamListener($messages, $this->store));
+
+        yield from $result->getContent();
     }
 }

--- a/src/chat/src/ChatInterface.php
+++ b/src/chat/src/ChatInterface.php
@@ -27,4 +27,11 @@ interface ChatInterface
      * @throws ExceptionInterface When the chat submission fails due to agent errors
      */
     public function submit(UserMessage $message): AssistantMessage;
+
+    /**
+     * @return \Generator<string>
+     *
+     * @throws ExceptionInterface When the chat submission fails due to agent errors
+     */
+    public function stream(UserMessage $message): \Generator;
 }

--- a/src/chat/src/ChatStreamListener.php
+++ b/src/chat/src/ChatStreamListener.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Chat;
+
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\AbstractStreamListener;
+use Symfony\AI\Platform\Result\Stream\ChunkEvent;
+use Symfony\AI\Platform\Result\Stream\CompleteEvent;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class ChatStreamListener extends AbstractStreamListener
+{
+    private string $content = '';
+
+    public function __construct(
+        private readonly MessageBag $messages,
+        private readonly MessageStoreInterface $store,
+    ) {
+    }
+
+    public function onChunk(ChunkEvent $event): void
+    {
+        $chunk = $event->getChunk();
+
+        if (\is_string($chunk)) {
+            $this->content .= $chunk;
+        }
+    }
+
+    public function onComplete(CompleteEvent $event): void
+    {
+        $assistantMessage = Message::ofAssistant($this->content);
+        $assistantMessage->getMetadata()->merge($event->getResult()->getMetadata());
+
+        $this->messages->add($assistantMessage);
+
+        $this->store->save($this->messages);
+    }
+}

--- a/src/chat/tests/ChatStreamListenerTest.php
+++ b/src/chat/tests/ChatStreamListenerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Chat\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Chat\ChatStreamListener;
+use Symfony\AI\Chat\InMemory\Store as InMemoryStore;
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\StreamResult;
+
+final class ChatStreamListenerTest extends TestCase
+{
+    public function testItAccumulatesStringChunks()
+    {
+        $store = new InMemoryStore();
+        $messages = new MessageBag();
+        $messages->add(Message::ofUser('Hello'));
+
+        $generator = (static function () {
+            yield 'I am ';
+            yield 'doing well!';
+        })();
+
+        $stream = new StreamResult($generator);
+        $stream->addListener(new ChatStreamListener($messages, $store));
+
+        $chunks = iterator_to_array($stream->getContent());
+
+        $this->assertSame(['I am ', 'doing well!'], $chunks);
+
+        $stored = $store->load();
+        $this->assertCount(2, $stored);
+
+        $assistantMessage = $stored->getMessages()[1];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('I am doing well!', $assistantMessage->getContent());
+    }
+
+    public function testItIgnoresNonStringChunks()
+    {
+        $store = new InMemoryStore();
+        $messages = new MessageBag();
+        $messages->add(Message::ofUser('Hello'));
+
+        $generator = (static function () {
+            yield 'Hello ';
+            yield new \stdClass();
+            yield 'World';
+        })();
+
+        $stream = new StreamResult($generator);
+        $stream->addListener(new ChatStreamListener($messages, $store));
+
+        iterator_to_array($stream->getContent());
+
+        $stored = $store->load();
+        $assistantMessage = $stored->getMessages()[1];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('Hello World', $assistantMessage->getContent());
+    }
+
+    public function testItMergesMetadataOntoAssistantMessage()
+    {
+        $store = new InMemoryStore();
+        $messages = new MessageBag();
+        $messages->add(Message::ofUser('Hello'));
+
+        $generator = (static function () {
+            yield 'Response';
+        })();
+
+        $stream = new StreamResult($generator);
+        $stream->getMetadata()->add('model', 'gpt-4');
+        $stream->addListener(new ChatStreamListener($messages, $store));
+
+        iterator_to_array($stream->getContent());
+
+        $stored = $store->load();
+        $assistantMessage = $stored->getMessages()[1];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('gpt-4', $assistantMessage->getMetadata()->get('model'));
+    }
+
+    public function testItSavesToStoreOnComplete()
+    {
+        $store = new InMemoryStore();
+        $messages = new MessageBag();
+        $messages->add(Message::ofUser('Hello'));
+
+        $generator = (static function () {
+            yield 'chunk1';
+            yield 'chunk2';
+        })();
+
+        $stream = new StreamResult($generator);
+        $stream->addListener(new ChatStreamListener($messages, $store));
+
+        // Before consuming the stream, store should be empty
+        $this->assertCount(0, $store->load());
+
+        iterator_to_array($stream->getContent());
+
+        // After consuming, store should have user + assistant messages
+        $stored = $store->load();
+        $this->assertCount(2, $stored);
+
+        $assistantMessage = $stored->getMessages()[1];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('chunk1chunk2', $assistantMessage->getContent());
+    }
+}

--- a/src/chat/tests/ChatTest.php
+++ b/src/chat/tests/ChatTest.php
@@ -19,6 +19,7 @@ use Symfony\AI\Chat\InMemory\Store as InMemoryStore;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\StreamResult;
 
 final class ChatTest extends TestCase
 {
@@ -35,13 +36,13 @@ final class ChatTest extends TestCase
 
     public function testItInitiatesChatByClearingAndSavingMessages()
     {
-        $messages = $this->createMock(MessageBag::class);
+        $agent = new MockAgent();
 
-        $this->chat->initiate($messages);
+        $chat = new Chat($agent, new InMemoryStore());
+        $chat->initiate(new MessageBag());
 
+        $agent->assertNotCalled();
         $this->assertCount(0, $this->store->load());
-
-        $this->agent->assertNotCalled();
     }
 
     public function testItSubmitsUserMessageAndReturnsAssistantMessage()
@@ -107,5 +108,66 @@ final class ChatTest extends TestCase
 
         $this->agent->assertCallCount(1);
         $this->agent->assertCalledWith($userPrompt);
+    }
+
+    public function testItStreamsResponseChunks()
+    {
+        $store = new InMemoryStore();
+
+        $agent = new MockAgent([
+            'Hello' => new StreamResult((static function (): \Generator {
+                yield 'I am ';
+                yield 'doing well!';
+            })()),
+        ], 'mock-stream');
+
+        $chat = new Chat($agent, $store);
+
+        $chunks = iterator_to_array($chat->stream(Message::ofUser('Hello')));
+
+        $this->assertSame(['I am ', 'doing well!'], $chunks);
+
+        $agent->assertCallCount(1);
+        $agent->assertCalledWith('Hello');
+
+        $stored = $store->load();
+        $this->assertCount(2, $stored);
+
+        $assistantMessage = $stored->getMessages()[1];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('I am doing well!', $assistantMessage->getContent());
+    }
+
+    public function testItStreamsAndPreservesExistingConversation()
+    {
+        $existingMessages = new MessageBag();
+        $existingMessages->add(Message::ofUser('What is the weather?'));
+        $existingMessages->add(Message::ofAssistant('I cannot provide weather information.'));
+
+        $store = new InMemoryStore();
+        $store->save($existingMessages);
+
+        $agent = new MockAgent([
+            'Can you help?' => new StreamResult((static function (): \Generator {
+                yield 'Yes, ';
+                yield 'I can!';
+            })()),
+        ], 'mock-stream');
+
+        $chat = new Chat($agent, $store);
+
+        $chunks = iterator_to_array($chat->stream(Message::ofUser('Can you help?')));
+
+        $this->assertSame(['Yes, ', 'I can!'], $chunks);
+
+        $agent->assertCallCount(1);
+        $agent->assertCalledWith('Can you help?');
+
+        $stored = $store->load();
+        $this->assertCount(4, $stored);
+
+        $assistantMessage = $stored->getMessages()[3];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('Yes, I can!', $assistantMessage->getContent());
     }
 }

--- a/src/platform/src/Message/AssistantMessage.php
+++ b/src/platform/src/Message/AssistantMessage.php
@@ -27,10 +27,10 @@ final class AssistantMessage implements MessageInterface
      * @param ?ToolCall[] $toolCalls
      */
     public function __construct(
-        private ?string $content = null,
-        private ?array $toolCalls = null,
-        private ?string $thinkingContent = null,
-        private ?string $thinkingSignature = null,
+        private readonly ?string $content = null,
+        private readonly ?array $toolCalls = null,
+        private readonly ?string $thinkingContent = null,
+        private readonly ?string $thinkingSignature = null,
     ) {
         $this->id = Uuid::v7();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Rework of #928 - Part of #1301
| License       | MIT

Solve the streaming aspect of `Chat` by using the `StreamResult` listeners, `TraceableChat` use a `return` to prevent waiting for the `Generator` to be consumed before storing informations.