### PR TITLE
[Store] Add RstToctreeLoader for RST documentation parsing

### DIFF
--- a/docs/components/store.rst
+++ b/docs/components/store.rst
@@ -122,9 +122,13 @@ Document loaders are responsible for fetching and preparing documents for indexi
 
 To help loading documents and integrate them into your RAG system, you can use the provided document loaders or create your own custom loaders to suit your specific needs:
 
+* :class:`Symfony\\AI\\Store\\Document\\Loader\\CsvLoader`
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\InMemoryLoader`
+* :class:`Symfony\\AI\\Store\\Document\\Loader\\JsonFileLoader`
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\MarkdownLoader`
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\RssFeedLoader`
+* :class:`Symfony\\AI\\Store\\Document\\Loader\\RstLoader`
+* :class:`Symfony\\AI\\Store\\Document\\Loader\\RstToctreeLoader`
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\TextFileLoader`
 
 Create a Custom Loader

--- a/examples/rag/.gitignore
+++ b/examples/rag/.gitignore
@@ -1,0 +1,1 @@
+.symfony-docs/

--- a/examples/rag/symfony-docs.php
+++ b/examples/rag/symfony-docs.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Store\Document\Loader\RstToctreeLoader;
+use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Indexer\SourceIndexer;
+use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Retriever;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+echo "=== Symfony Docs RAG with RstToctreeLoader ===\n\n";
+echo "This example demonstrates loading the Symfony documentation from RST files,\n";
+echo "indexing them into a vector store, and retrieving relevant sections for a question.\n\n";
+
+// 1. Clone or update Symfony docs
+$docsDir = __DIR__.'/.symfony-docs';
+if (!is_dir($docsDir.'/.git')) {
+    output()->writeln('Cloning symfony/symfony-docs (this may take a moment)...');
+    exec('git clone --depth 1 https://github.com/symfony/symfony-docs.git '.escapeshellarg($docsDir), $out, $code);
+    if (0 !== $code) {
+        output()->writeln('<error>Failed to clone symfony-docs repository.</error>');
+        exit(1);
+    }
+} else {
+    output()->writeln('Updating symfony/symfony-docs...');
+    exec('git -C '.escapeshellarg($docsDir).' pull --ff-only', $out, $code);
+    if (0 !== $code) {
+        output()->writeln('<error>Failed to update symfony-docs repository.</error>');
+        exit(1);
+    }
+}
+
+// 2. Load & Index
+$store = new InMemoryStore();
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+$vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
+$processor = new DocumentProcessor($vectorizer, $store, logger: logger());
+
+$loader = new RstToctreeLoader();
+$indexer = new SourceIndexer($loader, $processor);
+
+output()->writeln('Indexing Symfony docs — this will produce many chunks and use embedding API credits...');
+$indexer->index($docsDir.'/index.rst');
+output()->writeln('<info>Indexing complete.</info>');
+
+// 3. Retrieve
+$retriever = new Retriever($store, $vectorizer, logger());
+$question = $argv[1] ?? 'How do I create a custom console command in Symfony?';
+
+output()->writeln('');
+output()->writeln(sprintf('Question: <comment>%s</comment>', $question));
+output()->writeln('');
+
+foreach ($retriever->retrieve($question, ['maxItems' => 5]) as $document) {
+    $metadata = $document->getMetadata();
+    output()->writeln(sprintf(
+        '<info>[%.4f]</info> <comment>%s</comment> (%s)',
+        $document->getScore() ?? 0.0,
+        $metadata->getTitle() ?? '(no title)',
+        $metadata->getSource() ?? '(unknown)',
+    ));
+
+    $text = $metadata->getText() ?? '';
+    output()->writeln('  '.substr($text, 0, 200).'...');
+    output()->writeln('');
+}

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.7
+---
+
+ * Add `RstLoader` and `RstToctreeLoader` for loading RST files and following toctree directives
+
 0.6
 ---
 

