### PR TITLE
 Fixing instructions that contradict PHP CS fixer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Each component uses:
 - Do not use void return type for testcase methods
 - Always run PHP-CS-Fixer to ensure proper code style
 - Always add a newline at the end of the file
-- Prefer self::assert* over $this->assert* in tests
+- Prefer $this->assert* over self::assert* in tests
 - Never add Claude as co-author in the commits
 - Add @author tags to newly introduced classes by the user
 - Prefer classic if statements over short-circuit evaluation when possible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ Each component uses:
 - Do not use void return type for testcase methods
 - Always run PHP-CS-Fixer to ensure proper code style
 - Always add a newline at the end of the file
-- Prefer self::assert* over $this->assert* in tests
+- Prefer $this->assert* over self::assert* in tests
 - Never add Claude as co-author in the commits
 - Add @author tags to newly introduced classes by the user
 - Prefer classic if statements over short-circuit evaluation when possible


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Docs?         | no 
| License       | MIT

Read through all the MD files whilst looking for a way to link changes in one PR to another.

Noticed the instructions for tests contradict the PHPCS rules.
