### PR TITLE
[Store] Add PreQueryEvent for query enhancement

### DIFF
--- a/examples/retriever/hybrid-rrf-reranking.php
+++ b/examples/retriever/hybrid-rrf-reranking.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Fixtures\Movies;
+use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
+use Symfony\AI\Store\CombinedStore;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Event\PostQueryEvent;
+use Symfony\AI\Store\EventListener\RerankerListener;
+use Symfony\AI\Store\Indexer\DocumentIndexer;
+use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Reranker\Reranker;
+use Symfony\AI\Store\Retriever;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Uid\Uuid;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+echo "=== Hybrid RRF + HuggingFace Reranking via PostQueryEvent ===\n\n";
+echo "This example demonstrates CombinedStore with RRF, followed by\n";
+echo "cross-encoder reranking via a PostQueryEvent listener.\n\n";
+
+$store = new InMemoryStore();
+
+$documents = [];
+foreach (Movies::all() as $movie) {
+    $documents[] = new TextDocument(
+        id: Uuid::v4(),
+        content: 'Title: '.$movie['title'].\PHP_EOL.'Director: '.$movie['director'].\PHP_EOL.'Description: '.$movie['description'],
+        metadata: new Metadata($movie),
+    );
+}
+
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
+$vectorizer = new Vectorizer($platform, 'BAAI/bge-small-en-v1.5?task=feature-extraction', logger());
+$indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
+$indexer->index($documents);
+
+$queryText = 'crime family mafia';
+echo "Query: \"$queryText\"\n\n";
+
+// 1. Hybrid RRF without reranking
+echo "--- Hybrid RRF Results (no reranking) ---\n";
+$combinedStore = new CombinedStore($store, $store, rrfK: 60);
+$hybridRetriever = new Retriever($combinedStore, $vectorizer, logger: logger());
+
+$results = iterator_to_array($hybridRetriever->retrieve($queryText));
+
+foreach ($results as $i => $document) {
+    echo sprintf(
+        "  %d. %s (RRF Score: %.6f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+// 2. Hybrid RRF + reranking via PostQueryEvent
+echo "--- Hybrid RRF + HuggingFace Reranking Results ---\n";
+$reranker = new Reranker($platform, 'BAAI/bge-reranker-base?task=text-ranking', logger());
+
+$dispatcher = new EventDispatcher();
+$dispatcher->addListener(PostQueryEvent::class, new RerankerListener($reranker, topK: 5));
+
+$hybridWithReranker = new Retriever($combinedStore, $vectorizer, $dispatcher, logger: logger());
+
+$rerankedResults = iterator_to_array($hybridWithReranker->retrieve($queryText));
+
+foreach ($rerankedResults as $i => $document) {
+    echo sprintf(
+        "  %d. %s (Relevance: %.4f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+echo "=== Summary ===\n";
+echo "- CombinedStore merges vector and text results using RRF scoring\n";
+echo "- RerankerListener on PostQueryEvent refines results using a cross-encoder model\n";

--- a/examples/retriever/hybrid-rrf.php
+++ b/examples/retriever/hybrid-rrf.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Fixtures\Movies;
+use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
+use Symfony\AI\Store\CombinedStore;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Indexer\DocumentIndexer;
+use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Retriever;
+use Symfony\Component\Uid\Uuid;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+echo "=== Hybrid Retrieval with CombinedStore + RRF ===\n\n";
+echo "This example demonstrates combining vector (semantic) and text (keyword)\n";
+echo "retrieval using CombinedStore with Reciprocal Rank Fusion (RRF).\n\n";
+
+$store = new InMemoryStore();
+
+$documents = [];
+foreach (Movies::all() as $movie) {
+    $documents[] = new TextDocument(
+        id: Uuid::v4(),
+        content: 'Title: '.$movie['title'].\PHP_EOL.'Director: '.$movie['director'].\PHP_EOL.'Description: '.$movie['description'],
+        metadata: new Metadata($movie),
+    );
+}
+
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
+$vectorizer = new Vectorizer($platform, 'BAAI/bge-small-en-v1.5?task=feature-extraction', logger());
+$indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
+$indexer->index($documents);
+
+$queryText = 'crime family mafia';
+echo "Query: \"$queryText\"\n\n";
+
+// 1. Vector-only results
+echo "--- Vector-Only Results (semantic similarity) ---\n";
+$vectorRetriever = new Retriever($store, $vectorizer, logger: logger());
+$results = iterator_to_array($vectorRetriever->retrieve($queryText));
+
+foreach ($results as $i => $document) {
+    echo sprintf(
+        "  %d. %s (Score: %.4f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+// 2. Text-only results
+echo "--- Text-Only Results (keyword matching) ---\n";
+$textRetriever = new Retriever($store, logger: logger());
+$results = iterator_to_array($textRetriever->retrieve($queryText));
+
+foreach ($results as $i => $document) {
+    echo sprintf(
+        "  %d. %s (Score: %.4f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+// 3. Hybrid retrieval with CombinedStore + RRF
+echo "--- Hybrid RRF Results (CombinedStore) ---\n";
+$combinedStore = new CombinedStore($store, $store, rrfK: 60);
+$hybridRetriever = new Retriever($combinedStore, $vectorizer, logger: logger());
+
+$results = iterator_to_array($hybridRetriever->retrieve($queryText));
+
+foreach ($results as $i => $document) {
+    echo sprintf(
+        "  %d. %s (RRF Score: %.6f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+echo "=== Summary ===\n";
+echo "- Vector retrieval finds semantically similar documents via embeddings\n";
+echo "- Text retrieval matches documents by keyword overlap\n";
+echo "- CombinedStore merges both result lists using rank-based RRF scoring\n";

--- a/examples/retriever/query-expansion.php
+++ b/examples/retriever/query-expansion.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Fixtures\Movies;
+use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
+use Symfony\AI\Store\CombinedStore;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Event\PostQueryEvent;
+use Symfony\AI\Store\Event\PreQueryEvent;
+use Symfony\AI\Store\EventListener\RerankerListener;
+use Symfony\AI\Store\Indexer\DocumentIndexer;
+use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Reranker\Reranker;
+use Symfony\AI\Store\Retriever;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Uid\Uuid;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+echo "=== Query Expansion via PreQueryEvent + Reranking ===\n\n";
+echo "This example demonstrates using PreQueryEvent to expand a vague query\n";
+echo "with related terms, and PostQueryEvent to rerank with a cross-encoder.\n\n";
+
+$store = new InMemoryStore();
+
+$documents = [];
+foreach (Movies::all() as $movie) {
+    $documents[] = new TextDocument(
+        id: Uuid::v4(),
+        content: 'Title: '.$movie['title'].\PHP_EOL.'Director: '.$movie['director'].\PHP_EOL.'Description: '.$movie['description'],
+        metadata: new Metadata($movie),
+    );
+}
+
+$platform = PlatformFactory::create(env('HUGGINGFACE_KEY'), httpClient: http_client());
+$vectorizer = new Vectorizer($platform, 'BAAI/bge-small-en-v1.5?task=feature-extraction', logger());
+$indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
+$indexer->index($documents);
+
+$combinedStore = new CombinedStore($store, $store, rrfK: 60);
+$reranker = new Reranker($platform, 'BAAI/bge-reranker-base?task=text-ranking', logger());
+
+$vagueQuery = 'gangster';
+echo "Original query: \"$vagueQuery\"\n\n";
+
+// 1. Without query expansion
+echo "--- Without Query Expansion ---\n";
+$retriever = new Retriever($combinedStore, $vectorizer, logger: logger());
+$results = iterator_to_array($retriever->retrieve($vagueQuery));
+
+foreach (array_slice($results, 0, 5) as $i => $document) {
+    echo sprintf(
+        "  %d. %s (Score: %.6f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+// 2. With query expansion via PreQueryEvent + reranking via PostQueryEvent
+echo "--- With Query Expansion + Reranking ---\n";
+$dispatcher = new EventDispatcher();
+
+// Pre-retrieval: expand the query with related terms
+$dispatcher->addListener(PreQueryEvent::class, static function (PreQueryEvent $event) {
+    $expanded = $event->getQuery().' crime family mafia organized crime';
+    echo "Enhanced query: \"$expanded\"\n";
+    $event->setQuery($expanded);
+});
+
+// Post-retrieval: rerank with cross-encoder
+$dispatcher->addListener(PostQueryEvent::class, new RerankerListener($reranker, topK: 5));
+
+$expandedRetriever = new Retriever($combinedStore, $vectorizer, $dispatcher, logger: logger());
+$results = iterator_to_array($expandedRetriever->retrieve($vagueQuery));
+
+foreach ($results as $i => $document) {
+    echo sprintf(
+        "  %d. %s (Relevance: %.4f)\n",
+        $i + 1,
+        $document->getMetadata()['title'] ?? 'Unknown',
+        $document->getScore() ?? 0.0,
+    );
+}
+echo "\n";
+
+echo "=== Summary ===\n";
+echo "- PreQueryEvent allows modifying the query before vectorization and store lookup\n";
+echo "- Use cases: query expansion, spelling correction, synonym injection\n";
+echo "- Combined with PostQueryEvent reranking for a full retrieval pipeline\n";

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `RstLoader` and `RstToctreeLoader` for loading RST files and following toctree directives
+ * Add pre-query event dispatching for query enhancement before vectorization
  * Add platform-based `Reranker` for cross-encoder reranking via `PlatformInterface`
  * Add `CombinedStore` combining vector and text stores with Reciprocal Rank Fusion (RRF)
  * [BC BREAK] Add `?EventDispatcherInterface $eventDispatcher` as 3rd constructor parameter of `Retriever` (before `$logger`)

--- a/src/store/src/Event/PreQueryEvent.php
+++ b/src/store/src/Event/PreQueryEvent.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event dispatched before documents are retrieved from the store.
+ *
+ * Listeners can modify the query string and options, for example to expand
+ * the query, correct spelling, inject synonyms, or adjust options like semanticRatio.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PreQueryEvent extends Event
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(
+        private string $query,
+        private array $options = [],
+    ) {
+    }
+
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+
+    public function setQuery(string $query): void
+    {
+        $this->query = $query;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+}

--- a/src/store/src/Retriever.php
+++ b/src/store/src/Retriever.php
@@ -17,6 +17,7 @@ use Psr\Log\NullLogger;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Document\VectorizerInterface;
 use Symfony\AI\Store\Event\PostQueryEvent;
+use Symfony\AI\Store\Event\PreQueryEvent;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\QueryInterface;
 use Symfony\AI\Store\Query\TextQuery;
@@ -44,6 +45,10 @@ final class Retriever implements RetrieverInterface
     {
         $this->logger->debug('Starting document retrieval', ['query' => $query, 'options' => $options]);
 
+        if (null !== $this->eventDispatcher) {
+            [$query, $options] = $this->dispatchPreQuery($query, $options);
+        }
+
         $queryObject = $this->createQuery($query, $options);
 
         $this->logger->debug('Searching store', ['query_type' => $queryObject::class]);
@@ -51,7 +56,7 @@ final class Retriever implements RetrieverInterface
         $documents = $this->store->query($queryObject, $options);
 
         if (null !== $this->eventDispatcher) {
-            $documents = $this->dispatchPostRetrieval($query, $documents, $options);
+            $documents = $this->dispatchPostQuery($query, $documents, $options);
         }
 
         return $this->yieldDocuments($documents);
@@ -74,12 +79,25 @@ final class Retriever implements RetrieverInterface
     }
 
     /**
+     * @param array<string, mixed> $options
+     *
+     * @return array{string, array<string, mixed>}
+     */
+    private function dispatchPreQuery(string $query, array $options): array
+    {
+        $event = new PreQueryEvent($query, $options);
+        $this->eventDispatcher?->dispatch($event);
+
+        return [$event->getQuery(), $event->getOptions()];
+    }
+
+    /**
      * @param iterable<VectorDocument> $documents
      * @param array<string, mixed>     $options
      *
      * @return iterable<VectorDocument>
      */
-    private function dispatchPostRetrieval(string $query, iterable $documents, array $options): iterable
+    private function dispatchPostQuery(string $query, iterable $documents, array $options): iterable
     {
         $event = new PostQueryEvent($query, $documents, $options);
         $this->eventDispatcher?->dispatch($event);

--- a/src/store/tests/RetrieverTest.php
+++ b/src/store/tests/RetrieverTest.php
@@ -19,6 +19,7 @@ use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Event\PostQueryEvent;
+use Symfony\AI\Store\Event\PreQueryEvent;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
@@ -297,20 +298,24 @@ final class RetrieverTest extends TestCase
             'text-embedding-3-small'
         );
 
+        $postRetrievalEvent = null;
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $dispatcher->expects($this->once())
+        $dispatcher->expects($this->exactly(2))
             ->method('dispatch')
-            ->with($this->callback(static function ($event) {
-                return $event instanceof PostQueryEvent
-                    && 'test query' === $event->getQuery()
-                    && 1 === \count(iterator_to_array($event->getDocuments()));
-            }))
-            ->willReturnArgument(0);
+            ->willReturnCallback(static function ($event) use (&$postRetrievalEvent) {
+                if ($event instanceof PostQueryEvent) {
+                    $postRetrievalEvent = $event;
+                }
+
+                return $event;
+            });
 
         $retriever = new Retriever($store, $vectorizer, $dispatcher);
         $results = iterator_to_array($retriever->retrieve('test query'));
 
         $this->assertCount(1, $results);
+        $this->assertInstanceOf(PostQueryEvent::class, $postRetrievalEvent);
+        $this->assertSame('test query', $postRetrievalEvent->getQuery());
     }
 
     public function testRetrieveWithEventDispatcherReturnsModifiedDocuments()
@@ -336,9 +341,12 @@ final class RetrieverTest extends TestCase
         );
 
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $dispatcher->method('dispatch')
-            ->willReturnCallback(static function (PostQueryEvent $event) use ($rerankedDocument) {
-                $event->setDocuments([$rerankedDocument]);
+        $dispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(static function ($event) use ($rerankedDocument) {
+                if ($event instanceof PostQueryEvent) {
+                    $event->setDocuments([$rerankedDocument]);
+                }
 
                 return $event;
             });
@@ -373,5 +381,103 @@ final class RetrieverTest extends TestCase
         // Without dispatcher, should be a Generator (yield behavior)
         $this->assertInstanceOf(\Generator::class, $results);
         $this->assertCount(1, iterator_to_array($results));
+    }
+
+    public function testRetrieveWithPreQueryEventModifiesQuery()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, true],
+                [HybridQuery::class, true],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->with(
+                $this->callback(static function ($query) {
+                    return $query instanceof HybridQuery && 'expanded query terms' === $query->getText();
+                }),
+                $this->anything()
+            )
+            ->willReturn([$document]);
+
+        $queryVector = new Vector([0.2, 0.3, 0.4]);
+        $vectorizer = new Vectorizer(
+            PlatformTestHandler::createPlatform(new VectorResult($queryVector)),
+            'text-embedding-3-small'
+        );
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(static function ($event) {
+                if ($event instanceof PreQueryEvent) {
+                    $event->setQuery('expanded query terms');
+                }
+
+                return $event;
+            });
+
+        $retriever = new Retriever($store, $vectorizer, $dispatcher);
+        $results = iterator_to_array($retriever->retrieve('original query'));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrieveWithPreQueryEventModifiesOptions()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, true],
+                [HybridQuery::class, true],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->with(
+                $this->callback(static function ($query) {
+                    return $query instanceof HybridQuery && 0.9 === $query->getSemanticRatio();
+                }),
+                $this->anything()
+            )
+            ->willReturn([$document]);
+
+        $queryVector = new Vector([0.2, 0.3, 0.4]);
+        $vectorizer = new Vectorizer(
+            PlatformTestHandler::createPlatform(new VectorResult($queryVector)),
+            'text-embedding-3-small'
+        );
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(static function ($event) {
+                if ($event instanceof PreQueryEvent) {
+                    $event->setOptions(['semanticRatio' => 0.9]);
+                }
+
+                return $event;
+            });
+
+        $retriever = new Retriever($store, $vectorizer, $dispatcher);
+        $results = iterator_to_array($retriever->retrieve('test query', ['semanticRatio' => 0.5]));
+
+        $this->assertCount(1, $results);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

## Summary

Requires: https://github.com/symfony/ai/pull/1704 (merged)

This adds a `PreQueryEvent` dispatched **before vectorization** in the `Retriever`, symmetric to the existing `PostQueryEvent`. Together they give full control over both the input and output of the retrieval pipeline.

### Use cases

- **Query expansion** — enrich vague queries with synonyms or related terms
- **Spelling correction** — fix typos before they get vectorized
- **Query rewriting** — rephrase via LLM for better embedding quality
- **Option adjustment** — dynamically change `semanticRatio` or other options

### Pipeline

```
Retriever::retrieve("search text", $options)
  → dispatch PreQueryEvent($query, $options)
      → listeners may modify query and options
  → createQuery() → store->query()
  → dispatch PostQueryEvent($query, $documents, $options)
  → yield documents
```

### Usage

**Query expansion:**
```php
$dispatcher->addListener(PreQueryEvent::class, function (PreQueryEvent $event) {
    $event->setQuery($event->getQuery() . ' crime family mafia organized crime');
});
```

**Option adjustment:**
```php
$dispatcher->addListener(PreQueryEvent::class, function (PreQueryEvent $event) {
    $event->setOptions(['semanticRatio' => 0.9]);
});
```