### PR TITLE
[Mate] Add Codex wrappers and refresh agent instructions on discover

### DIFF
--- a/demo/AGENTS.md
+++ b/demo/AGENTS.md
@@ -77,3 +77,10 @@ symfony console mcp:server
 - ChromaDB on port 8080
 - LiveComponents for real-time UI
 - Symfony DI and best practices
+
+<!-- BEGIN AI_MATE_INSTRUCTIONS -->
+AI Mate Summary:
+- Role: MCP-powered, project-aware coding guidance and tools.
+- Required action: Read and follow `mate/AGENT_INSTRUCTIONS.md` before taking any action in this project, and prefer MCP tools over raw CLI commands whenever possible.
+- Installed extensions: symfony/ai-mate, symfony/ai-monolog-mate-extension, symfony/ai-symfony-mate-extension.
+<!-- END AI_MATE_INSTRUCTIONS -->

--- a/demo/bin/codex
+++ b/demo/bin/codex
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+PROJECT_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+
+if ! command -v codex >/dev/null 2>&1; then
+    echo "Codex CLI is not installed or not available in PATH." >&2
+    echo "Install Codex and try again." >&2
+    exit 1
+fi
+
+cd "$PROJECT_DIR"
+
+exec codex \
+    -c "mcp_servers.symfony_ai_mate_local.command='./vendor/bin/mate'" \
+    -c "mcp_servers.symfony_ai_mate_local.args=['serve','--force-keep-alive']" \
+    "$@"

--- a/demo/bin/codex.bat
+++ b/demo/bin/codex.bat
@@ -1,0 +1,19 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+for %%I in ("%SCRIPT_DIR%..") do set "PROJECT_DIR=%%~fI"
+
+where codex >nul 2>nul
+if errorlevel 1 (
+    echo Codex CLI is not installed or not available in PATH. 1>&2
+    echo Install Codex and try again. 1>&2
+    exit /b 1
+)
+
+pushd "%PROJECT_DIR%" >nul
+codex -c "mcp_servers.symfony_ai_mate_local.command='./vendor/bin/mate'" -c "mcp_servers.symfony_ai_mate_local.args=['serve','--force-keep-alive']" %*
+set "CODE=%ERRORLEVEL%"
+popd >nul
+
+exit /b %CODE%

--- a/demo/mate/AGENT_INSTRUCTIONS.md
+++ b/demo/mate/AGENT_INSTRUCTIONS.md
@@ -1,0 +1,53 @@
+## AI Mate Agent Instructions
+
+This MCP server provides specialized tools for PHP development.
+The following extensions are installed and provide MCP tools that you should
+prefer over running CLI commands directly.
+
+---
+
+### Monolog Bridge
+
+Use MCP tools instead of CLI for log analysis:
+
+| Instead of...                     | Use                                |
+|-----------------------------------|------------------------------------|
+| `tail -f var/log/dev.log`         | `monolog-tail`                     |
+| `grep "error" var/log/*.log`      | `monolog-search` with term "error" |
+| `grep -E "pattern" var/log/*.log` | `monolog-search-regex`             |
+
+#### Benefits
+
+- Structured output with parsed log entries
+- Multi-file search across all logs at once
+- Filter by environment, level, or channel
+
+---
+
+### Symfony Bridge
+
+#### Container Introspection
+
+| Instead of...                  | Use                 |
+|--------------------------------|---------------------|
+| `bin/console debug:container`  | `symfony-services`  |
+
+- Direct access to compiled container
+- Environment-aware (auto-detects dev/test/prod)
+
+#### Profiler Access
+
+When `symfony/http-kernel` is installed, profiler tools become available:
+
+| Tool                        | Description                                |
+|-----------------------------|--------------------------------------------|
+| `symfony-profiler-list`     | List profiles with optional filtering      |
+| `symfony-profiler-latest`   | Get the most recent profile                |
+| `symfony-profiler-search`   | Search by route, method, status, date      |
+| `symfony-profiler-get`      | Get profile by token                       |
+
+**Resources:**
+- `symfony-profiler://profile/{token}` - Full profile with collector list
+- `symfony-profiler://profile/{token}/{collector}` - Collector-specific data
+
+**Security:** Cookies, session data, auth headers, and sensitive env vars are automatically redacted.

