### PR TITLE
[MCP Bundle][Docs] Add discovery configuration for php-sdk example in docs

### DIFF
--- a/docs/bundles/mcp-bundle.rst
+++ b/docs/bundles/mcp-bundle.rst
@@ -202,6 +202,10 @@ Configuration
 
             Example contexts: logging, debugging, time-sensitive operations.
 
+        # Provide configuration for modelcontextprotocol/php-sdk built in discovery
+        discovery:
+            scan_dirs: ['src/Mcp'] # limit discovery scanning to a directory where you can group all your tools, resources, prompts, etc ...
+
         client_transports:
             stdio: true # Enable STDIO via command
             http: true # Enable HTTP transport via controller


### PR DESCRIPTION
Added configuration example for discovery in mcp-bundle. Default behaviour scans entire codebase which is no fun on a bigger project.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | No
| License       | MIT

A simple documentation example update to provide, from my view, a really important configuration to stop mcp sdk from scaning entire codebase without need.
