### PR TITLE
[Platform][Store] Consistently use symfony/event-dispatcher-contracts

### DIFF
--- a/src/platform/src/Bridge/AiMlApi/PlatformFactory.php
+++ b/src/platform/src/Bridge/AiMlApi/PlatformFactory.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\AI\Platform\Bridge\AiMlApi;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Platform;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Albert/PlatformFactory.php
+++ b/src/platform/src/Bridge/Albert/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\Albert;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/AmazeeAi/PlatformFactory.php
+++ b/src/platform/src/Bridge/AmazeeAi/PlatformFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Platform\Bridge\AmazeeAi;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Generic\Completions\ModelClient;
 use Symfony\AI\Platform\Bridge\Generic\Embeddings;
 use Symfony\AI\Platform\Bridge\Generic\FallbackModelCatalog;
@@ -19,6 +18,7 @@ use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class PlatformFactory

--- a/src/platform/src/Bridge/Anthropic/PlatformFactory.php
+++ b/src/platform/src/Bridge/Anthropic/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\Anthropic;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Anthropic\Contract\AnthropicContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Azure/Meta/PlatformFactory.php
+++ b/src/platform/src/Bridge/Azure/Meta/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\Meta;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Meta\ModelCatalog;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Azure/OpenAi/PlatformFactory.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/PlatformFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\OpenAi;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Azure\Responses\ModelClient as ResponsesModelClient;
 use Symfony\AI\Platform\Bridge\Generic\Embeddings;
 use Symfony\AI\Platform\Bridge\OpenAi\Contract\OpenAiContract;
@@ -21,6 +20,7 @@ use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Bedrock/PlatformFactory.php
+++ b/src/platform/src/Bridge/Bedrock/PlatformFactory.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Platform\Bridge\Bedrock;
 
 use AsyncAws\BedrockRuntime\BedrockRuntimeClient;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Anthropic\Contract as AnthropicContract;
 use Symfony\AI\Platform\Bridge\Bedrock\Anthropic\ClaudeModelClient;
 use Symfony\AI\Platform\Bridge\Bedrock\Anthropic\ClaudeResultConverter;
@@ -26,6 +25,7 @@ use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Björn Altmann

--- a/src/platform/src/Bridge/Cartesia/PlatformFactory.php
+++ b/src/platform/src/Bridge/Cartesia/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\Cartesia;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Cartesia\Contract\CartesiaContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Cerebras/PlatformFactory.php
+++ b/src/platform/src/Bridge/Cerebras/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\Cerebras;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Cerebras\Contract\ToolNormalizer;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/ClaudeCode/PlatformFactory.php
+++ b/src/platform/src/Bridge/ClaudeCode/PlatformFactory.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\AI\Platform\Bridge\ClaudeCode;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Platform\Bridge\ClaudeCode\Contract\ClaudeCodeContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>

--- a/src/platform/src/Bridge/Decart/PlatformFactory.php
+++ b/src/platform/src/Bridge/Decart/PlatformFactory.php
@@ -15,8 +15,8 @@ use Symfony\AI\Platform\Bridge\Decart\Contract\DecartContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/DeepSeek/PlatformFactory.php
+++ b/src/platform/src/Bridge/DeepSeek/PlatformFactory.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\AI\Platform\Bridge\DeepSeek;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class PlatformFactory

--- a/src/platform/src/Bridge/DockerModelRunner/PlatformFactory.php
+++ b/src/platform/src/Bridge/DockerModelRunner/PlatformFactory.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\AI\Platform\Bridge\DockerModelRunner;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/ElevenLabs/PlatformFactory.php
+++ b/src/platform/src/Bridge/ElevenLabs/PlatformFactory.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\AI\Platform\Bridge\ElevenLabs;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\ElevenLabs\Contract\ElevenLabsContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Component\HttpClient\ScopingHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Gemini/PlatformFactory.php
+++ b/src/platform/src/Bridge/Gemini/PlatformFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Platform\Bridge\Gemini;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Gemini\Contract\GeminiContract;
 use Symfony\AI\Platform\Bridge\Gemini\Embeddings\ModelClient as EmbeddingsModelClient;
 use Symfony\AI\Platform\Bridge\Gemini\Embeddings\ResultConverter as EmbeddingsResultConverter;
@@ -21,6 +20,7 @@ use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Generic/PlatformFactory.php
+++ b/src/platform/src/Bridge/Generic/PlatformFactory.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\AI\Platform\Bridge\Generic;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/HuggingFace/PlatformFactory.php
+++ b/src/platform/src/Bridge/HuggingFace/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\HuggingFace;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\HuggingFace\Contract\HuggingFaceContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/LmStudio/PlatformFactory.php
+++ b/src/platform/src/Bridge/LmStudio/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\LmStudio;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Mistral/PlatformFactory.php
+++ b/src/platform/src/Bridge/Mistral/PlatformFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Platform\Bridge\Mistral;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Mistral\Contract\DocumentNormalizer;
 use Symfony\AI\Platform\Bridge\Mistral\Contract\DocumentUrlNormalizer;
 use Symfony\AI\Platform\Bridge\Mistral\Contract\ImageUrlNormalizer;
