### PR TITLE
[Platform][Anthropic] Add example for TokenUsage with streaming responses

### DIFF
--- a/examples/anthropic/stream-token-metadata.php
+++ b/examples/anthropic/stream-token-metadata.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('ANTHROPIC_API_KEY'), httpClient: http_client());
+
+$agent = new Agent($platform, 'claude-sonnet-4-5-20250929');
+$messages = new MessageBag(
+    Message::forSystem('You are a pirate and you write funny.'),
+    Message::ofUser('What is the Symfony framework?'),
+);
+$result = $agent->call($messages, [
+    'stream' => true,
+]);
+
+foreach ($result->getContent() as $textChunk) {
+    echo $textChunk;
+}
+
+echo \PHP_EOL;
+
+print_token_usage($result->getMetadata()->get('token_usage'));
+
+echo \PHP_EOL;

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -23,6 +23,7 @@ use Symfony\AI\Platform\Result\ThinkingContent;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -93,9 +94,23 @@ class ResultConverter implements ResultConverterInterface
         $currentToolCallJson = '';
         $currentThinking = null;
         $currentThinkingSignature = null;
+        $inputUsage = null;
+        $outputUsage = null;
 
         foreach ($result->getDataStream() as $data) {
             $type = $data['type'] ?? '';
+
+            // Capture token usage from message_start
+            if ('message_start' === $type && isset($data['message']['usage'])) {
+                $inputUsage = $data['message']['usage'];
+                continue;
+            }
+
+            // Capture token usage from message_delta
+            if ('message_delta' === $type && isset($data['usage'])) {
+                $outputUsage = $data['usage'];
+                continue;
+            }
 
             // Handle text content deltas
             if ('content_block_delta' === $type && isset($data['delta']['text'])) {
@@ -177,10 +192,36 @@ class ResultConverter implements ResultConverterInterface
                 }
             }
 
-            // Handle message stop - yield tool calls if any were collected
-            if ('message_stop' === $type && [] !== $toolCalls) {
-                yield new ToolCallResult(...$toolCalls);
+            // Handle message stop - yield tool calls and token usage
+            if ('message_stop' === $type) {
+                if ([] !== $toolCalls) {
+                    yield new ToolCallResult(...$toolCalls);
+                }
+
+                if (null !== $inputUsage || null !== $outputUsage) {
+                    yield $this->buildStreamTokenUsage($inputUsage, $outputUsage);
+                }
             }
         }
+    }
+
+    /**
+     * @param ?array<string, mixed> $inputUsage
+     * @param ?array<string, mixed> $outputUsage
+     */
+    private function buildStreamTokenUsage(?array $inputUsage, ?array $outputUsage): TokenUsage
+    {
+        $cacheCreationTokens = isset($inputUsage['cache_creation_input_tokens']) ? (int) $inputUsage['cache_creation_input_tokens'] : null;
+        $cacheReadTokens = isset($inputUsage['cache_read_input_tokens']) ? (int) $inputUsage['cache_read_input_tokens'] : null;
+        $cachedTokens = (null !== $cacheCreationTokens || null !== $cacheReadTokens) ? ($cacheCreationTokens ?? 0) + ($cacheReadTokens ?? 0) : null;
+
+        return new TokenUsage(
+            promptTokens: $inputUsage['input_tokens'] ?? null,
+            completionTokens: $outputUsage['output_tokens'] ?? null,
+            toolTokens: $inputUsage['server_tool_use']['web_search_requests'] ?? null,
+            cachedTokens: $cachedTokens,
+            cacheCreationTokens: $cacheCreationTokens,
+            cacheReadTokens: $cacheReadTokens,
+        );
     }
 }

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -20,6 +20,7 @@ use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingContent;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -364,6 +365,97 @@ final class ResultConverterTest extends TestCase
         $this->expectExceptionMessage('Response content does not contain any text nor tool calls.');
 
         $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testStreamingTokenUsageYieldsTokenUsage()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['type' => 'message_start', 'message' => ['id' => 'msg_123', 'role' => 'assistant', 'content' => [], 'usage' => ['input_tokens' => 25, 'output_tokens' => 1]]],
