### PR TITLE
[Store] Add SummaryGeneratorTransformer for LLM-based document summaries

### DIFF
--- a/examples/indexer/summary-generator.php
+++ b/examples/indexer/summary-generator.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\Transformer\SummaryGeneratorTransformer;
+use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Indexer\DocumentIndexer;
+use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Query\VectorQuery;
+use Symfony\Component\Uid\Uuid;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+echo "=== Summary Generator Transformer ===\n\n";
+echo "This example demonstrates using the SummaryGeneratorTransformer to automatically\n";
+echo "generate LLM-based summaries during document indexing and store them in metadata.\n\n";
+
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+$store = new InMemoryStore();
+$vectorizer = new Vectorizer($platform, 'text-embedding-3-small');
+
+$documents = [
+    new TextDocument(
+        Uuid::v4(),
+        'Symfony is a set of reusable PHP components and a PHP framework for web projects. It was published as free software in 2005. The framework follows the model-view-controller design pattern, and provides components for routing, templating, form creation, authentication, and caching among others.',
+        new Metadata(['title' => 'Symfony Framework'])
+    ),
+    new TextDocument(
+        Uuid::v4(),
+        'Retrieval Augmented Generation (RAG) is a technique that combines the power of large language models with external knowledge retrieval. It works by first retrieving relevant documents from a knowledge base, then using those documents as context for the language model to generate more accurate and grounded responses.',
+        new Metadata(['title' => 'RAG Technique'])
+    ),
+];
+
+$indexer = new DocumentIndexer(
+    new DocumentProcessor(
+        vectorizer: $vectorizer,
+        store: $store,
+        transformers: [
+            new SummaryGeneratorTransformer($platform, 'gpt-4o-mini'),
+        ],
+        logger: logger(),
+    ),
+);
+
+echo "Indexing documents with LLM summary generation...\n\n";
+$indexer->index($documents);
+
+$vector = $vectorizer->vectorize('What is RAG?');
+$results = $store->query(new VectorQuery($vector));
+
+echo "Search results for 'What is RAG?':\n\n";
+foreach ($results as $i => $document) {
+    $summary = $document->getMetadata()->getSummary();
+    echo sprintf("%d. %s\n", $i + 1, $document->getId());
+    if (null !== $summary) {
+        echo sprintf("   Summary: %s\n", $summary);
+    }
+    echo "\n";
+}

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.6
+---
+
+ * Add `SummaryGeneratorTransformer` for generating LLM-based summaries of documents
+
 0.4
 ---
 

--- a/src/store/src/Document/Metadata.php
+++ b/src/store/src/Document/Metadata.php
@@ -21,6 +21,7 @@ final class Metadata extends \ArrayObject
     public const KEY_PARENT_ID = '_parent_id';
     public const KEY_TEXT = '_text';
     public const KEY_SOURCE = '_source';
+    public const KEY_SUMMARY = '_summary';
 
     public function hasParentId(): bool
     {
@@ -71,5 +72,22 @@ final class Metadata extends \ArrayObject
     public function setSource(string $source): void
     {
         $this->offsetSet(self::KEY_SOURCE, $source);
+    }
+
+    public function hasSummary(): bool
+    {
+        return $this->offsetExists(self::KEY_SUMMARY);
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->offsetExists(self::KEY_SUMMARY)
+            ? $this->offsetGet(self::KEY_SUMMARY)
+            : null;
+    }
+
+    public function setSummary(string $summary): void
+    {
+        $this->offsetSet(self::KEY_SUMMARY, $summary);
     }
 }

--- a/src/store/src/Document/Transformer/SummaryGeneratorTransformer.php
+++ b/src/store/src/Document/Transformer/SummaryGeneratorTransformer.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Document\Transformer;
+
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\TransformerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Generates LLM summaries for documents and stores them in metadata.
+ *
+ * When $yieldSummaryDocuments is true, also yields an additional TextDocument
+ * with the summary as content (dual-indexing mode).
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SummaryGeneratorTransformer implements TransformerInterface
+{
+    private const DEFAULT_SYSTEM_PROMPT = 'Summarize the following text in 2-3 sentences, capturing the key concepts and any technical terms. Be concise and precise.';
+
+    public function __construct(
+        private readonly PlatformInterface $platform,
+        private readonly string $model,
+        private readonly bool $yieldSummaryDocuments = false,
+        private readonly string $systemPrompt = self::DEFAULT_SYSTEM_PROMPT,
+    ) {
+    }
+
+    public function transform(iterable $documents, array $options = []): iterable
+    {
+        foreach ($documents as $document) {
+            $summary = $this->generateSummary($document->getContent());
+            $document->getMetadata()->setSummary($summary);
+
+            yield $document;
+
+            if ($this->yieldSummaryDocuments) {
+                $summaryMetadata = new Metadata([...$document->getMetadata()]);
+                $summaryMetadata->setText($summary);
+
+                yield new TextDocument(Uuid::v4()->toRfc4122(), $summary, $summaryMetadata);
+            }
+        }
+    }
+
+    private function generateSummary(string $content): string
+    {
+        $messages = new MessageBag(
+            Message::forSystem($this->systemPrompt),
+            Message::ofUser($content),
+        );
+
+        return $this->platform->invoke($this->model, $messages)->asText();
+    }
+}

