### PR TITLE
[Platform][Cohere] Add native bridge for chat, embeddings, and reranking

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -153,6 +153,10 @@ deptrac:
       collectors:
         - type: classLike
           value: Symfony\\AI\\Platform\\Bridge\\Codex\\.*
+    - name: CoherePlatform
+      collectors:
+        - type: classLike
+          value: Symfony\\AI\\Platform\\Bridge\\Cohere\\.*
     - name: DecartPlatform
       collectors:
         - type: classLike
@@ -454,6 +458,8 @@ deptrac:
     ClaudeCodePlatform:
       - PlatformComponent
     CodexPlatform:
+      - PlatformComponent
+    CoherePlatform:
       - PlatformComponent
     DecartPlatform:
       - PlatformComponent

--- a/examples/.env
+++ b/examples/.env
@@ -9,6 +9,9 @@ ANTHROPIC_API_KEY=
 # For using Mistral
 MISTRAL_API_KEY=
 
+# For using Cohere
+COHERE_API_KEY=
+
 # For using Voyage
 VOYAGE_API_KEY=
 

--- a/examples/cohere/chat.php
+++ b/examples/cohere/chat.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Cohere\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('COHERE_API_KEY'), http_client());
+
+$messages = new MessageBag(Message::ofUser('What is the largest ocean on Earth?'));
+$result = $platform->invoke('command-a-03-2025', $messages, [
+    'temperature' => 0.7,
+]);
+
+echo $result->asText().\PHP_EOL;
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/cohere/embeddings.php
+++ b/examples/cohere/embeddings.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Cohere\InputType;
+use Symfony\AI\Platform\Bridge\Cohere\PlatformFactory;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('COHERE_API_KEY'), http_client());
+
+$result = $platform->invoke('embed-english-v3.0', <<<TEXT
+    Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.
+    The people of Japan were very kind and hardworking. They loved their country very much and took care of it. The
+    country was very peaceful and prosperous. The people lived happily ever after.
+    TEXT, [
+    'input_type' => InputType::SearchDocument,
+]);
+
+print_vectors($result);
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/cohere/rerank.php
+++ b/examples/cohere/rerank.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Cohere\PlatformFactory;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('COHERE_API_KEY'), http_client());
+
+$result = $platform->invoke('rerank-v3.5', [
+    'query' => 'What is artificial intelligence?',
+    'texts' => [
+        'Artificial intelligence is the simulation of human intelligence processes by machines.',
+        'The weather today is sunny with a high of 75 degrees.',
+        'Machine learning is a subset of AI that enables systems to learn from data.',
+        'The best recipe for chocolate cake requires cocoa powder and butter.',
+    ],
+]);
+
+foreach ($result->asReranking() as $entry) {
+    echo sprintf("Index: %d, Score: %.4f\n", $entry->getIndex(), $entry->getScore());
+}
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/cohere/stream.php
+++ b/examples/cohere/stream.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Cohere\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('COHERE_API_KEY'), http_client());
+
+$messages = new MessageBag(Message::ofUser('What is the eighth prime number?'));
+$result = $platform->invoke('command-a-03-2025', $messages, [
+    'stream' => true,
+]);
+
+foreach ($result->asStream() as $word) {
+    echo $word;
+}
+echo \PHP_EOL;

--- a/examples/cohere/toolcall-stream.php
+++ b/examples/cohere/toolcall-stream.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Bridge\Clock\Clock;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Cohere\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('COHERE_API_KEY'), http_client());
+
+$toolbox = new Toolbox([new Clock()], logger: logger());
+$processor = new AgentProcessor($toolbox);
+$agent = new Agent($platform, 'command-a-03-2025', [$processor], [$processor]);
+
+$messages = new MessageBag(Message::ofUser('What time is it? Please tell me the current time.'));
+$result = $agent->call($messages, [
+    'stream' => true,
+]);
+
+foreach ($result->getContent() as $word) {
+    echo $word;
+}
+
+echo \PHP_EOL;

--- a/examples/cohere/toolcall.php
+++ b/examples/cohere/toolcall.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Bridge\Clock\Clock;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Cohere\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('COHERE_API_KEY'), http_client());
+
+$toolbox = new Toolbox([new Clock()], logger: logger());
+$processor = new AgentProcessor($toolbox);
+$agent = new Agent($platform, 'command-a-03-2025', [$processor], [$processor]);
+
+$messages = new MessageBag(Message::ofUser('What time is it?'));
+$result = $agent->call($messages);
+
+echo $result->getContent().\PHP_EOL;
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -3,6 +3,9 @@
     "description": "Example scripts about using Symfony AI",
     "license": "MIT",
     "type": "project",
