### PR TITLE
[Store] Add platform-level reranking and hybrid retriever

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,18 @@
+UPGRADE FROM 0.6 to 0.7
+=======================
+
+Store
+-----
+
+ * The `Retriever` constructor has a new `?EventDispatcherInterface $eventDispatcher` parameter
+   inserted as 3rd argument before `LoggerInterface $logger`. If you pass `$logger` positionally,
+   update to use a named argument:
+
+   ```diff
+   -$retriever = new Retriever($store, $vectorizer, $logger);
+   +$retriever = new Retriever($store, $vectorizer, logger: $logger);
+   ```
+
 UPGRADE FROM 0.5 to 0.6
 =======================
 

--- a/examples/huggingface/feature-extraction.php
+++ b/examples/huggingface/feature-extraction.php
@@ -16,7 +16,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 
-$result = $platform->invoke('thenlper/gte-large', 'Today is a sunny day and I will get some ice cream.', [
+$result = $platform->invoke('BAAI/bge-large-en-v1.5', 'Today is a sunny day and I will get some ice cream.', [
     'task' => Task::FEATURE_EXTRACTION,
 ]);
 

--- a/examples/huggingface/text-to-image.php
+++ b/examples/huggingface/text-to-image.php
@@ -16,7 +16,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
 
-$result = $platform->invoke('black-forest-labs/FLUX.1-dev', 'Astronaut riding a horse', [
+$result = $platform->invoke('stabilityai/stable-diffusion-xl-base-1.0', 'Astronaut riding a horse', [
     'task' => Task::TEXT_TO_IMAGE,
 ]);
 

--- a/examples/rag/hybrid-reranking.php
+++ b/examples/rag/hybrid-reranking.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Fixtures\Movies;
+use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
+use Symfony\AI\Store\CombinedStore;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Event\PostQueryEvent;
+use Symfony\AI\Store\EventListener\RerankerListener;
+use Symfony\AI\Store\Indexer\DocumentIndexer;
+use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Reranker\Reranker;
+use Symfony\AI\Store\Retriever;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Uid\Uuid;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+echo "=== Hybrid Retrieval with RRF + HuggingFace Reranking ===\n\n";
+echo "This example demonstrates combining vector (semantic) and text (keyword)\n";
+echo "retrieval using CombinedStore with Reciprocal Rank Fusion (RRF), with\n";
+echo "optional reranking via a PostQueryEvent listener.\n\n";
+
+$store = new InMemoryStore();
+
+$documents = [];
+foreach (Movies::all() as $movie) {
+    $documents[] = new TextDocument(
+        id: Uuid::v4(),
+        content: 'Title: '.$movie['title'].\PHP_EOL.'Director: '.$movie['director'].\PHP_EOL.'Description: '.$movie['description'],
+        metadata: new Metadata($movie),
+    );
+}
+
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
+$vectorizer = new Vectorizer($platform, 'BAAI/bge-small-en-v1.5?task=feature-extraction', logger());
+$indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
+$indexer->index($documents);
+
+$vectorRetriever = new Retriever($store, $vectorizer, logger: logger());
+
+$textRetriever = new Retriever($store, logger: logger());
+
+$queryText = 'crime family mafia';
+echo "Query: \"$queryText\"\n\n";
+
+// 1. Vector-only results (semantic similarity)
+echo "--- Vector-Only Results (semantic similarity) ---\n";
+$results = iterator_to_array($vectorRetriever->retrieve($queryText));
+
+foreach ($results as $i => $document) {
+    echo sprintf(
+        "  %d. %s (Score: %.4f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+// 2. Text-only results (keyword matching)
+echo "--- Text-Only Results (keyword matching) ---\n";
+$results = iterator_to_array($textRetriever->retrieve($queryText));
+
+foreach ($results as $i => $document) {
+    echo sprintf(
+        "  %d. %s (Score: %.4f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+// 3. Hybrid retrieval with CombinedStore + RRF (no reranker)
+echo "--- Hybrid RRF Results (CombinedStore, no reranker) ---\n";
+$combinedStore = new CombinedStore($store, $store, rrfK: 60);
+$hybridRetriever = new Retriever($combinedStore, $vectorizer, logger: logger());
+
+$results = iterator_to_array($hybridRetriever->retrieve($queryText));
+
+foreach ($results as $i => $document) {
+    echo sprintf(
+        "  %d. %s (RRF Score: %.6f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+// 4. Hybrid retrieval with CombinedStore + RRF + Platform reranking via event listener
+echo "--- Hybrid RRF + HuggingFace Reranking Results ---\n";
+$reranker = new Reranker($platform, 'BAAI/bge-reranker-base?task=text-ranking', logger());
+
+$dispatcher = new EventDispatcher();
+$dispatcher->addListener(PostQueryEvent::class, new RerankerListener($reranker, topK: 5));
+
+$hybridWithReranker = new Retriever($combinedStore, $vectorizer, $dispatcher, logger: logger());
+
+$rerankedResults = iterator_to_array($hybridWithReranker->retrieve($queryText));
+
+foreach ($rerankedResults as $i => $document) {
+    echo sprintf(
+        "  %d. %s (Relevance: %.4f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+echo "=== Summary ===\n";
+echo "- Vector retrieval finds semantically similar documents via embeddings\n";
+echo "- Text retrieval matches documents by keyword overlap\n";
+echo "- CombinedStore merges both result lists using rank-based RRF scoring\n";
+echo "- Adding a RerankerListener via EventDispatcher further refines results using a cross-encoder\n";

--- a/examples/rag/symfony-docs.php
+++ b/examples/rag/symfony-docs.php
@@ -55,7 +55,7 @@ $indexer->index($docsDir.'/index.rst');
 output()->writeln('<info>Indexing complete.</info>');
 
 // 3. Retrieve
-$retriever = new Retriever($store, $vectorizer, logger());
+$retriever = new Retriever($store, $vectorizer, logger: logger());
 $question = $argv[1] ?? 'How do I create a custom console command in Symfony?';
 
 output()->writeln('');

--- a/examples/retriever/movies.php
+++ b/examples/retriever/movies.php
@@ -39,7 +39,7 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$retriever = new Retriever($store, $vectorizer, logger());
+$retriever = new Retriever($store, $vectorizer, logger: logger());
 
 echo "Searching for movies about 'crime family mafia'\n";
 echo "================================================\n\n";

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -2382,6 +2382,7 @@ final class AiBundle extends AbstractBundle
         $definition = new Definition(Retriever::class, [
             new Reference($config['store']),
             new Reference($config['vectorizer']),
+            new Reference('event_dispatcher', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
         ]);
         $definition->addTag('ai.retriever', ['name' => $name]);

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -6158,8 +6158,11 @@ class AiBundleTest extends TestCase
         $this->assertInstanceOf(Reference::class, $arguments[1]);
         $this->assertSame('ai.vectorizer.my_vectorizer', (string) $arguments[1]);
 
-        $this->assertInstanceOf(Reference::class, $arguments[2]); // logger
-        $this->assertSame('logger', (string) $arguments[2]);
+        $this->assertInstanceOf(Reference::class, $arguments[2]); // eventDispatcher
+        $this->assertSame('event_dispatcher', (string) $arguments[2]);
+
+        $this->assertInstanceOf(Reference::class, $arguments[3]); // logger
+        $this->assertSame('logger', (string) $arguments[3]);
     }
 
     public function testRetrieverAliasIsRegistered()

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -1,10 +1,15 @@
 CHANGELOG
 =========
 
+0.7
+---
+
+ * Add reranking support via `RerankingResult`, `RerankingEntry`, and `Capability::RERANKING`
+
 0.6
 ---
 
-* [BC BREAK] Change `Symfony\AI\Platform\Contract\JsonSchema\Factory` constructor signature in order to make schema generation extensible
+ * [BC BREAK] Change `Symfony\AI\Platform\Contract\JsonSchema\Factory` constructor signature in order to make schema generation extensible
 
 0.4
 ---

--- a/src/platform/src/Bridge/HuggingFace/CHANGELOG.md
+++ b/src/platform/src/Bridge/HuggingFace/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.7
+---
+
+ * Add text-ranking task support for cross-encoder reranking models
+
 0.1
 ---
 

--- a/src/platform/src/Bridge/HuggingFace/ModelClient.php
+++ b/src/platform/src/Bridge/HuggingFace/ModelClient.php
@@ -48,20 +48,22 @@ final class ModelClient implements ModelClientInterface
 
         return new RawHttpResult($this->httpClient->request('POST', $this->getUrl($model, $provider, $task), [
             'auth_bearer' => $this->apiKey,
-            ...$this->getPayload($payload, $options),
+            ...$this->getPayload($model, $payload, $options, $task, $provider),
         ]));
     }
 
     private function getUrl(Model $model, string $provider, ?string $task): string
     {
-        $endpoint = Task::FEATURE_EXTRACTION === $task ? 'pipeline/feature-extraction' : 'models';
-        $url = \sprintf('https://router.huggingface.co/%s/%s/%s', $provider, $endpoint, $model->getName());
-
         if (Task::CHAT_COMPLETION === $task) {
-            $url .= '/v1/chat/completions';
+            if (Provider::HF_INFERENCE === $provider) {
+                return \sprintf('https://router.huggingface.co/%s/models/%s/v1/chat/completions', $provider, $model->getName());
+            }
+
+            // Third-party providers use OpenAI-compatible endpoint
+            return \sprintf('https://router.huggingface.co/%s/v1/chat/completions', $provider);
         }
 
-        return $url;
+        return \sprintf('https://router.huggingface.co/%s/models/%s', $provider, $model->getName());
     }
 
     /**
@@ -70,8 +72,21 @@ final class ModelClient implements ModelClientInterface
      *
      * @return array<string, mixed>
      */
-    private function getPayload(array|string $payload, array $options): array
+    private function getPayload(Model $model, array|string $payload, array $options, ?string $task, string $provider): array
     {
+        // Text ranking: convert {query, texts} into text/text_pair pairs for the HF text-classification pipeline
+        if (Task::TEXT_RANKING === $task && \is_array($payload) && isset($payload['query'], $payload['texts'])) {
+            $inputs = [];
+            foreach ($payload['texts'] as $text) {
+                $inputs[] = ['text' => $payload['query'], 'text_pair' => $text];
+            }
+
+            return [
+                'json' => ['inputs' => $inputs],
+                'headers' => ['Content-Type' => 'application/json'],
+            ];
+        }
+
         // Expect JSON input if string or not
         if (\is_string($payload) || !(isset($payload['body']) || isset($payload['json']))) {
             $payload = ['json' => ['inputs' => $payload]];
@@ -84,6 +99,11 @@ final class ModelClient implements ModelClientInterface
         // Merge options into JSON payload
         if (isset($payload['json'])) {
             $payload['json'] = array_merge($payload['json'], $options);
+        }
+
+        // Third-party providers need the model name in the JSON body
+        if (Task::CHAT_COMPLETION === $task && Provider::HF_INFERENCE !== $provider && isset($payload['json'])) {
+            $payload['json']['model'] = $model->getName();
         }
 
         $payload['headers'] ??= ['Content-Type' => 'application/json'];

--- a/src/platform/src/Bridge/HuggingFace/Output/ZeroShotClassificationResult.php
+++ b/src/platform/src/Bridge/HuggingFace/Output/ZeroShotClassificationResult.php
@@ -28,10 +28,18 @@ final class ZeroShotClassificationResult
     }
 
     /**
-     * @param array{labels: array<string>, scores: array<float>, sequence?: string} $data
+     * @param array{labels: array<string>, scores: array<float>, sequence?: string}|list<array{label: string, score: float}> $data
      */
     public static function fromArray(array $data): self
     {
+        // Serverless format: [{label: "refund", score: 0.97}, ...]
+        if (isset($data[0]['label'])) {
+            return new self(
+                array_map(static fn (array $item): string => $item['label'], $data),
+                array_map(static fn (array $item): float => $item['score'], $data),
+            );
+        }
+
         return new self(
             $data['labels'],
             $data['scores'],

--- a/src/platform/src/Bridge/HuggingFace/ResultConverter.php
+++ b/src/platform/src/Bridge/HuggingFace/ResultConverter.php
@@ -23,10 +23,12 @@ use Symfony\AI\Platform\Bridge\HuggingFace\Output\ZeroShotClassificationResult;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Reranking\RerankingEntry;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\RerankingResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\VectorResult;
@@ -80,7 +82,10 @@ final class ResultConverter implements ResultConverterInterface
             Task::AUDIO_CLASSIFICATION, Task::IMAGE_CLASSIFICATION => new ObjectResult(ClassificationResult::fromArray($content)),
             Task::AUTOMATIC_SPEECH_RECOGNITION => new TextResult($content['text'] ?? ''),
             Task::CHAT_COMPLETION => new TextResult($content['choices'][0]['message']['content'] ?? ''),
-            Task::FEATURE_EXTRACTION => new VectorResult(new Vector($content)),
+            Task::FEATURE_EXTRACTION => new VectorResult(...(isset($content[0]) && \is_array($content[0])
+                ? array_map(static fn (array $v): Vector => new Vector($v), $content)
+                : [new Vector($content)]
+            )),
             Task::TEXT_CLASSIFICATION => new ObjectResult(ClassificationResult::fromArray(reset($content) ?? [])),
             Task::FILL_MASK => new ObjectResult(FillMaskResult::fromArray($content)),
             Task::IMAGE_SEGMENTATION => new ObjectResult(ImageSegmentationResult::fromArray($content)),
@@ -90,6 +95,7 @@ final class ResultConverter implements ResultConverterInterface
             Task::QUESTION_ANSWERING => new ObjectResult(QuestionAnsweringResult::fromArray($content)),
             Task::SENTENCE_SIMILARITY => new ObjectResult(SentenceSimilarityResult::fromArray($content)),
             Task::SUMMARIZATION => new TextResult($content[0]['summary_text']),
+            Task::TEXT_RANKING => self::convertTextRanking($content),
             Task::TABLE_QUESTION_ANSWERING => new ObjectResult(TableQuestionAnsweringResult::fromArray($content)),
             Task::TOKEN_CLASSIFICATION => new ObjectResult(TokenClassificationResult::fromArray($content)),
             Task::TRANSLATION => new TextResult($content[0]['translation_text'] ?? ''),
@@ -102,5 +108,35 @@ final class ResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
     {
         return null;
+    }
+
+    /**
+     * The HF serverless API runs reranker models as text-classification and returns
+     * [[{label, score}, {label, score}, ...]] — one score per input pair.
+     * TEI returns [{index, score}, ...] directly.
+     *
+     * @param array<mixed> $content
+     */
+    private static function convertTextRanking(array $content): RerankingResult
+    {
+        // TEI format: [{index: 0, score: 0.95}, ...]
+        if (isset($content[0]['index'])) {
+            return new RerankingResult(...array_map(
+                static fn (array $item): RerankingEntry => new RerankingEntry((int) $item['index'], (float) $item['score']),
+                $content,
+            ));
+        }
+
+        // HF serverless format: [[{label, score}, ...]] — one result per input pair.
+        // Cross-encoder reranker models (e.g. bge-reranker-base) use a single output class
+        // where the score directly represents relevance.
+        $items = isset($content[0][0]) ? $content[0] : $content;
+
+        $entries = [];
+        foreach ($items as $index => $item) {
+            $entries[] = new RerankingEntry($index, (float) $item['score']);
+        }
+
+        return new RerankingResult(...$entries);
     }
 }

--- a/src/platform/src/Bridge/HuggingFace/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/HuggingFace/Tests/ModelClientTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\HuggingFace\Contract\FileNormalizer;
 use Symfony\AI\Platform\Bridge\HuggingFace\Contract\MessageBagNormalizer;
 use Symfony\AI\Platform\Bridge\HuggingFace\ModelClient;
+use Symfony\AI\Platform\Bridge\HuggingFace\Provider;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\Content\Text;
@@ -28,7 +29,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 final class ModelClientTest extends TestCase
 {
     #[DataProvider('urlTestCases')]
-    public function testGetUrlForDifferentInputsAndTasks(?string $task, string $expectedUrl)
+    public function testGetUrlForDifferentInputsAndTasks(?string $task, string $expectedUrl, ?string $provider = null)
     {
         $response = new MockResponse('{"result": "test"}', [
             'http_code' => 200,
@@ -46,6 +47,9 @@ final class ModelClientTest extends TestCase
 
         // Make a request to trigger URL generation
         $options = $task ? ['task' => $task] : [];
+        if (null !== $provider) {
+            $options['provider'] = $provider;
+        }
         $modelClient->request($model, 'test input', $options);
     }
 
@@ -67,12 +71,126 @@ final class ModelClientTest extends TestCase
         ];
         yield 'feature extraction' => [
             'task' => Task::FEATURE_EXTRACTION,
-            'expectedUrl' => 'https://router.huggingface.co/test-provider/pipeline/feature-extraction/test-model',
+            'expectedUrl' => 'https://router.huggingface.co/test-provider/models/test-model',
         ];
-        yield 'message bag' => [
+        yield 'chat completion with hf-inference' => [
             'task' => Task::CHAT_COMPLETION,
-            'expectedUrl' => 'https://router.huggingface.co/test-provider/models/test-model/v1/chat/completions',
+            'expectedUrl' => 'https://router.huggingface.co/hf-inference/models/test-model/v1/chat/completions',
+            'provider' => Provider::HF_INFERENCE,
         ];
+        yield 'chat completion with third-party provider' => [
+            'task' => Task::CHAT_COMPLETION,
+            'expectedUrl' => 'https://router.huggingface.co/featherless-ai/v1/chat/completions',
+            'provider' => Provider::FEATHERLESS_AI,
+        ];
+        yield 'feature extraction with third-party provider uses standard url' => [
+            'task' => Task::FEATURE_EXTRACTION,
+            'expectedUrl' => 'https://router.huggingface.co/together/models/test-model',
+            'provider' => Provider::TOGETHER,
+        ];
+        yield 'text ranking' => [
+            'task' => Task::TEXT_RANKING,
+            'expectedUrl' => 'https://router.huggingface.co/test-provider/models/test-model',
+        ];
+    }
+
+    public function testThirdPartyProviderInjectsModelNameInPayload()
+    {
+        $response = new MockResponse('{"result": "test"}');
+        $httpClient = new MockHttpClient($response);
+
+        $model = new Model('HuggingFaceH4/zephyr-7b-beta');
+        $modelClient = new ModelClient($httpClient, Provider::FEATHERLESS_AI, 'test-api-key');
+
+        $contract = Contract::create(
+            new FileNormalizer(),
+            new MessageBagNormalizer()
+        );
+
+        $messageBag = new MessageBag();
+        $messageBag->add(new UserMessage(new Text('Test message')));
+
+        $payload = $contract->createRequestPayload($model, $messageBag);
+
+        $modelClient->request($model, $payload, [
+            'task' => Task::CHAT_COMPLETION,
+        ]);
+
+        $requestOptions = $response->getRequestOptions();
+        $body = json_decode($requestOptions['body'], true);
+
+        $this->assertSame('HuggingFaceH4/zephyr-7b-beta', $body['model']);
+    }
+
+    public function testProviderOptionOverridesDefaultProvider()
+    {
+        $response = new MockResponse('{"result": "test"}', [
+            'http_code' => 200,
+        ]);
+
+        $expectedUrl = 'https://router.huggingface.co/hyperbolic/v1/chat/completions';
+
+        $httpClient = new MockHttpClient(function (string $method, string $url) use ($expectedUrl, $response): MockResponse {
+            $this->assertSame($expectedUrl, $url);
+
+            return $response;
+        });
+
+        $model = new Model('test-model');
+        // Default provider is hf-inference, but we override with hyperbolic
+        $modelClient = new ModelClient($httpClient, Provider::HF_INFERENCE, 'test-api-key');
+
+        $modelClient->request($model, 'test input', [
+            'task' => Task::CHAT_COMPLETION,
+            'provider' => Provider::HYPERBOLIC,
+        ]);
+
+        $body = json_decode($response->getRequestOptions()['body'], true);
+        $this->assertSame('test-model', $body['model']);
+    }
+
+    public function testThirdPartyProviderWithNonChatTaskDoesNotInjectModelName()
+    {
+        $response = new MockResponse('{"result": "test"}');
+        $httpClient = new MockHttpClient($response);
+
+        $model = new Model('BAAI/bge-small-en-v1.5');
+        $modelClient = new ModelClient($httpClient, Provider::TOGETHER, 'test-api-key');
+
+        $modelClient->request($model, 'Some text to embed', [
+            'task' => Task::FEATURE_EXTRACTION,
+        ]);
+
+        $body = json_decode($response->getRequestOptions()['body'], true);
+        $this->assertArrayNotHasKey('model', $body);
+    }
+
+    public function testHfInferenceDoesNotInjectModelNameInPayload()
+    {
+        $response = new MockResponse('{"result": "test"}');
+        $httpClient = new MockHttpClient($response);
+
+        $model = new Model('test-model');
+        $modelClient = new ModelClient($httpClient, Provider::HF_INFERENCE, 'test-api-key');
+
+        $contract = Contract::create(
+            new FileNormalizer(),
+            new MessageBagNormalizer()
+        );
+
+        $messageBag = new MessageBag();
+        $messageBag->add(new UserMessage(new Text('Test message')));
+
+        $payload = $contract->createRequestPayload($model, $messageBag);
+
+        $modelClient->request($model, $payload, [
+            'task' => Task::CHAT_COMPLETION,
+        ]);
+
+        $requestOptions = $response->getRequestOptions();
+        $body = json_decode($requestOptions['body'], true);
+
+        $this->assertArrayNotHasKey('model', $body);
     }
 
     /**
@@ -137,6 +255,46 @@ final class ModelClientTest extends TestCase
         }
     }
 
+    public function testStringInputWithOptionsWrapsInParametersKey()
+    {
+        $response = new MockResponse('{"result": "test"}');
+        $httpClient = new MockHttpClient($response);
+
+        $model = new Model('test-model');
+        $modelClient = new ModelClient($httpClient, 'test-provider', 'test-api-key');
+
+        $modelClient->request($model, 'Hello world', [
+            'temperature' => 0.7,
+            'max_tokens' => 50,
+        ]);
+
+        $body = json_decode($response->getRequestOptions()['body'], true);
+
+        $this->assertSame('Hello world', $body['inputs']);
+        $this->assertSame(0.7, $body['parameters']['temperature']);
+        $this->assertSame(50, $body['parameters']['max_tokens']);
+    }
+
+    public function testPreBuiltBodyPayloadIsPassedThrough()
+    {
+        $response = new MockResponse('{"result": "test"}');
+        $httpClient = new MockHttpClient($response);
+
+        $model = new Model('test-model');
+        $modelClient = new ModelClient($httpClient, 'test-provider', 'test-api-key');
+
+        $binaryContent = 'fake-binary-image-data';
+        $modelClient->request($model, [
+            'body' => $binaryContent,
+            'headers' => ['Content-Type' => 'image/jpeg'],
+        ]);
+
+        $requestOptions = $response->getRequestOptions();
+
+        $this->assertSame($binaryContent, $requestOptions['body']);
+        $this->assertContains('Content-Type: image/jpeg', $requestOptions['headers']);
+    }
+
     public static function payloadTestCases(): \Iterator
     {
         yield 'string input' => [
@@ -170,6 +328,19 @@ final class ModelClientTest extends TestCase
             'expectedValues' => [
                 'headers.Content-Type' => 'application/json',
                 'json.max_tokens' => 100,
+            ],
+        ];
+
+        yield 'text ranking' => [
+            'input' => ['query' => 'search query', 'texts' => ['doc one', 'doc two']],
+            'options' => ['task' => Task::TEXT_RANKING],
+            'expectedKeys' => ['headers', 'json'],
+            'expectedValues' => [
+                'headers.Content-Type' => 'application/json',
+                'json.inputs' => [
+                    ['text' => 'search query', 'text_pair' => 'doc one'],
+                    ['text' => 'search query', 'text_pair' => 'doc two'],
+                ],
             ],
         ];
     }

--- a/src/platform/src/Bridge/HuggingFace/Tests/Output/ZeroShotClassificationResultTest.php
+++ b/src/platform/src/Bridge/HuggingFace/Tests/Output/ZeroShotClassificationResultTest.php
@@ -66,6 +66,22 @@ final class ZeroShotClassificationResultTest extends TestCase
         $this->assertSame($sequence, $result->sequence);
     }
 
+    #[TestDox('fromArray creates instance from new serverless format')]
+    public function testFromArrayWithNewServerlessFormat()
+    {
+        $data = [
+            ['label' => 'refund', 'score' => 0.878],
+            ['label' => 'faq', 'score' => 0.105],
+            ['label' => 'legal', 'score' => 0.017],
+        ];
+
+        $result = ZeroShotClassificationResult::fromArray($data);
+
+        $this->assertSame(['refund', 'faq', 'legal'], $result->labels);
+        $this->assertSame([0.878, 0.105, 0.017], $result->scores);
+        $this->assertNull($result->sequence);
+    }
+
     #[TestDox('fromArray creates instance with required fields')]
     public function testFromArrayWithRequiredFields()
     {

--- a/src/platform/src/Bridge/HuggingFace/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/HuggingFace/Tests/ResultConverterTest.php
@@ -22,6 +22,7 @@ use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RerankingResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -221,6 +222,56 @@ final class ResultConverterTest extends TestCase
         $convertedResult = (new ResultConverter())->convert($result, ['task' => $task]);
 
         $this->assertInstanceOf(ObjectResult::class, $convertedResult);
+    }
+
+    #[TestDox('Converts TEI text-ranking response to RerankingResult')]
+    public function testConvertTextRankingTeiFormat()
+    {
+        $responseData = [
+            ['index' => 0, 'score' => 0.95],
+            ['index' => 1, 'score' => 0.42],
+        ];
+        $response = new JsonMockResponse($responseData);
+        $httpClient = new MockHttpClient($response);
+        $httpResponse = $httpClient->request('GET', 'https://example.com');
+        $result = new RawHttpResult($httpResponse);
+
+        $convertedResult = (new ResultConverter())->convert($result, ['task' => Task::TEXT_RANKING]);
+
+        $this->assertInstanceOf(RerankingResult::class, $convertedResult);
+        $entries = $convertedResult->getContent();
+        $this->assertCount(2, $entries);
+        $this->assertSame(0, $entries[0]->getIndex());
+        $this->assertSame(0.95, $entries[0]->getScore());
+        $this->assertSame(1, $entries[1]->getIndex());
+        $this->assertSame(0.42, $entries[1]->getScore());
+    }
+
+    #[TestDox('Converts HF serverless text-ranking response to RerankingResult')]
+    public function testConvertTextRankingServerlessFormat()
+    {
+        // HF serverless returns one result per input pair, wrapped in an extra array.
+        // Score represents relevance directly for cross-encoder reranker models.
+        $responseData = [
+            [
+                ['label' => 'LABEL_0', 'score' => 0.024],
+                ['label' => 'LABEL_0', 'score' => 0.00003],
+            ],
+        ];
+        $response = new JsonMockResponse($responseData);
+        $httpClient = new MockHttpClient($response);
+        $httpResponse = $httpClient->request('GET', 'https://example.com');
+        $result = new RawHttpResult($httpResponse);
+
+        $convertedResult = (new ResultConverter())->convert($result, ['task' => Task::TEXT_RANKING]);
+
+        $this->assertInstanceOf(RerankingResult::class, $convertedResult);
+        $entries = $convertedResult->getContent();
+        $this->assertCount(2, $entries);
+        $this->assertSame(0, $entries[0]->getIndex());
+        $this->assertSame(0.024, $entries[0]->getScore());
+        $this->assertSame(1, $entries[1]->getIndex());
+        $this->assertSame(3.0E-5, $entries[1]->getScore());
     }
 
     #[TestDox('Converts text-to-image response to BinaryResult with correct MIME type')]

--- a/src/platform/src/Capability.php
+++ b/src/platform/src/Capability.php
@@ -56,6 +56,9 @@ enum Capability: string
     // EMBEDDINGS
     case EMBEDDINGS = 'embeddings';
 
+    // RERANKING
+    case RERANKING = 'reranking';
+
     // Thinking
     case THINKING = 'thinking';
 }

--- a/src/platform/src/Reranking/RerankingEntry.php
+++ b/src/platform/src/Reranking/RerankingEntry.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Reranking;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RerankingEntry
+{
+    public function __construct(
+        private readonly int $index,
+        private readonly float $score,
+    ) {
+    }
+
+    public function getIndex(): int
+    {
+        return $this->index;
+    }
+
+    public function getScore(): float
+    {
+        return $this->score;
+    }
+}

--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Result;
 use Symfony\AI\Platform\Exception\ExceptionInterface;
 use Symfony\AI\Platform\Exception\UnexpectedResultTypeException;
 use Symfony\AI\Platform\Metadata\MetadataAwareTrait;
+use Symfony\AI\Platform\Reranking\RerankingEntry;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\TokenUsage\StreamListener;
 use Symfony\AI\Platform\TokenUsage\TokenUsage;
@@ -128,6 +129,16 @@ final class DeferredResult
     public function asVectors(): array
     {
         return $this->as(VectorResult::class)->getContent();
+    }
+
+    /**
+     * @return list<RerankingEntry>
+     *
+     * @throws ExceptionInterface
+     */
+    public function asReranking(): array
+    {
+        return $this->as(RerankingResult::class)->getContent();
     }
 
     /**

--- a/src/platform/src/Result/RerankingResult.php
+++ b/src/platform/src/Result/RerankingResult.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+use Symfony\AI\Platform\Reranking\RerankingEntry;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RerankingResult extends BaseResult
+{
+    /**
+     * @var list<RerankingEntry>
+     */
+    private readonly array $entries;
+
+    public function __construct(RerankingEntry ...$entries)
+    {
+        $this->entries = $entries;
+    }
+
+    /**
+     * @return list<RerankingEntry>
+     */
+    public function getContent(): array
+    {
+        return $this->entries;
+    }
+}

--- a/src/platform/tests/Result/RerankingResultTest.php
+++ b/src/platform/tests/Result/RerankingResultTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Reranking\RerankingEntry;
+use Symfony\AI\Platform\Result\RerankingResult;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RerankingResultTest extends TestCase
+{
+    public function testGetContentWithSingleEntry()
+    {
+        $entry = new RerankingEntry(0, 0.95);
+        $result = new RerankingResult($entry);
+
+        $this->assertSame([$entry], $result->getContent());
+    }
+
+    public function testGetContentWithMultipleEntries()
+    {
+        $entry1 = new RerankingEntry(0, 0.95);
+        $entry2 = new RerankingEntry(1, 0.80);
+        $entry3 = new RerankingEntry(2, 0.60);
+
+        $result = new RerankingResult($entry1, $entry2, $entry3);
+
+        $this->assertSame([$entry1, $entry2, $entry3], $result->getContent());
+    }
+
+    public function testGetContentWithNoEntries()
+    {
+        $result = new RerankingResult();
+
+        $this->assertSame([], $result->getContent());
+    }
+
+    public function testConstructorAcceptsVariadicEntries()
+    {
+        $entries = [
+            new RerankingEntry(0, 0.9),
+            new RerankingEntry(1, 0.7),
+            new RerankingEntry(2, 0.5),
+        ];
+
+        $result = new RerankingResult(...$entries);
+
+        $this->assertSame($entries, $result->getContent());
+    }
+}

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -5,6 +5,10 @@ CHANGELOG
 ---
 
  * Add `RstLoader` and `RstToctreeLoader` for loading RST files and following toctree directives
+ * Add platform-based `Reranker` for cross-encoder reranking via `PlatformInterface`
+ * Add `CombinedStore` combining vector and text stores with Reciprocal Rank Fusion (RRF)
+ * [BC BREAK] Add `?EventDispatcherInterface $eventDispatcher` as 3rd constructor parameter of `Retriever` (before `$logger`)
+ * Add automatic text content preservation in `Vectorizer` metadata
 
 0.6
 ---

--- a/src/store/composer.json
+++ b/src/store/composer.json
@@ -41,12 +41,14 @@
     "require": {
         "php": ">=8.2",
         "ext-fileinfo": "*",
+        "psr/event-dispatcher": "^1.0",
         "psr/log": "^3.0",
         "symfony/ai-platform": "^0.6",
         "symfony/clock": "^7.3|^8.0",
         "symfony/http-client": "^7.3|^8.0",
         "symfony/polyfill-php83": "^1.32",
         "symfony/service-contracts": "^2.5|^3",
+        "symfony/event-dispatcher-contracts": "^3.0",
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/store/src/CombinedStore.php
+++ b/src/store/src/CombinedStore.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store;
+
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\QueryInterface;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
+
+/**
+ * Combines vector and text stores using Reciprocal Rank Fusion (RRF).
+ *
+ * Decomposes HybridQuery into VectorQuery and TextQuery, queries both
+ * sub-stores independently, and merges results using RRF scoring.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class CombinedStore implements StoreInterface
+{
+    public function __construct(
+        private readonly StoreInterface $vectorStore,
+        private readonly StoreInterface $textStore,
+        private readonly int $rrfK = 60,
+    ) {
+    }
+
+    public function add(VectorDocument|array $documents): void
+    {
+        $this->vectorStore->add($documents);
+
+        if ($this->textStore !== $this->vectorStore) {
+            $this->textStore->add($documents);
+        }
+    }
+
+    public function remove(string|array $ids, array $options = []): void
+    {
+        $this->vectorStore->remove($ids, $options);
+
+        if ($this->textStore !== $this->vectorStore) {
+            $this->textStore->remove($ids, $options);
+        }
+    }
+
+    public function query(QueryInterface $query, array $options = []): iterable
+    {
+        if ($query instanceof HybridQuery) {
+            return $this->hybridQuery($query, $options);
+        }
+
+        if ($query instanceof VectorQuery && $this->vectorStore->supports(VectorQuery::class)) {
+            return $this->vectorStore->query($query, $options);
+        }
+
+        if ($query instanceof TextQuery && $this->textStore->supports(TextQuery::class)) {
+            return $this->textStore->query($query, $options);
+        }
+
+        throw new UnsupportedQueryTypeException($query::class, $this);
+    }
+
+    public function supports(string $queryClass): bool
+    {
+        if (HybridQuery::class === $queryClass) {
+            return $this->vectorStore->supports(VectorQuery::class)
+                && $this->textStore->supports(TextQuery::class);
+        }
+
+        return $this->vectorStore->supports($queryClass)
+            || $this->textStore->supports($queryClass);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return list<VectorDocument>
+     */
+    private function hybridQuery(HybridQuery $query, array $options): array
+    {
+        $vectorResults = iterator_to_array(
+            $this->vectorStore->query(new VectorQuery($query->getVector()), $options),
+        );
+
+        $textResults = iterator_to_array(
+            $this->textStore->query(new TextQuery($query->getText()), $options),
+        );
+
+        return $this->reciprocalRankFusion($vectorResults, $textResults);
+    }
+
+    /**
+     * @param list<VectorDocument> $list1
+     * @param list<VectorDocument> $list2
+     *
+     * @return list<VectorDocument>
+     */
+    private function reciprocalRankFusion(array $list1, array $list2): array
+    {
+        /** @var array<string, float> $scores */
+        $scores = [];
+
+        /** @var array<string, VectorDocument> $documentsById */
+        $documentsById = [];
+
+        foreach ($list1 as $rank => $document) {
+            $id = (string) $document->getId();
+            $scores[$id] = ($scores[$id] ?? 0.0) + 1.0 / ($this->rrfK + $rank + 1);
+            $documentsById[$id] = $document;
+        }
+
+        foreach ($list2 as $rank => $document) {
+            $id = (string) $document->getId();
+            $scores[$id] = ($scores[$id] ?? 0.0) + 1.0 / ($this->rrfK + $rank + 1);
+            $documentsById[$id] = $document;
+        }
+
+        arsort($scores);
+
+        $result = [];
+        foreach (array_keys($scores) as $id) {
+            $result[] = $documentsById[$id]->withScore($scores[$id]);
+        }
+
+        return $result;
+    }
+}

--- a/src/store/src/Document/Vectorizer.php
+++ b/src/store/src/Document/Vectorizer.php
@@ -109,7 +109,14 @@ final class Vectorizer implements VectorizerInterface
             throw new RuntimeException('No vector returned for vectorization.');
         }
 
-        return new VectorDocument($document->getId(), $vectors[0], $document->getMetadata());
+        // Preserve the original text in metadata so downstream consumers
+        // (e.g. text search, reranking) can access it via Metadata::getText().
+        $metadata = $document->getMetadata();
+        if (!$metadata->hasText()) {
+            $metadata->setText($document->getContent());
+        }
+
+        return new VectorDocument($document->getId(), $vectors[0], $metadata);
     }
 
     /**
@@ -186,7 +193,14 @@ final class Vectorizer implements VectorizerInterface
 
         $vectorDocuments = [];
         foreach ($documents as $i => $document) {
-            $vectorDocuments[] = new VectorDocument($document->getId(), $vectors[$i], $document->getMetadata());
+            // Preserve the original text in metadata so downstream consumers
+            // (e.g. text search, reranking) can access it via Metadata::getText().
+            $metadata = $document->getMetadata();
+            if (!$metadata->hasText()) {
+                $metadata->setText($document->getContent());
+            }
+
+            $vectorDocuments[] = new VectorDocument($document->getId(), $vectors[$i], $metadata);
         }
 
         $this->logger->info('Vectorization process completed', [

--- a/src/store/src/Event/PostQueryEvent.php
+++ b/src/store/src/Event/PostQueryEvent.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Event;
+
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event dispatched after documents are retrieved from the store.
+ *
+ * Listeners can modify the documents list, for example to rerank results.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PostQueryEvent extends Event
+{
+    /**
+     * @param iterable<VectorDocument> $documents
+     * @param array<string, mixed>     $options
+     */
+    public function __construct(
+        private readonly string $query,
+        private iterable $documents,
+        private readonly array $options = [],
+    ) {
+    }
+
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+
+    /**
+     * @return iterable<VectorDocument>
+     */
+    public function getDocuments(): iterable
+    {
+        return $this->documents;
+    }
+
+    /**
+     * @param iterable<VectorDocument> $documents
+     */
+    public function setDocuments(iterable $documents): void
+    {
+        $this->documents = $documents;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/store/src/EventListener/RerankerListener.php
+++ b/src/store/src/EventListener/RerankerListener.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\EventListener;
+
+use Symfony\AI\Store\Event\PostQueryEvent;
+use Symfony\AI\Store\Reranker\RerankerInterface;
+
+/**
+ * Reranks retrieved documents using a cross-encoder model.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RerankerListener
+{
+    public function __construct(
+        private readonly RerankerInterface $reranker,
+        private readonly int $topK = 5,
+    ) {
+    }
+
+    public function __invoke(PostQueryEvent $event): void
+    {
+        $documents = $event->getDocuments();
+        if (!\is_array($documents)) {
+            $documents = iterator_to_array($documents);
+        }
+
+        $reranked = $this->reranker->rerank(
+            $event->getQuery(),
+            array_values($documents),
+            $event->getOptions()['topK'] ?? $this->topK,
+        );
+
+        $event->setDocuments($reranked);
+    }
+}

--- a/src/store/src/Reranker/Reranker.php
+++ b/src/store/src/Reranker/Reranker.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Reranker;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Store\Document\VectorDocument;
+
+/**
+ * Platform-based reranker that delegates to PlatformInterface for cross-encoder scoring.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class Reranker implements RerankerInterface
+{
+    public function __construct(
+        private readonly PlatformInterface $platform,
+        private readonly string $model,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function rerank(string $query, array $documents, int $topK = 5): array
+    {
+        if ([] === $documents) {
+            return [];
+        }
+
+        $texts = array_map(
+            static fn (VectorDocument $doc): string => $doc->getMetadata()->getText()
+                ?? $doc->getMetadata()->getSource() ?? '',
+            $documents,
+        );
+
+        $this->logger->debug('Reranking {count} documents', ['count' => \count($documents)]);
+
+        $entries = $this->platform
+            ->invoke($this->model, ['query' => $query, 'texts' => $texts])
+            ->asReranking();
+
+        usort($entries, static fn ($a, $b): int => $b->getScore() <=> $a->getScore());
+        $entries = \array_slice($entries, 0, $topK);
+
+        $reranked = [];
+        foreach ($entries as $entry) {
+            $reranked[] = $documents[$entry->getIndex()]->withScore($entry->getScore());
+        }
+
+        $this->logger->debug('Reranking completed, returning {topK} documents', ['topK' => \count($reranked)]);
+
+        return $reranked;
+    }
+}

--- a/src/store/src/Reranker/RerankerInterface.php
+++ b/src/store/src/Reranker/RerankerInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Reranker;
+
+use Symfony\AI\Store\Document\VectorDocument;
+
+/**
+ * Reranks a list of retrieved documents using a cross-encoder model.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+interface RerankerInterface
+{
+    /**
+     * Rerank documents for the given query.
+     *
+     * @param list<VectorDocument> $documents
+     *
+     * @return list<VectorDocument> Reranked documents with updated scores, limited to $topK
+     */
+    public function rerank(string $query, array $documents, int $topK = 5): array;
+}

--- a/src/store/src/Retriever.php
+++ b/src/store/src/Retriever.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\AI\Store;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Document\VectorizerInterface;
+use Symfony\AI\Store\Event\PostQueryEvent;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\QueryInterface;
 use Symfony\AI\Store\Query\TextQuery;
@@ -28,6 +30,7 @@ final class Retriever implements RetrieverInterface
     public function __construct(
         private readonly StoreInterface $store,
         private readonly ?VectorizerInterface $vectorizer = null,
+        private readonly ?EventDispatcherInterface $eventDispatcher = null,
         private readonly LoggerInterface $logger = new NullLogger(),
     ) {
     }
@@ -47,6 +50,20 @@ final class Retriever implements RetrieverInterface
 
         $documents = $this->store->query($queryObject, $options);
 
+        if (null !== $this->eventDispatcher) {
+            $documents = $this->dispatchPostRetrieval($query, $documents, $options);
+        }
+
+        return $this->yieldDocuments($documents);
+    }
+
+    /**
+     * @param iterable<VectorDocument> $documents
+     *
+     * @return \Generator<VectorDocument>
+     */
+    private function yieldDocuments(iterable $documents): \Generator
+    {
         $count = 0;
         foreach ($documents as $document) {
             ++$count;
@@ -54,6 +71,20 @@ final class Retriever implements RetrieverInterface
         }
 
         $this->logger->debug('Document retrieval completed', ['retrieved_count' => $count]);
+    }
+
+    /**
+     * @param iterable<VectorDocument> $documents
+     * @param array<string, mixed>     $options
+     *
+     * @return iterable<VectorDocument>
+     */
+    private function dispatchPostRetrieval(string $query, iterable $documents, array $options): iterable
+    {
+        $event = new PostQueryEvent($query, $documents, $options);
+        $this->eventDispatcher?->dispatch($event);
+
+        return $event->getDocuments();
     }
 
     /**

--- a/src/store/tests/CombinedStoreTest.php
+++ b/src/store/tests/CombinedStoreTest.php
@@ -1,0 +1,256 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\CombinedStore;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\TextQuery;
+use Symfony\AI\Store\Query\VectorQuery;
+use Symfony\AI\Store\StoreInterface;
+
+final class CombinedStoreTest extends TestCase
+{
+    public function testRrfScoringWithKnownRanks()
+    {
+        $docA = new VectorDocument('doc-a', new Vector([0.1, 0.2]), new Metadata([Metadata::KEY_TEXT => 'Document A']));
+        $docB = new VectorDocument('doc-b', new Vector([0.3, 0.4]), new Metadata([Metadata::KEY_TEXT => 'Document B']));
+        $docC = new VectorDocument('doc-c', new Vector([0.5, 0.6]), new Metadata([Metadata::KEY_TEXT => 'Document C']));
+
+        $vectorStore = $this->createMock(StoreInterface::class);
+        $vectorStore->method('supports')->willReturnMap([
+            [VectorQuery::class, true],
+        ]);
+        $vectorStore->method('query')->willReturn([$docA, $docB]);
+
+        $textStore = $this->createMock(StoreInterface::class);
+        $textStore->method('supports')->willReturnMap([
+            [TextQuery::class, true],
+        ]);
+        $textStore->method('query')->willReturn([$docB, $docC]);
+
+        $store = new CombinedStore($vectorStore, $textStore, 60);
+
+        $query = new HybridQuery(new Vector([0.1, 0.2]), 'test query');
+        $results = iterator_to_array($store->query($query));
+
+        // docB appears in both lists (rank 2 in vector, rank 1 in text) so should score highest
+        $this->assertCount(3, $results);
+        $this->assertSame('doc-b', $results[0]->getId());
+    }
+
+    public function testRrfScoresAreUpdatedOnDocuments()
+    {
+        $doc = new VectorDocument('doc-1', new Vector([0.1, 0.2]));
+
+        $vectorStore = $this->createMock(StoreInterface::class);
+        $vectorStore->method('supports')->willReturnMap([
+            [VectorQuery::class, true],
+        ]);
+        $vectorStore->method('query')->willReturn([$doc]);
+
+        $textStore = $this->createMock(StoreInterface::class);
+        $textStore->method('supports')->willReturnMap([
+            [TextQuery::class, true],
+        ]);
+        $textStore->method('query')->willReturn([$doc]);
+
+        $store = new CombinedStore($vectorStore, $textStore, 60);
+
+        $query = new HybridQuery(new Vector([0.1, 0.2]), 'test query');
+        $results = iterator_to_array($store->query($query));
+
+        $this->assertCount(1, $results);
+        // Score should be sum of RRF contributions from both lists: 2 * (1 / (60 + 0 + 1))
+        $expectedScore = 2.0 / 61.0;
+        $this->assertEqualsWithDelta($expectedScore, $results[0]->getScore(), 0.0001);
+    }
+
+    public function testHybridQueryDecomposesIntoVectorAndTextQueries()
+    {
+        $vectorStore = $this->createMock(StoreInterface::class);
+        $vectorStore->method('supports')->willReturnMap([
+            [VectorQuery::class, true],
+        ]);
+        $vectorStore->expects($this->once())
+            ->method('query')
+            ->with($this->isInstanceOf(VectorQuery::class), $this->anything())
+            ->willReturn([]);
+
+        $textStore = $this->createMock(StoreInterface::class);
+        $textStore->method('supports')->willReturnMap([
+            [TextQuery::class, true],
+        ]);
+        $textStore->expects($this->once())
+            ->method('query')
+            ->with($this->isInstanceOf(TextQuery::class), $this->anything())
+            ->willReturn([]);
+
+        $store = new CombinedStore($vectorStore, $textStore);
+
+        $query = new HybridQuery(new Vector([0.1, 0.2]), 'test query');
+        iterator_to_array($store->query($query));
+    }
+
+    public function testNonHybridVectorQueryForwardsToVectorStore()
+    {
+        $doc = new VectorDocument('doc-1', new Vector([0.1, 0.2]));
+
+        $vectorStore = $this->createMock(StoreInterface::class);
+        $vectorStore->method('supports')->willReturnMap([
+            [VectorQuery::class, true],
+        ]);
+        $vectorStore->expects($this->once())
+            ->method('query')
+            ->willReturn([$doc]);
+
+        $textStore = $this->createMock(StoreInterface::class);
+        $textStore->expects($this->never())->method('query');
+
+        $store = new CombinedStore($vectorStore, $textStore);
+
+        $query = new VectorQuery(new Vector([0.1, 0.2]));
+        $results = iterator_to_array($store->query($query));
+
+        $this->assertCount(1, $results);
+        $this->assertSame('doc-1', $results[0]->getId());
+    }
+
+    public function testNonHybridTextQueryForwardsToTextStore()
+    {
+        $doc = new VectorDocument('doc-1', new Vector([0.1, 0.2]));
+
+        $vectorStore = $this->createMock(StoreInterface::class);
+        $vectorStore->method('supports')->willReturnMap([
+            [VectorQuery::class, true],
+        ]);
+        $vectorStore->expects($this->never())->method('query');
+
+        $textStore = $this->createMock(StoreInterface::class);
+        $textStore->method('supports')->willReturnMap([
+            [TextQuery::class, true],
+        ]);
+        $textStore->expects($this->once())
+            ->method('query')
+            ->willReturn([$doc]);
+
+        $store = new CombinedStore($vectorStore, $textStore);
+
+        $query = new TextQuery('test query');
+        $results = iterator_to_array($store->query($query));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testUnsupportedQueryThrowsException()
+    {
+        $vectorStore = $this->createMock(StoreInterface::class);
+        $vectorStore->method('supports')->willReturn(false);
+
+        $textStore = $this->createMock(StoreInterface::class);
+        $textStore->method('supports')->willReturn(false);
+
+        $store = new CombinedStore($vectorStore, $textStore);
+
+        $this->expectException(UnsupportedQueryTypeException::class);
+
+        $store->query(new VectorQuery(new Vector([0.1, 0.2])));
+    }
+
+    public function testSupportsHybridQueryWhenBothSubStoresSupport()
+    {
+        $vectorStore = $this->createMock(StoreInterface::class);
+        $vectorStore->method('supports')->willReturnMap([
+            [VectorQuery::class, true],
+            [TextQuery::class, false],
+            [HybridQuery::class, false],
+        ]);
+
+        $textStore = $this->createMock(StoreInterface::class);
+        $textStore->method('supports')->willReturnMap([
+            [VectorQuery::class, false],
+            [TextQuery::class, true],
+            [HybridQuery::class, false],
+        ]);
+
+        $store = new CombinedStore($vectorStore, $textStore);
+
+        $this->assertTrue($store->supports(HybridQuery::class));
+        $this->assertTrue($store->supports(VectorQuery::class));
+        $this->assertTrue($store->supports(TextQuery::class));
+    }
+
+    public function testDoesNotSupportHybridQueryWhenVectorStoreDoesNotSupportVectorQuery()
+    {
+        $vectorStore = $this->createMock(StoreInterface::class);
+        $vectorStore->method('supports')->willReturn(false);
+
+        $textStore = $this->createMock(StoreInterface::class);
+        $textStore->method('supports')->willReturnMap([
+            [TextQuery::class, true],
+        ]);
+
+        $store = new CombinedStore($vectorStore, $textStore);
+
+        $this->assertFalse($store->supports(HybridQuery::class));
+    }
+
+    public function testAddDelegatesToBothStoresWhenDifferentInstances()
+    {
+        $doc = new VectorDocument('doc-1', new Vector([0.1, 0.2]));
+
+        $vectorStore = $this->createMock(StoreInterface::class);
+        $vectorStore->expects($this->once())->method('add')->with($doc);
+
+        $textStore = $this->createMock(StoreInterface::class);
+        $textStore->expects($this->once())->method('add')->with($doc);
+
+        $store = new CombinedStore($vectorStore, $textStore);
+        $store->add($doc);
+    }
+
+    public function testAddDelegatesToStoreOnceWhenSameInstance()
+    {
+        $doc = new VectorDocument('doc-1', new Vector([0.1, 0.2]));
+
+        $sharedStore = $this->createMock(StoreInterface::class);
+        $sharedStore->expects($this->once())->method('add')->with($doc);
+
+        $store = new CombinedStore($sharedStore, $sharedStore);
+        $store->add($doc);
+    }
+
+    public function testRemoveDelegatesToBothStoresWhenDifferentInstances()
+    {
+        $vectorStore = $this->createMock(StoreInterface::class);
+        $vectorStore->expects($this->once())->method('remove')->with('doc-1');
+
+        $textStore = $this->createMock(StoreInterface::class);
+        $textStore->expects($this->once())->method('remove')->with('doc-1');
+
+        $store = new CombinedStore($vectorStore, $textStore);
+        $store->remove('doc-1');
+    }
+
+    public function testRemoveDelegatesToStoreOnceWhenSameInstance()
+    {
+        $sharedStore = $this->createMock(StoreInterface::class);
+        $sharedStore->expects($this->once())->method('remove')->with('doc-1');
+
+        $store = new CombinedStore($sharedStore, $sharedStore);
+        $store->remove('doc-1');
+    }
+}

--- a/src/store/tests/Document/VectorizerTest.php
+++ b/src/store/tests/Document/VectorizerTest.php
@@ -125,8 +125,8 @@ final class VectorizerTest extends TestCase
         $this->assertCount(2, $vectorDocuments);
         $this->assertSame($metadata1, $vectorDocuments[0]->getMetadata());
         $this->assertSame($metadata2, $vectorDocuments[1]->getMetadata());
-        $this->assertSame(['source' => 'file1.txt', 'author' => 'Alice', 'tags' => ['important']], $vectorDocuments[0]->getMetadata()->getArrayCopy());
-        $this->assertSame(['source' => 'file2.txt', 'author' => 'Bob', 'version' => 2], $vectorDocuments[1]->getMetadata()->getArrayCopy());
+        $this->assertSame(['source' => 'file1.txt', 'author' => 'Alice', 'tags' => ['important'], '_text' => 'Content 1'], $vectorDocuments[0]->getMetadata()->getArrayCopy());
+        $this->assertSame(['source' => 'file2.txt', 'author' => 'Bob', 'version' => 2, '_text' => 'Content 2'], $vectorDocuments[1]->getMetadata()->getArrayCopy());
     }
 
     public function testVectorizeDocumentsPreservesDocumentIds()
@@ -185,7 +185,7 @@ final class VectorizerTest extends TestCase
             $this->assertSame($documents[$i]->getId(), $vectorDoc->getId());
             $this->assertEquals($vectors[$i], $vectorDoc->getVector());
             $this->assertSame($documents[$i]->getMetadata(), $vectorDoc->getMetadata());
-            $this->assertSame(['index' => $i], $vectorDoc->getMetadata()->getArrayCopy());
+            $this->assertSame(['index' => $i, '_text' => \sprintf('Document %d content', $i)], $vectorDoc->getMetadata()->getArrayCopy());
         }
     }
 

--- a/src/store/tests/EventListener/RerankerListenerTest.php
+++ b/src/store/tests/EventListener/RerankerListenerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Event\PostQueryEvent;
+use Symfony\AI\Store\EventListener\RerankerListener;
+use Symfony\AI\Store\Reranker\RerankerInterface;
+
+final class RerankerListenerTest extends TestCase
+{
+    public function testListenerCallsRerankerAndSetsDocuments()
+    {
+        $doc1 = new VectorDocument('doc-1', new Vector([0.1, 0.2]));
+        $doc2 = new VectorDocument('doc-2', new Vector([0.3, 0.4]));
+        $rerankedDoc = new VectorDocument('doc-2', new Vector([0.3, 0.4]), score: 0.95);
+
+        $reranker = $this->createMock(RerankerInterface::class);
+        $reranker->expects($this->once())
+            ->method('rerank')
+            ->with('test query', [$doc1, $doc2], 5)
+            ->willReturn([$rerankedDoc]);
+
+        $event = new PostQueryEvent('test query', [$doc1, $doc2]);
+
+        $listener = new RerankerListener($reranker, 5);
+        $listener($event);
+
+        $documents = iterator_to_array($event->getDocuments());
+        $this->assertCount(1, $documents);
+        $this->assertSame(0.95, $documents[0]->getScore());
+    }
+
+    public function testTopKFromEventOptionsOverridesConstructorDefault()
+    {
+        $doc = new VectorDocument('doc-1', new Vector([0.1, 0.2]));
+
+        $reranker = $this->createMock(RerankerInterface::class);
+        $reranker->expects($this->once())
+            ->method('rerank')
+            ->with('test query', [$doc], 10)
+            ->willReturn([$doc]);
+
+        $event = new PostQueryEvent('test query', [$doc], ['topK' => 10]);
+
+        $listener = new RerankerListener($reranker, 5);
+        $listener($event);
+    }
+}

--- a/src/store/tests/Indexer/DocumentIndexerTest.php
+++ b/src/store/tests/Indexer/DocumentIndexerTest.php
@@ -70,7 +70,7 @@ final class DocumentIndexerTest extends TestCase
         $this->assertInstanceOf(VectorDocument::class, $store->documents[0]);
         $this->assertSame($id, $store->documents[0]->getId());
         $this->assertSame($vector, $store->documents[0]->getVector());
-        $this->assertSame(['key' => 'value'], $store->documents[0]->getMetadata()->getArrayCopy());
+        $this->assertSame(['key' => 'value', '_text' => 'Test content'], $store->documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testIndexMultipleDocuments()

--- a/src/store/tests/Indexer/DocumentProcessorTest.php
+++ b/src/store/tests/Indexer/DocumentProcessorTest.php
@@ -66,7 +66,7 @@ final class DocumentProcessorTest extends TestCase
         $this->assertCount(1, $store->documents);
         $this->assertSame($id, $store->documents[0]->getId());
         $this->assertSame($vector, $store->documents[0]->getVector());
-        $this->assertSame(['key' => 'value'], $store->documents[0]->getMetadata()->getArrayCopy());
+        $this->assertSame(['key' => 'value', '_text' => 'Test content'], $store->documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testProcessMultipleDocuments()

--- a/src/store/tests/Indexer/SourceIndexerTest.php
+++ b/src/store/tests/Indexer/SourceIndexerTest.php
@@ -74,7 +74,7 @@ final class SourceIndexerTest extends TestCase
         $this->assertInstanceOf(VectorDocument::class, $store->documents[0]);
         $this->assertSame($id, $store->documents[0]->getId());
         $this->assertSame($vector, $store->documents[0]->getVector());
-        $this->assertSame(['key' => 'value'], $store->documents[0]->getMetadata()->getArrayCopy());
+        $this->assertSame(['key' => 'value', '_text' => 'Test content'], $store->documents[0]->getMetadata()->getArrayCopy());
     }
 
     public function testIndexWithSource()

--- a/src/store/tests/Reranker/RerankerTest.php
+++ b/src/store/tests/Reranker/RerankerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests\Reranker;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Reranking\RerankingEntry;
+use Symfony\AI\Platform\Result\RerankingResult;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Reranker\Reranker;
+use Symfony\AI\Store\Tests\Double\PlatformTestHandler;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RerankerTest extends TestCase
+{
+    public function testReranksDocumentsInCorrectOrder()
+    {
+        $platform = PlatformTestHandler::createPlatform(new RerankingResult(
+            new RerankingEntry(0, 0.55),
+            new RerankingEntry(1, 0.91),
+        ));
+
+        $reranker = new Reranker($platform, 'BAAI/bge-reranker-base?task=text-ranking');
+
+        $doc0 = new VectorDocument('doc-0', new Vector([0.1, 0.2]), new Metadata([Metadata::KEY_TEXT => 'First document']));
+        $doc1 = new VectorDocument('doc-1', new Vector([0.3, 0.4]), new Metadata([Metadata::KEY_TEXT => 'Second document']));
+
+        $result = $reranker->rerank('test query', [$doc0, $doc1], 2);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('doc-1', $result[0]->getId());
+        $this->assertSame(0.91, $result[0]->getScore());
+        $this->assertSame('doc-0', $result[1]->getId());
+        $this->assertSame(0.55, $result[1]->getScore());
+    }
+
+    public function testReturnsEmptyForEmptyDocuments()
+    {
+        $platform = PlatformTestHandler::createPlatform();
+        $reranker = new Reranker($platform, 'BAAI/bge-reranker-base?task=text-ranking');
+
+        $result = $reranker->rerank('query', [], 5);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testTopKLimitsResults()
+    {
+        $platform = PlatformTestHandler::createPlatform(new RerankingResult(
+            new RerankingEntry(0, 0.9),
+            new RerankingEntry(1, 0.8),
+            new RerankingEntry(2, 0.7),
+        ));
+
+        $reranker = new Reranker($platform, 'BAAI/bge-reranker-base?task=text-ranking');
+
+        $docs = [
+            new VectorDocument('doc-0', new Vector([0.1]), new Metadata([Metadata::KEY_TEXT => 'First'])),
+            new VectorDocument('doc-1', new Vector([0.2]), new Metadata([Metadata::KEY_TEXT => 'Second'])),
+            new VectorDocument('doc-2', new Vector([0.3]), new Metadata([Metadata::KEY_TEXT => 'Third'])),
+        ];
+
+        $result = $reranker->rerank('query', $docs, 2);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('doc-0', $result[0]->getId());
+        $this->assertSame('doc-1', $result[1]->getId());
+    }
+
+    public function testFallsBackToSourceWhenTextIsNull()
+    {
+        $platform = PlatformTestHandler::createPlatform(new RerankingResult(
+            new RerankingEntry(0, 0.85),
+        ));
+
+        $reranker = new Reranker($platform, 'BAAI/bge-reranker-base?task=text-ranking');
+
+        $doc = new VectorDocument('doc-0', new Vector([0.1]), new Metadata([Metadata::KEY_SOURCE => 'source-text']));
+        $result = $reranker->rerank('query', [$doc], 1);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('doc-0', $result[0]->getId());
+        $this->assertSame(0.85, $result[0]->getScore());
+    }
+}

--- a/src/store/tests/RetrieverTest.php
+++ b/src/store/tests/RetrieverTest.php
@@ -12,11 +12,13 @@
 namespace Symfony\AI\Store\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Event\PostQueryEvent;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
@@ -276,5 +278,100 @@ final class RetrieverTest extends TestCase
         $results = iterator_to_array($retriever->retrieve('test query', ['semanticRatio' => 0.7]));
 
         $this->assertCount(1, $results);
+    }
+
+    public function testRetrieveWithEventDispatcherDispatchesPostQueryEvent()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $store = new TestStore();
+        $store->add([$document]);
+
+        $queryVector = new Vector([0.2, 0.3, 0.4]);
+        $vectorizer = new Vectorizer(
+            PlatformTestHandler::createPlatform(new VectorResult($queryVector)),
+            'text-embedding-3-small'
+        );
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(static function ($event) {
+                return $event instanceof PostQueryEvent
+                    && 'test query' === $event->getQuery()
+                    && 1 === \count(iterator_to_array($event->getDocuments()));
+            }))
+            ->willReturnArgument(0);
+
+        $retriever = new Retriever($store, $vectorizer, $dispatcher);
+        $results = iterator_to_array($retriever->retrieve('test query'));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrieveWithEventDispatcherReturnsModifiedDocuments()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Original']),
+        );
+        $rerankedDocument = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.4, 0.5, 0.6]),
+            new Metadata(['title' => 'Reranked']),
+        );
+
+        $store = new TestStore();
+        $store->add([$document]);
+
+        $queryVector = new Vector([0.2, 0.3, 0.4]);
+        $vectorizer = new Vectorizer(
+            PlatformTestHandler::createPlatform(new VectorResult($queryVector)),
+            'text-embedding-3-small'
+        );
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->method('dispatch')
+            ->willReturnCallback(static function (PostQueryEvent $event) use ($rerankedDocument) {
+                $event->setDocuments([$rerankedDocument]);
+
+                return $event;
+            });
+
+        $retriever = new Retriever($store, $vectorizer, $dispatcher);
+        $results = iterator_to_array($retriever->retrieve('test query'));
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Reranked', $results[0]->getMetadata()['title']);
+    }
+
+    public function testRetrieveWithoutEventDispatcherYieldsDocuments()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $store = new TestStore();
+        $store->add([$document]);
+
+        $queryVector = new Vector([0.2, 0.3, 0.4]);
+        $vectorizer = new Vectorizer(
+            PlatformTestHandler::createPlatform(new VectorResult($queryVector)),
+            'text-embedding-3-small'
+        );
+
+        $retriever = new Retriever($store, $vectorizer);
+        $results = $retriever->retrieve('test query');
+
+        // Without dispatcher, should be a Generator (yield behavior)
+        $this->assertInstanceOf(\Generator::class, $results);
+        $this->assertCount(1, iterator_to_array($results));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

## Description

This PR adds reranking support to the **Platform** abstraction layer and a hybrid retriever to the **Store** component, enabling more accurate document retrieval in RAG pipelines.

### Platform: Reranking Abstraction

Reranking is now a first-class platform capability, following the same pattern as embeddings (`Vectorizer → PlatformInterface → VectorResult`):

- `RerankingResult` / `RerankingEntry` — typed result objects for reranking scores
- `Capability::RERANKING` — new capability enum case
- `DeferredResult::asRerankingResult()` — convenience accessor
- **HuggingFace bridge** — `text-ranking` task support in `ModelClient` and `ResultConverter`, compatible with both the serverless Inference API and self-hosted TEI

### Store: Platform-based Reranker

A single `Reranker` replaces the previous vendor-specific bridge implementations (Cohere, Jina, HuggingFace). It delegates to `PlatformInterface`, so it works with **any provider** that supports reranking:

```php
use Symfony\AI\Store\Reranker\Reranker;

$reranker = new Reranker($platform, 'BAAI/bge-reranker-base?task=text-ranking');
$reranked = $reranker->rerank('query', $documents, topK: 5);
```

### Store: HybridRetriever

A new `HybridRetriever` combines results from two retrievers (e.g. vector and full-text) using Reciprocal Rank Fusion (RRF), with optional cross-encoder reranking:

```php
use Symfony\AI\Store\HybridRetriever;
use Symfony\AI\Store\Reranker\Reranker;

$retriever = new HybridRetriever(
    vectorRetriever: $vectorRetriever,
    textRetriever: $textRetriever,
    reranker: new Reranker($platform, 'BAAI/bge-reranker-base?task=text-ranking'),
    rrfK: 60,
    candidateCount: 20,
    topK: 5,
);

$results = $retriever->retrieve('search query');
```

### Store: Vectorizer text preservation

The `Vectorizer` now automatically stores the document content as `_text` in metadata during vectorization, so text search and reranking have access to the original content without requiring manual metadata setup.