--- a/src/store/src/Document/Loader/RstLoader.php
+++ b/src/store/src/Document/Loader/RstLoader.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Document\Loader;
+
+use Symfony\AI\Store\Document\EmbeddableDocumentInterface;
+use Symfony\AI\Store\Document\LoaderInterface;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Loads a single RST file and splits it into sections at heading boundaries.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RstLoader implements LoaderInterface
+{
+    private const RST_ADORNMENT_CHARS = '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~';
+    private const MAX_SECTION_LENGTH = 15000;
+    private const OVERFLOW_OVERLAP = 200;
+
+    /**
+     * @param array<string, mixed> $options accepts 'depth' (int, default 0)
+     *
+     * @return iterable<EmbeddableDocumentInterface>
+     */
+    public function load(?string $source = null, array $options = []): iterable
+    {
+        if (null === $source) {
+            throw new InvalidArgumentException('RstLoader requires a file path as source, null given.');
+        }
+
+        if (!file_exists($source)) {
+            throw new RuntimeException(\sprintf('File "%s" does not exist.', $source));
+        }
+
+        $content = file_get_contents($source);
+
+        if (false === $content) {
+            throw new RuntimeException(\sprintf('Could not read file "%s".', $source));
+        }
+
+        $depth = (int) ($options['depth'] ?? 0);
+
+        yield from $this->splitIntoSections($content, $source, $depth);
+    }
+
+    /**
+     * Loads pre-read RST content without performing file I/O.
+     *
+     * @param array<string, mixed> $options accepts 'depth' (int, default 0)
+     *
+     * @return iterable<EmbeddableDocumentInterface>
+     */
+    public function loadContent(string $content, string $source, array $options = []): iterable
+    {
+        $depth = (int) ($options['depth'] ?? 0);
+
+        yield from $this->splitIntoSections($content, $source, $depth);
+    }
+
+    /**
+     * @return iterable<EmbeddableDocumentInterface>
+     */
+    private function splitIntoSections(string $content, string $source, int $depth): iterable
+    {
+        $lines = explode(\PHP_EOL, $content);
+        $count = \count($lines);
+
+        $currentTitle = '';
+        $sectionStartIndex = 0;
+        $i = 0;
+
+        while ($i < $count) {
+            $line = $lines[$i];
+            $nextLine = $i + 1 < $count ? $lines[$i + 1] : '';
+
+            if ($this->isHeading($line, $nextLine)) {
+                if ($i > $sectionStartIndex) {
+                    $sectionLines = \array_slice($lines, $sectionStartIndex, $i - $sectionStartIndex);
+                    $sectionText = implode(\PHP_EOL, $sectionLines);
+                    if ('' !== trim($sectionText)) {
+                        yield from $this->yieldSection($sectionText, $currentTitle, $source, $depth);
+                    }
+                }
+
+                $currentTitle = trim($line);
+                $sectionStartIndex = $i;
+                $i += 2; // Skip the heading line and adornment line
+
+                continue;
+            }
+
+            ++$i;
+        }
+
+        if ($sectionStartIndex < $count) {
+            $sectionLines = \array_slice($lines, $sectionStartIndex);
+            $sectionText = implode(\PHP_EOL, $sectionLines);
+            if ('' !== trim($sectionText)) {
+                yield from $this->yieldSection($sectionText, $currentTitle, $source, $depth);
+            }
+        }
+    }
+
+    /**
+     * @return iterable<EmbeddableDocumentInterface>
+     */
+    private function yieldSection(string $text, string $title, string $source, int $depth): iterable
+    {
+        if (mb_strlen($text) <= self::MAX_SECTION_LENGTH) {
+            $metadata = new Metadata([
+                Metadata::KEY_SOURCE => $source,
+                Metadata::KEY_TEXT => $text,
+                Metadata::KEY_TITLE => $title,
+                Metadata::KEY_DEPTH => $depth,
+            ]);
+
+            yield new TextDocument(Uuid::v4()->toRfc4122(), $text, $metadata);
+
+            return;
+        }
+
+        // Section overflow: split using character-based chunking
+        $sectionId = Uuid::v4()->toRfc4122();
+        $length = mb_strlen($text);
+        $start = 0;
+
+        while ($start < $length) {
+            $end = min($start + self::MAX_SECTION_LENGTH, $length);
+            $chunkText = mb_substr($text, $start, $end - $start);
+
+            $metadata = new Metadata([
+                Metadata::KEY_SOURCE => $source,
+                Metadata::KEY_TEXT => $chunkText,
+                Metadata::KEY_TITLE => $title,
+                Metadata::KEY_DEPTH => $depth,
+                Metadata::KEY_PARENT_ID => $sectionId,
+            ]);
+
+            yield new TextDocument(Uuid::v4()->toRfc4122(), $chunkText, $metadata);
+
+            $start += (self::MAX_SECTION_LENGTH - self::OVERFLOW_OVERLAP);
+        }
+    }
+
+    private function isHeading(string $line, string $nextLine): bool
+    {
+        $trimmedLine = trim($line);
+        $trimmedNext = trim($nextLine);
+
+        if ('' === $trimmedLine || '' === $trimmedNext) {
+            return false;
+        }
+
+        if (!$this->isAdornmentLine($trimmedNext)) {
+            return false;
+        }
+
+        return mb_strlen($trimmedNext) >= mb_strlen($trimmedLine);
+    }
+
+    private function isAdornmentLine(string $line): bool
+    {
+        if ('' === $line) {
+            return false;
+        }
+
+        $char = $line[0];
+
+        if (!str_contains(self::RST_ADORNMENT_CHARS, $char)) {
+            return false;
+        }
+
+        return str_repeat($char, \strlen($line)) === $line;
+    }
+}

