### PR TITLE
[Mate] Add Toon format support to command outputs

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.7
 ---
 
+ * Add TOON format (requires `helgesverre/toon`) to `mcp:tools:list`, `mcp:tools:inspect`, `mcp:tools:call`, `debug:capabilities`, `debug:extensions` to allow token efficient usage in CLI
  * Add raw data fallback for profiler collectors without a registered formatter
  * Add Codex wrapper generation (`bin/codex`, `bin/codex.bat`) to `mate init`
  * Add AGENT instruction artifact materialization to `mate discover` (`mate/AGENT_INSTRUCTIONS.md` and managed `AGENTS.md` block)

--- a/src/mate/composer.json
+++ b/src/mate/composer.json
@@ -40,6 +40,7 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
+        "helgesverre/toon": "^3.1",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",

--- a/src/mate/src/Command/DebugCapabilitiesCommand.php
+++ b/src/mate/src/Command/DebugCapabilitiesCommand.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Mate\Command;
 
+use HelgeSverre\Toon\Toon;
+use Symfony\AI\Mate\Command\Trait\EnsuresToonFormatAvailabilityTrait;
 use Symfony\AI\Mate\Discovery\CapabilityCollector;
 use Symfony\AI\Mate\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -27,12 +29,24 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * @phpstan-import-type ExtensionData from DebugExtensionsCommand
  *
  * @phpstan-type CapabilitiesByExtension array<string, Capabilities>
+ * @phpstan-type DebugCapabilitiesArrayResult array{
+ *     extensions: CapabilitiesByExtension,
+ *     summary: array{
+ *         extensions: int,
+ *         tools: int,
+ *         resources: int,
+ *         prompts: int,
+ *         resource_templates: int
+ *     }
+ * }
  *
  * @author Johannes Wachter <johannes@sulu.io>
  */
 #[AsCommand('debug:capabilities', 'Display all MCP capabilities grouped by extension')]
 class DebugCapabilitiesCommand extends Command
 {
+    use EnsuresToonFormatAvailabilityTrait;
+
     /**
      * @var array<string, ExtensionData>
      */
@@ -62,10 +76,11 @@ class DebugCapabilitiesCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (text, json)', 'text')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (text, json, toon)', 'text')
             ->addOption('extension', null, InputOption::VALUE_REQUIRED, 'Filter by extension package name')
             ->addOption('type', null, InputOption::VALUE_REQUIRED, 'Filter by type (tool, resource, prompt, template)')
