### PR TITLE
[Examples] Add agentic search example demonstrating multi-hop RAG pattern

### DIFF
--- a/examples/rag/agentic-search.php
+++ b/examples/rag/agentic-search.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\InputProcessor\SystemPromptInputProcessor;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Event\ToolCallSucceeded;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Fixtures\AgenticSearch\AgenticSearchTools;
+use Symfony\AI\Fixtures\AgenticSearch\DocumentCorpus;
+use Symfony\AI\Fixtures\Movies;
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Store\Document\Metadata;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Indexer\DocumentIndexer;
+use Symfony\AI\Store\Indexer\DocumentProcessor;
+use Symfony\AI\Store\InMemory\Store as InMemoryStore;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Uid\Uuid;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+/*
+ * Agentic Search Example
+ *
+ * Demonstrates an iterative, multi-hop search pattern inspired by Chroma's Context 1 model.
+ * Instead of single-hop RAG (one query -> one result set), an LLM agent uses four
+ * specialized tools to iteratively explore a document corpus:
+ *
+ * - corpus_search:        Semantic vector search for broad topic discovery (deduplicated across calls)
+ * - corpus_grep:          Line-by-line keyword matching on full document content
+ * - corpus_read_document: Full document retrieval by ID for deeper investigation
+ * - corpus_prune:         Permanently exclude irrelevant documents from future results
+ *
+ * The agent plans its search strategy, discovers information across multiple hops,
+ * and curates a focused set of relevant documents.
+ */
+
+echo "=== Agentic Search Example ===\n\n";
+echo "Building document corpus from movie fixtures...\n";
+
+// 1. Build the document corpus - one document per movie, preferring detailed markdown versions
+$store = new InMemoryStore();
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+$vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
+
+$originalDocuments = [];
+$documents = [];
+
+// Load detailed markdown files and track which movies have them
+$fixturesDir = dirname(__DIR__, 2).'/fixtures/movies';
+$movieFiles = glob($fixturesDir.'/*.md') ?: [];
+$detailedMovies = [];
+
+foreach ($movieFiles as $file) {
+    $id = (string) Uuid::v4();
+    $content = (string) file_get_contents($file);
+
+    // Extract title from first markdown heading
+    $title = basename($file, '.md');
+    if (preg_match('/^#\s+(.+)/m', $content, $matches)) {
+        $title = $matches[1];
+    }
+
+    // Extract the plain movie name (without year) for dedup matching
+    $plainTitle = preg_replace('/\s*\(\d{4}\)$/', '', $title) ?? $title;
+    $detailedMovies[strtolower($plainTitle)] = true;
+
+    $metadata = new Metadata([
+        'source' => basename($file),
+        'type' => 'detailed',
+    ]);
+    $metadata->setTitle($title);
+
+    $textDoc = new TextDocument(id: $id, content: $content, metadata: $metadata);
+    $documents[] = $textDoc;
+    $originalDocuments[$id] = $textDoc;
+}
+
+// Add short descriptions only for movies that don't have a detailed markdown version
+foreach (Movies::all() as $movie) {
+    if (isset($detailedMovies[strtolower($movie['title'])])) {
+        continue;
+    }
+
+    $id = (string) Uuid::v4();
+    $content = 'Title: '.$movie['title']."\nDirector: ".$movie['director']."\nDescription: ".$movie['description'];
+
+    $metadata = new Metadata($movie);
+    $metadata->setTitle($movie['title']);
+
+    $textDoc = new TextDocument(id: $id, content: $content, metadata: $metadata);
+    $documents[] = $textDoc;
+    $originalDocuments[$id] = $textDoc;
+}
+
+echo sprintf("Indexing %d documents...\n", count($documents));
+
+// 2. Index documents into the vector store
+$indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
+$indexer->index($documents);
+
+echo "Done.\n\n";
+
+// 3. Wire up the agentic search tools with event-based logging
+$corpus = new DocumentCorpus($vectorizer, $store, $originalDocuments);
+$tools = new AgenticSearchTools($corpus);
+
+$dispatcher = new EventDispatcher();
+$dispatcher->addListener(ToolCallSucceeded::class, static function (ToolCallSucceeded $event): void {
+    $name = $event->getMetadata()->getName();
+    $args = $event->getArguments();
+    $resultPreview = $event->getResult()->getResult();
+
+    if (is_string($resultPreview) && strlen($resultPreview) > 300) {
+        $resultPreview = substr($resultPreview, 0, 300).'... (truncated)';
+    }
+
+    output()->writeln(sprintf('<info>[Tool Call] %s</info>', $name));
+    output()->writeln(sprintf('  <comment>Args:</comment> %s', json_encode($args, \JSON_UNESCAPED_SLASHES)));
+    output()->writeln(sprintf('  <comment>Result:</comment> %s', $resultPreview));
+    output()->writeln('');
+});
+
+$toolbox = new Toolbox([$tools], logger: logger(), eventDispatcher: $dispatcher);
+$processor = new AgentProcessor($toolbox, eventDispatcher: $dispatcher);
+
+$systemPrompt = <<<'PROMPT'
+You are a thorough search research agent. Your job is to find ALL relevant documents in a corpus to answer a research question completely.
+
+## Strategy
+1. Start by planning what information you need to find.
+2. Use corpus_search for broad semantic discovery (find documents by topic/meaning).
+3. Use corpus_grep for specific facts (names, dates, numbers, exact terms). This is especially powerful for structured fields like "Director:", "Cast", or other metadata.
+4. Use corpus_read_document to get full document content when snippets aren't enough.
+5. Use corpus_prune to permanently exclude irrelevant documents from your results.
+6. Iterate: each discovery may reveal new leads requiring additional searches. A single search is almost never enough. Follow every lead — if a document mentions other related entities, search for those too.
+
+## Important
+- Search results are automatically deduplicated: each document appears only once across all your search calls.
+- Pruned documents are permanently excluded from all future search and grep results.
+- Search broadly first, then narrow down with grep or by reading full documents.
+- Prune documents that turned out to be irrelevant to keep your working set focused.
+- Do NOT stop after one round of searching. Combine corpus_search and corpus_grep with different queries to ensure full coverage. For example, if you find a director, grep for their name to find ALL their movies — do not rely on a single semantic search.
+- Read every document that might be relevant. Skipping documents leads to incomplete answers.
+- When you're done, provide a clear and exhaustive summary of your findings organized by the question asked.
+PROMPT;
+
+$agent = new Agent(
+    $platform,
+    'gpt-4.1',
+    [new SystemPromptInputProcessor($systemPrompt), $processor],
+    [$processor],
+);
+
+// 4. Ask a multi-hop question that requires iterative search
+$question = 'Identify directors who have directed multiple movies in our corpus. '
+    .'For these directors, list all their movies and identify if any actors appear in more than one of their films.';
+
+echo "Question: {$question}\n\n";
+echo "--- Agent Search Process ---\n\n";
+
+$messages = new MessageBag(Message::ofUser($question));
+$result = $agent->call($messages);
+
+echo $result->getContent()."\n\n";
+
+// 5. Show the final working set
+echo "--- Final Working Set ---\n";
+echo $corpus->formatFoundSummary()."\n";

