### PR TITLE
[Store] Allow to retrieve documents without vectors

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -188,6 +188,15 @@ Store
 
    This change aligns the constructor with the primary dependency (the store) being first, followed by the optional vectorizer.
 
+ * When using `Store::query()`, `Vector` are no longer returned in `VectorDocument`, to retrieve them, use `include_vectors` option:
+
+   ```php
+   use Symfony\AI\Store\Bridge\Cache;
+
+   $store = new Store(new ArrayAdapter());
+   $results = $store->query(new VectorQuery($vector), ['include_vectors' => true])
+   ```
+
 UPGRADE FROM 0.2 to 0.3
 =======================
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -188,13 +188,13 @@ Store
 
    This change aligns the constructor with the primary dependency (the store) being first, followed by the optional vectorizer.
 
- * When using `Store::query()`, `Vector` are no longer returned in `VectorDocument`, to retrieve them, use `include_vectors` option:
+ * When using `Store::query()`, use `include_vectors` option to retrieve `VectorDocument` without vectors:
 
    ```php
    use Symfony\AI\Store\Bridge\Cache;
 
    $store = new Store(new ArrayAdapter());
-   $results = $store->query(new VectorQuery($vector), ['include_vectors' => true])
+   $results = $store->query(new VectorQuery($vector), ['include_vectors' => false])
    ```
 
 UPGRADE FROM 0.2 to 0.3

--- a/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
+++ b/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
@@ -39,7 +39,7 @@ final class SimilaritySearch
      */
     public function __invoke(string $searchTerm): string
     {
-        $vector = $this->vectorizer->vectorize($searchTerm, ['include_vectors' => true]);
+        $vector = $this->vectorizer->vectorize($searchTerm);
         $this->usedDocuments = iterator_to_array($this->store->query(new VectorQuery($vector)));
 
         if ([] === $this->usedDocuments) {

--- a/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
+++ b/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
@@ -39,7 +39,7 @@ final class SimilaritySearch
      */
     public function __invoke(string $searchTerm): string
     {
-        $vector = $this->vectorizer->vectorize($searchTerm);
+        $vector = $this->vectorizer->vectorize($searchTerm, ['include_vectors' => true]);
         $this->usedDocuments = iterator_to_array($this->store->query(new VectorQuery($vector)));
 
         if ([] === $this->usedDocuments) {

--- a/src/platform/src/Bridge/Voyage/ResultConverter.php
+++ b/src/platform/src/Bridge/Voyage/ResultConverter.php
@@ -39,7 +39,7 @@ final class ResultConverter implements ResultConverterInterface
 
         return new VectorResult(
             ...array_map(
-                static fn (array $data) => new Vector($data['embedding']),
+                static fn (array $data): Vector => new Vector($data['embedding']),
                 $result['data'],
             ),
         );

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Add `MarkdownLoader`
  * Add `JsonFileLoader`
  * Add `ResetInterface` support to in-memory store
+ * [BC BREAK] `Vector` are no longer returned in `VectorDocument` when using `Store::query()`, to retrieve them, use `include_vectors` option
 
 0.3
 ---

--- a/src/store/src/Bridge/AzureSearch/SearchStore.php
+++ b/src/store/src/Bridge/AzureSearch/SearchStore.php
@@ -127,11 +127,19 @@ final class SearchStore implements StoreInterface
      */
     private function convertToVectorDocument(array $data, array $options): VectorDocument
     {
+        $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
+            ? new NullVector()
+            : new Vector($data[$this->vectorFieldName]);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($data[$this->vectorFieldName]);
+
+            $vector = new NullVector();
+        }
+
         return new VectorDocument(
             id: $data['id'],
-            vector: !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
-                ? new NullVector()
-                : ($options['include_vectors'] ?? true ? new Vector($data[$this->vectorFieldName]) : new NullVector()),
+            vector: $vector,
             metadata: new Metadata($data),
         );
     }

--- a/src/store/src/Bridge/AzureSearch/SearchStore.php
+++ b/src/store/src/Bridge/AzureSearch/SearchStore.php
@@ -87,7 +87,7 @@ final class SearchStore implements StoreInterface
         ]);
 
         foreach ($result['value'] as $item) {
-            yield $this->convertToVectorDocument($item);
+            yield $this->convertToVectorDocument($item, $options);
         }
     }
 
@@ -123,14 +123,15 @@ final class SearchStore implements StoreInterface
 
     /**
      * @param array<string, mixed> $data
+     * @param array<string, mixed> $options
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data, array $options): VectorDocument
     {
         return new VectorDocument(
             id: $data['id'],
             vector: !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
                 ? new NullVector()
-                : new Vector($data[$this->vectorFieldName]),
+                : ($options['include_vectors'] ?? false ? new Vector($data[$this->vectorFieldName]) : new NullVector()),
             metadata: new Metadata($data),
         );
     }

--- a/src/store/src/Bridge/AzureSearch/SearchStore.php
+++ b/src/store/src/Bridge/AzureSearch/SearchStore.php
@@ -131,7 +131,7 @@ final class SearchStore implements StoreInterface
             id: $data['id'],
             vector: !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
                 ? new NullVector()
-                : ($options['include_vectors'] ?? false ? new Vector($data[$this->vectorFieldName]) : new NullVector()),
+                : ($options['include_vectors'] ?? true ? new Vector($data[$this->vectorFieldName]) : new NullVector()),
             metadata: new Metadata($data),
         );
     }

--- a/src/store/src/Bridge/Cache/Store.php
+++ b/src/store/src/Bridge/Cache/Store.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Store\Bridge\Cache;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Distance\DistanceCalculator;
 use Symfony\AI\Store\Document\Metadata;
@@ -113,7 +114,8 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool
+     *     filter?: callable(VectorDocument): bool,
+     *     include_vectors?: bool,
      * } $options If maxItems is provided, only the top N results will be returned.
      *            If filter is provided, only documents matching the filter will be considered.
      */
@@ -150,7 +152,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vectorDocuments = array_map(static fn (array $document): VectorDocument => new VectorDocument(
             id: $document['id'],
-            vector: new Vector($document['vector']),
+            vector: $options['include_vectors'] ?? false ? new Vector($document['vector']) : new NullVector(),
             metadata: new Metadata($document['metadata']),
         ), $documents);
 

