### PR TITLE
[Mate] Fix profiler collector names to use short names

### DIFF
--- a/src/ai-bundle/src/Profiler/DataCollector.php
+++ b/src/ai-bundle/src/Profiler/DataCollector.php
@@ -90,6 +90,11 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
         ];
     }
 
+    public function getName(): string
+    {
+        return 'ai';
+    }
+
     public static function getTemplate(): string
     {
         return '@Ai/data_collector.html.twig';

--- a/src/ai-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/ai-bundle/tests/Profiler/DataCollectorTest.php
@@ -166,4 +166,16 @@ class DataCollectorTest extends TestCase
         $this->assertInstanceOf(UserMessage::class, $calls[0]['message']);
         $this->assertInstanceOf(\DateTimeImmutable::class, $calls[0]['saved_at']);
     }
+
+    public function testGetNameReturnsShortName()
+    {
+        $dataCollector = new DataCollector([], [], [], []);
+
+        $name = $dataCollector->getName();
+
+        $this->assertSame('ai', $name);
+        // Verify it's a short name, not a class name
+        $this->assertStringNotContainsString('\\', $name);
+        $this->assertStringNotContainsString('DataCollector', $name);
+    }
 }

--- a/src/mate/src/Bridge/Symfony/Capability/ProfilerTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ProfilerTool.php
@@ -31,7 +31,7 @@ final class ProfilerTool
     }
 
     /**
-     * @return list<ProfileIndexData>
+     * @return array{profiles: list<ProfileIndexData>}
      */
     #[McpTool('symfony-profiler-list', 'List available profiler profiles. Returns summary data with resource_uri field - use the resource_uri to fetch full profile details including collectors')]
     public function listProfiles(
@@ -52,10 +52,12 @@ final class ProfilerTool
 
         $profiles = $this->dataProvider->searchProfiles(array_filter($criteria), $limit);
 
-        return array_values(array_map(
-            static fn (ProfileIndex $profile): array => $profile->toArray(),
-            $profiles,
-        ));
+        return [
+            'profiles' => array_values(array_map(
+                static fn (ProfileIndex $profile): array => $profile->toArray(),
+                $profiles,
+            )),
+        ];
     }
 
     /**
@@ -70,7 +72,7 @@ final class ProfilerTool
     }
 
     /**
-     * @return list<ProfileIndexData>
+     * @return array{profiles: list<ProfileIndexData>}
      */
     #[McpTool('symfony-profiler-search', 'Search profiles by criteria. Returns summary data with resource_uri field - use the resource_uri to fetch full profile details including collectors')]
     public function searchProfiles(
@@ -93,10 +95,12 @@ final class ProfilerTool
 
         $profiles = $this->dataProvider->searchProfiles(array_filter($criteria), $limit);
 
-        return array_values(array_map(
-            static fn (ProfileIndex $profile): array => $profile->toArray(),
-            $profiles,
-        ));
+        return [
+            'profiles' => array_values(array_map(
+                static fn (ProfileIndex $profile): array => $profile->toArray(),
+                $profiles,
+            )),
+        ];
     }
 
     /**

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/ProfilerDataProvider.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/ProfilerDataProvider.php
@@ -156,12 +156,21 @@ final class ProfilerDataProvider
         }
 
         $profile = $profileData->profile;
+        $collectors = $profile->getCollectors();
 
-        if (!$profile->hasCollector($collectorName)) {
+        // Find collector by short name
+        $collectorData = null;
+        foreach ($collectors as $collector) {
+            if ($collector->getName() === $collectorName) {
+                $collectorData = $collector;
+                break;
+            }
+        }
+
+        if (null === $collectorData) {
             throw new InvalidCollectorException(\sprintf('Collector "%s" not found in profile "%s"', $collectorName, $token));
         }
 
-        $collectorData = $profile->getCollector($collectorName);
         $formatter = $this->collectorRegistry->get($collectorName);
 
         if (null === $formatter) {
@@ -190,7 +199,12 @@ final class ProfilerDataProvider
             throw new ProfileNotFoundException(\sprintf('Profile not found for token: "%s"', $token));
         }
 
-        return array_keys($profileData->profile->getCollectors());
+        $collectors = $profileData->profile->getCollectors();
+
+        return array_values(array_map(
+            static fn ($collector) => $collector->getName(),
+            $collectors
+        ));
     }
 
     public function getLatestProfile(): ?ProfileIndex

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ProfilerToolTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ProfilerToolTest.php
@@ -35,8 +35,10 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesReturnsAllProfiles()
     {
-        $profiles = $this->tool->listProfiles();
+        $result = $this->tool->listProfiles();
 
+        $this->assertArrayHasKey('profiles', $result);
+        $profiles = $result['profiles'];
         $this->assertCount(3, $profiles);
         $this->assertArrayHasKey('token', $profiles[0]);
         $this->assertArrayHasKey('time_formatted', $profiles[0]);
@@ -45,39 +47,46 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesWithLimit()
     {
-        $profiles = $this->tool->listProfiles(limit: 2);
+        $result = $this->tool->listProfiles(limit: 2);
 
-        $this->assertCount(2, $profiles);
+        $this->assertArrayHasKey('profiles', $result);
+        $this->assertCount(2, $result['profiles']);
     }
 
     public function testListProfilesFilterByMethod()
     {
-        $profiles = $this->tool->listProfiles(method: 'POST');
+        $result = $this->tool->listProfiles(method: 'POST');
 
+        $this->assertArrayHasKey('profiles', $result);
+        $profiles = $result['profiles'];
         $this->assertCount(1, $profiles);
         $this->assertSame('def456', $profiles[0]['token']);
     }
 
     public function testListProfilesFilterByStatusCode()
     {
-        $profiles = $this->tool->listProfiles(statusCode: 404);
+        $result = $this->tool->listProfiles(statusCode: 404);
 
+        $this->assertArrayHasKey('profiles', $result);
+        $profiles = $result['profiles'];
         $this->assertCount(1, $profiles);
         $this->assertSame('ghi789', $profiles[0]['token']);
     }
 
     public function testListProfilesFilterByUrl()
     {
-        $profiles = $this->tool->listProfiles(url: 'users');
+        $result = $this->tool->listProfiles(url: 'users');
 
-        $this->assertCount(2, $profiles);
+        $this->assertArrayHasKey('profiles', $result);
+        $this->assertCount(2, $result['profiles']);
     }
 
     public function testListProfilesFilterByIp()
     {
-        $profiles = $this->tool->listProfiles(ip: '127.0.0.1');
+        $result = $this->tool->listProfiles(ip: '127.0.0.1');
 
-        $this->assertCount(2, $profiles);
+        $this->assertArrayHasKey('profiles', $result);
+        $this->assertCount(2, $result['profiles']);
     }
 
     public function testGetLatestProfileReturnsFirstProfile()
@@ -105,38 +114,44 @@ final class ProfilerToolTest extends TestCase
 
     public function testSearchProfilesWithoutCriteria()
     {
-        $profiles = $this->tool->searchProfiles();
+        $result = $this->tool->searchProfiles();
 
-        $this->assertCount(3, $profiles);
+        $this->assertArrayHasKey('profiles', $result);
+        $this->assertCount(3, $result['profiles']);
     }
 
     public function testSearchProfilesByMethod()
     {
-        $profiles = $this->tool->searchProfiles(method: 'GET');
+        $result = $this->tool->searchProfiles(method: 'GET');
 
-        $this->assertCount(2, $profiles);
+        $this->assertArrayHasKey('profiles', $result);
+        $this->assertCount(2, $result['profiles']);
     }
 
     public function testSearchProfilesByStatusCode()
     {
-        $profiles = $this->tool->searchProfiles(statusCode: 200);
+        $result = $this->tool->searchProfiles(statusCode: 200);
 
+        $this->assertArrayHasKey('profiles', $result);
+        $profiles = $result['profiles'];
         $this->assertCount(1, $profiles);
         $this->assertSame('abc123', $profiles[0]['token']);
     }
 
     public function testSearchProfilesByRoute()
     {
-        $profiles = $this->tool->searchProfiles(route: '/api/users');
+        $result = $this->tool->searchProfiles(route: '/api/users');
 
-        $this->assertCount(2, $profiles);
+        $this->assertArrayHasKey('profiles', $result);
+        $this->assertCount(2, $result['profiles']);
     }
 
     public function testSearchProfilesWithLimit()
     {
-        $profiles = $this->tool->searchProfiles(limit: 1);
+        $result = $this->tool->searchProfiles(limit: 1);
 
-        $this->assertCount(1, $profiles);
+        $this->assertArrayHasKey('profiles', $result);
+        $this->assertCount(1, $result['profiles']);
     }
 
     public function testGetProfileReturnsProfileWithResourceUri()
@@ -159,8 +174,10 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesIncludesResourceUri()
     {
-        $profiles = $this->tool->listProfiles();
+        $result = $this->tool->listProfiles();
 
+        $this->assertArrayHasKey('profiles', $result);
+        $profiles = $result['profiles'];
         $this->assertCount(3, $profiles);
         foreach ($profiles as $profile) {
             $this->assertArrayHasKey('resource_uri', $profile);
@@ -174,9 +191,10 @@ final class ProfilerToolTest extends TestCase
 
     public function testSearchProfilesIncludesResourceUri()
     {
-        $profiles = $this->tool->searchProfiles();
+        $result = $this->tool->searchProfiles();
 
-        foreach ($profiles as $profile) {
+        $this->assertArrayHasKey('profiles', $result);
+        foreach ($result['profiles'] as $profile) {
             $this->assertArrayHasKey('resource_uri', $profile);
             $this->assertStringStartsWith('symfony-profiler://profile/', $profile['resource_uri']);
         }
@@ -184,17 +202,19 @@ final class ProfilerToolTest extends TestCase
 
     public function testListProfilesReturnsIntegerKeys()
     {
-        $profiles = $this->tool->listProfiles();
+        $result = $this->tool->listProfiles();
 
-        $keys = array_keys($profiles);
+        $this->assertArrayHasKey('profiles', $result);
+        $keys = array_keys($result['profiles']);
         $this->assertSame([0, 1, 2], $keys);
     }
 
     public function testSearchProfilesReturnsIntegerKeys()
     {
-        $profiles = $this->tool->searchProfiles();
+        $result = $this->tool->searchProfiles();
 
-        $keys = array_keys($profiles);
+        $this->assertArrayHasKey('profiles', $result);
+        $keys = array_keys($result['profiles']);
         $this->assertSame([0, 1, 2], $keys);
     }
 }

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/ProfilerDataProviderTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/ProfilerDataProviderTest.php
@@ -168,6 +168,30 @@ final class ProfilerDataProviderTest extends TestCase
         $this->assertContains('request', $collectors);
     }
 
+    public function testListAvailableCollectorsReturnsShortNamesNotClassNames()
+    {
+        $collectors = $this->provider->listAvailableCollectors('abc123');
+
+        foreach ($collectors as $collectorName) {
+            $this->assertIsString($collectorName);
+            $this->assertStringNotContainsString('\\', $collectorName);
+            $this->assertDoesNotMatchRegularExpression('/^[A-Z]/', $collectorName);
+        }
+
+        $this->assertContains('request', $collectors);
+    }
+
+    public function testGetCollectorDataWorksWithShortNames()
+    {
+        $data = $this->provider->getCollectorData('abc123', 'request');
+
+        $this->assertIsArray($data);
+        $this->assertSame('request', $data['name']);
+
+        $this->assertArrayHasKey('name', $data);
+        $this->assertStringNotContainsString('\\', $data['name']);
+    }
+
     public function testGetLatestProfileReturnsFirstProfile()
     {
         $profile = $this->provider->getLatestProfile();

--- a/src/mcp-bundle/src/Profiler/DataCollector.php
+++ b/src/mcp-bundle/src/Profiler/DataCollector.php
@@ -121,6 +121,11 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
         return \count($this->getTools()) + \count($this->getPrompts()) + \count($this->getResources()) + \count($this->getResourceTemplates());
     }
 
+    public function getName(): string
+    {
+        return 'mcp';
+    }
+
     public static function getTemplate(): string
     {
         return '@Mcp/data_collector.html.twig';

--- a/src/mcp-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/mcp-bundle/tests/Profiler/DataCollectorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\Profiler;
+
+use Mcp\Capability\Registry;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\McpBundle\Profiler\DataCollector;
+use Symfony\AI\McpBundle\Profiler\TraceableRegistry;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class DataCollectorTest extends TestCase
+{
+    public function testGetNameReturnsShortName()
+    {
+        $registry = new Registry(null, new NullLogger());
+        $traceableRegistry = new TraceableRegistry($registry);
+        $dataCollector = new DataCollector($traceableRegistry);
+
+        $name = $dataCollector->getName();
+
+        $this->assertSame('mcp', $name);
+        // Verify it's a short name, not a class name
+        $this->assertStringNotContainsString('\\', $name);
+        $this->assertStringNotContainsString('DataCollector', $name);
+    }
+
+    public function testLateCollectPopulatesData()
+    {
+        $registry = new Registry(null, new NullLogger());
+        $traceableRegistry = new TraceableRegistry($registry);
+        $dataCollector = new DataCollector($traceableRegistry);
+
+        $dataCollector->lateCollect();
+
+        // Verify data is collected
+        $this->assertIsArray($dataCollector->getTools());
+        $this->assertIsArray($dataCollector->getPrompts());
+        $this->assertIsArray($dataCollector->getResources());
+        $this->assertIsArray($dataCollector->getResourceTemplates());
+    }
+
+    public function testGetTotalCountReturnsZeroForEmptyRegistry()
+    {
+        $registry = new Registry(null, new NullLogger());
+        $traceableRegistry = new TraceableRegistry($registry);
+        $dataCollector = new DataCollector($traceableRegistry);
+
+        $dataCollector->lateCollect();
+
+        $this->assertSame(0, $dataCollector->getTotalCount());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

## Summary

This PR fixes profiler collector lookups to use short names (e.g., `ai`, `mcp`, `request`) instead of class names.

**Problem:**
The `ProfilerDataProvider` was using `hasCollector()` and `getCollector()` which look up collectors by their class name
(e.g., `Symfony\AI\Bundle\Profiler\DataCollector`). However, the `listAvailableCollectors()` method was returning class
names as keys from `getCollectors()`, creating inconsistency and making it difficult for MCP tools to reference
collectors.

**Changes:**

- **AiBundle**: Add `getName()` method to `DataCollector` returning `'ai'`
- **McpBundle**: Add `getName()` method to `DataCollector` returning `'mcp'`
- **Mate/ProfilerDataProvider**:
  - Update `getCollectorData()` to find collectors by iterating and matching `getName()`
  - Update `listAvailableCollectors()` to return short names via `getName()` instead of array keys
- **Mate/ProfilerTool**: Wrap `listProfiles()` and `searchProfiles()` results in `{'profiles': [...]}` for clearer JSON
structure

**Benefits:**
- Consistent collector naming across the profiler API
- MCP tools can now reliably reference collectors by their short names
- Better alignment with Symfony's profiler conventions