### PR TITLE
 Fix RateLimitExceededException TypeError in Generic Embeddings ResultConverter

### DIFF
--- a/src/platform/src/Bridge/Generic/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Generic/Embeddings/ResultConverter.php
@@ -52,8 +52,8 @@ class ResultConverter implements ResultConverterInterface
         }
 
         if (429 === $response->getStatusCode()) {
-            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? 'Bad Request';
-            throw new RateLimitExceededException($errorMessage);
+            $retryAfter = $response->getHeaders(false)['retry-after'][0] ?? null;
+            throw new RateLimitExceededException(null !== $retryAfter ? (int) $retryAfter : null);
         }
 
         if (!isset($data['data'][0]['embedding'])) {

--- a/src/platform/src/Bridge/Generic/Tests/Embeddings/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Embeddings/ResultConverterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Generic\Tests\Embeddings;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Generic\Embeddings\ResultConverter;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -32,6 +33,40 @@ class ResultConverterTest extends TestCase
 
         $this->assertSame([0.3, 0.4, 0.4], $convertedContent[0]->getData());
         $this->assertSame([0.0, 0.0, 0.2], $convertedContent[1]->getData());
+    }
+
+    public function testThrowsRateLimitExceededExceptionWithRetryAfterHeader()
+    {
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(429);
+        $httpResponse->method('getHeaders')->willReturn(['retry-after' => ['60']]);
+
+        $exception = null;
+        try {
+            (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertSame(60, $exception->getRetryAfter());
+    }
+
+    public function testThrowsRateLimitExceededExceptionWithoutRetryAfterHeader()
+    {
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(429);
+        $httpResponse->method('getHeaders')->willReturn([]);
+
+        $exception = null;
+        try {
+            (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertNull($exception->getRetryAfter());
     }
 
     private function getEmbeddingStub(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

This is a fix for the following exception:

```
{
  "class": "TypeError",
  "message": "Symfony\\AI\\Platform\\Exception\\RateLimitExceededException::__construct(): Argument #1 ($retryAfter) must be of type ?int, string given, called in /app/vendor/symfony/ai-generic-platform/Embeddings/ResultConverter.php on line 56",
  "code": 0,
  "file": "/app/vendor/symfony/ai-platform/src/Exception/RateLimitExceededException.php:19"
}
```

The 429 rate-limit handler in `Bridge/Generic/Embeddings/ResultConverter` was passing
a string error message to `RateLimitExceededException::__construct()`, whose first
argument is `?int $retryAfter`. This caused a `TypeError` at runtime whenever a
429 response was received while indexing via the Generic embeddings bridge.

Fix it by reading the standard `Retry-After` response header (an integer number of
seconds per RFC 7231) and casting it to `int`, falling back to `null` when the header
is absent — consistent with how `Bridge/Anthropic/ResultConverter` handles the same case.

Two unit tests are added to cover both scenarios (with and without the `Retry-After` header).