### PR TITLE
[Platform] Extract duplicated completions conversion methods into CompletionsConversionTrait

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -442,14 +442,17 @@ deptrac:
       - PlatformComponent
     CerebrasPlatform:
       - PlatformComponent
+      - GenericPlatform
     ClaudeCodePlatform:
       - PlatformComponent
     DecartPlatform:
       - PlatformComponent
     DeepSeekPlatform:
       - PlatformComponent
+      - GenericPlatform
     DockerModelRunnerPlatform:
       - PlatformComponent
+      - GenericPlatform
     ElevenLabsPlatform:
       - PlatformComponent
     FailoverPlatform:
@@ -467,6 +470,7 @@ deptrac:
       - PlatformComponent
     MistralPlatform:
       - PlatformComponent
+      - GenericPlatform
     ModelsDevPlatform:
       - PlatformComponent
       - GenericPlatform
@@ -494,6 +498,7 @@ deptrac:
       - MetaPlatform
     ScalewayPlatform:
       - PlatformComponent
+      - GenericPlatform
     TransformersPhpPlatform:
       - PlatformComponent
     VertexAiPlatform:

--- a/src/platform/src/Bridge/AmazeeAi/CompletionsResultConverter.php
+++ b/src/platform/src/Bridge/AmazeeAi/CompletionsResultConverter.php
@@ -11,24 +11,11 @@
 
 namespace Symfony\AI\Platform\Bridge\AmazeeAi;
 
-use Symfony\AI\Platform\Bridge\Generic\CompletionsModel;
-use Symfony\AI\Platform\Exception\AuthenticationException;
-use Symfony\AI\Platform\Exception\BadRequestException;
-use Symfony\AI\Platform\Exception\ContentFilterException;
-use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Bridge\Generic\Completions\ResultConverter;
 use Symfony\AI\Platform\Exception\RuntimeException;
-use Symfony\AI\Platform\Model;
-use Symfony\AI\Platform\Result\ChoiceResult;
-use Symfony\AI\Platform\Result\RawHttpResult;
-use Symfony\AI\Platform\Result\RawResultInterface;
-use Symfony\AI\Platform\Result\ResultInterface;
-use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
-use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
-use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * Completions ResultConverter for amazee.ai's LiteLLM proxy.
@@ -38,121 +25,11 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * message.tool_calls. This converter handles that quirk by checking
  * for tool_calls first and falling back to message.content as TextResult.
  */
