### PR TITLE
 Fix scientific notation strings being cast to int instead of float in model option parsing

### DIFF
--- a/src/platform/src/ModelCatalog/AbstractModelCatalog.php
+++ b/src/platform/src/ModelCatalog/AbstractModelCatalog.php
@@ -123,7 +123,7 @@ abstract class AbstractModelCatalog implements ModelCatalogInterface
                 $data[$key] = false;
             } elseif (is_numeric($value) && \is_string($value)) {
                 // Convert to int if it's a whole number, otherwise to float
-                $data[$key] = str_contains($value, '.') ? (float) $value : (int) $value;
+                $data[$key] = str_contains($value, '.') || str_contains($value, 'e') || str_contains($value, 'E') ? (float) $value : (int) $value;
             }
         }
 

--- a/src/platform/tests/ModelCatalog/AbstractModelCatalogTest.php
+++ b/src/platform/tests/ModelCatalog/AbstractModelCatalogTest.php
@@ -158,6 +158,19 @@ final class AbstractModelCatalogTest extends TestCase
         $this->assertFalse($options['a']['e']);
     }
 
+    public function testScientificNotationIsConvertedToFloat()
+    {
+        $catalog = $this->createTestCatalog();
+        $model = $catalog->getModel('test-model?frequency_penalty=1e-5&presence_penalty=2.5E3');
+
+        $options = $model->getOptions();
+
+        $this->assertIsFloat($options['frequency_penalty']);
+        $this->assertSame(1e-5, $options['frequency_penalty']);
+        $this->assertIsFloat($options['presence_penalty']);
+        $this->assertSame(2.5E3, $options['presence_penalty']);
+    }
+
     private function createTestCatalog(): AbstractModelCatalog
     {
         return new class extends AbstractModelCatalog {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