--- a/src/store/src/Bridge/Cache/Store.php
+++ b/src/store/src/Bridge/Cache/Store.php
@@ -152,7 +152,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vectorDocuments = array_map(static fn (array $document): VectorDocument => new VectorDocument(
             id: $document['id'],
-            vector: $options['include_vectors'] ?? false ? new Vector($document['vector']) : new NullVector(),
+            vector: $options['include_vectors'] ?? true ? new Vector($document['vector']) : new NullVector(),
             metadata: new Metadata($document['metadata']),
         ), $documents);
 

--- a/src/store/src/Bridge/Cache/Store.php
+++ b/src/store/src/Bridge/Cache/Store.php
@@ -150,11 +150,21 @@ final class Store implements ManagedStoreInterface, StoreInterface
             return;
         }
 
-        $vectorDocuments = array_map(static fn (array $document): VectorDocument => new VectorDocument(
-            id: $document['id'],
-            vector: $options['include_vectors'] ?? true ? new Vector($document['vector']) : new NullVector(),
-            metadata: new Metadata($document['metadata']),
-        ), $documents);
+        $vectorDocuments = array_map(static function (array $document): VectorDocument {
+            $vector = new Vector($document['vector_field']);
+
+            if (!($options['include_vectors'] ?? true)) {
+                unset($document['vector_field']);
+
+                $vector = new NullVector();
+            }
+
+            return new VectorDocument(
+                id: $document['id'],
+                vector: $vector,
+                metadata: new Metadata($document['metadata']),
+            );
+        }, $documents);
 
         if (isset($options['filter'])) {
             $vectorDocuments = array_values(array_filter($vectorDocuments, $options['filter']));

--- a/src/store/src/Bridge/Cache/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Cache/Tests/StoreTest.php
@@ -47,16 +47,12 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'include_vectors' => true,
-        ]));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(3, $result);
 
         $store->drop();
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'include_vectors' => true,
-        ]));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(0, $result);
     }
 

--- a/src/store/src/Bridge/Cache/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Cache/Tests/StoreTest.php
@@ -19,7 +19,9 @@ use Symfony\AI\Store\Distance\DistanceStrategy;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\QueryInterface;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -45,12 +47,16 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(3, $result);
 
         $store->drop();
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(0, $result);
     }
 
@@ -63,7 +69,9 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(3, $result);
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->getVector()->getData());
 
@@ -73,7 +81,9 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(6, $result);
         $this->assertSame([0.1, 0.1, 0.5], $result[0]->getVector()->getData());
     }
@@ -89,7 +99,9 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.0, 0.1, 0.6])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(5, $result);
         $this->assertSame([0.0, 0.1, 0.6], $result[0]->getVector()->getData());
         $this->assertSame([0.1, 0.1, 0.5], $result[1]->getVector()->getData());
@@ -109,6 +121,7 @@ final class StoreTest extends TestCase
 
         $this->assertCount(1, iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
             'maxItems' => 1,
+            'include_vectors' => true,
         ])));
     }
 
@@ -120,7 +133,9 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4])), [
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -134,7 +149,9 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 2.0, 3.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4])), [
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -148,7 +165,9 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4])), [
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -162,7 +181,9 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([1.0, 5.0, 7.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.2, 2.3, 3.4])), [
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertSame([1.0, 2.0, 3.0], $result[0]->getVector()->getData());
@@ -178,7 +199,8 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc) => 'products' === $doc->getMetadata()['category'],
+            'filter' => static fn (VectorDocument $doc): bool => 'products' === $doc->getMetadata()['category'],
+            'include_vectors' => true,
         ]));
 
         $this->assertCount(2, $result);
@@ -197,8 +219,9 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc) => 'products' === $doc->getMetadata()['category'],
+            'filter' => static fn (VectorDocument $doc): bool => 'products' === $doc->getMetadata()['category'],
             'maxItems' => 2,
+            'include_vectors' => true,
         ]));
 
         $this->assertCount(2, $result);
@@ -216,7 +239,8 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc) => $doc->getMetadata()['price'] <= 150 && $doc->getMetadata()['stock'] > 0,
+            'filter' => static fn (VectorDocument $doc): bool => $doc->getMetadata()['price'] <= 150 && $doc->getMetadata()['stock'] > 0,
+            'include_vectors' => true,
         ]));
 
         $this->assertCount(2, $result);
@@ -232,7 +256,8 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc) => 'S' === $doc->getMetadata()['options']['size'],
+            'filter' => static fn (VectorDocument $doc): bool => 'S' === $doc->getMetadata()['options']['size'],
+            'include_vectors' => true,
         ]));
 
         $this->assertCount(2, $result);
@@ -251,7 +276,8 @@ final class StoreTest extends TestCase
 
         $allowedBrands = ['Nike', 'Adidas', 'Puma'];
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc) => \in_array($doc->getMetadata()['brand'] ?? '', $allowedBrands, true),
+            'filter' => static fn (VectorDocument $doc): bool => \in_array($doc->getMetadata()['brand'] ?? '', $allowedBrands, true),
+            'include_vectors' => true,
         ]));
 
         $this->assertCount(2, $result);
@@ -272,15 +298,19 @@ final class StoreTest extends TestCase
             new VectorDocument($id3, new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(3, $result);
 
         $store->remove($id2->toRfc4122());
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(2, $result);
 
-        $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->getId(), $result);
+        $remainingIds = array_map(static fn (VectorDocument $doc): int|string => $doc->getId(), $result);
         $this->assertNotContains($id2->toRfc4122(), $remainingIds);
         $this->assertContains($id1->toRfc4122(), $remainingIds);
         $this->assertContains($id3->toRfc4122(), $remainingIds);
@@ -303,12 +333,16 @@ final class StoreTest extends TestCase
             new VectorDocument($id4, new Vector([0.0, 0.1, 0.6])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(4, $result);
 
         $store->remove([$id2->toRfc4122(), $id4->toRfc4122()]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(2, $result);
 
         $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->getId(), $result);
@@ -332,12 +366,16 @@ final class StoreTest extends TestCase
             new VectorDocument($id2, new Vector([0.7, -0.3, 0.0])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(2, $result);
 
         $store->remove($nonExistentId->toRfc4122());
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(2, $result);
     }
 
@@ -356,12 +394,16 @@ final class StoreTest extends TestCase
             new VectorDocument($id3, new Vector([0.3, 0.7, 0.1])),
         ]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(3, $result);
 
         $store->remove([$id1->toRfc4122(), $id2->toRfc4122(), $id3->toRfc4122()]);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