-class CompletionsResultConverter implements ResultConverterInterface
+class CompletionsResultConverter extends ResultConverter
 {
-    public function supports(Model $model): bool
-    {
-        return $model instanceof CompletionsModel;
-    }
-
-    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
-    {
-        $response = $result->getObject();
-        \assert($response instanceof ResponseInterface);
-
-        if (401 === $response->getStatusCode()) {
-            $errorMessage = json_decode($response->getContent(false), true)['error']['message'];
-            throw new AuthenticationException($errorMessage);
-        }
-
-        if (400 === $response->getStatusCode()) {
-            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? 'Bad Request';
-            throw new BadRequestException($errorMessage);
-        }
-
-        if (429 === $response->getStatusCode()) {
-            throw new RateLimitExceededException();
-        }
-
-        if ($options['stream'] ?? false) {
-            return new StreamResult($this->convertStream($result));
-        }
-
-        $data = $result->getData();
-
-        if (isset($data['error']['code']) && 'content_filter' === $data['error']['code']) {
-            throw new ContentFilterException($data['error']['message']);
-        }
-
-        if (isset($data['error'])) {
-            throw new RuntimeException(\sprintf('Error "%s"-%s (%s): "%s".', $data['error']['code'] ?? '-', $data['error']['type'] ?? '-', $data['error']['param'] ?? '-', $data['error']['message'] ?? '-'));
-        }
-
-        if (!isset($data['choices'])) {
-            throw new RuntimeException('Response does not contain choices.');
-        }
-
-        $choices = array_map($this->convertChoice(...), $data['choices']);
-
-        return 1 === \count($choices) ? $choices[0] : new ChoiceResult($choices);
-    }
-
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
     {
         return null;
-    }
-
-    private function convertStream(RawResultInterface|RawHttpResult $result): \Generator
-    {
-        $toolCalls = [];
-        foreach ($result->getDataStream() as $data) {
-            if ($this->streamIsToolCall($data)) {
-                $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);
-            }
-
-            if ([] !== $toolCalls && $this->isToolCallsStreamFinished($data)) {
-                yield new ToolCallResult(...array_map($this->convertToolCall(...), $toolCalls));
-            }
-
-            if (!isset($data['choices'][0]['delta']['content'])) {
-                continue;
-            }
-
-            yield $data['choices'][0]['delta']['content'];
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $toolCalls
-     * @param array<string, mixed> $data
-     *
-     * @return array<string, mixed>
-     */
-    private function convertStreamToToolCalls(array $toolCalls, array $data): array
-    {
-        if (!isset($data['choices'][0]['delta']['tool_calls'])) {
-            return $toolCalls;
-        }
-
-        foreach ($data['choices'][0]['delta']['tool_calls'] as $i => $toolCall) {
-            if (isset($toolCall['id'])) {
-                $toolCalls[$i] = [
-                    'id' => $toolCall['id'],
-                    'function' => $toolCall['function'],
-                ];
-                continue;
-            }
-
-            $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
-        }
-
-        return $toolCalls;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function streamIsToolCall(array $data): bool
-    {
-        return isset($data['choices'][0]['delta']['tool_calls']);
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function isToolCallsStreamFinished(array $data): bool
-    {
-        return isset($data['choices'][0]['finish_reason']) && 'tool_calls' === $data['choices'][0]['finish_reason'];
     }
 
     /**
@@ -162,7 +39,7 @@ class CompletionsResultConverter implements ResultConverterInterface
      *
      * @param array<string, mixed> $choice
      */
-    private function convertChoice(array $choice): ToolCallResult|TextResult
+    protected function convertChoice(array $choice): ToolCallResult|TextResult
     {
         if ('tool_calls' === $choice['finish_reason']) {
             if (isset($choice['message']['tool_calls'])) {
@@ -181,22 +58,5 @@ class CompletionsResultConverter implements ResultConverterInterface
         }
 
         throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));
-    }
-
-    /**
-     * @param array{
-     *     id: string,
-     *     type: 'function',
-     *     function: array{
-     *         name: string,
-     *         arguments: string
-     *     }
-     * } $toolCall
-     */
-    private function convertToolCall(array $toolCall): ToolCall
-    {
-        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
-
-        return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }
 }

--- a/src/platform/src/Bridge/Cerebras/ResultConverter.php
+++ b/src/platform/src/Bridge/Cerebras/ResultConverter.php
@@ -11,15 +11,13 @@
 
 namespace Symfony\AI\Platform\Bridge\Cerebras;
 
+use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
-use Symfony\AI\Platform\Result\TextResult;
-use Symfony\AI\Platform\Result\ToolCall;
-use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 
@@ -28,6 +26,8 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use CompletionsConversionTrait;
+
     public function supports(BaseModel $model): bool
     {
         return $model instanceof Model;
@@ -57,116 +57,5 @@ final class ResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
     {
         return null;
-    }
-
-    /**
-     * @param array{
-     *     index: int,
-     *     message: array{
-     *         role: 'assistant',
-     *         content: ?string,
-     *         tool_calls?: list<array{
-     *             id: string,
-     *             type: 'function',
-     *             function: array{
-     *                 name: string,
-     *                 arguments: string
-     *             },
-     *         }>,
-     *     },
-     *     finish_reason: 'stop'|'length'|'tool_calls',
-     * } $choice
-     */
-    private function convertChoice(array $choice): ToolCallResult|TextResult
-    {
-        if ('tool_calls' === $choice['finish_reason']) {
-            return new ToolCallResult(...array_map($this->convertToolCall(...), $choice['message']['tool_calls']));
-        }
-
-        if (\in_array($choice['finish_reason'], ['stop', 'length'], true)) {
-            return new TextResult($choice['message']['content']);
-        }
-
-        throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));
-    }
-
-    /**
-     * @param array{
-     *     id: string,
-     *     type: 'function',
-     *     function: array{
-     *         name: string,
-     *         arguments: string
-     *     }
-     * } $toolCall
-     */
-    private function convertToolCall(array $toolCall): ToolCall
-    {
-        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
-
-        return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
-    }
-
-    private function convertStream(RawResultInterface $result): \Generator
-    {
-        $toolCalls = [];
-        foreach ($result->getDataStream() as $data) {
-            if ($this->streamIsToolCall($data)) {
-                $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);
-            }
-
-            if ([] !== $toolCalls && $this->isToolCallsStreamFinished($data)) {
-                yield new ToolCallResult(...array_map($this->convertToolCall(...), $toolCalls));
-            }
-
-            if (!isset($data['choices'][0]['delta']['content'])) {
-                continue;
-            }
-
-            yield $data['choices'][0]['delta']['content'];
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $toolCalls
-     * @param array<string, mixed> $data
-     *
-     * @return array<string, mixed>
-     */
-    private function convertStreamToToolCalls(array $toolCalls, array $data): array
-    {
-        if (!isset($data['choices'][0]['delta']['tool_calls'])) {
-            return $toolCalls;
-        }
-
-        foreach ($data['choices'][0]['delta']['tool_calls'] as $i => $toolCall) {
-            if (isset($toolCall['id'])) {
-                $toolCalls[$i] = [
-                    'id' => $toolCall['id'],
-                    'function' => $toolCall['function'],
-                ];
-                continue;
-            }
-
-            $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
-        }
-
-        return $toolCalls;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function streamIsToolCall(array $data): bool
-    {
-        return isset($data['choices'][0]['delta']['tool_calls']);
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function isToolCallsStreamFinished(array $data): bool
-    {
-        return isset($data['choices'][0]['finish_reason']) && 'tool_calls' === $data['choices'][0]['finish_reason'];
     }
 }

--- a/src/platform/src/Bridge/Cerebras/composer.json
+++ b/src/platform/src/Bridge/Cerebras/composer.json
@@ -25,6 +25,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/ai-generic-platform": "^0.6",
         "symfony/ai-platform": "^0.6",
         "symfony/http-client": "^7.3|^8.0"
     },

--- a/src/platform/src/Bridge/DeepSeek/ResultConverter.php
+++ b/src/platform/src/Bridge/DeepSeek/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\DeepSeek;
 
+use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\InvalidRequestException;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -19,9 +20,7 @@ use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
-use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingContent;
-use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 
@@ -30,6 +29,8 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use CompletionsConversionTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof DeepSeek;
@@ -65,7 +66,7 @@ final class ResultConverter implements ResultConverterInterface
         return new TokenUsageExtractor();
     }
 
-    private function convertStream(RawResultInterface $result): \Generator
+    protected function convertStream(RawResultInterface $result): \Generator
     {
         $toolCalls = [];
         $reasoning = '';
@@ -103,100 +104,5 @@ final class ResultConverter implements ResultConverterInterface
         if ('' !== $reasoning) {
             yield new ThinkingContent($reasoning);
         }
-    }
-
-    /**
-     * @param array<string, mixed> $toolCalls
-     * @param array<string, mixed> $data
-     *
-     * @return array<string, mixed>
-     */
-    private function convertStreamToToolCalls(array $toolCalls, array $data): array
-    {
-        if (!isset($data['choices'][0]['delta']['tool_calls'])) {
-            return $toolCalls;
-        }
-
-        foreach ($data['choices'][0]['delta']['tool_calls'] as $i => $toolCall) {
-            if (isset($toolCall['id'])) {
-                // initialize tool call
-                $toolCalls[$i] = [
-                    'id' => $toolCall['id'],
-                    'function' => $toolCall['function'],
-                ];
-                continue;
-            }
-
-            // add arguments delta to tool call
-            $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
-        }
-
-        return $toolCalls;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function streamIsToolCall(array $data): bool
-    {
-        return isset($data['choices'][0]['delta']['tool_calls']);
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function isToolCallsStreamFinished(array $data): bool
-    {
-        return isset($data['choices'][0]['finish_reason']) && 'tool_calls' === $data['choices'][0]['finish_reason'];
-    }
-
-    /**
-     * @param array{
-     *     index: int,
-     *     message: array{
-     *         role: 'assistant',
-     *         content: ?string,
-     *         tool_calls: array{
-     *             id: string,
-     *             type: 'function',
-     *             function: array{
-     *                 name: string,
-     *                 arguments: string
-     *             },
-     *         },
-     *         refusal: ?mixed
-     *     },
-     *     logprobs: string,
-     *     finish_reason: 'stop'|'length'|'tool_calls'|'content_filter',
-     * } $choice
-     */
-    private function convertChoice(array $choice): ToolCallResult|TextResult
-    {
-        if ('tool_calls' === $choice['finish_reason']) {
-            return new ToolCallResult(...array_map([$this, 'convertToolCall'], $choice['message']['tool_calls']));
-        }
-
-        if (\in_array($choice['finish_reason'], ['stop', 'length'], true)) {
-            return new TextResult($choice['message']['content']);
-        }
-
-        throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));
-    }
-
-    /**
-     * @param array{
-     *     id: string,
-     *     type: 'function',
-     *     function: array{
-     *         name: string,
-     *         arguments: string
-     *     }
-     * } $toolCall
-     */
-    private function convertToolCall(array $toolCall): ToolCall
-    {
-        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
-
-        return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }
 }

