### PR TITLE
[Platform][VertexAI] Support API key authentication with global endpoint

### DIFF
--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -64,10 +64,15 @@ Advanced Example with Multiple Agents
                 api_key: '%env(GEMINI_API_KEY)%'
             perplexity:
                 api_key: '%env(PERPLEXITY_API_KEY)%'
+            # VertexAI with project-scoped endpoint (requires google/auth)
             vertexai:
                 location: '%env(GOOGLE_CLOUD_LOCATION)%'
                 project_id: '%env(GOOGLE_CLOUD_PROJECT)%'
-                api_key: '%env(GOOGLE_CLOUD_VERTEX_API_KEY)%' # Only needed if authenticating with API keys
+                api_key: '%env(GOOGLE_CLOUD_VERTEX_API_KEY)%' # Optional: uses ADC by default
+
+            # Or with global endpoint (API key only, no google/auth needed)
+            # vertexai:
+            #     api_key: '%env(GOOGLE_CLOUD_VERTEX_API_KEY)%'
             ollama:
                 host_url: '%env(OLLAMA_HOST_URL)%'
             transformersphp: ~

--- a/docs/components/platform/vertexai.rst
+++ b/docs/components/platform/vertexai.rst
@@ -73,10 +73,11 @@ Similar to the first approach, but instead of authenticating with the `gcloud` c
 
     GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account-key.json"
 
-3. API Key
-..........
+3. API Key (Project-Scoped Endpoint)
+....................................
 
-Similar to the first approach, but instead of authenticating with the `gcloud` command, you provide the API keys when creating the platform::
+You can provide an API key together with a location and project ID. This still uses the
+project-scoped endpoint but authenticates with the API key instead of ADC::
 
     $platform = PlatformFactory::create(
         $_ENV['GOOGLE_CLOUD_LOCATION'],
@@ -85,6 +86,23 @@ Similar to the first approach, but instead of authenticating with the `gcloud` c
     );
 
 To get an API key, visit: `Vertex AI Studio (API keys)`_.
+
+4. API Key (Global Endpoint)
+............................
+
+If you only provide an API key without a location or project ID, the platform uses the
+VertexAI **global endpoint** (``https://aiplatform.googleapis.com/v1/publishers/google/models/...``).
+This is the simplest setup and does not require the ``google/auth`` package::
+
+    $platform = PlatformFactory::create(
+        apiKey: $_ENV['GOOGLE_CLOUD_VERTEX_API_KEY'],
+    );
+
+.. caution::
+
+    API keys only identify the calling project for billing purposes. They do not provide
+    identity-based access control. For production workloads that require IAM, audit logging,
+    or data residency, use the project-scoped endpoint with ADC or a service account.
 
 Model Availability by Location
 ------------------------------

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `TraceableAgent`
  * Add `TraceableStore`
  * Add `setup_options` configuration for PostgreSQL store to pass extra fields to `ai:store:setup`
+ * Add support for VertexAI global endpoint with API key authentication (no `location`/`project_id` required)
 
 0.5
 ---

--- a/src/ai-bundle/config/platform/vertexai.php
+++ b/src/ai-bundle/config/platform/vertexai.php
@@ -14,10 +14,22 @@ namespace Symfony\Component\Config\Definition\Configurator;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
 return (new ArrayNodeDefinition('vertexai'))
+    ->validate()
+        ->ifTrue(static function ($v) {
+            $hasLocation = isset($v['location']);
+            $hasProjectId = isset($v['project_id']);
+            if ($hasLocation !== $hasProjectId) {
+                return true;
+            }
+
+            return !$hasLocation && !isset($v['api_key']);
+        })
+        ->thenInvalid('VertexAI requires either both "location" and "project_id" for the project-scoped endpoint, or "api_key" alone for the global endpoint.')
+    ->end()
     ->children()
-        ->stringNode('location')->isRequired()->end()
-        ->stringNode('project_id')->isRequired()->end()
-        ->stringNode('api_key')->defaultNull()->end()
+        ->stringNode('location')->defaultNull()->info('Required for the project-scoped endpoint. Must be set together with "project_id".')->end()
+        ->stringNode('project_id')->defaultNull()->info('Required for the project-scoped endpoint. Must be set together with "location".')->end()
+        ->stringNode('api_key')->defaultNull()->info('When set without "location" and "project_id", uses the global endpoint. Note: API keys only identify the project for billing and do not provide identity-based access control. For production use with IAM, audit logging, or data residency, prefer the project-scoped endpoint with service account authentication.')->end()
         ->stringNode('http_client')
             ->defaultValue('http_client')
             ->info('Service ID of the HTTP client to use')

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -7570,6 +7570,32 @@ class AiBundleTest extends TestCase
         $this->assertSame('withOptions', $factory[1]);
     }
 
