### PR TITLE
[Platform] Add getTokenUsage() convenience method to DeferredResult

### DIFF
--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Metadata\MetadataAwareTrait;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\TokenUsage\StreamListener;
 use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
 use Symfony\AI\Platform\Vector\Vector;
 
 /**
@@ -146,6 +147,17 @@ final class DeferredResult
     public function asToolCalls(): array
     {
         return $this->as(ToolCallResult::class)->getContent();
+    }
+
+    public function getTokenUsage(): ?TokenUsageInterface
+    {
+        $tokenUsage = $this->getMetadata()->get('token_usage');
+
+        if ($tokenUsage instanceof TokenUsageInterface) {
+            return $tokenUsage;
+        }
+
+        return null;
     }
 
     /**

--- a/src/platform/tests/Result/DeferredResultTest.php
+++ b/src/platform/tests/Result/DeferredResultTest.php
@@ -167,6 +167,28 @@ final class DeferredResultTest extends TestCase
         $this->assertSame(123456, $tokenUsage->getPromptTokens());
     }
 
+    public function testGetTokenUsageReturnsTokenUsageFromMetadata()
+    {
+        $tokenUsage = new TokenUsage(promptTokens: 10, totalTokens: 10);
+        $result = new TextResult('Hello World');
+        $result->getMetadata()->add('token_usage', $tokenUsage);
+
+        $deferredResult = new DeferredResult(new PlainConverter($result), new InMemoryRawResult());
+        $deferredResult->getResult();
+
+        $this->assertSame($tokenUsage, $deferredResult->getTokenUsage());
+    }
+
+    public function testGetTokenUsageReturnsNullWhenNoTokenUsage()
+    {
+        $result = new TextResult('Hello World');
+
+        $deferredResult = new DeferredResult(new PlainConverter($result), new InMemoryRawResult());
+        $deferredResult->getResult();
+
+        $this->assertNull($deferredResult->getTokenUsage());
+    }
+
     /**
      * Workaround for low deps because mocking the ResponseInterface leads to an exception with
      * mock creation "Type Traversable|object|array|string|null contains both object and a class type"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

## Description

Adds a typed `getTokenUsage(): ?TokenUsageInterface` convenience method to `DeferredResult`, avoiding the verbose `$result->getMetadata()->get('token_usage')` pattern.

This delegates to the existing metadata system — no data duplication. Returns `null` when no token usage is available.

Scoped out from #1765 for separate discussion, as the relationship between structured accessors and the flexible metadata system deserves its own review.

### Usage

```php
$result = $platform->invoke('mistral-embed', 'Some text to embed');

// Before
$tokenUsage = $result->getMetadata()->get('token_usage');

// After
$tokenUsage = $result->getTokenUsage();
$tokenUsage->getPromptTokens();
$tokenUsage->getTotalTokens();
```