--- a/src/platform/src/Bridge/DeepSeek/composer.json
+++ b/src/platform/src/Bridge/DeepSeek/composer.json
@@ -25,6 +25,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/ai-generic-platform": "^0.6",
         "symfony/ai-platform": "^0.6",
         "symfony/http-client": "^7.3|^8.0"
     },

--- a/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\DockerModelRunner\Completions;
 
 use Symfony\AI\Platform\Bridge\DockerModelRunner\Completions;
+use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
@@ -22,9 +23,6 @@ use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
-use Symfony\AI\Platform\Result\TextResult;
-use Symfony\AI\Platform\Result\ToolCall;
-use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 
@@ -33,6 +31,8 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use CompletionsConversionTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Completions;
@@ -71,120 +71,5 @@ final class ResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
     {
         return null;
-    }
-
-    private function convertStream(RawResultInterface $result): \Generator
-    {
-        $toolCalls = [];
-        foreach ($result->getDataStream() as $data) {
-            if ($this->streamIsToolCall($data)) {
-                $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);
-            }
-
-            if ([] !== $toolCalls && $this->isToolCallsStreamFinished($data)) {
-                yield new ToolCallResult(...array_map($this->convertToolCall(...), $toolCalls));
-            }
-
-            if (!isset($data['choices'][0]['delta']['content'])) {
-                continue;
-            }
-
-            yield $data['choices'][0]['delta']['content'];
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $toolCalls
-     * @param array<string, mixed> $data
-     *
-     * @return array<string, mixed>
-     */
-    private function convertStreamToToolCalls(array $toolCalls, array $data): array
-    {
-        if (!isset($data['choices'][0]['delta']['tool_calls'])) {
-            return $toolCalls;
-        }
-
-        foreach ($data['choices'][0]['delta']['tool_calls'] as $i => $toolCall) {
-            if (isset($toolCall['id'])) {
-                // initialize tool call
-                $toolCalls[$i] = [
-                    'id' => $toolCall['id'],
-                    'function' => $toolCall['function'],
-                ];
-                continue;
-            }
-
-            // add arguments delta to tool call
-            $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
-        }
-
-        return $toolCalls;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function streamIsToolCall(array $data): bool
-    {
-        return isset($data['choices'][0]['delta']['tool_calls']);
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function isToolCallsStreamFinished(array $data): bool
-    {
-        return isset($data['choices'][0]['finish_reason']) && 'tool_calls' === $data['choices'][0]['finish_reason'];
-    }
-
-    /**
-     * @param array{
-     *     index: int,
-     *     message: array{
-     *         role: 'assistant',
-     *         content: ?string,
-     *         tool_calls: array{
-     *             id: string,
-     *             type: 'function',
-     *             function: array{
-     *                 name: string,
-     *                 arguments: string
-     *             },
-     *         },
-     *         refusal: ?mixed
-     *     },
-     *     logprobs: string,
-     *     finish_reason: 'stop'|'length'|'tool_calls'|'content_filter',
-     * } $choice
-     */
-    private function convertChoice(array $choice): ToolCallResult|TextResult
-    {
-        if ('tool_calls' === $choice['finish_reason']) {
-            return new ToolCallResult(...array_map([$this, 'convertToolCall'], $choice['message']['tool_calls']));
-        }
-
-        if (\in_array($choice['finish_reason'], ['stop', 'length'], true)) {
-            return new TextResult($choice['message']['content']);
-        }
-
-        throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));
-    }
-
-    /**
-     * @param array{
-     *     id: string,
-     *     type: 'function',
-     *     function: array{
-     *         name: string,
-     *         arguments: string
-     *     }
-     * } $toolCall
-     */
-    private function convertToolCall(array $toolCall): ToolCall
-    {
-        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
-
-        return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }
 }

