### PR TITLE
[Platform][Cerebras] Add structured output and tool calling support

### DIFF
--- a/examples/cerebras/structured-output-math.php
+++ b/examples/cerebras/structured-output-math.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Cerebras\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\MathReasoning;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$dispatcher = new EventDispatcher();
+$dispatcher->addSubscriber(new PlatformSubscriber());
+
+$platform = PlatformFactory::create(env('CEREBRAS_API_KEY'), http_client(), eventDispatcher: $dispatcher);
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful math tutor. Guide the user through the solution step by step.'),
+    Message::ofUser('how can I solve 8x + 7 = -23'),
+);
+
+$result = $platform->invoke('gpt-oss-120b', $messages, ['response_format' => MathReasoning::class]);
+
+dump($result->asObject());

--- a/examples/cerebras/toolcall.php
+++ b/examples/cerebras/toolcall.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Bridge\Clock\Clock;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Cerebras\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('CEREBRAS_API_KEY'), http_client());
+
+$toolbox = new Toolbox([new Clock()], logger: logger());
+$processor = new AgentProcessor($toolbox);
+$agent = new Agent($platform, 'gpt-oss-120b', [$processor], [$processor]);
+
+$messages = new MessageBag(Message::ofUser('How many days until next Christmas?'));
+$result = $agent->call($messages);
+
+echo $result->getContent().\PHP_EOL;

--- a/src/platform/src/Bridge/Cerebras/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cerebras/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.4
+---
+
+ * Add structured output support
+ * Add tool call support
+
 0.1
 ---
 

--- a/src/platform/src/Bridge/Cerebras/Contract/ToolNormalizer.php
+++ b/src/platform/src/Bridge/Cerebras/Contract/ToolNormalizer.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cerebras\Contract;
+
+use Symfony\AI\Platform\Contract\Normalizer\ToolNormalizer as BaseToolNormalizer;
+
+/**
+ * @author Alexander Hinze <alexander@hinze.berlin>
+ */
+class ToolNormalizer extends BaseToolNormalizer
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        $array = parent::normalize($data, $format, $context);
+
+        $array['function']['parameters'] ??= ['type' => 'object'];
+
+        return $array;
+    }
+}

--- a/src/platform/src/Bridge/Cerebras/ModelCatalog.php
+++ b/src/platform/src/Bridge/Cerebras/ModelCatalog.php
@@ -31,6 +31,7 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => Model::class,
                 'capabilities' => [
                     Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_STRUCTURED,
                     Capability::OUTPUT_TEXT,
                     Capability::OUTPUT_STREAMING,
                 ],
@@ -39,6 +40,7 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => Model::class,
                 'capabilities' => [
                     Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_STRUCTURED,
                     Capability::OUTPUT_TEXT,
                     Capability::OUTPUT_STREAMING,
                 ],
@@ -47,6 +49,7 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => Model::class,
                 'capabilities' => [
                     Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_STRUCTURED,
                     Capability::OUTPUT_TEXT,
                     Capability::OUTPUT_STREAMING,
                 ],
@@ -55,6 +58,7 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => Model::class,
                 'capabilities' => [
                     Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_STRUCTURED,
                     Capability::OUTPUT_TEXT,
                     Capability::OUTPUT_STREAMING,
                 ],
@@ -63,14 +67,17 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => Model::class,
                 'capabilities' => [
                     Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_STRUCTURED,
                     Capability::OUTPUT_TEXT,
                     Capability::OUTPUT_STREAMING,
+                    Capability::TOOL_CALLING,
                 ],
             ],
             'qwen-3-235b-a22b-instruct-2507' => [
                 'class' => Model::class,
                 'capabilities' => [
                     Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_STRUCTURED,
                     Capability::OUTPUT_TEXT,
                     Capability::OUTPUT_STREAMING,
                 ],
@@ -79,6 +86,7 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => Model::class,
                 'capabilities' => [
                     Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_STRUCTURED,
                     Capability::OUTPUT_TEXT,
                     Capability::OUTPUT_STREAMING,
                 ],
@@ -87,6 +95,7 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => Model::class,
                 'capabilities' => [
                     Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_STRUCTURED,
                     Capability::OUTPUT_TEXT,
                     Capability::OUTPUT_STREAMING,
                 ],
@@ -95,8 +104,20 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => Model::class,
                 'capabilities' => [
                     Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_STRUCTURED,
                     Capability::OUTPUT_TEXT,
                     Capability::OUTPUT_STREAMING,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            'zai-glm-4.7' => [
+                'class' => Model::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::TOOL_CALLING,
                 ],
             ],
         ];

