### PR TITLE
[Store] Use Reciprocal Rank Fusion for hybrid queries in SQLite store

### DIFF
--- a/src/store/src/Bridge/Sqlite/Store.php
+++ b/src/store/src/Bridge/Sqlite/Store.php
@@ -30,6 +30,8 @@ use Symfony\AI\Store\StoreInterface;
  */
 final class Store implements ManagedStoreInterface, StoreInterface
 {
+    private const RRF_K = 60;
+
     public function __construct(
         private readonly \PDO $connection,
         private readonly string $tableName,
@@ -235,11 +237,17 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $searchTerms = $query->getTexts();
         $ftsQuery = implode(' OR ', array_map(static fn (string $term): string => '"'.$term.'"', $searchTerms));
 
-        $statement = $this->connection->prepare(\sprintf(
+        $sql = \sprintf(
             'SELECT id, rank FROM %s_fts WHERE %s_fts MATCH :query ORDER BY rank',
             $this->tableName,
             $this->tableName,
-        ));
+        );
+
+        if (isset($options['maxItems'])) {
+            $sql .= \sprintf(' LIMIT %d', $options['maxItems']);
+        }
+
+        $statement = $this->connection->prepare($sql);
         $statement->bindValue(':query', $ftsQuery);
         $statement->execute();
 
@@ -299,8 +307,20 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
+     * Uses Reciprocal Rank Fusion (RRF) to combine vector and text search results.
+     *
+     * RRF assigns each document a score of `ratio / (k + rank)` from each ranked list
+     * it appears in, then sums these scores. Documents appearing in both lists receive
+     * higher combined scores than those in only one, solving the null-text-score problem
+     * and the no-overlap scenario where vector and text results are entirely disjoint.
+     *
+     * Each sub-query fetches a candidate pool of `rrfCandidatePoolSize` documents (defaults
+     * to `maxItems * 10`, minimum 100). RRF merges and re-ranks the pool, then `maxItems`
+     * is applied. Override via `$options['rrfCandidatePoolSize']`.
+     *
      * @param array{
      *     maxItems?: positive-int,
+     *     rrfCandidatePoolSize?: positive-int,
      *     filter?: callable(VectorDocument): bool,
      * } $options
      *
@@ -308,53 +328,68 @@ final class Store implements ManagedStoreInterface, StoreInterface
      */
     private function queryHybrid(HybridQuery $query, array $options): iterable
     {
+        $maxItems = $options['maxItems'] ?? null;
+
+        // Each sub-query fetches a candidate pool larger than maxItems so RRF has
+        // enough documents to rank before trimming. Falls back to no limit when
+        // maxItems is not set (caller explicitly requested all results).
+        $candidatePoolSize = $options['rrfCandidatePoolSize']
+            ?? (null !== $maxItems ? max($maxItems * 10, 100) : null);
+
+        $subOptions = $options;
+        unset($subOptions['rrfCandidatePoolSize']);
+        if (null !== $candidatePoolSize) {
+            $subOptions['maxItems'] = $candidatePoolSize;
+        } else {
+            unset($subOptions['maxItems']);
+        }
+
         $vectorResults = iterator_to_array($this->queryVector(
             new VectorQuery($query->getVector()),
-            $options,
+            $subOptions,
         ));
 
         $textResults = iterator_to_array($this->queryText(
             new TextQuery($query->getTexts()),
-            $options,
+            $subOptions,
         ));
 
-        $mergedResults = [];
-        $seenIds = [];
+        /** @var array<string, array{doc: VectorDocument, score: float}> $scores */
+        $scores = [];
 
-        foreach ($vectorResults as $doc) {
+        foreach ($vectorResults as $rank => $doc) {
             $id = (string) $doc->getId();
-            if (!isset($seenIds[$id])) {
-                $mergedResults[] = new VectorDocument(
-                    id: $doc->getId(),
-                    vector: $doc->getVector(),
-                    metadata: $doc->getMetadata(),
-                    score: null !== $doc->getScore() ? $doc->getScore() * $query->getSemanticRatio() : null,
-                );
-                $seenIds[$id] = true;
+            $scores[$id] = [
+                'doc' => $doc,
+                'score' => $query->getSemanticRatio() * (1.0 / (self::RRF_K + $rank + 1)),
+            ];
+        }
+
+        foreach ($textResults as $rank => $doc) {
+            $id = (string) $doc->getId();
+            $rrfScore = $query->getKeywordRatio() * (1.0 / (self::RRF_K + $rank + 1));
+            if (isset($scores[$id])) {
+                $scores[$id]['score'] += $rrfScore;
+            } else {
+                $scores[$id] = ['doc' => $doc, 'score' => $rrfScore];
             }
         }
 
-        foreach ($textResults as $doc) {
-            $id = (string) $doc->getId();
-            if (!isset($seenIds[$id])) {
-                $mergedResults[] = $doc;
-                $seenIds[$id] = true;
-            }
-        }
+        usort($scores, static fn (array $a, array $b): int => $b['score'] <=> $a['score']);
 
-        if (isset($options['filter'])) {
-            $mergedResults = array_values(array_filter($mergedResults, $options['filter']));
-        }
-
-        $maxItems = $options['maxItems'] ?? null;
         $count = 0;
 
-        foreach ($mergedResults as $document) {
+        foreach ($scores as ['doc' => $doc, 'score' => $score]) {
             if (null !== $maxItems && $count >= $maxItems) {
                 break;
             }
 
-            yield $document;
+            yield new VectorDocument(
+                id: $doc->getId(),
+                vector: $doc->getVector(),
+                metadata: $doc->getMetadata(),
+                score: $score,
+            );
             ++$count;
         }
     }

--- a/src/store/src/Bridge/Sqlite/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Sqlite/Tests/StoreTest.php
@@ -336,6 +336,235 @@ final class StoreTest extends TestCase
         );
     }
 
+    public function testQueryHybridScoresAreNeverNull()
+    {
+        $store = $this->createStore();
+        $store->setup();
+
+        $metadata1 = new Metadata();
+        $metadata1->setText('vector match only');
+
+        $metadata2 = new Metadata();
+        $metadata2->setText('keyword match here');
+
+        $store->add([
+            new VectorDocument('doc-1', new Vector([1.0, 0.0, 0.0]), $metadata1),
+            new VectorDocument('doc-2', new Vector([0.0, 1.0, 0.0]), $metadata2),
+        ]);
+
+        $results = iterator_to_array($store->query(
+            new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.5),
+        ));
+
+        foreach ($results as $doc) {
+            $this->assertNotNull($doc->getScore(), 'Hybrid query score must never be null');
+            $this->assertGreaterThan(0.0, $doc->getScore());
+        }
+    }
+
+    public function testQueryHybridWithNoOverlapBetweenVectorAndTextResults()
+    {
+        $store = $this->createStore();
+        $store->setup();
+
+        $metadata1 = new Metadata();
+        $metadata1->setText('unrelated content here');
+
+        $metadata2 = new Metadata();
+        $metadata2->setText('keyword appears here');
+
+        $store->add([
+            // Vector-close doc, no text match
+            new VectorDocument('doc-vector', new Vector([1.0, 0.0, 0.0]), $metadata1),
+            // Text-match doc, distant vector
+            new VectorDocument('doc-text', new Vector([0.0, 0.0, 1.0]), $metadata2),
+        ]);
+
+        $results = iterator_to_array($store->query(
+            new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.5),
+        ));
+
+        // Both documents must appear and have non-null scores
+        $this->assertCount(2, $results);
+
+        $ids = array_map(static fn (VectorDocument $doc): string|int => $doc->getId(), $results);
+        $this->assertContains('doc-vector', $ids);
+        $this->assertContains('doc-text', $ids);
+
+        foreach ($results as $doc) {
+            $this->assertNotNull($doc->getScore());
+            $this->assertGreaterThan(0.0, $doc->getScore());
+        }
+    }
+
+    public function testQueryHybridDocumentInBothListsRanksHigher()
+    {
+        $store = $this->createStore();
+        $store->setup();
+
+        $metadata1 = new Metadata();
+        $metadata1->setText('keyword relevant');
+
+        $metadata2 = new Metadata();
+        $metadata2->setText('no match');
+
+        $metadata3 = new Metadata();
+        $metadata3->setText('keyword here');
+
+        $store->add([
+            // Matches both: close vector AND contains the keyword
+            new VectorDocument('doc-both', new Vector([1.0, 0.0, 0.0]), $metadata1),
+            // Close vector but no text match
+            new VectorDocument('doc-vector', new Vector([0.99, 0.1, 0.0]), $metadata2),
+            // Distant vector but text match
+            new VectorDocument('doc-text', new Vector([0.0, 0.0, 1.0]), $metadata3),
+        ]);
+
+        $results = iterator_to_array($store->query(
+            new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.5),
+        ));
+
+        $this->assertCount(3, $results);
+
+        // The document appearing in both lists must have the highest RRF score
+        $this->assertSame('doc-both', $results[0]->getId());
+    }
+
+    public function testQueryHybridRespectsMaxItems()
+    {
+        $store = $this->createStore();
+        $store->setup();
+
+        for ($i = 1; $i <= 10; ++$i) {
+            $metadata = new Metadata();
+            $metadata->setText(\sprintf('document number %d keyword', $i));
+            $store->add(new VectorDocument(
+                \sprintf('doc-%d', $i),
+                new Vector([1.0, 0.0, 0.0]),
+                $metadata,
+            ));
+        }
+
+        $results = iterator_to_array($store->query(
+            new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.5),
+            ['maxItems' => 3],
+        ));
+
+        $this->assertCount(3, $results);
+    }
+
+    public function testQueryHybridHighSemanticRatioScoresVectorDocHigher()
+    {
+        $store = $this->createStore();
+        $store->setup();
+
+        $metadata1 = new Metadata();
+        $metadata1->setText('unrelated content here');
+
+        $metadata2 = new Metadata();
+        $metadata2->setText('keyword match');
+
+        $store->add([
+            // Vector-only doc (no text match): score depends entirely on semantic ratio
+            new VectorDocument('doc-vector', new Vector([1.0, 0.0, 0.0]), $metadata1),
+            new VectorDocument('doc-text', new Vector([0.0, 0.0, 1.0]), $metadata2),
+        ]);
+
+        $scoreAt09 = $this->getScoreForDoc('doc-vector', $store, new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.9));
+        $scoreAt01 = $this->getScoreForDoc('doc-vector', $store, new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.1));
+
+        // Higher semantic ratio → higher RRF weight on vector contribution → higher score for vector-only doc
+        $this->assertGreaterThan($scoreAt01, $scoreAt09);
+    }
+
+    public function testQueryHybridLowSemanticRatioScoresTextDocHigher()
+    {
+        $store = $this->createStore();
+        $store->setup();
+
+        $metadata1 = new Metadata();
+        $metadata1->setText('unrelated content here');
+
+        $metadata2 = new Metadata();
+        $metadata2->setText('keyword match');
+
+        $store->add([
+            // Push doc-text to vector rank 1 so its text contribution is the variable
+            new VectorDocument('doc-vector', new Vector([1.0, 0.0, 0.0]), $metadata1),
+            new VectorDocument('doc-text', new Vector([0.0, 0.0, 1.0]), $metadata2),
+        ]);
+
+        $scoreAt09 = $this->getScoreForDoc('doc-text', $store, new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.9));
+        $scoreAt01 = $this->getScoreForDoc('doc-text', $store, new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.1));
+
+        // Lower semantic ratio (= higher keyword ratio) → higher RRF weight on text contribution
+        $this->assertGreaterThan($scoreAt09, $scoreAt01);
+    }
+
+    public function testQueryHybridRespectsFilter()
+    {
+        $store = $this->createStore();
+        $store->setup();
+
+        $metadata1 = new Metadata(['category' => 'a']);
+        $metadata1->setText('keyword match');
+
+        $metadata2 = new Metadata(['category' => 'b']);
+        $metadata2->setText('keyword match');
+
+        $store->add([
+            new VectorDocument('doc-1', new Vector([1.0, 0.0, 0.0]), $metadata1),
+            new VectorDocument('doc-2', new Vector([0.9, 0.1, 0.0]), $metadata2),
+        ]);
+
+        $results = iterator_to_array($store->query(
+            new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.5),
+            ['filter' => static fn (VectorDocument $doc): bool => 'a' === $doc->getMetadata()['category']],
+        ));
+
+        $this->assertCount(1, $results);
+        $this->assertSame('doc-1', $results[0]->getId());
+    }
+
+    public function testQueryHybridWithRrfCandidatePoolSize()
+    {
+        $store = $this->createStore();
+        $store->setup();
+
+        for ($i = 1; $i <= 10; ++$i) {
+            $metadata = new Metadata();
+            $metadata->setText(\sprintf('document number %d keyword', $i));
+            $store->add(new VectorDocument(
+                \sprintf('doc-%d', $i),
+                new Vector([1.0, 0.0, 0.0]),
+                $metadata,
+            ));
+        }
+
+        $results = iterator_to_array($store->query(
+            new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.5),
+            ['maxItems' => 3, 'rrfCandidatePoolSize' => 5],
+        ));
+
+        $this->assertCount(3, $results);
+
+        foreach ($results as $doc) {
+            $this->assertNotNull($doc->getScore());
+        }
+    }
+
+    public function testQueryHybridWithEmptyStore()
+    {
+        $store = $this->createStore();
+        $store->setup();
+
+        $results = iterator_to_array($store->query(
+            new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.5),
+        ));
+
+        $this->assertCount(0, $results);
+    }
+
     public function testSupportsAllQueryTypes()
     {
         $store = $this->createStore();
@@ -421,6 +650,20 @@ final class StoreTest extends TestCase
         // No FTS entry since no text metadata
         $result = $pdo->query('SELECT COUNT(*) FROM test_vectors_fts');
         $this->assertSame(0, (int) $result->fetchColumn());
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function getScoreForDoc(string $id, Store $store, HybridQuery $query, array $options = []): float
+    {
+        foreach ($store->query($query, $options) as $doc) {
+            if ($doc->getId() === $id) {
+                return $doc->getScore() ?? 0.0;
+            }
+        }
+
+        $this->fail(\sprintf('Document %s not found in query results', $id));
     }
 
     private function createPdo(): \PDO


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

## Problem

The previous `queryHybrid()` implementation in the SQLite store had two related bugs:

1. **Text scores were always `null`** — `queryText()` returns documents as stored, with no relevance score assigned. When a document appeared only in text results its score stayed `null`; when it appeared in both results only the vector score was kept (text result skipped via `seenIds`). The combined score was therefore always `vectorScore * semanticRatio` — at most half the original.

2. **No-overlap scenario** — when vector search returns N documents and text search returns N *different* documents, the two sets were simply concatenated with no unified ranking, and `maxItems` was applied before the merge, so the candidate pool was too small.

## Solution

Replace the naive merge with **Reciprocal Rank Fusion (RRF)**:

```
score(doc) = Σ ratio / (k + rank)   — summed over each ranked list the doc appears in
```

- Documents in **both** lists accumulate scores from both contributions and naturally rank higher.
- Documents in **only one** list still receive a proper non-null score.
- All candidates are merged and re-ranked **before** `maxItems` is applied.

A configurable **candidate pool** (`rrfCandidatePoolSize`, default `maxItems * 10`, minimum 100) limits how many candidates each sub-query fetches, avoiding the previous problem of loading thousands of documents into memory when `maxItems` is set.

```php
// override the candidate pool if needed
$store->query($hybridQuery, ['maxItems' => 10, 'rrfCandidatePoolSize' => 500]);
```