### PR TITLE
[Platform][Anthropic] Fix AssistantMessageNormalizer producing null content for Anthropic API

### DIFF
--- a/src/platform/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
@@ -48,7 +48,7 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
         if (!$hasBlocks) {
             return [
                 'role' => 'assistant',
-                'content' => $data->getContent(),
+                'content' => $data->getContent() ?? '',
             ];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

When an AssistantMessage has no content, no tool calls, and no thinking, the normalizer returns "content": null in the payload. The Anthropic API rejects this with: messages.X.content: Input should be a valid list.

This can happen when the AssistantMessage is constructed with null content, which is a valid state per its constructor signature (?string $content = null).
