### PR TITLE
[Platform][OpenAI] Add error handling for stream conversions

### DIFF
--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -37,6 +37,7 @@ use Symfony\AI\Platform\ResultConverterInterface;
  * @phpstan-type Refusal array{type: 'refusal', refusal: string}
  * @phpstan-type FunctionCall array{id: string, arguments: string, call_id: string, name: string, type: 'function_call'}
  * @phpstan-type Reasoning array{summary: array{text?: string}, id: string}
+ * @phpstan-type Error array{code?: string|null, type?: string|null, param?: string|null, message?: string|null}
  */
 final class ResultConverter implements ResultConverterInterface
 {
@@ -81,7 +82,7 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if (isset($data['error'])) {
-            throw new RuntimeException(\sprintf('Error "%s"-%s (%s): "%s".', $data['error']['code'] ?? '-', $data['error']['type'] ?? '-', $data['error']['param'] ?? '-', $data['error']['message'] ?? '-'));
+            throw new RuntimeException($this->generateErrorMessage($data['error']));
         }
 
         if (!isset($data[self::KEY_OUTPUT])) {
@@ -133,6 +134,10 @@ final class ResultConverter implements ResultConverterInterface
     {
         foreach ($result->getDataStream() as $event) {
             $type = $event['type'] ?? '';
+
+            if ('error' === $type && isset($event['error'])) {
+                throw new RuntimeException($this->generateErrorMessage($event['error']));
+            }
 
             if (isset($event['response']['usage'])) {
                 yield $this->getTokenUsageExtractor()->fromDataArray($event['response']);
@@ -235,5 +240,13 @@ final class ResultConverter implements ResultConverterInterface
         $summary = $item['summary']['text'] ?? null;
 
         return $summary ? new TextResult($summary) : null;
+    }
+
+    /**
+     * @param Error $error
+     */
+    private function generateErrorMessage(array $error): string
+    {
+        return \sprintf('Error "%s"-%s (%s): "%s".', $error['code'] ?? '-', $error['type'] ?? '-', $error['param'] ?? '-', $error['message'] ?? '-');
     }
 }

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -254,33 +255,7 @@ class ResultConverterTest extends TestCase
             ],
         ];
 
-        $raw = new class($httpResponse, $events) implements RawResultInterface {
-            /**
-             * @param array<array<string, mixed>> $events
-             */
-            public function __construct(
-                private readonly ResponseInterface $response,
-                private readonly array $events,
-            ) {
-            }
-
-            public function getData(): array
-            {
-                return [];
-            }
-
-            public function getDataStream(): iterable
-            {
-                foreach ($this->events as $event) {
-                    yield $event;
-                }
-            }
-
-            public function getObject(): object
-            {
-                return $this->response;
-            }
-        };
+        $raw = new InMemoryRawResult([], $events, $httpResponse);
 
         $streamResult = $converter->convert($raw, ['stream' => true]);
 
@@ -300,5 +275,37 @@ class ResultConverterTest extends TestCase
         $this->assertSame(2, $chunks[2]->getThinkingTokens());
         $this->assertSame(3, $chunks[2]->getCachedTokens());
         $this->assertSame(18, $chunks[2]->getTotalTokens());
+    }
+
+    public function testStreamThrowsExceptionOnErrorEvent()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $events = [
+            [
+                'type' => 'error',
+                'error' => [
+                    'type' => 'insufficient_quota',
+                    'code' => 'insufficient_quota',
+                    'message' => 'You exceeded your current quota',
+                    'param' => null,
+                ],
+                'sequence_number' => 2,
+            ],
+        ];
+
+        $raw = new InMemoryRawResult([], $events, $httpResponse);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Error "insufficient_quota"-insufficient_quota (-): "You exceeded your current quota".');
+
+        foreach ($streamResult->getContent() as $part) {
+            // Iterate to trigger the generator
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

When an error chunk type is received while using streams, it is ignored, resulting in an unexpected situation where something is not working, but the platform does not return any error. This PR provides handling for an error type chunk by throwing a RuntimeException.