+            'include_vectors' => true,
+        ]));
         $this->assertCount(0, $result);
     }
 
@@ -391,7 +433,9 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['_text' => 'Lorem ipsum dolor sit amet'])),
         ]);
 
-        $result = iterator_to_array($store->query(new TextQuery('quick brown')));
+        $result = iterator_to_array($store->query(new TextQuery('quick brown'), [
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(1, $result);
         $this->assertStringContainsString('quick brown', $result[0]->getMetadata()->getText());
@@ -406,7 +450,10 @@ final class StoreTest extends TestCase
             new VectorDocument(Uuid::v4(), new Vector([0.3, 0.7, 0.1]), new Metadata(['_text' => 'Yet another test entry'])),
         ]);
 
-        $result = iterator_to_array($store->query(new TextQuery('test'), ['maxItems' => 2]));
+        $result = iterator_to_array($store->query(new TextQuery('test'), [
+            'maxItems' => 2,
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(2, $result);
     }
@@ -425,13 +472,15 @@ final class StoreTest extends TestCase
         ]);
 
         $queryVector = new Vector([0.0, 0.1, 0.6]);
-        $result = iterator_to_array($store->query(new HybridQuery($queryVector, 'space', 0.7)));
+        $result = iterator_to_array($store->query(new HybridQuery($queryVector, 'space', 0.7), [
+            'include_vectors' => true,
+        ]));
 
         // Should find documents matching either vector similarity or text content
         $this->assertGreaterThanOrEqual(2, \count($result));
 
         // Check that space-related documents are in results
-        $texts = array_map(static fn (VectorDocument $doc) => $doc->getMetadata()->getText(), $result);
+        $texts = array_map(static fn (VectorDocument $doc): ?string => $doc->getMetadata()->getText(), $result);
         $this->assertContains('deep space mission', $texts);
     }
 
@@ -446,11 +495,15 @@ final class StoreTest extends TestCase
         $queryVector = new Vector([0.0, 0.1, 0.6]);
 
         // High semantic ratio (favor vector similarity)
-        $resultHighSemantic = iterator_to_array($store->query(new HybridQuery($queryVector, 'exact text match', 0.9)));
+        $resultHighSemantic = iterator_to_array($store->query(new HybridQuery($queryVector, 'exact text match', 0.9), [
+            'include_vectors' => true,
+        ]));
         $this->assertNotEmpty($resultHighSemantic);
 
         // Low semantic ratio (favor text matching)
-        $resultLowSemantic = iterator_to_array($store->query(new HybridQuery($queryVector, 'exact text match', 0.1)));
+        $resultLowSemantic = iterator_to_array($store->query(new HybridQuery($queryVector, 'exact text match', 0.1), [
+            'include_vectors' => true,
+        ]));
         $this->assertNotEmpty($resultLowSemantic);
     }
 
@@ -467,10 +520,10 @@ final class StoreTest extends TestCase
         $store = new Store(new ArrayAdapter());
 
         // Create a mock query type that Cache store doesn't support
-        $unsupportedQuery = new class implements \Symfony\AI\Store\Query\QueryInterface {
+        $unsupportedQuery = new class implements QueryInterface {
         };
 
-        $this->expectException(\Symfony\AI\Store\Exception\UnsupportedQueryTypeException::class);
+        $this->expectException(UnsupportedQueryTypeException::class);
         $this->expectExceptionMessageMatches('/not supported/');
 
         $store->query($unsupportedQuery);

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -200,7 +200,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
             yield new VectorDocument(
                 id: $queryResponse->ids[0][$i],
-                vector: $options['include_vectors'] ?? false ? new Vector($queryResponse->embeddings[0][$i]) : new NullVector(),
+                vector: $options['include_vectors'] ?? true ? new Vector($queryResponse->embeddings[0][$i]) : new NullVector(),
                 metadata: $metaData,
                 score: $queryResponse->distances[0][$i] ?? null,
             );

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -198,9 +198,17 @@ final class Store implements ManagedStoreInterface, StoreInterface
                 $metaData->setText($queryResponse->documents[0][$i]);
             }
 
+            $vector = new Vector($queryResponse->embeddings[0][$i]);
+
+            if (!($options['include_vectors'] ?? true)) {
+                unset($queryResponse->embeddings[0][$i]);
+
+                $vector = new NullVector();
+            }
+
             yield new VectorDocument(
                 id: $queryResponse->ids[0][$i],
-                vector: $options['include_vectors'] ?? true ? new Vector($queryResponse->embeddings[0][$i]) : new NullVector(),
+                vector: $vector,
                 metadata: $metaData,
                 score: $queryResponse->distances[0][$i] ?? null,
             );

