### PR TITLE
[Platform] Fix OpenAI tool call serialization

### DIFF
--- a/src/platform/src/Bridge/OpenResponses/Contract/ToolCallNormalizer.php
+++ b/src/platform/src/Bridge/OpenResponses/Contract/ToolCallNormalizer.php
@@ -31,7 +31,7 @@ final class ToolCallNormalizer extends ModelContractNormalizer
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         return [
-            'arguments' => json_encode($data->getArguments()),
+            'arguments' => json_encode($data->getArguments() ?: new \stdClass()),
             'call_id' => $data->getId(),
             'name' => $data->getName(),
             'type' => 'function_call',

--- a/src/platform/src/Contract/Normalizer/Message/AssistantMessageNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/AssistantMessageNormalizer.php
@@ -38,17 +38,14 @@ final class AssistantMessageNormalizer implements NormalizerInterface, Normalize
     /**
      * @param AssistantMessage $data
      *
-     * @return array{role: 'assistant', content?: string, tool_calls?: array<array<string, mixed>>}
+     * @return array{role: 'assistant', content: string|null, tool_calls?: array<array<string, mixed>>}
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         $array = [
             'role' => $data->getRole()->value,
+            'content' => $data->getContent(),
         ];
-
-        if (null !== $data->getContent()) {
-            $array['content'] = $data->getContent();
-        }
 
         if ($data->hasToolCalls()) {
             $array['tool_calls'] = $this->normalizer->normalize($data->getToolCalls(), $format, $context);

--- a/src/platform/src/Contract/Normalizer/Result/ToolCallNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Result/ToolCallNormalizer.php
@@ -50,7 +50,7 @@ final class ToolCallNormalizer implements NormalizerInterface
             'type' => 'function',
             'function' => [
                 'name' => $data->getName(),
-                'arguments' => json_encode($data->getArguments()),
+                'arguments' => json_encode($data->getArguments() ?: new \stdClass()),
             ],
         ];
     }

--- a/src/platform/src/Result/ToolCall.php
+++ b/src/platform/src/Result/ToolCall.php
@@ -61,7 +61,7 @@ final class ToolCall implements \JsonSerializable
             'type' => 'function',
             'function' => [
                 'name' => $this->name,
-                'arguments' => json_encode($this->arguments),
+                'arguments' => json_encode($this->arguments ?: new \stdClass()),
             ],
         ];
     }

--- a/src/platform/tests/Contract/Normalizer/Message/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/AssistantMessageNormalizerTest.php
@@ -94,11 +94,10 @@ final class AssistantMessageNormalizerTest extends TestCase
 
         $this->normalizer->setNormalizer($innerNormalizer);
 
-        $expected = [
-            'role' => 'assistant',
-            'tool_calls' => $expectedToolCalls,
-        ];
+        $result = $this->normalizer->normalize($message);
 
-        $this->assertSame($expected, $this->normalizer->normalize($message));
+        $this->assertSame('assistant', $result['role']);
+        $this->assertNull($result['content']);
+        $this->assertSame($expectedToolCalls, $result['tool_calls']);
     }
 }

--- a/src/platform/tests/Result/ToolCallTest.php
+++ b/src/platform/tests/Result/ToolCallTest.php
@@ -61,4 +61,13 @@ final class ToolCallTest extends TestCase
             ],
         ], $toolCall->jsonSerialize());
     }
+
+    public function testToolCallJsonSerializeWithEmptyArguments()
+    {
+        $toolCall = new ToolCall('id', 'name');
+        $serialized = $toolCall->jsonSerialize();
+
+        // Empty arguments must serialize to a JSON object "{}", not a JSON array "[]"
+        $this->assertSame('{}', $serialized['function']['arguments']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | 
| License       | MIT

When a tool has no required parameters and is called with no arguments, the empty PHP array was serialized as `[]` instead of `{}`. Also ensure assistant messages always include a `content` key (`null` when there is no text) as required by the OpenAI specification for messages with `tool_calls`.