### PR TITLE
[Platform][Anthropic] Fix `AssistantMessageNormalizer` to support tools properly

### DIFF
--- a/src/platform/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
@@ -32,10 +32,11 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
      * @return array{
      *     role: 'assistant',
      *     content: string|list<array{
-     *         type: 'tool_use',
-     *         id: string,
-     *         name: string,
-     *         input: array<string, mixed>
+     *         type: 'text'|'tool_use',
+     *         id?: string,
+     *         name?: string,
+     *         input?: array<string, mixed>,
+     *         text?: string
      *     }>
      * }
      */
@@ -43,14 +44,17 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
     {
         return [
             'role' => 'assistant',
-            'content' => $data->hasToolCalls() ? array_map(static function (ToolCall $toolCall) {
-                return [
-                    'type' => 'tool_use',
-                    'id' => $toolCall->getId(),
-                    'name' => $toolCall->getName(),
-                    'input' => [] !== $toolCall->getArguments() ? $toolCall->getArguments() : new \stdClass(),
-                ];
-            }, $data->getToolCalls()) : $data->getContent(),
+            'content' => $data->hasToolCalls() ? array_merge(
+                null !== $data->getContent() ? [['type' => 'text', 'text' => $data->getContent()]] : [],
+                array_map(static function (ToolCall $toolCall) {
+                    return [
+                        'type' => 'tool_use',
+                        'id' => $toolCall->getId(),
+                        'name' => $toolCall->getName(),
+                        'input' => [] !== $toolCall->getArguments() ? $toolCall->getArguments() : new \stdClass(),
+                    ];
+                }, $data->getToolCalls())
+            ) : $data->getContent(),
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | 
| License       | MIT

When Claude prefixes a tool call with a sentence, the `text` block must be preserved in the serialized content array alongside the `tool_use` block. Previously a ternary chose either `text` OR `tool_use`, silently dropping the text.

See https://platform.claude.com/docs/en/agents-and-tools/tool-use/implement-tool-use#model-responses-with-tools