--- a/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
@@ -170,7 +170,9 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query(new VectorQuery($queryVector)));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), [
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(2, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -214,7 +216,9 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), ['where' => $whereFilter]));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), [
+            'where' => $whereFilter,
+        ]));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -492,7 +496,9 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query(new VectorQuery($queryVector)));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), [
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -526,7 +532,10 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), ['include' => ['documents']]));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), [
+            'include' => ['documents'],
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -560,7 +569,10 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), ['include' => ['embeddings', 'metadatas', 'distances', 'documents']]));
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), [
+            'include' => ['embeddings', 'metadatas', 'distances', 'documents'],
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
@@ -723,7 +735,9 @@ final class StoreTest extends TestCase
             ->willReturn($queryResponse);
 
         $store = new Store($client, 'test-collection');
-        $documents = iterator_to_array($store->query(new TextQuery('search for this text')));
+        $documents = iterator_to_array($store->query(new TextQuery('search for this text'), [
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(1, $documents);
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Store\Bridge\ClickHouse;
 
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Document\Metadata;
@@ -126,7 +127,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         foreach ($results as $result) {
             yield new VectorDocument(
                 id: $result['id'],
-                vector: new Vector($result['embedding']),
+                vector: $options['include_vectors'] ?? false ? new Vector($result['embedding']) : new NullVector(),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],
             );

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -125,9 +125,19 @@ class Store implements ManagedStoreInterface, StoreInterface
         ;
 
         foreach ($results as $result) {
+            $vector = !\array_key_exists('embedding', $result) || null === $result['embedding']
+                ? new NullVector()
+                : new Vector($result['embedding']);
+
+            if (!($options['include_vectors'] ?? true)) {
+                unset($result['embedding']);
+
+                $vector = new NullVector();
+            }
+
             yield new VectorDocument(
                 id: $result['id'],
-                vector: $options['include_vectors'] ?? true ? new Vector($result['embedding']) : new NullVector(),
+                vector: $vector,
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],
             );

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -127,7 +127,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         foreach ($results as $result) {
             yield new VectorDocument(
                 id: $result['id'],
-                vector: $options['include_vectors'] ?? false ? new Vector($result['embedding']) : new NullVector(),
+                vector: $options['include_vectors'] ?? true ? new Vector($result['embedding']) : new NullVector(),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],
             );

--- a/src/store/src/Bridge/Cloudflare/Store.php
+++ b/src/store/src/Bridge/Cloudflare/Store.php
@@ -155,7 +155,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists('values', $data) || null === $data['values']
             ? new NullVector()
-            : ($options['include_vectors'] ?? false ? new Vector($data['values']) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($data['values']) : new NullVector());
 
         return new VectorDocument(
             id: $id,

--- a/src/store/src/Bridge/Cloudflare/Store.php
+++ b/src/store/src/Bridge/Cloudflare/Store.php
@@ -153,9 +153,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
     {
         $id = $data['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
 
-        $vector = !\array_key_exists('values', $data) || null === $data['values']
-            ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($data['values']) : new NullVector());
+        $vector = new Vector($data['values']);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($data['values']);
+
+            $vector = new NullVector();
+        }
 
         return new VectorDocument(
             id: $id,

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -187,7 +187,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->vectorsField, $document['_source']) || null === $document['_source'][$this->vectorsField]
             ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($document['_source'][$this->vectorsField]) : new NullVector());
+            : new Vector($document['_source'][$this->vectorsField]);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($document['_source'][$this->vectorsField]);
+
+            $vector = new NullVector();
+        }
 
         return new VectorDocument(Uuid::fromString($id), $vector, new Metadata(json_decode($document['_source']['metadata'], true)), $document['_score'] ?? null);
     }

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -187,7 +187,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->vectorsField, $document['_source']) || null === $document['_source'][$this->vectorsField]
             ? new NullVector()
-            : ($options['include_vectors'] ? new Vector($document['_source'][$this->vectorsField]) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($document['_source'][$this->vectorsField]) : new NullVector());
 
         return new VectorDocument(Uuid::fromString($id), $vector, new Metadata(json_decode($document['_source']['metadata'], true)), $document['_score'] ?? null);
     }

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -142,7 +142,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
 
         foreach ($documents['hits']['hits'] as $document) {
-            yield $this->convertToVectorDocument($document);
+            yield $this->convertToVectorDocument($document, $options);
         }
     }
 
@@ -179,14 +179,15 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     '_source': array<string, mixed>,
      *     '_score': float,
      * } $document
+     * @param array{include_vectors?: bool} $options
      */
-    private function convertToVectorDocument(array $document): VectorDocument
+    private function convertToVectorDocument(array $document, array $options): VectorDocument
     {
         $id = $document['_id'] ?? throw new InvalidArgumentException('Missing "_id" field in the document data.');
 
         $vector = !\array_key_exists($this->vectorsField, $document['_source']) || null === $document['_source'][$this->vectorsField]
             ? new NullVector()
-            : new Vector($document['_source'][$this->vectorsField]);
+            : ($options['include_vectors'] ? new Vector($document['_source'][$this->vectorsField]) : new NullVector());
 
         return new VectorDocument(Uuid::fromString($id), $vector, new Metadata(json_decode($document['_source']['metadata'], true)), $document['_score'] ?? null);
     }

--- a/src/store/src/Bridge/Elasticsearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Elasticsearch/Tests/StoreTest.php
@@ -191,7 +191,9 @@ final class StoreTest extends TestCase
         ]);
 
         $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
-        $results = $store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])));
+        $results = $store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), [
+            'include_vectors' => true,
+        ]);
 
         $this->assertCount(2, iterator_to_array($results));
         $this->assertSame(1, $httpClient->getRequestsCount());

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -195,9 +195,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
             throw new InvalidArgumentException('Missing "uuid" field in the document data.');
         }
 
-        $vector = !\array_key_exists($this->field, $payload) || null === $payload[$this->field]
-            ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($payload[$this->field]) : new NullVector());
+        $vector = new Vector($payload[$this->field]);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($payload[$this->field]);
+
+            $vector = new NullVector();
+        }
 
         return new VectorDocument(
             id: $payload['uuid'],

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -144,7 +144,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
 
         foreach ($documents['hits']['hits'] as $item) {
-            yield $this->convertToVectorDocument($item);
+            yield $this->convertToVectorDocument($item, $options);
         }
     }
 
@@ -185,8 +185,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     _knn_dist: float,
      *     _source: array<string, mixed>,
      * } $data
+     * @param array{include_vectors?: bool} $options
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data, array $options): VectorDocument
     {
         $payload = $data['_source'];
 
@@ -196,7 +197,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->field, $payload) || null === $payload[$this->field]
             ? new NullVector()
-            : new Vector($payload[$this->field]);
+            : ($options['include_vectors'] ?? false ? new Vector($payload[$this->field]) : new NullVector());
 
         return new VectorDocument(
             id: $payload['uuid'],

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -197,7 +197,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->field, $payload) || null === $payload[$this->field]
             ? new NullVector()
-            : ($options['include_vectors'] ?? false ? new Vector($payload[$this->field]) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($payload[$this->field]) : new NullVector());
 
         return new VectorDocument(
             id: $payload['uuid'],

--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -229,7 +229,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
             yield new VectorDocument(
                 id: Uuid::fromRfc4122($result['id']),
-                vector: $options['include_vectors'] ?? false ? new Vector(json_decode((string) $result['embedding'], true)) : new NullVector(),
+                vector: $options['include_vectors'] ?? true ? new Vector(json_decode((string) $result['embedding'], true)) : new NullVector(),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true)),
                 score: $result['score'],
             );

--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Store\Bridge\MariaDb;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
@@ -169,6 +170,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     maxScore?: float|null,
      *     where?: string,
      *     params?: array<string, mixed>,