+    "repositories": [
+        {"type": "path", "url": "../src/platform/src/Bridge/Cohere" }
+    ],
     "require": {
         "php": ">=8.2",
         "symfony/ai-agent": "^0.6",
@@ -25,6 +28,7 @@
         "symfony/ai-clock-tool": "^0.6",
         "symfony/ai-cloudflare-message-store": "^0.6",
         "symfony/ai-cloudflare-store": "^0.6",
+        "symfony/ai-cohere-platform": "@dev",
         "symfony/ai-decart-platform": "^0.6",
         "symfony/ai-deep-seek-platform": "^0.6",
         "symfony/ai-doctrine-message-store": "^0.6",

--- a/splitsh.json
+++ b/splitsh.json
@@ -51,6 +51,7 @@
         "ai-cerebras-platform": "src/platform/src/Bridge/Cerebras",
         "ai-claude-code-platform": "src/platform/src/Bridge/ClaudeCode",
         "ai-codex-platform": "src/platform/src/Bridge/Codex",
+        "ai-cohere-platform": "src/platform/src/Bridge/Cohere",
         "ai-decart-platform": "src/platform/src/Bridge/Decart",
         "ai-deep-seek-platform": "src/platform/src/Bridge/DeepSeek",
         "ai-docker-model-runner-platform": "src/platform/src/Bridge/DockerModelRunner",

--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -35,6 +35,7 @@ return static function (DefinitionConfigurator $configurator): void {
                     ->append($import('platform/cache'))
                     ->append($import('platform/cartesia'))
                     ->append($import('platform/cerebras'))
+                    ->append($import('platform/cohere'))
                     ->append($import('platform/decart'))
                     ->append($import('platform/deepseek'))
                     ->append($import('platform/dockermodelrunner'))

--- a/src/ai-bundle/config/platform/cohere.php
+++ b/src/ai-bundle/config/platform/cohere.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition\Configurator;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+return (new ArrayNodeDefinition('cohere'))
+    ->children()
+        ->stringNode('api_key')->isRequired()->end()
+        ->stringNode('http_client')
+            ->defaultValue('http_client')
+            ->info('Service ID of the HTTP client to use')
+        ->end()
+    ->end();

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -33,6 +33,7 @@ use Symfony\AI\Platform\Bridge\Azure\OpenAi\ModelCatalog as AzureOpenAiModelCata
 use Symfony\AI\Platform\Bridge\Bedrock\ModelCatalog as BedrockModelCatalog;
 use Symfony\AI\Platform\Bridge\Cartesia\ModelCatalog as CartesiaModelCatalog;
 use Symfony\AI\Platform\Bridge\Cerebras\ModelCatalog as CerebrasModelCatalog;
+use Symfony\AI\Platform\Bridge\Cohere\ModelCatalog as CohereModelCatalog;
 use Symfony\AI\Platform\Bridge\Decart\ModelCatalog as DecartModelCatalog;
 use Symfony\AI\Platform\Bridge\DeepSeek\ModelCatalog as DeepSeekModelCatalog;
 use Symfony\AI\Platform\Bridge\DockerModelRunner\ModelCatalog as DockerModelRunnerModelCatalog;
@@ -109,6 +110,7 @@ return static function (ContainerConfigurator $container): void {
         ->set('ai.platform.model_catalog.bedrock', BedrockModelCatalog::class)
         ->set('ai.platform.model_catalog.cartesia', CartesiaModelCatalog::class)
         ->set('ai.platform.model_catalog.cerebras', CerebrasModelCatalog::class)
+        ->set('ai.platform.model_catalog.cohere', CohereModelCatalog::class)
         ->set('ai.platform.model_catalog.decart', DecartModelCatalog::class)
         ->set('ai.platform.model_catalog.deepseek', DeepSeekModelCatalog::class)
         ->set('ai.platform.model_catalog.dockermodelrunner', DockerModelRunnerModelCatalog::class)

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -61,6 +61,7 @@ use Symfony\AI\Platform\Bridge\Cache\CachePlatform;
 use Symfony\AI\Platform\Bridge\Cache\ResultNormalizer;
 use Symfony\AI\Platform\Bridge\Cartesia\PlatformFactory as CartesiaPlatformFactory;
 use Symfony\AI\Platform\Bridge\Cerebras\PlatformFactory as CerebrasPlatformFactory;
+use Symfony\AI\Platform\Bridge\Cohere\PlatformFactory as CoherePlatformFactory;
 use Symfony\AI\Platform\Bridge\Decart\PlatformFactory as DecartPlatformFactory;
 use Symfony\AI\Platform\Bridge\DeepSeek\PlatformFactory as DeepSeekPlatformFactory;
 use Symfony\AI\Platform\Bridge\DockerModelRunner\PlatformFactory as DockerModelRunnerPlatformFactory;
@@ -936,6 +937,30 @@ final class AiBundle extends AbstractBundle
                     new Reference('event_dispatcher'),
                 ])
                 ->addTag('ai.platform', ['name' => 'cerebras']);
+
+            $container->setDefinition($platformId, $definition);
+
+            return;
+        }
+
+        if ('cohere' === $type) {
+            if (!ContainerBuilder::willBeAvailable('symfony/ai-cohere-platform', CoherePlatformFactory::class, ['symfony/ai-bundle'])) {
+                throw new RuntimeException('Cohere platform configuration requires "symfony/ai-cohere-platform" package. Try running "composer require symfony/ai-cohere-platform".');
+            }
+
+            $platformId = 'ai.platform.cohere';
+            $definition = (new Definition(Platform::class))
+                ->setFactory(CoherePlatformFactory::class.'::create')
+                ->setLazy(true)
+                ->addTag('proxy', ['interface' => PlatformInterface::class])
+                ->setArguments([
+                    $platform['api_key'],
+                    new Reference($platform['http_client'], ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                    new Reference('ai.platform.model_catalog.cohere'),
+                    null,
+                    new Reference('event_dispatcher'),
+                ])
+                ->addTag('ai.platform', ['name' => 'cohere']);
 
             $container->setDefinition($platformId, $definition);
 

--- a/src/platform/src/Bridge/Cohere/.gitattributes
+++ b/src/platform/src/Bridge/Cohere/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/platform/src/Bridge/Cohere/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/platform/src/Bridge/Cohere/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/ai
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/platform/src/Bridge/Cohere/.github/workflows/close-pull-request.yml
+++ b/src/platform/src/Bridge/Cohere/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/ai
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/platform/src/Bridge/Cohere/.gitignore
+++ b/src/platform/src/Bridge/Cohere/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+phpunit.xml
+.phpunit.result.cache

--- a/src/platform/src/Bridge/Cohere/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cohere/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+0.7
+---
+
+ * Add the bridge

--- a/src/platform/src/Bridge/Cohere/Cohere.php
+++ b/src/platform/src/Bridge/Cohere/Cohere.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere;
+
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class Cohere extends Model
+{
+}

--- a/src/platform/src/Bridge/Cohere/Embeddings.php
+++ b/src/platform/src/Bridge/Cohere/Embeddings.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere;
+
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class Embeddings extends Model
+{
+}

--- a/src/platform/src/Bridge/Cohere/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Cohere/Embeddings/ModelClient.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Embeddings;
+
+use Symfony\AI\Platform\Bridge\Cohere\Embeddings;
+use Symfony\AI\Platform\Bridge\Cohere\InputType;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelClient implements ModelClientInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        #[\SensitiveParameter] private readonly string $apiKey,
+    ) {
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Embeddings;
+    }
+
+    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    {
+        $texts = \is_array($payload) ? $payload : [$payload];
+
+        $body = [
+            'model' => $model->getName(),
+            'texts' => $texts,
+            'input_type' => ($options['input_type'] ?? $model->getOptions()['input_type'] ?? InputType::SearchDocument)->value,
+        ];
+
+        if (isset($options['embedding_types'])) {
+            $body['embedding_types'] = $options['embedding_types'];
+        }
+
+        return new RawHttpResult($this->httpClient->request('POST', 'https://api.cohere.com/v2/embed', [
+            'auth_bearer' => $this->apiKey,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'json' => $body,
+        ]));
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Embeddings/ResultConverter.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Embeddings;
+
+use Symfony\AI\Platform\Bridge\Cohere\Embeddings;
+use Symfony\AI\Platform\Bridge\Cohere\MetaBilledUnitsTokenUsageExtractor;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+use Symfony\AI\Platform\Vector\Vector;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResultConverter implements ResultConverterInterface
+{
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Embeddings;
+    }
+
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): VectorResult
+    {
+        $httpResponse = $result->getObject();
+
+        if (200 !== $httpResponse->getStatusCode()) {
+            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $httpResponse->getStatusCode(), $httpResponse->getContent(false)));
+        }
+
+        $data = $result->getData();
+
+        if (!isset($data['embeddings']['float'])) {
+            throw new RuntimeException('Response does not contain embedding data.');
+        }
+
+        return new VectorResult(
+            ...array_map(
+                static fn (array $embedding): Vector => new Vector($embedding),
+                $data['embeddings']['float'],
+            ),
+        );
+    }
+
+    public function getTokenUsageExtractor(): TokenUsageExtractorInterface
+    {
+        return new MetaBilledUnitsTokenUsageExtractor();
+    }
+}

