### PR TITLE
[Platform][ModelsDev] Add `ModelResolver`

### DIFF
--- a/src/platform/src/Bridge/ModelsDev/ModelResolver.php
+++ b/src/platform/src/Bridge/ModelsDev/ModelResolver.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\ModelsDev;
+
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+
+/**
+ * Resolves a model specification string to a (provider, model ID) pair.
+ *
+ * Accepted input formats (resolved in that order):
+ *
+ *   * "provider::model": Explicit form like "anthropic::claude-opus-4-5"
+ *
+ *   * "provider": Provider-only, returns the first non-deprecated model listed
+ *     in that provider's catalog.
+ *
+ *   * "model": Model ID, scans all provider catalogs to find the owning
+ *     provider, checking canonical providers first over aggregator/proxy
+ *     providers being preferred.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class ModelResolver
+{
+    /**
+     * @var list<string>
+     */
+    private const CANONICAL_PROVIDERS = [
+        'anthropic', 'openai', 'google', 'mistral', 'xai',
+        'deepseek', 'groq', 'cerebras', 'cohere',
+    ];
+
+    private readonly ProviderRegistry $registry;
+
+    public function __construct(
+        ?ProviderRegistry $registry = null,
+        ?string $dataPath = null,
+    ) {
+        $this->registry = $registry ?? new ProviderRegistry($dataPath);
+    }
+
+    /**
+     * Resolves a model specification to a (provider, modelId) pair.
+     *
+     * @return array{provider: string, model_id: string}
+     *
+     * @throws InvalidArgumentException when the provider or model cannot be determined
+     */
+    public function resolve(string $modelSpec): array
+    {
+        // "provider::model"
+        if (str_contains($modelSpec, '::')) {
+            [$provider, $modelId] = explode('::', $modelSpec, 2);
+
+            if ('' === $provider) {
+                throw new InvalidArgumentException(\sprintf('Invalid model specification "%s": provider part is empty.', $modelSpec));
+            }
+            if ('' === $modelId) {
+                throw new InvalidArgumentException(\sprintf('Invalid model specification "%s": model ID part is empty.', $modelSpec));
+            }
+
+            return ['provider' => $provider, 'model_id' => $modelId];
+        }
+
+        // "provider"
+        if ($this->registry->has($modelSpec)) {
+            return ['provider' => $modelSpec, 'model_id' => $this->resolveFirstModel($modelSpec)];
+        }
+
+        // "model-id"
+        return ['provider' => $this->findProviderForModel($modelSpec), 'model_id' => $modelSpec];
+    }
+
+    /**
+     * Returns the first non-deprecated model ID from a provider's catalog.
+     *
+     * @throws InvalidArgumentException when no models are found for the provider
+     */
+    private function resolveFirstModel(string $provider): string
+    {
+        if (null === $catalog = $this->registry->getCatalog($provider)) {
+            throw new InvalidArgumentException(\sprintf('No model catalog found for provider "%s"; use "provider::model" format.', $provider));
+        }
+
+        if ([] === $models = array_keys($catalog->getModels())) {
+            throw new InvalidArgumentException(\sprintf('No models found for provider "%s"; use "provider::model" format.', $provider));
+        }
+
+        return $models[0];
+    }
+
+    /**
+     * Scans provider catalogs to find which provider owns a given model ID.
+     *
+     * Canonical providers are checked first; all others follow in registry order.
+     *
+     * @throws InvalidArgumentException when no provider lists the model
+     */
+    private function findProviderForModel(string $modelId): string
+    {
+        // Check canonical providers first for deterministic resolution
+        foreach (self::CANONICAL_PROVIDERS as $providerId) {
+            if (isset($this->registry->getCatalog($providerId)?->getModels()[$modelId])) {
+                return $providerId;
+            }
+        }
+
+        // Fall back to full registry scan
+        foreach ($this->registry->getProviderIds() as $providerId) {
+            if (\in_array($providerId, self::CANONICAL_PROVIDERS, true)) {
+                continue; // already checked
+            }
+
+            if (isset($this->registry->getCatalog($providerId)?->getModels()[$modelId])) {
+                return $providerId;
+            }
+        }
+
+        throw new InvalidArgumentException(\sprintf('Cannot determine provider for model "%s"; Use "provider::model" format to specify it explicitly.', $modelId));
+    }
+}

--- a/src/platform/src/Bridge/ModelsDev/ProviderRegistry.php
+++ b/src/platform/src/Bridge/ModelsDev/ProviderRegistry.php
@@ -25,8 +25,9 @@ final class ProviderRegistry
      */
     private readonly array $providers;
 
