### PR TITLE
[Platform] Clarify thrown exceptions and normalize exception taxonomy

### DIFF
--- a/src/platform/README.md
+++ b/src/platform/README.md
@@ -56,6 +56,57 @@ To use a specific AI platform, install the corresponding bridge package:
 **This repository is a READ-ONLY sub-tree split**. See
 https://github.com/symfony/ai to create issues or submit pull requests.
 
+## Exception strategy
+
+The Platform component defines its own exception taxonomy. Consumers of this component should depend on Platform exceptions rather than on exceptions from lower-level libraries such as HTTP clients, process execution libraries, or provider SDKs.
+
+In other words, the public contract of this component is expressed through exceptions in the `Symfony\AI\Platform\Exception\` namespace. Bridge implementations are expected to normalize provider-specific and transport-specific failures into these Platform exceptions before they cross the `PlatformInterface`, `ModelClientInterface`, or `ResultConverterInterface` boundaries.
+
+### Exception categories
+
+The current exception set is intended to cover several different kinds of failures, including:
+
+- authentication and authorization problems, for example `AuthenticationException`
+- invalid input or request problems:
+  - `InvalidArgumentException` for invalid usage of the Platform API by the caller
+  - `InvalidRequestException` for semantically invalid requests in the Platform/provider contract
+  - `BadRequestException` for generic provider-side request rejection when no narrower Platform exception applies
+- model resolution and support problems, for example `ModelNotFoundException` or `MissingModelSupportException`
+- provider-side runtime limits or policies, for example `RateLimitExceededException`, `ExceedContextSizeException`, or `ContentFilterException`
+- conversion or contract mismatches, for example `UnexpectedResultTypeException`
+- broader component-level failures, through `LogicException`, `RuntimeException`, and `ExceptionInterface`
+
+### Recoverable and unrecoverable failures
+
+When handling failures, consumers will often want to distinguish between:
+
+- recoverable runtime failures, such as temporary transport errors, transient provider failures, or rate limiting, where retry, backoff, or failover may be appropriate
+- unrecoverable failures, such as authentication errors, invalid requests, unsupported models, or invalid configuration, where the request is not expected to succeed without changing the input or setup
+
+Concrete Platform exceptions should make that distinction clear enough for consumers to write reliable error-handling and retry logic.
+
+### What consumers should catch
+
+Code that depends on this component should prefer catching Platform exceptions at the appropriate level of specificity.
+
+Typical strategies include:
+
+- catching a specific exception, such as `RateLimitExceededException`, when a dedicated reaction is needed
+- catching a broader Platform runtime exception when multiple provider/runtime failures should be handled the same way
+- catching `ExceptionInterface` as a final fallback for component-level handling
+
+Consumers should avoid coupling application code to bridge-specific exceptions or to exceptions from lower-level dependencies, because that reduces the value of the Platform abstraction and makes switching providers harder.
+
+### What bridge authors should do
+
+Implementers of Platform bridges should normalize lower-level failures into Platform exceptions as close as possible to where the failure is detected.
+
+As a rule of thumb:
+
+- `ModelClientInterface` implementations should normalize transport, provider, authentication, throttling, and model lookup/support failures
+- `ResultConverterInterface` implementations should normalize response-shape, content filtering, context-size, and conversion failures
+- `PlatformInterface` implementations should preserve the Platform-level exception contract and should not leak raw dependency exceptions across the abstraction boundary
+
 ## Resources
 
 - [Documentation](https://symfony.com/doc/current/ai/components/platform.html)

--- a/src/platform/src/Exception/AuthenticationException.php
+++ b/src/platform/src/Exception/AuthenticationException.php
@@ -17,6 +17,6 @@ namespace Symfony\AI\Platform\Exception;
  * @author Vitalii Kyktov <vitalii.kyktov@gmail.com>
  * @author Dmytro Liashko <dmlyashko@gmail.com>
  */
-class AuthenticationException extends RuntimeException
+class AuthenticationException extends UnrecoverableRuntimeException
 {
 }

--- a/src/platform/src/Exception/BadRequestException.php
+++ b/src/platform/src/Exception/BadRequestException.php
@@ -14,6 +14,6 @@ namespace Symfony\AI\Platform\Exception;
 /**
  * @author Oscar Esteve <oscarsdt@gmail.com>
  */
-class BadRequestException extends RuntimeException
+class BadRequestException extends UnrecoverableRuntimeException
 {
 }

--- a/src/platform/src/Exception/ContentFilterException.php
+++ b/src/platform/src/Exception/ContentFilterException.php
@@ -14,6 +14,6 @@ namespace Symfony\AI\Platform\Exception;
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-class ContentFilterException extends InvalidArgumentException
+class ContentFilterException extends UnrecoverableRuntimeException
 {
 }

--- a/src/platform/src/Exception/DebugAwareExceptionInterface.php
+++ b/src/platform/src/Exception/DebugAwareExceptionInterface.php
@@ -12,8 +12,11 @@
 namespace Symfony\AI\Platform\Exception;
 
 /**
- * @author Mathieu Santostefano <msantostefano@proton.me>
+ * @author Dezső Biczó <mxr576@gmail.com>
  */
-class ExceedContextSizeException extends UnrecoverableRuntimeException
+interface DebugAwareExceptionInterface extends ExceptionInterface
 {
+    public function getDebug(): string;
+
+    public function appendDebug(string $debug): void;
 }

--- a/src/platform/src/Exception/InvalidRequestException.php
+++ b/src/platform/src/Exception/InvalidRequestException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\AI\Platform\Exception;
 
-class InvalidRequestException extends InvalidArgumentException
+class InvalidRequestException extends UnrecoverableRuntimeException
 {
 }

--- a/src/platform/src/Exception/MissingModelSupportException.php
+++ b/src/platform/src/Exception/MissingModelSupportException.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Model;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class MissingModelSupportException extends RuntimeException
+final class MissingModelSupportException extends UnrecoverableRuntimeException
 {
     private function __construct(Model $model, string $support)
     {

--- a/src/platform/src/Exception/ModelNotFoundException.php
+++ b/src/platform/src/Exception/ModelNotFoundException.php
@@ -14,6 +14,6 @@ namespace Symfony\AI\Platform\Exception;
 /**
  * @author Mathieu Santostefano <msantostefano@proton.me>
  */
-class ModelNotFoundException extends \InvalidArgumentException implements ExceptionInterface
+class ModelNotFoundException extends UnrecoverableRuntimeException
 {
 }

--- a/src/platform/src/Exception/ProviderUnavailableException.php
+++ b/src/platform/src/Exception/ProviderUnavailableException.php
@@ -12,8 +12,8 @@
 namespace Symfony\AI\Platform\Exception;
 
 /**
- * @author Mathieu Santostefano <msantostefano@proton.me>
+ * @author Dezső Biczó <mxr576@gmail.com>
  */
-class ExceedContextSizeException extends UnrecoverableRuntimeException
+final class ProviderUnavailableException extends RecoverableRuntimeException
 {
 }

--- a/src/platform/src/Exception/RateLimitExceededException.php
+++ b/src/platform/src/Exception/RateLimitExceededException.php
@@ -14,7 +14,7 @@ namespace Symfony\AI\Platform\Exception;
 /**
  * @author Floran Pagliai <floran.pagliai@gmail.com>
  */
-final class RateLimitExceededException extends RuntimeException
+final class RateLimitExceededException extends RecoverableRuntimeException
 {
     public function __construct(
         private readonly ?int $retryAfter = null,

--- a/src/platform/src/Exception/RecoverableExceptionInterface.php
+++ b/src/platform/src/Exception/RecoverableExceptionInterface.php
@@ -12,8 +12,10 @@
 namespace Symfony\AI\Platform\Exception;
 
 /**
- * @author Mathieu Santostefano <msantostefano@proton.me>
+ * Marks failures that may succeed when retried later.
+ *
+ * @author Dezső Biczó <mxr576@gmail.com>
  */
-class ExceedContextSizeException extends UnrecoverableRuntimeException
+interface RecoverableExceptionInterface extends ExceptionInterface
 {
 }

--- a/src/platform/src/Exception/RecoverableRuntimeException.php
+++ b/src/platform/src/Exception/RecoverableRuntimeException.php
@@ -12,8 +12,8 @@
 namespace Symfony\AI\Platform\Exception;
 
 /**
- * @author Mathieu Santostefano <msantostefano@proton.me>
+ * @author Dezső Biczó <mxr576@gmail.com>
  */
-class ExceedContextSizeException extends UnrecoverableRuntimeException
+abstract class RecoverableRuntimeException extends RuntimeException implements RecoverableExceptionInterface
 {
 }

--- a/src/platform/src/Exception/TransportException.php
+++ b/src/platform/src/Exception/TransportException.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Exception;
+
+final class TransportException extends RecoverableRuntimeException implements DebugAwareExceptionInterface
+{
+    private string $debug = '';
+
+    public function getDebug(): string
+    {
+        return $this->debug;
+    }
+
+    public function appendDebug(string $debug): void
+    {
+        if ('' === $debug) {
+            return;
+        }
+
+        if ('' !== $this->debug) {
+            $this->debug .= "\n";
+        }
+
+        $this->debug .= $debug;
+    }
+}

--- a/src/platform/src/Exception/UnexpectedResultTypeException.php
+++ b/src/platform/src/Exception/UnexpectedResultTypeException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Platform\Exception;
 
-class UnexpectedResultTypeException extends RuntimeException
+class UnexpectedResultTypeException extends UnrecoverableRuntimeException
 {
     public function __construct(string $expectedType, string $actualType)
     {

--- a/src/platform/src/Exception/UnrecoverableExceptionInterface.php
+++ b/src/platform/src/Exception/UnrecoverableExceptionInterface.php
@@ -12,8 +12,10 @@
 namespace Symfony\AI\Platform\Exception;
 
 /**
- * @author Mathieu Santostefano <msantostefano@proton.me>
+ * Marks failures that are not expected to succeed without changing the request or configuration.
+ *
+ * @author Dezső Biczó <mxr576@gmail.com>
  */
-class ExceedContextSizeException extends UnrecoverableRuntimeException
+interface UnrecoverableExceptionInterface extends ExceptionInterface
 {
 }

--- a/src/platform/src/Exception/UnrecoverableRuntimeException.php
+++ b/src/platform/src/Exception/UnrecoverableRuntimeException.php
@@ -12,8 +12,8 @@
 namespace Symfony\AI\Platform\Exception;
 
 /**
- * @author Mathieu Santostefano <msantostefano@proton.me>
+ * @author Dezső Biczó <mxr576@gmail.com>
  */
-class ExceedContextSizeException extends UnrecoverableRuntimeException
+abstract class UnrecoverableRuntimeException extends RuntimeException implements UnrecoverableExceptionInterface
 {
 }

--- a/src/platform/src/ModelClientInterface.php
+++ b/src/platform/src/ModelClientInterface.php
@@ -11,6 +11,15 @@
 
 namespace Symfony\AI\Platform;
 
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\ExceptionInterface;
+use Symfony\AI\Platform\Exception\InvalidRequestException;
+use Symfony\AI\Platform\Exception\MissingModelSupportException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Exception\RecoverableExceptionInterface;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\TransportException;
+use Symfony\AI\Platform\Exception\UnrecoverableExceptionInterface;
 use Symfony\AI\Platform\Result\RawResultInterface;
 
 /**
@@ -23,6 +32,16 @@ interface ModelClientInterface
     /**
      * @param array<string|int, mixed> $payload
      * @param array<string, mixed>     $options
+     *
+     * @throws ExceptionInterface
+     * @throws RuntimeException
+     * @throws RecoverableExceptionInterface
+     * @throws UnrecoverableExceptionInterface
+     * @throws AuthenticationException
+     * @throws InvalidRequestException
+     * @throws MissingModelSupportException
+     * @throws RateLimitExceededException
+     * @throws TransportException
      */
     public function request(Model $model, array|string $payload, array $options = []): RawResultInterface;
 }

--- a/src/platform/src/PlatformInterface.php
+++ b/src/platform/src/PlatformInterface.php
@@ -11,6 +11,20 @@
 
 namespace Symfony\AI\Platform;
 
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
+use Symfony\AI\Platform\Exception\ExceptionInterface;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Exception\InvalidRequestException;
+use Symfony\AI\Platform\Exception\MissingModelSupportException;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Exception\RecoverableExceptionInterface;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\TransportException;
+use Symfony\AI\Platform\Exception\UnexpectedResultTypeException;
+use Symfony\AI\Platform\Exception\UnrecoverableExceptionInterface;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 
@@ -23,6 +37,21 @@ interface PlatformInterface
      * @param non-empty-string           $model   The model name
      * @param array<mixed>|string|object $input   The input data
      * @param array<string, mixed>       $options The options to customize the model invocation
+     *
+     * @throws ExceptionInterface
+     * @throws RuntimeException
+     * @throws RecoverableExceptionInterface
+     * @throws UnrecoverableExceptionInterface
+     * @throws AuthenticationException
+     * @throws InvalidArgumentException
+     * @throws InvalidRequestException
+     * @throws MissingModelSupportException
+     * @throws ModelNotFoundException
+     * @throws RateLimitExceededException
+     * @throws TransportException
+     * @throws ContentFilterException
+     * @throws ExceedContextSizeException
+     * @throws UnexpectedResultTypeException
      */
     public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult;
 

--- a/src/platform/src/ResultConverterInterface.php
+++ b/src/platform/src/ResultConverterInterface.php
@@ -11,7 +11,14 @@
 
 namespace Symfony\AI\Platform;
 
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\ExceptionInterface;
+use Symfony\AI\Platform\Exception\InvalidRequestException;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\UnexpectedResultTypeException;
+use Symfony\AI\Platform\Exception\UnrecoverableExceptionInterface;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
@@ -31,6 +38,13 @@ interface ResultConverterInterface
      * @param array<string, mixed> $options
      *
      * @throws ExceptionInterface
+     * @throws RuntimeException
+     * @throws UnrecoverableExceptionInterface
+     * @throws AuthenticationException
+     * @throws InvalidRequestException
+     * @throws ContentFilterException
+     * @throws ExceedContextSizeException
+     * @throws UnexpectedResultTypeException
      */
     public function convert(RawResultInterface $result, array $options = []): ResultInterface;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | yes
| Issues        | Fix #1637
| License       | MIT

This PR showcases potential improvements that could be added related to #1637. Code in this PR got inspired by how [Symfony Messenger component ](https://github.com/symfony/messenger/tree/8.1/Exception)categories and exposes exceptions. 

TODO:
-  [ ] Consider moving exception hierarchy documentation to docs