--- a/src/platform/src/Bridge/DockerModelRunner/composer.json
+++ b/src/platform/src/Bridge/DockerModelRunner/composer.json
@@ -25,6 +25,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/ai-generic-platform": "^0.6",
         "symfony/ai-platform": "^0.6",
         "symfony/http-client": "^7.3|^8.0"
     },

--- a/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
+++ b/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Generic\Completions;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+
+/**
+ * Shared streaming and tool-call conversion logic for OpenAI-compatible completions APIs.
+ *
+ * Used by bridges whose response format follows the OpenAI chat completions schema
+ * (choices[].delta.tool_calls, choices[].finish_reason, etc.).
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+trait CompletionsConversionTrait
+{
+    protected function convertStream(RawResultInterface $result): \Generator
+    {
+        $toolCalls = [];
+        foreach ($result->getDataStream() as $data) {
+            if ($this->streamIsToolCall($data)) {
+                $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);
+            }
+
+            if ([] !== $toolCalls && $this->isToolCallsStreamFinished($data)) {
+                yield new ToolCallResult(...array_map($this->convertToolCall(...), $toolCalls));
+            }
+
+            if (!isset($data['choices'][0]['delta']['content'])) {
+                continue;
+            }
+
+            yield $data['choices'][0]['delta']['content'];
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $toolCalls
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    protected function convertStreamToToolCalls(array $toolCalls, array $data): array
+    {
+        if (!isset($data['choices'][0]['delta']['tool_calls'])) {
+            return $toolCalls;
+        }
+
+        foreach ($data['choices'][0]['delta']['tool_calls'] as $i => $toolCall) {
+            if (isset($toolCall['id'])) {
+                // initialize tool call
+                $toolCalls[$i] = [
+                    'id' => $toolCall['id'],
+                    'function' => $toolCall['function'],
+                ];
+                continue;
+            }
+
+            // add arguments delta to tool call
+            $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
+        }
+
+        return $toolCalls;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    protected function streamIsToolCall(array $data): bool
+    {
+        return isset($data['choices'][0]['delta']['tool_calls']);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    protected function isToolCallsStreamFinished(array $data): bool
+    {
+        return isset($data['choices'][0]['finish_reason']) && 'tool_calls' === $data['choices'][0]['finish_reason'];
+    }
+
+    /**
+     * @param array{
+     *     index: int,
+     *     message: array{
+     *         role: 'assistant',
+     *         content: ?string,
+     *         tool_calls: list<array{
+     *             id: string,
+     *             type: 'function',
+     *             function: array{
+     *                 name: string,
+     *                 arguments: string
+     *             },
+     *         }>,
+     *         refusal: ?mixed
+     *     },
+     *     logprobs: string,
+     *     finish_reason: 'stop'|'length'|'tool_calls'|'content_filter',
+     * } $choice
+     */
+    protected function convertChoice(array $choice): ToolCallResult|TextResult
+    {
+        if ('tool_calls' === $choice['finish_reason']) {
+            return new ToolCallResult(...array_map([$this, 'convertToolCall'], $choice['message']['tool_calls']));
+        }
+
+        if (\in_array($choice['finish_reason'], ['stop', 'length'], true)) {
+            return new TextResult($choice['message']['content']);
+        }
+
+        throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));
+    }
+
+    /**
+     * @param array{
+     *     id: string,
+     *     type: 'function',
+     *     function: array{
+     *         name: string,
+     *         arguments: string
+     *     }
+     * } $toolCall
+     */
+    protected function convertToolCall(array $toolCall): ToolCall
+    {
+        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
+
+        return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
+    }
+}