--- a/src/platform/src/Bridge/Cerebras/PlatformFactory.php
+++ b/src/platform/src/Bridge/Cerebras/PlatformFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Cerebras;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\AI\Platform\Bridge\Cerebras\Contract\ToolNormalizer;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
@@ -36,7 +37,9 @@ final class PlatformFactory
             [new ModelClient($httpClient, $apiKey)],
             [new ResultConverter()],
             $modelCatalog,
-            $contract,
+            $contract ?? Contract::create(
+                new ToolNormalizer(),
+            ),
             $eventDispatcher,
         );
     }

--- a/src/platform/src/Bridge/Cerebras/ResultConverter.php
+++ b/src/platform/src/Bridge/Cerebras/ResultConverter.php
@@ -13,10 +13,13 @@ namespace Symfony\AI\Platform\Bridge\Cerebras;
 
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model as BaseModel;
+use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 
@@ -38,15 +41,17 @@ final class ResultConverter implements ResultConverterInterface
 
         $data = $result->getData();
 
-        if (!isset($data['choices'][0]['message']['content'])) {
-            if (isset($data['type'], $data['message']) && str_ends_with($data['type'], 'error')) {
-                throw new RuntimeException(\sprintf('Cerebras API error: "%s"', $data['message']));
-            }
+        if (isset($data['type'], $data['message']) && str_ends_with($data['type'], 'error')) {
+            throw new RuntimeException(\sprintf('Cerebras API error: "%s"', $data['message']));
+        }
 
+        if (!isset($data['choices'][0])) {
             throw new RuntimeException('Response does not contain output.');
         }
 
-        return new TextResult($data['choices'][0]['message']['content']);
+        $choices = array_map($this->convertChoice(...), $data['choices']);
+
+        return 1 === \count($choices) ? $choices[0] : new ChoiceResult($choices);
     }
 
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
@@ -54,14 +59,114 @@ final class ResultConverter implements ResultConverterInterface
         return null;
     }
 
+    /**
+     * @param array{
+     *     index: int,
+     *     message: array{
+     *         role: 'assistant',
+     *         content: ?string,
+     *         tool_calls?: list<array{
+     *             id: string,
+     *             type: 'function',
+     *             function: array{
+     *                 name: string,
+     *                 arguments: string
+     *             },
+     *         }>,
+     *     },
+     *     finish_reason: 'stop'|'length'|'tool_calls',
+     * } $choice
+     */
+    private function convertChoice(array $choice): ToolCallResult|TextResult
+    {
+        if ('tool_calls' === $choice['finish_reason']) {
+            return new ToolCallResult(...array_map($this->convertToolCall(...), $choice['message']['tool_calls']));
+        }
+
+        if (\in_array($choice['finish_reason'], ['stop', 'length'], true)) {
+            return new TextResult($choice['message']['content']);
+        }
+
+        throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));
+    }
+
+    /**
+     * @param array{
+     *     id: string,
+     *     type: 'function',
+     *     function: array{
+     *         name: string,
+     *         arguments: string
+     *     }
+     * } $toolCall
+     */
+    private function convertToolCall(array $toolCall): ToolCall
+    {
+        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
+
+        return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
+    }
+
     private function convertStream(RawResultInterface $result): \Generator
     {
+        $toolCalls = [];
         foreach ($result->getDataStream() as $data) {
+            if ($this->streamIsToolCall($data)) {
+                $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);
+            }
+
+            if ([] !== $toolCalls && $this->isToolCallsStreamFinished($data)) {
+                yield new ToolCallResult(...array_map($this->convertToolCall(...), $toolCalls));
+            }
+
             if (!isset($data['choices'][0]['delta']['content'])) {
                 continue;
             }
 
             yield $data['choices'][0]['delta']['content'];
         }