+     *     include_vectors?: bool,
      * } $options
      */
     public function query(QueryInterface $query, array $options = []): iterable
@@ -227,7 +229,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
             yield new VectorDocument(
                 id: Uuid::fromRfc4122($result['id']),
-                vector: new Vector(json_decode((string) $result['embedding'], true)),
+                vector: $options['include_vectors'] ?? false ? new Vector(json_decode((string) $result['embedding'], true)) : new NullVector(),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true)),
                 score: $result['score'],
             );

--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -227,9 +227,17 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $statement->execute();
 
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
+            $vector = new Vector(json_decode((string) $result['embedding'], true));
+
+            if (!($options['include_vectors'] ?? true)) {
+                unset($result['embedding']);
+
+                $vector = new NullVector();
+            }
+
             yield new VectorDocument(
                 id: Uuid::fromRfc4122($result['id']),
-                vector: $options['include_vectors'] ?? true ? new Vector(json_decode((string) $result['embedding'], true)) : new NullVector(),
+                vector: $vector,
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true)),
                 score: $result['score'],
             );

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -179,7 +179,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
             ? new NullVector()
-            : ($options['include_vectors'] ?? false ? new Vector($data[$this->vectorFieldName][$this->embedder]['embeddings']) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($data[$this->vectorFieldName][$this->embedder]['embeddings']) : new NullVector());
 
         $score = $data['_rankingScore'] ?? null;
 

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -177,9 +177,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
     {
         $id = $data['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
 
-        $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
-            ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($data[$this->vectorFieldName][$this->embedder]['embeddings']) : new NullVector());
+        $vector = new Vector($data[$this->vectorFieldName]);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($data[$this->vectorFieldName]);
+
+            $vector = new NullVector();
+        }
 
         $score = $data['_rankingScore'] ?? null;
 

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -126,7 +126,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
 
         foreach ($result['hits'] as $item) {
-            yield $this->convertToVectorDocument($item);
+            yield $this->convertToVectorDocument($item, $options);
         }
     }
 
@@ -170,14 +170,16 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param array<string, mixed>          $data
+     * @param array{include_vectors?: bool} $options
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data, array $options): VectorDocument
     {
         $id = $data['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
+
         $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
             ? new NullVector()
-            : new Vector($data[$this->vectorFieldName][$this->embedder]['embeddings']);
+            : ($options['include_vectors'] ?? false ? new Vector($data[$this->vectorFieldName][$this->embedder]['embeddings']) : new NullVector());
 
         $score = $data['_rankingScore'] ?? null;
 

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -199,7 +199,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
             ? new NullVector()
-            : ($options['include_vectors'] ?? false ? new Vector($data[$this->vectorFieldName]) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($data[$this->vectorFieldName]) : new NullVector());
 
         $score = $data['distance'] ?? null;
 

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -199,7 +199,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
             ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($data[$this->vectorFieldName]) : new NullVector());
+            : new Vector($data[$this->vectorFieldName]);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($data[$this->vectorFieldName]);
+
+            $vector = new NullVector();
+        }
 
         $score = $data['distance'] ?? null;
 

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -150,7 +150,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $documents = $this->request('POST', 'v2/vectordb/entities/search', $payload);
 
         foreach ($documents['data'] as $item) {
-            yield $this->convertToVectorDocument($item);
+            yield $this->convertToVectorDocument($item, $options);
         }
     }
 
@@ -190,15 +190,16 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param array<string, mixed>          $data
+     * @param array{include_vectors?: bool} $options
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data, array $options): VectorDocument
     {
         $id = $data['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
 
         $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
             ? new NullVector()
-            : new Vector($data[$this->vectorFieldName]);
+            : ($options['include_vectors'] ?? false ? new Vector($data[$this->vectorFieldName]) : new NullVector());
 
         $score = $data['distance'] ?? null;
 

--- a/src/store/src/Bridge/MongoDb/Store.php
+++ b/src/store/src/Bridge/MongoDb/Store.php
@@ -207,9 +207,17 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
 
         foreach ($results as $result) {
+            $vector = new Vector($result[$this->vectorFieldName]);
+
+            if (!$withVectors) {
+                unset($result[$this->vectorFieldName]);
+
+                $vector = new NullVector();
+            }
+
             yield new VectorDocument(
                 id: $result['_id'],
-                vector: $withVectors ? new Vector($result[$this->vectorFieldName]) : new NullVector(),
+                vector: $vector,
                 metadata: new Metadata($result['metadata'] ?? []),
                 score: $result['score'],
             );

--- a/src/store/src/Bridge/MongoDb/Store.php
+++ b/src/store/src/Bridge/MongoDb/Store.php
@@ -171,7 +171,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             unset($options['minScore']);
         }
 
-        $withVectors = $options['include_vectors'] ?? false;
+        $withVectors = $options['include_vectors'] ?? true;
         if (\array_key_exists('include_vectors', $options)) {
             unset($options['include_vectors']);
         }

--- a/src/store/src/Bridge/MongoDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/MongoDb/Tests/StoreTest.php
@@ -560,7 +560,9 @@ final class StoreTest extends TestCase
             'custom_embeddings',
         );
 
-        $documents = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
+        $documents = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), [
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(1, $documents);
         $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -109,7 +109,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
 
         foreach ($response['data']['values'] as $item) {
-            yield $this->convertToVectorDocument($item);
+            yield $this->convertToVectorDocument($item, $options);
         }
     }
 
@@ -138,9 +138,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
-     * @param array<string|int, mixed> $data
+     * @param array<string|int, mixed>      $data
+     * @param array{include_vectors?: bool} $options
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data, array $options): VectorDocument
     {
         $payload = $data[0];
 
@@ -148,7 +149,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->embeddingsField, $payload['properties']) || null === $payload['properties'][$this->embeddingsField]
             ? new NullVector()
-            : new Vector($payload['properties'][$this->embeddingsField]);
+            : ($options['include_vectors'] ?? false ? new Vector($payload['properties'][$this->embeddingsField]) : new NullVector());
 
         return new VectorDocument(
             id: $id,

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -149,7 +149,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->embeddingsField, $payload['properties']) || null === $payload['properties'][$this->embeddingsField]
             ? new NullVector()