+    #[TestDox('VertexAI platform uses global endpoint with api_key only')]
+    public function testVertexAiPlatformUsesGlobalEndpoint()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'vertexai' => [
+                        'api_key' => 'my-vertex-api-key',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.vertexai'));
+
+        $definition = $container->getDefinition('ai.platform.vertexai');
+        $arguments = $definition->getArguments();
+
+        $this->assertNull($arguments[0]);
+        $this->assertNull($arguments[1]);
+        $this->assertSame('my-vertex-api-key', $arguments[2]);
+
+        // For global endpoint, http client should be a plain Reference, not a bearer-token-wrapping Definition
+        $this->assertInstanceOf(Reference::class, $arguments[3]);
+    }
+
     #[TestDox('Model configuration is ignored for unknown platform')]
     public function testModelConfigurationIsIgnoredForUnknownPlatform()
     {

--- a/src/platform/src/Bridge/VertexAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/VertexAi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.6
+---
+
+ * Add support for global endpoint with API key authentication (no `location`/`project_id` required)
+
 0.2
 ---
 

--- a/src/platform/src/Bridge/VertexAi/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/VertexAi/Embeddings/ModelClient.php
@@ -24,8 +24,8 @@ final class ModelClient implements ModelClientInterface
 {
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        private readonly string $location,
-        private readonly string $projectId,
+        private readonly ?string $location = null,
+        private readonly ?string $projectId = null,
         #[\SensitiveParameter] private readonly ?string $apiKey = null,
     ) {
     }
@@ -40,13 +40,21 @@ final class ModelClient implements ModelClientInterface
      */
     public function request(BaseModel $model, array|string $payload, array $options = []): RawHttpResult
     {
-        $url = \sprintf(
-            'https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:%s',
-            $this->projectId,
-            $this->location,
-            $model->getName(),
-            'predict',
-        );
+        if (null !== $this->location && null !== $this->projectId) {
+            $url = \sprintf(
+                'https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:%s',
+                $this->projectId,
+                $this->location,
+                $model->getName(),
+                'predict',
+            );
+        } else {
+            $url = \sprintf(
+                'https://aiplatform.googleapis.com/v1/publishers/google/models/%s:%s',
+                $model->getName(),
+                'predict',
+            );
+        }
 
         $query = [];
         if (null !== $this->apiKey) {

--- a/src/platform/src/Bridge/VertexAi/PlatformFactory.php
+++ b/src/platform/src/Bridge/VertexAi/PlatformFactory.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\ResultConverter as Embeddings
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ModelClient as GeminiModelClient;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ResultConverter as GeminiResultConverter;
 use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
@@ -31,16 +32,24 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class PlatformFactory
 {
     public static function create(
-        string $location,
-        string $projectId,
+        ?string $location = null,
+        ?string $projectId = null,
         #[\SensitiveParameter] ?string $apiKey = null,
         ?HttpClientInterface $httpClient = null,
         ModelCatalogInterface $modelCatalog = new ModelCatalog(),
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
     ): Platform {
-        if (!class_exists(ApplicationDefaultCredentials::class)) {
-            throw new RuntimeException('For using the Vertex AI platform, google/auth package is required for authentication via application default credentials. Try running "composer require google/auth".');
+        if ((null === $location) !== (null === $projectId)) {
+            throw new InvalidArgumentException('Both "location" and "projectId" must be provided together for the project-scoped VertexAI endpoint, or both must be null to use the global endpoint.');
+        }
+
+        if (null === $location && null === $apiKey) {
+            throw new InvalidArgumentException('An API key is required when using the global VertexAI endpoint (no location/projectId).');
+        }
+
+        if (null !== $location && !class_exists(ApplicationDefaultCredentials::class)) {
+            throw new RuntimeException('For using the project-scoped Vertex AI endpoint, google/auth package is required for authentication via application default credentials. Try running "composer require google/auth".');
         }
 
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1460
| License       | MIT

This adds support for the VertexAI **global endpoint** (`https://aiplatform.googleapis.com/v1/publishers/google/models/...`), which only requires an API key — no `location`, `project_id`, or `google/auth` package needed.

Previously, VertexAI always required `location` and `project_id` (the project-scoped endpoint). Now there are two modes:

1. **Project-scoped endpoint** (existing behavior): provide `location` + `project_id`, optionally with an API key. Requires `google/auth` for ADC.
2. **Global endpoint** (new): provide only `api_key`. No `google/auth` dependency. Simplest setup.

### Bundle configuration

```yaml
# Project-scoped (existing)
vertexai:
    location: '%env(GOOGLE_CLOUD_LOCATION)%'
    project_id: '%env(GOOGLE_CLOUD_PROJECT)%'
    api_key: '%env(GOOGLE_CLOUD_VERTEX_API_KEY)%' # optional, uses ADC by default

# Global endpoint (new)
vertexai:
    api_key: '%env(GOOGLE_CLOUD_VERTEX_API_KEY)%'
```

### Standalone usage

```php
// Global endpoint
$platform = PlatformFactory::create(
    apiKey: $_ENV['GOOGLE_CLOUD_VERTEX_API_KEY'],
);
```

### Changes

- **Platform**: `PlatformFactory::create()`, `Gemini\ModelClient`, and `Embeddings\ModelClient` now accept nullable `$location`/`$projectId` and build the appropriate URL
- **AI Bundle**: Config validation ensures either both `location`+`project_id` or `api_key` alone; skips `google/auth` credential setup for the global endpoint
- **Docs**: Updated VertexAI platform docs and bundle configuration example
- **Tests**: Added test for global endpoint container configuration