### PR TITLE
[Docs] Add cookbook articles for multi-agent orchestration and streaming responses

### DIFF
--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -12,7 +12,9 @@ Getting Started Guides
 
     chatbot-with-memory
     dynamic-tools
+    multi-agent-orchestration
     rag-implementation
+    streaming-responses
     structured-output-object-instances
 
 Memory & Context Management
@@ -25,10 +27,20 @@ Tools
 
 * :doc:`dynamic-tools` - Build a dynamic Toolbox for flexible tool management at runtime
 
+Multi-Agent Systems
+-------------------
+
+* :doc:`multi-agent-orchestration` - Orchestrate multiple specialized agents with automatic routing and handoffs
+
 Retrieval Augmented Generation
 ------------------------------
 
 * :doc:`rag-implementation` - Implement complete RAG systems with vector stores and semantic search
+
+Streaming
+---------
+
+* :doc:`streaming-responses` - Stream AI responses token by token for a faster user experience
 
 Structured Output
 -----------------

--- a/docs/cookbook/multi-agent-orchestration.rst
+++ b/docs/cookbook/multi-agent-orchestration.rst
@@ -1,0 +1,324 @@
+Multi-Agent Orchestration
+=========================
+
+This guide explains how to build multi-agent systems with Symfony AI, where
+a central orchestrator routes user requests to specialized agents based on
+the content of the message.
+
+What is Multi-Agent Orchestration?
+-----------------------------------
+
+A single monolithic agent quickly becomes hard to maintain as capabilities
+grow. Multi-agent systems solve this by splitting responsibilities:
+
+* **Orchestrator** – analyses each request and decides which specialist handles it
+* **Specialized agents** – each expert in a narrow domain (support, billing, research, …)
+* **Fallback agent** – catches everything that does not match a specialist
+
+Symfony AI ships two complementary patterns for this:
+
+1. **MultiAgent** – a ready-made orchestrator-with-handoffs component
+2. **Subagent tool** – wraps any agent as a callable tool so a parent agent
+   can invoke it just like any other tool
+
+Prerequisites
+-------------
+
+* Symfony AI Agent component (``symfony/ai-agent``)
+* An API key for at least one supported platform
+* Basic understanding of :doc:`../components/agent`
+
+Pattern 1: MultiAgent with Handoffs
+------------------------------------
+
+The :class:`Symfony\\AI\\Agent\\MultiAgent\\MultiAgent` class implements
+:class:`Symfony\\AI\\Agent\\AgentInterface`, so it can replace any regular
+agent transparently.
+
+Minimal Example
+~~~~~~~~~~~~~~~
+
+.. code-block:: terminal
+
+    $ composer require symfony/ai-agent
+
+::
+
+    use Symfony\AI\Agent\Agent;
+    use Symfony\AI\Agent\InputProcessor\SystemPromptInputProcessor;
+    use Symfony\AI\Agent\MultiAgent\Handoff;
+    use Symfony\AI\Agent\MultiAgent\MultiAgent;
+    use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+    use Symfony\AI\Platform\Message\Message;
+    use Symfony\AI\Platform\Message\MessageBag;
+    use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+    use Symfony\Component\EventDispatcher\EventDispatcher;
+
+    // Structured output is required for the orchestrator's routing decision
+    $dispatcher = new EventDispatcher();
+    $dispatcher->addSubscriber(new PlatformSubscriber());
+
+    $platform = PlatformFactory::create(
+        apiKey: $_ENV['OPENAI_API_KEY'],
+        eventDispatcher: $dispatcher,
+    );
+
+    // The orchestrator only routes – keep it cheap and fast
+    $orchestrator = new Agent(
+        $platform,
+        'gpt-4o-mini',
+        [new SystemPromptInputProcessor(
+            'You are an intelligent agent orchestrator that routes user questions to specialized agents.'
+        )],
+    );
+
+    // Specialist: technical support
+    $technical = new Agent(
+        $platform,
+        'gpt-4o-mini',
+        [new SystemPromptInputProcessor('You are a technical support specialist. Help users resolve bugs, errors, and technical problems.')],
+        name: 'technical',
+    );
+
+    // Fallback for everything else
+    $general = new Agent(
+        $platform,
+        'gpt-4o-mini',
+        [new SystemPromptInputProcessor('You are a helpful general assistant.')],
+        name: 'general',
+    );
+
+    $multiAgent = new MultiAgent(
+        orchestrator: $orchestrator,
+        handoffs: [
+            new Handoff(to: $technical, when: ['bug', 'error', 'exception', 'crash', 'technical']),
+        ],
+        fallback: $general,
+    );
+
+    $result = $multiAgent->call(new MessageBag(
+        Message::ofUser('I get "Call to undefined method" in my PHP code, how do I fix it?')
+    ));
+
+    echo $result->getContent();
+
+How It Works
+~~~~~~~~~~~~
+
+When ``call()`` is invoked, the ``MultiAgent``:
+
+1. Extracts the user message text.
+2. Builds a routing prompt listing all registered agents and their trigger
+   keywords (``when``).
+3. Asks the **orchestrator** to pick the best agent using structured output
+   (a :class:`Symfony\\AI\\Agent\\MultiAgent\\Handoff\\Decision` object).
+4. Delegates the **original** user message to the selected specialist, or to
+   the fallback if no specialist matches.
+
+.. note::
+
+    The orchestrator uses structured output internally, so a
+    :class:`Symfony\\AI\\Platform\\StructuredOutput\\PlatformSubscriber` must
+    be registered with the platform's event dispatcher.
+
+Handoff Configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+Each :class:`Symfony\\AI\\Agent\\MultiAgent\\Handoff` requires:
+
+* ``to`` – the target :class:`Symfony\\AI\\Agent\\AgentInterface` instance
+* ``when`` – a non-empty list of keywords/phrases that trigger this handoff
+
+The orchestrator converts these into plain English descriptions that are
+included in its routing prompt, so the more descriptive the keywords, the
+better the routing decisions::
+
+    new Handoff(
+        to: $billingAgent,
+        when: ['invoice', 'payment', 'subscription', 'refund', 'billing'],
+    ),
+    new Handoff(
+        to: $securityAgent,
+        when: ['password', 'login', 'account locked', '2fa', 'security'],
+    ),
+
+Multiple Specialists
+~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    $multiAgent = new MultiAgent(
+        orchestrator: $orchestrator,
+        handoffs: [
+            new Handoff(to: $technical,  when: ['bug', 'error', 'technical']),
+            new Handoff(to: $billing,    when: ['invoice', 'payment', 'refund']),
+            new Handoff(to: $onboarding, when: ['getting started', 'install', 'setup']),
+        ],
+        fallback: $general,
+    );
+
+Agent Names
+~~~~~~~~~~~
+
+Give each specialist a descriptive ``name`` via the ``name`` constructor
+parameter of :class:`Symfony\\AI\\Agent\\Agent`. The ``MultiAgent`` uses this
+name to match the orchestrator's routing decision to the correct agent::
+
+    $technical = new Agent($platform, 'gpt-4o-mini', [...], name: 'technical_support');
+
+Debug Logging
+~~~~~~~~~~~~~
+
+Pass a :class:`Psr\\Log\\LoggerInterface` to ``MultiAgent`` to trace routing
+decisions at runtime::
+
+    use Psr\Log\LoggerInterface;
+
+    $multiAgent = new MultiAgent(
+        orchestrator: $orchestrator,
+        handoffs: [...],
+        fallback: $general,
+        logger: $logger, // logs agent selection and reasoning
+    );
+
+The logger emits ``debug``-level messages for every routing step.
+
+Pattern 2: Subagent Tool
+-------------------------
+
+The :class:`Symfony\\AI\\Agent\\Toolbox\\Tool\\Subagent` class wraps an agent
+as a tool. This is useful when the parent agent should decide *when* to invoke
+a specialist based on the conversation context, rather than having a fixed
+routing table::
+
+    use Symfony\AI\Agent\Agent;
+    use Symfony\AI\Agent\Toolbox\AgentProcessor;
+    use Symfony\AI\Agent\Toolbox\Tool\Subagent;
+    use Symfony\AI\Agent\Toolbox\Toolbox;
+    use Symfony\AI\Agent\Toolbox\ToolFactory\MemoryToolFactory;
+
+    // A Wikipedia research agent
+    $researchAgent = new Agent($platform, 'gpt-4o-mini', [
+        new SystemPromptInputProcessor('You are a research specialist. Answer questions with facts from Wikipedia.'),
+    ]);
+
+    $subagent = new Subagent($researchAgent);
+
+    $metadataFactory = (new MemoryToolFactory())
+        ->addTool(
+            class: $subagent,
+            name: 'research',
+            description: 'Researches a topic and returns a factual summary.',
+        );
+
+    $toolbox = new Toolbox($metadataFactory, [$subagent]);
+    $processor = new AgentProcessor($toolbox);
+
+    // Parent agent that can delegate to the research specialist
+    $parent = new Agent($platform, 'gpt-4o', [$processor], [$processor]);
+    $result = $parent->call(new MessageBag(
+        Message::ofUser('Summarise the history of PHP in two paragraphs.')
+    ));
+
+The ``Subagent`` wrapper also propagates sources from the inner agent, so
+citations from a Wikipedia tool remain available on the outer result.
+
+Choosing a Pattern
+------------------
+
++----------------------------+---------------------------------------------------+
+| Use **MultiAgent**         | Use **Subagent**                                  |
++============================+===================================================+
+| Fixed routing table        | Dynamic tool-based delegation                     |
++----------------------------+---------------------------------------------------+
+| Single entry point needed  | Parent agent decides when to delegate             |
++----------------------------+---------------------------------------------------+
+| Specialist hidden from LLM | Specialist visible to LLM as a named tool         |
++----------------------------+---------------------------------------------------+
+| Routing driven by keywords | Routing driven by full conversation context       |
++----------------------------+---------------------------------------------------+
+
+Bundle Configuration
+--------------------
+
+When using :doc:`../bundles/ai-bundle`, agents are defined in YAML and can
+reference each other by their service name:
+
+.. code-block:: yaml
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            openai:
+                api_key: '%env(OPENAI_API_KEY)%'
+
+        agent:
+            # Specialized agents
+            technical_support:
+                model: 'gpt-4o-mini'
+                prompt:
+                    text: 'You are a technical support specialist.'
+
+            research:
+                model: 'gpt-4o-mini'
+                prompt:
+                    text: 'You are a research specialist.'
+                tools:
+                    - 'Symfony\AI\Agent\Bridge\Wikipedia\Wikipedia'
+
+            # Parent agent that uses the research agent as a sub-agent tool
+            assistant:
+                model: 'gpt-4o'
+                prompt:
+                    text: 'You are a helpful assistant. Use the research tool for factual questions.'
+                tools:
+                    - agent: 'research'
+                      name: 'research'
+                      description: 'Researches a topic and returns a factual summary.'
+
+Inject the agent services into your controllers or services via
+autowiring using the ``#[Target]`` attribute::
+
+    use Symfony\AI\Agent\AgentInterface;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
+
+    class AssistantController
+    {
+        public function __construct(
+            #[Target('ai.agent.assistant')]
+            private AgentInterface $agent,
+        ) {
+        }
+    }
+
+Best Practices
+--------------
+
+* **Keep the orchestrator cheap.** Use a fast, small model for routing (e.g.
+  ``gpt-4o-mini``) and reserve bigger models for the specialists that actually
+  answer users.
+* **Name your handoffs precisely.** Vague keywords like ``"help"`` will
+  confuse the orchestrator. Prefer domain-specific terms.
+* **Limit specialist scope.** A specialist with a narrow, well-defined purpose
+  produces better answers. If a specialist drifts into general territory,
+  restrict it in its system prompt.
+* **Enable fault tolerance.** Wrap toolboxes in
+  :class:`Symfony\\AI\\Agent\\Toolbox\\FaultTolerantToolbox` to prevent a
+  single failed tool call from crashing the entire multi-agent pipeline.
+* **Log routing decisions in development.** Pass a logger to ``MultiAgent``
+  and set the log level to ``debug`` so you can verify that requests are
+  routed to the intended specialist.
+
+Complete Example
+----------------
+
+See the complete runnable example:
+`multi-agent/orchestrator.php <https://github.com/symfony/ai/blob/main/examples/multi-agent/orchestrator.php>`_
+
+Related Documentation
+---------------------
+
+* :doc:`../components/agent` – Agent component documentation
+* :doc:`../bundles/ai-bundle` – AI Bundle configuration reference
+* :doc:`streaming-responses` – Stream agent responses token by token
+* :doc:`rag-implementation` – Augment agents with external knowledge