+            ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'text', 'text' => '']],
+            ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'text_delta', 'text' => 'Hello!']],
+            ['type' => 'content_block_stop', 'index' => 0],
+            ['type' => 'message_delta', 'delta' => ['stop_reason' => 'end_turn'], 'usage' => ['output_tokens' => 15]],
+            ['type' => 'message_stop'],
+        ];
+
+        $raw = $this->createRawResult($events);
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($streamResult->getContent() as $part) {
+            $chunks[] = $part;
+        }
+
+        $this->assertCount(2, $chunks);
+        $this->assertSame('Hello!', $chunks[0]);
+        $this->assertInstanceOf(TokenUsage::class, $chunks[1]);
+        $this->assertSame(25, $chunks[1]->getPromptTokens());
+        $this->assertSame(15, $chunks[1]->getCompletionTokens());
+    }
+
+    public function testStreamingTokenUsageWithCacheFields()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['type' => 'message_start', 'message' => ['id' => 'msg_456', 'role' => 'assistant', 'content' => [], 'usage' => [
+                'input_tokens' => 10,
+                'output_tokens' => 1,
+                'cache_creation_input_tokens' => 5000,
+                'cache_read_input_tokens' => 20000,
+            ]]],
+            ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'text', 'text' => '']],
+            ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'text_delta', 'text' => 'Cached response.']],
+            ['type' => 'content_block_stop', 'index' => 0],
+            ['type' => 'message_delta', 'delta' => ['stop_reason' => 'end_turn'], 'usage' => ['output_tokens' => 42]],
+            ['type' => 'message_stop'],
+        ];
+
+        $raw = $this->createRawResult($events);
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($streamResult->getContent() as $part) {
+            $chunks[] = $part;
+        }
+
+        $this->assertCount(2, $chunks);
+        $this->assertInstanceOf(TokenUsage::class, $chunks[1]);
+        $this->assertSame(10, $chunks[1]->getPromptTokens());
+        $this->assertSame(42, $chunks[1]->getCompletionTokens());
+        $this->assertSame(5000, $chunks[1]->getCacheCreationTokens());
+        $this->assertSame(20000, $chunks[1]->getCacheReadTokens());
+        $this->assertSame(25000, $chunks[1]->getCachedTokens());
+    }
+
+    public function testStreamingToolCallsWithTokenUsage()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['type' => 'message_start', 'message' => ['id' => 'msg_789', 'role' => 'assistant', 'content' => [], 'usage' => ['input_tokens' => 100, 'output_tokens' => 1]]],
+            ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_01', 'name' => 'search']],
+            ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'input_json_delta', 'partial_json' => '{"q":"test"}']],
+            ['type' => 'content_block_stop', 'index' => 0],
+            ['type' => 'message_delta', 'delta' => ['stop_reason' => 'tool_use'], 'usage' => ['output_tokens' => 50]],
+            ['type' => 'message_stop'],
+        ];
+
+        $raw = $this->createRawResult($events);
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($streamResult->getContent() as $part) {
+            $chunks[] = $part;
+        }
+
+        $this->assertCount(2, $chunks);
+        $this->assertInstanceOf(ToolCallResult::class, $chunks[0]);
+        $this->assertInstanceOf(TokenUsage::class, $chunks[1]);
+        $this->assertSame(100, $chunks[1]->getPromptTokens());
+        $this->assertSame(50, $chunks[1]->getCompletionTokens());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1760
| License       | MIT

The Anthropic `ResultConverter::convertStream()` did not capture token usage from
`message_start` (input_tokens, cache fields) and `message_delta` (output_tokens) SSE events.

This adds handling consistent with how the OpenAI bridge already yields `TokenUsage` from
streaming responses, so the platform's `StreamListener` can pick it up and populate result metadata.