--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -45,7 +45,9 @@ This creates:
 
 * ``mate/`` directory with configuration files
 * ``mate/src`` directory for custom extensions
-* ``mcp.json`` for MCP client configuration
+* ``mate/AGENT_INSTRUCTIONS.md`` placeholder (refreshed by ``mate discover``)
+* ``mcp.json`` for MCP clients that support it (e.g. Claude Desktop)
+* ``bin/codex`` and ``bin/codex.bat`` wrappers for Codex runtime MCP injection
 
 It also updates your ``composer.json`` with the following configuration:
 
@@ -77,11 +79,22 @@ Discover available extensions:
 
     $ vendor/bin/mate discover
 
+This command also refreshes:
+
+* ``mate/AGENT_INSTRUCTIONS.md``
+* Managed AI Mate instruction section in ``AGENTS.md``
+
 Start the MCP server:
 
 .. code-block:: terminal
 
     $ vendor/bin/mate serve
+
+For Codex, start with the generated wrapper (``./bin/codex``); Codex does not read this project's ``mcp.json``:
+
+.. code-block:: terminal
+
+    $ ./bin/codex
 
 Add Custom Tools
 ----------------

--- a/docs/components/mate/integration.rst
+++ b/docs/components/mate/integration.rst
@@ -66,6 +66,25 @@ To add Symfony AI Mate to Claude Code (see `Claude Code MCP documentation`_ for 
     $ claude mcp add mate $(pwd)/vendor/bin/mate serve --scope local
     $ claude mcp list  # Verify: mate - ✓ Connected
 
+Codex
+-----
+
+Symfony AI Mate initializes project-local Codex wrappers:
+
+* ``bin/codex`` (macOS/Linux)
+* ``bin/codex.bat`` (Windows)
+
+Use these wrappers to start Codex with runtime MCP injection:
+
+.. code-block:: terminal
+
+    $ ./bin/codex
+
+.. note::
+
+    Codex does not read this project's ``mcp.json``. The wrappers pass
+    runtime ``-c mcp_servers...`` options so no persistent Codex config is written.
+
 Troubleshooting
 ---------------
 
@@ -126,6 +145,26 @@ Claude Code Not Connecting
        $ claude mcp add mate $(pwd)/vendor/bin/mate serve --scope local
 
 3. **Check for conflicting servers** with similar names.
+
+Codex Not Showing Mate Tools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. **Use the wrapper**:
+
+   .. code-block:: terminal
+
+       $ ./bin/codex
+
+2. **Refresh extension and agent instructions**:
+
+   .. code-block:: terminal
+
+       $ vendor/bin/mate discover
+
+3. **Check wrapper scripts exist**:
+
+   - macOS/Linux: ``bin/codex``
+   - Windows: ``bin/codex.bat``
 
 For general server issues and debugging tips, see the :doc:`troubleshooting` guide.
 

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.7
+---
+
+ * Add Codex wrapper generation (`bin/codex`, `bin/codex.bat`) to `mate init`
+ * Add AGENT instruction artifact materialization to `mate discover` (`mate/AGENT_INSTRUCTIONS.md` and managed `AGENTS.md` block)
+
 0.3
 ---
 

--- a/src/mate/resources/bin/codex
+++ b/src/mate/resources/bin/codex
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+PROJECT_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+
+if ! command -v codex >/dev/null 2>&1; then
+    echo "Codex CLI is not installed or not available in PATH." >&2
+    echo "Install Codex and try again." >&2
+    exit 1
+fi
+
+cd "$PROJECT_DIR"
+
+exec codex \
+    -c "mcp_servers.symfony_ai_mate_local.command='./vendor/bin/mate'" \
+    -c "mcp_servers.symfony_ai_mate_local.args=['serve','--force-keep-alive']" \
+    "$@"

--- a/src/mate/resources/bin/codex.bat
+++ b/src/mate/resources/bin/codex.bat
@@ -1,0 +1,19 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+for %%I in ("%SCRIPT_DIR%..") do set "PROJECT_DIR=%%~fI"
+
+where codex >nul 2>nul
+if errorlevel 1 (
+    echo Codex CLI is not installed or not available in PATH. 1>&2
+    echo Install Codex and try again. 1>&2
+    exit /b 1
+)
+
+pushd "%PROJECT_DIR%" >nul
+codex -c "mcp_servers.symfony_ai_mate_local.command='./vendor/bin/mate'" -c "mcp_servers.symfony_ai_mate_local.args=['serve','--force-keep-alive']" %*
+set "CODE=%ERRORLEVEL%"
+popd >nul
+
+exit /b %CODE%

--- a/src/mate/resources/mate/AGENT_INSTRUCTIONS.md
+++ b/src/mate/resources/mate/AGENT_INSTRUCTIONS.md
@@ -1,0 +1,6 @@
+# AI Mate Agent Instructions
+
+This file is managed by `mate discover`.
+Run `vendor/bin/mate discover` after installing, removing, or updating Mate extensions.
+
+Prefer MCP tools over equivalent shell commands when possible.

--- a/src/mate/resources/mate/config.php
+++ b/src/mate/resources/mate/config.php
@@ -13,6 +13,10 @@ return static function (ContainerConfigurator $container): void {
     ;
 
     $container->services()
+        ->defaults()
+            ->autowire()
+            ->autoconfigure()
+
         // Register your custom services here
     ;
 };

--- a/src/mate/src/Agent/AgentInstructionsMaterializer.php
+++ b/src/mate/src/Agent/AgentInstructionsMaterializer.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Agent;
+
+use Psr\Log\LoggerInterface;
+use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
+
+/**
+ * Writes instruction artifacts that are consumed by coding agents.
+ *
+ * @phpstan-import-type ExtensionData from ComposerExtensionDiscovery
+ *
+ * @phpstan-type MaterializationResult array{
+ *     instructions_file_updated: bool,
+ *     agents_file_updated: bool,
+ * }
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class AgentInstructionsMaterializer
+{
+    public const AGENTS_START_MARKER = '<!-- BEGIN AI_MATE_INSTRUCTIONS -->';
+    public const AGENTS_END_MARKER = '<!-- END AI_MATE_INSTRUCTIONS -->';
+
+    public function __construct(
+        private string $rootDir,
+        private AgentInstructionsAggregator $aggregator,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param array<string, ExtensionData> $extensions
+     *
+     * @return MaterializationResult
+     */
+    public function materializeForExtensions(array $extensions): array
+    {
+        $instructions = $this->aggregator->aggregate($extensions);
+        if (null === $instructions) {
+            $instructions = $this->getFallbackInstructions();
+        }
+
+        $instructionsFileUpdated = $this->writeInstructionsFile($instructions);
+        $agentsFileUpdated = $this->writeAgentsFile($extensions);
+
+        return [
+            'instructions_file_updated' => $instructionsFileUpdated,
+            'agents_file_updated' => $agentsFileUpdated,
+        ];
+    }
+
+    /**
+     * @return MaterializationResult
+     */
+    public function synchronizeFromCurrentInstructionsFile(): array
+    {
+        $agentsFileUpdated = $this->writeAgentsFile();
+
+        return [
+            'instructions_file_updated' => true,
+            'agents_file_updated' => $agentsFileUpdated,
+        ];
+    }
+
+    private function getInstructionsFilePath(): string
+    {
+        return $this->rootDir.'/mate/AGENT_INSTRUCTIONS.md';
+    }
+
+    private function getAgentsFilePath(): string
+    {
+        return $this->rootDir.'/AGENTS.md';
+    }
+
+    private function writeInstructionsFile(string $instructions): bool
+    {
+        $path = $this->getInstructionsFilePath();
+        $directory = \dirname($path);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        $written = @file_put_contents($path, $this->normalizeContent($instructions));
+        if (false === $written) {
+            $this->logger->warning('Failed to write AGENT_INSTRUCTIONS.md file', [
+                'path' => $path,
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, ExtensionData>|null $extensions
+     */
+    private function writeAgentsFile(?array $extensions = null): bool
+    {
+        $path = $this->getAgentsFilePath();
+        $managedBlock = $this->buildManagedBlock($extensions);
+
+        if (!file_exists($path)) {
+            $written = @file_put_contents($path, $this->normalizeContent($managedBlock));
+            if (false === $written) {
+                $this->logger->warning('Failed to create AGENTS.md file', [
+                    'path' => $path,
+                ]);
+
+                return false;
+            }
+
+            return true;
+        }
+
+        $content = @file_get_contents($path);
+        if (false === $content) {
+            $this->logger->warning('Failed to read AGENTS.md file', [
+                'path' => $path,
+            ]);
+
+            return false;
+        }
+
+        $updatedContent = $this->replaceManagedBlock($content, $managedBlock);
+        $written = @file_put_contents($path, $this->normalizeContent($updatedContent));
+        if (false === $written) {
+            $this->logger->warning('Failed to update AGENTS.md file', [
+                'path' => $path,
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function replaceManagedBlock(string $content, string $managedBlock): string
+    {
+        $startPos = strpos($content, self::AGENTS_START_MARKER);
+        $endPos = strpos($content, self::AGENTS_END_MARKER);
+
+        if (false === $startPos || false === $endPos || $endPos < $startPos) {
+            $trimmedContent = trim($content);
+            if ('' === $trimmedContent) {
+                return $managedBlock;
+            }
+
+            return $trimmedContent."\n\n".$managedBlock;
+        }
+
+        $endPos += \strlen(self::AGENTS_END_MARKER);
+
+        $prefix = rtrim(substr($content, 0, $startPos));
+        $suffix = ltrim(substr($content, $endPos));
+
+        $newContent = $managedBlock;
+        if ('' !== $prefix) {
+            $newContent = $prefix."\n\n".$managedBlock;
+        }
+
+        if ('' !== $suffix) {
+            $newContent .= "\n\n".$suffix;
+        }
+
+        return $newContent;
+    }
+
+    /**
+     * @param array<string, ExtensionData>|null $extensions
+     */
+    private function buildManagedBlock(?array $extensions = null): string
+    {
+        return implode("\n", [
+            self::AGENTS_START_MARKER,
+            'AI Mate Summary:',
+            '- Role: MCP-powered, project-aware coding guidance and tools.',
+            '- Required action: Read and follow `mate/AGENT_INSTRUCTIONS.md` before taking any action in this project, and prefer MCP tools over raw CLI commands whenever possible.',
+            '- Installed extensions: '.$this->buildInstalledExtensionsText($extensions),
+            self::AGENTS_END_MARKER,
+        ]);
+    }
+
+    /**
+     * @param array<string, ExtensionData>|null $extensions
+     */
+    private function buildInstalledExtensionsText(?array $extensions): string
+    {
+        if (null === $extensions) {
+            return 'See `mate/extensions.php`.';
+        }
+
+        $extensionNames = [];
+        foreach (array_keys($extensions) as $packageName) {
+            if ('_custom' === $packageName) {
+                continue;
+            }
+
+            $extensionNames[] = $packageName;
+        }
+
+        if ([] === $extensionNames) {
+            return 'Custom project tools only.';
+        }
+
+        sort($extensionNames);
+
+        return implode(', ', $extensionNames).'.';
+    }
+
+    private function normalizeContent(string $content): string
+    {
+        return rtrim($content)."\n";
+    }
+
+    private function getFallbackInstructions(): string
+    {
+        return <<<'TEXT'
+# AI Mate Agent Instructions
+
+No extension-specific instructions are currently available.
+Run `vendor/bin/mate discover` to refresh discovered extensions and instructions.
+Prefer MCP tools over equivalent shell commands when possible.
+TEXT;
+    }
+}

--- a/src/mate/src/Service/ExtensionConfigSynchronizer.php
+++ b/src/mate/src/Service/ExtensionConfigSynchronizer.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Service;
+
+use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
+
+/**
+ * Synchronizes discovered extensions with mate/extensions.php while preserving enabled flags.
+ *
+ * @phpstan-import-type ExtensionData from ComposerExtensionDiscovery
+ *
+ * @phpstan-type ExtensionConfig array{enabled: bool}
+ * @phpstan-type ExtensionConfigMap array<string, ExtensionConfig>
+ * @phpstan-type SynchronizationResult array{
+ *     extensions: ExtensionConfigMap,
+ *     new_packages: string[],
+ *     removed_packages: string[],
+ *     file: string,
+ * }
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ExtensionConfigSynchronizer
+{
+    public function __construct(
+        private string $rootDir,
+    ) {
+    }
+
+    /**
+     * @param array<string, ExtensionData> $discoveredExtensions
+     *
+     * @return SynchronizationResult
+     */
+    public function synchronize(array $discoveredExtensions): array
+    {
+        $extensionsFile = $this->rootDir.'/mate/extensions.php';
+        $existingExtensions = $this->readExistingExtensions($extensionsFile);
+
+        $newPackages = [];
+        foreach (array_keys($discoveredExtensions) as $packageName) {
+            if (!isset($existingExtensions[$packageName])) {
+                $newPackages[] = $packageName;
+            }
+        }
+
+        $removedPackages = [];
+        foreach (array_keys($existingExtensions) as $packageName) {
+            if (!isset($discoveredExtensions[$packageName])) {
+                $removedPackages[] = $packageName;
+            }
+        }
+
+        $finalExtensions = [];
+        foreach (array_keys($discoveredExtensions) as $packageName) {
+            $enabled = true;
+            if (isset($existingExtensions[$packageName]) && \is_array($existingExtensions[$packageName])) {
+                $enabledValue = $existingExtensions[$packageName]['enabled'] ?? true;
+                if (\is_bool($enabledValue)) {
+                    $enabled = $enabledValue;
+                }
+            }
+
+            $finalExtensions[$packageName] = [
+                'enabled' => $enabled,
+            ];
+        }
+
+        $this->writeExtensionsFile($extensionsFile, $finalExtensions);
+
+        return [
+            'extensions' => $finalExtensions,
+            'new_packages' => $newPackages,
+            'removed_packages' => $removedPackages,
+            'file' => $extensionsFile,
+        ];
+    }
+
+    /**
+     * @return array<string, array{enabled?: bool}>
+     */
+    private function readExistingExtensions(string $extensionsFile): array
+    {
+        if (!file_exists($extensionsFile)) {
+            return [];
+        }
+
+        $existingExtensions = include $extensionsFile;
+        if (!\is_array($existingExtensions)) {
+            return [];
+        }
+
+        /* @var array<string, array{enabled?: bool}> $existingExtensions */
+        return $existingExtensions;
+    }
+
+    /**
+     * @param ExtensionConfigMap $extensions
+     */
+    private function writeExtensionsFile(string $filePath, array $extensions): void
+    {
+        $dir = \dirname($filePath);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $content = "<?php\n\n";
+        $content .= "// This file is managed by 'mate discover'\n";
+        $content .= "// You can manually edit to enable/disable extensions\n\n";
+        $content .= "return [\n";
+
+        foreach ($extensions as $packageName => $config) {
+            $enabled = $config['enabled'] ? 'true' : 'false';
+            $content .= "    '$packageName' => ['enabled' => $enabled],\n";
+        }
+
+        $content .= "];\n";
+
+        file_put_contents($filePath, $content);
+    }
+}

--- a/src/mate/src/default.config.php
+++ b/src/mate/src/default.config.php
@@ -13,6 +13,7 @@ use Mcp\Capability\Discovery\Discoverer;
 use Mcp\Capability\Discovery\DiscovererInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Agent\AgentInstructionsAggregator;
+use Symfony\AI\Mate\Agent\AgentInstructionsMaterializer;
 use Symfony\AI\Mate\Command\ClearCacheCommand;
 use Symfony\AI\Mate\Command\DebugCapabilitiesCommand;
 use Symfony\AI\Mate\Command\DebugExtensionsCommand;
@@ -26,6 +27,7 @@ use Symfony\AI\Mate\Command\ToolsListCommand;
 use Symfony\AI\Mate\Discovery\CapabilityCollector;
 use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
 use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
+use Symfony\AI\Mate\Service\ExtensionConfigSynchronizer;
 use Symfony\AI\Mate\Service\Logger;
 use Symfony\AI\Mate\Service\RegistryProvider;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -91,6 +93,8 @@ return static function (ContainerConfigurator $container): void {
         ->set(CapabilityCollector::class)
 
         ->set(AgentInstructionsAggregator::class)
+        ->set(AgentInstructionsMaterializer::class)
+        ->set(ExtensionConfigSynchronizer::class)
 
         // Register all commands
         ->set(InitCommand::class)

--- a/src/mate/tests/Agent/AgentInstructionsMaterializerTest.php
+++ b/src/mate/tests/Agent/AgentInstructionsMaterializerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Agent;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Agent\AgentInstructionsAggregator;
+use Symfony\AI\Mate\Agent\AgentInstructionsMaterializer;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class AgentInstructionsMaterializerTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir().'/mate-agent-materializer-test-'.uniqid();
+        mkdir($this->tempDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+    }
+
+    public function testMaterializeForExtensionsWritesInstructionArtifacts()
+    {
+        mkdir($this->tempDir.'/vendor/vendor/package-a', 0755, true);
+        file_put_contents(
+            $this->tempDir.'/vendor/vendor/package-a/INSTRUCTIONS.md',
+            "# Package A\n\nUse package A tools."
+        );
+
+        $logger = new NullLogger();
+        $aggregator = new AgentInstructionsAggregator($this->tempDir, [], $logger);
+        $materializer = new AgentInstructionsMaterializer($this->tempDir, $aggregator, $logger);
+
+        $result = $materializer->materializeForExtensions([
+            '_custom' => ['dirs' => [], 'includes' => []],
+            'vendor/package-a' => [
+                'dirs' => [],
+                'includes' => [],
+                'instructions' => 'INSTRUCTIONS.md',
+            ],
+        ]);
+
+        $this->assertTrue($result['instructions_file_updated']);
+        $this->assertTrue($result['agents_file_updated']);
+        $this->assertFileExists($this->tempDir.'/mate/AGENT_INSTRUCTIONS.md');
+        $this->assertFileExists($this->tempDir.'/AGENTS.md');
+
+        $instructions = file_get_contents($this->tempDir.'/mate/AGENT_INSTRUCTIONS.md');
+        $this->assertIsString($instructions);
+        $this->assertStringContainsString('Use package A tools.', $instructions);
+
+        $agents = file_get_contents($this->tempDir.'/AGENTS.md');
+        $this->assertIsString($agents);
+        $this->assertStringContainsString(AgentInstructionsMaterializer::AGENTS_START_MARKER, $agents);
+        $this->assertStringContainsString(AgentInstructionsMaterializer::AGENTS_END_MARKER, $agents);
+        $this->assertStringContainsString('AI Mate Summary:', $agents);
+        $this->assertStringContainsString('- Role: MCP-powered, project-aware coding guidance and tools.', $agents);
+        $this->assertStringContainsString('- Required action: Read and follow `mate/AGENT_INSTRUCTIONS.md` before taking any action in this project, and prefer MCP tools over raw CLI commands whenever possible.', $agents);
+        $this->assertStringContainsString('- Installed extensions: vendor/package-a.', $agents);
+    }
+
+    public function testSynchronizeFromCurrentInstructionsFileReplacesManagedBlock()
+    {
+        mkdir($this->tempDir.'/mate', 0755, true);
+
+        file_put_contents(
+            $this->tempDir.'/mate/AGENT_INSTRUCTIONS.md',
+            "# Updated Instructions\n\nUse synced instructions."
+        );
+
+        file_put_contents($this->tempDir.'/AGENTS.md', <<<'MD'
+# Project Rules
+
+Keep this line.
+
+<!-- BEGIN AI_MATE_INSTRUCTIONS -->
+old content
+<!-- END AI_MATE_INSTRUCTIONS -->
+
+Footer line.
+MD
+        );
+
+        $logger = new NullLogger();
+        $aggregator = new AgentInstructionsAggregator($this->tempDir, [], $logger);
+        $materializer = new AgentInstructionsMaterializer($this->tempDir, $aggregator, $logger);
+
+        $result = $materializer->synchronizeFromCurrentInstructionsFile();
+
+        $this->assertTrue($result['agents_file_updated']);
+
+        $agents = file_get_contents($this->tempDir.'/AGENTS.md');
+        $this->assertIsString($agents);
+        $this->assertStringContainsString('Keep this line.', $agents);
+        $this->assertStringContainsString('Footer line.', $agents);
+        $this->assertStringContainsString('AI Mate Summary:', $agents);
+        $this->assertStringContainsString('- Required action: Read and follow `mate/AGENT_INSTRUCTIONS.md` before taking any action in this project, and prefer MCP tools over raw CLI commands whenever possible.', $agents);
+        $this->assertStringContainsString('- Installed extensions: See `mate/extensions.php`.', $agents);
+        $this->assertSame(1, substr_count($agents, AgentInstructionsMaterializer::AGENTS_START_MARKER));
+        $this->assertSame(1, substr_count($agents, AgentInstructionsMaterializer::AGENTS_END_MARKER));
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir) ?: [], ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir.'/'.$file;
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
| Q             | A |
| ------------- | --- |
| Bug fix?      | yes |
| New feature?  | yes |
| Docs?         | yes |
| Issues        | n/a (no related issue) |
| License       | MIT |

## Description

This PR improves Symfony AI Mate integration for Codex and keeps agent instructions in sync with extension discovery.

### What changed

- mate discover now also refreshes agent instruction artifacts:
    - updates mate/AGENT_INSTRUCTIONS.md
    - updates a managed AI Mate section in AGENTS.md
- mate init now scaffolds all integration artifacts (without running discover):
    - keeps mcp.json + .mcp.json behavior
    - adds Codex runtime wrappers:
        - bin/codex (macOS/Linux)
        - bin/codex.bat (Windows)
    - adds mate/AGENT_INSTRUCTIONS.md template
    - updates AGENTS.md managed section from current instruction file
    - prints explicit next step to run vendor/bin/mate discover
- extracted extension sync logic to ExtensionConfigSynchronizer
- added AgentInstructionsMaterializer to centralize writing:
    - mate/AGENT_INSTRUCTIONS.md
    - managed block in AGENTS.md
- extended AgentInstructionsAggregator with aggregateForExtensions(...) to support fresh discovered maps and avoid stale container state
- updated Mate docs and changelog accordingly

## Usage

vendor/bin/mate init
vendor/bin/mate discover
./bin/codex

discover is now the command that refreshes both extension config and instruction artifacts.
