### PR TITLE
[Platform][Failover] Add support for model override

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -117,6 +117,32 @@ Platform
    +    echo $chunk->getText();
    +}
    ```
+ * The `FailoverPlatform` constructor now accepts both bare `PlatformInterface` instances and
+   associative arrays with a `platform` key. When no model override is needed, you can pass the
+   platform directly instead of wrapping it in an array:
+
+   ```diff
+   -$platform = new FailoverPlatform([
+   -    ['platform' => $openai],
+   -    ['platform' => $anthropic],
+   -], $rateLimiter);
+   +$platform = new FailoverPlatform([
+   +    $openai,
+   +    $anthropic,
+   +], $rateLimiter);
+   ```
+
+ * The `model` option in `FailoverPlatform` now accepts an array of model names for "multi-models"
+   fallback per platform. Models are tried in order; the failover proceeds to the next platform
+   only when all models on the current platform have been exhausted:
+
+   ```php
+   $platform = new FailoverPlatform([
+       ['platform' => $openRouter, 'model' => ['minimax/minimax-m2.5:free', 'openai/gpt-oss-120b:free']],
+       $openai,
+   ], $rateLimiter);
+   ```
+
  * `Symfony\AI\Platform\Bridge\Perplexity\PerplexitySearchResults`,
    `Symfony\AI\Platform\Bridge\Perplexity\PerplexityCitations`, and
    `Symfony\AI\Platform\Bridge\Perplexity\StreamListener` have been

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -783,6 +783,99 @@ This platform can also be configured when using the bundle::
 
     Platforms are executed in the order they're injected into :class:`Symfony\\AI\\Platform\\Bridge\\Failover\\FailoverPlatform`.
 
+Model Overrides
+~~~~~~~~~~~~~~~
+
+By default, the model name passed to ``invoke()`` is forwarded to every platform.
+This means that all platforms must support the same model name.
+
+To enable cross-provider failover (e.g. OpenAI GPT → Anthropic Claude), you can assign
+a specific model name to each platform by using the ``model`` key. Reusing the ``$rateLimiter``
+from the example above::
+
+    use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory as AnthropicPlatformFactory;
+
+    $platform = new FailoverPlatform([
+        OpenAiPlatformFactory::create(env('OPENAI_API_KEY'), HttpClient::create()),
+        ['platform' => AnthropicPlatformFactory::create(env('ANTHROPIC_API_KEY'), HttpClient::create()), 'model' => 'claude-sonnet-4-20250514'],
+    ], $rateLimiter);
+
+    // OpenAI receives the model passed to invoke(), if it fails, Anthropic receives 'claude-sonnet-4-20250514'
+    $result = $platform->invoke('gpt-4o', new MessageBag(
+        Message::forSystem('You are a helpful assistant.'),
+        Message::ofUser('What is the capital of France?'),
+    ));
+
+When using the bundle, use the ``model`` key in the ``platforms`` configuration::
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            openai:
+                # ...
+            anthropic:
+                # ...
+            failover:
+                cross_provider:
+                    platforms:
+                        - { platform: 'ai.platform.openai', model: 'gpt-4o' }
+                        - { platform: 'ai.platform.anthropic', model: 'claude-sonnet-4-20250514' }
+                    rate_limiter: 'limiter.failover_platform'
+
+When no model override is needed, platforms can be configured using the simple string format::
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            failover:
+                same_provider:
+                    platforms:
+                        - 'ai.platform.ollama'
+                        - 'ai.platform.openai'
+                    rate_limiter: 'limiter.failover_platform'
+
+.. note::
+
+    Platforms without a ``model`` key use the model name passed to ``invoke()``, which
+    allows mixing overridden and non-overridden platforms in the same configuration.
+
+Multiple Model Fallbacks
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``model`` key also accepts an array of model names. When multiple models are configured
+for a single platform, they are tried in order. The failover proceeds to the next platform
+only when all models on the current platform have been exhausted.
+
+Reusing the ``$rateLimiter`` from the example above::
+
+    use Symfony\AI\Platform\Bridge\OpenRouter\PlatformFactory as OpenRouterPlatformFactory;
+
+    $platform = new FailoverPlatform([
+        ['platform' => OpenRouterPlatformFactory::create(env('OPENROUTER_API_KEY'), HttpClient::create()), 'model' => ['minimax/minimax-m2.5:free', 'openai/gpt-oss-120b:free']],
+        OpenAiPlatformFactory::create(env('OPENAI_API_KEY'), HttpClient::create()),
+    ], $rateLimiter);
+
+When using the bundle::
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            openrouter:
+                # ...
+            openai:
+                # ...
+            failover:
+                resilient:
+                    platforms:
+                        - { platform: 'ai.platform.openrouter', model: ['minimax/minimax-m2.5:free', 'openai/gpt-oss-120b:free'] }
+                        - { platform: 'ai.platform.openai', model: 'gpt-4o' }
+                    rate_limiter: 'limiter.failover_platform'
+
+.. note::
+
+    Model-level failures are logged at ``warning`` level, while platform-level failures
+    (when all models on a platform are exhausted) are logged at ``error`` level.
+
 Testing Tools
 -------------
 

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -1415,6 +1415,99 @@ This platform can also be configured when using the bundle::
     For catalog-based routing (e.g. sending ``gpt-4o`` to OpenAI and ``claude-*`` to Anthropic
     in the same ``Platform`` instance), see `Providers and Multi-Provider Platforms`_.
 
+Model Overrides
+~~~~~~~~~~~~~~~
+
+By default, the model name passed to ``invoke()`` is forwarded to every platform.
+This means that all platforms must support the same model name.
+
+To enable cross-provider failover (e.g. OpenAI GPT → Anthropic Claude), you can assign
+a specific model name to each platform by using the ``model`` key. Reusing the ``$rateLimiter``
+from the example above::
+
+    use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory as AnthropicPlatformFactory;
+
+    $platform = new FailoverPlatform([
+        OpenAiPlatformFactory::create(env('OPENAI_API_KEY'), HttpClient::create()),
+        ['platform' => AnthropicPlatformFactory::create(env('ANTHROPIC_API_KEY'), HttpClient::create()), 'model' => 'claude-sonnet-4-20250514'],
+    ], $rateLimiter);
+
+    // OpenAI receives the model passed to invoke(), if it fails, Anthropic receives 'claude-sonnet-4-20250514'
+    $result = $platform->invoke('gpt-4o', new MessageBag(
+        Message::forSystem('You are a helpful assistant.'),
+        Message::ofUser('What is the capital of France?'),
+    ));
+
+When using the bundle, use the ``model`` key in the ``platforms`` configuration::
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            openai:
+                # ...
+            anthropic:
+                # ...
+            failover:
+                cross_provider:
+                    platforms:
+                        - { platform: 'ai.platform.openai', model: 'gpt-4o' }
+                        - { platform: 'ai.platform.anthropic', model: 'claude-sonnet-4-20250514' }
+                    rate_limiter: 'limiter.failover_platform'
+
+When no model override is needed, platforms can be configured using the simple string format::
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            failover:
+                same_provider:
+                    platforms:
+                        - 'ai.platform.ollama'
+                        - 'ai.platform.openai'
+                    rate_limiter: 'limiter.failover_platform'
+
+.. note::
+
+    Platforms without a ``model`` key use the model name passed to ``invoke()``, which
+    allows mixing overridden and non-overridden platforms in the same configuration.
+
+Multiple Model Fallbacks
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``model`` key also accepts an array of model names. When multiple models are configured
+for a single platform, they are tried in order. The failover proceeds to the next platform
+only when all models on the current platform have been exhausted.
+
+Reusing the ``$rateLimiter`` from the example above::
+
+    use Symfony\AI\Platform\Bridge\OpenRouter\PlatformFactory as OpenRouterPlatformFactory;
+
+    $platform = new FailoverPlatform([
+        ['platform' => OpenRouterPlatformFactory::create(env('OPENROUTER_API_KEY'), HttpClient::create()), 'model' => ['minimax/minimax-m2.5:free', 'openai/gpt-oss-120b:free']],
+        OpenAiPlatformFactory::create(env('OPENAI_API_KEY'), HttpClient::create()),
+    ], $rateLimiter);
+
+When using the bundle::
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            openrouter:
+                # ...
+            openai:
+                # ...
+            failover:
+                resilient:
+                    platforms:
+                        - { platform: 'ai.platform.openrouter', model: ['minimax/minimax-m2.5:free', 'openai/gpt-oss-120b:free'] }
+                        - { platform: 'ai.platform.openai', model: 'gpt-4o' }
+                    rate_limiter: 'limiter.failover_platform'
+
+.. note::
+
+    Model-level failures are logged at ``warning`` level, while platform-level failures
+    (when all models on a platform are exhausted) are logged at ``error`` level.
+
 Testing Tools
 -------------
 

--- a/examples/misc/failover-platform-with-model-override.php
+++ b/examples/misc/failover-platform-with-model-override.php
@@ -9,16 +9,13 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\AI\Platform\Bridge\Anthropic\PlatformFactory as AnthropicPlatformFactory;
 use Symfony\AI\Platform\Bridge\Failover\FailoverPlatform;
-use Symfony\AI\Platform\Bridge\Ollama\PlatformFactory as OllamaPlatformFactory;
-use Symfony\AI\Platform\Bridge\OpenAi\Gpt\ResultConverter;
 use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory as OpenAiPlatformFactory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
-
-require_once dirname(__DIR__).'/bootstrap.php';
 
 $rateLimiter = new RateLimiterFactory([
     'policy' => 'sliding_window',
@@ -27,17 +24,13 @@ $rateLimiter = new RateLimiterFactory([
     'limit' => 1,
 ], new InMemoryStorage());
 
-// # Ollama will fail as 'gpt-5.2' is not available in the catalog
 $platform = new FailoverPlatform([
-    ['platform' => OllamaPlatformFactory::create(env('OLLAMA_HOST_URL'), httpClient: http_client())],
-    ['platform' => OpenAiPlatformFactory::create(env('OPENAI_API_KEY'), http_client())],
+    ['platform' => OpenAiPlatformFactory::create(env('OPENAI_API_KEY'), http_client()), 'model' => 'gpt-4o'],
+    ['platform' => AnthropicPlatformFactory::create(env('ANTHROPIC_API_KEY'), http_client()), 'model' => 'claude-sonnet-4-20250514'],
 ], $rateLimiter);
 
-$result = $platform->invoke('gpt-5.2', new MessageBag(
+// OpenAI receives 'gpt-4o', if it fails, Anthropic receives 'claude-sonnet-4-20250514'
+$result = $platform->invoke('gpt-4o', new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
-    Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
+    Message::ofUser('What is the capital of France?'),
 ));
-
-assert($result->getResultConverter() instanceof ResultConverter);
-
-echo $result->asText().\PHP_EOL;

--- a/examples/misc/failover-platform-with-model-override.php
+++ b/examples/misc/failover-platform-with-model-override.php
@@ -9,16 +9,13 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\AI\Platform\Bridge\Anthropic\Factory as AnthropicFactory;
 use Symfony\AI\Platform\Bridge\Failover\FailoverPlatform;
-use Symfony\AI\Platform\Bridge\Ollama\Factory as OllamaFactory;
 use Symfony\AI\Platform\Bridge\OpenAi\Factory as OpenAiFactory;
-use Symfony\AI\Platform\Bridge\OpenAi\Gpt\ResultConverter;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
-
-require_once dirname(__DIR__).'/bootstrap.php';
 
 $rateLimiter = new RateLimiterFactory([
     'policy' => 'sliding_window',
@@ -27,17 +24,13 @@ $rateLimiter = new RateLimiterFactory([
     'limit' => 1,
 ], new InMemoryStorage());
 
-// # Ollama will fail as 'gpt-5.2' is not available in the catalog
 $platform = new FailoverPlatform([
-    ['platform' => OllamaFactory::createPlatform(env('OLLAMA_HOST_URL'), httpClient: http_client())],
-    ['platform' => OpenAiFactory::createPlatform(env('OPENAI_API_KEY'), http_client())],
+    ['platform' => OpenAiFactory::createPlatform(env('OPENAI_API_KEY'), http_client()), 'model' => 'gpt-4o'],
+    ['platform' => AnthropicFactory::createPlatform(env('ANTHROPIC_API_KEY'), http_client()), 'model' => 'claude-sonnet-4-20250514'],
 ], $rateLimiter);
 
-$result = $platform->invoke('gpt-5.2', new MessageBag(
+// OpenAI receives 'gpt-4o', if it fails, Anthropic receives 'claude-sonnet-4-20250514'
+$result = $platform->invoke('gpt-4o', new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
-    Message::ofUser('Tina has one brother and one sister. How many sisters do Tina\'s siblings have?'),
+    Message::ofUser('What is the capital of France?'),
 ));
-
-assert($result->getResultConverter() instanceof ResultConverter);
-
-echo $result->asText().\PHP_EOL;

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -25,6 +25,7 @@ CHANGELOG
  * Add `speech` configuration node for automatic `SpeechAgent` decoration with TTS/STT support
  * The `strategy` option for `Cache` store is now `cosine` by default
  * The `DistanceCalculator` is no longer a service when using `Cache` store
+ * Add support for model overrides per platform when using `Failover` platform
 
 0.6
 ---

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Add support for model overrides per platform when using `Failover` platform
+
 0.11
 ----
 

--- a/src/ai-bundle/config/platform/failover.php
+++ b/src/ai-bundle/config/platform/failover.php
@@ -18,7 +18,37 @@ return (new ArrayNodeDefinition('failover'))
     ->arrayPrototype()
         ->children()
             ->arrayNode('platforms')
-                ->scalarPrototype()->end()
+                ->arrayPrototype()
+                    ->children()
+                        ->stringNode('platform')->end()
+                        ->variableNode('model')
+                            ->validate()
+                                ->ifTrue(static function (mixed $v): bool {
+                                    if (null === $v || (\is_string($v) && '' !== $v)) {
+                                        return false;
+                                    }
+
+                                    if (\is_array($v)) {
+                                        foreach ($v as $item) {
+                                            if (!\is_string($item) || '' === $item) {
+                                                return true;
+                                            }
+                                        }
+
+                                        return [] === $v;
+                                    }
+
+                                    return true;
+                                })
+                                ->thenInvalid('The "model" option must be a non-empty string or a non-empty array of non-empty strings.')
+                            ->end()
+                        ->end()
+                    ->end()
+                    ->beforeNormalization()
+                        ->ifString()
+                        ->then(static fn (string $v): array => ['platform' => $v])
+                    ->end()
+                ->end()
             ->end()
             ->stringNode('rate_limiter')->cannotBeEmpty()->end()
         ->end()

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -650,7 +650,16 @@ final class AiBundle extends AbstractBundle
                     ->setLazy(true)
                     ->setArguments([
                         array_map(
-                            static fn (string $wrappedPlatform): Reference => new Reference($wrappedPlatform),
+                            static function (array $wrappedPlatform): Reference|array {
+                                if (!isset($wrappedPlatform['model'])) {
+                                    return new Reference($wrappedPlatform['platform']);
+                                }
+
+                                return [
+                                    'platform' => new Reference($wrappedPlatform['platform']),
+                                    'model' => $wrappedPlatform['model'],
+                                ];
+                            },
                             $config['platforms'],
                         ),
                         new Reference($config['rate_limiter']),

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -671,7 +671,16 @@ final class AiBundle extends AbstractBundle
                     ->setLazy(true)
                     ->setArguments([
                         array_map(
-                            static fn (string $wrappedPlatform): Reference => new Reference($wrappedPlatform),
+                            static function (array $wrappedPlatform): Reference|array {
+                                if (!isset($wrappedPlatform['model'])) {
+                                    return new Reference($wrappedPlatform['platform']);
+                                }
+
+                                return [
+                                    'platform' => new Reference($wrappedPlatform['platform']),
+                                    'model' => $wrappedPlatform['model'],
+                                ];
+                            },
                             $config['platforms'],
                         ),
                         new Reference($config['rate_limiter']),

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -4364,6 +4364,8 @@ class AiBundleTest extends TestCase
             ],
         ]);
 
+        $this->assertTrue($container->hasDefinition('ai.platform.ollama'));
+        $this->assertTrue($container->hasDefinition('ai.platform.openai'));
         $this->assertTrue($container->hasDefinition('ai.platform.failover.main'));
 
         $definition = $container->getDefinition('ai.platform.failover.main');
@@ -4394,6 +4396,88 @@ class AiBundleTest extends TestCase
         $this->assertSame([['name' => 'failover']], $definition->getTag('ai.platform'));
 
         $this->assertTrue($container->hasAlias(PlatformInterface::class.' $main'));
+
+        // Model override
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'ollama' => [
+                        'endpoint' => 'http://127.0.0.1:11434',
+                    ],
+                    'openai' => [
+                        'api_key' => 'sk-openai_key_full',
+                    ],
+                    'failover' => [
+                        'main' => [
+                            'platforms' => [
+                                ['platform' => 'ai.platform.ollama', 'model' => 'llama3'],
+                                ['platform' => 'ai.platform.openai', 'model' => 'gpt-4'],
+                            ],
+                            'rate_limiter' => 'limiter.failover_platform',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.ollama'));
+        $this->assertTrue($container->hasDefinition('ai.platform.openai'));
+        $this->assertTrue($container->hasDefinition('ai.platform.failover.main'));
+
+        $definition = $container->getDefinition('ai.platform.failover.main');
+
+        $this->assertCount(2, $definition->getArgument(0));
+
+        $this->assertEquals([
+            ['platform' => new Reference('ai.platform.ollama'), 'model' => 'llama3'],
+            ['platform' => new Reference('ai.platform.openai'), 'model' => 'gpt-4'],
+        ], $definition->getArgument(0));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(1));
+        $this->assertSame('limiter.failover_platform', (string) $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame(ClockInterface::class, (string) $definition->getArgument(2));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
+        $this->assertSame(LoggerInterface::class, (string) $definition->getArgument(3));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.platform'));
+        $this->assertSame([['name' => 'failover']], $definition->getTag('ai.platform'));
+
+        $this->assertTrue($container->hasAlias(PlatformInterface::class.' $main'));
+
+        // Multiple model overrides
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'ollama' => [
+                        'endpoint' => 'http://127.0.0.1:11434',
+                    ],
+                    'openai' => [
+                        'api_key' => 'sk-openai_key_full',
+                    ],
+                    'failover' => [
+                        'main' => [
+                            'platforms' => [
+                                ['platform' => 'ai.platform.ollama', 'model' => ['llama3', 'mistral']],
+                                'ai.platform.openai',
+                            ],
+                            'rate_limiter' => 'limiter.failover_platform',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.failover.main'));
+
+        $definition = $container->getDefinition('ai.platform.failover.main');
+
+        $this->assertCount(2, $definition->getArgument(0));
+        $this->assertEquals([
+            ['platform' => new Reference('ai.platform.ollama'), 'model' => ['llama3', 'mistral']],
+            new Reference('ai.platform.openai'),
+        ], $definition->getArgument(0));
     }
 
     public function testOpenAiPlatformWithDefaultRegion()

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -5082,6 +5082,8 @@ class AiBundleTest extends TestCase
             ],
         ]);
 
+        $this->assertTrue($container->hasDefinition('ai.platform.ollama'));
+        $this->assertTrue($container->hasDefinition('ai.platform.openai'));
         $this->assertTrue($container->hasDefinition('ai.platform.failover.main'));
 
         $definition = $container->getDefinition('ai.platform.failover.main');
@@ -5112,6 +5114,88 @@ class AiBundleTest extends TestCase
         $this->assertSame([['name' => 'failover']], $definition->getTag('ai.platform'));
 
         $this->assertTrue($container->hasAlias(PlatformInterface::class.' $main'));
+
+        // Model override
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'ollama' => [
+                        'endpoint' => 'http://127.0.0.1:11434',
+                    ],
+                    'openai' => [
+                        'api_key' => 'sk-openai_key_full',
+                    ],
+                    'failover' => [
+                        'main' => [
+                            'platforms' => [
+                                ['platform' => 'ai.platform.ollama', 'model' => 'llama3'],
+                                ['platform' => 'ai.platform.openai', 'model' => 'gpt-4'],
+                            ],
+                            'rate_limiter' => 'limiter.failover_platform',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.ollama'));
+        $this->assertTrue($container->hasDefinition('ai.platform.openai'));
+        $this->assertTrue($container->hasDefinition('ai.platform.failover.main'));
+
+        $definition = $container->getDefinition('ai.platform.failover.main');
+
+        $this->assertCount(2, $definition->getArgument(0));
+
+        $this->assertEquals([
+            ['platform' => new Reference('ai.platform.ollama'), 'model' => 'llama3'],
+            ['platform' => new Reference('ai.platform.openai'), 'model' => 'gpt-4'],
+        ], $definition->getArgument(0));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(1));
+        $this->assertSame('limiter.failover_platform', (string) $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame(ClockInterface::class, (string) $definition->getArgument(2));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
+        $this->assertSame(LoggerInterface::class, (string) $definition->getArgument(3));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.platform'));
+        $this->assertSame([['name' => 'failover']], $definition->getTag('ai.platform'));
+
+        $this->assertTrue($container->hasAlias(PlatformInterface::class.' $main'));
+
+        // Multiple model overrides
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'ollama' => [
+                        'endpoint' => 'http://127.0.0.1:11434',
+                    ],
+                    'openai' => [
+                        'api_key' => 'sk-openai_key_full',
+                    ],
+                    'failover' => [
+                        'main' => [
+                            'platforms' => [
+                                ['platform' => 'ai.platform.ollama', 'model' => ['llama3', 'mistral']],
+                                'ai.platform.openai',
+                            ],
+                            'rate_limiter' => 'limiter.failover_platform',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.failover.main'));
+
+        $definition = $container->getDefinition('ai.platform.failover.main');
+
+        $this->assertCount(2, $definition->getArgument(0));
+        $this->assertEquals([
+            ['platform' => new Reference('ai.platform.ollama'), 'model' => ['llama3', 'mistral']],
+            new Reference('ai.platform.openai'),
+        ], $definition->getArgument(0));
     }
 
     public function testOpenAiPlatformWithDefaultRegion()

--- a/src/platform/src/Bridge/Failover/CHANGELOG.md
+++ b/src/platform/src/Bridge/Failover/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.7
+---
+
+ * Add support for model overrides per platform
+ * Add support for multiple model fallbacks per platform entry
+
 0.2
 ---
 

--- a/src/platform/src/Bridge/Failover/CHANGELOG.md
+++ b/src/platform/src/Bridge/Failover/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Add support for model overrides per platform
+ * Add support for multiple model fallbacks per platform entry
+
 0.2
 ---
 

--- a/src/platform/src/Bridge/Failover/FailoverPlatform.php
+++ b/src/platform/src/Bridge/Failover/FailoverPlatform.php
@@ -28,15 +28,25 @@ use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 final class FailoverPlatform implements PlatformInterface
 {
     /**
+     * @var list<PlatformInterface>
+     */
+    private readonly array $platforms;
+
+    /**
+     * @var \WeakMap<PlatformInterface, non-empty-string|non-empty-list<non-empty-string>>
+     */
+    private \WeakMap $modelOverrides;
+
+    /**
      * @var \WeakMap<PlatformInterface, int>
      */
     private readonly \WeakMap $failedPlatforms;
 
     /**
-     * @param PlatformInterface[] $platforms
+     * @param list<PlatformInterface|array{platform: PlatformInterface, model?: string|list<string>|null}> $platforms
      */
     public function __construct(
-        private readonly iterable $platforms,
+        array $platforms,
         private readonly RateLimiterFactoryInterface $rateLimiterFactory,
         private readonly ClockInterface $clock = new MonotonicClock(),
         private readonly LoggerInterface $logger = new NullLogger(),
@@ -45,12 +55,67 @@ final class FailoverPlatform implements PlatformInterface
             throw new InvalidArgumentException(\sprintf('"%s" must have at least one platform configured.', self::class));
         }
 
+        $this->modelOverrides = new \WeakMap();
+        $resolvedPlatforms = [];
+
+        foreach ($platforms as $config) {
+            if ($config instanceof PlatformInterface) {
+                $resolvedPlatforms[] = $config;
+
+                continue;
+            }
+
+            $platform = $config['platform'];
+            $model = $config['model'] ?? null;
+
+            if (\is_string($model) && '' !== $model) {
+                $this->modelOverrides[$platform] = $model;
+            } elseif (\is_array($model)) {
+                /** @var list<string> $model */
+                $filtered = array_values(array_filter($model, static fn (string $m): bool => '' !== $m));
+
+                if ([] !== $filtered) {
+                    $this->modelOverrides[$platform] = $filtered;
+                }
+            }
+
+            $resolvedPlatforms[] = $platform;
+        }
+
+        $this->platforms = $resolvedPlatforms;
         $this->failedPlatforms = new \WeakMap();
     }
 
     public function invoke(string $model, object|array|string $input, array $options = []): DeferredResult
     {
-        return $this->do(static fn (PlatformInterface $platform): DeferredResult => $platform->invoke($model, $input, $options));
+        $modelOverrides = $this->modelOverrides;
+        $logger = $this->logger;
+
+        return $this->do(static function (PlatformInterface $platform) use ($modelOverrides, $model, $input, $options, $logger): DeferredResult {
+            $override = $modelOverrides[$platform] ?? null;
+
+            if (!\is_array($override)) {
+                return $platform->invoke($override ?? $model, $input, $options);
+            }
+
+            $lastException = null;
+
+            foreach ($override as $modelName) {
+                try {
+                    return $platform->invoke($modelName, $input, $options);
+                } catch (\Throwable $throwable) {
+                    $lastException = $throwable;
+
+                    $logger->warning('Model "{model}" failed: {message}', [
+                        'model' => $modelName,
+                        'message' => $throwable->getMessage(),
+                        'exception' => $throwable,
+                    ]);
+                }
+            }
+
+            throw $lastException;
+        });
     }
 
     public function getModelCatalog(): ModelCatalogInterface
@@ -58,6 +123,13 @@ final class FailoverPlatform implements PlatformInterface
         return $this->do(static fn (PlatformInterface $platform): ModelCatalogInterface => $platform->getModelCatalog());
     }
 
+    /**
+     * @template T of DeferredResult|ModelCatalogInterface
+     *
+     * @param \Closure(PlatformInterface): T $func
+     *
+     * @return T
+     */
     private function do(\Closure $func): DeferredResult|ModelCatalogInterface
     {
         foreach ($this->platforms as $platform) {

--- a/src/platform/src/Bridge/Failover/FailoverPlatform.php
+++ b/src/platform/src/Bridge/Failover/FailoverPlatform.php
@@ -29,15 +29,25 @@ use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 final class FailoverPlatform implements PlatformInterface
 {
     /**
+     * @var list<PlatformInterface>
+     */
+    private readonly array $platforms;
+
+    /**
+     * @var \WeakMap<PlatformInterface, non-empty-string|non-empty-list<non-empty-string>>
+     */
+    private \WeakMap $modelOverrides;
+
+    /**
      * @var \WeakMap<PlatformInterface, int>
      */
     private readonly \WeakMap $failedPlatforms;
 
     /**
-     * @param PlatformInterface[] $platforms
+     * @param list<PlatformInterface|array{platform: PlatformInterface, model?: string|list<string>|null}> $platforms
      */
     public function __construct(
-        private readonly iterable $platforms,
+        array $platforms,
         private readonly RateLimiterFactoryInterface $rateLimiterFactory,
         private readonly ClockInterface $clock = new MonotonicClock(),
         private readonly LoggerInterface $logger = new NullLogger(),
@@ -46,12 +56,67 @@ final class FailoverPlatform implements PlatformInterface
             throw new InvalidArgumentException(\sprintf('"%s" must have at least one platform configured.', self::class));
         }
 
+        $this->modelOverrides = new \WeakMap();
+        $resolvedPlatforms = [];
+
+        foreach ($platforms as $config) {
+            if ($config instanceof PlatformInterface) {
+                $resolvedPlatforms[] = $config;
+
+                continue;
+            }
+
+            $platform = $config['platform'];
+            $model = $config['model'] ?? null;
+
+            if (\is_string($model) && '' !== $model) {
+                $this->modelOverrides[$platform] = $model;
+            } elseif (\is_array($model)) {
+                /** @var list<string> $model */
+                $filtered = array_values(array_filter($model, static fn (string $m): bool => '' !== $m));
+
+                if ([] !== $filtered) {
+                    $this->modelOverrides[$platform] = $filtered;
+                }
+            }
+
+            $resolvedPlatforms[] = $platform;
+        }
+
+        $this->platforms = $resolvedPlatforms;
         $this->failedPlatforms = new \WeakMap();
     }
 
     public function invoke(string|Model $model, object|array|string $input, array $options = []): DeferredResult
     {
-        return $this->do(static fn (PlatformInterface $platform): DeferredResult => $platform->invoke($model, $input, $options));
+        $modelOverrides = $this->modelOverrides;
+        $logger = $this->logger;
+
+        return $this->do(static function (PlatformInterface $platform) use ($modelOverrides, $model, $input, $options, $logger): DeferredResult {
+            $override = $modelOverrides[$platform] ?? null;
+
+            if (!\is_array($override)) {
+                return $platform->invoke($override ?? $model, $input, $options);
+            }
+
+            $lastException = null;
+
+            foreach ($override as $modelName) {
+                try {
+                    return $platform->invoke($modelName, $input, $options);
+                } catch (\Throwable $throwable) {
+                    $lastException = $throwable;
+
+                    $logger->warning('Model "{model}" failed: {message}', [
+                        'model' => $modelName,
+                        'message' => $throwable->getMessage(),
+                        'exception' => $throwable,
+                    ]);
+                }
+            }
+
+            throw $lastException;
+        });
     }
 
     public function getModelCatalog(): ModelCatalogInterface
@@ -59,6 +124,13 @@ final class FailoverPlatform implements PlatformInterface
         return $this->do(static fn (PlatformInterface $platform): ModelCatalogInterface => $platform->getModelCatalog());
     }
 
+    /**
+     * @template T of DeferredResult|ModelCatalogInterface
+     *
+     * @param \Closure(PlatformInterface): T $func
+     *
+     * @return T
+     */
     private function do(\Closure $func): DeferredResult|ModelCatalogInterface
     {
         foreach ($this->platforms as $platform) {

--- a/src/platform/src/Bridge/Failover/FailoverPlatformFactory.php
+++ b/src/platform/src/Bridge/Failover/FailoverPlatformFactory.php
@@ -24,19 +24,14 @@ use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 final class FailoverPlatformFactory
 {
     /**
-     * @param PlatformInterface[] $platforms
+     * @param list<PlatformInterface|array{platform: PlatformInterface, model?: string|list<string>|null}> $platforms
      */
     public static function create(
-        iterable $platforms,
+        array $platforms,
         RateLimiterFactoryInterface $rateLimiterFactory,
         ClockInterface $clock = new MonotonicClock(),
         LoggerInterface $logger = new NullLogger(),
     ): PlatformInterface {
-        return new FailoverPlatform(
-            $platforms,
-            $rateLimiterFactory,
-            $clock,
-            $logger,
-        );
+        return new FailoverPlatform($platforms, $rateLimiterFactory, $clock, $logger);
     }
 }

--- a/src/platform/src/Bridge/Failover/Tests/FailoverPlatformTest.php
+++ b/src/platform/src/Bridge/Failover/Tests/FailoverPlatformTest.php
@@ -130,6 +130,7 @@ final class FailoverPlatformTest extends TestCase
         $failedPlatform = $this->createMock(PlatformInterface::class);
         $failedPlatform->expects($this->any())->method('invoke')
             ->willReturnCallback(static function (): DeferredResult {
+                /** @var int $call */
                 static $call = 0;
 
                 if (1 === ++$call) {
@@ -168,6 +169,7 @@ final class FailoverPlatformTest extends TestCase
         $failedPlatform = $this->createMock(PlatformInterface::class);
         $failedPlatform->expects($this->any())->method('getModelCatalog')
             ->willReturnCallback(static function (): ModelCatalogInterface {
+                /** @var int $call */
                 static $call = 0;
 
                 if (1 === ++$call) {
@@ -199,6 +201,7 @@ final class FailoverPlatformTest extends TestCase
         $firstPlatform = $this->createMock(PlatformInterface::class);
         $firstPlatform->expects($this->any())->method('invoke')
             ->willReturnCallback(static function (): DeferredResult {
+                /** @var int $call */
                 static $call = 0;
 
                 if (1 === ++$call) {
@@ -214,6 +217,7 @@ final class FailoverPlatformTest extends TestCase
         $failedPlatform = $this->createMock(PlatformInterface::class);
         $failedPlatform->expects($this->any())->method('invoke')
             ->willReturnCallback(static function (): DeferredResult {
+                /** @var int $call */
                 static $call = 0;
 
                 if (1 === ++$call) {
@@ -250,6 +254,7 @@ final class FailoverPlatformTest extends TestCase
         $firstPlatform = $this->createMock(PlatformInterface::class);
         $firstPlatform->expects($this->any())->method('getModelCatalog')
             ->willReturnCallback(static function (): ModelCatalogInterface {
+                /** @var int $call */
                 static $call = 0;
 
                 if (1 === ++$call) {
@@ -262,6 +267,7 @@ final class FailoverPlatformTest extends TestCase
         $failedPlatform = $this->createMock(PlatformInterface::class);
         $failedPlatform->expects($this->any())->method('getModelCatalog')
             ->willReturnCallback(static function (): ModelCatalogInterface {
+                /** @var int $call */
                 static $call = 0;
 
                 if (1 === ++$call) {
@@ -296,6 +302,7 @@ final class FailoverPlatformTest extends TestCase
         $firstPlatform = $this->createMock(PlatformInterface::class);
         $firstPlatform->expects($this->any())->method('invoke')
             ->willReturnCallback(static function (): DeferredResult {
+                /** @var int $call */
                 static $call = 0;
 
                 if (4 === ++$call) {
@@ -311,6 +318,7 @@ final class FailoverPlatformTest extends TestCase
         $failedPlatform = $this->createMock(PlatformInterface::class);
         $failedPlatform->expects($this->any())->method('invoke')
             ->willReturnCallback(static function (): DeferredResult {
+                /** @var int $call */
                 static $call = 0;
 
                 if (1 === ++$call) {
@@ -352,6 +360,7 @@ final class FailoverPlatformTest extends TestCase
         $firstPlatform = $this->createMock(PlatformInterface::class);
         $firstPlatform->expects($this->any())->method('getModelCatalog')
             ->willReturnCallback(static function (): ModelCatalogInterface {
+                /** @var int $call */
                 static $call = 0;
 
                 if (4 === ++$call) {
@@ -364,6 +373,7 @@ final class FailoverPlatformTest extends TestCase
         $failedPlatform = $this->createMock(PlatformInterface::class);
         $failedPlatform->expects($this->any())->method('getModelCatalog')
             ->willReturnCallback(static function (): ModelCatalogInterface {
+                /** @var int $call */
                 static $call = 0;
 
                 if (1 === ++$call) {
@@ -394,6 +404,260 @@ final class FailoverPlatformTest extends TestCase
         $clock->sleep(1);
 
         $failoverPlatform->getModelCatalog();
+    }
+
+    public function testPlatformCanPerformInvokeWithoutModelOverride()
+    {
+        $failedPlatform = $this->createMock(PlatformInterface::class);
+        $failedPlatform->expects($this->once())->method('invoke')
+            ->with('gpt-4', 'foo', [])
+            ->willThrowException(new \Exception('Primary platform failed.'));
+
+        $fallbackPlatform = $this->createMock(PlatformInterface::class);
+        $fallbackPlatform->expects($this->once())->method('invoke')
+            ->with('gpt-4', 'foo', [])
+            ->willReturn(new DeferredResult(
+                new PlainConverter(new TextResult('fallback result')),
+                new InMemoryRawResult(['foo' => 'bar']),
+            ));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $failoverPlatform = new FailoverPlatform([
+            $failedPlatform,
+            $fallbackPlatform,
+        ], self::createRateLimiterFactory(), logger: $logger);
+
+        $result = $failoverPlatform->invoke('gpt-4', 'foo');
+
+        $this->assertSame('fallback result', $result->asText());
+    }
+
+    public function testPlatformCanPerformInvokeWithModelOverride()
+    {
+        $failedPlatform = $this->createMock(PlatformInterface::class);
+        $failedPlatform->expects($this->once())->method('invoke')
+            ->willThrowException(new \Exception('Primary platform failed.'));
+
+        $fallbackPlatform = $this->createMock(PlatformInterface::class);
+        $fallbackPlatform->expects($this->once())->method('invoke')
+            ->with('claude-3-opus', 'foo', [])
+            ->willReturn(new DeferredResult(
+                new PlainConverter(new TextResult('fallback result')),
+                new InMemoryRawResult(['foo' => 'bar']),
+            ));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $failoverPlatform = new FailoverPlatform([
+            $failedPlatform,
+            ['platform' => $fallbackPlatform, 'model' => 'claude-3-opus'],
+        ], self::createRateLimiterFactory(), logger: $logger);
+
+        $result = $failoverPlatform->invoke('gpt-4', 'foo');
+
+        $this->assertSame('fallback result', $result->asText());
+    }
+
+    public function testPlatformCanPerformInvokeWithModelOverrideOnAllPlatforms()
+    {
+        $primaryPlatform = $this->createMock(PlatformInterface::class);
+        $primaryPlatform->expects($this->once())->method('invoke')
+            ->with('llama3', 'foo', [])
+            ->willReturn(new DeferredResult(
+                new PlainConverter(new TextResult('primary result')),
+                new InMemoryRawResult(['foo' => 'bar']),
+            ));
+
+        $failoverPlatform = new FailoverPlatform([
+            ['platform' => $primaryPlatform, 'model' => 'llama3'],
+        ], self::createRateLimiterFactory());
+
+        $result = $failoverPlatform->invoke('gpt-4', 'foo');
+
+        $this->assertSame('primary result', $result->asText());
+    }
+
+    public function testPlatformCanPerformInvokeWithMixedKeysAndModelOverrides()
+    {
+        $firstPlatform = $this->createMock(PlatformInterface::class);
+        $firstPlatform->expects($this->once())->method('invoke')
+            ->with('gpt-4', 'foo', [])
+            ->willThrowException(new \Exception('First platform failed.'));
+
+        $secondPlatform = $this->createMock(PlatformInterface::class);
+        $secondPlatform->expects($this->once())->method('invoke')
+            ->with('claude-3-opus', 'foo', [])
+            ->willReturn(new DeferredResult(
+                new PlainConverter(new TextResult('second result')),
+                new InMemoryRawResult(['foo' => 'bar']),
+            ));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $failoverPlatform = new FailoverPlatform([
+            $firstPlatform,
+            ['platform' => $secondPlatform, 'model' => 'claude-3-opus'],
+        ], self::createRateLimiterFactory(), logger: $logger);
+
+        $result = $failoverPlatform->invoke('gpt-4', 'foo');
+
+        $this->assertSame('second result', $result->asText());
+    }
+
+    public function testPlatformWithoutModelOverrideUsesDefaultModel()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')
+            ->with('gpt-4', 'foo', [])
+            ->willReturn(new DeferredResult(
+                new PlainConverter(new TextResult('result')),
+                new InMemoryRawResult(['foo' => 'bar']),
+            ));
+
+        $failoverPlatform = new FailoverPlatform([
+            $platform,
+        ], self::createRateLimiterFactory());
+
+        $result = $failoverPlatform->invoke('gpt-4', 'foo');
+
+        $this->assertSame('result', $result->asText());
+    }
+
+    public function testPlatformCanPerformInvokeWithMultipleModelOverrides()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')
+            ->with('model-a', 'foo', [])
+            ->willReturn(new DeferredResult(
+                new PlainConverter(new TextResult('result')),
+                new InMemoryRawResult(['foo' => 'bar']),
+            ));
+
+        $failoverPlatform = new FailoverPlatform([
+            ['platform' => $platform, 'model' => ['model-a', 'model-b']],
+        ], self::createRateLimiterFactory());
+
+        $result = $failoverPlatform->invoke('default', 'foo');
+
+        $this->assertSame('result', $result->asText());
+    }
+
+    public function testPlatformCanPerformInvokeWithMultipleModelOverridesAfterFirstModelFails()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')
+            ->willReturnCallback(static function (string $model): DeferredResult {
+                if ('model-a' === $model) {
+                    throw new \Exception('model-a failed.');
+                }
+
+                return new DeferredResult(
+                    new PlainConverter(new TextResult('result from model-b')),
+                    new InMemoryRawResult(['foo' => 'bar']),
+                );
+            });
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning');
+        $logger->expects($this->never())->method('error');
+
+        $failoverPlatform = new FailoverPlatform([
+            ['platform' => $platform, 'model' => ['model-a', 'model-b']],
+        ], self::createRateLimiterFactory(), logger: $logger);
+
+        $result = $failoverPlatform->invoke('default', 'foo');
+
+        $this->assertSame('result from model-b', $result->asText());
+    }
+
+    public function testPlatformFallsToNextPlatformWhenAllModelsExhausted()
+    {
+        $firstPlatform = $this->createMock(PlatformInterface::class);
+        $firstPlatform->expects($this->exactly(2))->method('invoke')
+            ->willThrowException(new \Exception('All models failed on platform A.'));
+
+        $secondPlatform = $this->createMock(PlatformInterface::class);
+        $secondPlatform->expects($this->once())->method('invoke')
+            ->with('default-model', 'foo', [])
+            ->willReturn(new DeferredResult(
+                new PlainConverter(new TextResult('fallback result')),
+                new InMemoryRawResult(['foo' => 'bar']),
+            ));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->exactly(2))->method('warning');
+        $logger->expects($this->once())->method('error');
+
+        $failoverPlatform = new FailoverPlatform([
+            ['platform' => $firstPlatform, 'model' => ['model-a', 'model-b']],
+            $secondPlatform,
+        ], self::createRateLimiterFactory(), logger: $logger);
+
+        $result = $failoverPlatform->invoke('default-model', 'foo');
+
+        $this->assertSame('fallback result', $result->asText());
+    }
+
+    public function testPlatformThrowsWhenAllPlatformsAndAllModelsExhausted()
+    {
+        $firstPlatform = $this->createMock(PlatformInterface::class);
+        $firstPlatform->expects($this->exactly(2))->method('invoke')
+            ->willThrowException(new \Exception('Platform A model failed.'));
+
+        $secondPlatform = $this->createMock(PlatformInterface::class);
+        $secondPlatform->expects($this->once())->method('invoke')
+            ->willThrowException(new \Exception('Platform B failed.'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->exactly(2))->method('warning');
+        $logger->expects($this->exactly(2))->method('error');
+
+        $failoverPlatform = new FailoverPlatform([
+            ['platform' => $firstPlatform, 'model' => ['model-a', 'model-b']],
+            ['platform' => $secondPlatform, 'model' => 'model-c'],
+        ], self::createRateLimiterFactory(), logger: $logger);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('All platforms failed.');
+        $failoverPlatform->invoke('default', 'foo');
+    }
+
+    public function testPlatformCanPerformInvokeWithMixedSingleAndMultipleModelOverrides()
+    {
+        $firstPlatform = $this->createMock(PlatformInterface::class);
+        $firstPlatform->expects($this->once())->method('invoke')
+            ->with('single-model', 'foo', [])
+            ->willThrowException(new \Exception('Platform A failed.'));
+
+        $secondPlatform = $this->createMock(PlatformInterface::class);
+        $secondPlatform->expects($this->exactly(2))->method('invoke')
+            ->willReturnCallback(static function (string $model): DeferredResult {
+                if ('model-x' === $model) {
+                    throw new \Exception('model-x failed.');
+                }
+
+                return new DeferredResult(
+                    new PlainConverter(new TextResult('result from model-y')),
+                    new InMemoryRawResult(['foo' => 'bar']),
+                );
+            });
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning');
+        $logger->expects($this->once())->method('error');
+
+        $failoverPlatform = new FailoverPlatform([
+            ['platform' => $firstPlatform, 'model' => 'single-model'],
+            ['platform' => $secondPlatform, 'model' => ['model-x', 'model-y']],
+        ], self::createRateLimiterFactory(), logger: $logger);
+
+        $result = $failoverPlatform->invoke('default', 'foo');
+
+        $this->assertSame('result from model-y', $result->asText());
     }
 
     private static function createRateLimiterFactory(): RateLimiterFactoryInterface

--- a/src/platform/src/Bridge/Failover/phpstan.dist.neon
+++ b/src/platform/src/Bridge/Failover/phpstan.dist.neon
@@ -3,7 +3,7 @@ includes:
     - ../../../../../.phpstan/extension.neon
 
 parameters:
-    level: 6
+    level: 10
     paths:
         - .
         - Tests/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1716
| License       | MIT

Add support for model override when using `FailoverPlatform`

PS: PHPStan has been pushed to `10` to ensure bug free and correct types.