-    public function __construct(?string $dataPath = null)
-    {
+    public function __construct(
+        private ?string $dataPath = null,
+    ) {
         $providers = [];
         foreach (DataLoader::load($dataPath) as $providerId => $providerData) {
             $providers[$providerId] = [
@@ -57,6 +58,15 @@ final class ProviderRegistry
         }
 
         return $this->providers[$providerId]['name'];
+    }
+
+    public function getCatalog(string $providerId): ?ModelCatalog
+    {
+        if (!isset($this->providers[$providerId])) {
+            return null;
+        }
+
+        return new ModelCatalog($providerId, $this->dataPath);
     }
 
     public function has(string $providerId): bool

--- a/src/platform/src/Bridge/ModelsDev/Tests/ModelResolverTest.php
+++ b/src/platform/src/Bridge/ModelsDev/Tests/ModelResolverTest.php
@@ -1,0 +1,305 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\ModelsDev\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\ModelsDev\ModelResolver;
+use Symfony\AI\Platform\Bridge\ModelsDev\ProviderRegistry;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class ModelResolverTest extends TestCase
+{
+    public function testExplicitProviderColonModel()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('anthropic::claude-opus-4-5');
+
+        $this->assertSame('anthropic', $result['provider']);
+        $this->assertSame('claude-opus-4-5', $result['model_id']);
+    }
+
+    public function testExplicitProviderColonModelWithSlashInModelId()
+    {
+        // OpenRouter uses slash-separated namespaced model IDs
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('openrouter::meta-llama/llama-3.3-70b-instruct');
+
+        $this->assertSame('openrouter', $result['provider']);
+        $this->assertSame('meta-llama/llama-3.3-70b-instruct', $result['model_id']);
+    }
+
+    public function testExplicitFormPreservesEverythingAfterFirstColon()
+    {
+        // Only the first colon is the delimiter; subsequent colons belong to the model ID
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('groq::llama-3.3-70b:free');
+
+        $this->assertSame('groq', $result['provider']);
+        $this->assertSame('llama-3.3-70b:free', $result['model_id']);
+    }
+
+    public function testExplicitFormWithUnknownProviderIsAllowed()
+    {
+        // Unknown providers are fine in explicit form — validation happens later
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('my-local-server::custom-model');
+
+        $this->assertSame('my-local-server', $result['provider']);
+        $this->assertSame('custom-model', $result['model_id']);
+    }
+
+    public function testExplicitFormThrowsOnEmptyProvider()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('provider part is empty');
+
+        $resolver = new ModelResolver();
+        $resolver->resolve('::claude-opus-4-5');
+    }
+
+    public function testExplicitFormThrowsOnEmptyModelId()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('model ID part is empty');
+
+        $resolver = new ModelResolver();
+        $resolver->resolve('anthropic::');
+    }
+
+    public function testProviderOnlyReturnsFirstModel()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('anthropic');
+
+        $this->assertSame('anthropic', $result['provider']);
+        $this->assertNotEmpty($result['model_id']);
+    }
+
+    public function testProviderOnlyReturnsFirstModelForOpenAI()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('openai');
+
+        $this->assertSame('openai', $result['provider']);
+        $this->assertNotEmpty($result['model_id']);
+    }
+
+    public function testProviderOnlyReturnsFirstModelForGoogle()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('google');
+
+        $this->assertSame('google', $result['provider']);
+        $this->assertNotEmpty($result['model_id']);
+    }
+
+    public function testProviderOnlyReturnsFirstModelForGroq()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('groq');
+
+        $this->assertSame('groq', $result['provider']);
+        $this->assertNotEmpty($result['model_id']);
+    }
+
+    public function testProviderOnlyReturnsFirstModelForDeepSeek()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('deepseek');
+
+        $this->assertSame('deepseek', $result['provider']);
+        $this->assertNotEmpty($result['model_id']);
+    }
+
+    public function testBareModelIdInfersAnthropicProvider()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('claude-opus-4-5');
+
+        $this->assertSame('anthropic', $result['provider']);
+        $this->assertSame('claude-opus-4-5', $result['model_id']);
+    }
+
+    public function testBareModelIdInfersOpenAIProvider()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('gpt-4o');
+
+        $this->assertSame('openai', $result['provider']);
+        $this->assertSame('gpt-4o', $result['model_id']);
+    }
+
+    public function testBareModelIdInfersGoogleProvider()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('gemini-2.5-pro');
+
+        $this->assertSame('google', $result['provider']);
+        $this->assertSame('gemini-2.5-pro', $result['model_id']);
+    }
+
+    public function testBareModelIdInfersMistralProvider()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('mistral-large-latest');
+
+        $this->assertSame('mistral', $result['provider']);
+        $this->assertSame('mistral-large-latest', $result['model_id']);
+    }
+
+    public function testBareModelIdInfersXAIProvider()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('grok-4');
+
+        $this->assertSame('xai', $result['provider']);
+        $this->assertSame('grok-4', $result['model_id']);
+    }
+
+    public function testBareModelIdInfersDeepSeekProvider()
+    {
+        $resolver = new ModelResolver();
+        $result = $resolver->resolve('deepseek-chat');
+
+        $this->assertSame('deepseek', $result['provider']);
+        $this->assertSame('deepseek-chat', $result['model_id']);
+    }
+
+    public function testBareModelIdThrowsForCompletelyUnknownModel()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot determine provider for model');
+        $this->expectExceptionMessage('"completely-unknown-model-xyz-404"');
+
+        $resolver = new ModelResolver();
+        $resolver->resolve('completely-unknown-model-xyz-404');
+    }
+
+    public function testErrorMessageSuggestsExplicitFormat()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Use "provider::model" format');
+
+        $resolver = new ModelResolver();
+        $resolver->resolve('nonexistent-model-abc');
+    }
+
+    public function testCustomDataPathIsUsed()
+    {
+        $fixturePath = $this->createFixtureFile([
+            'my-provider' => [
+                'id' => 'my-provider',
+                'name' => 'My Provider',
+                'api' => 'https://api.my-provider.example.com/v1',
+                'models' => [
+                    'my-model-v1' => [
+                        'id' => 'my-model-v1',
+                        'name' => 'My Model v1',
+                        'family' => 'my-model',
+                        'attachment' => false,
+                        'reasoning' => false,
+                        'tool_call' => true,
+                        'temperature' => true,
+                        'modalities' => ['input' => ['text'], 'output' => ['text']],
+                        'cost' => ['input' => 1.0, 'output' => 2.0],
+                        'limit' => ['context' => 8192, 'output' => 4096],
+                    ],
+                    'my-model-v2' => [
+                        'id' => 'my-model-v2',
+                        'name' => 'My Model v2',
+                        'family' => 'my-model',
+                        'attachment' => false,
+                        'reasoning' => false,
+                        'tool_call' => true,
+                        'temperature' => true,
+                        'modalities' => ['input' => ['text'], 'output' => ['text']],
+                        'cost' => ['input' => 1.5, 'output' => 3.0],
+                        'limit' => ['context' => 16384, 'output' => 8192],
+                    ],
+                ],
+            ],
+        ]);
+
+        try {
+            $resolver = new ModelResolver(dataPath: $fixturePath);
+
+            // Provider-only: should return first model
+            $result = $resolver->resolve('my-provider');
+            $this->assertSame('my-provider', $result['provider']);
+            $this->assertSame('my-model-v1', $result['model_id']);
+
+            // Bare model ID: should find the provider
+            $result = $resolver->resolve('my-model-v2');
+            $this->assertSame('my-provider', $result['provider']);
+            $this->assertSame('my-model-v2', $result['model_id']);
+
+            // Explicit form: always works
+            $result = $resolver->resolve('my-provider::my-model-v1');
+            $this->assertSame('my-provider', $result['provider']);
+            $this->assertSame('my-model-v1', $result['model_id']);
+        } finally {
+            unlink($fixturePath);
+        }
+    }
+
+    public function testAcceptsExternalProviderRegistry()
+    {
+        // The resolver should accept an externally constructed registry
+        // (e.g. with a custom data path) without creating its own.
+        $fixturePath = $this->createFixtureFile([
+            'external-provider' => [
+                'id' => 'external-provider',
+                'name' => 'External',
+                'api' => 'https://api.external.example.com/v1',
+                'models' => [
+                    'ext-model-1' => [
+                        'id' => 'ext-model-1',
+                        'name' => 'Ext Model 1',
+                        'family' => 'ext',
+                        'attachment' => false,
+                        'reasoning' => false,
+                        'tool_call' => false,
+                        'temperature' => true,
+                        'modalities' => ['input' => ['text'], 'output' => ['text']],
+                        'cost' => ['input' => 0.5, 'output' => 1.0],
+                        'limit' => ['context' => 4096, 'output' => 2048],
+                    ],
+                ],
+            ],
+        ]);
+
+        try {
+            $registry = new ProviderRegistry($fixturePath);
+            $resolver = new ModelResolver($registry, $fixturePath);
+
+            $result = $resolver->resolve('external-provider');
+            $this->assertSame('external-provider', $result['provider']);
+            $this->assertSame('ext-model-1', $result['model_id']);
+        } finally {
+            unlink($fixturePath);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function createFixtureFile(array $data): string
+    {
+        $path = sys_get_temp_dir().'/model-resolver-test-'.uniqid().'.json';
+        file_put_contents($path, json_encode($data, \JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+}

--- a/src/platform/src/Bridge/ModelsDev/composer.json
+++ b/src/platform/src/Bridge/ModelsDev/composer.json
@@ -30,7 +30,10 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5.53",
         "symfony/ai-anthropic-platform": "^0.3",
-        "symfony/ai-gemini-platform": "^0.3"
+        "symfony/ai-bedrock-platform": "^0.3",
+        "symfony/ai-gemini-platform": "^0.3",
+        "symfony/ai-meta-platform": "^0.3",
+        "symfony/ai-vertex-ai-platform": "^0.3"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | 
| License       | MIT

A small addition to let users use "shortcuts" for the model names they want to use.
We are now sorting models as well so that when using just "anthropic" as a model name, we get back the latest available model.
