### PR TITLE
[Examples] Store SQLite database in .sqlite directory

### DIFF
--- a/examples/rag/.gitignore
+++ b/examples/rag/.gitignore
@@ -1,1 +1,2 @@
 .symfony-docs/
+.sqlite/

--- a/examples/rag/sqlite.php
+++ b/examples/rag/sqlite.php
@@ -28,7 +28,10 @@ use Symfony\Component\Uid\Uuid;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 // initialize the store — file-based SQLite for persistence
-$pdo = new PDO('sqlite:'.__DIR__.'/var/vectors.db');
+if (!is_dir(__DIR__.'/.sqlite')) {
+    mkdir(__DIR__.'/.sqlite', 0777, true);
+}
+$pdo = new PDO('sqlite:'.__DIR__.'/.sqlite/vectors.db');
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $store = new Store($pdo, 'movies');
 $store->setup();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Move the SQLite vector database from `var/` to `.sqlite/` with auto-creation of the directory. Keeps generated files in a gitignored hidden directory.