### PR TITLE
[Examples] Fix composer setup of examples before 0.6

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -3,6 +3,10 @@
     "description": "Example scripts about using Symfony AI",
     "license": "MIT",
     "type": "project",
+    "repositories": [
+        {"type": "path", "url": "../src/store/src/Bridge/S3Vectors" },
+        {"type": "path", "url": "../src/store/src/Bridge/Vektor" }
+    ],
     "require": {
         "php": ">=8.2",
         "symfony/ai-agent": "^0.5",
@@ -58,7 +62,7 @@
         "symfony/ai-qdrant-store": "^0.5",
         "symfony/ai-redis-message-store": "^0.5",
         "symfony/ai-redis-store": "^0.5",
-        "symfony/ai-s3vectors-store": "^0.6",
+        "symfony/ai-s3vectors-store": "dev-main",
         "symfony/ai-scaleway-platform": "^0.5",
         "symfony/ai-scraper-tool": "^0.5",
         "symfony/ai-serp-api-tool": "^0.5",
@@ -70,7 +74,7 @@
         "symfony/ai-tavily-tool": "^0.5",
         "symfony/ai-transformers-php-platform": "^0.5",
         "symfony/ai-typesense-store": "^0.5",
-        "symfony/ai-vektor-store": "^0.6",
+        "symfony/ai-vektor-store": "dev-main",
         "symfony/ai-vertex-ai-platform": "^0.5",
         "symfony/ai-voyage-platform": "^0.5",
         "symfony/ai-weaviate-store": "^0.5",

--- a/src/store/src/Bridge/S3Vectors/composer.json
+++ b/src/store/src/Bridge/S3Vectors/composer.json
@@ -25,8 +25,8 @@
     "require": {
         "php": ">=8.2",
         "async-aws/s3-vectors": "^2.0",
-        "symfony/ai-platform": "^0.6",
-        "symfony/ai-store": "^0.6",
+        "symfony/ai-platform": "^0.5",
+        "symfony/ai-store": "^0.5",
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/store/src/Bridge/Vektor/composer.json
+++ b/src/store/src/Bridge/Vektor/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": ">=8.2",
         "centamiv/vektor": "^2.0.1",
-        "symfony/ai-platform": "^0.6",
-        "symfony/ai-store": "^0.6",
+        "symfony/ai-platform": "^0.5",
+        "symfony/ai-store": "^0.5",
         "symfony/filesystem": "^7.3|^8.0",
         "symfony/uid": "^7.3|^8.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Follows #1561 and #1554.

We should never require unreleased versions when no branch-alias is defined, and since we bump the versions prior to release we can go with `dev-main`. cc @OskarStark @Guikingone 