### PR TITLE
[Platform][Scaleway] Add Qwen 3-embedding and Qwen 3.5

### DIFF
--- a/src/platform/src/Bridge/Scaleway/ModelCatalog.php
+++ b/src/platform/src/Bridge/Scaleway/ModelCatalog.php
@@ -136,6 +136,21 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::OUTPUT_STRUCTURED,
                 ],
             ],
+            'qwen3.5-397b-a17b' => [
+                'class' => Scaleway::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::TOOL_CALLING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::THINKING,
+                ],
+            ],
+            'qwen3-embedding-8b' => [
+                'class' => Embeddings::class,
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
+            ],
             'bge-multilingual-gemma2' => [
                 'class' => Embeddings::class,
                 'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | N/A
| License       | MIT

Added Qwen 3 Embedding and Qwen 3.5 models for Scaleway platform.
See [Supported models](https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/) page.