### PR TITLE
[Mate] Add DoctrineCollectorFormatter for Symfony profiler bridge

### DIFF
--- a/src/mate/src/Bridge/Symfony/CHANGELOG.md
+++ b/src/mate/src/Bridge/Symfony/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `query` parameter to `symfony-services` for filtering by service ID or class name
  * Add `@param` docblocks to all tool methods for AI-readable parameter descriptions
  * Add automatic detection of compiled container XML for kernels with custom class names
+ * Add `DoctrineCollectorFormatter` to expose Doctrine DBAL query data (query count, execution times, SQL, duplicate detection) to AI via the profiler
 
 0.6
 ---

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/DoctrineCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/DoctrineCollectorFormatter.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
+
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+
+/**
+ * Formats Doctrine collector data.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ *
+ * @implements CollectorFormatterInterface<DoctrineDataCollector>
+ */
+final class DoctrineCollectorFormatter implements CollectorFormatterInterface
+{
+    private const MAX_QUERIES = 50;
+    private const MAX_PARAM_LENGTH = 100;
+
+    public function getName(): string
+    {
+        return 'db';
+    }
+
+    public function format(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof DoctrineDataCollector);
+
+        $queries = $this->flattenQueries($collector);
+        $truncated = \count($queries) > self::MAX_QUERIES;
+        $queries = \array_slice($queries, 0, self::MAX_QUERIES);
+
+        return [
+            'query_count' => $collector->getQueryCount(),
+            'total_time_ms' => round($collector->getTime() * 1000, 2),
+            'connections' => array_keys($collector->getConnections()),
+            'queries' => $queries,
+            'queries_truncated' => $truncated,
+            'duplicate_queries' => $this->detectDuplicateQueries($collector),
+        ];
+    }
+
+    public function getSummary(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof DoctrineDataCollector);
+
+        return [
+            'query_count' => $collector->getQueryCount(),
+            'total_time_ms' => round($collector->getTime() * 1000, 2),
+            'duplicate_query_count' => \count($this->detectDuplicateQueries($collector)),
+        ];
+    }
+
+    /**
+     * @return list<array{connection: string, sql: string, params: mixed, time_ms: float}>
+     */
+    private function flattenQueries(DoctrineDataCollector $collector): array
+    {
+        $flattened = [];
+
+        foreach ($collector->getQueries() as $connection => $queries) {
+            foreach ($queries as $query) {
+                $flattened[] = [
+                    'connection' => $connection,
+                    'sql' => $query['sql'] ?? '',
+                    'params' => $this->truncateParams($query['params'] ?? null),
+                    'time_ms' => round(($query['executionMS'] ?? 0.0) * 1000, 2),
+                ];
+            }
+        }
+
+        return $flattened;
+    }
+
+    /**
+     * @return list<array{sql: string, count: int, total_time_ms: float}>
+     */
+    private function detectDuplicateQueries(DoctrineDataCollector $collector): array
+    {
+        /** @var array<string, array{count: int, total_time_ms: float}> $grouped */
+        $grouped = [];
+
+        foreach ($collector->getQueries() as $queries) {
+            foreach ($queries as $query) {
+                $sql = $query['sql'] ?? '';
+                if (!isset($grouped[$sql])) {
+                    $grouped[$sql] = ['count' => 0, 'total_time_ms' => 0.0];
+                }
+
+                ++$grouped[$sql]['count'];
+                $grouped[$sql]['total_time_ms'] += ($query['executionMS'] ?? 0.0) * 1000;
+            }
+        }
+
+        $duplicates = [];
+        foreach ($grouped as $sql => $data) {
+            if ($data['count'] <= 1) {
+                continue;
+            }
+
+            $duplicates[] = [
+                'sql' => $sql,
+                'count' => $data['count'],
+                'total_time_ms' => round($data['total_time_ms'], 2),
+            ];
+        }
+
+        return $duplicates;
+    }
+
+    private function truncateParams(mixed $params): mixed
+    {
+        if (\is_string($params) && \strlen($params) > self::MAX_PARAM_LENGTH) {
+            return substr($params, 0, self::MAX_PARAM_LENGTH).'...';
+        }
+
+        if (\is_array($params)) {
+            return array_map(fn (mixed $param): mixed => $this->truncateParams($param), $params);
+        }
+
+        return $params;
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterIntegrationTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterIntegrationTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorFormatter;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+use Symfony\Bridge\Doctrine\Middleware\Debug\Query;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Integration test using real DoctrineDataCollector with DebugDataHolder.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class DoctrineCollectorFormatterIntegrationTest extends TestCase
+{
+    private DoctrineCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new DoctrineCollectorFormatter();
+    }
+
+    public function testFormatWithRealCollector()
+    {
+        $collector = $this->createRealCollector([
+            'default' => [
+                ['sql' => 'SELECT * FROM users', 'params' => []],
+                ['sql' => 'SELECT * FROM posts WHERE user_id = ?', 'params' => [1 => 42]],
+            ],
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(2, $result['query_count']);
+        $this->assertArrayHasKey('total_time_ms', $result);
+        $this->assertGreaterThanOrEqual(0.0, $result['total_time_ms']);
+        $this->assertSame(['default'], $result['connections']);
+        $this->assertCount(2, $result['queries']);
+        $this->assertFalse($result['queries_truncated']);
+
+        $this->assertSame('default', $result['queries'][0]['connection']);
+        $this->assertSame('SELECT * FROM users', $result['queries'][0]['sql']);
+        $this->assertArrayHasKey('time_ms', $result['queries'][0]);
+
+        $this->assertSame('SELECT * FROM posts WHERE user_id = ?', $result['queries'][1]['sql']);
+    }
+
+    public function testFormatDetectsDuplicatesWithRealCollector()
+    {
+        $collector = $this->createRealCollector([
+            'default' => [
+                ['sql' => 'SELECT * FROM users WHERE id = ?', 'params' => [1 => 1]],
+                ['sql' => 'SELECT * FROM users WHERE id = ?', 'params' => [1 => 2]],
+                ['sql' => 'SELECT * FROM users WHERE id = ?', 'params' => [1 => 3]],
+                ['sql' => 'SELECT * FROM posts', 'params' => []],
+            ],
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(4, $result['query_count']);
+        $this->assertCount(4, $result['queries']);
+        $this->assertCount(1, $result['duplicate_queries']);
+        $this->assertSame('SELECT * FROM users WHERE id = ?', $result['duplicate_queries'][0]['sql']);
+        $this->assertSame(3, $result['duplicate_queries'][0]['count']);
+    }
+
+    public function testGetSummaryWithRealCollector()
+    {
+        $collector = $this->createRealCollector([
+            'default' => [
+                ['sql' => 'SELECT * FROM users WHERE id = ?', 'params' => [1 => 1]],
+                ['sql' => 'SELECT * FROM users WHERE id = ?', 'params' => [1 => 2]],
+                ['sql' => 'SELECT * FROM posts', 'params' => []],
+            ],
+        ]);
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertSame(3, $result['query_count']);
+        $this->assertArrayHasKey('total_time_ms', $result);
+        $this->assertSame(1, $result['duplicate_query_count']);
+        $this->assertArrayNotHasKey('queries', $result);
+    }
+
+    public function testFormatMultipleConnectionsWithRealCollector()
+    {
+        $collector = $this->createRealCollector([
+            'default' => [
+                ['sql' => 'SELECT 1', 'params' => []],
+            ],
+            'legacy' => [
+                ['sql' => 'SELECT 2', 'params' => []],
+            ],
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(2, $result['query_count']);
+        $this->assertSame(['default', 'legacy'], $result['connections']);
+        $this->assertCount(2, $result['queries']);
+        $this->assertSame('default', $result['queries'][0]['connection']);
+        $this->assertSame('legacy', $result['queries'][1]['connection']);
+    }
+
+    /**
+     * @param array<string, list<array{sql: string, params: array<int, mixed>}>> $queriesByConnection
+     */
+    private function createRealCollector(array $queriesByConnection): DoctrineDataCollector
+    {
+        $debugDataHolder = new DebugDataHolder();
+
+        $connectionNames = [];
+        foreach ($queriesByConnection as $connection => $queries) {
+            $connectionNames[$connection] = 'doctrine.'.$connection.'_connection';
+
+            foreach ($queries as $queryData) {
+                $query = new Query($queryData['sql']);
+                $query->start();
+
+                foreach ($queryData['params'] as $index => $value) {
+                    $query->setValue($index, $value, \Doctrine\DBAL\ParameterType::STRING);
+                }
+
+                $query->stop();
+                $debugDataHolder->addQuery($connection, $query);
+            }
+        }
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getConnectionNames')->willReturn($connectionNames);
+        $registry->method('getManagerNames')->willReturn([]);
+        $registry->method('getManagers')->willReturn([]);
+
+        $collector = new DoctrineDataCollector($registry, false, $debugDataHolder);
+        $collector->collect(new Request(), new Response());
+
+        return $collector;
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorFormatter;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class DoctrineCollectorFormatterTest extends TestCase
+{
+    private DoctrineCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new DoctrineCollectorFormatter();
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('db', $this->formatter->getName());
+    }
+
+    public function testFormat()
+    {
+        $collector = $this->createCollector(
+            ['default' => 'doctrine.default'],
+            [
+                'default' => [
+                    ['sql' => 'SELECT * FROM users', 'params' => [], 'executionMS' => 0.0012, 'types' => []],
+                    ['sql' => 'SELECT * FROM posts WHERE user_id = ?', 'params' => [1], 'executionMS' => 0.0008, 'types' => []],
+                ],
+            ],
+        );
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(2, $result['query_count']);
+        $this->assertSame(2.0, $result['total_time_ms']);
+        $this->assertSame(['default'], $result['connections']);
+        $this->assertCount(2, $result['queries']);
+        $this->assertFalse($result['queries_truncated']);
+        $this->assertSame([], $result['duplicate_queries']);
+
+        $this->assertSame('default', $result['queries'][0]['connection']);
+        $this->assertSame('SELECT * FROM users', $result['queries'][0]['sql']);
+        $this->assertSame([], $result['queries'][0]['params']);
+        $this->assertSame(1.2, $result['queries'][0]['time_ms']);
+
+        $this->assertSame('default', $result['queries'][1]['connection']);
+        $this->assertSame('SELECT * FROM posts WHERE user_id = ?', $result['queries'][1]['sql']);
+        $this->assertSame([1], $result['queries'][1]['params']);
+        $this->assertSame(0.8, $result['queries'][1]['time_ms']);
+    }
+
+    public function testFormatMultipleConnections()
+    {
+        $collector = $this->createCollector(
+            ['default' => 'doctrine.default', 'legacy' => 'doctrine.legacy'],
+            [
+                'default' => [
+                    ['sql' => 'SELECT 1', 'params' => [], 'executionMS' => 0.001, 'types' => []],
+                ],
+                'legacy' => [
+                    ['sql' => 'SELECT 2', 'params' => [], 'executionMS' => 0.002, 'types' => []],
+                ],
+            ],
+        );
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(2, $result['query_count']);
+        $this->assertSame(['default', 'legacy'], $result['connections']);
+        $this->assertCount(2, $result['queries']);
+        $this->assertSame('default', $result['queries'][0]['connection']);
+        $this->assertSame('legacy', $result['queries'][1]['connection']);
+    }
+
+    public function testFormatTruncatesQueries()
+    {
+        $queries = [];
+        for ($i = 0; $i < 60; ++$i) {
+            $queries[] = ['sql' => 'SELECT '.$i, 'params' => [], 'executionMS' => 0.001, 'types' => []];
+        }
+
+        $collector = $this->createCollector(
+            ['default' => 'doctrine.default'],
+            ['default' => $queries],
+        );
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(60, $result['query_count']);
+        $this->assertCount(50, $result['queries']);
+        $this->assertTrue($result['queries_truncated']);
+    }
+
+    public function testFormatTruncatesLongParams()
+    {
+        $longParam = str_repeat('a', 150);
+
+        $collector = $this->createCollector(
+            ['default' => 'doctrine.default'],
+            [
+                'default' => [
+                    ['sql' => 'SELECT * FROM users WHERE bio = ?', 'params' => [$longParam], 'executionMS' => 0.001, 'types' => []],
+                ],
+            ],
+        );
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(103, \strlen($result['queries'][0]['params'][0]));
+        $this->assertStringEndsWith('...', $result['queries'][0]['params'][0]);
+    }
+
+    public function testFormatDetectsDuplicateQueries()
+    {
+        $collector = $this->createCollector(
+            ['default' => 'doctrine.default'],
+            [
+                'default' => [
+                    ['sql' => 'SELECT * FROM users WHERE id = ?', 'params' => [1], 'executionMS' => 0.001, 'types' => []],
+                    ['sql' => 'SELECT * FROM users WHERE id = ?', 'params' => [2], 'executionMS' => 0.002, 'types' => []],
+                    ['sql' => 'SELECT * FROM users WHERE id = ?', 'params' => [3], 'executionMS' => 0.003, 'types' => []],
+                    ['sql' => 'SELECT * FROM posts', 'params' => [], 'executionMS' => 0.001, 'types' => []],
+                ],
+            ],
+        );
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertCount(1, $result['duplicate_queries']);
+        $this->assertSame('SELECT * FROM users WHERE id = ?', $result['duplicate_queries'][0]['sql']);
+        $this->assertSame(3, $result['duplicate_queries'][0]['count']);
+        $this->assertSame(6.0, $result['duplicate_queries'][0]['total_time_ms']);
+    }
+
+    public function testFormatNoQueries()
+    {
+        $collector = $this->createCollector(
+            ['default' => 'doctrine.default'],
+            ['default' => []],
+        );
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(0, $result['query_count']);
+        $this->assertSame(0.0, $result['total_time_ms']);
+        $this->assertSame([], $result['queries']);
+        $this->assertFalse($result['queries_truncated']);
+        $this->assertSame([], $result['duplicate_queries']);
+    }
+
+    public function testGetSummary()
+    {
+        $collector = $this->createCollector(
+            ['default' => 'doctrine.default'],
+            [
+                'default' => [
+                    ['sql' => 'SELECT 1', 'params' => [], 'executionMS' => 0.005, 'types' => []],
+                    ['sql' => 'SELECT 2', 'params' => [], 'executionMS' => 0.003, 'types' => []],
+                ],
+            ],
+        );
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertSame(2, $result['query_count']);
+        $this->assertSame(8.0, $result['total_time_ms']);
+        $this->assertSame(0, $result['duplicate_query_count']);
+        $this->assertArrayNotHasKey('queries', $result);
+        $this->assertArrayNotHasKey('connections', $result);
+    }
+
+    public function testGetSummaryWithDuplicates()
+    {
+        $collector = $this->createCollector(
+            ['default' => 'doctrine.default'],
+            [
+                'default' => [
+                    ['sql' => 'SELECT * FROM users WHERE id = ?', 'params' => [1], 'executionMS' => 0.001, 'types' => []],
+                    ['sql' => 'SELECT * FROM users WHERE id = ?', 'params' => [2], 'executionMS' => 0.001, 'types' => []],
+                    ['sql' => 'SELECT * FROM posts WHERE id = ?', 'params' => [1], 'executionMS' => 0.001, 'types' => []],
+                    ['sql' => 'SELECT * FROM posts WHERE id = ?', 'params' => [2], 'executionMS' => 0.001, 'types' => []],
+                    ['sql' => 'SELECT 1', 'params' => [], 'executionMS' => 0.001, 'types' => []],
+                ],
+            ],
+        );
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertSame(5, $result['query_count']);
+        $this->assertSame(2, $result['duplicate_query_count']);
+    }
+
+    /**
+     * @param array<string, string>                                                                      $connections
+     * @param array<string, list<array{sql: string, params: mixed, executionMS: float, types: mixed[]}>> $queries
+     */
+    private function createCollector(array $connections, array $queries): DoctrineDataCollector
+    {
+        $collector = $this->createMock(DoctrineDataCollector::class);
+
+        $collector->method('getConnections')->willReturn($connections);
+        $collector->method('getQueries')->willReturn($queries);
+
+        $totalCount = 0;
+        $totalTime = 0.0;
+        foreach ($queries as $connectionQueries) {
+            $totalCount += \count($connectionQueries);
+            foreach ($connectionQueries as $query) {
+                $totalTime += $query['executionMS'];
+            }
+        }
+
+        $collector->method('getQueryCount')->willReturn($totalCount);
+        $collector->method('getTime')->willReturn($totalTime);
+
+        return $collector;
+    }
+}

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -32,6 +32,7 @@
         "symfony/dependency-injection": "^7.3|^8.0"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^2.13|^3.0",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
@@ -43,6 +44,7 @@
         "symfony/web-profiler-bundle": "^7.3|^8.0"
     },
     "suggest": {
+        "doctrine/doctrine-bundle": "Required for Doctrine database profiler formatter",
         "symfony/http-kernel": "Required for profiler data access tools",
         "symfony/mailer": "Required for mailer profiler formatter",
         "symfony/translation": "Required for translation profiler collector formatter",

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -13,6 +13,7 @@ use Symfony\AI\Mate\Bridge\Symfony\Capability\ProfilerResourceTemplate;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ProfilerTool;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ServiceTool;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MailerCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RequestCollectorFormatter;
@@ -69,6 +70,10 @@ return static function (ContainerConfigurator $configurator) {
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(TranslationCollectorFormatter::class)
+            ->lazy()
+            ->tag('ai_mate.profiler_collector_formatter');
+
+        $services->set(DoctrineCollectorFormatter::class)
             ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        |
| License       | MIT

This adds a `DoctrineCollectorFormatter` to the Mate Symfony bridge, enabling AI assistants to inspect Doctrine DBAL query data directly from the Symfony profiler via MCP.

**Formatted output includes:**
- Query count and total execution time
- Flattened query list (SQL, params, timing) across all connections, limited to 50
- Duplicate query detection (same SQL pattern executed more than once) — useful for spotting N+1 issues
- Long string params truncated to 100 characters

**Summary output** provides a condensed view with query count, total time, and duplicate query count.

Follows the same pattern as the existing `TranslationCollectorFormatter` and `MailerCollectorFormatter`.