### PR TITLE
[Platform] Improve structured output test coverage

### DIFF
--- a/src/platform/tests/Fixtures/StructuredOutput/UserWithAccessors.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/UserWithAccessors.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput;
+
+final class UserWithAccessors
+{
+    private int $id;
+    /**
+     * @var string The name of the user in lowercase
+     */
+    private string $name;
+    private \DateTimeInterface $createdAt;
+    private bool $isActive;
+    private ?int $age = null;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function setIsActive(bool $isActive): void
+    {
+        $this->isActive = $isActive;
+    }
+
+    public function getAge(): ?int
+    {
+        return $this->age;
+    }
+
+    public function setAge(?int $age): void
+    {
+        $this->age = $age;
+    }
+}

--- a/src/platform/tests/StructuredOutput/ResponseFormatFactoryTest.php
+++ b/src/platform/tests/StructuredOutput/ResponseFormatFactoryTest.php
@@ -11,18 +11,24 @@
 
 namespace Symfony\AI\Platform\Tests\StructuredOutput;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactory;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\User;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\UserWithAccessors;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\UserWithConstructor;
 
 final class ResponseFormatFactoryTest extends TestCase
 {
-    public function testCreate()
+    #[TestWith(['User', User::class])]
+    #[TestWith(['UserWithConstructor', UserWithConstructor::class])]
+    #[TestWith(['UserWithAccessors', UserWithAccessors::class])]
+    public function testCreate(string $expectedName, string $class)
     {
         $this->assertSame([
             'type' => 'json_schema',
             'json_schema' => [
-                'name' => 'User',
+                'name' => $expectedName,
                 'schema' => [
                     'type' => 'object',
                     'properties' => [
@@ -43,6 +49,6 @@ final class ResponseFormatFactoryTest extends TestCase
                 ],
                 'strict' => true,
             ],
-        ], (new ResponseFormatFactory())->create(User::class));
+        ], (new ResponseFormatFactory())->create($class));
     }
 }

--- a/src/platform/tests/StructuredOutput/ResultConverterTest.php
+++ b/src/platform/tests/StructuredOutput/ResultConverterTest.php
@@ -21,6 +21,7 @@ use Symfony\AI\Platform\StructuredOutput\ResultConverter;
 use Symfony\AI\Platform\StructuredOutput\Serializer;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\City;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\SomeStructure;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\UserWithAccessors;
 
 final class ResultConverterTest extends TestCase
 {
@@ -152,5 +153,17 @@ final class ResultConverterTest extends TestCase
         $extractor = $converter->getTokenUsageExtractor();
 
         $this->assertNull($extractor);
+    }
+
+    public function testConvertWithAccessors()
+    {
+        $innerConverter = new PlainConverter(new TextResult('{"age": 10}'));
+        $converter = new ResultConverter($innerConverter, new Serializer(), UserWithAccessors::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(ObjectResult::class, $result);
+        $this->assertInstanceOf(UserWithAccessors::class, $result->getContent());
+        $this->assertSame(10, $result->getContent()->getAge());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| License       | MIT

Related to comment https://github.com/symfony/ai/pull/1683#issuecomment-4000631686 I added a test that makes sure the getters/setters work with `StructuredOutput\Serializer`.

---

We probably should aim to use the normal `serializer` (or maybe add a child definition of it) because currently even basic things like `DateTime`s are not supported – let alone custom types with custom normalizers.
But the comment in `StructuredOutput\Serializer` still partly holds – so I'd say it's good enough for now / good for release.