--- a/src/platform/src/Bridge/Cohere/InputType.php
+++ b/src/platform/src/Bridge/Cohere/InputType.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+enum InputType: string
+{
+    case SearchDocument = 'search_document';
+    case SearchQuery = 'search_query';
+    case Classification = 'classification';
+    case Clustering = 'clustering';
+    case Image = 'image';
+}

--- a/src/platform/src/Bridge/Cohere/LICENSE
+++ b/src/platform/src/Bridge/Cohere/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/platform/src/Bridge/Cohere/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ModelClient.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Llm;
+
+use Symfony\AI\Platform\Bridge\Cohere\Cohere;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelClient implements ModelClientInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        #[\SensitiveParameter] private readonly string $apiKey,
+    ) {
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Cohere;
+    }
+
+    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface
+    {
+        if (\is_string($payload)) {
+            throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
+        }
+
+        return new RawHttpResult($this->httpClient->request('POST', 'https://api.cohere.com/v2/chat', [
+            'auth_bearer' => $this->apiKey,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'json' => array_merge($options, $payload),
+        ]));
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Llm;
+
+use Symfony\AI\Platform\Bridge\Cohere\Cohere;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResultConverter implements ResultConverterInterface
+{
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Cohere;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
+    {
+        $httpResponse = $result->getObject();
+
+        if ($httpResponse instanceof ResponseInterface && 200 !== $code = $httpResponse->getStatusCode()) {
+            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $httpResponse->getContent(false)));
+        }
+
+        if ($options['stream'] ?? false) {
+            return new StreamResult($this->convertStream($result));
+        }
+
+        $data = $result->getData();
+
+        $finishReason = $data['finish_reason'] ?? null;
+
+        if ('COMPLETE' === $finishReason) {
+            $text = $data['message']['content'][0]['text'] ?? '';
+
+            return new TextResult($text);
+        }
+
+        if ('TOOL_CALL' === $finishReason) {
+            return new ToolCallResult(...array_map($this->convertToolCall(...), $data['message']['tool_calls'] ?? []));
+        }
+
+        throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $finishReason));
+    }
+
+    public function getTokenUsageExtractor(): TokenUsageExtractor
+    {
+        return new TokenUsageExtractor();
+    }
+
+    private function convertStream(RawResultInterface $result): \Generator
+    {
+        $toolCalls = [];
+        foreach ($result->getDataStream() as $data) {
+            $type = $data['type'] ?? null;
+
+            if ('content-delta' === $type) {
+                yield new TextDelta($data['delta']['message']['content']['text'] ?? '');
+                continue;
+            }
+
+            if ('tool-call-start' === $type) {
+                $toolCall = $data['delta']['message']['tool_calls'] ?? null;
+                if (null !== $toolCall) {
+                    $toolCalls[] = [
+                        'id' => $toolCall['id'] ?? '',
+                        'function' => [
+                            'name' => $toolCall['function']['name'] ?? '',
+                            'arguments' => $toolCall['function']['arguments'] ?? '',
+                        ],
+                    ];
+                }
+                continue;
+            }
+
+            if ('tool-call-delta' === $type) {
+                if ([] !== $toolCalls) {
+                    $lastIndex = \count($toolCalls) - 1;
+                    $toolCalls[$lastIndex]['function']['arguments'] .= $data['delta']['message']['tool_calls']['function']['arguments'] ?? '';
+                }
+                continue;
+            }
+
+            if ('message-end' === $type && [] !== $toolCalls) {
+                yield new ToolCallComplete(...array_map($this->convertToolCall(...), $toolCalls));
+            }
+        }
+    }
+
+    /**
+     * @param array{
+     *     id: string,
+     *     function: array{
+     *         name: string,
+     *         arguments: string
+     *     }
+     * } $toolCall
+     */
+    private function convertToolCall(array $toolCall): ToolCall
+    {
+        $argumentsJson = (string) $toolCall['function']['arguments'];
+        $arguments = '' !== $argumentsJson
+            ? json_decode($argumentsJson, true, flags: \JSON_THROW_ON_ERROR)
+            : [];
+
+        return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Llm/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/Cohere/Llm/TokenUsageExtractor.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Llm;
+
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class TokenUsageExtractor implements TokenUsageExtractorInterface
+{
+    public function extract(RawResultInterface $rawResult, array $options = []): ?TokenUsage
+    {
+        if ($options['stream'] ?? false) {
+            return null;
+        }
+
+        $content = $rawResult->getData();
+
+        $tokens = $content['usage']['tokens'] ?? null;
+        if (null === $tokens) {
+            return null;
+        }
+
+        return new TokenUsage(
+            promptTokens: $tokens['input_tokens'] ?? null,
+            completionTokens: $tokens['output_tokens'] ?? null,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Cohere/MetaBilledUnitsTokenUsageExtractor.php
+++ b/src/platform/src/Bridge/Cohere/MetaBilledUnitsTokenUsageExtractor.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere;
+
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
+
+/**
+ * Extracts token usage from the `meta.billed_units` field returned by
+ * Cohere's embeddings and reranking API responses.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class MetaBilledUnitsTokenUsageExtractor implements TokenUsageExtractorInterface
+{
+    public function extract(RawResultInterface $rawResult, array $options = []): ?TokenUsageInterface
+    {
+        $content = $rawResult->getData();
+
+        $billedUnits = $content['meta']['billed_units'] ?? null;
+        if (null === $billedUnits) {
+            return null;
+        }
+
+        $inputTokens = $billedUnits['input_tokens'] ?? null;
+        $searchUnits = $billedUnits['search_units'] ?? null;
+
+        if (null === $inputTokens && null === $searchUnits) {
+            return null;
+        }
+
+        return new TokenUsage(
+            promptTokens: $inputTokens ?? $searchUnits,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Cohere/ModelCatalog.php
+++ b/src/platform/src/Bridge/Cohere/ModelCatalog.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere;
+
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\ModelCatalog\AbstractModelCatalog;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelCatalog extends AbstractModelCatalog
+{
+    /**
+     * @param array<string, array{class: string, capabilities: list<Capability>}> $additionalModels
+     */
+    public function __construct(array $additionalModels = [])
+    {
+        $defaultModels = [
+            // Chat models
+            'command-a-03-2025' => [
+                'class' => Cohere::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            'command-r-plus-08-2024' => [
+                'class' => Cohere::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            'command-r-08-2024' => [
+                'class' => Cohere::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            'command-r7b-12-2024' => [
+                'class' => Cohere::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            // Embedding models
+            'embed-v4.0' => [
+                'class' => Embeddings::class,
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::INPUT_MULTIMODAL, Capability::EMBEDDINGS],
+            ],
+            'embed-english-v3.0' => [
+                'class' => Embeddings::class,
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+            ],
+            'embed-multilingual-v3.0' => [
+                'class' => Embeddings::class,
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+            ],
+            'embed-english-light-v3.0' => [
+                'class' => Embeddings::class,
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+            ],
+            'embed-multilingual-light-v3.0' => [
+                'class' => Embeddings::class,
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+            ],
+            // Reranking models
+            'rerank-v3.5' => [
+                'class' => Reranker::class,
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::RERANKING],
+            ],
+            'rerank-english-v3.0' => [
+                'class' => Reranker::class,
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::RERANKING],
+            ],
+            'rerank-multilingual-v3.0' => [
+                'class' => Reranker::class,
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::RERANKING],
+            ],
+        ];
+
+        $this->models = array_merge($defaultModels, $additionalModels);
+    }
+}

--- a/src/platform/src/Bridge/Cohere/PlatformFactory.php
+++ b/src/platform/src/Bridge/Cohere/PlatformFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere;
+
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\Platform;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PlatformFactory
+{
+    public static function create(
+        #[\SensitiveParameter] string $apiKey,
+        ?HttpClientInterface $httpClient = null,
+        ModelCatalogInterface $modelCatalog = new ModelCatalog(),
+        ?Contract $contract = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+    ): Platform {
+        $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+
+        return new Platform(
+            [new Embeddings\ModelClient($httpClient, $apiKey), new Reranker\ModelClient($httpClient, $apiKey), new Llm\ModelClient($httpClient, $apiKey)],
+            [new Embeddings\ResultConverter(), new Reranker\ResultConverter(), new Llm\ResultConverter()],
+            $modelCatalog,
+            $contract ?? Contract::create(),
+            $eventDispatcher,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Cohere/README.md
+++ b/src/platform/src/Bridge/Cohere/README.md
@@ -1,0 +1,12 @@
+Cohere Platform
+===============
+
+Cohere platform bridge for Symfony AI.
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/ai/issues) and
+   [send Pull Requests](https://github.com/symfony/ai/pulls)
+   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/platform/src/Bridge/Cohere/Reranker.php
+++ b/src/platform/src/Bridge/Cohere/Reranker.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere;
+
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class Reranker extends Model
+{
+}

--- a/src/platform/src/Bridge/Cohere/Reranker/ModelClient.php
+++ b/src/platform/src/Bridge/Cohere/Reranker/ModelClient.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Reranker;
+
+use Symfony\AI\Platform\Bridge\Cohere\Reranker;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelClient implements ModelClientInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        #[\SensitiveParameter] private readonly string $apiKey,
+    ) {
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Reranker;
+    }
+
+    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    {
+        if (!\is_array($payload) || !isset($payload['query'], $payload['texts'])) {
+            throw new InvalidArgumentException('Reranker payload must be an array with "query" and "texts" keys.');
+        }
+
+        $body = [
+            'model' => $model->getName(),
+            'query' => $payload['query'],
+            'documents' => $payload['texts'],
+        ];
+
+        if (isset($options['top_n'])) {
+            $body['top_n'] = $options['top_n'];
+        }
+
+        return new RawHttpResult($this->httpClient->request('POST', 'https://api.cohere.com/v2/rerank', [
+            'auth_bearer' => $this->apiKey,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'json' => $body,
+        ]));
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Reranker/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Reranker/ResultConverter.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Reranker;
+
+use Symfony\AI\Platform\Bridge\Cohere\MetaBilledUnitsTokenUsageExtractor;
+use Symfony\AI\Platform\Bridge\Cohere\Reranker;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Reranking\RerankingEntry;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\RerankingResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResultConverter implements ResultConverterInterface
+{
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Reranker;
+    }
+
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): RerankingResult
+    {
+        $httpResponse = $result->getObject();
+
+        if (200 !== $httpResponse->getStatusCode()) {
+            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $httpResponse->getStatusCode(), $httpResponse->getContent(false)));
+        }
+
+        $data = $result->getData();
+
+        if (!isset($data['results'])) {
+            throw new RuntimeException('Response does not contain reranking results.');
+        }
+
+        return new RerankingResult(
+            ...array_map(
+                static fn (array $item): RerankingEntry => new RerankingEntry((int) $item['index'], (float) $item['relevance_score']),
+                $data['results'],
+            ),
+        );
+    }
+
+    public function getTokenUsageExtractor(): TokenUsageExtractorInterface
+    {
+        return new MetaBilledUnitsTokenUsageExtractor();
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/CohereTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/CohereTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Cohere;
+use Symfony\AI\Platform\Model;
+
+final class CohereTest extends TestCase
+{
+    public function testItExtendsModel()
+    {
+        $model = new Cohere('command-a-03-2025');
+
+        $this->assertInstanceOf(Model::class, $model);
+        $this->assertSame('command-a-03-2025', $model->getName());
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/Embeddings/ModelClientTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Embeddings/ModelClientTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests\Embeddings;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Cohere;
+use Symfony\AI\Platform\Bridge\Cohere\Embeddings;
+use Symfony\AI\Platform\Bridge\Cohere\Embeddings\ModelClient;
+use Symfony\AI\Platform\Bridge\Cohere\InputType;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ModelClientTest extends TestCase
+{
+    public function testItSupportsEmbeddingsModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertTrue($client->supports(new Embeddings('embed-english-v3.0')));
+    }
+
+    public function testItDoesNotSupportCohereModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertFalse($client->supports(new Cohere('command-a-03-2025')));
+    }
+
+    public function testItSendsExpectedRequest()
+    {
+        $httpClient = new MockHttpClient([function (
+            string $method,
+            string $url,
+            array $options,
+        ): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.cohere.com/v2/embed', $url);
+
+            $body = json_decode($options['body'], true);
+            $this->assertSame('embed-english-v3.0', $body['model']);
+            $this->assertSame(['Hello, world!'], $body['texts']);
+            $this->assertSame('search_document', $body['input_type']);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key');
+
+        $client->request(new Embeddings('embed-english-v3.0'), 'Hello, world!');
+    }
+
+    public function testItUsesInputTypeFromOptions()
+    {
+        $httpClient = new MockHttpClient([function (
+            string $method,
+            string $url,
+            array $options,
+        ): MockResponse {
+            $body = json_decode($options['body'], true);
+            $this->assertSame('search_query', $body['input_type']);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key');
+
+        $client->request(new Embeddings('embed-english-v3.0'), 'Hello, world!', [
+            'input_type' => InputType::SearchQuery,
+        ]);
+    }
+
+    public function testItUsesInputTypeFromModelOptions()
+    {
+        $httpClient = new MockHttpClient([function (
+            string $method,
+            string $url,
+            array $options,
+        ): MockResponse {
+            $body = json_decode($options['body'], true);
+            $this->assertSame('classification', $body['input_type']);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key');
+
+        $model = new Embeddings('embed-english-v3.0', [], ['input_type' => InputType::Classification]);
+        $client->request($model, 'Hello, world!');
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/Embeddings/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Embeddings/ResultConverterTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests\Embeddings;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Embeddings;
+use Symfony\AI\Platform\Bridge\Cohere\Embeddings\ResultConverter;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ResultConverterTest extends TestCase
+{
+    public function testItSupportsEmbeddingsModel()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertTrue($converter->supports(new Embeddings('embed-english-v3.0')));
+    }
+
+    public function testItThrowsExceptionOnNon200StatusCode()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(500);
+        $response->method('getContent')->willReturn('Internal Server Error');
+
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testItConvertsAResponseToAVectorResult()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'embeddings' => [
+                'float' => [
+                    [0.1, 0.2, 0.3],
+                ],
+            ],
+        ]);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(VectorResult::class, $result);
+        $this->assertSame([0.1, 0.2, 0.3], $result->getContent()[0]->getData());
+    }
+
+    public function testItConvertsMultipleEmbeddings()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'embeddings' => [
+                'float' => [
+                    [0.1, 0.2, 0.3],
+                    [0.4, 0.5, 0.6],
+                ],
+            ],
+        ]);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(VectorResult::class, $result);
+        $this->assertCount(2, $result->getContent());
+        $this->assertSame([0.1, 0.2, 0.3], $result->getContent()[0]->getData());
+        $this->assertSame([0.4, 0.5, 0.6], $result->getContent()[1]->getData());
+    }
+
+    public function testItThrowsExceptionWhenResponseDoesNotContainData()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn(['invalid' => 'response']);
+
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Response does not contain embedding data.');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/EmbeddingsTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/EmbeddingsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Embeddings;
+use Symfony\AI\Platform\Bridge\Cohere\InputType;
+use Symfony\AI\Platform\Model;
+
+final class EmbeddingsTest extends TestCase
+{
+    public function testItExtendsModel()
+    {
+        $model = new Embeddings('embed-english-v3.0');
+
+        $this->assertInstanceOf(Model::class, $model);
+        $this->assertSame('embed-english-v3.0', $model->getName());
+    }
+
+    public function testItAcceptsInputTypeOption()
+    {
+        $model = new Embeddings('embed-english-v3.0', [], ['input_type' => InputType::SearchQuery]);
+
+        $this->assertSame(['input_type' => InputType::SearchQuery], $model->getOptions());
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/ModelClientTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/ModelClientTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests\Llm;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Cohere;
+use Symfony\AI\Platform\Bridge\Cohere\Embeddings;
+use Symfony\AI\Platform\Bridge\Cohere\Llm\ModelClient;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ModelClientTest extends TestCase
+{
+    public function testItSupportsCohereModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertTrue($client->supports(new Cohere('command-a-03-2025')));
+    }
+
+    public function testItDoesNotSupportEmbeddingsModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertFalse($client->supports(new Embeddings('embed-english-v3.0')));
+    }
+
+    public function testItSendsExpectedRequest()
+    {
+        $httpClient = new MockHttpClient([function (
+            string $method,
+            string $url,
+            array $options,
+        ): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.cohere.com/v2/chat', $url);
+            $this->assertStringContainsString('Bearer test-key', $options['normalized_headers']['authorization'][0]);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key');
+
+        $client->request(new Cohere('command-a-03-2025'), ['model' => 'command-a-03-2025', 'messages' => []]);
+    }
+
+    public function testStringPayloadThrowsException()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Payload must be an array, but a string was given');
+
+        $client->request(new Cohere('command-a-03-2025'), 'string payload');
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests\Llm;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Cohere;
+use Symfony\AI\Platform\Bridge\Cohere\Llm\ResultConverter;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ResultConverterTest extends TestCase
+{
+    public function testItSupportsCohereModel()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertTrue($converter->supports(new Cohere('command-a-03-2025')));
+    }
+
+    public function testItThrowsExceptionOnNon200StatusCode()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(500);
+        $response->method('getContent')->willReturn('Internal Server Error');
+
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testItConvertsCompleteResponseToTextResult()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'finish_reason' => 'COMPLETE',
+            'message' => [
+                'content' => [
+                    ['type' => 'text', 'text' => 'Hello, world!'],
+                ],
+            ],
+        ]);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello, world!', $result->getContent());
+    }
+
+    public function testItConvertsToolCallResponseToToolCallResult()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'finish_reason' => 'TOOL_CALL',
+            'message' => [
+                'tool_calls' => [
+                    [
+                        'id' => 'call_123',
+                        'function' => [
+                            'name' => 'get_weather',
+                            'arguments' => '{"city":"Paris"}',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertInstanceOf(ToolCall::class, $toolCalls[0]);
+        $this->assertSame('call_123', $toolCalls[0]->getId());
+        $this->assertSame('get_weather', $toolCalls[0]->getName());
+        $this->assertSame(['city' => 'Paris'], $toolCalls[0]->getArguments());
+    }
+
+    public function testItThrowsExceptionOnUnsupportedFinishReason()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'finish_reason' => 'UNKNOWN',
+            'message' => [],
+        ]);
+
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported finish reason "UNKNOWN".');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testItConvertsStreamWithTextContent()
+    {
+        $converter = new ResultConverter();
+        $result = $converter->convert(
+            new InMemoryRawResult([], [
+                ['type' => 'content-delta', 'delta' => ['message' => ['content' => ['text' => 'Hello']]]],
+                ['type' => 'content-delta', 'delta' => ['message' => ['content' => ['text' => ', world!']]]],
+                ['type' => 'message-end', 'delta' => []],
+            ]),
+            ['stream' => true],
+        );
+
+        $chunks = iterator_to_array($result->getContent(), false);
+        $this->assertCount(2, $chunks);
+        $this->assertInstanceOf(TextDelta::class, $chunks[0]);
+        $this->assertInstanceOf(TextDelta::class, $chunks[1]);
+        $this->assertSame('Hello', $chunks[0]->getText());
+        $this->assertSame(', world!', $chunks[1]->getText());
+    }
+
+    public function testItConvertsStreamWithToolCalls()
+    {
+        $converter = new ResultConverter();
+        $result = $converter->convert(
+            new InMemoryRawResult([], [
+                ['type' => 'tool-call-start', 'delta' => ['message' => ['tool_calls' => ['id' => 'call_1', 'function' => ['name' => 'get_time', 'arguments' => '']]]]],
+                ['type' => 'tool-call-delta', 'delta' => ['message' => ['tool_calls' => ['function' => ['arguments' => '{"tz":']]]]],
+                ['type' => 'tool-call-delta', 'delta' => ['message' => ['tool_calls' => ['function' => ['arguments' => '"UTC"}']]]]],
+                ['type' => 'message-end', 'delta' => []],
+            ]),
+            ['stream' => true],
+        );
+
+        $chunks = iterator_to_array($result->getContent(), false);
+        $this->assertCount(1, $chunks);
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $toolCalls = $chunks[0]->getToolCalls();
+        $this->assertSame('call_1', $toolCalls[0]->getId());
+        $this->assertSame('get_time', $toolCalls[0]->getName());
+        $this->assertSame(['tz' => 'UTC'], $toolCalls[0]->getArguments());
+    }
+
+    public function testItConvertsToolCallWithEmptyArguments()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'finish_reason' => 'TOOL_CALL',
+            'message' => [
+                'tool_calls' => [
+                    [
+                        'id' => 'call_456',
+                        'function' => [
+                            'name' => 'get_time',
+                            'arguments' => '',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call_456', $toolCalls[0]->getId());
+        $this->assertSame('get_time', $toolCalls[0]->getName());
+        $this->assertSame([], $toolCalls[0]->getArguments());
+    }
+
+    public function testItConvertsStreamWithToolCallsWithEmptyArguments()
+    {
+        $converter = new ResultConverter();
+        $result = $converter->convert(
+            new InMemoryRawResult([], [
+                ['type' => 'tool-call-start', 'delta' => ['message' => ['tool_calls' => ['id' => 'call_1', 'function' => ['name' => 'get_time', 'arguments' => '']]]]],
+                ['type' => 'message-end', 'delta' => []],
+            ]),
+            ['stream' => true],
+        );
+
+        $chunks = iterator_to_array($result->getContent(), false);
+        $this->assertCount(1, $chunks);
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $toolCalls = $chunks[0]->getToolCalls();
+        $this->assertSame('call_1', $toolCalls[0]->getId());
+        $this->assertSame('get_time', $toolCalls[0]->getName());
+        $this->assertSame([], $toolCalls[0]->getArguments());
+    }
+
+    public function testGetTokenUsageExtractor()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertNotNull($converter->getTokenUsageExtractor());
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/TokenUsageExtractorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests\Llm;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Llm\TokenUsageExtractor;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+final class TokenUsageExtractorTest extends TestCase
+{
+    public function testItHandlesStreamResponsesWithoutProcessing()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $this->assertNull($extractor->extract(new InMemoryRawResult(), ['stream' => true]));
+    }
+
+    public function testItReturnsNullWithoutUsageData()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $this->assertNull($extractor->extract(new InMemoryRawResult(['some' => 'data'])));
+    }
+
+    public function testItExtractsTokenUsage()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'tokens' => [
+                    'input_tokens' => 15,
+                    'output_tokens' => 25,
+                ],
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(15, $tokenUsage->getPromptTokens());
+        $this->assertSame(25, $tokenUsage->getCompletionTokens());
+    }
+
+    public function testItHandlesMissingTokenFields()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'tokens' => [
+                    'input_tokens' => 10,
+                ],
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(10, $tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getCompletionTokens());
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/MetaBilledUnitsTokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/MetaBilledUnitsTokenUsageExtractorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\MetaBilledUnitsTokenUsageExtractor;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+final class MetaBilledUnitsTokenUsageExtractorTest extends TestCase
+{
+    public function testItReturnsNullWithoutMetaData()
+    {
+        $extractor = new MetaBilledUnitsTokenUsageExtractor();
+
+        $this->assertNull($extractor->extract(new InMemoryRawResult(['some' => 'data'])));
+    }
+
+    public function testItReturnsNullWithoutBilledUnitsFields()
+    {
+        $extractor = new MetaBilledUnitsTokenUsageExtractor();
+
+        $result = new InMemoryRawResult([
+            'meta' => [
+                'billed_units' => [],
+            ],
+        ]);
+
+        $this->assertNull($extractor->extract($result));
+    }
+
+    public function testItExtractsInputTokensFromEmbeddingsResponse()
+    {
+        $extractor = new MetaBilledUnitsTokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'meta' => [
+                'billed_units' => [
+                    'input_tokens' => 7,
+                ],
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(7, $tokenUsage->getPromptTokens());
+    }
+
+    public function testItExtractsSearchUnitsFromRerankingResponse()
+    {
+        $extractor = new MetaBilledUnitsTokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'meta' => [
+                'billed_units' => [
+                    'search_units' => 1,
+                ],
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(1, $tokenUsage->getPromptTokens());
+    }
+
+    public function testInputTokensTakePrecedenceOverSearchUnits()
+    {
+        $extractor = new MetaBilledUnitsTokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'meta' => [
+                'billed_units' => [
+                    'input_tokens' => 10,
+                    'search_units' => 1,
+                ],
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(10, $tokenUsage->getPromptTokens());
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/ModelCatalogTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests;
+
+use Symfony\AI\Platform\Bridge\Cohere\Cohere;
+use Symfony\AI\Platform\Bridge\Cohere\Embeddings;
+use Symfony\AI\Platform\Bridge\Cohere\ModelCatalog;
+use Symfony\AI\Platform\Bridge\Cohere\Reranker;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
+
+final class ModelCatalogTest extends ModelCatalogTestCase
+{
+    public static function modelsProvider(): iterable
+    {
+        // Chat models
+        yield 'command-a-03-2025' => ['command-a-03-2025', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
+        yield 'command-r-plus-08-2024' => ['command-r-plus-08-2024', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
+        yield 'command-r-08-2024' => ['command-r-08-2024', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
+        yield 'command-r7b-12-2024' => ['command-r7b-12-2024', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
+
+        // Embedding models
+        yield 'embed-v4.0' => ['embed-v4.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::INPUT_MULTIMODAL, Capability::EMBEDDINGS]];
+        yield 'embed-english-v3.0' => ['embed-english-v3.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'embed-multilingual-v3.0' => ['embed-multilingual-v3.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'embed-english-light-v3.0' => ['embed-english-light-v3.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'embed-multilingual-light-v3.0' => ['embed-multilingual-light-v3.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+
+        // Reranking models
+        yield 'rerank-v3.5' => ['rerank-v3.5', Reranker::class, [Capability::INPUT_MULTIPLE, Capability::RERANKING]];
+        yield 'rerank-english-v3.0' => ['rerank-english-v3.0', Reranker::class, [Capability::INPUT_MULTIPLE, Capability::RERANKING]];
+        yield 'rerank-multilingual-v3.0' => ['rerank-multilingual-v3.0', Reranker::class, [Capability::INPUT_MULTIPLE, Capability::RERANKING]];
+    }
+
+    protected function createModelCatalog(): ModelCatalogInterface
+    {
+        return new ModelCatalog();
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/PlatformFactoryTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/PlatformFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\PlatformFactory;
+use Symfony\AI\Platform\Platform;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PlatformFactoryTest extends TestCase
+{
+    public function testItCreatesPlatformWithDefaultSettings()
+    {
+        $platform = PlatformFactory::create('test-api-key');
+
+        $this->assertInstanceOf(Platform::class, $platform);
+    }
+
+    public function testItCreatesPlatformWithCustomHttpClient()
+    {
+        $httpClient = new MockHttpClient();
+        $platform = PlatformFactory::create('test-api-key', $httpClient);
+
+        $this->assertInstanceOf(Platform::class, $platform);
+    }
+
+    public function testItCreatesPlatformWithEventSourceHttpClient()
+    {
+        $httpClient = new EventSourceHttpClient(new MockHttpClient());
+        $platform = PlatformFactory::create('test-api-key', $httpClient);
+
+        $this->assertInstanceOf(Platform::class, $platform);
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/Reranker/ModelClientTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Reranker/ModelClientTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests\Reranker;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Cohere;
+use Symfony\AI\Platform\Bridge\Cohere\Reranker;
+use Symfony\AI\Platform\Bridge\Cohere\Reranker\ModelClient;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ModelClientTest extends TestCase
+{
+    public function testItSupportsRerankerModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertTrue($client->supports(new Reranker('rerank-v3.5')));
+    }
+
+    public function testItDoesNotSupportCohereModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertFalse($client->supports(new Cohere('command-a-03-2025')));
+    }
+
+    public function testItSendsExpectedRequest()
+    {
+        $httpClient = new MockHttpClient([function (
+            string $method,
+            string $url,
+            array $options,
+        ): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.cohere.com/v2/rerank', $url);
+
+            $body = json_decode($options['body'], true);
+            $this->assertSame('rerank-v3.5', $body['model']);
+            $this->assertSame('What is AI?', $body['query']);
+            $this->assertSame(['Document about AI', 'Document about cooking'], $body['documents']);
+            $this->assertArrayNotHasKey('top_n', $body);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key');
+
+        $client->request(new Reranker('rerank-v3.5'), [
+            'query' => 'What is AI?',
+            'texts' => ['Document about AI', 'Document about cooking'],
+        ]);
+    }
+
+    public function testItSendsTopNOption()
+    {
+        $httpClient = new MockHttpClient([function (
+            string $method,
+            string $url,
+            array $options,
+        ): MockResponse {
+            $body = json_decode($options['body'], true);
+            $this->assertSame(3, $body['top_n']);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key');
+
+        $client->request(new Reranker('rerank-v3.5'), [
+            'query' => 'What is AI?',
+            'texts' => ['Doc 1', 'Doc 2', 'Doc 3', 'Doc 4'],
+        ], ['top_n' => 3]);
+    }
+
+    public function testItThrowsExceptionForStringPayload()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Reranker payload must be an array with "query" and "texts" keys.');
+
+        $client->request(new Reranker('rerank-v3.5'), 'invalid string payload');
+    }
+
+    public function testItThrowsExceptionForMissingQueryKey()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Reranker payload must be an array with "query" and "texts" keys.');
+
+        $client->request(new Reranker('rerank-v3.5'), ['texts' => ['doc1']]);
+    }
+
+    public function testItThrowsExceptionForMissingTextsKey()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Reranker payload must be an array with "query" and "texts" keys.');
+
+        $client->request(new Reranker('rerank-v3.5'), ['query' => 'test']);
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/Reranker/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Reranker/ResultConverterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests\Reranker;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Reranker;
+use Symfony\AI\Platform\Bridge\Cohere\Reranker\ResultConverter;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RerankingResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ResultConverterTest extends TestCase
+{
+    public function testItSupportsRerankerModel()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertTrue($converter->supports(new Reranker('rerank-v3.5')));
+    }
+
+    public function testItThrowsExceptionOnNon200StatusCode()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(500);
+        $response->method('getContent')->willReturn('Internal Server Error');
+
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testItConvertsResponseToRerankingResult()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'results' => [
+                ['index' => 0, 'relevance_score' => 0.95],
+                ['index' => 1, 'relevance_score' => 0.42],
+            ],
+        ]);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(RerankingResult::class, $result);
+        $entries = $result->getContent();
+        $this->assertCount(2, $entries);
+        $this->assertSame(0, $entries[0]->getIndex());
+        $this->assertSame(0.95, $entries[0]->getScore());
+        $this->assertSame(1, $entries[1]->getIndex());
+        $this->assertSame(0.42, $entries[1]->getScore());
+    }
+
+    public function testItThrowsExceptionWhenResponseDoesNotContainResults()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn(['invalid' => 'response']);
+
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Response does not contain reranking results.');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/RerankerTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/RerankerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Reranker;
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RerankerTest extends TestCase
+{
+    public function testItExtendsModel()
+    {
+        $model = new Reranker('rerank-v3.5');
+
+        $this->assertInstanceOf(Model::class, $model);
+        $this->assertSame('rerank-v3.5', $model->getName());
+    }
+}

--- a/src/platform/src/Bridge/Cohere/composer.json
+++ b/src/platform/src/Bridge/Cohere/composer.json
@@ -1,0 +1,57 @@
+{
+    "name": "symfony/ai-cohere-platform",
+    "description": "Cohere platform bridge for Symfony AI",
+    "license": "MIT",
+    "type": "symfony-ai-platform",
+    "keywords": [
+        "ai",
+        "bridge",
+        "chat",
+        "cohere",
+        "embeddings",
+        "platform",
+        "reranking"
+    ],
+    "authors": [
+        {
+            "name": "Johannes Wachter",
+            "email": "johannes@sulu.io"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/ai-platform": "^0.6",
+        "symfony/http-client": "^7.3|^8.0"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.5.53"
+    },
+    "minimum-stability": "dev",
+    "autoload": {
+        "psr-4": {
+            "Symfony\\AI\\Platform\\Bridge\\Cohere\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\AI\\PHPStan\\": "../../../../../.phpstan/",
+            "Symfony\\AI\\Platform\\Bridge\\Cohere\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ai",
+            "url": "https://github.com/symfony/ai"
+        }
+    }
+}

--- a/src/platform/src/Bridge/Cohere/phpstan.dist.neon
+++ b/src/platform/src/Bridge/Cohere/phpstan.dist.neon
@@ -1,0 +1,29 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../../../../../.phpstan/extension.neon
+
+parameters:
+    level: 6
+    paths:
+        - .
+        - Tests/
+    excludePaths:
+        - vendor/
+    treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+            reportUnmatched: false
+        -
+            message: '#^Call to( static)? method PHPUnit\\Framework\\Assert::.* will always evaluate to true\.$#'
+            reportUnmatched: false
+        -
+            identifier: 'symfonyAi.forbidNativeException'
+            path: Tests/*
+            reportUnmatched: false
+
+services:
+    - # Conditionally enabled by bleeding edge in phpstan/phpstan-phpunit 2.x
+        class: PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension
+        tags:
+            - phpstan.ignoreErrorExtension

--- a/src/platform/src/Bridge/Cohere/phpunit.xml.dist
+++ b/src/platform/src/Bridge/Cohere/phpunit.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         executionOrder="random"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony AI Cohere Platform Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

### Summary

Requires: https://github.com/symfony/ai/pull/1704#discussion_r2891409991

Add a dedicated bridge for the [Cohere](https://cohere.com/) v2 API covering chat (streaming + tool calling), embeddings (with `input_type` support), and reranking.

### Usage

```php
$platform = PlatformFactory::create($apiKey);

// Chat (+ streaming with ['stream' => true])
$result = $platform->invoke('command-a-03-2025', $messages);

// Embeddings with InputType enum
$result = $platform->invoke('embed-english-v3.0', 'text', [
    'input_type' => InputType::SearchDocument,
]);

// Reranking
$result = $platform->invoke('rerank-v3.5', ['query' => '...', 'texts' => ['...']]);
```

### Features

- **Chat**: Streaming, tool calling, token usage tracking via `Llm\TokenUsageExtractor`
- **Embeddings**: `InputType` enum (`SearchDocument`, `SearchQuery`, `Classification`, `Clustering`, `Image`) for discoverable input type selection
- **Reranking**: Full reranking support with relevance scores
- **Token usage**: `MetaBilledUnitsTokenUsageExtractor` extracts token usage from `meta.billed_units` for embeddings and reranking responses (first bridge to do so)
- **Model catalog**: Pre-configured models for chat, embeddings, and reranking
- **AI Bundle integration**: Full Symfony bundle configuration support

### Notes

Cohere v2 SSE uses event: + data: fields. A custom `Llm\RawHttpResult` ensures the response is streamed through the same `EventSourceHttpClient` that created it, which is required for proper SSE event parsing.