### PR TITLE
[AI Bundle] Defer DataCollector to lateCollect

### DIFF
--- a/src/ai-bundle/src/Profiler/DataCollector.php
+++ b/src/ai-bundle/src/Profiler/DataCollector.php
@@ -76,7 +76,7 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
 
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
-        $this->lateCollect();
+        // Deferred to lateCollect() to avoid blocking the response.
     }
 
     public function lateCollect(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        |
| License       | MIT

`DataCollector::collect()` calls `$this->lateCollect()` directly, defeating the purpose of implementing `LateDataCollectorInterface`. This causes all tool and platform call resolution to happen during the HTTP response instead of after it.

By making `collect()` a no-op, the data collection is deferred to `kernel.terminate` (via `Profiler::saveProfile()`), no longer blocking the HTTP response.