### PR TITLE
[Platform] Add onResolved callback to `DeferredResult`

### DIFF
--- a/src/platform/src/Result/Stream/CallbackStreamListener.php
+++ b/src/platform/src/Result/Stream/CallbackStreamListener.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Stream;
+
+/**
+ * @author Paul Clegg <hello@clegginabox.co.uk>
+ */
+final class CallbackStreamListener extends AbstractStreamListener
+{
+    /**
+     * @param \Closure(): void $onComplete
+     */
+    public function __construct(private readonly \Closure $onComplete)
+    {
+    }
+
+    public function onComplete(CompleteEvent $event): void
+    {
+        ($this->onComplete)();
+    }
+}

--- a/src/platform/tests/Result/StreamResultTest.php
+++ b/src/platform/tests/Result/StreamResultTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Tests\Result;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Result\Stream\AbstractStreamListener;
 use Symfony\AI\Platform\Result\Stream\ChunkEvent;
+use Symfony\AI\Platform\Result\Stream\CompleteEvent;
 use Symfony\AI\Platform\Result\StreamResult;
 
 final class StreamResultTest extends TestCase
@@ -84,5 +85,35 @@ final class StreamResultTest extends TestCase
 
         // After consumption, metadata is populated
         $this->assertTrue($result->getMetadata()->has('seen_chunk2'));
+    }
+
+    public function testOnCompleteRunsWhenStreamingStopsEarly()
+    {
+        $state = new \ArrayObject(['completed' => false]);
+        $result = new StreamResult((static function () {
+            yield 'chunk1';
+            yield 'chunk2';
+        })());
+        $result->addListener(new class($state) extends AbstractStreamListener {
+            /** @param \ArrayObject<string, bool> $state */
+            public function __construct(private \ArrayObject $state) /* @phpstan-ignore property.onlyWritten */
+            {
+            }
+
+            public function onComplete(CompleteEvent $event): void
+            {
+                $this->state['completed'] = true;
+            }
+        });
+
+        $stream = $result->getContent();
+        $this->assertTrue($stream->valid());
+        $this->assertSame('chunk1', $stream->current());
+        $this->assertFalse($state['completed']);
+
+        unset($stream);
+        gc_collect_cycles();
+
+        $this->assertTrue($state['completed']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes/no
| License       | MIT

Linked to: https://github.com/symfony/ai/pull/1452

Adds `onResolved()` to `DeferredResult` - triggered when a stream is fully consumed/a request is complete. 

Provides a hook to release capacity for the load balanced platform.