### PR TITLE
[Mate] Add RegistryProvider service to eliminate Registry duplication

### DIFF
--- a/src/mate/src/Command/ServeCommand.php
+++ b/src/mate/src/Command/ServeCommand.php
@@ -19,7 +19,7 @@ use Mcp\Server\Transport\StdioTransport;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Agent\AgentInstructionsAggregator;
 use Symfony\AI\Mate\App;
-use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
+use Symfony\AI\Mate\Service\RegistryProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -39,7 +39,7 @@ class ServeCommand extends Command
     public function __construct(
         private string $cacheDir,
         private string $mcpProtocolVersion,
-        private FilteredDiscoveryLoader $loader,
+        private RegistryProvider $registryProvider,
         private AgentInstructionsAggregator $instructionsAggregator,
         private LoggerInterface $logger,
         private ContainerInterface $container,
@@ -81,7 +81,7 @@ class ServeCommand extends Command
                 $this->getIcon(),
                 'https://symfony.com/doc/current/ai/components/mate.html',
             )
-            ->addLoader($this->loader)
+            ->setRegistry($this->registryProvider->getRegistry())
             ->setSession(new FileSessionStore($this->cacheDir.'/sessions'))
             ->setLogger($this->logger)
             ->setContainer($this->container);

--- a/src/mate/src/Command/ToolsCallCommand.php
+++ b/src/mate/src/Command/ToolsCallCommand.php
@@ -11,13 +11,12 @@
 
 namespace Symfony\AI\Mate\Command;
 
-use Mcp\Capability\Registry;
 use Mcp\Capability\Registry\ReferenceHandler;
+use Mcp\Capability\RegistryInterface;
 use Mcp\Exception\ToolNotFoundException;
 use Mcp\Schema\Request\CallToolRequest;
-use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Command\Session\CliSession;
-use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
+use Symfony\AI\Mate\Service\RegistryProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -35,19 +34,16 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 #[AsCommand('mcp:tools:call', 'Execute MCP tools via JSON input')]
 class ToolsCallCommand extends Command
 {
-    private Registry $registry;
+    private RegistryInterface $registry;
     private ReferenceHandler $referenceHandler;
 
     public function __construct(
-        FilteredDiscoveryLoader $loader,
+        RegistryProvider $registryProvider,
         ContainerInterface $container,
-        LoggerInterface $logger,
     ) {
         parent::__construct(self::getDefaultName());
 
-        $this->registry = new Registry(null, $logger);
-        $loader->load($this->registry);
-
+        $this->registry = $registryProvider->getRegistry();
         $this->referenceHandler = new ReferenceHandler($container);
     }
 

--- a/src/mate/src/Service/RegistryProvider.php
+++ b/src/mate/src/Service/RegistryProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Service;
+
+use Mcp\Capability\Registry;
+use Mcp\Capability\RegistryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
+
+/**
+ * Provides a shared Registry instance populated with discovered capabilities.
+ *
+ * The Registry is lazily initialized on first access to avoid unnecessary
+ * capability discovery during container compilation.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RegistryProvider
+{
+    private ?RegistryInterface $registry = null;
+
+    public function __construct(
+        private FilteredDiscoveryLoader $loader,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Gets the Registry instance, creating and populating it on first access.
+     */
+    public function getRegistry(): RegistryInterface
+    {
+        if (null === $this->registry) {
+            $this->registry = new Registry(null, $this->logger);
+            $this->loader->load($this->registry);
+        }
+
+        return $this->registry;
+    }
+}

--- a/src/mate/src/default.config.php
+++ b/src/mate/src/default.config.php
@@ -27,6 +27,7 @@ use Symfony\AI\Mate\Discovery\CapabilityCollector;
 use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
 use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
 use Symfony\AI\Mate\Service\Logger;
+use Symfony\AI\Mate\Service\RegistryProvider;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -84,6 +85,8 @@ return static function (ContainerConfigurator $container): void {
         ->set(ComposerExtensionDiscovery::class)
 
         ->set(FilteredDiscoveryLoader::class)
+
+        ->set(RegistryProvider::class)
 
         ->set(CapabilityCollector::class)
 

--- a/src/mate/tests/Command/ToolsCallCommandTest.php
+++ b/src/mate/tests/Command/ToolsCallCommandTest.php
@@ -17,6 +17,7 @@ use Psr\Log\NullLogger;
 use Symfony\AI\Mate\Capability\ServerInfo;
 use Symfony\AI\Mate\Command\ToolsCallCommand;
 use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
+use Symfony\AI\Mate\Service\RegistryProvider;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -124,10 +125,11 @@ final class ToolsCallCommandTest extends TestCase
         $logger = new NullLogger();
         $discoverer = new Discoverer($logger);
         $loader = new FilteredDiscoveryLoader($rootDir, $extensions, [], $discoverer, $logger);
+        $registryProvider = new RegistryProvider($loader, $logger);
 
         $container = new ContainerBuilder();
         $container->set(ServerInfo::class, new ServerInfo());
 
-        return new ToolsCallCommand($loader, $container, $logger);
+        return new ToolsCallCommand($registryProvider, $container);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

## Summary

This PR introduces a `RegistryProvider` service to centralize Registry creation and eliminate code duplication.

**Problem:**
Both `ServeCommand` and `ToolsCallCommand` were independently creating and populating `Registry` instances with the same
 logic:
```php
$this->registry = new Registry(null, $logger);
$loader->load($this->registry);
```

#### Solution:
- Add RegistryProvider service that lazily creates and populates a shared Registry instance
- Update ServeCommand to use RegistryProvider::getRegistry() instead of addLoader()
- Update ToolsCallCommand to depend on RegistryProvider instead of creating its own Registry
- Commands now depend on RegistryInterface rather than the concrete Registry class

#### Benefits:
- Single source of truth for Registry creation
- Lazy initialization avoids unnecessary capability discovery during container compilation
- Better separation of concerns - commands don't need to know how to populate the Registry
- Improved testability through interface dependency