### PR TITLE
[Platform][Anthropic] Add prompt caching for tool definitions

### DIFF
--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -63,6 +63,7 @@ final class ModelClient implements ModelClientInterface
 
         if (isset($options['tools'])) {
             $options['tool_choice'] = ['type' => 'auto'];
+            $options['tools'] = $this->injectToolsCacheControl($options['tools']);
         }
 
         if (isset($options['thinking'])) {
@@ -88,6 +89,33 @@ final class ModelClient implements ModelClientInterface
             'headers' => $headers,
             'json' => array_merge($options, $payload),
         ]));
+    }
+
+    /**
+     * Injects a prompt-caching marker on the last tool definition.
+     *
+     * This creates an additional cache breakpoint after all tool definitions,
+     * so the prefix "system → tools" can be cached independently of the
+     * messages that follow.  Tool definitions are typically identical across
+     * requests, making this a very effective caching target.
+     *
+     * @param list<array<string, mixed>> $tools Normalised tool definitions
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function injectToolsCacheControl(array $tools): array
+    {
+        if ('none' === $this->cacheRetention || [] === $tools) {
+            return $tools;
+        }
+
+        $cacheControl = 'long' === $this->cacheRetention
+            ? ['type' => 'ephemeral', 'ttl' => '1h']
+            : ['type' => 'ephemeral'];
+
+        $tools[\count($tools) - 1]['cache_control'] = $cacheControl;
+
+        return $tools;
     }
 
     /**

--- a/src/platform/tests/Bridge/Anthropic/ModelClientTest.php
+++ b/src/platform/tests/Bridge/Anthropic/ModelClientTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\Anthropic;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Anthropic\Claude;
+use Symfony\AI\Platform\Bridge\Anthropic\ModelClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * @author Hannes Kandulla <hannes@faibl.org>
+ */
+final class ModelClientTest extends TestCase
+{
+    public function testToolsCacheControlIsInjectedWithShortRetention()
+    {
+        $capturedBody = null;
+
+        $httpClient = new MockHttpClient(static function ($method, $url, $options) use (&$capturedBody) {
+            $capturedBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'type' => 'message',
+                'content' => [['type' => 'text', 'text' => 'Hello']],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]));
+        });
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'short');
+
+        $tools = [
+            ['name' => 'tool_a', 'description' => 'First tool', 'input_schema' => ['type' => 'object']],
+            ['name' => 'tool_b', 'description' => 'Second tool', 'input_schema' => ['type' => 'object']],
+        ];
+
+        $payload = [
+            'model' => Claude::SONNET_4,
+            'messages' => [['role' => 'user', 'content' => 'Hello']],
+        ];
+
+        $client->request(new Claude(Claude::SONNET_4), $payload, ['tools' => $tools]);
+
+        $this->assertNotNull($capturedBody);
+
+        // Last tool should have cache_control
+        $this->assertArrayHasKey('cache_control', $capturedBody['tools'][1]);
+        $this->assertSame(['type' => 'ephemeral'], $capturedBody['tools'][1]['cache_control']);
+
+        // First tool should NOT have cache_control
+        $this->assertArrayNotHasKey('cache_control', $capturedBody['tools'][0]);
+    }
+
+    public function testToolsCacheControlIsInjectedWithLongRetention()
+    {
+        $capturedBody = null;
+
+        $httpClient = new MockHttpClient(static function ($method, $url, $options) use (&$capturedBody) {
+            $capturedBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'type' => 'message',
+                'content' => [['type' => 'text', 'text' => 'Hello']],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]));
+        });
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'long');
+
+        $tools = [
+            ['name' => 'tool_a', 'description' => 'A tool', 'input_schema' => ['type' => 'object']],
+        ];
+
+        $payload = [
+            'model' => Claude::SONNET_4,
+            'messages' => [['role' => 'user', 'content' => 'Hello']],
+        ];
+
+        $client->request(new Claude(Claude::SONNET_4), $payload, ['tools' => $tools]);
+
+        $this->assertNotNull($capturedBody);
+        $this->assertSame(['type' => 'ephemeral', 'ttl' => '1h'], $capturedBody['tools'][0]['cache_control']);
+    }
+
+    public function testToolsCacheControlIsNotInjectedWithNoneRetention()
+    {
+        $capturedBody = null;
+
+        $httpClient = new MockHttpClient(static function ($method, $url, $options) use (&$capturedBody) {
+            $capturedBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'type' => 'message',
+                'content' => [['type' => 'text', 'text' => 'Hello']],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]));
+        });
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'none');
+
+        $tools = [
+            ['name' => 'tool_a', 'description' => 'A tool', 'input_schema' => ['type' => 'object']],
+        ];
+
+        $payload = [
+            'model' => Claude::SONNET_4,
+            'messages' => [['role' => 'user', 'content' => 'Hello']],
+        ];
+
+        $client->request(new Claude(Claude::SONNET_4), $payload, ['tools' => $tools]);
+
+        $this->assertNotNull($capturedBody);
+        $this->assertArrayNotHasKey('cache_control', $capturedBody['tools'][0]);
+    }
+}


### PR DESCRIPTION
  | Q             | A
  | ------------- | ---
  | Bug fix?      | no
  | New feature?  | yes
  | Tickets       | -
  | License       | MIT

  ## Summary

  This PR adds automatic prompt caching (`cache_control`) to tool definitions in the Anthropic `ModelClient`, complementing the existing caching for system
  prompts and user messages.

  ### Problem

  Currently, `injectCacheControl()` only sets `cache_control` on the last user message. Tool definitions — which are typically **identical across all requests** —
   are not cached independently. This means they are re-processed as regular input tokens on every request, even though their content never changes.

  ### Solution

  Add `cache_control` to the last tool definition, creating an additional cache breakpoint:

  System (breakpoint 1) → Tools (breakpoint 2) → Messages (breakpoint 3)

  This allows the prefix "system + tools" to be cached and reused independently of the messages, which change with every request.

  ### Details

  - New private method `injectToolsCacheControl()` mirrors the pattern of the existing `injectCacheControl()`
  - Respects the existing `$cacheRetention` setting (`none` / `short` / `long`)
  - No new configuration needed — follows the same caching strategy already in place
  - Tool definitions are an ideal caching target: they are static across requests and can be substantial in size (descriptions + JSON schemas)

  ### Cost impact

  With Anthropic's pricing:
  - `cache_creation`: 1.25× input price (one-time per cache entry)
  - `cache_read`: 0.1× input price (every subsequent request)

  Since tool definitions don't change, the cache entry is created once and read on every subsequent request within the TTL — a significant cost reduction for
  tool-heavy agents.