### PR TITLE
[Platform][Generic][Scaleway] Fix tool call without arguments

### DIFF
--- a/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
+++ b/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
@@ -70,7 +70,13 @@ trait CompletionsConversionTrait
             }
 
             // add arguments delta to tool call
-            $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
+            if (isset($toolCall['function']['arguments'])) {
+                if (!isset($toolCalls[$i]['function']['arguments'])) {
+                    $toolCalls[$i]['function']['arguments'] = '';
+                }
+
+                $toolCalls[$i]['function']['arguments'] .= $toolCall['function']['arguments'];
+            }
         }
 
         return $toolCalls;
@@ -131,13 +137,17 @@ trait CompletionsConversionTrait
      *     type: 'function',
      *     function: array{
      *         name: string,
-     *         arguments: string
+     *         arguments?: string
      *     }
      * } $toolCall
      */
     protected function convertToolCall(array $toolCall): ToolCall
     {
-        $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
+        if (isset($toolCall['function']['arguments']) && '' !== $toolCall['function']['arguments']) {
+            $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
+        } else {
+            $arguments = [];
+        }
 
         return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
@@ -48,7 +48,7 @@ class ResultConverterTest extends TestCase
         $this->assertSame('Hello world', $result->getContent());
     }
 
-    public function testConvertToolCallResult()
+    public function testConvertToolWithArgsCallResult()
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -82,6 +82,77 @@ class ResultConverterTest extends TestCase
         $this->assertSame('call_123', $toolCalls[0]->getId());
         $this->assertSame('test_function', $toolCalls[0]->getName());
         $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertToolWithEmptyArgsCallResult()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_123',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'test_function',
+                                    'arguments' => '',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call_123', $toolCalls[0]->getId());
+        $this->assertSame('test_function', $toolCalls[0]->getName());
+        $this->assertSame([], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertToolWithoutArgsCallResult()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_123',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'test_function',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call_123', $toolCalls[0]->getId());
+        $this->assertSame('test_function', $toolCalls[0]->getName());
+        $this->assertSame([], $toolCalls[0]->getArguments());
     }
 
     public function testConvertMultipleChoices()

--- a/src/platform/src/Bridge/Scaleway/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Llm/ResultConverterTest.php
@@ -49,7 +49,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('Hello world', $result->getContent());
     }
 
-    public function testConvertToolCallResult()
+    public function testConvertToolWithArgsCallResult()
     {
         $converter = new ResultConverter();
         $httpResponse = self::createMock(ResponseInterface::class);
@@ -83,6 +83,77 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('call_123', $toolCalls[0]->getId());
         $this->assertSame('test_function', $toolCalls[0]->getName());
         $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertToolWithEmptyArgsCallResult()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_123',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'test_function',
+                                    'arguments' => '',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call_123', $toolCalls[0]->getId());
+        $this->assertSame('test_function', $toolCalls[0]->getName());
+        $this->assertSame([], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertToolWithoutArgsCallResult()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_123',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'test_function',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call_123', $toolCalls[0]->getId());
+        $this->assertSame('test_function', $toolCalls[0]->getName());
+        $this->assertSame([], $toolCalls[0]->getArguments());
     }
 
     public function testConvertMultipleChoices()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | None <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

When calling a tool on Scaleway (extends Generic, the `arguments` array may not be included in the results, which causes problems when converting the result with `ResultConverter`.

This PR fixes the issue by checking that the array exists before retrieving its content.

Linked to #1649 (closed - merge conflicts)