-            : ($options['include_vectors'] ?? false ? new Vector($payload['properties'][$this->embeddingsField]) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($payload['properties'][$this->embeddingsField]) : new NullVector());
 
         return new VectorDocument(
             id: $id,

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -149,7 +149,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->embeddingsField, $payload['properties']) || null === $payload['properties'][$this->embeddingsField]
             ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($payload['properties'][$this->embeddingsField]) : new NullVector());
+            : new Vector($payload['properties'][$this->embeddingsField]);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($payload['properties'][$this->embeddingsField]);
+
+            $vector = new NullVector();
+        }
 
         return new VectorDocument(
             id: $id,

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -190,7 +190,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->vectorsField, $document['_source']) || null === $document['_source'][$this->vectorsField]
             ? new NullVector()
-            : ($options['include_vectors'] ?? false ? new Vector($document['_source'][$this->vectorsField]) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($document['_source'][$this->vectorsField]) : new NullVector());
 
         return new VectorDocument($id, $vector, new Metadata(json_decode($document['_source']['metadata'], true)), $document['_score'] ?? null);
     }

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -188,9 +188,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
     {
         $id = $document['_id'] ?? throw new InvalidArgumentException('Missing "_id" field in the document data.');
 
-        $vector = !\array_key_exists($this->vectorsField, $document['_source']) || null === $document['_source'][$this->vectorsField]
-            ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($document['_source'][$this->vectorsField]) : new NullVector());
+        $vector = new Vector($document['_source']);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($document['_source']);
+
+            $vector = new NullVector();
+        }
 
         return new VectorDocument($id, $vector, new Metadata(json_decode($document['_source']['metadata'], true)), $document['_score'] ?? null);
     }

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -145,7 +145,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
 
         foreach ($documents['hits']['hits'] as $document) {
-            yield $this->convertToVectorDocument($document);
+            yield $this->convertToVectorDocument($document, $options);
         }
     }
 
@@ -182,14 +182,15 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     '_source': array<string, mixed>,
      *     '_score': float,
      * } $document
+     * @param array{include_vectors?: bool} $options
      */
-    private function convertToVectorDocument(array $document): VectorDocument
+    private function convertToVectorDocument(array $document, array $options): VectorDocument
     {
         $id = $document['_id'] ?? throw new InvalidArgumentException('Missing "_id" field in the document data.');
 
         $vector = !\array_key_exists($this->vectorsField, $document['_source']) || null === $document['_source'][$this->vectorsField]
             ? new NullVector()
-            : new Vector($document['_source'][$this->vectorsField]);
+            : ($options['include_vectors'] ?? false ? new Vector($document['_source'][$this->vectorsField]) : new NullVector());
 
         return new VectorDocument($id, $vector, new Metadata(json_decode($document['_source']['metadata'], true)), $document['_score'] ?? null);
     }

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -136,9 +136,17 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
 
         foreach ($result->json()['matches'] as $match) {
+            $vector = new Vector($match['values']);
+
+            if (!($options['include_vectors'] ?? true)) {
+                unset($match['values']);
+
+                $vector = new NullVector();
+            }
+
             yield new VectorDocument(
                 id: $match['id'],
-                vector: $options['include_vectors'] ?? true ? new Vector($match['values']) : new NullVector(),
+                vector: $vector,
                 metadata: new Metadata($match['metadata']),
                 score: $match['score'],
             );

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Store\Bridge\Pinecone;
 
 use Probots\Pinecone\Client;
 use Probots\Pinecone\Resources\Data\VectorResource;
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
@@ -137,7 +138,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         foreach ($result->json()['matches'] as $match) {
             yield new VectorDocument(
                 id: $match['id'],
-                vector: new Vector($match['values']),
+                vector: $options['include_vectors'] ?? false ? new Vector($match['values']) : new NullVector(),
                 metadata: new Metadata($match['metadata']),
                 score: $match['score'],
             );

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -138,7 +138,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         foreach ($result->json()['matches'] as $match) {
             yield new VectorDocument(
                 id: $match['id'],
-                vector: $options['include_vectors'] ?? false ? new Vector($match['values']) : new NullVector(),
+                vector: $options['include_vectors'] ?? true ? new Vector($match['values']) : new NullVector(),
                 metadata: new Metadata($match['metadata']),
                 score: $match['score'],
             );

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -228,9 +228,17 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $statement->execute();
 
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
+            $vector = new Vector($this->fromPgvector($result['embedding']));
+
+            if (!($options['include_vectors'] ?? true)) {
+                unset($result['embedding']);
+
+                $vector = new NullVector();
+            }
+
             yield new VectorDocument(
                 id: $result['id'],
-                vector: new Vector($this->fromPgvector($result['embedding'])),
+                vector: $vector,
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],
             );
@@ -283,9 +291,17 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $statement->execute();
 
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
+            $vector = new Vector($this->fromPgvector($result['embedding']));
+
+            if (!($options['include_vectors'] ?? true)) {
+                unset($result['embedding']);
+
+                $vector = new NullVector();
+            }
+
             yield new VectorDocument(
                 id: $result['id'],
-                vector: new Vector($this->fromPgvector($result['embedding'])),
+                vector: $vector,
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],
             );
@@ -357,9 +373,17 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $statement->execute();
 
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
+            $vector = new Vector($this->fromPgvector($result['embedding']));
+
+            if (!($options['include_vectors'] ?? true)) {
+                unset($result['embedding']);
+
+                $vector = new NullVector();
+            }
+
             yield new VectorDocument(
                 id: $result['id'],
-                vector: $options['include_vectors'] ?? true ? new Vector($this->fromPgvector($result['embedding'])) : new NullVector(),
+                vector: $vector,
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],
             );

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Store\Bridge\Postgres;
 
 use Doctrine\DBAL\Connection;
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Document\Metadata;
@@ -358,7 +359,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
             yield new VectorDocument(
                 id: $result['id'],
-                vector: new Vector($this->fromPgvector($result['embedding'])),
+                vector: $options['include_vectors'] ?? false ? new Vector($this->fromPgvector($result['embedding'])) : new NullVector(),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],
             );

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -293,7 +293,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
-     * @param array{limit?: positive-int, maxScore?: float} $options
+     * @param array{limit?: positive-int, maxScore?: float, include_vectors?: bool} $options
      *
      * @return iterable<VectorDocument>
      */
