### PR TITLE
[Platform][Gemini] Skip streaming candidates without content parts

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -75,7 +75,7 @@ final class ResultConverter implements ResultConverterInterface
     private function convertStream(RawResultInterface $result): \Generator
     {
         foreach ($result->getDataStream() as $data) {
-            $choices = array_map($this->convertChoice(...), $data['candidates'] ?? []);
+            $choices = array_values(array_filter(array_map($this->convertChoice(...), $data['candidates'] ?? [])));
 
             if (!$choices) {
                 continue;
@@ -93,7 +93,7 @@ final class ResultConverter implements ResultConverterInterface
     /**
      * @param array{
      *     finishReason?: string,
-     *     content: array{
+     *     content?: array{
      *         parts: array{
      *             functionCall?: array{
      *                 id: string,
@@ -113,8 +113,12 @@ final class ResultConverter implements ResultConverterInterface
      *     }
      * } $choice
      */
-    private function convertChoice(array $choice): ToolCallResult|TextResult|BinaryResult
+    private function convertChoice(array $choice): ToolCallResult|TextResult|BinaryResult|null
     {
+        if (!isset($choice['content']['parts'])) {
+            return null;
+        }
+
         $contentParts = $choice['content']['parts'];
 
         // If any part is a function call, return it immediately and ignore all other parts.


### PR DESCRIPTION
| Q             | A
  | ------------- | ---
  | Bug fix?      | yes
  | New feature?  | no
  | Docs?         | no
  | Issues        | Related #1053
  | License       | MIT

  The `convertStream()` method passes all candidates to `convertChoice()`,
  which directly accesses `$choice['content']['parts']`. During streaming,
  Gemini can send chunks without `content.parts` (e.g. the final chunk
  with only `finishReason`), causing:

  > Warning: Undefined array key "parts"

  The non-streaming path already guards against this on line 57. This PR
  adds the same guard to the streaming path by filtering out candidates
  that don't have `content.parts` set.