--- a/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
@@ -23,9 +23,6 @@ use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
-use Symfony\AI\Platform\Result\TextResult;
-use Symfony\AI\Platform\Result\ToolCall;
-use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 
@@ -37,6 +34,8 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 class ResultConverter implements ResultConverterInterface
 {
+    use CompletionsConversionTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof CompletionsModel;
@@ -86,120 +85,5 @@ class ResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
     {
         return new TokenUsageExtractor();
-    }
-
-    private function convertStream(RawResultInterface|RawHttpResult $result): \Generator
-    {
-        $toolCalls = [];
-        foreach ($result->getDataStream() as $data) {
-            if ($this->streamIsToolCall($data)) {
-                $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);
-            }
-
-            if ([] !== $toolCalls && $this->isToolCallsStreamFinished($data)) {
-                yield new ToolCallResult(...array_map($this->convertToolCall(...), $toolCalls));
-            }
-
-            if (!isset($data['choices'][0]['delta']['content'])) {
-                continue;
-            }
-
-            yield $data['choices'][0]['delta']['content'];
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $toolCalls
-     * @param array<string, mixed> $data
-     *
-     * @return array<string, mixed>
-     */
-    private function convertStreamToToolCalls(array $toolCalls, array $data): array
-    {
-        if (!isset($data['choices'][0]['delta']['tool_calls'])) {
-            return $toolCalls;
-        }
-
-        foreach ($data['choices'][0]['delta']['tool_calls'] as $i => $toolCall) {
-            if (isset($toolCall['id'])) {
-                // initialize tool call
-                $toolCalls[$i] = [
-                    'id' => $toolCall['id'],
-                    'function' => $toolCall['function'],
-                ];
-                continue;
-            }
-
-            // add arguments delta to tool call
-            $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
-        }
-
-        return $toolCalls;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function streamIsToolCall(array $data): bool
-    {
-        return isset($data['choices'][0]['delta']['tool_calls']);
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function isToolCallsStreamFinished(array $data): bool
-    {
-        return isset($data['choices'][0]['finish_reason']) && 'tool_calls' === $data['choices'][0]['finish_reason'];
-    }
-
-    /**
-     * @param array{
-     *     index: int,
-     *     message: array{
-     *         role: 'assistant',
-     *         content: ?string,
-     *         tool_calls: list<array{
-     *             id: string,
-     *             type: 'function',
-     *             function: array{
-     *                 name: string,
-     *                 arguments: string
-     *             },
-     *         }>,
-     *         refusal: ?mixed
-     *     },
-     *     logprobs: string,
-     *     finish_reason: 'stop'|'length'|'tool_calls'|'content_filter',
-     * } $choice
-     */
-    private function convertChoice(array $choice): ToolCallResult|TextResult
-    {
-        if ('tool_calls' === $choice['finish_reason']) {
-            return new ToolCallResult(...array_map([$this, 'convertToolCall'], $choice['message']['tool_calls']));
-        }
-
-        if (\in_array($choice['finish_reason'], ['stop', 'length'], true)) {
-            return new TextResult($choice['message']['content']);
-        }
-
-        throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));
-    }
-
-    /**
-     * @param array{
-     *     id: string,
-     *     type: 'function',
-     *     function: array{
-     *         name: string,
-     *         arguments: string
-     *     }
-     * } $toolCall
-     */
-    private function convertToolCall(array $toolCall): ToolCall
-    {
-        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
-
-        return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }
 }

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Mistral\Llm;
 
+use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -29,6 +30,8 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use CompletionsConversionTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Mistral;
@@ -65,71 +68,6 @@ final class ResultConverter implements ResultConverterInterface
         return new TokenUsageExtractor();
     }
 
