### PR TITLE
 Change 'host_url' to 'endpoint' for ollama in the docs

### DIFF
--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -74,7 +74,7 @@ Advanced Example with Multiple Agents
             # vertexai:
             #     api_key: '%env(GOOGLE_CLOUD_VERTEX_API_KEY)%'
             ollama:
-                host_url: '%env(OLLAMA_HOST_URL)%'
+                endpoint: '%env(OLLAMA_HOST_URL)%'
             transformersphp: ~
         agent:
             rag:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->

I recently updated symfony/ai-ollama from 0.2.0 to 0.6.0 and I noticed that 'host_url' in the config is now 'endpoint', but the docs weren't updated to reflect this.