--- a/src/store/tests/Document/MetadataTest.php
+++ b/src/store/tests/Document/MetadataTest.php
@@ -39,6 +39,7 @@ final class MetadataTest extends TestCase
         $this->assertSame('_parent_id', Metadata::KEY_PARENT_ID);
         $this->assertSame('_text', Metadata::KEY_TEXT);
         $this->assertSame('_source', Metadata::KEY_SOURCE);
+        $this->assertSame('_summary', Metadata::KEY_SUMMARY);
     }
 
     #[DataProvider('parentIdProvider')]
@@ -125,12 +126,41 @@ final class MetadataTest extends TestCase
         ];
     }
 
+    #[DataProvider('summaryProvider')]
+    public function testSummaryMethods(?string $summary)
+    {
+        $metadata = new Metadata();
+
+        $this->assertFalse($metadata->hasSummary());
+        $this->assertNull($metadata->getSummary());
+
+        $metadata->setSummary($summary);
+
+        $this->assertTrue($metadata->hasSummary());
+        $this->assertSame($summary, $metadata->getSummary());
+    }
+
+    /**
+     * @return \Iterator<string, array{summary: string|null}>
+     */
+    public static function summaryProvider(): \Iterator
+    {
+        yield 'string summary' => [
+            'summary' => 'This document covers authentication patterns.',
+        ];
+
+        yield 'empty string summary' => [
+            'summary' => '',
+        ];
+    }
+
     public function testMetadataInitializedWithSpecialKeys()
     {
         $data = [
             Metadata::KEY_PARENT_ID => 'parent-123',
             Metadata::KEY_TEXT => 'This is the text content',
             Metadata::KEY_SOURCE => 'document.pdf',
+            Metadata::KEY_SUMMARY => 'A brief summary.',
             'title' => 'Test Document',
         ];
 
@@ -144,6 +174,9 @@ final class MetadataTest extends TestCase
 
         $this->assertTrue($metadata->hasSource());
         $this->assertSame('document.pdf', $metadata->getSource());
+
+        $this->assertTrue($metadata->hasSummary());
+        $this->assertSame('A brief summary.', $metadata->getSummary());
 
         $this->assertSame('Test Document', $metadata['title']);
     }
@@ -187,6 +220,7 @@ final class MetadataTest extends TestCase
         $this->assertNull($metadata->getParentId());
         $this->assertNull($metadata->getText());
         $this->assertNull($metadata->getSource());
+        $this->assertNull($metadata->getSummary());
     }
 
     public function testHasMethodsReturnFalseForMissingKeys()
@@ -196,6 +230,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->hasParentId());
         $this->assertFalse($metadata->hasText());
         $this->assertFalse($metadata->hasSource());
+        $this->assertFalse($metadata->hasSummary());
     }
 
     public function testOverwritingSpecialKeys()
@@ -205,13 +240,16 @@ final class MetadataTest extends TestCase
         $metadata->setParentId('parent-1');
         $metadata->setText('initial text');
         $metadata->setSource('initial.pdf');
+        $metadata->setSummary('initial summary');
 
         $metadata->setParentId('parent-2');
         $metadata->setText('updated text');
         $metadata->setSource('updated.pdf');
+        $metadata->setSummary('updated summary');
 
         $this->assertSame('parent-2', $metadata->getParentId());
         $this->assertSame('updated text', $metadata->getText());
         $this->assertSame('updated.pdf', $metadata->getSource());
+        $this->assertSame('updated summary', $metadata->getSummary());
     }
 }