@@ -359,7 +359,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $result) {
             yield new VectorDocument(
                 id: $result['id'],
-                vector: $options['include_vectors'] ?? false ? new Vector($this->fromPgvector($result['embedding'])) : new NullVector(),
+                vector: $options['include_vectors'] ?? true ? new Vector($this->fromPgvector($result['embedding'])) : new NullVector(),
                 metadata: new Metadata(json_decode($result['metadata'] ?? '{}', true, 512, \JSON_THROW_ON_ERROR)),
                 score: $result['score'],
             );

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -174,7 +174,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists('vector', $data) || null === $data['vector']
             ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($data['vector']) : new NullVector());
+            : new Vector($data['vector']);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($data['vector']);
+
+            $vector = new NullVector();
+        }
 
         return new VectorDocument(
             id: $id,

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -174,7 +174,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists('vector', $data) || null === $data['vector']
             ? new NullVector()
-            : ($options['include_vectors'] ?? false ? new Vector($data['vector']) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($data['vector']) : new NullVector());
 
         return new VectorDocument(
             id: $id,

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -206,7 +206,7 @@ class Store implements ManagedStoreInterface, StoreInterface
 
             yield new VectorDocument(
                 id: $data['$.id'],
-                vector: $options['include_vectors'] ?? false ? new Vector($data['$.embedding'] ?? []) : new NullVector(),
+                vector: $options['include_vectors'] ?? true ? new Vector($data['$.embedding'] ?? []) : new NullVector(),
                 metadata: new Metadata($data['$.metadata'] ?? []),
                 score: $score,
             );

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -204,9 +204,17 @@ class Store implements ManagedStoreInterface, StoreInterface
                 continue;
             }
 
+            $vector = new Vector($data['$.embedding'] ?? []);
+
+            if (!($options['include_vectors'] ?? true)) {
+                unset($data['$.embedding']);
+
+                $vector = new NullVector();
+            }
+
             yield new VectorDocument(
                 id: $data['$.id'],
-                vector: $options['include_vectors'] ?? true ? new Vector($data['$.embedding'] ?? []) : new NullVector(),
+                vector: $vector,
                 metadata: new Metadata($data['$.metadata'] ?? []),
                 score: $score,
             );

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Store\Bridge\Redis;
 
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Document\Metadata;
@@ -137,7 +138,7 @@ class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
-     * @param array{limit?: positive-int, maxScore?: float, where?: string} $options
+     * @param array{limit?: positive-int, maxScore?: float, where?: string, include_vectors?: bool} $options
      *
      * @return VectorDocument[]
      */
@@ -205,7 +206,7 @@ class Store implements ManagedStoreInterface, StoreInterface
 
             yield new VectorDocument(
                 id: $data['$.id'],
-                vector: new Vector($data['$.embedding'] ?? []),
+                vector: $options['include_vectors'] ?? false ? new Vector($data['$.embedding'] ?? []) : new NullVector(),
                 metadata: new Metadata($data['$.metadata'] ?? []),
                 score: $score,
             );

--- a/src/store/src/Bridge/Supabase/Store.php
+++ b/src/store/src/Bridge/Supabase/Store.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Store\Bridge\Supabase;
 
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
@@ -110,7 +111,8 @@ final class Store implements StoreInterface
      * @param array{
      *      max_items?: int,
      *      limit?: int,
-     *      min_score?: float
+     *      min_score?: float,
+     *      include_vectors?: bool,
      *  } $options
      */
     public function query(QueryInterface $query, array $options = []): iterable
@@ -160,7 +162,7 @@ final class Store implements StoreInterface
 
             yield new VectorDocument(
                 id: $record['id'],
-                vector: new Vector($embedding),
+                vector: $options['include_vectors'] ?? false ? new Vector($embedding) : new NullVector(),
                 metadata: new Metadata($metadata),
                 score: (float) $record['score'],
             );

--- a/src/store/src/Bridge/Supabase/Store.php
+++ b/src/store/src/Bridge/Supabase/Store.php
@@ -160,9 +160,17 @@ final class Store implements StoreInterface
             $embedding = \is_array($record[$this->vectorFieldName]) ? $record[$this->vectorFieldName] : json_decode($record[$this->vectorFieldName] ?? '{}', true, 512, \JSON_THROW_ON_ERROR);
             $metadata = \is_array($record['metadata']) ? $record['metadata'] : json_decode($record['metadata'], true, 512, \JSON_THROW_ON_ERROR);
 
+            $vector = new Vector($embedding);
+
+            if (!($options['include_vectors'] ?? true)) {
+                unset($record[$this->vectorFieldName]);
+
+                $vector = new NullVector();
+            }
+
             yield new VectorDocument(
                 id: $record['id'],
-                vector: $options['include_vectors'] ?? true ? new Vector($embedding) : new NullVector(),
+                vector: $vector,
                 metadata: new Metadata($metadata),
                 score: (float) $record['score'],
             );

--- a/src/store/src/Bridge/Supabase/Store.php
+++ b/src/store/src/Bridge/Supabase/Store.php
@@ -162,7 +162,7 @@ final class Store implements StoreInterface
 
             yield new VectorDocument(
                 id: $record['id'],
-                vector: $options['include_vectors'] ?? false ? new Vector($embedding) : new NullVector(),
+                vector: $options['include_vectors'] ?? true ? new Vector($embedding) : new NullVector(),
                 metadata: new Metadata($metadata),
                 score: (float) $record['score'],
             );

--- a/src/store/src/Bridge/Supabase/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Supabase/Tests/StoreTest.php
@@ -143,7 +143,11 @@ class StoreTest extends TestCase
         ];
         $httpClient = new MockHttpClient(new JsonMockResponse($expectedResponse));
         $store = $this->createStore($httpClient, 3);
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0, 3.0])), ['max_items' => 5, 'min_score' => 0.7]));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0, 3.0])), [
+            'max_items' => 5,
+            'min_score' => 0.7,
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(1, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
@@ -175,7 +179,11 @@ class StoreTest extends TestCase
         $httpClient = new MockHttpClient(new JsonMockResponse($expectedResponse));
         $store = $this->createStore($httpClient, 2);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0])), ['max_items' => 2, 'min_score' => 0.8]));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0])), [
+            'max_items' => 2,
+            'min_score' => 0.8,
+            'include_vectors' => true,
+        ]));
 
         $this->assertCount(2, $result);
         $this->assertInstanceOf(VectorDocument::class, $result[0]);
