### PR TITLE
[Platform][Bedrock] Add match statement to determine bedrock inference profile region

### DIFF
--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
@@ -15,6 +15,7 @@ use AsyncAws\BedrockRuntime\BedrockRuntimeClient;
 use AsyncAws\BedrockRuntime\Input\InvokeModelRequest;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
+use Symfony\AI\Platform\Bridge\Bedrock\RegionMapper;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -104,7 +105,7 @@ final class ClaudeModelClient implements ModelClientInterface
 
     private function getModelId(Model $model): string
     {
-        $regionPrefix = substr((string) $this->bedrockRuntimeClient->getConfiguration()->get('region'), 0, 2);
+        $regionPrefix = RegionMapper::map((string) $this->bedrockRuntimeClient->getConfiguration()->get('region'));
         $name = $model->getName();
 
         return $regionPrefix.'.anthropic.'.($this->modelMap[$name] ?? $name);

--- a/src/platform/src/Bridge/Bedrock/Meta/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Meta/LlamaModelClient.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Bedrock\Meta;
 use AsyncAws\BedrockRuntime\BedrockRuntimeClient;
 use AsyncAws\BedrockRuntime\Input\InvokeModelRequest;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
+use Symfony\AI\Platform\Bridge\Bedrock\RegionMapper;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -45,7 +46,7 @@ class LlamaModelClient implements ModelClientInterface
     private function getModelId(Model $model): string
     {
         $configuredRegion = $this->bedrockRuntimeClient->getConfiguration()->get('region');
-        $regionPrefix = substr((string) $configuredRegion, 0, 2);
+        $regionPrefix = RegionMapper::map((string) $configuredRegion);
         $modifiedModelName = str_replace('llama-3', 'llama3', $model->getName());
 
         return $regionPrefix.'.meta.'.str_replace('.', '-', $modifiedModelName).'-v1:0';

--- a/src/platform/src/Bridge/Bedrock/Nova/NovaModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/NovaModelClient.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Bedrock\Nova;
 use AsyncAws\BedrockRuntime\BedrockRuntimeClient;
 use AsyncAws\BedrockRuntime\Input\InvokeModelRequest;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
+use Symfony\AI\Platform\Bridge\Bedrock\RegionMapper;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -66,7 +67,7 @@ class NovaModelClient implements ModelClientInterface
     private function getModelId(Model $model): string
     {
         $configuredRegion = $this->bedrockRuntimeClient->getConfiguration()->get('region');
-        $regionPrefix = substr((string) $configuredRegion, 0, 2);
+        $regionPrefix = RegionMapper::map((string) $configuredRegion);
 
         return $regionPrefix.'.amazon.'.$model->getName().'-v1:0';
     }

--- a/src/platform/src/Bridge/Bedrock/RegionMapper.php
+++ b/src/platform/src/Bridge/Bedrock/RegionMapper.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Bedrock;
+
+/**
+ * Maps an AWS region to the geographic prefix used in Bedrock cross-region
+ * inference profile IDs (e.g. "ap-southeast-2" resolves to "apac").
+ *
+ * Only mappings confirmed against the AWS documentation are listed here; every
+ * other region falls through to its raw two-character prefix, which already
+ * matches the inference profile prefix for the US ("us") and EU ("eu") geos.
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+ *
+ * @author Ryan Rigby <16025441+rrigby@users.noreply.github.com>
+ */
+final class RegionMapper
+{
+    public static function map(string $region): string
+    {
+        $prefix = substr($region, 0, 2);
+
+        return match ($prefix) {
+            'ap' => 'apac',
+            default => $prefix,
+        };
+    }
+}

--- a/src/platform/src/Bridge/Bedrock/Tests/RegionMapperTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/RegionMapperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Bedrock\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Bedrock\RegionMapper;
+
+final class RegionMapperTest extends TestCase
+{
+    #[DataProvider('provideRegions')]
+    public function testMap(string $region, string $expectedPrefix)
+    {
+        $this->assertSame($expectedPrefix, RegionMapper::map($region));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function provideRegions(): iterable
+    {
+        yield 'asia pacific resolves to apac' => ['ap-southeast-2', 'apac'];
+        yield 'asia pacific north resolves to apac' => ['ap-northeast-1', 'apac'];
+        yield 'us falls through to raw prefix' => ['us-east-1', 'us'];
+        yield 'eu falls through to raw prefix' => ['eu-west-1', 'eu'];
+        yield 'unknown region falls through to raw prefix' => ['af-south-1', 'af'];
+        yield 'empty region resolves to empty prefix' => ['', ''];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         |  no
| Issues        | N/A
| License       | MIT

The model client was operating under the assumption that all inference profiles use a 2 character region taken from the AWS region .e.g `ap-southeast-2 -> ap`. For US and EU regions this worked fine.

However, this is not the case for Asia Pacific regions and some others, see here for AWS documentation: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html

This is not the most elegant solution, maybe a trait or utility method somewhere should provide this functionality.


