### PR TITLE
 update copyright year to include 2026

### DIFF
--- a/ai.symfony.com/templates/base.html.twig
+++ b/ai.symfony.com/templates/base.html.twig
@@ -34,7 +34,7 @@
             <div class="container">
                 <div class="row align-items-center justify-content-between gy-3">
                     <div class="col-md-4">
-                        <span class="footer-meta d-block">&copy; 2025 Symfony. All rights reserved.</span>
+                        <span class="footer-meta d-block">&copy; 2025-present Symfony. All rights reserved.</span>
                     </div>
 
                     <div class="col-md-4">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | Fix #1696 
| License       | MIT

Just updates the copyright string on the landing page to include the current year.