### PR TITLE
[Store][Pinecone] Return `NullVector` when `includeValues` is set to `false`

### DIFF
--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Store\Bridge\Pinecone;
 
 use Probots\Pinecone\Client;
 use Probots\Pinecone\Resources\Data\VectorResource;
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
@@ -136,9 +137,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
 
         foreach ($result->json()['matches'] as $match) {
+            $vector = isset($match['values']) && [] !== $match['values']
+                ? new Vector($match['values'])
+                : new NullVector();
+
             yield new VectorDocument(
                 id: $match['id'],
-                vector: new Vector($match['values']),
+                vector: $vector,
                 metadata: new Metadata($match['metadata'] ?? []),
                 score: $match['score'],
             );

--- a/src/store/src/Bridge/Pinecone/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Pinecone/Tests/StoreTest.php
@@ -18,6 +18,7 @@ use Probots\Pinecone\Resources\ControlResource;
 use Probots\Pinecone\Resources\Data\VectorResource;
 use Probots\Pinecone\Resources\DataResource;
 use Saloon\Http\Response;
+use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Pinecone\Store;
 use Symfony\AI\Store\Document\Metadata;
@@ -397,6 +398,42 @@ final class StoreTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertEmpty($results[0]->getMetadata());
+    }
+
+    public function testQueryWithoutValuesReturnsNullVector()
+    {
+        $vectorResource = $this->createMock(VectorResource::class);
+        $dataResource = $this->createMock(DataResource::class);
+        $client = $this->createMock(Client::class);
+
+        $dataResource->expects($this->once())
+            ->method('vectors')
+            ->willReturn($vectorResource);
+
+        $client->expects($this->once())
+            ->method('data')
+            ->willReturn($dataResource);
+
+        $response = $this->createMock(Response::class);
+        $response->method('json')->willReturn([
+            'matches' => [
+                [
+                    'id' => 'vector-id',
+                    'values' => [],
+                    'metadata' => ['title' => 'Test Document'],
+                    'score' => 0.95,
+                ],
+            ],
+        ]);
+
+        $vectorResource->expects($this->once())
+            ->method('query')
+            ->willReturn($response);
+
+        $results = iterator_to_array(self::createStore($client)->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(NullVector::class, $results[0]->getVector());
     }
 
     public function testQueryWithEmptyResults()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Pinecone allows querying data without vector values, but the `Vector` class cannot be instantiated without values, so it needs tu return an instance of the `NullVector` class