+    }
+
+    /**
+     * @param array<string, mixed> $toolCalls
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    private function convertStreamToToolCalls(array $toolCalls, array $data): array
+    {
+        if (!isset($data['choices'][0]['delta']['tool_calls'])) {
+            return $toolCalls;
+        }
+
+        foreach ($data['choices'][0]['delta']['tool_calls'] as $i => $toolCall) {
+            if (isset($toolCall['id'])) {
+                $toolCalls[$i] = [
+                    'id' => $toolCall['id'],
+                    'function' => $toolCall['function'],
+                ];
+                continue;
+            }
+
+            $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
+        }
+
+        return $toolCalls;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function streamIsToolCall(array $data): bool
+    {
+        return isset($data['choices'][0]['delta']['tool_calls']);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function isToolCallsStreamFinished(array $data): bool
+    {
+        return isset($data['choices'][0]['finish_reason']) && 'tool_calls' === $data['choices'][0]['finish_reason'];
     }
 }

--- a/src/platform/src/Bridge/Cerebras/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Cerebras/Tests/ModelCatalogTest.php
@@ -24,15 +24,16 @@ final class ModelCatalogTest extends ModelCatalogTestCase
 {
     public static function modelsProvider(): iterable
     {
-        yield 'llama-4-scout-17b-16e-instruct' => ['llama-4-scout-17b-16e-instruct', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
-        yield 'llama3.1-8b' => ['llama3.1-8b', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
-        yield 'llama-3.3-70b' => ['llama-3.3-70b', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
-        yield 'llama-4-maverick-17b-128e-instruct' => ['llama-4-maverick-17b-128e-instruct', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
-        yield 'qwen-3-32b' => ['qwen-3-32b', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
-        yield 'qwen-3-235b-a22b-instruct-2507' => ['qwen-3-235b-a22b-instruct-2507', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
-        yield 'qwen-3-235b-a22b-thinking-2507' => ['qwen-3-235b-a22b-thinking-2507', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
-        yield 'qwen-3-coder-480b' => ['qwen-3-coder-480b', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
-        yield 'gpt-oss-120b' => ['gpt-oss-120b', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
+        yield 'llama-4-scout-17b-16e-instruct' => ['llama-4-scout-17b-16e-instruct', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_STRUCTURED, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
+        yield 'llama3.1-8b' => ['llama3.1-8b', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_STRUCTURED, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
+        yield 'llama-3.3-70b' => ['llama-3.3-70b', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_STRUCTURED, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
+        yield 'llama-4-maverick-17b-128e-instruct' => ['llama-4-maverick-17b-128e-instruct', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_STRUCTURED, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
+        yield 'qwen-3-32b' => ['qwen-3-32b', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_STRUCTURED, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING]];
+        yield 'qwen-3-235b-a22b-instruct-2507' => ['qwen-3-235b-a22b-instruct-2507', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_STRUCTURED, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
+        yield 'qwen-3-235b-a22b-thinking-2507' => ['qwen-3-235b-a22b-thinking-2507', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_STRUCTURED, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
+        yield 'qwen-3-coder-480b' => ['qwen-3-coder-480b', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_STRUCTURED, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
+        yield 'gpt-oss-120b' => ['gpt-oss-120b', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_STRUCTURED, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING]];
+        yield 'zai-glm-4.7' => ['zai-glm-4.7', Model::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_STRUCTURED, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/Cerebras/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cerebras/Tests/ResultConverterTest.php
@@ -13,18 +13,195 @@ namespace Symfony\AI\Platform\Bridge\Cerebras\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Cerebras\Model;
-use Symfony\AI\Platform\Bridge\Cerebras\ModelClient;
+use Symfony\AI\Platform\Bridge\Cerebras\ResultConverter;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model as BaseModel;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 
 /**
  * @author Junaid Farooq <ulislam.junaid125@gmail.com>
  */