-            ->setHelp(<<<'HELP'
+            ->setHelp(
+                <<<'HELP'
 The <info>%command.name%</info> command displays all discovered MCP capabilities
 grouped by their providing extension/package.
 
@@ -96,6 +111,13 @@ HELP
     {
         $io = new SymfonyStyle($input, $output);
 
+        $format = $input->getOption('format');
+        \assert(\is_string($format));
+
+        if (!$this->ensureToonFormatAvailable($io, $format)) {
+            return Command::FAILURE;
+        }
+
         $capabilities = [];
         foreach ($this->extensions as $extensionName => $extension) {
             $capabilities[$extensionName] = $this->collector->collectCapabilities($extensionName, $extension);
@@ -114,11 +136,10 @@ HELP
             $capabilities = $this->filterByType($capabilities, $typeFilter);
         }
 
-        $format = $input->getOption('format');
-        \assert(\is_string($format));
-
         if ('json' === $format) {
-            $this->outputJson($capabilities, $output);
+            $output->writeln(json_encode($this->getArrayResult($capabilities), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        } elseif ('toon' === $format) {
+            $output->writeln(Toon::encode($this->getArrayResult($capabilities)));
         } else {
             $this->outputText($capabilities, $io);
         }
@@ -258,8 +279,10 @@ HELP
 
     /**
      * @param CapabilitiesByExtension $capabilitiesByExtension
+     *
+     * @return DebugCapabilitiesArrayResult
      */
-    private function outputJson(array $capabilitiesByExtension, OutputInterface $output): void
+    private function getArrayResult(array $capabilitiesByExtension): array
     {
         $totalTools = 0;
         $totalResources = 0;
@@ -284,6 +307,6 @@ HELP
             ],
         ];
 
-        $output->writeln(json_encode($result, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        return $result;
     }
 }

--- a/src/mate/src/Command/DebugExtensionsCommand.php
+++ b/src/mate/src/Command/DebugExtensionsCommand.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Mate\Command;
 
+use HelgeSverre\Toon\Toon;
+use Symfony\AI\Mate\Command\Trait\EnsuresToonFormatAvailabilityTrait;
 use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -24,11 +26,31 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  * @phpstan-import-type ExtensionData from ComposerExtensionDiscovery
  *
+ * @phpstan-type DebugExtensionEntry array{
+ *     type: 'root_project'|'vendor_extension',
+ *     status: 'enabled'|'disabled',
+ *     loaded: bool,
+ *     scan_dirs: string[],
+ *     includes: string[],
+ *     agent_instructions?: string
+ * }
+ * @phpstan-type DebugExtensionsArrayResult array{
+ *     extensions: array<string, DebugExtensionEntry>,
+ *     summary: array{
+ *         total_discovered: int,
+ *         enabled: int,
+ *         disabled: int,
+ *         loaded: int
+ *     }
+ * }
+ *
  * @author Johannes Wachter <johannes@sulu.io>
  */
 #[AsCommand('debug:extensions', 'Display detailed information about discovered and loaded MCP extensions')]
 class DebugExtensionsCommand extends Command
 {
+    use EnsuresToonFormatAvailabilityTrait;
+
     /**
      * @var array<string, ExtensionData>
      */
@@ -79,9 +101,10 @@ class DebugExtensionsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (text, json)', 'text')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (text, json, toon)', 'text')
             ->addOption('show-all', null, InputOption::VALUE_NONE, 'Show all discovered extensions including disabled ones')
-            ->setHelp(<<<'HELP'
+            ->setHelp(
+                <<<'HELP'
 The <info>%command.name%</info> command displays detailed information about MCP extension
 discovery and loading.
 
@@ -121,8 +144,14 @@ HELP
         $format = $input->getOption('format');
         \assert(\is_string($format));
 
+        if (!$this->ensureToonFormatAvailable($io, $format)) {
+            return Command::FAILURE;
+        }
+
         if ('json' === $format) {
-            $this->outputJson($output);
+            $output->writeln(json_encode($this->getArrayResult(), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        } elseif ('toon' === $format) {
+            $output->writeln(Toon::encode($this->getArrayResult()));
         } else {
             $this->outputText($showAll, $io);
         }
@@ -224,7 +253,10 @@ HELP
         $io->newLine();
     }
 
-    private function outputJson(OutputInterface $output): void
+    /**
+     * @return DebugExtensionsArrayResult
+     */
+    private function getArrayResult(): array
     {
         $extensions = [];
 
@@ -275,6 +307,6 @@ HELP
             ],
         ];
 
-        $output->writeln(json_encode($result, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        return $result;
     }
 }

--- a/src/mate/src/Command/ToolsCallCommand.php
+++ b/src/mate/src/Command/ToolsCallCommand.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\AI\Mate\Command;
 
+use HelgeSverre\Toon\Toon;
 use Mcp\Capability\Registry\ReferenceHandler;
 use Mcp\Capability\RegistryInterface;
 use Mcp\Exception\ToolNotFoundException;
 use Mcp\Schema\Request\CallToolRequest;
 use Symfony\AI\Mate\Command\Session\CliSession;
+use Symfony\AI\Mate\Command\Trait\EnsuresToonFormatAvailabilityTrait;
 use Symfony\AI\Mate\Service\RegistryProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -34,6 +36,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 #[AsCommand('mcp:tools:call', 'Execute MCP tools via JSON input')]
 class ToolsCallCommand extends Command
 {
+    use EnsuresToonFormatAvailabilityTrait;
+
     private RegistryInterface $registry;
     private ReferenceHandler $referenceHandler;
 
@@ -62,8 +66,9 @@ class ToolsCallCommand extends Command
         $this
             ->addArgument('tool-name', InputArgument::REQUIRED, 'Name of the tool to execute')
             ->addArgument('json-input', InputArgument::REQUIRED, 'JSON object with tool parameters')
-            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (json, pretty)', 'pretty')
-            ->setHelp(<<<'HELP'
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (json, pretty, toon)', 'pretty')
+            ->setHelp(
+                <<<'HELP'
 The <info>%command.name%</info> command executes MCP tools with JSON input parameters.
 
 <info>Usage Examples:</info>
@@ -110,6 +115,13 @@ HELP
             return Command::FAILURE;
         }
 
+        $format = $input->getOption('format');
+        \assert(\is_string($format));
+
+        if (!$this->ensureToonFormatAvailable($io, $format)) {
+            return Command::FAILURE;
+        }
+
         try {
             $tool = $this->registry->getTool($toolName);
         } catch (ToolNotFoundException $e) {
@@ -128,9 +140,6 @@ HELP
         $arguments = $params;
         $arguments['_session'] = $session;
         $arguments['_request'] = $request;
-
-        $format = $input->getOption('format');
-        \assert(\is_string($format));
 
         if ('pretty' === $format) {
             $io->title(\sprintf('Executing Tool: %s', $toolName));
@@ -155,6 +164,8 @@ HELP
 
         if ('json' === $format) {
             $output->writeln(json_encode($result, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+        } elseif ('toon' === $format) {
+            $output->writeln(Toon::encode($result));
         } else {
             $io->section('Result');
             $this->renderPretty($result, $io);

--- a/src/mate/src/Command/ToolsInspectCommand.php
+++ b/src/mate/src/Command/ToolsInspectCommand.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Mate\Command;
 
+use HelgeSverre\Toon\Toon;
+use Symfony\AI\Mate\Command\Trait\EnsuresToonFormatAvailabilityTrait;
 use Symfony\AI\Mate\Discovery\CapabilityCollector;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -38,6 +40,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand('mcp:tools:inspect', 'Display detailed information about a specific MCP tool')]
 class ToolsInspectCommand extends Command
 {
+    use EnsuresToonFormatAvailabilityTrait;
+
     /**
      * @var array<string, array{dirs: string[], includes: string[]}>
      */
@@ -68,8 +72,9 @@ class ToolsInspectCommand extends Command
     {
         $this
             ->addArgument('tool-name', InputArgument::REQUIRED, 'Name of the tool to inspect')
-            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (text, json)', 'text')
-            ->setHelp(<<<'HELP'
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (text, json, toon)', 'text')
+            ->setHelp(
+                <<<'HELP'
 The <info>%command.name%</info> command displays detailed information about a specific MCP tool including its full JSON schema.
 
 <info>Usage Examples:</info>
@@ -96,6 +101,13 @@ HELP
         $toolName = $input->getArgument('tool-name');
         \assert(\is_string($toolName));
 
+        $format = $input->getOption('format');
+        \assert(\is_string($format));
+
+        if (!$this->ensureToonFormatAvailable($io, $format)) {
+            return Command::FAILURE;
+        }
+
         $allTools = [];
         foreach ($this->extensions as $extensionName => $extension) {
             $capabilities = $this->collector->collectCapabilities($extensionName, $extension);
@@ -113,11 +125,14 @@ HELP
 
         $toolData = $allTools[$toolName];
 
-        $format = $input->getOption('format');
-        \assert(\is_string($format));
-
         if ('json' === $format) {
             $this->outputJson($toolData, $output);
+
+            return Command::SUCCESS;
+        }
+
+        if ('toon' === $format) {
+            $output->writeln(Toon::encode($toolData));
 
             return Command::SUCCESS;
         }

--- a/src/mate/src/Command/ToolsListCommand.php
+++ b/src/mate/src/Command/ToolsListCommand.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Mate\Command;
 
+use HelgeSverre\Toon\Toon;
+use Symfony\AI\Mate\Command\Trait\EnsuresToonFormatAvailabilityTrait;
 use Symfony\AI\Mate\Discovery\CapabilityCollector;
 use Symfony\AI\Mate\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -39,6 +41,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand('mcp:tools:list', 'Display available MCP tools with metadata')]
 class ToolsListCommand extends Command
 {
+    use EnsuresToonFormatAvailabilityTrait;
+
     /**
      * @var array<string, array{dirs: string[], includes: string[]}>
      */
@@ -70,8 +74,9 @@ class ToolsListCommand extends Command
         $this
             ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter by tool name pattern (supports wildcards)')
             ->addOption('extension', null, InputOption::VALUE_REQUIRED, 'Filter by extension package name')
-            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (table, json)', 'table')
-            ->setHelp(<<<'HELP'
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (table, json, toon)', 'table')
+            ->setHelp(
+                <<<'HELP'
 The <info>%command.name%</info> command displays all available MCP tools with their metadata.
 
 <info>Usage Examples:</info>
@@ -102,6 +107,13 @@ HELP
     {
         $io = new SymfonyStyle($input, $output);
 
+        $format = $input->getOption('format');
+        \assert(\is_string($format));
+
+        if (!$this->ensureToonFormatAvailable($io, $format)) {
+            return Command::FAILURE;
+        }
+
         $allTools = [];
         foreach ($this->extensions as $extensionName => $extension) {
             $capabilities = $this->collector->collectCapabilities($extensionName, $extension);
@@ -122,11 +134,14 @@ HELP
             $allTools = $this->filterByName($allTools, $nameFilter);
         }
 
-        $format = $input->getOption('format');
-        \assert(\is_string($format));
-
         if ('json' === $format) {
-            $this->outputJson($allTools, $output);
+            $output->writeln(json_encode($this->getArrayResult($allTools), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+            return Command::SUCCESS;
+        }
+
+        if ('toon' === $format) {
+            $output->writeln(Toon::encode($this->getArrayResult($allTools)));
 
             return Command::SUCCESS;
         }
@@ -214,17 +229,20 @@ HELP
 
     /**
      * @param array<string, ToolData> $tools
+     *
+     * @return array{
+     *     tools: array<string, ToolData>,
+     *     summary: array{total: int}
+     * }
      */
-    private function outputJson(array $tools, OutputInterface $output): void
+    private function getArrayResult(array $tools): array
     {
-        $result = [
+        return [
             'tools' => $tools,
             'summary' => [
                 'total' => \count($tools),
             ],
         ];
-
-        $output->writeln(json_encode($result, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
     }
 
     private function truncate(string $text, int $length): string

--- a/src/mate/src/Command/Trait/EnsuresToonFormatAvailabilityTrait.php
+++ b/src/mate/src/Command/Trait/EnsuresToonFormatAvailabilityTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command\Trait;
+
+use HelgeSverre\Toon\Toon;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+trait EnsuresToonFormatAvailabilityTrait
+{
+    /**
+     * @internal Used to check TOON availability
+     */
+    protected function isToonFormatAvailable(): bool
+    {
+        return class_exists(Toon::class);
+    }
+
+    private function ensureToonFormatAvailable(SymfonyStyle $io, string $format): bool
+    {
+        if ('toon' !== $format) {
+            return true;
+        }
+
+        if ($this->isToonFormatAvailable()) {
+            return true;
+        }
+
+        $io->error('The "toon" output format requires the `helgesverre/toon` package.');
+        $io->note('Install it with: `composer require helgesverre/toon`');
+
+        return false;
+    }
+}

--- a/src/mate/tests/Command/DebugCapabilitiesCommandTest.php
+++ b/src/mate/tests/Command/DebugCapabilitiesCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Tests\Command;
 
+use HelgeSverre\Toon\Toon;
 use Mcp\Capability\Discovery\Discoverer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -95,6 +96,33 @@ final class DebugCapabilitiesCommandTest extends TestCase
         $this->assertArrayHasKey('resources', $json['summary']);
         $this->assertArrayHasKey('prompts', $json['summary']);
         $this->assertArrayHasKey('resource_templates', $json['summary']);
+    }
+
+    public function testExecuteWithToonFormat()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $extensions = [
+            'vendor/package-a' => ['dirs' => ['mate/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ];
+
+        $command = $this->createCommand($rootDir, $extensions);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--format' => 'toon']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $toon = Toon::decode($output);
+        $this->assertIsArray($toon);
+        $this->assertArrayHasKey('extensions', $toon);
+        $this->assertArrayHasKey('summary', $toon);
+        $this->assertArrayHasKey('extensions', $toon['summary']);
+        $this->assertArrayHasKey('tools', $toon['summary']);
+        $this->assertArrayHasKey('resources', $toon['summary']);
+        $this->assertArrayHasKey('prompts', $toon['summary']);
+        $this->assertArrayHasKey('resource_templates', $toon['summary']);
     }
 
     public function testExecuteWithExtensionFilter()
@@ -224,6 +252,11 @@ final class DebugCapabilitiesCommandTest extends TestCase
         $loader = new FilteredDiscoveryLoader($rootDir, $extensions, $disabledFeatures, $discoverer, $logger);
         $collector = new CapabilityCollector($loader);
 
-        return new DebugCapabilitiesCommand($extensions, $collector);
+        return new class($extensions, $collector) extends DebugCapabilitiesCommand {
+            protected function isToonFormatAvailable(): bool
+            {
+                return true;
+            }
+        };
     }
 }

--- a/src/mate/tests/Command/DebugExtensionsCommandTest.php
+++ b/src/mate/tests/Command/DebugExtensionsCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Tests\Command;
 
+use HelgeSverre\Toon\Toon;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\AI\Mate\Command\DebugExtensionsCommand;
@@ -122,6 +123,35 @@ final class DebugExtensionsCommandTest extends TestCase
         $this->assertArrayHasKey('enabled', $json['summary']);
         $this->assertArrayHasKey('disabled', $json['summary']);
         $this->assertArrayHasKey('loaded', $json['summary']);
+    }
+
+    public function testExecuteWithToonFormat()
+    {
+        $rootDir = $this->fixturesDir.'/with-ai-mate-config';
+        $enabledExtensions = ['vendor/package-a'];
+        $loadedExtensions = [
+            'vendor/package-a' => ['dirs' => ['vendor/vendor/package-a/src'], 'includes' => []],
+            '_custom' => ['dirs' => [], 'includes' => []],
+        ];
+
+        $command = $this->createCommand($rootDir, $enabledExtensions, $loadedExtensions);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--format' => 'toon']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $toon = Toon::decode($output);
+        $this->assertIsArray($toon);
+        $this->assertArrayHasKey('extensions', $toon);
+        $this->assertArrayHasKey('summary', $toon);
+        $this->assertArrayHasKey('_custom', $toon['extensions']);
+        $this->assertArrayHasKey('vendor/package-a', $toon['extensions']);
+        $this->assertArrayHasKey('total_discovered', $toon['summary']);
+        $this->assertArrayHasKey('enabled', $toon['summary']);
+        $this->assertArrayHasKey('disabled', $toon['summary']);
+        $this->assertArrayHasKey('loaded', $toon['summary']);
     }
 
     public function testExecuteShowsExtensionDetails()
@@ -236,6 +266,11 @@ final class DebugExtensionsCommandTest extends TestCase
         $logger = new NullLogger();
         $discoverer = new ComposerExtensionDiscovery($rootDir, $logger);
 
-        return new DebugExtensionsCommand($enabledExtensions, $extensions, $discoverer);
+        return new class($enabledExtensions, $extensions, $discoverer) extends DebugExtensionsCommand {
+            protected function isToonFormatAvailable(): bool
+            {
+                return true;
+            }
+        };
     }
 }

--- a/src/mate/tests/Command/ToolsCallCommandTest.php
+++ b/src/mate/tests/Command/ToolsCallCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Tests\Command;
 
+use HelgeSverre\Toon\Toon;
 use Mcp\Capability\Discovery\Discoverer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -77,6 +78,30 @@ final class ToolsCallCommandTest extends TestCase
         $this->assertSame(\PHP_VERSION, $result['php_version']);
     }
 
+    public function testExecuteWithToonFormat()
+    {
+        $rootDir = __DIR__.'/../..';
+        $extensions = [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ];
+
+        $command = $this->createCommand($rootDir, $extensions);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'tool-name' => 'server-info',
+            'json-input' => '{}',
+            '--format' => 'toon',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $result = Toon::decode($output);
+        $this->assertIsArray($result);
+        $this->assertSame(\PHP_VERSION, $result['php_version']);
+    }
+
     public function testExecuteWithInvalidToolName()
     {
         $rootDir = __DIR__.'/../..';
@@ -130,6 +155,11 @@ final class ToolsCallCommandTest extends TestCase
         $container = new ContainerBuilder();
         $container->set(ServerInfo::class, new ServerInfo());
 
-        return new ToolsCallCommand($registryProvider, $container);
+        return new class($registryProvider, $container) extends ToolsCallCommand {
+            protected function isToonFormatAvailable(): bool
+            {
+                return true;
+            }
+        };
     }
 }

--- a/src/mate/tests/Command/ToolsInspectCommandTest.php
+++ b/src/mate/tests/Command/ToolsInspectCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Tests\Command;
 
+use HelgeSverre\Toon\Toon;
 use Mcp\Capability\Discovery\Discoverer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -69,6 +70,31 @@ final class ToolsInspectCommandTest extends TestCase
         $this->assertArrayHasKey('input_schema', $json);
         $this->assertArrayHasKey('extension', $json);
         $this->assertSame('server-info', $json['name']);
+    }
+
+    public function testExecuteWithToonFormat()
+    {
+        $rootDir = __DIR__.'/../..';
+        $extensions = [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ];
+
+        $command = $this->createCommand($rootDir, $extensions);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['tool-name' => 'server-info', '--format' => 'toon']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $toon = Toon::decode($output);
+        $this->assertIsArray($toon);
+        $this->assertArrayHasKey('name', $toon);
+        $this->assertArrayHasKey('description', $toon);
+        $this->assertArrayHasKey('handler', $toon);
+        $this->assertArrayHasKey('input_schema', $toon);
+        $this->assertArrayHasKey('extension', $toon);
+        $this->assertSame('server-info', $toon['name']);
     }
 
     public function testExecuteWithInvalidToolName()
@@ -144,6 +170,11 @@ final class ToolsInspectCommandTest extends TestCase
         $loader = new FilteredDiscoveryLoader($rootDir, $extensions, $disabledFeatures, $discoverer, $logger);
         $collector = new CapabilityCollector($loader);
 
-        return new ToolsInspectCommand($extensions, $collector);
+        return new class($extensions, $collector) extends ToolsInspectCommand {
+            protected function isToonFormatAvailable(): bool
+            {
+                return true;
+            }
+        };
     }
 }

--- a/src/mate/tests/Command/ToolsListCommandTest.php
+++ b/src/mate/tests/Command/ToolsListCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Tests\Command;
 
+use HelgeSverre\Toon\Toon;
 use Mcp\Capability\Discovery\Discoverer;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -80,6 +81,33 @@ final class ToolsListCommandTest extends TestCase
         $this->assertArrayHasKey('extension', $json['tools']['server-info']);
     }
 
+    public function testExecuteWithToonFormat()
+    {
+        $rootDir = __DIR__.'/../..';
+        $extensions = [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ];
+
+        $command = $this->createCommand($rootDir, $extensions);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--format' => 'toon']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $toon = Toon::decode($output);
+        $this->assertIsArray($toon);
+        $this->assertArrayHasKey('tools', $toon);
+        $this->assertArrayHasKey('summary', $toon);
+        $this->assertArrayHasKey('total', $toon['summary']);
+        $this->assertGreaterThanOrEqual(1, $toon['summary']['total']);
+        $this->assertArrayHasKey('server-info', $toon['tools']);
+        $this->assertArrayHasKey('name', $toon['tools']['server-info']);
+        $this->assertArrayHasKey('handler', $toon['tools']['server-info']);
+        $this->assertArrayHasKey('extension', $toon['tools']['server-info']);
+    }
+
     public function testExecuteWithInvalidExtensionFilter()
     {
         $rootDir = $this->fixturesDir.'/with-ai-mate-config';
@@ -135,6 +163,34 @@ final class ToolsListCommandTest extends TestCase
         $this->assertStringContainsString('Extension', $output);
     }
 
+    public function testExecuteWithToonFormatFailsWhenToonIsNotAvailable()
+    {
+        $rootDir = __DIR__.'/../..';
+        $extensions = [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ];
+
+        $logger = new NullLogger();
+        $discoverer = new Discoverer($logger);
+        $loader = new FilteredDiscoveryLoader($rootDir, $extensions, [], $discoverer, $logger);
+        $collector = new CapabilityCollector($loader);
+
+        $command = new class($extensions, $collector) extends ToolsListCommand {
+            protected function isToonFormatAvailable(): bool
+            {
+                return false;
+            }
+        };
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--format' => 'toon']);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('helgesverre/toon', $output);
+        $this->assertStringContainsString('composer require helgesverre/toon', $output);
+    }
+
     public function testExecuteWithNameFilterMatchingTools()
     {
         $rootDir = __DIR__.'/../..';
@@ -163,6 +219,11 @@ final class ToolsListCommandTest extends TestCase
         $loader = new FilteredDiscoveryLoader($rootDir, $extensions, $disabledFeatures, $discoverer, $logger);
         $collector = new CapabilityCollector($loader);
 
-        return new ToolsListCommand($extensions, $collector);
+        return new class($extensions, $collector) extends ToolsListCommand {
+            protected function isToonFormatAvailable(): bool
+            {
+                return true;
+            }
+        };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        |
| License       | MIT

## What was done
- Updated `DebugCapabilitiesCommand`, `DebugExtensionsCommand`, `ToolsCallCommand`, `ToolsInspectCommand`, and `ToolsListCommand` to support a new output format 'toon'.
- Modified the `composer.json` to require the `helgesverre/toon` package.
- Adjusted help messages and output methods to accommodate the new format.
- Added tests for the `TOON` format in respective command test classes.

## **Why?**

This enhancement allows users to output command results in a more structured format using the `TOON` encoding.
This reduce token consumption when communicating with LLMs.
This unlocks commands to be used inside custom SKILLs instead of MCP servers with token efficient format.

It's related to [https://github.com/symfony/ai/pull/1439](https://github.com/symfony/ai/pull/1439) and adds more broader support for `TOON`.