--- a/fixtures/AgenticSearch/AgenticSearchTools.php
+++ b/fixtures/AgenticSearch/AgenticSearchTools.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Fixtures\AgenticSearch;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+use Symfony\AI\Store\Document\Metadata;
+
+/**
+ * Agentic search tools for iterative document corpus exploration.
+ *
+ * Provides four tools that enable an LLM agent to perform multi-hop search:
+ * - corpus_search: semantic vector search for broad discovery (results are deduplicated across calls)
+ * - corpus_grep: keyword matching on full document content for specific facts
+ * - corpus_read_document: full document retrieval by ID
+ * - corpus_prune: permanently exclude a document from results and working set
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsTool('corpus_search', description: 'Semantic search over the document corpus. Returns new document snippets ranked by relevance. Already-seen and pruned documents are automatically excluded. Does NOT add documents to the working set - use corpus_read_document for that.', method: 'search')]
+#[AsTool('corpus_grep', description: 'Keyword search across full document content. Returns matching lines with line numbers. Use this to find concrete facts like names, dates, or specific terms. Does NOT add documents to the working set - use corpus_read_document for that.', method: 'grep')]
+#[AsTool('corpus_read_document', description: 'Read the full content of a document by its ID and add it to the working set. Use after search or grep to investigate a specific document in depth. Only read documents you actually need.', method: 'readDocument')]
+#[AsTool('corpus_prune', description: 'Permanently exclude a document from search results and the working set. Use this to discard irrelevant documents. Pruned documents will not appear in future search or grep results.', method: 'prune')]
+final class AgenticSearchTools
+{
+    public function __construct(
+        private readonly DocumentCorpus $corpus,
+    ) {
+    }
+
+    /**
+     * @param string $query natural language search query for semantic similarity
+     */
+    public function search(string $query): string
+    {
+        $results = $this->corpus->semanticSearch($query);
+
+        if ([] === $results) {
+            return \sprintf("No new results found for query: \"%s\" (all matching documents were already seen or pruned)\n\n%s", $query, $this->corpus->formatFoundSummary());
+        }
+
+        $output = \sprintf("Search results for \"%s\":\n\n", $query);
+
+        foreach ($results as $doc) {
+            $id = (string) $doc->getId();
+            $title = $this->resolveTitle($doc->getMetadata());
+            $text = $doc->getMetadata()->getText() ?? '';
+            $snippet = \strlen($text) > 200 ? substr($text, 0, 200).'...' : $text;
+            $score = $doc->getScore();
+
+            $output .= \sprintf("- [ID: %s] %s (relevance: %.2f)\n  %s\n\n", $id, $title, $score ?? 0.0, $snippet);
+        }
+
+        $output .= \sprintf("\nUse corpus_read_document with a document ID to add it to your working set.\n\n%s", $this->corpus->formatFoundSummary());
+
+        return $output;
+    }
+
+    /**
+     * @param string $pattern text pattern or keyword to search for in document content
+     */
+    public function grep(string $pattern): string
+    {
+        $results = $this->corpus->grepDocuments($pattern);
+
+        if ([] === $results) {
+            return \sprintf("No matches found for pattern: \"%s\"\n\n%s", $pattern, $this->corpus->formatFoundSummary());
+        }
+
+        $output = \sprintf("Grep results for \"%s\":\n\n", $pattern);
+
+        foreach ($results as $id => $result) {
+            $matchLines = \array_slice($result['matches'], 0, 5);
+            $output .= \sprintf("[ID: %s] %s\n%s\n\n", $id, $result['title'], implode("\n", $matchLines));
+
+            if (\count($result['matches']) > 5) {
+                $output .= \sprintf("  ... and %d more matches\n\n", \count($result['matches']) - 5);
+            }
+        }
+
+        $output .= \sprintf("\nUse corpus_read_document with a document ID to add it to your working set.\n\n%s", $this->corpus->formatFoundSummary());
+
+        return $output;
+    }
+
+    /**
+     * @param string $documentId the document ID obtained from search or grep results
+     */
+    public function readDocument(string $documentId): string
+    {
+        if ($this->corpus->isPruned($documentId)) {
+            return \sprintf("Document %s has been pruned and is no longer available.\n\n%s", $documentId, $this->corpus->formatFoundSummary());
+        }
+
+        $doc = $this->corpus->getOriginalDocument($documentId);
+
+        if (null === $doc) {
+            return \sprintf('No document found with ID: %s', $documentId);
+        }
+
+        $title = $this->resolveTitle($doc->getMetadata());
+
+        $content = $doc->getContent();
+        $snippet = \strlen($content) > 100 ? substr($content, 0, 100).'...' : $content;
+
+        $this->corpus->addToFound($documentId, $title, $snippet);
+
+        return \sprintf(
+            "=== Document: %s (ID: %s) ===\n\n%s\n\n%s",
+            $title,
+            $documentId,
+            $doc->getContent(),
+            $this->corpus->formatFoundSummary(),
+        );
+    }
+
+    /**
+     * @param string $documentId the document ID to permanently exclude
+     */
+    public function prune(string $documentId): string
+    {
+        $this->corpus->pruneDocument($documentId);
+
+        return \sprintf("Pruned document %s. It will be excluded from all future search and grep results.\n\n%s", $documentId, $this->corpus->formatFoundSummary());
+    }
+
+    /**
+     * Resolves the document title from metadata using the typed accessor.
+     */
+    private function resolveTitle(Metadata $metadata): string
+    {
+        return $metadata->getTitle() ?? 'Unknown';
+    }
+}