-class ResultConverterTest extends TestCase
+final class ResultConverterTest extends TestCase
 {
-    public function testItSupportsTheCorrectModel()
+    public function testSupportsModel()
     {
-        $client = new ModelClient(new MockHttpClient(), 'csk-1234567890abcdef');
+        $converter = new ResultConverter();
 
-        $this->assertTrue($client->supports(new Model('llama3.1-8b')));
+        $this->assertTrue($converter->supports(new Model('gpt-oss-120b')));
+    }
+
+    public function testDoesNotSupportOtherModels()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertFalse($converter->supports(new BaseModel('gpt-4')));
+    }
+
+    public function testConvertTextResponse()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Hello, how can I help you?',
+                    ],
+                    'finish_reason' => 'stop',
+                ],
+            ],
+        ]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.cerebras.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello, how can I help you?', $result->getContent());
+    }
+
+    public function testConvertToolCallResponse()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_abc123',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'get_weather',
+                                    'arguments' => '{"location":"Paris"}',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+        ]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.cerebras.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $this->assertCount(1, $result->getContent());
+        $this->assertSame('call_abc123', $result->getContent()[0]->getId());
+        $this->assertSame('get_weather', $result->getContent()[0]->getName());
+        $this->assertSame(['location' => 'Paris'], $result->getContent()[0]->getArguments());
+    }
+
+    public function testConvertMultipleToolCallsResponse()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_abc123',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'get_weather',
+                                    'arguments' => '{"location":"Paris"}',
+                                ],
+                            ],
+                            [
+                                'id' => 'call_def456',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'get_weather',
+                                    'arguments' => '{"location":"London"}',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+        ]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.cerebras.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $this->assertCount(2, $result->getContent());
+        $this->assertSame('call_abc123', $result->getContent()[0]->getId());
+        $this->assertSame('get_weather', $result->getContent()[0]->getName());
+        $this->assertSame(['location' => 'Paris'], $result->getContent()[0]->getArguments());
+        $this->assertSame('call_def456', $result->getContent()[1]->getId());
+        $this->assertSame('get_weather', $result->getContent()[1]->getName());
+        $this->assertSame(['location' => 'London'], $result->getContent()[1]->getArguments());
+    }
+
+    public function testConvertThrowsOnApiError()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cerebras API error: "Invalid API key"');
+
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'type' => 'authentication_error',
+            'message' => 'Invalid API key',
+        ]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.cerebras.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testConvertThrowsOnMissingChoices()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Response does not contain output.');
+
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'id' => 'chatcmpl-123',
+        ]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.cerebras.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testConvertThrowsOnUnsupportedFinishReason()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported finish reason "content_filter".');
+
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                    ],
+                    'finish_reason' => 'content_filter',
+                ],
+            ],
+        ]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.cerebras.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $converter->convert(new RawHttpResult($httpResponse));
     }
 }


### PR DESCRIPTION
| Q             | A                                                                                                                                                                           
| ------------- | ---
| Bug fix?      | no                                                                                                                                                                          
| New feature?  | yes                  
| Docs?         | no                                                                                                                                                                          
| Issues        |                                                                                                                                                                             
| License       | MIT

Update the Cerebras bridge with current model catalog, structured output and tool calling support.

- Add `zai-glm-4.7` model to the catalog
- Add `OUTPUT_STRUCTURED` capability to all models
- Add `TOOL_CALLING` capability to `gpt-oss-120b`, `zai-glm-4.7` and `qwen-3-32b`
- Implement tool call handling in `ResultConverter` for both regular and streamed responses
- Add `ToolNormalizer` to ensure empty parameters schema for parameterless tools
- Add structured output and tool call examples
