### PR TITLE
[Platform][Azure] Pass deployment name to `ResponsesModelClient`

### DIFF
--- a/src/platform/src/Bridge/Azure/OpenAi/PlatformFactory.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/PlatformFactory.php
@@ -42,7 +42,7 @@ final class PlatformFactory
 
         return new Platform(
             [
-                new ResponsesModelClient($httpClient, $baseUrl, $apiKey),
+                new ResponsesModelClient($httpClient, $baseUrl, $apiKey, $deployment),
                 new EmbeddingsModelClient($httpClient, $baseUrl, $deployment, $apiVersion, $apiKey),
                 new WhisperModelClient($httpClient, $baseUrl, $deployment, $apiVersion, $apiKey),
             ],

--- a/src/platform/src/Bridge/Azure/Responses/ModelClient.php
+++ b/src/platform/src/Bridge/Azure/Responses/ModelClient.php
@@ -31,6 +31,7 @@ final class ModelClient implements ModelClientInterface
         HttpClientInterface $httpClient,
         string $baseUrl,
         #[\SensitiveParameter] private readonly string $apiKey,
+        private readonly ?string $deployment = null,
     ) {
         if ('' === $baseUrl) {
             throw new InvalidArgumentException('The base URL must not be empty.');
@@ -57,7 +58,7 @@ final class ModelClient implements ModelClientInterface
             'headers' => [
                 'api-key' => $this->apiKey,
             ],
-            'json' => array_merge($options, ['model' => $model->getName()], $payload),
+            'json' => array_merge($options, ['model' => $this->deployment ?? $model->getName()], $payload),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Azure/Tests/Responses/ModelClientTest.php
+++ b/src/platform/src/Bridge/Azure/Tests/Responses/ModelClientTest.php
@@ -75,6 +75,32 @@ final class ModelClientTest extends TestCase
         };
 
         $httpClient = new MockHttpClient([$resultCallback]);
+        $client = new ModelClient($httpClient, 'test.openai.azure.com', 'test-api-key', 'gpt-4o');
+        $client->request(new ResponsesModel('gpt-4o'), ['input' => [['role' => 'user', 'content' => 'Hello']]]);
+    }
+
+    public function testItUsesDeploymentNameInsteadOfModelName()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): MockResponse {
+            self::assertSame('{"model":"my-custom-deployment","input":[{"role":"user","content":"Hello"}]}', $options['body']);
+
+            return new MockResponse();
+        };
+
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $client = new ModelClient($httpClient, 'test.openai.azure.com', 'test-api-key', 'my-custom-deployment');
+        $client->request(new ResponsesModel('gpt-4o'), ['input' => [['role' => 'user', 'content' => 'Hello']]]);
+    }
+
+    public function testItFallsBackToModelNameWhenDeploymentIsNull()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): MockResponse {
+            self::assertSame('{"model":"gpt-4o","input":[{"role":"user","content":"Hello"}]}', $options['body']);
+
+            return new MockResponse();
+        };
+
+        $httpClient = new MockHttpClient([$resultCallback]);
         $client = new ModelClient($httpClient, 'test.openai.azure.com', 'test-api-key');
         $client->request(new ResponsesModel('gpt-4o'), ['input' => [['role' => 'user', 'content' => 'Hello']]]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        |
| License       | MIT

## Summary

`ResponsesModelClient` was not receiving the configured deployment name, so it always sent `$model->getName()` (e.g. `gpt-5`) as the `model` field in the Azure Responses API request body.

Azure OpenAI requires the **deployment name** as the `model` field — not the model family name — so any project where the Azure deployment is not named identically to the OpenAI model would receive a `404 DeploymentNotFound` error.

**Changes:**
- Add `$deployment` parameter to `ResponsesModelClient::__construct()`, placed before `$apiKey` to match the convention of `EmbeddingsModelClient` and `WhisperModelClient`
- Use `$this->deployment ?? $model->getName()` in the request, falling back to the model name when no deployment is configured
- Pass `$deployment` from `PlatformFactory::create()` to `ResponsesModelClient`
- Add tests covering deployment name override and null fallback