@@ -206,7 +214,9 @@ class StoreTest extends TestCase
         $httpClient = new MockHttpClient(new JsonMockResponse($expectedResponse));
         $store = $this->createStore($httpClient, 3);
 
-        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0, 3.0]))));
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([1.0, 2.0, 3.0])), [
+            'include_vectors' => true,
+        ]));
 
         $document = $result[0];
         $metadata = $document->getMetadata()->getArrayCopy();

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -165,9 +165,13 @@ class Store implements ManagedStoreInterface, StoreInterface
     {
         $id = $data['_metadata']['_id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
 
-        $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
-            ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($data[$this->vectorFieldName]) : new NullVector());
+        $vector = new Vector($data[$this->vectorFieldName]);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($data[$this->vectorFieldName]);
+
+            $vector = new NullVector();
+        }
 
         unset($data['_metadata']['_id']);
 

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -167,7 +167,7 @@ class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
             ? new NullVector()
-            : ($options['include_vectors'] ?? false ? new Vector($data[$this->vectorFieldName]) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($data[$this->vectorFieldName]) : new NullVector());
 
         unset($data['_metadata']['_id']);
 

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -63,7 +63,13 @@ class Store implements ManagedStoreInterface, StoreInterface
         }
 
         foreach ($documents as $document) {
-            $this->request('POST', \sprintf('key/%s', $this->table), $this->convertToIndexableArray($document));
+            $this->request('POST', \sprintf('key/%s', $this->table), [
+                'id' => $document->getId(),
+                $this->vectorFieldName => $document->getVector()->getData(),
+                '_metadata' => array_merge($document->getMetadata()->getArrayCopy(), [
+                    '_id' => $document->getId(),
+                ]),
+            ]);
         }
     }
 
@@ -101,7 +107,7 @@ class Store implements ManagedStoreInterface, StoreInterface
         ));
 
         foreach ($results[0]['result'] as $item) {
-            yield $this->convertToVectorDocument($item);
+            yield $this->convertToVectorDocument($item, $options);
         }
     }
 
@@ -152,29 +158,16 @@ class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
-     * @return array<string, mixed>
-     */
-    private function convertToIndexableArray(VectorDocument $document): array
-    {
-        return [
-            'id' => $document->getId(),
-            $this->vectorFieldName => $document->getVector()->getData(),
-            '_metadata' => array_merge($document->getMetadata()->getArrayCopy(), [
-                '_id' => $document->getId(),
-            ]),
-        ];
-    }
-
-    /**
      * @param array<string, mixed> $data
+     * @param array<string, mixed> $options
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data, array $options): VectorDocument
     {
         $id = $data['_metadata']['_id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
 
         $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]
             ? new NullVector()
-            : new Vector($data[$this->vectorFieldName]);
+            : ($options['include_vectors'] ?? false ? new Vector($data[$this->vectorFieldName]) : new NullVector());
 
         unset($data['_metadata']['_id']);
 

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -160,9 +160,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $id = $document['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
 
-        $vector = !\array_key_exists($this->vectorFieldName, $document) || null === $document[$this->vectorFieldName]
-            ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($document[$this->vectorFieldName]) : new NullVector());
+        $vector = new Vector($document[$this->vectorFieldName]);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($document[$this->vectorFieldName]);
+
+            $vector = new NullVector();
+        }
 
         $score = $data['vector_distance'] ?? null;
 

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -162,7 +162,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->vectorFieldName, $document) || null === $document[$this->vectorFieldName]
             ? new NullVector()
-            : ($options['include_vectors'] ?? false ? new Vector($document[$this->vectorFieldName]) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($document[$this->vectorFieldName]) : new NullVector());
 
         $score = $data['vector_distance'] ?? null;
 

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -71,7 +71,11 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
 
         foreach ($documents as $document) {
-            $this->request('POST', \sprintf('collections/%s/documents', $this->collection), $this->convertToIndexableArray($document));
+            $this->request('POST', \sprintf('collections/%s/documents', $this->collection), [
+                'id' => $document->getId(),
+                $this->vectorFieldName => $document->getVector()->getData(),
+                'metadata' => json_encode($document->getMetadata()->getArrayCopy()),
+            ]);
         }
     }
 
@@ -119,7 +123,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
 
         foreach ($documents['results'][0]['hits'] as $item) {
-            yield $this->convertToVectorDocument($item);
+            yield $this->convertToVectorDocument($item, $options);
         }
     }
 
@@ -147,21 +151,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
-     * @return array<string, mixed>
-     */
-    private function convertToIndexableArray(VectorDocument $document): array
-    {
-        return [
-            'id' => $document->getId(),
-            $this->vectorFieldName => $document->getVector()->getData(),
-            'metadata' => json_encode($document->getMetadata()->getArrayCopy()),
-        ];
-    }
-
-    /**
      * @param array<string, mixed> $data
+     * @param array<string, mixed> $options
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data, array $options): VectorDocument
     {
         $document = $data['document'] ?? throw new InvalidArgumentException('Missing "document" field in the document data.');
 
@@ -169,7 +162,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists($this->vectorFieldName, $document) || null === $document[$this->vectorFieldName]
             ? new NullVector()
-            : new Vector($document[$this->vectorFieldName]);
+            : ($options['include_vectors'] ?? false ? new Vector($document[$this->vectorFieldName]) : new NullVector());
 
         $score = $data['vector_distance'] ?? null;
 

--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -175,7 +175,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists('vector', $data) || null === $data['vector']
             ? new NullVector()
-            : ($options['include_vectors'] ?? false ? new Vector($data['vector']) : new NullVector());
+            : ($options['include_vectors'] ?? true ? new Vector($data['vector']) : new NullVector());
 
         return new VectorDocument($id, $vector, new Metadata(json_decode($data['_metadata'], true)));
     }

--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -175,7 +175,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $vector = !\array_key_exists('vector', $data) || null === $data['vector']
             ? new NullVector()
-            : ($options['include_vectors'] ?? true ? new Vector($data['vector']) : new NullVector());
+            : new Vector($data['vector']);
+
+        if (!($options['include_vectors'] ?? true)) {
+            unset($data['vector']);
+
+            $vector = new NullVector();
+        }
 
         return new VectorDocument($id, $vector, new Metadata(json_decode($data['_metadata'], true)));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT


* Introduce a `include_vectors` option in stores to retrieve documents + vectors at runtime
* By default, vectors are not retrieved when using `Store::query()`