### PR TITLE
[Store] Skip missing toctree entries gracefully

### DIFF
--- a/src/store/src/Document/Loader/RstToctreeLoader.php
+++ b/src/store/src/Document/Loader/RstToctreeLoader.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Store\Document\Loader;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\AI\Store\Document\EmbeddableDocumentInterface;
 use Symfony\AI\Store\Document\LoaderInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
@@ -25,6 +27,8 @@ final class RstToctreeLoader implements LoaderInterface
 {
     public function __construct(
         private RstLoader $rstLoader = new RstLoader(),
+        private bool $throwOnMissingEntry = false,
+        private LoggerInterface $logger = new NullLogger(),
     ) {
     }
 
@@ -135,7 +139,17 @@ final class RstToctreeLoader implements LoaderInterface
                             }
                         } else {
                             if (!file_exists($pattern)) {
-                                throw new RuntimeException(\sprintf('Toctree entry "%s" resolved to "%s" which does not exist.', $entryPath, $pattern));
+                                if ($this->throwOnMissingEntry) {
+                                    throw new RuntimeException(\sprintf('Toctree entry "%s" resolved to "%s" which does not exist.', $entryPath, $pattern));
+                                }
+
+                                $this->logger->warning('Skipping toctree entry "{entry}" — resolved to "{path}" which does not exist.', [
+                                    'entry' => $entryPath,
+                                    'path' => $pattern,
+                                ]);
+
+                                ++$i;
+                                continue;
                             }
 
                             if (!\in_array($pattern, $entries, true)) {

--- a/src/store/tests/Document/Loader/RstToctreeLoaderTest.php
+++ b/src/store/tests/Document/Loader/RstToctreeLoaderTest.php
@@ -242,11 +242,28 @@ final class RstToctreeLoaderTest extends TestCase
         file_put_contents($tempDir.'/index.rst', "Title\n=====\n\n.. toctree::\n\n   missing_page\n");
 
         try {
-            $loader = new RstToctreeLoader();
+            $loader = new RstToctreeLoader(throwOnMissingEntry: true);
 
             $this->expectException(RuntimeException::class);
             $this->expectExceptionMessage('does not exist');
             iterator_to_array($loader->load($tempDir.'/index.rst'), false);
+        } finally {
+            unlink($tempDir.'/index.rst');
+            rmdir($tempDir);
+        }
+    }
+
+    public function testLoadToctreeSkipsMissingEntryByDefault()
+    {
+        $tempDir = sys_get_temp_dir().'/rst_missing_test_'.uniqid();
+        mkdir($tempDir, 0777, true);
+        file_put_contents($tempDir.'/index.rst', "Title\n=====\n\n.. toctree::\n\n   missing_page\n");
+
+        try {
+            $loader = new RstToctreeLoader();
+            $documents = iterator_to_array($loader->load($tempDir.'/index.rst'), false);
+
+            $this->assertCount(1, $documents);
         } finally {
             unlink($tempDir.'/index.rst');
             rmdir($tempDir);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

## Summary

Skip missing toctree entries with a log warning instead of throwing. The previous strict behavior is available via the `throwOnMissingEntry` constructor parameter.