### PR TITLE
 Fix horizontal scrollbar on ai.symfony.com

### DIFF
--- a/ai.symfony.com/assets/styles/app.css
+++ b/ai.symfony.com/assets/styles/app.css
@@ -60,6 +60,7 @@ body {
     font-size: 16px;
     font-weight: 400;
     line-height: 26px;
+    overflow-x: hidden;
 }
 
 .text-balance {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

AOS fade-left/fade-right animations translate elements beyond the viewport, triggering a horizontal scrollbar on macOS. Adding overflow-x: hidden on body prevents this.
