### PR TITLE
[Store] Fix RstToctreeLoader trailing-slash toctree entry resolution

### DIFF
--- a/src/store/src/Document/Loader/RstToctreeLoader.php
+++ b/src/store/src/Document/Loader/RstToctreeLoader.php
@@ -116,6 +116,8 @@ final class RstToctreeLoader implements LoaderInterface
 
                         if (str_ends_with($entryPath, '.rst')) {
                             $pattern = $dir.'/'.$entryPath;
+                        } elseif (str_ends_with($entryPath, '/')) {
+                            $pattern = $dir.'/'.$entryPath.'index.rst';
                         } else {
                             $pattern = $dir.'/'.$entryPath.'.rst';
                         }

--- a/src/store/tests/Document/Loader/Fixtures/rst/with_trailing_slash_toctree/components/index.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/with_trailing_slash_toctree/components/index.rst
@@ -1,0 +1,4 @@
+Components
+==========
+
+This section describes the available components.

--- a/src/store/tests/Document/Loader/Fixtures/rst/with_trailing_slash_toctree/index.rst
+++ b/src/store/tests/Document/Loader/Fixtures/rst/with_trailing_slash_toctree/index.rst
@@ -1,0 +1,9 @@
+Main Index
+==========
+
+Welcome to the documentation.
+
+.. toctree::
+   :hidden:
+
+   components/

--- a/src/store/tests/Document/Loader/RstToctreeLoaderTest.php
+++ b/src/store/tests/Document/Loader/RstToctreeLoaderTest.php
@@ -221,6 +221,20 @@ final class RstToctreeLoaderTest extends TestCase
         $this->assertCount(1, $alphaDocs);
     }
 
+    public function testLoadToctreeWithTrailingSlashResolvesToIndex()
+    {
+        $loader = new RstToctreeLoader();
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_trailing_slash_toctree/index.rst'), false);
+
+        $titles = array_map(
+            static fn (EmbeddableDocumentInterface $doc): string => $doc->getMetadata()->getTitle() ?? '',
+            $documents,
+        );
+
+        $this->assertContains('Main Index', $titles);
+        $this->assertContains('Components', $titles);
+    }
+
     public function testLoadToctreeThrowsForMissingEntry()
     {
         $tempDir = sys_get_temp_dir().'/rst_missing_test_'.uniqid();


### PR DESCRIPTION
  | Q             | A
  | ------------- | ---
  | Bug fix?      | yes
  | New feature?  | no
  | Docs?         | no
  | Issues        | Fix #1771
  | License       | MIT

## Summary

  Trailing-slash toctree entries like `components/` are valid Sphinx syntax and resolve to `components/index.rst`. The
  loader now handles this convention instead of producing the invalid path `components/.rst`.