--- a/fixtures/AgenticSearch/DocumentCorpus.php
+++ b/fixtures/AgenticSearch/DocumentCorpus.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Fixtures\AgenticSearch;
+
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorizerInterface;
+use Symfony\AI\Store\Query\VectorQuery;
+use Symfony\AI\Store\StoreInterface;
+
+/**
+ * Shared state for agentic search tools.
+ *
+ * Manages the vector store, original documents, deduplication of search results,
+ * pruning state, and the "found documents" working set.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class DocumentCorpus
+{
+    /**
+     * @var array<string, array{id: string, title: string, snippet: string}>
+     */
+    private array $foundDocuments = [];
+
+    /**
+     * @var array<string, true>
+     */
+    private array $seenDocumentIds = [];
+
+    /**
+     * @var array<string, true>
+     */
+    private array $prunedDocumentIds = [];
+
+    /**
+     * @param array<string, TextDocument> $originalDocuments map of document ID to original TextDocument
+     */
+    public function __construct(
+        private readonly VectorizerInterface $vectorizer,
+        private readonly StoreInterface $store,
+        private readonly array $originalDocuments,
+    ) {
+    }
+
+    /**
+     * Semantic vector search, filtering out already-seen and pruned documents.
+     *
+     * @param int $maxResults maximum number of new results to return
+     *
+     * @return VectorDocument[]
+     */
+    public function semanticSearch(string $query, int $maxResults = 5): array
+    {
+        if ($maxResults <= 0) {
+            return [];
+        }
+
+        $vector = $this->vectorizer->vectorize($query);
+        $excludedCount = \count($this->seenDocumentIds) + \count($this->prunedDocumentIds);
+        $results = iterator_to_array($this->store->query(new VectorQuery($vector), ['maxItems' => $maxResults + $excludedCount]));
+
+        $filtered = [];
+        foreach ($results as $doc) {
+            $id = (string) $doc->getId();
+            if (isset($this->seenDocumentIds[$id]) || isset($this->prunedDocumentIds[$id])) {
+                continue;
+            }
+            $this->seenDocumentIds[$id] = true;
+            $filtered[] = $doc;
+
+            if (\count($filtered) >= $maxResults) {
+                break;
+            }
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * Grep: case-insensitive keyword search across original document content.
+     *
+     * Unlike semantic search, this performs exact substring matching on the full
+     * document text, returning matching lines with context. Pruned documents
+     * are excluded.
+     *
+     * @return array<string, array{title: string, matches: string[]}>
+     */
+    public function grepDocuments(string $pattern): array
+    {
+        if ('' === $pattern) {
+            return [];
+        }
+
+        $results = [];
+
+        foreach ($this->originalDocuments as $id => $doc) {
+            if (isset($this->prunedDocumentIds[$id])) {
+                continue;
+            }
+
+            $lines = explode("\n", $doc->getContent());
+            $matches = [];
+
+            foreach ($lines as $lineNum => $line) {
+                // Strip markdown formatting (bold, italic, links) for matching
+                $plainLine = preg_replace('/\*{1,2}([^*]+)\*{1,2}/', '$1', $line) ?? $line;
+                if (false !== stripos($plainLine, $pattern)) {
+                    $matches[] = \sprintf('  L%d: %s', $lineNum + 1, trim($line));
+                }
+            }
+
+            if ([] !== $matches) {
+                $results[$id] = [
+                    'title' => $doc->getMetadata()->getTitle() ?? 'Unknown',
+                    'matches' => $matches,
+                ];
+            }
+        }
+
+        return $results;
+    }
+
+    public function getOriginalDocument(string $id): ?TextDocument
+    {
+        return $this->originalDocuments[$id] ?? null;
+    }
+
+    public function isPruned(string $id): bool
+    {
+        return isset($this->prunedDocumentIds[$id]);
+    }
+
+    public function addToFound(string $id, string $title, string $snippet): void
+    {
+        if (isset($this->prunedDocumentIds[$id])) {
+            return;
+        }
+
+        $this->foundDocuments[$id] = [
+            'id' => $id,
+            'title' => $title,
+            'snippet' => $snippet,
+        ];
+    }
+
+    /**
+     * Prunes a document: removes from working set and excludes from future searches.
+     */
+    public function pruneDocument(string $id): void
+    {
+        $this->prunedDocumentIds[$id] = true;
+        unset($this->foundDocuments[$id]);
+    }
+
+    public function formatFoundSummary(): string
+    {
+        $count = \count($this->foundDocuments);
+
+        if (0 === $count) {
+            return 'Working set: empty (no documents found yet)';
+        }
+
+        $lines = [\sprintf('Working set (%d documents):', $count)];
+        foreach ($this->foundDocuments as $doc) {
+            $lines[] = \sprintf('  - [%s] %s', $doc['id'], $doc['title']);
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/fixtures/Movies.php
+++ b/fixtures/Movies.php
@@ -29,6 +29,16 @@ final readonly class Movies
             ['title' => 'Interstellar', 'description' => 'A team of explorers travel through a wormhole in space in an attempt to ensure humanity\'s survival.', 'director' => 'Christopher Nolan'],
             ['title' => 'The Shawshank Redemption', 'description' => 'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.', 'director' => 'Frank Darabont'],
             ['title' => 'Gladiator', 'description' => 'A former Roman General sets out to exact vengeance against the corrupt emperor who murdered his family and sent him into slavery.', 'director' => 'Ridley Scott'],
+            ['title' => 'The Prestige', 'description' => 'Two magicians engage in a competitive battle for supremacy in fin-de-siècle London.', 'director' => 'Christopher Nolan'],
+            ['title' => 'Cloud Atlas', 'description' => 'An epic story of how the actions of individuals influence others in different time and place.', 'director' => 'The Wachowskis'],
+            ['title' => 'Apocalypse Now', 'description' => 'A US Army officer is sent on a dangerous mission to terminate a renegade Special Forces Colonel in Cambodia.', 'director' => 'Francis Ford Coppola'],
+            ['title' => 'The Green Mile', 'description' => 'Death row guards discover a mysterious inmate with the ability to heal people.', 'director' => 'Frank Darabont'],
+            ['title' => 'Project Hail Mary', 'description' => 'A teacher and molecular biologist awakens aboard a spacecraft with no memory and must find a way to save Earth from extinction-level alien microorganisms threatening the sun.', 'director' => 'Phil Lord and Chris Miller'],
+            ['title' => 'The Dark Knight', 'description' => 'When the menace Joker wreaks havoc and chaos on the people of Gotham, Batman must accept one of the hardest trials of all.', 'director' => 'Christopher Nolan'],
+            ['title' => 'Memento', 'description' => 'A man with short-term memory loss attempts to find his wife\'s murderer.', 'director' => 'Christopher Nolan'],
+            ['title' => 'Pulp Fiction', 'description' => 'The lives of two mob hitmen, a boxer, a gangster and his wife intertwine in four tales of violence and redemption.', 'director' => 'Quentin Tarantino'],
+            ['title' => 'Reservoir Dogs', 'description' => 'A group of criminals gather after a diamond heist gone wrong.', 'director' => 'Quentin Tarantino'],
+            ['title' => 'Kill Bill: Vol. 1', 'description' => 'A former assassin seeks revenge against her former boss and colleagues.', 'director' => 'Quentin Tarantino'],
         ];
     }
 }

--- a/fixtures/movies/apocalypse-now.md
+++ b/fixtures/movies/apocalypse-now.md
@@ -1,0 +1,23 @@
+# Apocalypse Now (1979)
+
+**IMDB**: https://www.imdb.com/title/tt0077702/
+
+**Director:** Francis Ford Coppola
+
+## Cast
+
+- **Martin Sheen** as Captain Willard
+- **Marlon Brando** as Colonel Kurtz
+- **Robert Duvall** as Lt. Col. Kilgore
+
+## Plot
+
+A US Army officer is sent on a dangerous mission to terminate a renegade Special Forces Colonel in Cambodia.
+
+During the Vietnam War, **Captain Willard** is tasked with traveling up-river to find and "terminate with extreme prejudice" **Colonel Kurtz**, who has gone rogue and established himself as a god-like figure to the local population.
+
+As Willard moves closer to Kurtz, he is forced to confront the horrors of war and the thin line between civilization and madness.
+
+The film is a visceral exploration of *war*, *insanity*, and *moral collapse*.
+
+**Connections**: Directed by Francis Ford Coppola. Marlon Brando and Robert Duvall also starred in *The Godfather*.

--- a/fixtures/movies/cloud-atlas.md
+++ b/fixtures/movies/cloud-atlas.md
@@ -1,0 +1,24 @@
+# Cloud Atlas (2012)
+
+**IMDB**: https://www.imdb.com/title/tt0443001/
+
+**Director:** The Wachowskis
+
+## Cast
+
+- **Tom Hanks** as Various Roles
+- **Halle Berry** as Various Roles
+- **Hugh Grant** as Various Roles
+- **Jim Sturgess** as Adam Ewing
+
+## Plot
+
+An epic story of how the actions of individuals influence others in different time and place.
+
+The narrative spans multiple eras, from the 19th century to a post-apocalyptic future, showing how a single soul's journey affects others through reincarnation and echoes of history.
+
+Each segment reflects on the nature of power, greed, and the enduring strength of the human spirit across millennia.
+
+The film explores themes of *interconnectedness*, *karma*, and *eternal recurrence*.
+
+**Connections**: Directed by The Wachowskis, creators of *The Matrix*.

--- a/fixtures/movies/gladiator.md
+++ b/fixtures/movies/gladiator.md
@@ -30,3 +30,5 @@ Wounded and devastated, Maximus is captured by slave traders and forced to becom
 Using his newfound popularity with the people, Maximus seeks to avenge the murder of his family and fulfill his promise to Marcus Aurelius to restore Rome to a republic. The film culminates in a final confrontation between Maximus and Commodus in the arena.
 
 The film explores themes of *honor*, *revenge*, *political corruption*, and the struggle between personal desires and duty to the greater good.
+
+**Connections**: Directed by Ridley Scott.

--- a/fixtures/movies/inception.md
+++ b/fixtures/movies/inception.md
@@ -26,3 +26,5 @@ A skilled thief is given a chance at redemption if he can successfully perform i
 Now Cobb is being offered a chance at redemption. One last job could give him his life back but only if he can accomplish the impossible - **inception**. Instead of the perfect heist, Cobb and his team of specialists have to pull off the reverse: their task is not to steal an idea but to plant one. If they succeed, it could be the perfect crime.
 
 The film explores themes of *reality*, *dreams*, *memory*, and the nature of consciousness through multiple layers of dream states, creating a complex narrative structure that challenges both characters and audience to question what is real.
+
+**Connections**: Directed by Christopher Nolan, who also directed *Interstellar*, *The Prestige*, *The Dark Knight*, and *Memento*. Michael Caine also appears in *Interstellar*, *The Prestige*, and *The Dark Knight*.

--- a/fixtures/movies/interstellar.md
+++ b/fixtures/movies/interstellar.md
@@ -1,0 +1,24 @@
+# Interstellar (2014)
+
+**IMDB**: https://www.imdb.com/title/tt0816692/
+
+**Director:** Christopher Nolan
+
+## Cast
+
+- **Matthew McConaughey** as Cooper
+- **Anne Hathaway** as Brand
+- **Jessica Chastain** as Murphy
+- **Michael Caine** as Professor Brand
+
+## Plot
+
+A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.
+
+As Earth faces a global crop blight and impending extinction, a former NASA pilot **Cooper** is recruited to lead a mission through a newly discovered wormhole near Saturn. Along with a team of scientists, including **Amelia Brand**, Cooper searches for a habitable new home for mankind in another galaxy.
+
+The journey takes them to distant worlds where time behaves differently due to gravitational time dilation, leading to heartbreaking separations and a race against time to send critical data back to Earth.
+
+The film explores themes of *time*, *love*, *sacrifice*, and the *survival of the human species* across cosmic distances.
+
+**Connections**: Directed by Christopher Nolan, who also directed *Inception*, *The Prestige*, *The Dark Knight*, and *Memento*. Michael Caine also appears in *Inception*, *The Prestige*, and *The Dark Knight*.

--- a/fixtures/movies/jurassic-park.md
+++ b/fixtures/movies/jurassic-park.md
@@ -28,3 +28,5 @@ The tour begins smoothly, but things quickly go wrong when the park's computer s
 As the island descends into chaos, the visitors must survive encounters with various dangerous dinosaurs, including the intelligent and deadly **Velociraptors** and the massive **Tyrannosaurus Rex**. Dr. Grant finds himself responsible for Hammond's grandchildren, Tim and Lex, as they attempt to reach safety.
 
 The film explores themes of *scientific ethics*, the *hubris of trying to control nature*, and the *unintended consequences of genetic engineering*. It questions whether humans have the right to resurrect extinct species and whether scientific advancement should be pursued without considering the potential risks and moral implications.
+
+**Connections**: Directed by Steven Spielberg.

--- a/fixtures/movies/kill-bill-vol-1.md
+++ b/fixtures/movies/kill-bill-vol-1.md
@@ -1,0 +1,23 @@
+# Kill Bill: Vol. 1 (2003)
+
+**IMDB**: https://www.imdb.com/title/tt0356284/
+
+**Director:** Quentin Tarantino
+
+## Cast
+
+- **Uma Thurman** as The Bride
+- **Lucy Liu** as O-Ren Ishii
+- **David Carradine** as Bill
+
+## Plot
+
+A former assassin seeks revenge against her former boss and colleagues.
+
+**The Bride**, a former member of the Deadly Viper Assassination Squad, wakes up from a four-year coma to find her life in ruins. She embarks on a bloody quest to kill everyone who betrayed her, including her former lover, **Bill**.
+
+The film is a love letter to martial arts cinema, featuring stylized action and a diverse global setting.
+
+The film explores themes of *vengeance*, *loyalty*, and *resilience*.
+
+**Connections**: Directed by Quentin Tarantino, who also directed *Pulp Fiction* and *Reservoir Dogs*. Uma Thurman also stars in *Pulp Fiction*.

--- a/fixtures/movies/memento.md
+++ b/fixtures/movies/memento.md
@@ -1,0 +1,23 @@
+# Memento (2000)
+
+**IMDB**: https://www.imdb.com/title/tt0184630/
+
+**Director:** Christopher Nolan
+
+## Cast
+
+- **Guy Pearce** as Leonard Shelby
+- **Carrie-Anne Moss** as Natalie
+- **Joe Pantoliano** as Teddy
+
+## Plot
+
+A man with short-term memory loss attempts to find his wife's murderer.
+
+**Leonard Shelby** suffers from anterograde amnesia, meaning he cannot form new memories. He uses a system of tattoos, polaroids, and notes to track his investigation into the murder of his wife.
+
+The narrative is told in two different directions—one forward and one backward—mirroring the protagonist's fragmented perception of time.
+
+The film is a masterpiece of *non-linear storytelling* and an exploration of *memory*, *identity*, and *truth*.
+
+**Connections**: Directed by Christopher Nolan, who also directed *Inception*, *Interstellar*, *The Prestige*, and *The Dark Knight*.

--- a/fixtures/movies/project-hail-mary.md
+++ b/fixtures/movies/project-hail-mary.md
@@ -1,0 +1,21 @@
+# Project Hail Mary (2026)
+
+**IMDB**: https://www.imdb.com/title/tt12042730/
+
+**Director:** Phil Lord and Chris Miller
+
+## Cast
+
+- **Ryan Gosling** as Ryland Grace
+- **Sandra Hüller** as Eva Stratt
+- **James Ortiz** as Rocky (voice and puppeteer)
+
+## Plot
+
+A middle school teacher and molecular biologist awakens aboard a spacecraft light-years from Earth with no memory. He learns he has been sent on a desperate mission to prevent extinction-level darkness caused by alien microorganisms called Astrophage that are threatening the sun.
+
+Stranded with only his scientific knowledge and an unexpected extraterrestrial ally named **Rocky**, Grace must discover why a distant star resists this cosmic threat and find a solution to save both Earth and his new companion's world.
+
+The film explores themes of *science*, *friendship*, *sacrifice*, and *interspecies cooperation*.
+
+**Connections**: Directed by Phil Lord and Chris Miller.

--- a/fixtures/movies/pulp-fiction.md
+++ b/fixtures/movies/pulp-fiction.md
@@ -1,0 +1,24 @@
+# Pulp Fiction (1994)
+
+**IMDB**: https://www.imdb.com/title/tt0110912/
+
+**Director:** Quentin Tarantino
+
+## Cast
+
+- **John Travolta** as Vincent Vega
+- **Samuel L. Jackson** as Jules Winnfield
+- **Uma Thurman** as Mia Wallace
+- **Bruce Willis** as Butch Coolidge
+
+## Plot
+
+The lives of two mob hitmen, a boxer, a gangster and his wife intertwine in four tales of violence and redemption.
+
+The film follows several intersecting storylines in Los Angeles, centering on hitmen **Vincent** and **Jules**, a boxer who refuses to throw a fight, and the wife of a gang boss.
+
+Tarantino's signature style is evident in the sharp dialogue, non-linear structure, and pop-culture references.
+
+The film explores themes of *fate*, *redemption*, and *crime* with a unique cinematic flair.
+
+**Connections**: Directed by Quentin Tarantino, who also directed *Reservoir Dogs* and *Kill Bill: Vol. 1*. Uma Thurman also stars in *Kill Bill: Vol. 1*.

--- a/fixtures/movies/reservoir-dogs.md
+++ b/fixtures/movies/reservoir-dogs.md
@@ -1,0 +1,24 @@
+# Reservoir Dogs (1992)
+
+**IMDB**: https://www.imdb.com/title/tt0103034/
+
+**Director:** Quentin Tarantino
+
+## Cast
+
+- **Harvey Keitel** as Mr. White
+- **Tim Roth** as Mr. Orange
+- **Steve Buscemi** as Mr. Pink
+- **Michael Madsen** as Mr. Blonde
+
+## Plot
+
+A group of criminals gather after a diamond heist gone wrong.
+
+The story focuses on the aftermath of a jewelry store robbery. The criminals, who do not know each other's real names, suspect there is a police informant among them.
+
+The entire movie takes place primarily in a warehouse, relying on high-tension dialogue and character development.
+
+The film explores themes of *trust*, *betrayal*, and *professionalism* among criminals.
+
+**Connections**: Directed by Quentin Tarantino, who also directed *Pulp Fiction* and *Kill Bill: Vol. 1*.

--- a/fixtures/movies/the-dark-knight.md
+++ b/fixtures/movies/the-dark-knight.md
@@ -1,0 +1,23 @@
+# The Dark Knight (2008)
+
+**IMDB**: https://www.imdb.com/title/tt0468500/
+
+**Director:** Christopher Nolan
+
+## Cast
+
+- **Christian Bale** as Bruce Wayne / Batman
+- **Heath Ledger** as Joker
+- **Aaron Eckhart** as Harvey Dent
+- **Morgan Freeman** as Lucius Fox
+- **Michael Caine** as Alfred Pennyworth
+
+## Plot
+
+When the menace Joker wreaks havoc and chaos on the people of Gotham, Batman must accept one of the hardest trials of all.
+
+**Bruce Wayne** fights a losing battle against the corruption of Gotham City, but the arrival of **The Joker**, an agent of chaos, forces him to push his physical and mental limits. The conflict is not just physical but ideological, as Joker tries to prove that anyone can be corrupted.
+
+The film explores themes of *chaos*, *justice*, *morality*, and the *burden of heroism*.
+
+**Connections**: Directed by Christopher Nolan, who also directed *Inception*, *Interstellar*, *The Prestige*, and *Memento*. Christian Bale also stars in *The Prestige* and Michael Caine also appears in *Inception*, *Interstellar*, and *The Prestige*.

--- a/fixtures/movies/the-godfather.md
+++ b/fixtures/movies/the-godfather.md
@@ -1,0 +1,24 @@
+# The Godfather (1972)
+
+**IMDB**: https://www.imdb.com/title/tt0068646/
+
+**Director:** Francis Ford Coppola
+
+## Cast
+
+- **Marlon Brando** as Vito Corleone
+- **Al Pacino** as Michael Corleone
+- **James Caan** as Sonny Corleone
+- **Robert Duvall** as Tom Hagen
+
+## Plot
+
+The aging patriarch of an organized crime dynasty transfers control of his empire to his reluctant son.
+
+**Vito Corleone**, the head of a powerful New York Mafia family, seeks to maintain his family's influence and protect his children. However, when he refuses to enter the drug trade, a violent war breaks out between the five families.
+
+His youngest son, **Michael**, a war hero who initially wanted nothing to do with the family business, is drawn into the conflict to protect his father. As Michael takes over, he transforms from a reluctant outsider into a cold, calculating leader.
+
+The film is a study of *power*, *family loyalty*, and the *corruption of the American Dream*.
+
+**Connections**: Directed by Francis Ford Coppola, who also directed *Apocalypse Now*.

--- a/fixtures/movies/the-green-mile.md
+++ b/fixtures/movies/the-green-mile.md
@@ -1,0 +1,23 @@
+# The Green Mile (1999)
+
+**IMDB**: https://www.imdb.com/title/tt0120877/
+
+**Director:** Frank Darabont
+
+## Cast
+
+- **Tom Hanks** as Paul Edgecomb
+- **Michael Clarke Duncan** as John Coffey
+- **David Morse** as Brutus 'Brutal' Howell
+
+## Plot
+
+Death row guards discover a mysterious inmate with the ability to heal people.
+
+**Paul Edgecomb**, a guard at Cold Mountain Penitentiary, encounters **John Coffey**, a giant man accused of a terrible crime who possesses the supernatural ability to heal others through touch.
+
+As Paul and his colleagues witness Coffey's miracles, they struggle with the injustice of his situation and the burden of his gift.
+
+The film explores themes of *compassion*, *justice*, and the *supernatural*.
+
+**Connections**: Directed by Frank Darabont, who also directed *The Shawshank Redemption*.

--- a/fixtures/movies/the-matrix.md
+++ b/fixtures/movies/the-matrix.md
@@ -1,0 +1,24 @@
+# The Matrix (1999)
+
+**IMDB**: https://www.imdb.com/title/tt0133093/
+
+**Director:** The Wachowskis
+
+## Cast
+
+- **Keanu Reeves** as Neo
+- **Laurence Fishburne** as Morpheus
+- **Carrie-Anne Moss** as Trinity
+- **Hugo Weaving** as Agent Smith
+
+## Plot
+
+A hacker discovers the world he lives in is a simulated reality and joins a rebellion to overthrow its controllers.
+
+**Neo**, a computer programmer by day and hacker by night, is contacted by the mysterious **Morpheus**, who reveals that the world he knows is actually a sophisticated simulation created by machines to keep humanity enslaved.
+
+After taking the "red pill," Neo wakes up in the real world—a dystopian wasteland—and joins a resistance effort to reclaim Earth. He is trained in combat and hacking to fulfill his destiny as "The One," the only person capable of manipulating the Matrix to defeat the machines.
+
+The film explores themes of *simulation theory*, *fate vs. free will*, and *human consciousness*.
+
+**Connections**: Directed by The Wachowskis, who also directed *Cloud Atlas*.

--- a/fixtures/movies/the-prestige.md
+++ b/fixtures/movies/the-prestige.md
@@ -1,0 +1,24 @@
+# The Prestige (2006)
+
+**IMDB**: https://www.imdb.com/title/tt0400030/
+
+**Director:** Christopher Nolan
+
+## Cast
+
+- **Hugh Jackman** as Robert Angier
+- **Christian Bale** as Alfred Borden
+- **Scarlett Johansson** as Olivia
+- **Michael Caine** as Cutter
+
+## Plot
+
+Two magicians engage in a competitive battle for supremacy in fin-de-siècle London, leading to a deadly obsession.
+
+Following a tragic accident during a performance, **Robert Angier** and **Alfred Borden** become bitter rivals. Each attempts to outdo the other by discovering the secret behind the other's "Transported Man" trick.
+
+The obsession leads them to employ dangerous technologies and deceptive practices, eventually costing them their sanity and their lives.
+
+The film explores themes of *obsession*, *sacrifice*, and the *nature of illusion*.
+
+**Connections**: Directed by Christopher Nolan, who also directed *Inception*, *Interstellar*, *The Dark Knight*, and *Memento*. Michael Caine also appears in *Inception*, *Interstellar*, and *The Dark Knight*. Christian Bale also stars in *The Dark Knight*.

--- a/fixtures/movies/the-shawshank-redemption.md
+++ b/fixtures/movies/the-shawshank-redemption.md
@@ -1,0 +1,23 @@
+# The Shawshank Redemption (1994)
+
+**IMDB**: https://www.imdb.com/title/tt0111161/
+
+**Director:** Frank Darabont
+
+## Cast
+
+- **Tim Robbins** as Andy Dufresne
+- **Morgan Freeman** as Ellis Boyd 'Red' Redding
+- **Bob Gunton** as Warden Norton
+
+## Plot
+
+Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.
+
+**Andy Dufresne**, a banker wrongfully convicted of murdering his wife, is sent to Shawshank State Penitentiary. There, he befriends **Red**, a fellow inmate and contraband smuggler.
+
+Andy uses his financial expertise to help the guards and the corrupt Warden Norton, while secretly planning a long-term escape. Through his resilience and hope, he transforms the prison library and the lives of those around him.
+
+The film explores themes of *hope*, *friendship*, and *perseverance* in the face of injustice.
+
+**Connections**: Directed by Frank Darabont, who also directed *The Green Mile*.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

## Summary

Adds an example demonstrating the **agentic search** pattern inspired by [Chroma's Context 1 model](https://www.youtube.com/watch?v=4sAJLLWPAh4). Instead of single-hop RAG (one query → one result set), an LLM agent iteratively explores a document corpus using four specialized tools:

- **corpus_search** — Semantic vector search for broad topic discovery (deduplicated across calls)
- **corpus_grep** — Line-by-line keyword matching on full document content
- **corpus_read_document** — Full document retrieval by ID, adds to working set
- **corpus_prune** — Permanently exclude irrelevant documents from future results

### Key design decisions
- Search/grep are discovery-only; only `read_document` adds to the working set
- Search results are deduplicated across calls (already-seen documents are filtered)
- Pruned documents are permanently excluded from all future search and grep results
- Grep searches original document content line-by-line (not embeddings), making it genuinely different from semantic search
- One document per movie (detailed markdown preferred over short descriptions)

### Files
- `fixtures/AgenticSearch/DocumentCorpus.php` — Shared state: store, deduplication, pruning, working set
- `fixtures/AgenticSearch/AgenticSearchTools.php` — 4 tools in one class using multi-`#[AsTool]` pattern
- `examples/rag/agentic-search.php` — Example wiring with event-based tool call logging

### Usage
```bash
cd examples && php rag/agentic-search.php
```