@@ -20,6 +19,7 @@ use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/ModelsDev/PlatformFactory.php
+++ b/src/platform/src/Bridge/ModelsDev/PlatformFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Platform\Bridge\ModelsDev;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Generic\CompletionsModel;
 use Symfony\AI\Platform\Bridge\Generic\EmbeddingsModel;
 use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
@@ -19,6 +18,7 @@ use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Ollama/PlatformFactory.php
+++ b/src/platform/src/Bridge/Ollama/PlatformFactory.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\AI\Platform\Bridge\Ollama;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Ollama\Contract\OllamaContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Component\HttpClient\ScopingHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/OpenAi/PlatformFactory.php
+++ b/src/platform/src/Bridge/OpenAi/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenAi;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\OpenAi\Contract\OpenAiContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/OpenResponses/PlatformFactory.php
+++ b/src/platform/src/Bridge/OpenResponses/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenResponses;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\OpenResponses\Contract\OpenResponsesContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/OpenRouter/PlatformFactory.php
+++ b/src/platform/src/Bridge/OpenRouter/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\OpenRouter;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Ovh/PlatformFactory.php
+++ b/src/platform/src/Bridge/Ovh/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\Ovh;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Perplexity/PlatformFactory.php
+++ b/src/platform/src/Bridge/Perplexity/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\Perplexity;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Perplexity\Contract\PerplexityContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Replicate/PlatformFactory.php
+++ b/src/platform/src/Bridge/Replicate/PlatformFactory.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\AI\Platform\Bridge\Replicate;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Replicate\Contract\LlamaMessageBagNormalizer;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\Clock\Clock;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Scaleway/PlatformFactory.php
+++ b/src/platform/src/Bridge/Scaleway/PlatformFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Platform\Bridge\Scaleway;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Scaleway\Embeddings\ModelClient as ScalewayEmbeddingsModelClient;
 use Symfony\AI\Platform\Bridge\Scaleway\Embeddings\ResultConverter as ScalewayEmbeddingsResponseConverter;
 use Symfony\AI\Platform\Bridge\Scaleway\Llm\ModelClient as ScalewayModelClient;
@@ -20,6 +19,7 @@ use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/TransformersPhp/PlatformFactory.php
+++ b/src/platform/src/Bridge/TransformersPhp/PlatformFactory.php
@@ -12,10 +12,10 @@
 namespace Symfony\AI\Platform\Bridge\TransformersPhp;
 
 use Codewithkyrian\Transformers\Transformers;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>

--- a/src/platform/src/Bridge/VertexAi/PlatformFactory.php
+++ b/src/platform/src/Bridge/VertexAi/PlatformFactory.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Platform\Bridge\VertexAi;
 
 use Google\Auth\ApplicationDefaultCredentials;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\VertexAi\Contract\GeminiContract;
 use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\ModelClient as EmbeddingsModelClient;
 use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\ResultConverter as EmbeddingsResultConverter;
@@ -24,6 +23,7 @@ use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Bridge/Voyage/PlatformFactory.php
+++ b/src/platform/src/Bridge/Voyage/PlatformFactory.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\Voyage;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Bridge\Voyage\Contract\VoyageContract;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**

--- a/src/platform/src/Platform.php
+++ b/src/platform/src/Platform.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\AI\Platform;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Event\InvocationEvent;
 use Symfony\AI\Platform\Event\ResultEvent;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>

--- a/src/store/composer.json
+++ b/src/store/composer.json
@@ -41,7 +41,6 @@
     "require": {
         "php": ">=8.2",
         "ext-fileinfo": "*",
-        "psr/event-dispatcher": "^1.0",
         "psr/log": "^3.0",
         "symfony/ai-platform": "^0.6",
         "symfony/clock": "^7.3|^8.0",

--- a/src/store/src/Retriever.php
+++ b/src/store/src/Retriever.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Store;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Store\Document\VectorDocument;
@@ -22,6 +21,7 @@ use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\QueryInterface;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>

--- a/src/store/tests/RetrieverTest.php
+++ b/src/store/tests/RetrieverTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Store\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
@@ -28,6 +27,7 @@ use Symfony\AI\Store\StoreInterface;
 use Symfony\AI\Store\Tests\Double\PlatformTestHandler;
 use Symfony\AI\Store\Tests\Double\TestStore;
 use Symfony\Component\Uid\Uuid;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Always use `symfony/event-dispatcher-contracts`.