### PR TITLE
[Platform][OpenRouter] Add openrouter/free as base routing model

### DIFF
--- a/src/platform/src/Bridge/OpenRouter/AbstractOpenRouterModelCatalog.php
+++ b/src/platform/src/Bridge/OpenRouter/AbstractOpenRouterModelCatalog.php
@@ -21,6 +21,7 @@ use Symfony\AI\Platform\ModelCatalog\AbstractModelCatalog;
  * Routers:
  * - "openrouter/auto" -> https://openrouter.ai/docs/guides/routing/routers/auto-router
  * - "openrouter/bodybuilder" -> https://openrouter.ai/docs/guides/routing/routers/body-builder
+ * - "openrouter/free" -> https://openrouter.ai/openrouter/free & https://openrouter.ai/announcements/february-release-spotlight
  * - "@preset/" -> https://openrouter.ai/docs/guides/features/presets
  *
  * Provider selection modification
@@ -46,6 +47,10 @@ abstract class AbstractOpenRouterModelCatalog extends AbstractModelCatalog
                 'capabilities' => Capability::cases(),
             ],
             'openrouter/bodybuilder' => [
+                'class' => CompletionsModel::class,
+                'capabilities' => Capability::cases(),
+            ],
+            'openrouter/free' => [
                 'class' => CompletionsModel::class,
                 'capabilities' => Capability::cases(),
             ],

--- a/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.7
+---
+
+ * Add support for `openrouter/free`
+
 0.3
 ---
 

--- a/src/platform/src/Bridge/OpenRouter/Tests/ModelApiCatalogTest.php
+++ b/src/platform/src/Bridge/OpenRouter/Tests/ModelApiCatalogTest.php
@@ -88,6 +88,7 @@ final class ModelApiCatalogTest extends TestCase
 
         // Should include base models (openrouter/auto, @preset) + API models + embeddings
         $this->assertArrayHasKey('openrouter/auto', $models);
+        $this->assertArrayHasKey('openrouter/free', $models);
         $this->assertArrayHasKey('@preset', $models);
         $this->assertArrayHasKey('openai/gpt-4', $models);
         $this->assertArrayHasKey('google/gemini-pro-vision', $models);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

Add the generic routing model `openrouter/free` to the abstraction of the Model API Catalog