### PR TITLE
[Platform][Azure] Fix structured output in Responses API client

### DIFF
--- a/src/platform/src/Bridge/Azure/Responses/ModelClient.php
+++ b/src/platform/src/Bridge/Azure/Responses/ModelClient.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -54,6 +55,15 @@ final class ModelClient implements ModelClientInterface
 
     public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
     {
+        if (isset($options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema'])) {
+            $schema = $options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema'];
+            $options['text']['format'] = $schema;
+            $options['text']['format']['name'] = $schema['name'];
+            $options['text']['format']['type'] = $options[PlatformSubscriber::RESPONSE_FORMAT]['type'];
+
+            unset($options[PlatformSubscriber::RESPONSE_FORMAT]);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', $this->endpoint, [
             'headers' => [
                 'api-key' => $this->apiKey,

--- a/src/platform/src/Bridge/Azure/Tests/Responses/ModelClientTest.php
+++ b/src/platform/src/Bridge/Azure/Tests/Responses/ModelClientTest.php
@@ -104,4 +104,30 @@ final class ModelClientTest extends TestCase
         $client = new ModelClient($httpClient, 'test.openai.azure.com', 'test-api-key');
         $client->request(new ResponsesModel('gpt-4o'), ['input' => [['role' => 'user', 'content' => 'Hello']]]);
     }
+
+    public function testItHandlesStructuredOutputOption()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): MockResponse {
+            self::assertSame('POST', $method);
+            self::assertSame('https://test.openai.azure.com/openai/v1/responses', $url);
+            self::assertSame('{"temperature":0.7,"text":{"format":{"name":"foo","schema":[],"type":"json_schema"}},"model":"gpt-4o","input":[{"role":"user","content":"Hello"}]}', $options['body']);
+
+            return new MockResponse();
+        };
+
+        $options = [
+            'temperature' => 0.7,
+            'response_format' => [
+                'type' => 'json_schema',
+                'json_schema' => [
+                    'name' => 'foo',
+                    'schema' => [],
+                ],
+            ],
+        ];
+
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $client = new ModelClient($httpClient, 'test.openai.azure.com', 'test-api-key', 'gpt-4o');
+        $client->request(new ResponsesModel('gpt-4o'), ['input' => [['role' => 'user', 'content' => 'Hello']]], $options);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

## Problem

After the migration to the Responses API in commit 1e2df898, the `Azure/Responses/ModelClient` was missing the `response_format` → `text.format` option transformation. This caused structured output (JSON schema) requests to fail when using Azure OpenAI via the Responses API client, because the `response_format` key is not valid in the Responses API — it must be converted to `text.format`.

## Fix

Add the same option transformation block that exists in both `OpenAi/Gpt/ModelClient` and `OpenResponses/ModelClient`:

```php
if (isset($options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema'])) {
    $schema = $options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema'];
    $options['text']['format'] = $schema;
    $options['text']['format']['name'] = $schema['name'];
    $options['text']['format']['type'] = $options[PlatformSubscriber::RESPONSE_FORMAT]['type'];

    unset($options[PlatformSubscriber::RESPONSE_FORMAT]);
}
```

Also adds a `testItHandlesStructuredOutputOption` test to `Azure/Tests/Responses/ModelClientTest`.