--- a/src/store/tests/Document/Transformer/SummaryGeneratorTransformerTest.php
+++ b/src/store/tests/Document/Transformer/SummaryGeneratorTransformerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests\Document\Transformer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\Transformer\SummaryGeneratorTransformer;
+use Symfony\AI\Store\Tests\Double\PlatformTestHandler;
+
+final class SummaryGeneratorTransformerTest extends TestCase
+{
+    public function testSummaryIsStoredInMetadata()
+    {
+        $platform = PlatformTestHandler::createPlatform(new TextResult('This is a concise summary.'));
+        $transformer = new SummaryGeneratorTransformer($platform, 'gpt-4o-mini');
+
+        $document = new TextDocument('doc-1', 'This is the full document content that needs to be summarized.');
+        $result = iterator_to_array($transformer->transform([$document]));
+
+        $this->assertCount(1, $result);
+        $this->assertSame('This is a concise summary.', $result[0]->getMetadata()->getSummary());
+    }
+
+    public function testOriginalDocumentIsYielded()
+    {
+        $platform = PlatformTestHandler::createPlatform(new TextResult('Summary text.'));
+        $transformer = new SummaryGeneratorTransformer($platform, 'gpt-4o-mini');
+
+        $document = new TextDocument('doc-1', 'Document content.');
+        $result = iterator_to_array($transformer->transform([$document]));
+
+        $this->assertCount(1, $result);
+        $this->assertSame('doc-1', $result[0]->getId());
+        $this->assertSame('Document content.', $result[0]->getContent());
+    }
+
+    public function testDualDocModeYieldsAdditionalSummaryDocument()
+    {
+        $platform = PlatformTestHandler::createPlatform(new TextResult('A short summary.'));
+        $transformer = new SummaryGeneratorTransformer($platform, 'gpt-4o-mini', yieldSummaryDocuments: true);
+
+        $document = new TextDocument('doc-1', 'Full content here.');
+        $result = iterator_to_array($transformer->transform([$document]));
+
+        $this->assertCount(2, $result);
+
+        // First: original document with summary in metadata
+        $this->assertSame('doc-1', $result[0]->getId());
+        $this->assertSame('A short summary.', $result[0]->getMetadata()->getSummary());
+
+        // Second: summary document with summary as content
+        $this->assertSame('A short summary.', $result[1]->getContent());
+    }
+
+    public function testSummaryDocumentHasSameMetadata()
+    {
+        $platform = PlatformTestHandler::createPlatform(new TextResult('Summary.'));
+        $transformer = new SummaryGeneratorTransformer($platform, 'gpt-4o-mini', yieldSummaryDocuments: true);
+
+        $metadata = new Metadata([Metadata::KEY_SOURCE => 'test.rst']);
+        $document = new TextDocument('doc-1', 'Content.', $metadata);
+        $result = iterator_to_array($transformer->transform([$document]));
+
+        $this->assertCount(2, $result);
+        $this->assertSame('test.rst', $result[1]->getMetadata()->getSource());
+    }
+
+    public function testLlmIsCalledOncePerDocument()
+    {
+        $invocations = 0;
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->method('invoke')->willReturnCallback(
+            static function () use (&$invocations): \Symfony\AI\Platform\Result\DeferredResult {
+                ++$invocations;
+
+                return PlatformTestHandler::createPlatform(new TextResult('Summary.'))->invoke('test', 'test');
+            }
+        );
+
+        $transformer = new SummaryGeneratorTransformer($platform, 'gpt-4o-mini');
+
+        $documents = [
+            new TextDocument('doc-1', 'First document.'),
+            new TextDocument('doc-2', 'Second document.'),
+        ];
+
+        iterator_to_array($transformer->transform($documents));
+
+        $this->assertSame(2, $invocations);
+    }
+
+    public function testMultipleDocumentsAreTransformed()
+    {
+        $platform = PlatformTestHandler::createPlatform(new TextResult('Summary text.'));
+        $transformer = new SummaryGeneratorTransformer($platform, 'gpt-4o-mini');
+
+        $documents = [
+            new TextDocument('doc-1', 'First document content.'),
+            new TextDocument('doc-2', 'Second document content.'),
+        ];
+
+        $result = iterator_to_array($transformer->transform($documents));
+
+        $this->assertCount(2, $result);
+        foreach ($result as $doc) {
+            $this->assertTrue($doc->getMetadata()->hasSummary());
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

This PR adds a `SummaryGeneratorTransformer` to the Store component that uses
the Platform to generate LLM-based summaries of documents during indexing.

The transformer:
- Calls the configured LLM to generate a concise summary of each document's
content
- Stores the summary in the document's `Metadata` (new `_summary` key with
`hasSummary()`, `getSummary()`, `setSummary()` accessors)
- Optionally yields an additional `TextDocument` with the summary as content
(dual-indexing mode), useful for hybrid retrieval strategies where both full
content and summaries are embedded separately

### Usage

```php
use Symfony\AI\Store\Document\Transformer\SummaryGeneratorTransformer;

// Basic: store summary in metadata only
$transformer = new SummaryGeneratorTransformer($platform, 'gpt-4o-mini');

// Dual-indexing: also yield a separate summary document
$transformer = new SummaryGeneratorTransformer($platform, 'gpt-4o-mini',
yieldSummaryDocuments: true);

// Custom system prompt
$transformer = new SummaryGeneratorTransformer(
    $platform,
    'gpt-4o-mini',
    systemPrompt: 'Summarize this technical documentation in one sentence.',
);
```