--- a/src/store/src/Document/Loader/RstToctreeLoader.php
+++ b/src/store/src/Document/Loader/RstToctreeLoader.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Document\Loader;
+
+use Symfony\AI\Store\Document\EmbeddableDocumentInterface;
+use Symfony\AI\Store\Document\LoaderInterface;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
+
+/**
+ * Loads RST documentation files by following toctree directives and splitting at section boundaries.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RstToctreeLoader implements LoaderInterface
+{
+    public function __construct(
+        private RstLoader $rstLoader = new RstLoader(),
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return iterable<EmbeddableDocumentInterface>
+     */
+    public function load(?string $source = null, array $options = []): iterable
+    {
+        if (null === $source) {
+            throw new InvalidArgumentException('RstToctreeLoader requires a file path as source, null given.');
+        }
+
+        yield from $this->processFile($source, 0, \dirname($source));
+    }
+
+    /**
+     * @return iterable<EmbeddableDocumentInterface>
+     */
+    private function processFile(string $path, int $depth, string $rootDir): iterable
+    {
+        if (!file_exists($path)) {
+            throw new RuntimeException(\sprintf('File "%s" does not exist.', $path));
+        }
+
+        $content = file_get_contents($path);
+
+        if (false === $content) {
+            throw new RuntimeException(\sprintf('Could not read file "%s".', $path));
+        }
+
+        yield from $this->rstLoader->loadContent($content, $path, ['depth' => $depth]);
+
+        foreach ($this->parseToctreeEntries($content, \dirname($path), $rootDir) as $entryPath) {
+            yield from $this->processFile($entryPath, $depth + 1, $rootDir);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseToctreeEntries(string $content, string $baseDir, string $rootDir): array
+    {
+        $lines = explode(\PHP_EOL, $content);
+        $count = \count($lines);
+        $entries = [];
+        $i = 0;
+
+        while ($i < $count) {
+            if (preg_match('/^(\s*)\.\. toctree::/i', $lines[$i], $match)) {
+                $directiveIndent = \strlen($match[1]);
+                ++$i;
+
+                // Read directive body (lines indented more than the directive)
+                while ($i < $count) {
+                    $line = $lines[$i];
+
+                    if ('' === trim($line)) {
+                        ++$i;
+                        continue;
+                    }
+
+                    $lineIndent = \strlen($line) - \strlen(ltrim($line));
+
+                    if ($lineIndent <= $directiveIndent) {
+                        // End of directive body
+                        break;
+                    }
+
+                    $trimmed = trim($line);
+
+                    // Skip directive options (e.g., :maxdepth:, :caption:)
+                    if (!str_starts_with($trimmed, ':')) {
+                        // Handle "Title <entry>" format
+                        if (preg_match('/^.*<(.+?)>$/', $trimmed, $entryMatch)) {
+                            $entryPath = trim($entryMatch[1]);
+                        } else {
+                            $entryPath = $trimmed;
+                        }
+
+                        // Absolute paths (starting with /) resolve from doc root
+                        if (str_starts_with($entryPath, '/')) {
+                            $dir = $rootDir;
+                            $entryPath = ltrim($entryPath, '/');
+                        } else {
+                            $dir = $baseDir;
+                        }
+
+                        if (str_ends_with($entryPath, '.rst')) {
+                            $pattern = $dir.'/'.$entryPath;
+                        } else {
+                            $pattern = $dir.'/'.$entryPath.'.rst';
+                        }
+
+                        // Expand glob patterns (e.g. "setup/*")
+                        if (str_contains($entryPath, '*') || str_contains($entryPath, '?')) {
+                            $globbed = glob($pattern);
+                            if (false !== $globbed) {
+                                sort($globbed);
+                                foreach ($globbed as $globPath) {
+                                    if (!\in_array($globPath, $entries, true)) {
+                                        $entries[] = $globPath;
+                                    }
+                                }
+                            }
+                        } else {
+                            if (!file_exists($pattern)) {
+                                throw new RuntimeException(\sprintf('Toctree entry "%s" resolved to "%s" which does not exist.', $entryPath, $pattern));
+                            }
+
+                            if (!\in_array($pattern, $entries, true)) {
+                                $entries[] = $pattern;
+                            }
+                        }
+                    }
+
+                    ++$i;
+                }
+
+                continue;
+            }
+
+            ++$i;
+        }
+
+        return $entries;
+    }
+}

--- a/src/store/src/Document/Metadata.php
+++ b/src/store/src/Document/Metadata.php
@@ -22,6 +22,8 @@ final class Metadata extends \ArrayObject
     public const KEY_TEXT = '_text';
     public const KEY_SOURCE = '_source';
     public const KEY_SUMMARY = '_summary';
+    public const KEY_TITLE = '_title';
+    public const KEY_DEPTH = '_depth';
 
     public function hasParentId(): bool
     {
@@ -89,5 +91,39 @@ final class Metadata extends \ArrayObject
     public function setSummary(string $summary): void
     {
         $this->offsetSet(self::KEY_SUMMARY, $summary);
+    }
+
+    public function hasTitle(): bool
+    {
+        return $this->offsetExists(self::KEY_TITLE);
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->offsetExists(self::KEY_TITLE)
+            ? $this->offsetGet(self::KEY_TITLE)
+            : null;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->offsetSet(self::KEY_TITLE, $title);
+    }
+
+    public function hasDepth(): bool
+    {
+        return $this->offsetExists(self::KEY_DEPTH);
+    }
+
+    public function getDepth(): ?int
+    {
+        return $this->offsetExists(self::KEY_DEPTH)
+            ? $this->offsetGet(self::KEY_DEPTH)
+            : null;
+    }
+
+    public function setDepth(int $depth): void
+    {
+        $this->offsetSet(self::KEY_DEPTH, $depth);
     }
 }

--- a/src/store/tests/Document/Loader/Fixtures/rst/simple.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/simple.rst
@@ -1,0 +1,18 @@
+Introduction
+============
+
+This is the introduction section. It provides an overview of the topic.
+
+Getting Started
+---------------
+
+This section explains how to get started with the component.
+
+You need to install the package first using Composer.
+
+Advanced Usage
+--------------
+
+Once you have the basics down, you can explore advanced features.
+
+Here we describe more complex use cases and configurations.

--- a/src/store/tests/Document/Loader/Fixtures/rst/with_absolute_toctree/guides/getting-started.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/with_absolute_toctree/guides/getting-started.rst
@@ -1,0 +1,9 @@
+Getting Started
+===============
+
+This guide helps you get started.
+
+.. toctree::
+   :maxdepth: 1
+
+   /guides/setup

--- a/src/store/tests/Document/Loader/Fixtures/rst/with_absolute_toctree/guides/setup.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/with_absolute_toctree/guides/setup.rst
@@ -1,0 +1,4 @@
+Setup
+=====
+
+Follow these steps to set up your environment.

--- a/src/store/tests/Document/Loader/Fixtures/rst/with_absolute_toctree/index.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/with_absolute_toctree/index.rst
@@ -1,0 +1,9 @@
+Main Documentation
+==================
+
+Welcome to the main documentation.
+
+.. toctree::
+   :maxdepth: 2
+
+   guides/getting-started

--- a/src/store/tests/Document/Loader/Fixtures/rst/with_glob_toctree/index.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/with_glob_toctree/index.rst
@@ -1,0 +1,11 @@
+Topics Index
+============
+
+Overview of all topics.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   topics/alpha
+   topics/*

--- a/src/store/tests/Document/Loader/Fixtures/rst/with_glob_toctree/topics/alpha.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/with_glob_toctree/topics/alpha.rst
@@ -1,0 +1,4 @@
+Alpha Topic
+===========
+
+Content about the alpha topic.

--- a/src/store/tests/Document/Loader/Fixtures/rst/with_glob_toctree/topics/beta.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/with_glob_toctree/topics/beta.rst
@@ -1,0 +1,4 @@
+Beta Topic
+==========
+
+Content about the beta topic.

--- a/src/store/tests/Document/Loader/Fixtures/rst/with_toctree/index.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/with_toctree/index.rst
@@ -1,0 +1,10 @@
+Documentation Index
+===================
+
+Welcome to the documentation. This page provides an overview.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   page

--- a/src/store/tests/Document/Loader/Fixtures/rst/with_toctree/page.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/with_toctree/page.rst
@@ -1,0 +1,14 @@
+Component Overview
+==================
+
+This page describes the component in detail.
+
+Installation
+------------
+
+Install via Composer using the following command.
+
+Configuration
+-------------
+
+Configure the component in your application settings.

--- a/src/store/tests/Document/Loader/RstToctreeLoaderTest.php
+++ b/src/store/tests/Document/Loader/RstToctreeLoaderTest.php
@@ -1,0 +1,269 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests\Document\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Store\Document\EmbeddableDocumentInterface;
+use Symfony\AI\Store\Document\Loader\RstToctreeLoader;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
+
+final class RstToctreeLoaderTest extends TestCase
+{
+    private string $fixturesDir;
+
+    protected function setUp(): void
+    {
+        $this->fixturesDir = __DIR__.'/Fixtures/rst';
+    }
+
+    public function testLoadRequiresSource()
+    {
+        $loader = new RstToctreeLoader();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('RstToctreeLoader requires a file path as source, null given.');
+        iterator_to_array($loader->load(), false);
+    }
+
+    public function testLoadThrowsForNonExistentFile()
+    {
+        $loader = new RstToctreeLoader();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('File "/nonexistent/file.rst" does not exist.');
+        iterator_to_array($loader->load('/nonexistent/file.rst'), false);
+    }
+
+    public function testLoadSimpleFlatRst()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/simple.rst'), false);
+
+        $this->assertCount(3, $documents);
+        foreach ($documents as $doc) {
+            $this->assertInstanceOf(TextDocument::class, $doc);
+        }
+    }
+
+    public function testLoadSimpleRstSectionTitles()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/simple.rst'), false);
+
+        $titles = array_map(
+            static fn (EmbeddableDocumentInterface $doc): string => $doc->getMetadata()->getTitle() ?? '',
+            $documents,
+        );
+
+        $this->assertContains('Introduction', $titles);
+        $this->assertContains('Getting Started', $titles);
+        $this->assertContains('Advanced Usage', $titles);
+    }
+
+    public function testLoadSimpleRstMetadataFields()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/simple.rst'), false);
+
+        $source = $this->fixturesDir.'/simple.rst';
+        foreach ($documents as $doc) {
+            $this->assertSame($source, $doc->getMetadata()->getSource());
+            $this->assertSame(0, $doc->getMetadata()->getDepth());
+            $this->assertNotNull($doc->getMetadata()->getText());
+        }
+    }
+
+    public function testLoadSimpleRstSectionContent()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/simple.rst'), false);
+
+        $contentMap = [];
+        foreach ($documents as $doc) {
+            $title = $doc->getMetadata()->getTitle() ?? '';
+            $contentMap[$title] = $doc->getContent();
+        }
+
+        $this->assertStringContainsString('overview of the topic', $contentMap['Introduction']);
+        $this->assertStringContainsString('get started', $contentMap['Getting Started']);
+        $this->assertStringContainsString('advanced features', $contentMap['Advanced Usage']);
+    }
+
+    public function testLoadRstWithToctree()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_toctree/index.rst'), false);
+
+        // Should have sections from both index.rst and page.rst
+        $this->assertGreaterThanOrEqual(2, \count($documents));
+
+        $titles = array_map(
+            static fn (EmbeddableDocumentInterface $doc): string => $doc->getMetadata()->getTitle() ?? '',
+            $documents,
+        );
+
+        $this->assertContains('Documentation Index', $titles);
+        $this->assertContains('Component Overview', $titles);
+    }
+
+    public function testLoadToctreeIncreasesSectionDepth()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_toctree/index.rst'), false);
+
+        $depthByTitle = [];
+        foreach ($documents as $doc) {
+            $title = $doc->getMetadata()->getTitle() ?? '';
+            $depthByTitle[$title] = $doc->getMetadata()->getDepth();
+        }
+
+        // Root file sections at depth 0
+        $this->assertSame(0, $depthByTitle['Documentation Index']);
+
+        // Toctree referenced page at depth 1
+        $this->assertSame(1, $depthByTitle['Component Overview']);
+    }
+
+    public function testLoadToctreePageSectionsHaveCorrectSource()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_toctree/index.rst'), false);
+
+        $pageSource = $this->fixturesDir.'/with_toctree/page.rst';
+        $pageDocs = array_filter(
+            $documents,
+            static fn (EmbeddableDocumentInterface $doc): bool => $doc->getMetadata()->getSource() === $pageSource,
+        );
+
+        $this->assertNotEmpty($pageDocs);
+    }
+
+    public function testLoadSetsTextMetadata()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/simple.rst'), false);
+
+        foreach ($documents as $doc) {
+            $this->assertTrue($doc->getMetadata()->hasText());
+            $this->assertSame($doc->getContent(), $doc->getMetadata()->getText());
+        }
+    }
+
+    public function testLoadToctreeWithAbsolutePaths()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_absolute_toctree/index.rst'), false);
+
+        $titles = array_map(
+            static fn (EmbeddableDocumentInterface $doc): string => $doc->getMetadata()->getTitle() ?? '',
+            $documents,
+        );
+
+        $this->assertContains('Main Documentation', $titles);
+        $this->assertContains('Getting Started', $titles);
+        $this->assertContains('Setup', $titles);
+    }
+
+    public function testLoadToctreeAbsolutePathResolvesFromDocRoot()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_absolute_toctree/index.rst'), false);
+
+        $depthByTitle = [];
+        foreach ($documents as $doc) {
+            $title = $doc->getMetadata()->getTitle() ?? '';
+            $depthByTitle[$title] = $doc->getMetadata()->getDepth();
+        }
+
+        // /guides/setup is referenced via absolute path from a depth-1 file
+        $this->assertSame(0, $depthByTitle['Main Documentation']);
+        $this->assertSame(1, $depthByTitle['Getting Started']);
+        $this->assertSame(2, $depthByTitle['Setup']);
+    }
+
+    public function testLoadToctreeWithGlobPattern()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_glob_toctree/index.rst'), false);
+
+        $titles = array_map(
+            static fn (EmbeddableDocumentInterface $doc): string => $doc->getMetadata()->getTitle() ?? '',
+            $documents,
+        );
+
+        $this->assertContains('Topics Index', $titles);
+        $this->assertContains('Alpha Topic', $titles);
+        $this->assertContains('Beta Topic', $titles);
+    }
+
+    public function testLoadToctreeGlobDeduplicatesEntries()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_glob_toctree/index.rst'), false);
+
+        // alpha.rst is listed explicitly AND matched by the glob — it should appear only once
+        $alphaDocs = array_filter(
+            $documents,
+            static fn (EmbeddableDocumentInterface $doc): bool => 'Alpha Topic' === $doc->getMetadata()->getTitle(),
+        );
+
+        $this->assertCount(1, $alphaDocs);
+    }
+
+    public function testLoadToctreeThrowsForMissingEntry()
+    {
+        $tempDir = sys_get_temp_dir().'/rst_missing_test_'.uniqid();
+        mkdir($tempDir, 0777, true);
+        file_put_contents($tempDir.'/index.rst', "Title\n=====\n\n.. toctree::\n\n   missing_page\n");
+
+        try {
+            $loader = new RstToctreeLoader();
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('does not exist');
+            iterator_to_array($loader->load($tempDir.'/index.rst'), false);
+        } finally {
+            unlink($tempDir.'/index.rst');
+            rmdir($tempDir);
+        }
+    }
+
+    public function testLoadSectionOverflowCreatesMultipleChunks()
+    {
+        // Create a temporary file with a very long section
+        $tempFile = tempnam(sys_get_temp_dir(), 'rst_test_');
+        $longText = str_repeat('This is a very long sentence that gets repeated many times. ', 300);
+        file_put_contents($tempFile, "Long Section\n============\n\n".$longText);
+
+        try {
+            $loader = new RstToctreeLoader();
+            $documents = iterator_to_array($loader->load($tempFile), false);
+
+            // The section is longer than 15K chars, so it should be split
+            $this->assertGreaterThan(1, \count($documents));
+
+            // All chunks should have the same section title
+            foreach ($documents as $doc) {
+                $this->assertSame('Long Section', $doc->getMetadata()->getTitle());
+            }
+
+            // Overflow chunks should have parent_id set
+            foreach ($documents as $doc) {
+                $this->assertTrue($doc->getMetadata()->hasParentId());
+            }
+        } finally {
+            unlink($tempFile);
+        }
+    }
+}

--- a/src/store/tests/Document/MetadataTest.php
+++ b/src/store/tests/Document/MetadataTest.php
@@ -40,6 +40,8 @@ final class MetadataTest extends TestCase
         $this->assertSame('_text', Metadata::KEY_TEXT);
         $this->assertSame('_source', Metadata::KEY_SOURCE);
         $this->assertSame('_summary', Metadata::KEY_SUMMARY);
+        $this->assertSame('_title', Metadata::KEY_TITLE);
+        $this->assertSame('_depth', Metadata::KEY_DEPTH);
     }
 
     #[DataProvider('parentIdProvider')]
@@ -154,6 +156,62 @@ final class MetadataTest extends TestCase
         ];
     }
 
+    #[DataProvider('titleProvider')]
+    public function testTitleMethods(?string $title)
+    {
+        $metadata = new Metadata();
+
+        $this->assertFalse($metadata->hasTitle());
+        $this->assertNull($metadata->getTitle());
+
+        $metadata->setTitle($title);
+
+        $this->assertTrue($metadata->hasTitle());
+        $this->assertSame($title, $metadata->getTitle());
+    }
+
+    /**
+     * @return \Iterator<string, array{title: string|null}>
+     */
+    public static function titleProvider(): \Iterator
+    {
+        yield 'string title' => [
+            'title' => 'My Document Title',
+        ];
+
+        yield 'empty string title' => [
+            'title' => '',
+        ];
+    }
+
+    #[DataProvider('depthProvider')]
+    public function testDepthMethods(?int $depth)
+    {
+        $metadata = new Metadata();
+
+        $this->assertFalse($metadata->hasDepth());
+        $this->assertNull($metadata->getDepth());
+
+        $metadata->setDepth($depth);
+
+        $this->assertTrue($metadata->hasDepth());
+        $this->assertSame($depth, $metadata->getDepth());
+    }
+
+    /**
+     * @return \Iterator<string, array{depth: int|null}>
+     */
+    public static function depthProvider(): \Iterator
+    {
+        yield 'zero depth' => [
+            'depth' => 0,
+        ];
+
+        yield 'positive depth' => [
+            'depth' => 3,
+        ];
+    }
+
     public function testMetadataInitializedWithSpecialKeys()
     {
         $data = [
@@ -221,6 +279,8 @@ final class MetadataTest extends TestCase
         $this->assertNull($metadata->getText());
         $this->assertNull($metadata->getSource());
         $this->assertNull($metadata->getSummary());
+        $this->assertNull($metadata->getTitle());
+        $this->assertNull($metadata->getDepth());
     }
 
     public function testHasMethodsReturnFalseForMissingKeys()
@@ -231,6 +291,8 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->hasText());
         $this->assertFalse($metadata->hasSource());
         $this->assertFalse($metadata->hasSummary());
+        $this->assertFalse($metadata->hasTitle());
+        $this->assertFalse($metadata->hasDepth());
     }
 
     public function testOverwritingSpecialKeys()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | –
