### PR TITLE
[Platform][Gemini] Fix ResultConverter crash on multiple text content parts

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -143,14 +143,21 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         $content = '';
-        $successfulCodeExecutionDetected = false;
+        $collectText = true;
         foreach ($contentParts as $contentPart) {
             if ($this->isSuccessfulCodeExecution($contentPart)) {
-                $successfulCodeExecutionDetected = true;
+                $collectText = true;
+                $content = '';
                 continue;
             }
 
-            if ($successfulCodeExecutionDetected) {
+            if (isset($contentPart['codeExecutionResult']) || isset($contentPart['executableCode'])) {
+                $collectText = false;
+                $content = '';
+                continue;
+            }
+
+            if ($collectText && isset($contentPart['text'])) {
                 $content .= $contentPart['text'];
             }
         }
@@ -159,7 +166,6 @@ final class ResultConverter implements ResultConverterInterface
             return new TextResult($content);
         }
 
-        // TODO: see https://github.com/symfony/ai/issues/1053
         throw new RuntimeException('Choice conversion failed. Potentially due to multiple content parts.');
     }
 

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -137,6 +138,34 @@ final class ResultConverterTest extends TestCase
         $this->assertInstanceOf(BinaryResult::class, $result);
         $this->assertSame($image->asBinary(), $result->getContent());
         $this->assertNull($result->getMimeType());
+    }
+
+    public function testReturnsTextResultForMultipleTextContentParts()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            [
+                                'text' => 'Hello',
+                            ],
+                            [
+                                'text' => ' World',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello World', $result->getContent());
     }
 
     public function testStreamSkipsCandidatesWithoutContentParts()

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -134,14 +134,21 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         $content = '';
-        $successfulCodeExecutionDetected = false;
+        $collectText = true;
         foreach ($contentParts as $contentPart) {
             if ($this->isSuccessfulCodeExecution($contentPart)) {
-                $successfulCodeExecutionDetected = true;
+                $collectText = true;
+                $content = '';
                 continue;
             }
 
-            if ($successfulCodeExecutionDetected) {
+            if (isset($contentPart['codeExecutionResult']) || isset($contentPart['executableCode'])) {
+                $collectText = false;
+                $content = '';
+                continue;
+            }
+
+            if ($collectText && isset($contentPart['text'])) {
                 $content .= $contentPart['text'];
             }
         }

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
@@ -96,6 +96,36 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('some_tool', $toolCall->getId());
     }
 
+    public function testItReturnsTextResultForMultipleTextContentParts()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response
+            ->method('toArray')
+            ->willReturn([
+                'candidates' => [
+                    [
+                        'content' => [
+                            'parts' => [
+                                [
+                                    'text' => 'Hello',
+                                ],
+                                [
+                                    'text' => ' World',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+
+        $resultConverter = new ResultConverter();
+
+        $result = $resultConverter->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello World', $result->getContent());
+    }
+
     public function testItThrowsExceptionOnFailure()
     {
         $response = $this->createStub(ResponseInterface::class);


### PR DESCRIPTION
| Q             | A
  | ------------- | ---
  | Bug fix?      | yes
  | New feature?  | no
  | Docs?         | no
  | Issues        | Fix #1053
  | License       | MIT

When Gemini returns multiple text content parts in a single response (e.g. an explanation followed by an HTML code block), the `ResultConverter::convertChoice()` method only collected text parts that appeared after a successful code execution result. When no code execution was involved, no text was collected and a `RuntimeException` was thrown:

  > "Choice conversion failed. Potentially due to multiple content parts."

This happens when prompts ask for structured output like "description + code", causing Gemini to split its response into separate `parts[]` entries.

The fix replaces the `$successfulCodeExecutionDetected` flag with a `$collectText` state machine that handles both flows in a single loop:

  - **No code execution** (the bug): `$collectText` starts `true`, all text parts are concatenated
  - **Successful code execution**: text before execution is discarded, text after success is kept (same behavior as before)
  - **Failed code execution**: text is discarded, exception is thrown (same behavior as before)

  The fix is applied to both `Gemini\ResultConverter` and `VertexAi\ResultConverter`.