--- a/docs/cookbook/streaming-responses.rst
+++ b/docs/cookbook/streaming-responses.rst
@@ -1,0 +1,334 @@
+Streaming Responses
+===================
+
+This guide explains how to enable streaming in Symfony AI so that your
+application can display AI-generated text token by token instead of waiting
+for the complete response.
+
+What is Streaming?
+------------------
+
+Large language models generate text sequentially, word by word. Without
+streaming, your application must wait until the entire response has been
+generated before rendering anything. With streaming, each token is forwarded
+to the client as soon as it is produced via `Server-Sent Events`_ (SSE).
+
+The result is a much snappier user experience: the first word appears within
+milliseconds and the text builds up progressively, just like in ChatGPT.
+
+Symfony AI abstracts all SSE parsing and exposes the stream as a plain PHP
+:class:`Generator`.
+
+Prerequisites
+-------------
+
+* Symfony AI Platform component (``symfony/ai-platform``)
+* An API key for at least one supported platform
+* For web delivery: a mechanism to push chunks to the browser (see
+  :ref:`streaming-in-symfony-controllers`)
+
+Streaming at the Platform Level
+---------------------------------
+
+Pass ``'stream' => true`` in the options array when invoking the platform::
+
+    use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+    use Symfony\AI\Platform\Message\Message;
+    use Symfony\AI\Platform\Message\MessageBag;
+
+    $platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
+
+    $messages = new MessageBag(
+        Message::forSystem('You are a thoughtful philosopher.'),
+        Message::ofUser('What is the purpose of an ant?'),
+    );
+
+    $result = $platform->invoke('gpt-4o-mini', $messages, ['stream' => true]);
+
+    foreach ($result->asStream() as $chunk) {
+        echo $chunk;
+        flush();
+    }
+
+The same ``'stream' => true`` option works across all platforms that support
+streaming (OpenAI, Anthropic, Mistral, Gemini, Cerebras, …).
+
+Streaming at the Agent Level
+------------------------------
+
+When using the :class:`Symfony\\AI\\Agent\\Agent`, pass the same option to
+``call()``::
+
+    use Symfony\AI\Agent\Agent;
+    use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
+    use Symfony\AI\Platform\Message\Message;
+    use Symfony\AI\Platform\Message\MessageBag;
+
+    $platform = PlatformFactory::create($_ENV['ANTHROPIC_API_KEY']);
+    $agent = new Agent($platform, 'claude-sonnet-4-5-20250929');
+
+    $messages = new MessageBag(
+        Message::forSystem('You are a concise assistant.'),
+        Message::ofUser('Explain recursion in three sentences.'),
+    );
+
+    $result = $agent->call($messages, ['stream' => true]);
+
+    foreach ($result->getContent() as $chunk) {
+        echo $chunk;
+        flush();
+    }
+
+.. note::
+
+    Use ``$result->getContent()`` on an agent result and ``$result->asStream()``
+    on a platform result. Both yield the same generator of string chunks.
+
+Streaming with Tool Calls
+--------------------------
+
+Streaming works transparently alongside tool calling. The agent completes all
+tool call rounds first, and the **final** response is then streamed to the
+caller::
+
+    use Symfony\AI\Agent\Agent;
+    use Symfony\AI\Agent\Bridge\Wikipedia\Wikipedia;
+    use Symfony\AI\Agent\Toolbox\AgentProcessor;
+    use Symfony\AI\Agent\Toolbox\Toolbox;
+    use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+    use Symfony\AI\Platform\Message\Message;
+    use Symfony\AI\Platform\Message\MessageBag;
+    use Symfony\Component\HttpClient\HttpClient;
+
+    $platform = PlatformFactory::create($_ENV['OPENAI_API_KEY']);
+
+    $wikipedia = new Wikipedia(HttpClient::create());
+    $toolbox = new Toolbox([$wikipedia]);
+    $processor = new AgentProcessor($toolbox);
+
+    $agent = new Agent($platform, 'gpt-4o-mini', [$processor], [$processor]);
+    $messages = new MessageBag(
+        Message::ofUser('What is the capital of Austria? Look it up on Wikipedia.')
+    );
+
+    $result = $agent->call($messages, ['stream' => true]);
+
+    foreach ($result->getContent() as $chunk) {
+        echo $chunk;
+        flush();
+    }
+
+Handling Thinking Chunks in Streams
+-------------------------------------
+
+When using models that support extended reasoning (e.g. Claude with
+``thinking`` enabled), the stream may include
+:class:`Symfony\\AI\\Platform\\Result\\ThinkingContent` objects alongside
+regular text strings. Check the chunk type before echoing::
+
+    use Symfony\AI\Platform\Result\ThinkingContent;
+
+    $result = $platform->invoke('claude-sonnet-4-5', $messages, [
+        'stream' => true,
+        'thinking' => ['type' => 'enabled', 'budget_tokens' => 5000],
+    ]);
+
+    foreach ($result->getContent() as $chunk) {
+        if ($chunk instanceof ThinkingContent) {
+            // Optionally show the model's internal reasoning
+            continue;
+        }
+
+        echo $chunk;
+        flush();
+    }
+
+.. _streaming-in-symfony-controllers:
+
+Streaming in Symfony Controllers
+----------------------------------
+
+In a Symfony web application, use :class:`Symfony\\Component\\HttpFoundation\\StreamedResponse`
+to push chunks to the browser as they arrive::
+
+    use Symfony\AI\Agent\AgentInterface;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
+    use Symfony\Component\HttpFoundation\StreamedResponse;
+    use Symfony\Component\Routing\Attribute\Route;
+
+    #[Route('/chat', name: 'app_chat', methods: ['POST'])]
+    public function chat(
+        Request $request,
+        #[Target('ai.agent.default')]
+        AgentInterface $agent,
+    ): StreamedResponse {
+        $userMessage = $request->getPayload()->getString('message');
+
+        return new StreamedResponse(function () use ($agent, $userMessage): void {
+            $messages = new MessageBag(
+                Message::forSystem('You are a helpful assistant.'),
+                Message::ofUser($userMessage),
+            );
+
+            $result = $agent->call($messages, ['stream' => true]);
+
+            foreach ($result->getContent() as $chunk) {
+                echo $chunk;
+                ob_flush();
+                flush();
+            }
+        });
+    }
+
+.. note::
+
+    For a production-ready setup, consider using `Mercure`_ to push SSE
+    events from a background worker. This frees the web server from holding
+    long-lived HTTP connections.
+
+.. _streaming-with-mercure:
+
+Streaming with Mercure
+-----------------------
+
+When using Mercure, publish each chunk as a separate event from a background
+Symfony Messenger handler instead of the controller itself:
+
+1. **Controller** – accepts the user message, publishes a job to Messenger,
+   and immediately redirects or returns a job ID.
+2. **Message handler** – calls the agent with ``'stream' => true``, iterates
+   over the generator, and publishes each chunk to a Mercure hub.
+3. **Browser** – subscribes to the Mercure topic and appends chunks to the
+   DOM in real time.
+
+.. code-block:: yaml
+
+    # config/packages/mercure.yaml
+    mercure:
+        hubs:
+            default:
+                url: '%env(MERCURE_URL)%'
+                jwt_secret: '%env(MERCURE_JWT_SECRET)%'
+
+::
+
+    use Symfony\AI\Agent\AgentInterface;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
+    use Symfony\Component\Mercure\HubInterface;
+    use Symfony\Component\Mercure\Update;
+    use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+    #[AsMessageHandler]
+    final class StreamChatHandler
+    {
+        public function __construct(
+            #[Target('ai.agent.default')]
+            private AgentInterface $agent,
+            private HubInterface $hub,
+        ) {
+        }
+
+        public function __invoke(StreamChatMessage $message): void
+        {
+            $messages = new MessageBag(
+                Message::forSystem('You are a helpful assistant.'),
+                Message::ofUser($message->userInput),
+            );
+
+            $result = $this->agent->call($messages, ['stream' => true]);
+
+            foreach ($result->getContent() as $chunk) {
+                $this->hub->publish(new Update(
+                    topics: '/chat/'.$message->conversationId,
+                    data: json_encode(['chunk' => $chunk]),
+                ));
+            }
+
+            // Signal end of stream
+            $this->hub->publish(new Update(
+                topics: '/chat/'.$message->conversationId,
+                data: json_encode(['done' => true]),
+            ));
+        }
+    }
+
+Bundle Configuration
+---------------------
+
+When using :doc:`../bundles/ai-bundle`, streaming requires no additional
+configuration. Set ``'stream' => true`` at call time:
+
+.. code-block:: yaml
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            openai:
+                api_key: '%env(OPENAI_API_KEY)%'
+        agent:
+            default:
+                model: 'gpt-4o-mini'
+                prompt:
+                    text: 'You are a helpful assistant.'
+
+Inject the agent and call it with streaming enabled in your service or
+controller::
+
+    use Symfony\AI\Agent\AgentInterface;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
+
+    final class ChatService
+    {
+        public function __construct(
+            #[Target('ai.agent.default')]
+            private AgentInterface $agent,
+        ) {
+        }
+
+        public function streamResponse(string $userInput): \Generator
+        {
+            $messages = new MessageBag(
+                Message::ofUser($userInput),
+            );
+
+            $result = $this->agent->call($messages, ['stream' => true]);
+
+            yield from $result->getContent();
+        }
+    }
+
+Best Practices
+--------------
+
+* **Call ``flush()`` after each chunk.** PHP's output buffering will otherwise
+  collect chunks and send them in one batch, defeating the purpose of
+  streaming.
+* **Set appropriate timeouts.** Long-running streams need relaxed PHP and web
+  server timeouts (``max_execution_time``, nginx ``proxy_read_timeout``, etc.).
+* **Disable output buffering.** In some environments you may need to call
+  ``ob_implicit_flush(true)`` or disable buffering in your web server config.
+* **Consider Mercure for production.** Holding a long HTTP connection per
+  user does not scale. Mercure offloads fan-out and reconnection logic.
+* **Handle disconnects gracefully.** Catch ``\Throwable`` inside the stream
+  loop so a client disconnecting mid-stream does not leave orphaned API calls.
+
+Complete Examples
+-----------------
+
+* `Streaming with OpenAI <https://github.com/symfony/ai/blob/main/examples/openai/stream.php>`_
+* `Streaming with Anthropic <https://github.com/symfony/ai/blob/main/examples/anthropic/stream.php>`_
+* `Streaming with Mistral <https://github.com/symfony/ai/blob/main/examples/mistral/stream.php>`_
+* `Streaming with tool calls (OpenAI) <https://github.com/symfony/ai/blob/main/examples/openai/toolcall-stream.php>`_
+* `Streaming with tool calls (Anthropic) <https://github.com/symfony/ai/blob/main/examples/anthropic/toolcall-stream.php>`_
+* `Streaming with Cerebras <https://github.com/symfony/ai/blob/main/examples/cerebras/stream.php>`_
+
+Related Documentation
+---------------------
+
+* :doc:`../components/platform` – Platform component and result streaming
+* :doc:`../components/agent` – Agent component documentation
+* :doc:`../bundles/ai-bundle` – AI Bundle configuration reference
+* :doc:`multi-agent-orchestration` – Orchestrate multiple specialized agents
+
+.. _`Server-Sent Events`: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events
+.. _`Mercure`: https://mercure.rocks/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

Two new cookbook articles covering patterns that are frequently asked about but currently undocumented:

**Multi-Agent Orchestration** (`docs/cookbook/multi-agent-orchestration.rst`)

- Explains the two available patterns: `MultiAgent` with handoff routing and the `Subagent` tool
- Shows how to configure an orchestrator, define `Handoff` rules with keywords, and add a fallback agent
- Includes a comparison table to help readers choose between the two patterns
- Covers bundle YAML configuration (`agent: … tools: [agent: …]`)
- Documents debug logging via `LoggerInterface` and best practices

**Streaming Responses** (`docs/cookbook/streaming-responses.rst`)

- Covers platform-level streaming (`$result->asStream()`) and agent-level streaming (`$result->getContent()` with `stream: true`)
- Shows streaming alongside tool calls
- Explains how to handle `ThinkingContent` chunks from reasoning models
- Provides a `StreamedResponse` controller example for direct HTTP delivery
- Includes a Mercure integration pattern for scalable, production-grade streaming via Symfony Messenger
- Documents flush/buffering pitfalls and timeout configuration

Both articles follow the existing cookbook structure and cross-reference each other and related component docs.