### PR TITLE
 Bug: JsonException with SSE comments in RawHttpResult

### DIFF
--- a/src/platform/src/Result/RawHttpResult.php
+++ b/src/platform/src/Result/RawHttpResult.php
@@ -51,7 +51,8 @@ final class RawHttpResult implements RawResultInterface
             $deltas = explode(",\r\n", $jsonDelta);
 
             foreach ($deltas as $delta) {
-                if ('' === trim($delta)) {
+                // lines starting with a colon identify as comment
+                if ('' === trim($delta) || str_starts_with($delta, ':')) {
                     continue;
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Docs?         | no 
| Issues        | Fix #1588 
| License       | MIT

I was able to replicate the exception thrown with a test, and the link here - https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events, under the section 9.2.5 Parsing an event stream describes the format of a comment

`comment       = colon *any-char end-of-line
`