| License       | MIT

## RstLoader & RstToctreeLoader

Adds two new `LoaderInterface` implementations to the Store component for loading RST documentation into vector stores
for RAG.

- **`RstLoader`** — Parses a single RST file and splits it into documents at section heading boundaries. Handles
oversized sections by chunking with fixed overlap.
- **`RstToctreeLoader`** — Wraps `RstLoader` and recursively follows `.. toctree::` directives to load entire
documentation trees (e.g. Symfony docs).

### Features

- Splits RST files into documents at heading boundaries
- Recursively follows `.. toctree::` directives to load referenced pages
- Tracks `_title`, `_depth`, and `_source` in document metadata
- Handles oversized sections by chunking with fixed overlap
- Throws on missing toctree entries instead of silently skipping

### Metadata additions

Extends `Metadata` with two new keys and their accessors: `_title` and `_depth`.

### Usage

```php
use Symfony\AI\Store\Document\Loader\RstToctreeLoader;

$loader = new RstToctreeLoader();

foreach ($loader->load('/path/to/docs/index.rst') as $document) {
    $document->getMetadata()->getTitle();   // e.g. "Installation"
    $document->getMetadata()->getDepth();   // e.g. 1
    $document->getMetadata()->getSource();  // e.g. "/path/to/docs/getting-started.rst"
}
```