### PR TITLE
[AI Bundle] Fix `DataCollector` failing when iterables are `RewindableGenerator`

### DIFF
--- a/src/ai-bundle/src/Profiler/DataCollector.php
+++ b/src/ai-bundle/src/Profiler/DataCollector.php
@@ -37,17 +37,41 @@ use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 final class DataCollector extends AbstractDataCollector implements LateDataCollectorInterface
 {
     /**
-     * @param TraceablePlatform[]     $platforms
-     * @param TraceableToolbox[]      $toolboxes
-     * @param TraceableMessageStore[] $messageStores
-     * @param TraceableChat[]         $chats
+     * @var TraceablePlatform[]
+     */
+    private readonly array $platforms;
+
+    /**
+     * @var TraceableToolbox[]
+     */
+    private readonly array $toolboxes;
+
+    /**
+     * @var TraceableMessageStore[]
+     */
+    private readonly array $messageStores;
+
+    /**
+     * @var TraceableChat[]
+     */
+    private readonly array $chats;
+
+    /**
+     * @param iterable<TraceablePlatform>     $platforms
+     * @param iterable<TraceableToolbox>      $toolboxes
+     * @param iterable<TraceableMessageStore> $messageStores
+     * @param iterable<TraceableChat>         $chats
      */
     public function __construct(
-        private readonly iterable $platforms,
-        private readonly iterable $toolboxes,
-        private readonly iterable $messageStores,
-        private readonly iterable $chats,
+        iterable $platforms,
+        iterable $toolboxes,
+        iterable $messageStores,
+        iterable $chats,
     ) {
+        $this->platforms = iterator_to_array($platforms);
+        $this->toolboxes = iterator_to_array($toolboxes);
+        $this->messageStores = iterator_to_array($messageStores);
+        $this->chats = iterator_to_array($chats);
     }
 
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void

--- a/src/ai-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/ai-bundle/tests/Profiler/DataCollectorTest.php
@@ -178,4 +178,17 @@ class DataCollectorTest extends TestCase
         $this->assertStringNotContainsString('\\', $name);
         $this->assertStringNotContainsString('DataCollector', $name);
     }
+
+    public function testLateCollectWithRewindableGeneratorAsToolboxes()
+    {
+        $generator = (static function (): \Generator {
+            yield from [];
+        })();
+
+        $dataCollector = new DataCollector([], $generator, [], []);
+        $dataCollector->lateCollect();
+
+        $this->assertSame([], $dataCollector->getTools());
+        $this->assertSame([], $dataCollector->getToolCalls());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1640
| License       | MIT

When an application has no toolboxes, message stores, or chats registered, the profiler crashes with:

```
TypeError: array_map(): Argument #2 (\$array) must be of type array, Symfony\Component\DependencyInjection\Argument\RewindableGenerator given
in src/ai-bundle/src/Profiler/DataCollector.php (line 124)
```

This happens because Symfony's DI container injects a `RewindableGenerator` for `tagged_iterator` arguments when no services are tagged — and \`array_map()\` only accepts arrays.

This is a normal use case: using the bundle with just a platform (e.g. Ollama) and no tools, message stores or chats is perfectly valid. The `ai.traceable_toolbox` tag is only added when a toolbox is explicitly configured, so a minimal setup will always hit this.

This can be confirmed with `bin/console debug:container ai.data_collector`:

```
Arguments        Tagged Iterator for "ai.traceable_platform"
                 - Service(ai.traceable_platform.ollama)
                 Tagged Iterator for "ai.traceable_toolbox"        ← empty
                 Tagged Iterator for "ai.traceable_message_store"  ← empty
                 Tagged Iterator for "ai.traceable_chat"           ← empty
```