### PR TITLE
[Cache] Fix support for `MessageBag` and string

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -220,6 +220,22 @@ Platform
     }
    ```
 
+ * `Bridge\Cache\CachePlatform` now caches by default when its `$cacheKey` constructor argument is set.
+   The argument was previously never read: caching only engaged when the `prompt_cache_key` invocation
+   option was passed. Applications wiring a cache platform through the AI Bundle are affected, since its
+   `cache_key` option defaults to the platform name, so every call is cached instead of only the calls
+   opting in. Leave `$cacheKey` null and keep passing `prompt_cache_key` per call to preserve the previous
+   behaviour:
+
+   ```diff
+   -$platform = new CachePlatform($inner, cache: $cache, cacheKey: 'chat');
+   +$platform = new CachePlatform($inner, cache: $cache);
+
+    $platform->invoke($model, $messages, ['prompt_cache_key' => 'chat']);
+   ```
+
+   A single call can still opt out by passing an empty `prompt_cache_key`.
+
 UPGRADE FROM 0.11 to 0.12
 =========================
 

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -1482,7 +1482,7 @@ Thanks to Symfony's Cache component, platform calls can be cached to reduce call
     use Symfony\Component\HttpClient\HttpClient;
 
     $platform = Factory::createPlatform($apiKey, HttpClient::create());
-    $cachePlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+    $cachePlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()), cacheKey: 'capitals');
 
     $firstResult = $cachePlatform->invoke('gpt-4o-mini', new MessageBag(Message::ofUser('What is the capital of France?')));
 
@@ -1491,6 +1491,35 @@ Thanks to Symfony's Cache component, platform calls can be cached to reduce call
     $secondResult = $cachePlatform->invoke('gpt-4o-mini', new MessageBag(Message::ofUser('What is the capital of France?')));
 
     echo $secondResult->getContent().\PHP_EOL;
+
+The cache key is built from the namespace, the model name, a hash of the input content and a hash of the invocation
+options, so the two calls above share the same entry even though each one builds its own ``MessageBag`` instance,
+while the same input sent with a different temperature, tool set or response format is a distinct entry. Caching
+engages as soon as a namespace is available, either through the ``cacheKey`` constructor argument or through the
+``prompt_cache_key`` invocation option, which also allows partitioning the entries per call::
+
+    $result = $cachePlatform->invoke('gpt-4o-mini', $messages, [
+        'prompt_cache_key' => 'capitals',
+        'prompt_cache_ttl' => 3600,
+    ]);
+
+Passing an empty ``prompt_cache_key`` opts a single call out of caching, and a streamed call is never cached as
+reading the stream would consume it.
+
+A namespace holding one of the PSR-6 reserved characters ``{}()/\@:`` cannot be turned into a cache key and raises
+an exception.
+
+Every entry is tagged with the camelized model name and with ``namespace.<cache key>``, so a model or a whole
+namespace can be dropped at once::
+
+    $cachePlatform->invalidateTags(['gpt4OMini']);
+    $cachePlatform->invalidateTags(['namespace.capitals']);
+
+Inputs that are not a string, an array or a message are keyed by a
+:class:`Symfony\\AI\\Platform\\Bridge\\Cache\\CacheKeyGenerator`: the bridge ships generators for ``MessageBag``,
+``MessageInterface``, ``DocumentUrl``, ``ImageUrl`` and ``File`` (including ``Audio``, ``Image``, ``Video`` and
+``Document``), and additional input types can be supported by passing extra generators to the
+``cacheKeyGenerators`` constructor argument.
 
 High Availability
 -----------------

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -11,6 +11,10 @@ CHANGELOG
  * Encode `Test\Recording\Cassette` with `JSON_THROW_ON_ERROR` and `JSON_PRESERVE_ZERO_FRACTION` and check the write, so a result holding a value JSON cannot represent (`NAN`, `INF`, invalid UTF-8) raises instead of truncating the cassette and destroying the interactions already recorded in it, and a recorded float with no fractional part no longer replays as an integer
  * Add `Test\Replay\AbstractBridgeReplayTestCase` for cassette-driven bridge replay tests, and make the `examples/` corpus a record/replay harness: `examples/runner --record` captures every HTTP interaction of an example into a committed cassette and refreshes the replay goldens, `ExamplesReplayTest` re-runs each recorded example offline through the full bridge pipeline in CI, without credentials, against those goldens
  * Add `Result\CustomToolCallResult` for `custom_tool_call` output items reported by provider-specific server-side tools (e.g. xAI's `x_search`), converted the same way as the other built-in tool call results instead of being surfaced as a `ToolCall` the application is expected to execute
+ * Add base `Contract` normalizers for `DocumentUrl`, `File` (covering `Video` and `Document`), `Collection`, `Template`, `Thinking`, `ExecutableCode` and `CodeExecution`, so these content types can be normalized through the base contract instead of making the serializer throw
+ * Add `Contract::normalize()` to normalize an input through the contract serializer without binding a model to the context, producing a provider agnostic representation instead of a provider request payload
+ * Stop dropping provider specific parts (web search, MCP call, code execution, ...) in `AssistantMessageNormalizer` when no model is bound to the context: they are delegated to the serializer and emitted under a `content_parts` key, while a provider request payload keeps ignoring them
+ * Fix `SystemMessageNormalizer` to stringify a `Template` content, so a system prompt built from a template without variables serializes to its raw string instead of an empty object
 
 0.12
 ----

--- a/src/platform/src/Bridge/Cache/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cache/CHANGELOG.md
@@ -1,6 +1,22 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Fix the cache key computation for `MessageBag` and `MessageInterface` inputs: the key is now derived from the message content instead of the random identifier carried by the bag, so identical inputs built from separate instances hit the cache
+ * Fix the cache key computation for `array` inputs: the array is normalized through the platform contract and hashed instead of being used verbatim, so it no longer makes the cache adapter throw on a PSR-6 reserved character and an object nested in the array contributes its content to the key instead of being flattened into an empty JSON object
+ * Fix the caching of a `ToolCallResult`: tool calls are normalized inline by `ResultNormalizer` instead of being delegated to the serializer, so they are cacheable with the default serializer, which no longer requires a dedicated tool call normalizer to be registered
+ * Preserve the signature of `TextResult` and `ToolCall` across the cache round-trip, as already done for `ThinkingResult`, so a provider scoped signature (e.g. the Gemini and Vertex AI `thoughtSignature`) survives a cache hit
+ * [BC BREAK] Read the constructor level `cacheKey`, which was previously ignored: it now acts as the default cache namespace, so caching engages without a per-call `prompt_cache_key`; an empty per-call key still opts the call out of caching
+ * Include the invocation options in the cache key, so the same input answered with a different temperature, tool set or response format no longer shares a cached entry
+ * Strip `CachePlatform::OPTION_CACHE_KEY` and `CachePlatform::OPTION_CACHE_TTL` from the options handed to the decorated platform on every path, not only when the call is cached
+ * Throw an `InvalidArgumentException` when the cache namespace holds a PSR-6 reserved character, instead of letting the cache adapter fail with an opaque error
+ * Bypass the cache instead of breaking the request for a streamed invocation, an input no deterministic key can be derived from, a result the serializer cannot handle, and a stale or corrupted cache entry
+ * Add `MessageCacheKeyGenerator` to key a bare `MessageInterface` input, and `CachePlatform::OPTION_CACHE_KEY`/`CachePlatform::OPTION_CACHE_TTL` to reference the invocation options without repeating their name
+ * Add `CachePlatform::invalidateTags()` to drop cached entries by tag; each entry is tagged with the camelized model name and `namespace.<cache key>`, so a model or a whole namespace can be invalidated
+ * Build the cache key by joining its segments (the namespace, the camelized model name, the input hash and the options hash) with a `.` delimiter instead of concatenating them, to avoid collisions at the namespace/model boundary; entries written by a previous version are no longer read and are re-populated
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/Cache/CacheKeyGenerator.php
+++ b/src/platform/src/Bridge/Cache/CacheKeyGenerator.php
@@ -32,6 +32,11 @@ interface CacheKeyGenerator
      * The value is used verbatim as part of a cache key, so it must not contain
      * the PSR-6 reserved characters ("{}()/\@:"). Hash any value that might
      * (e.g. a URL or raw bytes).
+     *
+     * @throws UncacheableInputException When the input is supported but no deterministic
+     *                                   identifier can be derived from it, so that
+     *                                   {@see CachePlatform} serves the request live
+     *                                   instead of breaking it
      */
     public function generate(object $input): string;
 }

--- a/src/platform/src/Bridge/Cache/CachePlatform.php
+++ b/src/platform/src/Bridge/Cache/CachePlatform.php
@@ -44,6 +44,18 @@ use Symfony\Contracts\Cache\ItemInterface;
 final class CachePlatform implements PlatformInterface
 {
     /**
+     * Invocation option holding the cache namespace of the call, it defaults to the constructor
+     * level cache key and opts the call out of caching when set to an empty string.
+     */
+    public const OPTION_CACHE_KEY = 'prompt_cache_key';
+
+    /**
+     * Invocation option holding the lifetime (in seconds) of the cached entry, it defaults to the
+     * constructor level TTL.
+     */
+    public const OPTION_CACHE_TTL = 'prompt_cache_ttl';
+
+    /**
      * @param iterable<CacheKeyGenerator> $cacheKeyGenerators Tried in order to key non-scalar inputs (objects)
      */
     public function __construct(
@@ -60,39 +72,65 @@ final class CachePlatform implements PlatformInterface
         private readonly ?int $cacheTtl = null,
         private iterable $cacheKeyGenerators = [
             new MessageBagCacheKeyGenerator(),
+            new MessageCacheKeyGenerator(),
             new DocumentUrlCacheKeyGenerator(),
             new ImageUrlCacheKeyGenerator(),
             new FileCacheKeyGenerator(),
         ],
+        private readonly InputHasher $inputHasher = new InputHasher(),
     ) {
     }
 
     public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
     {
-        if (null === $this->cache || !\array_key_exists('prompt_cache_key', $options) || '' === $options['prompt_cache_key']) {
+        $namespace = $options[self::OPTION_CACHE_KEY] ?? $this->cacheKey;
+        $ttl = $options[self::OPTION_CACHE_TTL] ?? $this->cacheTtl;
+
+        // The decorator consumes its own options: they must not reach the decorated platform, whether
+        // the call is cached or bypasses the cache.
+        unset($options[self::OPTION_CACHE_KEY], $options[self::OPTION_CACHE_TTL]);
+
+        if (null === $this->cache || null === $namespace || '' === $namespace) {
+            return $this->platform->invoke($model, $input, $options);
+        }
+
+        if (false !== strpbrk($namespace, '{}()/\\@:')) {
+            throw new InvalidArgumentException(\sprintf('The cache namespace "%s" contains reserved characters ("{}()/\@:") and cannot be used to build a cache key.', $namespace));
+        }
+
+        // A stream is consumed while it is read, caching it would drain it before the caller sees it.
+        if (true === ($options['stream'] ?? false)) {
             return $this->platform->invoke($model, $input, $options);
         }
 
         $modelName = $model instanceof Model ? $model->getName() : $model;
 
-        $normalizedInput = match (true) {
-            \is_string($input) => md5($input),
-            \is_array($input) => json_encode($input),
-            default => $this->generateInputCacheKey($input),
-        };
+        try {
+            $normalizedInput = $this->generateInputCacheKey($input);
+            $normalizedOptions = $this->inputHasher->hash($options);
+        } catch (UncacheableInputException) {
+            // Fail open: an input or an option set that cannot be keyed deterministically is served live.
+            return $this->platform->invoke($model, $input, $options);
+        }
 
-        $cacheKey = (new UnicodeString())->join([
-            $options['prompt_cache_key'] ?? $this->cacheKey,
+        // "." separates the segments: ":" and "/" are reserved by PSR-6 and a delimiter avoids
+        // boundary collisions (namespace "sy" + model "m" versus namespace "s" + model "ym"). The
+        // options are part of the key: the same input answered with a different temperature, tool set
+        // or response format is a different request.
+        $cacheKey = (new UnicodeString('.'))->join([
+            $namespace,
             (new UnicodeString($modelName))->camel(),
             $normalizedInput,
+            $normalizedOptions,
         ]);
 
-        $ttl = $options['prompt_cache_ttl'] ?? $this->cacheTtl;
+        $uncacheableResult = null;
 
-        unset($options['prompt_cache_key'], $options['prompt_cache_ttl']);
-
-        $cached = $this->cache->get($cacheKey, function (ItemInterface $item) use ($model, $modelName, $input, $options, $cacheKey, $ttl): array {
-            $item->tag((new UnicodeString($modelName))->camel());
+        $cached = $this->cache->get($cacheKey, function (ItemInterface $item, bool &$save) use ($model, $modelName, $input, $options, $cacheKey, $namespace, $ttl, &$uncacheableResult): array {
+            $item->tag([
+                (new UnicodeString($modelName))->camel(),
+                'namespace.'.$namespace,
+            ]);
 
             if (null !== $ttl) {
                 $item->expiresAfter($ttl);
@@ -102,8 +140,18 @@ final class CachePlatform implements PlatformInterface
 
             $result = $deferredResult->getResult();
 
+            try {
+                $normalizedResult = $this->serializer->normalize($result);
+            } catch (\Throwable) {
+                // Fail open: a result the serializer cannot handle is served live and not stored.
+                $save = false;
+                $uncacheableResult = $deferredResult;
+
+                return [];
+            }
+
             return [
-                'result' => $this->serializer->normalize($result),
+                'result' => $normalizedResult,
                 'raw_data' => $deferredResult->getRawResult()->getData(),
                 'metadata' => $result->getMetadata()->all(),
                 'cached_at' => $this->clock->now()->getTimestamp(),
@@ -111,7 +159,18 @@ final class CachePlatform implements PlatformInterface
             ];
         });
 
-        $restoredResult = $this->serializer->denormalize($cached['result'], ResultInterface::class);
+        if (null !== $uncacheableResult) {
+            return $uncacheableResult;
+        }
+
+        try {
+            $restoredResult = $this->serializer->denormalize($cached['result'], ResultInterface::class);
+        } catch (\Throwable) {
+            // Fail open: a stale or corrupted entry is dropped and the result is fetched again.
+            $this->cache->delete((string) $cacheKey);
+
+            return $this->platform->invoke($model, $input, $options);
+        }
 
         $restoredResult->getMetadata()->set([
             ...$cached['metadata'],
@@ -136,8 +195,39 @@ final class CachePlatform implements PlatformInterface
         return $this->platform->getModelCatalog();
     }
 
-    private function generateInputCacheKey(object $input): string
+    /**
+     * Drops every cached entry tagged with one of the given tags.
+     *
+     * Entries are tagged with the camelized model name and "namespace.<cache key>" (the per-call
+     * key, or the constructor level one when the call does not provide any), so a model or a whole
+     * namespace can be invalidated.
+     *
+     * @param list<string> $tags
+     */
+    public function invalidateTags(array $tags): bool
     {
+        if (null === $this->cache) {
+            return false;
+        }
+
+        return $this->cache->invalidateTags($tags);
+    }
+
+    /**
+     * @param array<mixed>|string|object $input
+     *
+     * @throws UncacheableInputException When no deterministic key can be derived from the input
+     */
+    private function generateInputCacheKey(array|string|object $input): string
+    {
+        if (\is_string($input)) {
+            return md5($input);
+        }
+
+        if (\is_array($input)) {
+            return $this->inputHasher->hash($input);
+        }
+
         foreach ($this->cacheKeyGenerators as $generator) {
             if ($generator->supports($input)) {
                 return $generator->generate($input);

--- a/src/platform/src/Bridge/Cache/InputHasher.php
+++ b/src/platform/src/Bridge/Cache/InputHasher.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache;
+
+use Symfony\AI\Platform\Contract;
+
+/**
+ * Builds a deterministic, content based hash of an input handed to a platform.
+ *
+ * The input can be a message bag, a message, an option array or a string. Maps are key-sorted before
+ * being encoded, so that a set of options keyed in a different order resolves to the same hash, while
+ * lists keep their order, which carries the order of the messages and of the content parts.
+ *
+ * Normalization is delegated to the platform {@see Contract} serializer without a model bound to
+ * the context, so the provider specific (model gated) normalizers stay inactive and the base ones
+ * produce a stable, provider agnostic representation. The hash therefore excludes every
+ * non-deterministic identifier - the random {@see \Symfony\Component\Uid\Uuid::v7()} carried by a
+ * {@see \Symfony\AI\Platform\Message\MessageBag} and by each
+ * {@see \Symfony\AI\Platform\Message\MessageInterface}, as well as the lazily populated
+ * {@see \Symfony\AI\Platform\Metadata\Metadata} - so that two inputs carrying the exact same
+ * logical content always resolve to the same cache key, even when built from separate instances.
+ *
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class InputHasher
+{
+    public function __construct(
+        private ?Contract $contract = null,
+    ) {
+    }
+
+    /**
+     * @param array<mixed>|string|object $input
+     *
+     * @throws UncacheableInputException When the input cannot be normalized into a deterministic representation
+     */
+    public function hash(array|string|object $input): string
+    {
+        $contract = $this->contract ??= Contract::create();
+
+        try {
+            $normalized = $contract->normalize($input);
+        } catch (\Throwable $e) {
+            throw new UncacheableInputException(\sprintf('The contract cannot normalize "%s" into a deterministic cache key.', get_debug_type($input)), previous: $e);
+        }
+
+        try {
+            $encoded = json_encode(self::canonicalize($normalized), \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+        } catch (\JsonException $e) {
+            throw new UncacheableInputException(\sprintf('The normalized representation of "%s" cannot be encoded into a deterministic cache key.', get_debug_type($input)), previous: $e);
+        }
+
+        return hash('xxh128', $encoded);
+    }
+
+    /**
+     * Sorts the keys of every nested map so that two logically identical structures encode identically.
+     * Lists keep their order, which is significant: it carries the order of the messages and of the
+     * content parts.
+     */
+    private static function canonicalize(mixed $value): mixed
+    {
+        if (!\is_array($value)) {
+            return $value;
+        }
+
+        $value = array_map(self::canonicalize(...), $value);
+
+        if (!array_is_list($value)) {
+            ksort($value);
+        }
+
+        return $value;
+    }
+}

--- a/src/platform/src/Bridge/Cache/MessageCacheKeyGenerator.php
+++ b/src/platform/src/Bridge/Cache/MessageCacheKeyGenerator.php
@@ -12,17 +12,15 @@
 namespace Symfony\AI\Platform\Bridge\Cache;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
-use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\MessageInterface;
 
 /**
- * Keys a {@see MessageBag} on a hash of its content - every message of the bag, the system prompt
- * and the prior turns included - so that two bags carrying the same conversation resolve to the
- * same key even when they are separate instances.
+ * Keys a bare {@see MessageInterface} input - a message handed to the platform without being
+ * wrapped into a {@see \Symfony\AI\Platform\Message\MessageBag} - on a hash of its content.
  *
- * @author Tac Tacelosky <tacman@gmail.com>
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-final class MessageBagCacheKeyGenerator implements CacheKeyGenerator
+final class MessageCacheKeyGenerator implements CacheKeyGenerator
 {
     public function __construct(
         private readonly InputHasher $inputHasher = new InputHasher(),
@@ -31,13 +29,13 @@ final class MessageBagCacheKeyGenerator implements CacheKeyGenerator
 
     public function supports(object $input): bool
     {
-        return $input instanceof MessageBag;
+        return $input instanceof MessageInterface;
     }
 
     public function generate(object $input): string
     {
-        if (!$input instanceof MessageBag) {
-            throw new InvalidArgumentException(\sprintf('"%s" only supports "%s" inputs, "%s" given.', self::class, MessageBag::class, get_debug_type($input)));
+        if (!$input instanceof MessageInterface) {
+            throw new InvalidArgumentException(\sprintf('"%s" only supports "%s" inputs, "%s" given.', self::class, MessageInterface::class, get_debug_type($input)));
         }
 
         return $this->inputHasher->hash($input);

--- a/src/platform/src/Bridge/Cache/ResultNormalizer.php
+++ b/src/platform/src/Bridge/Cache/ResultNormalizer.php
@@ -25,18 +25,19 @@ use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 /**
+ * Normalizes and denormalizes {@see ResultInterface} instances for the cache.
+ *
+ * Object results rely on {@see get_debug_type()} to pick the denormalization type, which round-trips
+ * arrays and stdClass but may not fully restore objects with private or readonly properties.
+ *
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-final class ResultNormalizer implements NormalizerInterface, DenormalizerInterface, NormalizerAwareInterface
+final class ResultNormalizer implements NormalizerInterface, DenormalizerInterface
 {
-    use NormalizerAwareTrait;
-
     public function __construct(
         private readonly ObjectNormalizer $objectNormalizer,
     ) {
@@ -74,9 +75,17 @@ final class ResultNormalizer implements NormalizerInterface, DenormalizerInterfa
                     'content' => \is_array($data->getContent()) ? $data->getContent() : $this->objectNormalizer->normalize($data->getContent(), $format, $context),
                 ],
                 StreamResult::class => throw new InvalidArgumentException(\sprintf('"%s" cannot be normalized.', StreamResult::class)),
-                TextResult::class => $data->getContent(),
+                TextResult::class => [
+                    'content' => $data->getContent(),
+                    'signature' => $data->getSignature(),
+                ],
                 ToolCallResult::class => array_map(
-                    fn (ToolCall $toolCall): array => $this->normalizer->normalize($toolCall, $format, $context),
+                    static fn (ToolCall $toolCall): array => [
+                        'id' => $toolCall->getId(),
+                        'name' => $toolCall->getName(),
+                        'arguments' => $toolCall->getArguments(),
+                        'signature' => $toolCall->getSignature(),
+                    ],
                     $data->getContent(),
                 ),
                 VectorResult::class => array_map(
@@ -110,12 +119,13 @@ final class ResultNormalizer implements NormalizerInterface, DenormalizerInterfa
             )),
             ThinkingResult::class => new ThinkingResult($data['payload']['content'], $data['payload']['signature']),
             ObjectResult::class => new ObjectResult('array' === $data['payload']['type'] ? $data['payload']['content'] : $this->objectNormalizer->denormalize($data['payload']['content'], $data['payload']['type'], $format, $context)),
-            TextResult::class => new TextResult($data['payload']),
+            TextResult::class => new TextResult($data['payload']['content'], $data['payload']['signature'] ?? null),
             ToolCallResult::class => new ToolCallResult(array_map(
                 static fn (array $toolCall): ToolCall => new ToolCall(
                     $toolCall['id'],
-                    $toolCall['function']['name'],
-                    json_decode($toolCall['function']['arguments'], true),
+                    $toolCall['name'],
+                    $toolCall['arguments'],
+                    $toolCall['signature'] ?? null,
                 ),
                 $data['payload'],
             )),

--- a/src/platform/src/Bridge/Cache/Tests/CachePlatformTest.php
+++ b/src/platform/src/Bridge/Cache/Tests/CachePlatformTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Cache\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Cache\CacheKeyGenerator;
 use Symfony\AI\Platform\Bridge\Cache\CachePlatform;
+use Symfony\AI\Platform\Bridge\Cache\InputHasher;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\Content\DocumentUrl;
 use Symfony\AI\Platform\Message\Message;
@@ -22,10 +23,16 @@ use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Tool\ExecutionReference;
+use Symfony\AI\Platform\Tool\Tool;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Clock\MonotonicClock;
+use Symfony\Component\String\UnicodeString;
 
 final class CachePlatformTest extends TestCase
 {
@@ -72,36 +79,75 @@ final class CachePlatformTest extends TestCase
             cache: new TagAwareAdapter($adapter),
         );
 
-        $messageBag = new MessageBag(
-            Message::ofUser('Hello there'),
-        );
+        $userMessage = Message::ofUser('Hello there');
+        $messageBag = new MessageBag($userMessage);
 
         $deferredResult = $cachedPlatform->invoke('foo', $messageBag, [
             'prompt_cache_key' => 'symfony',
         ]);
 
-        $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
         $this->assertSame('test content', $deferredResult->getResult()->getContent());
+        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
 
         $secondDeferredResult = $cachedPlatform->invoke('foo', $messageBag, [
             'prompt_cache_key' => 'symfony',
         ]);
 
-        $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
         $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
         $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
         $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+        $this->assertSame(
+            (string) $deferredResult->getMetadata()->get('cache_key'),
+            (string) $secondDeferredResult->getMetadata()->get('cache_key'),
+        );
     }
 
-    public function testPlatformCanReturnCachedResultWhenCalledTwiceWithSeparateMessageBag()
+    /**
+     * Regression test for issue #2192: two MessageBags built from separately constructed
+     * Message instances (each carrying a fresh random UUID) must still hit the cache because the
+     * key is derived from the message content, not from the random identifiers.
+     */
+    public function testPlatformCanReturnCachedResultWhenCalledTwiceWithSeparateMessageBagsAndSeparateMessages()
     {
         $platform = $this->createMock(PlatformInterface::class);
-        $platform->expects($this->exactly(2))->method('invoke')->willReturn(new DeferredResult(
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
             new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
         ));
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $deferredResult = $cachedPlatform->invoke('foo', new MessageBag(Message::ofUser('Hello there')), [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('test content', $deferredResult->getResult()->getContent());
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', new MessageBag(Message::ofUser('Hello there')), [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
+        $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+        $this->assertSame(
+            (string) $deferredResult->getMetadata()->get('cache_key'),
+            (string) $secondDeferredResult->getMetadata()->get('cache_key'),
+        );
+    }
+
+    public function testPlatformCannotReturnCachedResultWhenCalledTwiceWithUpdatedMessageBag()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(
+                new PlainConverter(new TextResult('First content')), new InMemoryRawResult(),
+            ),
+            new DeferredResult(
+                new PlainConverter(new TextResult('Second content')), new InMemoryRawResult(),
+            ),
+        );
 
         $adapter = new ArrayAdapter();
 
@@ -110,51 +156,186 @@ final class CachePlatformTest extends TestCase
             cache: new TagAwareAdapter($adapter),
         );
 
-        $messageBag = new MessageBag(
+        $firstMessageBag = new MessageBag(Message::ofUser('Hello there'));
+
+        $deferredResult = $cachedPlatform->invoke('foo', $firstMessageBag, [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('First content', $deferredResult->getResult()->getContent());
+        $firstCacheKey = (string) $deferredResult->getMetadata()->get('cache_key');
+
+        // Replaying the exact same content hits the cache, the inner platform is not called again.
+        $secondDeferredResult = $cachedPlatform->invoke('foo', new MessageBag(Message::ofUser('Hello there')), [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('First content', $secondDeferredResult->getResult()->getContent());
+        $this->assertSame($firstCacheKey, (string) $secondDeferredResult->getMetadata()->get('cache_key'));
+
+        // A bag carrying a different user message produces a different key and therefore a miss.
+        $secondMessageBag = new MessageBag(
             Message::ofUser('Hello there'),
+            Message::ofAssistant('Second answer'),
+            Message::ofUser('Follow up'),
         );
+
+        $thirdDeferredResult = $cachedPlatform->invoke('foo', $secondMessageBag, [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('Second content', $thirdDeferredResult->getResult()->getContent());
+        $this->assertNotSame($firstCacheKey, (string) $thirdDeferredResult->getMetadata()->get('cache_key'));
+
+        // Replaying the second bag hits the cache and keeps the first entry cached.
+        $fourthDeferredResult = $cachedPlatform->invoke('foo', $secondMessageBag, [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('Second content', $fourthDeferredResult->getResult()->getContent());
+        $this->assertSame((string) $thirdDeferredResult->getMetadata()->get('cache_key'), (string) $fourthDeferredResult->getMetadata()->get('cache_key'));
+        $this->assertArrayHasKey($firstCacheKey, $adapter->getValues());
+        $this->assertArrayHasKey((string) $thirdDeferredResult->getMetadata()->get('cache_key'), $adapter->getValues());
+    }
+
+    public function testPlatformCachesWhenMessageBagHasNoUserMessage()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $messageBag = new MessageBag(Message::forSystem('Only a system message'));
 
         $deferredResult = $cachedPlatform->invoke('foo', $messageBag, [
             'prompt_cache_key' => 'symfony',
         ]);
 
-        $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
         $this->assertSame('test content', $deferredResult->getResult()->getContent());
 
         $secondDeferredResult = $cachedPlatform->invoke('foo', $messageBag, [
             'prompt_cache_key' => 'symfony',
         ]);
 
-        $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
         $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
-        $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
         $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+    }
 
-        $secondMessageBag = new MessageBag(
-            Message::ofUser('Hello there'),
+    public function testPlatformCachesBareMessageInput()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
         );
 
-        $deferredResult = $cachedPlatform->invoke('foo', $secondMessageBag, [
+        $message = Message::ofUser('Hello there');
+
+        $deferredResult = $cachedPlatform->invoke('foo', $message, [
             'prompt_cache_key' => 'symfony',
         ]);
 
-        $this->assertCount(5, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $secondMessageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
         $this->assertSame('test content', $deferredResult->getResult()->getContent());
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', Message::ofUser('Hello there'), [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
+        $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+    }
+
+    public function testPlatformMissesWhenSystemPromptDiffers()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(
+                new PlainConverter(new TextResult('First content')), new InMemoryRawResult(),
+            ),
+            new DeferredResult(
+                new PlainConverter(new TextResult('Second content')), new InMemoryRawResult(),
+            ),
+        );
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $firstMessageBag = new MessageBag(
+            Message::forSystem('You are a helpful assistant.'),
+            Message::ofUser('Hello there'),
+        );
+
+        $deferredResult = $cachedPlatform->invoke('foo', $firstMessageBag, [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('First content', $deferredResult->getResult()->getContent());
+
+        $secondMessageBag = new MessageBag(
+            Message::forSystem('You are a strict assistant.'),
+            Message::ofUser('Hello there'),
+        );
 
         $secondDeferredResult = $cachedPlatform->invoke('foo', $secondMessageBag, [
             'prompt_cache_key' => 'symfony',
         ]);
 
-        $this->assertCount(5, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $secondMessageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
-        $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
-        $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+        $this->assertSame('Second content', $secondDeferredResult->getResult()->getContent());
+        $this->assertNotSame((string) $deferredResult->getMetadata()->get('cache_key'), (string) $secondDeferredResult->getMetadata()->get('cache_key'));
+    }
+
+    public function testPlatformMissesWhenAssistantTurnDiffers()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(
+                new PlainConverter(new TextResult('First content')), new InMemoryRawResult(),
+            ),
+            new DeferredResult(
+                new PlainConverter(new TextResult('Second content')), new InMemoryRawResult(),
+            ),
+        );
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $firstMessageBag = new MessageBag(
+            Message::ofUser('Hello there'),
+            Message::ofAssistant('First answer'),
+            Message::ofUser('Follow up'),
+        );
+
+        $deferredResult = $cachedPlatform->invoke('foo', $firstMessageBag, [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('First content', $deferredResult->getResult()->getContent());
+
+        $secondMessageBag = new MessageBag(
+            Message::ofUser('Hello there'),
+            Message::ofAssistant('Second answer'),
+            Message::ofUser('Follow up'),
+        );
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', $secondMessageBag, [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('Second content', $secondDeferredResult->getResult()->getContent());
+        $this->assertNotSame((string) $deferredResult->getMetadata()->get('cache_key'), (string) $secondDeferredResult->getMetadata()->get('cache_key'));
     }
 
     public function testPlatformCachesContentObjectInput()
@@ -236,9 +417,14 @@ final class CachePlatformTest extends TestCase
     public function testPlatformCannotReturnCachedResultWhenCalledTwiceWhileUsingShortCustomTtl()
     {
         $platform = $this->createMock(PlatformInterface::class);
-        $platform->expects($this->exactly(2))->method('invoke')->willReturn(new DeferredResult(
-            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
-        ));
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(
+                new PlainConverter(new TextResult('First content')), new InMemoryRawResult(),
+            ),
+            new DeferredResult(
+                new PlainConverter(new TextResult('Second content')), new InMemoryRawResult(),
+            )
+        );
 
         $clock = new MonotonicClock();
 
@@ -255,7 +441,7 @@ final class CachePlatformTest extends TestCase
 
         $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
 
-        $this->assertSame('test content', $deferredResult->getResult()->getContent());
+        $this->assertSame('First content', $deferredResult->getResult()->getContent());
 
         $clock->sleep(3);
 
@@ -263,7 +449,7 @@ final class CachePlatformTest extends TestCase
             'prompt_cache_key' => 'symfony',
         ]);
 
-        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
+        $this->assertSame('Second content', $secondDeferredResult->getResult()->getContent());
         $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
         $this->assertNotSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
     }
@@ -301,5 +487,461 @@ final class CachePlatformTest extends TestCase
         $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
         $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
         $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+    }
+
+    /**
+     * Regression test: a tool-call result must be cacheable with the default serializer shipped
+     * with {@see CachePlatform} (which only registers the result normalizer), without relying on a
+     * dedicated tool-call normalizer being present in the serializer.
+     */
+    public function testPlatformCachesToolCallResultWithDefaultSerializer()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new ToolCallResult([
+                new ToolCall('call-1', 'get_weather', ['city' => 'Paris']),
+            ])),
+            new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $result = $deferredResult->getResult();
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertSame('call-1', $toolCalls[0]->getId());
+        $this->assertSame('get_weather', $toolCalls[0]->getName());
+        $this->assertSame(['city' => 'Paris'], $toolCalls[0]->getArguments());
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $secondResult = $secondDeferredResult->getResult();
+        $this->assertInstanceOf(ToolCallResult::class, $secondResult);
+        $this->assertSame('call-1', $secondResult->getContent()[0]->getId());
+        $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+    }
+
+    /**
+     * Streaming responses are not cacheable: the call must bypass the cache and delegate to the
+     * inner platform on every request, even when a cache key is provided.
+     */
+    public function testPlatformBypassesCacheForStreamingResponses()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(new PlainConverter(new TextResult('streamed content')), new InMemoryRawResult()),
+            new DeferredResult(new PlainConverter(new TextResult('streamed content')), new InMemoryRawResult()),
+        );
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $firstDeferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'stream' => true,
+        ]);
+
+        $this->assertSame('streamed content', $firstDeferredResult->getResult()->getContent());
+        $this->assertFalse($firstDeferredResult->getMetadata()->has('cached_at'));
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'stream' => true,
+        ]);
+
+        $this->assertSame('streamed content', $secondDeferredResult->getResult()->getContent());
+        $this->assertFalse($secondDeferredResult->getMetadata()->has('cached_at'));
+    }
+
+    /**
+     * A result that cannot be normalized into a cacheable representation (e.g. an unsupported
+     * result type) must not break the request: the live result is returned instead of throwing,
+     * and no cache metadata is attached.
+     */
+    public function testPlatformFailsOpenWhenResultCannotBeCached()
+    {
+        $uncacheableResult = $this->createMock(ResultInterface::class);
+
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter($uncacheableResult),
+            new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame($uncacheableResult, $deferredResult->getResult());
+        $this->assertFalse($deferredResult->getMetadata()->has('cached_at'));
+    }
+
+    /**
+     * A stale or corrupted cache entry (e.g. a payload shape from a previous version) must not
+     * break the request: the entry is dropped and the inner platform is re-invoked instead of
+     * throwing during denormalization.
+     */
+    public function testPlatformFailsOpenWhenCacheEntryIsCorrupted()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(new PlainConverter(new TextResult('First content')), new InMemoryRawResult()),
+            new DeferredResult(new PlainConverter(new TextResult('Recovered content')), new InMemoryRawResult()),
+        );
+
+        $adapter = new TagAwareAdapter(new ArrayAdapter());
+        $cachedPlatform = new CachePlatform($platform, cache: $adapter);
+
+        // First call populates a valid entry.
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+        ]);
+        $this->assertSame('First content', $deferredResult->getResult()->getContent());
+
+        // Corrupt the stored entry with an unknown result class so denormalization fails.
+        // The cache options are consumed by the decorator, so the options segment is the hash of an
+        // empty option set.
+        $cacheKey = (new UnicodeString('.'))->join([
+            'symfony',
+            (new UnicodeString('foo'))->camel(),
+            md5('bar'),
+            (new InputHasher())->hash([]),
+        ]);
+        $item = $adapter->getItem((string) $cacheKey);
+        $item->set([
+            'result' => ['class' => 'Unknown\\Result', 'payload' => []],
+            'raw_data' => [],
+            'metadata' => [],
+            'cached_at' => 0,
+            'cache_key' => $cacheKey,
+        ]);
+        $adapter->save($item);
+
+        // The corrupted entry is dropped and the inner platform is re-invoked instead of throwing.
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('Recovered content', $secondDeferredResult->getResult()->getContent());
+    }
+
+    /**
+     * When no per-call key is provided, caching engages thanks to the constructor-level cache key,
+     * which acts as the default namespace.
+     */
+    public function testPlatformCachesUsingConstructorCacheKeyAsDefaultNamespace()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+            cacheKey: 'default',
+        );
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar');
+        $this->assertSame('test content', $deferredResult->getResult()->getContent());
+        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar');
+        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
+        $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+    }
+
+    /**
+     * An empty per-call key explicitly disables caching for that call, even when a constructor-level
+     * cache key is configured.
+     */
+    public function testPlatformBypassesCacheWhenPerCallKeyIsEmpty()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(new PlainConverter(new TextResult('first content')), new InMemoryRawResult()),
+            new DeferredResult(new PlainConverter(new TextResult('second content')), new InMemoryRawResult()),
+        );
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+            cacheKey: 'default',
+        );
+
+        $firstDeferredResult = $cachedPlatform->invoke('foo', 'bar', ['prompt_cache_key' => '']);
+        $this->assertSame('first content', $firstDeferredResult->getResult()->getContent());
+        $this->assertFalse($firstDeferredResult->getMetadata()->has('cached_at'));
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar', ['prompt_cache_key' => '']);
+        $this->assertSame('second content', $secondDeferredResult->getResult()->getContent());
+        $this->assertFalse($secondDeferredResult->getMetadata()->has('cached_at'));
+    }
+
+    /**
+     * Cached entries are tagged with the camelized model name, so a model can be invalidated at once.
+     */
+    public function testPlatformInvalidatesCachedEntriesByModelTag()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(new PlainConverter(new TextResult('first content')), new InMemoryRawResult()),
+            new DeferredResult(new PlainConverter(new TextResult('second content')), new InMemoryRawResult()),
+        );
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', ['prompt_cache_key' => 'symfony']);
+        $this->assertSame('first content', $deferredResult->getResult()->getContent());
+
+        $this->assertTrue($cachedPlatform->invalidateTags(['foo']));
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar', ['prompt_cache_key' => 'symfony']);
+        $this->assertSame('second content', $secondDeferredResult->getResult()->getContent());
+    }
+
+    /**
+     * Cached entries are tagged with `namespace.<cache key>`, so a whole namespace can be invalidated
+     * regardless of the model.
+     */
+    public function testPlatformInvalidatesCachedEntriesByNamespaceTag()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(new PlainConverter(new TextResult('first content')), new InMemoryRawResult()),
+            new DeferredResult(new PlainConverter(new TextResult('second content')), new InMemoryRawResult()),
+        );
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', ['prompt_cache_key' => 'symfony']);
+        $this->assertSame('first content', $deferredResult->getResult()->getContent());
+
+        $this->assertTrue($cachedPlatform->invalidateTags(['namespace.symfony']));
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar', ['prompt_cache_key' => 'symfony']);
+        $this->assertSame('second content', $secondDeferredResult->getResult()->getContent());
+    }
+
+    public function testPlatformInvalidateTagsReturnsFalseWithoutCache()
+    {
+        $cachedPlatform = new CachePlatform($this->createMock(PlatformInterface::class));
+
+        $this->assertFalse($cachedPlatform->invalidateTags(['foo']));
+    }
+
+    /**
+     * The decorator consumes its own options: a streamed call bypasses the cache but must not leak
+     * them to the decorated platform, which would forward them to the provider.
+     */
+    public function testPlatformDoesNotForwardCacheOptionsWhenBypassingForStream()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())
+            ->method('invoke')
+            ->with('foo', 'bar', ['stream' => true])
+            ->willReturn(new DeferredResult(
+                new PlainConverter(new TextResult('streamed content')), new InMemoryRawResult(),
+            ));
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'prompt_cache_ttl' => 60,
+            'stream' => true,
+        ]);
+
+        $this->assertSame('streamed content', $deferredResult->getResult()->getContent());
+    }
+
+    /**
+     * Same as above for the bypass triggered by the absence of a cache adapter.
+     */
+    public function testPlatformDoesNotForwardCacheOptionsWhenNoCacheIsConfigured()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())
+            ->method('invoke')
+            ->with('foo', 'bar', [])
+            ->willReturn(new DeferredResult(
+                new PlainConverter(new TextResult('live content')), new InMemoryRawResult(),
+            ));
+
+        $cachedPlatform = new CachePlatform($platform);
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'prompt_cache_ttl' => 60,
+        ]);
+
+        $this->assertSame('live content', $deferredResult->getResult()->getContent());
+    }
+
+    /**
+     * A namespace holding a PSR-6 reserved character is a configuration error: it fails loudly with a
+     * clear message instead of letting the cache adapter throw an opaque one.
+     */
+    public function testPlatformThrowsWhenCacheNamespaceHoldsReservedCharacters()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->never())->method('invoke');
+
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The cache namespace "symfony:ai" contains reserved characters ("{}()/\@:") and cannot be used to build a cache key.');
+
+        $cachedPlatform->invoke('foo', 'bar', ['prompt_cache_key' => 'symfony:ai']);
+    }
+
+    public function testPlatformMissesWhenTemperatureDiffers()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(new PlainConverter(new TextResult('First content')), new InMemoryRawResult()),
+            new DeferredResult(new PlainConverter(new TextResult('Second content')), new InMemoryRawResult()),
+        );
+
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'temperature' => 0.1,
+        ]);
+
+        $this->assertSame('First content', $deferredResult->getResult()->getContent());
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'temperature' => 0.9,
+        ]);
+
+        $this->assertSame('Second content', $secondDeferredResult->getResult()->getContent());
+        $this->assertNotSame(
+            (string) $deferredResult->getMetadata()->get('cache_key'),
+            (string) $secondDeferredResult->getMetadata()->get('cache_key'),
+        );
+    }
+
+    public function testPlatformHitsWhenOptionsOnlyDifferInOrder()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'temperature' => 0.1,
+            'max_tokens' => 100,
+        ]);
+
+        $this->assertSame('test content', $deferredResult->getResult()->getContent());
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'max_tokens' => 100,
+            'temperature' => 0.1,
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
+        $this->assertSame(
+            (string) $deferredResult->getMetadata()->get('cache_key'),
+            (string) $secondDeferredResult->getMetadata()->get('cache_key'),
+        );
+    }
+
+    /**
+     * The options are normalized through the contract, so an option holding objects (here a tool set)
+     * contributes its content to the key instead of being flattened into an empty JSON object.
+     */
+    public function testPlatformMissesWhenToolSetDiffers()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(new PlainConverter(new TextResult('First content')), new InMemoryRawResult()),
+            new DeferredResult(new PlainConverter(new TextResult('Second content')), new InMemoryRawResult()),
+        );
+
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+
+        $reference = new ExecutionReference(\stdClass::class);
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'tools' => [new Tool($reference, 'get_weather', 'Returns the weather of a city')],
+        ]);
+
+        $this->assertSame('First content', $deferredResult->getResult()->getContent());
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'tools' => [new Tool($reference, 'get_time', 'Returns the time of a city')],
+        ]);
+
+        $this->assertSame('Second content', $secondDeferredResult->getResult()->getContent());
+        $this->assertNotSame(
+            (string) $deferredResult->getMetadata()->get('cache_key'),
+            (string) $secondDeferredResult->getMetadata()->get('cache_key'),
+        );
+    }
+
+    /**
+     * An option set that cannot be normalized deterministically must not break the request: the call
+     * bypasses the cache and is served live.
+     */
+    public function testPlatformBypassesCacheWhenAnOptionCannotBeNormalized()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(
+            new DeferredResult(new PlainConverter(new TextResult('First content')), new InMemoryRawResult()),
+            new DeferredResult(new PlainConverter(new TextResult('Second content')), new InMemoryRawResult()),
+        );
+
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+
+        $deferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'custom' => new \stdClass(),
+        ]);
+
+        $this->assertSame('First content', $deferredResult->getResult()->getContent());
+        $this->assertFalse($deferredResult->getMetadata()->has('cached_at'));
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', 'bar', [
+            'prompt_cache_key' => 'symfony',
+            'custom' => new \stdClass(),
+        ]);
+
+        $this->assertSame('Second content', $secondDeferredResult->getResult()->getContent());
+        $this->assertFalse($secondDeferredResult->getMetadata()->has('cached_at'));
     }
 }

--- a/src/platform/src/Bridge/Cache/Tests/InputHasherTest.php
+++ b/src/platform/src/Bridge/Cache/Tests/InputHasherTest.php
@@ -1,0 +1,298 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cache\InputHasher;
+use Symfony\AI\Platform\Bridge\Cache\UncacheableInputException;
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\Collection;
+use Symfony\AI\Platform\Message\Content\ContentInterface;
+use Symfony\AI\Platform\Message\Content\DocumentUrl;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
+use Symfony\AI\Platform\Message\Content\Image;
+use Symfony\AI\Platform\Message\Content\ImageUrl;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Content\WebSearch;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\Template;
+use Symfony\AI\Platform\Result\ToolCall;
+
+final class InputHasherTest extends TestCase
+{
+    private InputHasher $hasher;
+
+    protected function setUp(): void
+    {
+        $this->hasher = new InputHasher();
+    }
+
+    public function testIdenticalMessageBagsBuiltSeparatelyProduceSameHash()
+    {
+        $first = new MessageBag(Message::ofUser('Hello there'));
+        $second = new MessageBag(Message::ofUser('Hello there'));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testIdenticalBareMessagesBuiltSeparatelyProduceSameHash()
+    {
+        $this->assertSame(
+            $this->hasher->hash(Message::ofUser('Hello there')),
+            $this->hasher->hash(Message::ofUser('Hello there')),
+        );
+    }
+
+    public function testBareMessageAndOneElementMessageBagProduceDifferentHashes()
+    {
+        // Both inputs are normalized as they are handed to the platform, and a bag does not
+        // produce the same payload as the bare message it holds.
+        $message = Message::ofUser('Hello there');
+
+        $this->assertNotSame(
+            $this->hasher->hash(new MessageBag($message)),
+            $this->hasher->hash($message),
+        );
+    }
+
+    public function testDifferentUserContentProducesDifferentHash()
+    {
+        $first = new MessageBag(Message::ofUser('Hello there'));
+        $second = new MessageBag(Message::ofUser('Goodbye there'));
+
+        $this->assertNotSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testDifferentSystemPromptProducesDifferentHash()
+    {
+        $first = new MessageBag(
+            Message::forSystem('You are a helpful assistant.'),
+            Message::ofUser('Hello there'),
+        );
+        $second = new MessageBag(
+            Message::forSystem('You are a strict assistant.'),
+            Message::ofUser('Hello there'),
+        );
+
+        $this->assertNotSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testDifferentAssistantTurnProducesDifferentHash()
+    {
+        $first = new MessageBag(
+            Message::ofUser('Hello there'),
+            Message::ofAssistant('First answer'),
+            Message::ofUser('Follow up'),
+        );
+        $second = new MessageBag(
+            Message::ofUser('Hello there'),
+            Message::ofAssistant('Second answer'),
+            Message::ofUser('Follow up'),
+        );
+
+        $this->assertNotSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testMessageOrderMatters()
+    {
+        $first = new MessageBag(Message::ofUser('A'), Message::ofUser('B'));
+        $second = new MessageBag(Message::ofUser('B'), Message::ofUser('A'));
+
+        $this->assertNotSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testTextContentIsStable()
+    {
+        $first = new MessageBag(Message::ofUser(new Text('Hello'), new Text('World')));
+        $second = new MessageBag(Message::ofUser(new Text('Hello'), new Text('World')));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testTextSignatureDoesNotChangeHash()
+    {
+        // The cache key is content-based: the Text signature is provenance metadata (a provider
+        // guard for replayed turns), not part of the logical content, so it must not affect the key.
+        $withoutSignature = new MessageBag(Message::ofUser(new Text('Hello')));
+        $withSignature = new MessageBag(Message::ofUser(new Text('Hello', 'sig')));
+
+        $this->assertSame($this->hasher->hash($withoutSignature), $this->hasher->hash($withSignature));
+    }
+
+    public function testThinkingContentIsStable()
+    {
+        $first = new MessageBag(Message::ofAssistant(new Thinking('Reasoning', 'sig')));
+        $second = new MessageBag(Message::ofAssistant(new Thinking('Reasoning', 'sig')));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testImageUrlContentIsStable()
+    {
+        $first = new MessageBag(Message::ofUser(new ImageUrl('https://example.com/image.png')));
+        $second = new MessageBag(Message::ofUser(new ImageUrl('https://example.com/image.png')));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testDocumentUrlContentIsStable()
+    {
+        $first = new MessageBag(Message::ofUser(new DocumentUrl('https://example.com/doc.pdf')));
+        $second = new MessageBag(Message::ofUser(new DocumentUrl('https://example.com/doc.pdf')));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testFileContentWithSameBytesProducesSameHashEvenFromSeparateInstances()
+    {
+        $fixture = \dirname(__DIR__, 6).'/fixtures/image.jpg';
+
+        $first = new MessageBag(Message::ofUser(Image::fromFile($fixture)));
+        $second = new MessageBag(Message::ofUser(Image::fromFile($fixture)));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testFileContentWithDifferentBytesProducesDifferentHash()
+    {
+        $image = new MessageBag(Message::ofUser(Image::fromFile(\dirname(__DIR__, 6).'/fixtures/image.jpg')));
+        $audio = new MessageBag(Message::ofUser(Audio::fromFile(\dirname(__DIR__, 6).'/fixtures/audio.mp3')));
+
+        $this->assertNotSame($this->hasher->hash($image), $this->hasher->hash($audio));
+    }
+
+    public function testToolCallContentIsStable()
+    {
+        $toolCall = new ToolCall('call_1', 'find_movies', ['genre' => 'sci-fi']);
+
+        $first = new MessageBag(Message::ofAssistant($toolCall));
+        $second = new MessageBag(Message::ofAssistant(new ToolCall('call_1', 'find_movies', ['genre' => 'sci-fi'])));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testToolCallMessageIsStable()
+    {
+        $toolCall = new ToolCall('call_1', 'find_movies', ['genre' => 'sci-fi']);
+
+        $first = new MessageBag(Message::ofToolCall($toolCall, 'The Matrix'));
+        $second = new MessageBag(Message::ofToolCall(new ToolCall('call_1', 'find_movies', ['genre' => 'sci-fi']), 'The Matrix'));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testCollectionContentIsStableAndRecursive()
+    {
+        $collection = new Collection(new Text('Hello'), new Text('World'));
+
+        $first = new MessageBag(Message::ofUser($collection));
+        $second = new MessageBag(Message::ofUser(new Collection(new Text('Hello'), new Text('World'))));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testTemplateContentIsStable()
+    {
+        $first = new MessageBag(Message::forSystem(Template::string('You are a {role} assistant.')));
+        $second = new MessageBag(Message::forSystem(Template::string('You are a {role} assistant.')));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testExecutableCodeContentIsStable()
+    {
+        $first = new MessageBag(Message::ofAssistant(new ExecutableCode('echo "hi";', 'php', 'exec_1')));
+        $second = new MessageBag(Message::ofAssistant(new ExecutableCode('echo "hi";', 'php', 'exec_1')));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testCodeExecutionContentIsStable()
+    {
+        $first = new MessageBag(Message::ofAssistant(new CodeExecution(true, 'hi', 'exec_1')));
+        $second = new MessageBag(Message::ofAssistant(new CodeExecution(true, 'hi', 'exec_1')));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testUnsupportedInputTypeThrows()
+    {
+        $this->expectException(UncacheableInputException::class);
+
+        $this->hasher->hash(new \stdClass());
+    }
+
+    public function testUnsupportedContentTypeThrows()
+    {
+        $bag = new MessageBag(Message::ofUser($this->createStub(ContentInterface::class)));
+
+        $this->expectException(UncacheableInputException::class);
+
+        $this->hasher->hash($bag);
+    }
+
+    public function testProviderSpecificAssistantPartWithoutNormalizerThrows()
+    {
+        // The part is not silently dropped: the bag cannot be hashed deterministically, which
+        // makes CachePlatform bypass the cache instead of keying two different bags identically.
+        $bag = new MessageBag(Message::ofAssistant(new WebSearch('symfony ai', 'ws_1', 'completed')));
+
+        $this->expectException(UncacheableInputException::class);
+
+        $this->hasher->hash($bag);
+    }
+
+    public function testMessageBagWithoutUserMessageIsHashable()
+    {
+        $first = new MessageBag(Message::forSystem('Only a system message'));
+        $second = new MessageBag(Message::forSystem('Only a system message'));
+
+        $this->assertSame($this->hasher->hash($first), $this->hasher->hash($second));
+    }
+
+    public function testOptionArrayHashesDeterministically()
+    {
+        $this->assertSame(
+            $this->hasher->hash(['temperature' => 0.1, 'max_tokens' => 100]),
+            $this->hasher->hash(['temperature' => 0.1, 'max_tokens' => 100]),
+        );
+    }
+
+    public function testOptionArrayKeyOrderDoesNotChangeHash()
+    {
+        // Maps are key-sorted before being encoded: the order in which the options are declared is
+        // not part of the request.
+        $this->assertSame(
+            $this->hasher->hash(['temperature' => 0.1, 'max_tokens' => 100]),
+            $this->hasher->hash(['max_tokens' => 100, 'temperature' => 0.1]),
+        );
+    }
+
+    public function testListOrderChangesHash()
+    {
+        // Lists keep their order, which is significant.
+        $this->assertNotSame(
+            $this->hasher->hash(['first', 'second']),
+            $this->hasher->hash(['second', 'first']),
+        );
+    }
+
+    public function testArrayHoldingUnsupportedObjectThrows()
+    {
+        $this->expectException(UncacheableInputException::class);
+
+        $this->hasher->hash(['custom' => new \stdClass()]);
+    }
+}

--- a/src/platform/src/Bridge/Cache/Tests/MessageBagCacheKeyGeneratorTest.php
+++ b/src/platform/src/Bridge/Cache/Tests/MessageBagCacheKeyGeneratorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cache\MessageBagCacheKeyGenerator;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\DocumentUrl;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+final class MessageBagCacheKeyGeneratorTest extends TestCase
+{
+    private MessageBagCacheKeyGenerator $generator;
+
+    protected function setUp(): void
+    {
+        $this->generator = new MessageBagCacheKeyGenerator();
+    }
+
+    public function testGeneratorSupportsMessageBagOnly()
+    {
+        $this->assertTrue($this->generator->supports(new MessageBag(Message::ofUser('Hello there'))));
+        $this->assertFalse($this->generator->supports(Message::ofUser('Hello there')));
+        $this->assertFalse($this->generator->supports(new DocumentUrl('https://example.com/doc.pdf')));
+    }
+
+    public function testGeneratedKeyIsDerivedFromTheContentAndNotFromTheIdentifier()
+    {
+        $first = new MessageBag(Message::ofUser('Hello there'));
+        $second = new MessageBag(Message::ofUser('Hello there'));
+
+        $this->assertNotSame($first->getId()->toString(), $second->getId()->toString());
+        $this->assertSame($this->generator->generate($first), $this->generator->generate($second));
+    }
+
+    public function testGeneratedKeyChangesWithTheContent()
+    {
+        $first = new MessageBag(Message::ofUser('Hello there'));
+        $second = new MessageBag(Message::ofUser('Goodbye there'));
+
+        $this->assertNotSame($this->generator->generate($first), $this->generator->generate($second));
+    }
+
+    public function testGeneratedKeyDoesNotContainReservedCharacters()
+    {
+        $key = $this->generator->generate(new MessageBag(Message::ofUser('Hello there')));
+
+        $this->assertSame(0, preg_match('#[{}()/\\\\@:]#', $key));
+    }
+
+    public function testGeneratorThrowsOnUnsupportedInput()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('"%s" only supports "%s" inputs, "stdClass" given.', MessageBagCacheKeyGenerator::class, MessageBag::class));
+
+        $this->generator->generate(new \stdClass());
+    }
+}

--- a/src/platform/src/Bridge/Cache/Tests/MessageCacheKeyGeneratorTest.php
+++ b/src/platform/src/Bridge/Cache/Tests/MessageCacheKeyGeneratorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cache\MessageCacheKeyGenerator;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\MessageInterface;
+
+final class MessageCacheKeyGeneratorTest extends TestCase
+{
+    private MessageCacheKeyGenerator $generator;
+
+    protected function setUp(): void
+    {
+        $this->generator = new MessageCacheKeyGenerator();
+    }
+
+    public function testGeneratorSupportsMessageOnly()
+    {
+        $this->assertTrue($this->generator->supports(Message::ofUser('Hello there')));
+        $this->assertTrue($this->generator->supports(Message::forSystem('You are a helpful assistant.')));
+        $this->assertFalse($this->generator->supports(new MessageBag(Message::ofUser('Hello there'))));
+    }
+
+    public function testGeneratedKeyIsDerivedFromTheContentAndNotFromTheIdentifier()
+    {
+        $first = Message::ofUser('Hello there');
+        $second = Message::ofUser('Hello there');
+
+        $this->assertNotSame($first->getId()->toString(), $second->getId()->toString());
+        $this->assertSame($this->generator->generate($first), $this->generator->generate($second));
+    }
+
+    public function testGeneratedKeyChangesWithTheContent()
+    {
+        $this->assertNotSame(
+            $this->generator->generate(Message::ofUser('Hello there')),
+            $this->generator->generate(Message::ofUser('Goodbye there')),
+        );
+    }
+
+    public function testGeneratorThrowsOnUnsupportedInput()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('"%s" only supports "%s" inputs, "stdClass" given.', MessageCacheKeyGenerator::class, MessageInterface::class));
+
+        $this->generator->generate(new \stdClass());
+    }
+}

--- a/src/platform/src/Bridge/Cache/Tests/ResultNormalizerTest.php
+++ b/src/platform/src/Bridge/Cache/Tests/ResultNormalizerTest.php
@@ -14,7 +14,6 @@ namespace Symfony\AI\Platform\Bridge\Cache\Tests;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Cache\ResultNormalizer;
-use Symfony\AI\Platform\Contract\Normalizer\Result\ToolCallNormalizer;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -38,10 +37,10 @@ final class ResultNormalizerTest extends TestCase
 
     protected function setUp(): void
     {
-        $resultNormalizer = new ResultNormalizer(new ObjectNormalizer());
-        $toolCallNormalizer = new ToolCallNormalizer();
-
-        $this->normalizer = new Serializer([$toolCallNormalizer, $resultNormalizer]);
+        // Mirrors the default serializer shipped with {@see CachePlatform}: only the result
+        // normalizer is registered, so tool calls must be handled inline rather than delegated to
+        // a dedicated normalizer.
+        $this->normalizer = new Serializer([new ResultNormalizer(new ObjectNormalizer())]);
     }
 
     public function testNormalizerSupport()
@@ -115,11 +114,11 @@ final class ResultNormalizerTest extends TestCase
                 'payload' => [
                     [
                         'class' => TextResult::class,
-                        'payload' => 'foo',
+                        'payload' => ['content' => 'foo', 'signature' => null],
                     ],
                     [
                         'class' => TextResult::class,
-                        'payload' => 'bar',
+                        'payload' => ['content' => 'bar', 'signature' => null],
                     ],
                 ],
             ],
@@ -138,7 +137,7 @@ final class ResultNormalizerTest extends TestCase
                     ],
                     [
                         'class' => TextResult::class,
-                        'payload' => 'answer',
+                        'payload' => ['content' => 'answer', 'signature' => null],
                     ],
                 ],
             ],
@@ -178,7 +177,14 @@ final class ResultNormalizerTest extends TestCase
             new TextResult('foo'),
             [
                 'class' => TextResult::class,
-                'payload' => 'foo',
+                'payload' => ['content' => 'foo', 'signature' => null],
+            ],
+        ];
+        yield TextResult::class.'-signed' => [
+            new TextResult('foo', 'sig_abc'),
+            [
+                'class' => TextResult::class,
+                'payload' => ['content' => 'foo', 'signature' => 'sig_abc'],
             ],
         ];
         yield ToolCallResult::class => [
@@ -190,11 +196,25 @@ final class ResultNormalizerTest extends TestCase
                 'payload' => [
                     [
                         'id' => 'call-1',
-                        'type' => 'function',
-                        'function' => [
-                            'name' => 'get_weather',
-                            'arguments' => '{"city":"Paris"}',
-                        ],
+                        'name' => 'get_weather',
+                        'arguments' => ['city' => 'Paris'],
+                        'signature' => null,
+                    ],
+                ],
+            ],
+        ];
+        yield ToolCallResult::class.'-signed' => [
+            new ToolCallResult([
+                new ToolCall('call-2', 'search', ['q' => 'symfony'], 'sig_def'),
+            ]),
+            [
+                'class' => ToolCallResult::class,
+                'payload' => [
+                    [
+                        'id' => 'call-2',
+                        'name' => 'search',
+                        'arguments' => ['q' => 'symfony'],
+                        'signature' => 'sig_def',
                     ],
                 ],
             ],

--- a/src/platform/src/Bridge/Cache/UncacheableInputException.php
+++ b/src/platform/src/Bridge/Cache/UncacheableInputException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache;
+
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+
+/**
+ * Thrown by a {@see CacheKeyGenerator} that supports the given input but cannot derive a
+ * deterministic key from it, e.g. a message bag holding a content part that the platform contract
+ * is unable to normalize.
+ *
+ * {@see CachePlatform} treats it as a cache miss it cannot store: the request is served live
+ * instead of being broken.
+ *
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class UncacheableInputException extends InvalidArgumentException
+{
+}

--- a/src/platform/src/Contract.php
+++ b/src/platform/src/Contract.php
@@ -13,9 +13,16 @@ namespace Symfony\AI\Platform;
 
 use Symfony\AI\Platform\Contract\Normalizer\Message\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Contract\Normalizer\Message\Content\AudioNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\CodeExecutionNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\CollectionNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\DocumentUrlNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\ExecutableCodeNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\FileNormalizer;
 use Symfony\AI\Platform\Contract\Normalizer\Message\Content\ImageNormalizer;
 use Symfony\AI\Platform\Contract\Normalizer\Message\Content\ImageUrlNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\TemplateNormalizer;
 use Symfony\AI\Platform\Contract\Normalizer\Message\Content\TextNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\ThinkingNormalizer;
 use Symfony\AI\Platform\Contract\Normalizer\Message\MessageBagNormalizer;
 use Symfony\AI\Platform\Contract\Normalizer\Message\SystemMessageNormalizer;
 use Symfony\AI\Platform\Contract\Normalizer\Message\ToolCallMessageNormalizer;
@@ -58,6 +65,13 @@ class Contract
         $normalizers[] = new ImageNormalizer();
         $normalizers[] = new ImageUrlNormalizer();
         $normalizers[] = new TextNormalizer();
+        $normalizers[] = new DocumentUrlNormalizer();
+        $normalizers[] = new FileNormalizer();
+        $normalizers[] = new CollectionNormalizer();
+        $normalizers[] = new TemplateNormalizer();
+        $normalizers[] = new ThinkingNormalizer();
+        $normalizers[] = new ExecutableCodeNormalizer();
+        $normalizers[] = new CodeExecutionNormalizer();
 
         // Options
         $normalizers[] = new ToolNormalizer();
@@ -85,6 +99,21 @@ class Contract
             self::CONTEXT_MODEL => $model,
             self::CONTEXT_OPTIONS => $options,
         ]);
+    }
+
+    /**
+     * Normalizes the given input through the contract serializer without binding a model to the
+     * context, so the provider specific (model gated) normalizers stay inactive and the base ones
+     * produce a stable, provider agnostic representation instead of a provider request payload.
+     *
+     * @param object|array<string|int, mixed>|string $input
+     * @param array<string, mixed>                   $context
+     *
+     * @return array<string, mixed>|string
+     */
+    final public function normalize(object|array|string $input, array $context = []): array|string
+    {
+        return $this->normalizer->normalize($input, context: $context);
     }
 
     /**

--- a/src/platform/src/Contract/Normalizer/Message/AssistantMessageNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/AssistantMessageNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Contract\Normalizer\Message;
 
+use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
@@ -39,15 +40,22 @@ final class AssistantMessageNormalizer implements NormalizerInterface, Normalize
     }
 
     /**
+     * Provider specific parts - a web search, an MCP call, a code execution, ... - are dropped when
+     * a model is bound to the context, since the payload is then a provider request the part does
+     * not belong to. Without a model, the payload is a provider agnostic representation of the
+     * message (used e.g. to derive a cache key), so the parts are delegated to the serializer and
+     * emitted under "content_parts" rather than being silently lost.
+     *
      * @param AssistantMessage $data
      *
-     * @return array{role: 'assistant', content: string|null, tool_calls?: array<array<string, mixed>>, reasoning_content?: string}
+     * @return array{role: 'assistant', content: string|null, tool_calls?: array<array<string, mixed>>, reasoning_content?: string, content_parts?: array<array<string, mixed>>}
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         $text = '';
         $reasoning = '';
         $toolCalls = [];
+        $additional = [];
 
         foreach ($data->getContent() as $part) {
             if ($part instanceof Text) {
@@ -56,6 +64,8 @@ final class AssistantMessageNormalizer implements NormalizerInterface, Normalize
                 $reasoning .= $part->getContent();
             } elseif ($part instanceof ToolCall) {
                 $toolCalls[] = $part;
+            } elseif (!isset($context[Contract::CONTEXT_MODEL])) {
+                $additional[] = $this->normalizer->normalize($part, $format, $context);
             }
         }
 
@@ -70,6 +80,10 @@ final class AssistantMessageNormalizer implements NormalizerInterface, Normalize
 
         if ('' !== $reasoning) {
             $array['reasoning_content'] = $reasoning;
+        }
+
+        if ([] !== $additional) {
+            $array['content_parts'] = $additional;
         }
 
         return $array;

--- a/src/platform/src/Contract/Normalizer/Message/Content/CodeExecutionNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/Content/CodeExecutionNormalizer.php
@@ -9,38 +9,40 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Contract\Normalizer\Message;
+namespace Symfony\AI\Platform\Contract\Normalizer\Message\Content;
 
-use Symfony\AI\Platform\Message\SystemMessage;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * @author Christopher Hertel <mail@christopher-hertel.de>
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-final class SystemMessageNormalizer implements NormalizerInterface
+final class CodeExecutionNormalizer implements NormalizerInterface
 {
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return $data instanceof SystemMessage;
+        return $data instanceof CodeExecution;
     }
 
     public function getSupportedTypes(?string $format): array
     {
         return [
-            SystemMessage::class => true,
+            CodeExecution::class => true,
         ];
     }
 
     /**
-     * @param SystemMessage $data
+     * @param CodeExecution $data
      *
-     * @return array{role: 'system', content: string}
+     * @return array{type: 'code_execution', succeeded: bool, output: string|null, id: string|null}
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         return [
-            'role' => $data->getRole()->value,
-            'content' => (string) $data->getContent(),
+            'type' => 'code_execution',
+            'succeeded' => $data->isSucceeded(),
+            'output' => $data->getOutput(),
+            'id' => $data->getId(),
         ];
     }
 }

--- a/src/platform/src/Contract/Normalizer/Message/Content/CollectionNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/Content/CollectionNormalizer.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Contract\Normalizer\Message\Content;
+
+use Symfony\AI\Platform\Message\Content\Collection;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizes a {@see Collection} by delegating each of its nested parts back to the serializer, so
+ * every content type is covered regardless of the composite shape.
+ *
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class CollectionNormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Collection;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            Collection::class => true,
+        ];
+    }
+
+    /**
+     * @param Collection $data
+     *
+     * @return array{type: 'collection', content: list<array<array-key, mixed>>}
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        $content = [];
+        foreach ($data->getContent() as $part) {
+            $normalized = $this->normalizer->normalize($part, $format, $context);
+            \assert(\is_array($normalized));
+            $content[] = $normalized;
+        }
+
+        return [
+            'type' => 'collection',
+            'content' => $content,
+        ];
+    }
+}

--- a/src/platform/src/Contract/Normalizer/Message/Content/DocumentUrlNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/Content/DocumentUrlNormalizer.php
@@ -9,38 +9,38 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Contract\Normalizer\Message;
+namespace Symfony\AI\Platform\Contract\Normalizer\Message\Content;
 
-use Symfony\AI\Platform\Message\SystemMessage;
+use Symfony\AI\Platform\Message\Content\DocumentUrl;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * @author Christopher Hertel <mail@christopher-hertel.de>
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-final class SystemMessageNormalizer implements NormalizerInterface
+final class DocumentUrlNormalizer implements NormalizerInterface
 {
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return $data instanceof SystemMessage;
+        return $data instanceof DocumentUrl;
     }
 
     public function getSupportedTypes(?string $format): array
     {
         return [
-            SystemMessage::class => true,
+            DocumentUrl::class => true,
         ];
     }
 
     /**
-     * @param SystemMessage $data
+     * @param DocumentUrl $data
      *
-     * @return array{role: 'system', content: string}
+     * @return array{type: 'document_url', document_url: array{url: string}}
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         return [
-            'role' => $data->getRole()->value,
-            'content' => (string) $data->getContent(),
+            'type' => 'document_url',
+            'document_url' => ['url' => $data->getUrl()],
         ];
     }
 }

--- a/src/platform/src/Contract/Normalizer/Message/Content/ExecutableCodeNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/Content/ExecutableCodeNormalizer.php
@@ -9,38 +9,40 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Contract\Normalizer\Message;
+namespace Symfony\AI\Platform\Contract\Normalizer\Message\Content;
 
-use Symfony\AI\Platform\Message\SystemMessage;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * @author Christopher Hertel <mail@christopher-hertel.de>
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-final class SystemMessageNormalizer implements NormalizerInterface
+final class ExecutableCodeNormalizer implements NormalizerInterface
 {
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return $data instanceof SystemMessage;
+        return $data instanceof ExecutableCode;
     }
 
     public function getSupportedTypes(?string $format): array
     {
         return [
-            SystemMessage::class => true,
+            ExecutableCode::class => true,
         ];
     }
 
     /**
-     * @param SystemMessage $data
+     * @param ExecutableCode $data
      *
-     * @return array{role: 'system', content: string}
+     * @return array{type: 'executable_code', code: string, language: string|null, id: string|null}
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         return [
-            'role' => $data->getRole()->value,
-            'content' => (string) $data->getContent(),
+            'type' => 'executable_code',
+            'code' => $data->getCode(),
+            'language' => $data->getLanguage(),
+            'id' => $data->getId(),
         ];
     }
 }

--- a/src/platform/src/Contract/Normalizer/Message/Content/FileNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/Content/FileNormalizer.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Contract\Normalizer\Message\Content;
+
+use Symfony\AI\Platform\Message\Content\File;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizes any {@see File} (and its subclasses {@see \Symfony\AI\Platform\Message\Content\Video}
+ * and {@see \Symfony\AI\Platform\Message\Content\Document}) into a base64 representation. Provider
+ * specific normalizers for {@see \Symfony\AI\Platform\Message\Content\Image} and
+ * {@see \Symfony\AI\Platform\Message\Content\Audio} are registered earlier and keep precedence.
+ *
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class FileNormalizer implements NormalizerInterface
+{
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof File;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            File::class => true,
+        ];
+    }
+
+    /**
+     * @param File $data
+     *
+     * @return array{type: 'file', file: array{data: string, format: string}}
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        return [
+            'type' => 'file',
+            'file' => [
+                'data' => $data->asBase64(),
+                'format' => $data->getFormat(),
+            ],
+        ];
+    }
+}

--- a/src/platform/src/Contract/Normalizer/Message/Content/TemplateNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/Content/TemplateNormalizer.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Contract\Normalizer\Message\Content;
+
+use Symfony\AI\Platform\Message\Template;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizes a {@see Template} reached without template variables (when variables are provided, the
+ * {@see \Symfony\AI\Platform\EventListener\TemplateRendererListener} replaces it with a rendered
+ * {@see \Symfony\AI\Platform\Message\Content\Text} before serialization).
+ *
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class TemplateNormalizer implements NormalizerInterface
+{
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Template;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            Template::class => true,
+        ];
+    }
+
+    /**
+     * @param Template $data
+     *
+     * @return array{type: 'template', template: string, template_type: string}
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        return [
+            'type' => 'template',
+            'template' => $data->getTemplate(),
+            'template_type' => $data->getType(),
+        ];
+    }
+}

--- a/src/platform/src/Contract/Normalizer/Message/Content/ThinkingNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/Content/ThinkingNormalizer.php
@@ -9,38 +9,39 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Contract\Normalizer\Message;
+namespace Symfony\AI\Platform\Contract\Normalizer\Message\Content;
 
-use Symfony\AI\Platform\Message\SystemMessage;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * @author Christopher Hertel <mail@christopher-hertel.de>
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-final class SystemMessageNormalizer implements NormalizerInterface
+final class ThinkingNormalizer implements NormalizerInterface
 {
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return $data instanceof SystemMessage;
+        return $data instanceof Thinking;
     }
 
     public function getSupportedTypes(?string $format): array
     {
         return [
-            SystemMessage::class => true,
+            Thinking::class => true,
         ];
     }
 
     /**
-     * @param SystemMessage $data
+     * @param Thinking $data
      *
-     * @return array{role: 'system', content: string}
+     * @return array{type: 'thinking', content: string, signature: string|null}
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         return [
-            'role' => $data->getRole()->value,
-            'content' => (string) $data->getContent(),
+            'type' => 'thinking',
+            'content' => $data->getContent(),
+            'signature' => $data->getSignature(),
         ];
     }
 }

--- a/src/platform/tests/Contract/Normalizer/Message/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/AssistantMessageNormalizerTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Message;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Contract\Normalizer\Message\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Content\WebSearch;
+use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -127,6 +130,47 @@ final class AssistantMessageNormalizerTest extends TestCase
 
         $this->assertArrayNotHasKey('reasoning_content', $result);
         $this->assertSame('Just a normal response', $result['content']);
+    }
+
+    public function testNormalizeEmitsProviderSpecificPartsWhenNoModelIsBound()
+    {
+        $webSearch = new WebSearch('symfony ai', 'ws_1', 'completed');
+        $message = new AssistantMessage(new Text('Here is what I found'), $webSearch);
+
+        $normalizedPart = ['type' => 'web_search', 'query' => 'symfony ai'];
+
+        $innerNormalizer = $this->createMock(NormalizerInterface::class);
+        $innerNormalizer->expects($this->once())
+            ->method('normalize')
+            ->with($webSearch, null, [])
+            ->willReturn($normalizedPart);
+
+        $this->normalizer->setNormalizer($innerNormalizer);
+
+        $expected = [
+            'role' => 'assistant',
+            'content' => 'Here is what I found',
+            'content_parts' => [$normalizedPart],
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($message));
+    }
+
+    public function testNormalizeDropsProviderSpecificPartsWhenAModelIsBound()
+    {
+        $message = new AssistantMessage(new Text('Here is what I found'), new WebSearch('symfony ai'));
+
+        $innerNormalizer = $this->createMock(NormalizerInterface::class);
+        $innerNormalizer->expects($this->never())->method('normalize');
+
+        $this->normalizer->setNormalizer($innerNormalizer);
+
+        $expected = [
+            'role' => 'assistant',
+            'content' => 'Here is what I found',
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($message, context: [Contract::CONTEXT_MODEL => new Model('gpt-4o-mini')]));
     }
 
     public function testNormalizeWithThinkingContentAndToolCalls()

--- a/src/platform/tests/Contract/Normalizer/Message/Content/CodeExecutionNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/CodeExecutionNormalizerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Message\Content;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\CodeExecutionNormalizer;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
+
+final class CodeExecutionNormalizerTest extends TestCase
+{
+    private CodeExecutionNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new CodeExecutionNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new CodeExecution(true, 'hi', 'exec_1')));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame([CodeExecution::class => true], $this->normalizer->getSupportedTypes(null));
+    }
+
+    public function testNormalize()
+    {
+        $codeExecution = new CodeExecution(true, 'hi', 'exec_1');
+
+        $expected = [
+            'type' => 'code_execution',
+            'succeeded' => true,
+            'output' => 'hi',
+            'id' => 'exec_1',
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($codeExecution));
+    }
+}

--- a/src/platform/tests/Contract/Normalizer/Message/Content/CollectionNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/CollectionNormalizerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Message\Content;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\CollectionNormalizer;
+use Symfony\AI\Platform\Message\Content\Collection;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class CollectionNormalizerTest extends TestCase
+{
+    private CollectionNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new CollectionNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new Collection(new Text('Hello'))));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame([Collection::class => true], $this->normalizer->getSupportedTypes(null));
+    }
+
+    public function testNormalizeDelegatesEachPartToTheSerializer()
+    {
+        $first = new Text('Hello');
+        $second = new Text('World');
+        $collection = new Collection($first, $second);
+
+        $innerNormalizer = $this->createMock(NormalizerInterface::class);
+        $innerNormalizer->expects($this->exactly(2))
+            ->method('normalize')
+            ->willReturnCallback(static function (Text $text): array {
+                return ['type' => 'text', 'text' => $text->getText()];
+            });
+
+        $this->normalizer->setNormalizer($innerNormalizer);
+
+        $expected = [
+            'type' => 'collection',
+            'content' => [
+                ['type' => 'text', 'text' => 'Hello'],
+                ['type' => 'text', 'text' => 'World'],
+            ],
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($collection));
+    }
+}

--- a/src/platform/tests/Contract/Normalizer/Message/Content/DocumentUrlNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/DocumentUrlNormalizerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Message\Content;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\DocumentUrlNormalizer;
+use Symfony\AI\Platform\Message\Content\DocumentUrl;
+
+final class DocumentUrlNormalizerTest extends TestCase
+{
+    private DocumentUrlNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new DocumentUrlNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new DocumentUrl('https://example.com/doc.pdf')));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame([DocumentUrl::class => true], $this->normalizer->getSupportedTypes(null));
+    }
+
+    public function testNormalize()
+    {
+        $documentUrl = new DocumentUrl('https://example.com/doc.pdf');
+
+        $expected = [
+            'type' => 'document_url',
+            'document_url' => ['url' => 'https://example.com/doc.pdf'],
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($documentUrl));
+    }
+}

--- a/src/platform/tests/Contract/Normalizer/Message/Content/ExecutableCodeNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/ExecutableCodeNormalizerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Message\Content;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\ExecutableCodeNormalizer;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
+
+final class ExecutableCodeNormalizerTest extends TestCase
+{
+    private ExecutableCodeNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new ExecutableCodeNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new ExecutableCode('echo "hi";', 'php', 'exec_1')));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame([ExecutableCode::class => true], $this->normalizer->getSupportedTypes(null));
+    }
+
+    public function testNormalize()
+    {
+        $executableCode = new ExecutableCode('echo "hi";', 'php', 'exec_1');
+
+        $expected = [
+            'type' => 'executable_code',
+            'code' => 'echo "hi";',
+            'language' => 'php',
+            'id' => 'exec_1',
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($executableCode));
+    }
+}

--- a/src/platform/tests/Contract/Normalizer/Message/Content/FileNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/FileNormalizerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Message\Content;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\FileNormalizer;
+use Symfony\AI\Platform\Message\Content\Document;
+use Symfony\AI\Platform\Message\Content\File;
+use Symfony\AI\Platform\Message\Content\Video;
+
+final class FileNormalizerTest extends TestCase
+{
+    private FileNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new FileNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new File('data', 'application/pdf')));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame([File::class => true], $this->normalizer->getSupportedTypes(null));
+    }
+
+    public function testNormalize()
+    {
+        $file = new File('data', 'application/pdf');
+
+        $expected = [
+            'type' => 'file',
+            'file' => [
+                'data' => base64_encode('data'),
+                'format' => 'application/pdf',
+            ],
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($file));
+    }
+
+    public function testNormalizeHandlesVideoAndDocumentSubclasses()
+    {
+        $video = new Video('data', 'video/mp4');
+        $document = new Document('data', 'application/pdf');
+
+        $expected = [
+            'type' => 'file',
+            'file' => [
+                'data' => base64_encode('data'),
+                'format' => 'video/mp4',
+            ],
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($video));
+
+        $expectedDocument = [
+            'type' => 'file',
+            'file' => [
+                'data' => base64_encode('data'),
+                'format' => 'application/pdf',
+            ],
+        ];
+
+        $this->assertSame($expectedDocument, $this->normalizer->normalize($document));
+    }
+}

--- a/src/platform/tests/Contract/Normalizer/Message/Content/TemplateNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/TemplateNormalizerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Message\Content;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\TemplateNormalizer;
+use Symfony\AI\Platform\Message\Template;
+
+final class TemplateNormalizerTest extends TestCase
+{
+    private TemplateNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new TemplateNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(Template::string('You are a {role}.')));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame([Template::class => true], $this->normalizer->getSupportedTypes(null));
+    }
+
+    public function testNormalize()
+    {
+        $template = new Template('You are a {role}.', 'string');
+
+        $expected = [
+            'type' => 'template',
+            'template' => 'You are a {role}.',
+            'template_type' => 'string',
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($template));
+    }
+}

--- a/src/platform/tests/Contract/Normalizer/Message/Content/ThinkingNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/Content/ThinkingNormalizerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Message\Content;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\ThinkingNormalizer;
+use Symfony\AI\Platform\Message\Content\Thinking;
+
+final class ThinkingNormalizerTest extends TestCase
+{
+    private ThinkingNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new ThinkingNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new Thinking('Reasoning')));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame([Thinking::class => true], $this->normalizer->getSupportedTypes(null));
+    }
+
+    public function testNormalize()
+    {
+        $thinking = new Thinking('Let me think about this...');
+
+        $expected = [
+            'type' => 'thinking',
+            'content' => 'Let me think about this...',
+            'signature' => null,
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($thinking));
+    }
+
+    public function testNormalizeWithSignature()
+    {
+        $thinking = new Thinking('Let me think about this...', 'signature');
+
+        $expected = [
+            'type' => 'thinking',
+            'content' => 'Let me think about this...',
+            'signature' => 'signature',
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($thinking));
+    }
+}

--- a/src/platform/tests/Contract/Normalizer/Message/SystemMessageNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/SystemMessageNormalizerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Message;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Contract\Normalizer\Message\SystemMessageNormalizer;
 use Symfony\AI\Platform\Message\SystemMessage;
+use Symfony\AI\Platform\Message\Template;
 
 final class SystemMessageNormalizerTest extends TestCase
 {
@@ -42,6 +43,18 @@ final class SystemMessageNormalizerTest extends TestCase
         $expected = [
             'role' => 'system',
             'content' => 'You are a helpful assistant',
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($message));
+    }
+
+    public function testNormalizeTemplateContentReachedWithoutVariables()
+    {
+        $message = new SystemMessage(Template::string('You are a {role} assistant'));
+
+        $expected = [
+            'role' => 'system',
+            'content' => 'You are a {role} assistant',
         ];
 
         $this->assertSame($expected, $this->normalizer->normalize($message));

--- a/src/platform/tests/ContractTest.php
+++ b/src/platform/tests/ContractTest.php
@@ -212,6 +212,33 @@ final class ContractTest extends TestCase
         ];
     }
 
+    public function testNormalizeDoesNotBindAModelToTheContext()
+    {
+        $contract = Contract::create();
+
+        $input = new MessageBag(
+            Message::forSystem('System message'),
+            Message::ofUser('User message'),
+        );
+
+        $this->assertSame([
+            'messages' => [
+                ['role' => 'system', 'content' => 'System message'],
+                ['role' => 'user', 'content' => 'User message'],
+            ],
+        ], $contract->normalize($input));
+    }
+
+    public function testNormalizeIsStableAcrossSeparatelyBuiltInputs()
+    {
+        $contract = Contract::create();
+
+        $this->assertSame(
+            $contract->normalize(new MessageBag(Message::ofUser('User message'))),
+            $contract->normalize(new MessageBag(Message::ofUser('User message'))),
+        );
+    }
+
     public function testExtendedContractHandlesWhisper()
     {
         $contract = Contract::create([new AudioNormalizer()]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1734 - Fix #2192 - Part of #1742
| License       | MIT

`MessageBagCacheKeyGenerator` keys a bag on `MessageBag::getId()`, a random `Uuid::v7()` regenerated on
every construction, so a lookup only ever hits when the very same instance is passed twice. Two bags
carrying the same conversation never share an entry, which defeats the point of the decorator.

The key is now derived from the message content through the platform `Contract` serializer, without a
model bound to the context, so it reflects the whole bag - system prompt and prior turns included - and
stays provider agnostic. A bare `MessageInterface` input gets the same treatment through the new
`MessageCacheKeyGenerator`, and an `array` input is hashed instead of being concatenated raw, which could
produce a key holding PSR-6 reserved characters.

To keep that normalization complete, base `Contract` normalizers are added for `DocumentUrl`, `File`
(covering `Video` and `Document`), `Collection`, `Template`, `Thinking`, `ExecutableCode` and
`CodeExecution`, `AssistantMessageNormalizer` stops dropping the provider specific parts when no model is
bound (a provider request payload keeps ignoring them, so no unknown key reaches the API), and
`SystemMessageNormalizer` stringifies a `Template` content instead of serializing it to an empty object.

The cache layer is hardened so it never breaks the request:

 * a `ToolCallResult` is normalized inline, so it is cacheable with the default serializer, which no
   longer needs a dedicated tool call normalizer to be registered;
 * the signature of `TextResult` and `ToolCall` survives the round-trip, as it already did for
   `ThinkingResult`, so a provider scoped signature (Gemini/Vertex AI `thoughtSignature`) is not lost;
 * a streamed call bypasses the cache instead of throwing on `StreamResult`;
 * an input that cannot be keyed, a result the serializer cannot handle (every result type added since
   0.11 - web search, MCP calls, ... - currently makes the request throw) and a stale or corrupted entry
   all fall back to a live invocation;
 * the constructor `cacheKey`, which was never read, acts as the default namespace, the key segments are
   joined with a `.` to avoid collisions at the namespace/model boundary, and
   `CachePlatform::invalidateTags()` drops entries by model or namespace tag.