-    private function convertStream(RawResultInterface $result): \Generator
-    {
-        $toolCalls = [];
-        foreach ($result->getDataStream() as $data) {
-            if ($this->streamIsToolCall($data)) {
-                $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);
-            }
-
-            if ([] !== $toolCalls && $this->isToolCallsStreamFinished($data)) {
-                yield new ToolCallResult(...array_map($this->convertToolCall(...), $toolCalls));
-            }
-
-            if (!isset($data['choices'][0]['delta']['content'])) {
-                continue;
-            }
-
-            yield $data['choices'][0]['delta']['content'];
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $toolCalls
-     * @param array<string, mixed> $data
-     *
-     * @return array<string, mixed>
-     */
-    private function convertStreamToToolCalls(array $toolCalls, array $data): array
-    {
-        if (!isset($data['choices'][0]['delta']['tool_calls'])) {
-            return $toolCalls;
-        }
-
-        foreach ($data['choices'][0]['delta']['tool_calls'] as $i => $toolCall) {
-            if (isset($toolCall['id'])) {
-                // initialize tool call
-                $toolCalls[$i] = [
-                    'id' => $toolCall['id'],
-                    'function' => $toolCall['function'],
-                ];
-                continue;
-            }
-
-            // add arguments delta to tool call
-            $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
-        }
-
-        return $toolCalls;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function streamIsToolCall(array $data): bool
-    {
-        return isset($data['choices'][0]['delta']['tool_calls']);
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function isToolCallsStreamFinished(array $data): bool
-    {
-        return isset($data['choices'][0]['finish_reason']) && 'tool_calls' === $data['choices'][0]['finish_reason'];
-    }
-
     /**
      * @param array{
      *     index: int,
@@ -150,7 +88,7 @@ final class ResultConverter implements ResultConverterInterface
      *     finish_reason: 'stop'|'length'|'tool_calls'|'content_filter',
      * } $choice
      */
-    private function convertChoice(array $choice): ToolCallResult|TextResult
+    protected function convertChoice(array $choice): ToolCallResult|TextResult
     {
         if ('tool_calls' === $choice['finish_reason']) {
             return new ToolCallResult(...array_map([$this, 'convertToolCall'], $choice['message']['tool_calls']));
@@ -173,7 +111,7 @@ final class ResultConverter implements ResultConverterInterface
      *     }
      * } $toolCall
      */
-    private function convertToolCall(array $toolCall): ToolCall
+    protected function convertToolCall(array $toolCall): ToolCall
     {
         $arguments = json_decode((string) $toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
 

--- a/src/platform/src/Bridge/Mistral/composer.json
+++ b/src/platform/src/Bridge/Mistral/composer.json
@@ -25,6 +25,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/ai-generic-platform": "^0.6",
         "symfony/ai-platform": "^0.6",
         "symfony/http-client": "^7.3|^8.0"
     },

--- a/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Scaleway\Llm;
 
+use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
 use Symfony\AI\Platform\Bridge\Scaleway\Scaleway;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -19,9 +20,6 @@ use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
-use Symfony\AI\Platform\Result\TextResult;
-use Symfony\AI\Platform\Result\ToolCall;
-use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 
 /**
@@ -29,6 +27,8 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use CompletionsConversionTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Scaleway;
@@ -57,120 +57,5 @@ final class ResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): null
     {
         return null;
-    }
-
-    private function convertStream(RawResultInterface $result): \Generator
-    {
-        $toolCalls = [];
-        foreach ($result->getDataStream() as $data) {
-            if ($this->streamIsToolCall($data)) {
-                $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);
-            }
-
-            if ([] !== $toolCalls && $this->isToolCallsStreamFinished($data)) {
-                yield new ToolCallResult(...array_map($this->convertToolCall(...), $toolCalls));
-            }
-
-            if (!isset($data['choices'][0]['delta']['content'])) {
-                continue;
-            }
-
-            yield $data['choices'][0]['delta']['content'];
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $toolCalls
-     * @param array<string, mixed> $data
-     *
-     * @return array<string, mixed>
-     */
-    private function convertStreamToToolCalls(array $toolCalls, array $data): array
-    {
-        if (!isset($data['choices'][0]['delta']['tool_calls'])) {
-            return $toolCalls;
-        }
-
-        foreach ($data['choices'][0]['delta']['tool_calls'] as $i => $toolCall) {
-            if (isset($toolCall['id'])) {
-                // initialize tool call
-                $toolCalls[$i] = [
-                    'id' => $toolCall['id'],
-                    'function' => $toolCall['function'],
-                ];
-                continue;
-            }
-
-            // add arguments delta to tool call
-            $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
-        }
-
-        return $toolCalls;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function streamIsToolCall(array $data): bool
-    {
-        return isset($data['choices'][0]['delta']['tool_calls']);
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function isToolCallsStreamFinished(array $data): bool
-    {
-        return isset($data['choices'][0]['finish_reason']) && 'tool_calls' === $data['choices'][0]['finish_reason'];
-    }
-
-    /**
-     * @param array{
-     *     index: int,
-     *     message: array{
-     *         role: 'assistant',
-     *         content: ?string,
-     *         tool_calls: array{
-     *             id: string,
-     *             type: 'function',
-     *             function: array{
-     *                 name: string,
-     *                 arguments: string
-     *             },
-     *         },
-     *         refusal: ?mixed
-     *     },
-     *     logprobs: string,
-     *     finish_reason: 'stop'|'length'|'tool_calls'|'content_filter',
-     * } $choice
-     */
-    private function convertChoice(array $choice): ToolCallResult|TextResult
-    {
-        if ('tool_calls' === $choice['finish_reason']) {
-            return new ToolCallResult(...array_map([$this, 'convertToolCall'], $choice['message']['tool_calls']));
-        }
-
-        if (\in_array($choice['finish_reason'], ['stop', 'length'], true)) {
-            return new TextResult($choice['message']['content']);
-        }
-
-        throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));
-    }
-
-    /**
-     * @param array{
-     *     id: string,
-     *     type: 'function',
-     *     function: array{
-     *         name: string,
-     *         arguments: string
-     *     }
-     * } $toolCall
-     */
-    private function convertToolCall(array $toolCall): ToolCall
-    {
-        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
-
-        return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }
 }

--- a/src/platform/src/Bridge/Scaleway/composer.json
+++ b/src/platform/src/Bridge/Scaleway/composer.json
@@ -25,6 +25,7 @@
     ],
     "require": {
         "php": ">=8.2",
+        "symfony/ai-generic-platform": "^0.6",
         "symfony/ai-platform": "^0.6",
         "symfony/http-client": "^7.3|^8.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

A small cleanup to avoid code duplication.

The only difference is that the parameter type hint on `convertStream` for some bridges accepted `RawResultInterface` while the trait accepts `RawResultInterface|RawHttpResult`. I'm not sure it was done on purpose or not.