### PR TITLE
[Store] Refactoring on `Vectorizer` definition

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -2314,15 +2314,19 @@ final class AiBundle extends AbstractBundle
      */
     private function processVectorizerConfig(string $name, array $config, ContainerBuilder $container): void
     {
-        $vectorizerDefinition = new Definition(Vectorizer::class, [
-            new Reference($config['platform']),
-            $config['model'],
-            new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
-        ]);
-        $vectorizerDefinition->addTag('ai.vectorizer', ['name' => $name]);
-        $serviceId = 'ai.vectorizer.'.$name;
-        $container->setDefinition($serviceId, $vectorizerDefinition);
-        $container->registerAliasForArgument($serviceId, VectorizerInterface::class, (new Target((string) $name))->getParsedName());
+        $definition = new Definition(Vectorizer::class);
+        $definition
+            ->setLazy(true)
+            ->setArguments([
+                new Reference($config['platform']),
+                $config['model'],
+                new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+            ])
+            ->addTag('proxy', ['interface' => VectorizerInterface::class])
+            ->addTag('ai.vectorizer', ['name' => $name]);
+
+        $container->setDefinition('ai.vectorizer.'.$name, $definition);
+        $container->registerAliasForArgument('ai.vectorizer.'.$name, VectorizerInterface::class, $name);
     }
 
     /**

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -5475,11 +5475,24 @@ class AiBundleTest extends TestCase
         $this->assertTrue($container->hasDefinition('ai.vectorizer.my_vectorizer'));
 
         $vectorizerDefinition = $container->getDefinition('ai.vectorizer.my_vectorizer');
+
+        $this->assertTrue($vectorizerDefinition->isLazy());
         $this->assertSame(Vectorizer::class, $vectorizerDefinition->getClass());
         $this->assertTrue($vectorizerDefinition->hasTag('ai.vectorizer'));
 
         // Check that model is passed as a string with options as query params
         $this->assertSame('text-embedding-3-small?dimension=512', $vectorizerDefinition->getArgument(1));
+
+        $this->assertTrue($vectorizerDefinition->hasTag('ai.vectorizer'));
+        $this->assertSame([
+            ['name' => 'my_vectorizer'],
+        ], $vectorizerDefinition->getTag('ai.vectorizer'));
+        $this->assertTrue($vectorizerDefinition->hasTag('proxy'));
+        $this->assertSame([
+            ['interface' => VectorizerInterface::class],
+        ], $vectorizerDefinition->getTag('proxy'));
+
+        $this->assertTrue($container->hasAlias('Symfony\AI\Store\Document\VectorizerInterface $myVectorizer'));
     }
 
     public function testVectorizerWithLoggerInjection()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Discussed with @Jean-Beru
| License       | MIT

* Add support for `lazy`
* Change the alias to the name of the vectorizer without `Target` usage
* Improve tests