### PR TITLE
[Agent][SimilaritySearch] Use `RetrieverInterface` and add customizable prompt template

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,12 +1,3 @@
-UPGRADE FROM 0.7 to 0.8
-=======================
-
-Mate
-----
-
- * Run `vendor/bin/mate discover` to update the generated `AGENT_INSTRUCTIONS.md` file with the latest
-   tool descriptions and agent instructions.
-
 UPGRADE FROM 0.6 to 0.7
 =======================
 
@@ -22,6 +13,26 @@ Agent
    -public function getTool(string $reference): iterable;
    +public function getTool(object|string $reference): iterable;
    ```
+
+ * The `SimilaritySearch` tool now requires a `RetrieverInterface` instead of `VectorizerInterface` and `StoreInterface`:
+
+   ```diff
+   -use Symfony\AI\Store\Document\VectorizerInterface;
+   -use Symfony\AI\Store\StoreInterface;
+   +use Symfony\AI\Store\Retriever;
+
+   -$similaritySearch = new SimilaritySearch($vectorizer, $store);
+   +$retriever = new Retriever($store, $vectorizer);
+   +$similaritySearch = new SimilaritySearch($retriever);
+   ```
+
+ * The `SimilaritySearch` tool now accepts an optional `$promptTemplate` parameter to customize the result header (default: `'Found documents with the following information:'`)
+
+Mate
+----
+
+ * Run `vendor/bin/mate discover` to update the generated `AGENT_INSTRUCTIONS.md` file with the latest
+   tool descriptions and agent instructions.
 
 AI Bundle
 ---------

--- a/demo/composer.json
+++ b/demo/composer.json
@@ -12,7 +12,7 @@
         "mrmysql/youtube-transcript": "^0.0.5",
         "nyholm/psr7": "^1.8",
         "php-http/discovery": "^1.20",
-        "symfony/ai-agent": "^0.6",
+        "symfony/ai-agent": "^0.7",
         "symfony/ai-bundle": "^0.6",
         "symfony/ai-chat": "^0.6",
         "symfony/ai-chroma-db-store": "^0.6",

--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -119,8 +119,7 @@ services:
         autoconfigure: true
 
     Symfony\AI\Agent\Bridge\SimilaritySearch\SimilaritySearch:
-        $vectorizer: '@ai.vectorizer.openai'
-        $store: '@ai.store.chromadb.symfonycon'
+        $retriever: '@ai.retriever.blog'
 
     Symfony\AI\Store\Document\Loader\RssFeedLoader: ~
     Symfony\AI\Store\Document\Transformer\TextSplitTransformer: ~

--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -880,7 +880,7 @@ The following tools can be installed as dedicated packages, no configuration is 
     $ composer require symfony/ai-wikipedia-tool
     $ composer require symfony/ai-youtube-tool
 
-Some tools may require additional configuration even when installed as dedicated packages. For example, the SimilaritySearch tool requires a vectorizer and store:
+Some tools may require additional configuration even when installed as dedicated packages. For example, the SimilaritySearch tool requires a retriever:
 
 .. code-block:: yaml
 
@@ -890,8 +890,9 @@ Some tools may require additional configuration even when installed as dedicated
             autoconfigure: true
 
         Symfony\AI\Agent\Bridge\SimilaritySearch\SimilaritySearch:
-            $vectorizer: '@ai.vectorizer.openai'
-            $store: '@ai.store.main'
+            $retriever: '@ai.retriever.main'
+            # optionally customize the result header
+            # $promptTemplate: 'Here are the relevant results:'
 
 Creating Custom Tools
 ---------------------

--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -499,10 +499,12 @@ more accurate and context-aware results. Therefore, the component provides a bui
     use Symfony\AI\Agent\Toolbox\Toolbox;
     use Symfony\AI\Platform\Message\Message;
     use Symfony\AI\Platform\Message\MessageBag;
+    use Symfony\AI\Store\Retriever;
 
     // Initialize Platform & Models
 
-    $similaritySearch = new SimilaritySearch($model, $store);
+    $retriever = new Retriever($store, $vectorizer);
+    $similaritySearch = new SimilaritySearch($retriever);
     $toolbox = new Toolbox([$similaritySearch]);
     $processor = new AgentProcessor($toolbox);
     $agent = new Agent($platform, $model, [$processor], [$processor]);

--- a/docs/cookbook/rag-implementation.rst
+++ b/docs/cookbook/rag-implementation.rst
@@ -121,16 +121,21 @@ Create a tool that performs semantic search on your vector store::
     use Symfony\AI\Agent\Bridge\SimilaritySearch\SimilaritySearch;
     use Symfony\AI\Agent\Toolbox\AgentProcessor;
     use Symfony\AI\Agent\Toolbox\Toolbox;
+    use Symfony\AI\Store\Retriever;
 
-    $similaritySearch = new SimilaritySearch($vectorizer, $store);
+    $retriever = new Retriever($store, $vectorizer);
+    $similaritySearch = new SimilaritySearch($retriever);
     $toolbox = new Toolbox([$similaritySearch]);
     $processor = new AgentProcessor($toolbox);
 
 The :class:`Symfony\\AI\\Agent\\Bridge\\SimilaritySearch\\SimilaritySearch` tool:
 
-* Converts the user's query into a vector
-* Searches for similar vectors in the store
+* Uses the retriever to find similar documents in the store
 * Returns the most relevant documents
+
+You can customize the result header by passing a prompt template::
+
+    $similaritySearch = new SimilaritySearch($retriever, 'Here are the relevant results:');
 
 Step 5: Create RAG-Enabled Agent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/ollama/rag.php
+++ b/examples/ollama/rag.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
 use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -46,7 +47,8 @@ $vectorizer = new Vectorizer($platform, env('OLLAMA_EMBEDDINGS'), logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, env('OLLAMA_LLM'), [$processor], [$processor]);

--- a/examples/rag/azuresearch.php
+++ b/examples/rag/azuresearch.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -46,7 +47,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/cache.php
+++ b/examples/rag/cache.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Uid\Uuid;
 
@@ -47,7 +48,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/chromadb.php
+++ b/examples/rag/chromadb.php
@@ -24,6 +24,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -54,7 +55,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/clickhouse.php
+++ b/examples/rag/clickhouse.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Uid\Uuid;
 
@@ -54,7 +55,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/cloudflare.php
+++ b/examples/rag/cloudflare.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -54,7 +55,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/elasticsearch.php
+++ b/examples/rag/elasticsearch.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -53,7 +54,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/in-memory.php
+++ b/examples/rag/in-memory.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
 use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -46,7 +47,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/manticore.php
+++ b/examples/rag/manticore.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -54,7 +55,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/mariadb-gemini.php
+++ b/examples/rag/mariadb-gemini.php
@@ -25,6 +25,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -56,7 +57,8 @@ $vectorizer = new Vectorizer($platform, $model, logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gemini-2.5-flash-lite', [$processor], [$processor]);

--- a/examples/rag/mariadb-openai.php
+++ b/examples/rag/mariadb-openai.php
@@ -25,6 +25,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -55,7 +56,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/meilisearch.php
+++ b/examples/rag/meilisearch.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -54,7 +55,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/milvus.php
+++ b/examples/rag/milvus.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -55,7 +56,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/mongodb.php
+++ b/examples/rag/mongodb.php
@@ -24,6 +24,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -56,7 +57,8 @@ $indexer->index($documents);
 // initialize the index
 $store->setup();
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/neo4j.php
+++ b/examples/rag/neo4j.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -57,7 +58,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/opensearch.php
+++ b/examples/rag/opensearch.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -53,7 +54,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/pinecone.php
+++ b/examples/rag/pinecone.php
@@ -24,6 +24,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -47,7 +48,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/postgres.php
+++ b/examples/rag/postgres.php
@@ -25,6 +25,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -54,7 +55,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/qdrant.php
+++ b/examples/rag/qdrant.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -49,7 +50,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/redis.php
+++ b/examples/rag/redis.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -56,7 +57,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/sqlite.php
+++ b/examples/rag/sqlite.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -52,7 +53,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/supabase.php
+++ b/examples/rag/supabase.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -53,7 +54,8 @@ $vectorizer = new Vectorizer($platform, env('OLLAMA_EMBEDDINGS'));
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, env('OLLAMA_LLM'), [$processor], [$processor]);

--- a/examples/rag/surrealdb.php
+++ b/examples/rag/surrealdb.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -57,7 +58,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/typesense.php
+++ b/examples/rag/typesense.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -54,7 +55,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/vektor.php
+++ b/examples/rag/vektor.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -49,7 +50,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/examples/rag/weaviate.php
+++ b/examples/rag/weaviate.php
@@ -23,6 +23,7 @@ use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\AI\Store\Indexer\DocumentIndexer;
 use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\Retriever;
 use Symfony\Component\Uid\Uuid;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -54,7 +55,8 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
-$similaritySearch = new SimilaritySearch($vectorizer, $store);
+$retriever = new Retriever($store, $vectorizer);
+$similaritySearch = new SimilaritySearch($retriever);
 $toolbox = new Toolbox([$similaritySearch], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 0.7
 ---
 
+ * [BC BREAK] Change `SimilaritySearch` to use `RetrieverInterface` instead of `VectorizerInterface` and `StoreInterface`
+ * Add customizable `$promptTemplate` parameter to `SimilaritySearch` constructor
  * [BC BREAK] Remove `AbstractToolFactory` in favor of standalone `ReflectionToolFactory` and `MemoryToolFactory`
  * [BC BREAK] Change `ToolFactoryInterface::getTool()` signature from `string $reference` to `object|string $reference`
  * Add `ToolCallRequested` event dispatched before tool execution

--- a/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
+++ b/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
@@ -13,9 +13,7 @@ namespace Symfony\AI\Agent\Bridge\SimilaritySearch;
 
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 use Symfony\AI\Store\Document\VectorDocument;
-use Symfony\AI\Store\Document\VectorizerInterface;
-use Symfony\AI\Store\Query\VectorQuery;
-use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\RetrieverInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -29,8 +27,8 @@ final class SimilaritySearch
     public array $usedDocuments = [];
 
     public function __construct(
-        private readonly VectorizerInterface $vectorizer,
-        private readonly StoreInterface $store,
+        private readonly RetrieverInterface $retriever,
+        private readonly string $promptTemplate = 'Found documents with the following information:',
     ) {
     }
 
@@ -39,14 +37,13 @@ final class SimilaritySearch
      */
     public function __invoke(string $searchTerm): string
     {
-        $vector = $this->vectorizer->vectorize($searchTerm);
-        $this->usedDocuments = iterator_to_array($this->store->query(new VectorQuery($vector)));
+        $this->usedDocuments = iterator_to_array($this->retriever->retrieve($searchTerm));
 
         if ([] === $this->usedDocuments) {
             return 'No results found';
         }
 
-        $result = 'Found documents with following information:'.\PHP_EOL;
+        $result = $this->promptTemplate.\PHP_EOL;
         foreach ($this->usedDocuments as $document) {
             $result .= json_encode($document->getMetadata());
         }

--- a/src/agent/src/Bridge/SimilaritySearch/Tests/SimilaritySearchTest.php
+++ b/src/agent/src/Bridge/SimilaritySearch/Tests/SimilaritySearchTest.php
@@ -16,9 +16,7 @@ use Symfony\AI\Agent\Bridge\SimilaritySearch\SimilaritySearch;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
-use Symfony\AI\Store\Document\VectorizerInterface;
-use Symfony\AI\Store\Query\VectorQuery;
-use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\RetrieverInterface;
 use Symfony\Component\Uid\Uuid;
 
 final class SimilaritySearchTest extends TestCase
@@ -39,44 +37,31 @@ final class SimilaritySearchTest extends TestCase
             new Metadata(['title' => 'Document 2', 'content' => 'Second document content']),
         );
 
-        $vectorizer = $this->createMock(VectorizerInterface::class);
-        $vectorizer->expects($this->once())
-            ->method('vectorize')
+        $retriever = $this->createMock(RetrieverInterface::class);
+        $retriever->expects($this->once())
+            ->method('retrieve')
             ->with($searchTerm)
-            ->willReturn($vector);
-
-        $store = $this->createMock(StoreInterface::class);
-        $store->expects($this->once())
-            ->method('query')
-            ->with($this->callback(static fn ($query) => $query instanceof VectorQuery && $query->getVector() === $vector))
             ->willReturn([$document1, $document2]);
 
-        $similaritySearch = new SimilaritySearch($vectorizer, $store);
+        $similaritySearch = new SimilaritySearch($retriever);
 
         $result = $similaritySearch($searchTerm);
 
-        $this->assertSame('Found documents with following information:'.\PHP_EOL.'{"title":"Document 1","content":"First document content"}{"title":"Document 2","content":"Second document content"}', $result);
+        $this->assertSame('Found documents with the following information:'.\PHP_EOL.'{"title":"Document 1","content":"First document content"}{"title":"Document 2","content":"Second document content"}', $result);
         $this->assertSame([$document1, $document2], $similaritySearch->usedDocuments);
     }
 
     public function testSearchWithoutResults()
     {
         $searchTerm = 'find nothing';
-        $vector = new Vector([0.1, 0.2, 0.3]);
 
-        $vectorizer = $this->createMock(VectorizerInterface::class);
-        $vectorizer->expects($this->once())
-            ->method('vectorize')
+        $retriever = $this->createMock(RetrieverInterface::class);
+        $retriever->expects($this->once())
+            ->method('retrieve')
             ->with($searchTerm)
-            ->willReturn($vector);
-
-        $store = $this->createMock(StoreInterface::class);
-        $store->expects($this->once())
-            ->method('query')
-            ->with($this->callback(static fn ($query) => $query instanceof VectorQuery && $query->getVector() === $vector))
             ->willReturn([]);
 
-        $similaritySearch = new SimilaritySearch($vectorizer, $store);
+        $similaritySearch = new SimilaritySearch($retriever);
 
         $result = $similaritySearch($searchTerm);
 
@@ -95,23 +80,41 @@ final class SimilaritySearchTest extends TestCase
             new Metadata(['title' => 'Single Document', 'description' => 'Only one match']),
         );
 
-        $vectorizer = $this->createMock(VectorizerInterface::class);
-        $vectorizer->expects($this->once())
-            ->method('vectorize')
+        $retriever = $this->createMock(RetrieverInterface::class);
+        $retriever->expects($this->once())
+            ->method('retrieve')
             ->with($searchTerm)
-            ->willReturn($vector);
-
-        $store = $this->createMock(StoreInterface::class);
-        $store->expects($this->once())
-            ->method('query')
-            ->with($this->callback(static fn ($query) => $query instanceof VectorQuery && $query->getVector() === $vector))
             ->willReturn([$document]);
 
-        $similaritySearch = new SimilaritySearch($vectorizer, $store);
+        $similaritySearch = new SimilaritySearch($retriever);
 
         $result = $similaritySearch($searchTerm);
 
-        $this->assertSame('Found documents with following information:'.\PHP_EOL.'{"title":"Single Document","description":"Only one match"}', $result);
+        $this->assertSame('Found documents with the following information:'.\PHP_EOL.'{"title":"Single Document","description":"Only one match"}', $result);
         $this->assertSame([$document], $similaritySearch->usedDocuments);
+    }
+
+    public function testSearchWithCustomPromptTemplate()
+    {
+        $searchTerm = 'custom template query';
+        $vector = new Vector([0.1, 0.2, 0.3]);
+
+        $document = new VectorDocument(
+            Uuid::v4(),
+            $vector,
+            new Metadata(['title' => 'Document 1']),
+        );
+
+        $retriever = $this->createMock(RetrieverInterface::class);
+        $retriever->expects($this->once())
+            ->method('retrieve')
+            ->with($searchTerm)
+            ->willReturn([$document]);
+
+        $similaritySearch = new SimilaritySearch($retriever, 'Here are the relevant results:');
+
+        $result = $similaritySearch($searchTerm);
+
+        $this->assertSame('Here are the relevant results:'.\PHP_EOL.'{"title":"Document 1"}', $result);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | --
| License       | MIT

Replace `VectorizerInterface` + `StoreInterface` with `RetrieverInterface` to leverage the Retriever's built-in vectorization, hybrid query support, event dispatching, and logging. Add an optional `promptTemplate` parameter to customize the result header text.