### PR TITLE
[Platform][ModelsDev] Skip specialized bridge check when a custom baseUrl is provided

### DIFF
--- a/src/platform/src/Bridge/ModelsDev/CHANGELOG.md
+++ b/src/platform/src/Bridge/ModelsDev/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add well-known base URLs for providers with dedicated npm packages
+ * Skip specialized bridge check in `ModelsDevPlatformFactory` when a custom `$baseUrl` is provided
 
 0.4
 ---

--- a/src/platform/src/Bridge/ModelsDev/PlatformFactory.php
+++ b/src/platform/src/Bridge/ModelsDev/PlatformFactory.php
@@ -65,8 +65,10 @@ final class PlatformFactory
         $providerData = $data[$provider];
         $npmPackage = $providerData['npm'] ?? null;
 
-        // Check if this provider requires a specialized bridge (e.g., Anthropic, Google)
-        if (null !== $npmPackage && BridgeResolver::requiresSpecializedBridge($npmPackage)) {
+        // Check if this provider requires a specialized bridge (e.g., Anthropic, Google).
+        // When a custom baseUrl is given, skip this check: the user is pointing at an
+        // OpenAI-compatible proxy, so the generic bridge is always the right choice.
+        if (null === $baseUrl && null !== $npmPackage && BridgeResolver::requiresSpecializedBridge($npmPackage)) {
             $package = BridgeResolver::getComposerPackage($npmPackage);
             $factoryClass = BridgeResolver::getBridgeFactory($npmPackage);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/A
| License       | MIT

A custom `baseUrl` signals the user is pointing at an OpenAI-compatible proxy, so the generic bridge is always the right choice even for providers like `google-vertex` that would normally require a non-routable specialized bridge.
