### PR TITLE
[Store] Split query string into words for TextQuery and HybridQuery in Retriever

### DIFF
--- a/src/store/src/Retriever.php
+++ b/src/store/src/Retriever.php
@@ -113,19 +113,19 @@ final class Retriever implements RetrieverInterface
         if (null === $this->vectorizer) {
             $this->logger->debug('No vectorizer configured, using TextQuery if supported');
 
-            return new TextQuery($query);
+            return new TextQuery(explode(' ', $query));
         }
 
         if (!$this->store->supports(VectorQuery::class)) {
             $this->logger->debug('Store does not support vector queries, falling back to TextQuery');
 
-            return new TextQuery($query);
+            return new TextQuery(explode(' ', $query));
         }
 
         if ($this->store->supports(HybridQuery::class)) {
             $this->logger->debug('Store supports hybrid queries, using HybridQuery with semantic ratio', ['semanticRatio' => $options['semanticRatio'] ?? 0.5]);
 
-            return new HybridQuery($this->vectorizer->vectorize($query), $query, $options['semanticRatio'] ?? 0.5);
+            return new HybridQuery($this->vectorizer->vectorize($query), explode(' ', $query), $options['semanticRatio'] ?? 0.5);
         }
 
         $this->logger->debug('Store supports vector queries, using VectorQuery');

--- a/src/store/tests/RetrieverTest.php
+++ b/src/store/tests/RetrieverTest.php
@@ -124,7 +124,9 @@ final class RetrieverTest extends TestCase
         $store->expects($this->once())
             ->method('query')
             ->with(
-                $this->isInstanceOf(TextQuery::class),
+                $this->callback(static function ($query) {
+                    return $query instanceof TextQuery && ['test', 'query'] === $query->getTexts();
+                }),
                 $this->anything()
             )
             ->willReturn([$document]);
@@ -160,7 +162,9 @@ final class RetrieverTest extends TestCase
         $store->expects($this->once())
             ->method('query')
             ->with(
-                $this->isInstanceOf(TextQuery::class),
+                $this->callback(static function ($query) {
+                    return $query instanceof TextQuery && ['test', 'query'] === $query->getTexts();
+                }),
                 $this->anything()
             )
             ->willReturn([$document]);
@@ -196,7 +200,9 @@ final class RetrieverTest extends TestCase
         $store->expects($this->once())
             ->method('query')
             ->with(
-                $this->isInstanceOf(HybridQuery::class),
+                $this->callback(static function ($query) {
+                    return $query instanceof HybridQuery && ['test', 'query'] === $query->getTexts();
+                }),
                 $this->anything()
             )
             ->willReturn([$document]);
@@ -403,7 +409,7 @@ final class RetrieverTest extends TestCase
             ->method('query')
             ->with(
                 $this->callback(static function ($query) {
-                    return $query instanceof HybridQuery && 'expanded query terms' === $query->getText();
+                    return $query instanceof HybridQuery && ['expanded', 'query', 'terms'] === $query->getTexts();
                 }),
                 $this->anything()
             )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The `Retriever` was passing the full query string as a single text to `TextQuery` and `HybridQuery`. This makes little sense for keyword-based matching — stores use the texts with OR logic, so the query should be split into individual words to allow each term to be matched independently.

`explode(' ', $query)` is now used when constructing both `TextQuery` and `HybridQuery`, and the tests have been updated to assert that `getTexts()` returns the expected word array.