### PR TITLE
[Platform][Codex] Add Codex CLI platform bridge

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -149,6 +149,10 @@ deptrac:
       collectors:
         - type: classLike
           value: Symfony\\AI\\Platform\\Bridge\\ClaudeCode\\.*
+    - name: CodexPlatform
+      collectors:
+        - type: classLike
+          value: Symfony\\AI\\Platform\\Bridge\\Codex\\.*
     - name: DecartPlatform
       collectors:
         - type: classLike
@@ -448,6 +452,8 @@ deptrac:
       - PlatformComponent
       - GenericPlatform
     ClaudeCodePlatform:
+      - PlatformComponent
+    CodexPlatform:
       - PlatformComponent
     DecartPlatform:
       - PlatformComponent

--- a/examples/codex/chat.php
+++ b/examples/codex/chat.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Codex\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(
+    workingDirectory: dirname(__DIR__, 2),
+    environment: ['CODEX' => false], // To enable Codex to execute the example
+    logger: logger(),
+);
+
+$messages = new MessageBag(
+    Message::ofUser('Explain the architecture of this project in 3 sentences.'),
+);
+$result = $platform->invoke('gpt-5-codex', $messages, [
+    'sandbox' => 'read-only',
+]);
+
+echo $result->asText().\PHP_EOL;
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/codex/code-generation.php
+++ b/examples/codex/code-generation.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Codex\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+// Use a temporary directory as working directory so Codex can write files.
+// Codex requires a git repository, so we initialize one.
+$workingDirectory = sys_get_temp_dir().'/codex-example-'.bin2hex(random_bytes(4));
+mkdir($workingDirectory);
+shell_exec(sprintf('git -C %s init --quiet', escapeshellarg($workingDirectory)));
+
+$platform = PlatformFactory::create(
+    workingDirectory: $workingDirectory,
+    environment: ['CODEX' => false],
+    logger: logger(),
+);
+
+$messages = new MessageBag(
+    Message::ofUser('Create a file called hello.php that prints "Hello, World!" to the console.'),
+);
+$result = $platform->invoke('gpt-5-codex', $messages, [
+    'sandbox' => 'workspace-write',
+]);
+
+echo $result->asText().\PHP_EOL;
+
+$helloFile = $workingDirectory.'/hello.php';
+if (file_exists($helloFile)) {
+    echo \PHP_EOL.'--- Generated file content ---'.\PHP_EOL;
+    echo file_get_contents($helloFile);
+    echo \PHP_EOL.'--- Executing generated file ---'.\PHP_EOL;
+    passthru('php '.escapeshellarg($helloFile));
+}
+
+// Cleanup
+array_map('unlink', glob($workingDirectory.'/*'));
+shell_exec(sprintf('rm -rf %s', escapeshellarg($workingDirectory.'/.git')));
+rmdir($workingDirectory);
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/codex/stream.php
+++ b/examples/codex/stream.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Codex\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(
+    workingDirectory: dirname(__DIR__, 2),
+    environment: ['CODEX' => false], // To enable Codex to execute the example
+    logger: logger(),
+);
+
+$messages = new MessageBag(
+    Message::ofUser('What is Symfony? Explain in 3 sentences.'),
+);
+$result = $platform->invoke('gpt-5-codex', $messages, [
+    'stream' => true,
+    'sandbox' => 'read-only',
+]);
+
+foreach ($result->asStream() as $word) {
+    echo $word;
+}
+echo \PHP_EOL;
+
+$tokenUsage = $result->getMetadata()->get('token_usage');
+if (null !== $tokenUsage) {
+    print_token_usage($tokenUsage);
+}

--- a/examples/codex/token-metadata.php
+++ b/examples/codex/token-metadata.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Codex\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(
+    workingDirectory: dirname(__DIR__, 2),
+    environment: ['CODEX' => false], // To enable Codex to execute the example
+    logger: logger(),
+);
+
+$messages = new MessageBag(
+    Message::ofUser('What testing framework does this project use? Answer in one sentence.'),
+);
+$result = $platform->invoke('gpt-5-codex', $messages, [
+    'sandbox' => 'read-only',
+]);
+
+echo $result->asText().\PHP_EOL;
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/splitsh.json
+++ b/splitsh.json
@@ -49,6 +49,7 @@
         "ai-cartesia-platform": "src/platform/src/Bridge/Cartesia",
         "ai-cerebras-platform": "src/platform/src/Bridge/Cerebras",
         "ai-claude-code-platform": "src/platform/src/Bridge/ClaudeCode",
+        "ai-codex-platform": "src/platform/src/Bridge/Codex",
         "ai-decart-platform": "src/platform/src/Bridge/Decart",
         "ai-deep-seek-platform": "src/platform/src/Bridge/DeepSeek",
         "ai-docker-model-runner-platform": "src/platform/src/Bridge/DockerModelRunner",

--- a/src/platform/src/Bridge/Codex/.gitattributes
+++ b/src/platform/src/Bridge/Codex/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/platform/src/Bridge/Codex/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/platform/src/Bridge/Codex/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/ai
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/platform/src/Bridge/Codex/.github/workflows/close-pull-request.yml
+++ b/src/platform/src/Bridge/Codex/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/ai
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/platform/src/Bridge/Codex/.gitignore
+++ b/src/platform/src/Bridge/Codex/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+phpunit.xml
+.phpunit.result.cache

--- a/src/platform/src/Bridge/Codex/CHANGELOG.md
+++ b/src/platform/src/Bridge/Codex/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+0.7
+---
+
+ * Add the bridge

--- a/src/platform/src/Bridge/Codex/Codex.php
+++ b/src/platform/src/Bridge/Codex/Codex.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex;
+
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class Codex extends Model
+{
+}

--- a/src/platform/src/Bridge/Codex/Contract/CodexContract.php
+++ b/src/platform/src/Bridge/Codex/Contract/CodexContract.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex\Contract;
+
+use Symfony\AI\Platform\Contract;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class CodexContract extends Contract
+{
+    public static function create(NormalizerInterface ...$normalizer): Contract
+    {
+        return parent::create(
+            new MessageBagNormalizer(),
+            ...$normalizer,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Codex/Contract/MessageBagNormalizer.php
+++ b/src/platform/src/Bridge/Codex/Contract/MessageBagNormalizer.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex\Contract;
+
+use Symfony\AI\Platform\Bridge\Codex\Codex;
+use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Model;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+
+/**
+ * Normalizes a MessageBag for the Codex CLI by extracting the system
+ * prompt into a dedicated field and the last user message as the prompt.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class MessageBagNormalizer extends ModelContractNormalizer implements NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    /**
+     * @param MessageBag $data
+     *
+     * @return array{
+     *     prompt: string,
+     *     system_prompt?: string,
+     * }
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        $messages = $this->normalizer->normalize($data->withoutSystemMessage()->getMessages(), $format, $context);
+
+        $prompt = '';
+        foreach (array_reverse($messages) as $message) {
+            if ('user' !== ($message['role'] ?? null)) {
+                continue;
+            }
+
+            if (\is_string($message['content'])) {
+                $prompt = $message['content'];
+                break;
+            }
+
+            if (\is_array($message['content'])) {
+                foreach ($message['content'] as $block) {
+                    if ('text' === ($block['type'] ?? null)) {
+                        $prompt = $block['text'];
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        $array = ['prompt' => $prompt];
+
+        if (null !== $system = $data->getSystemMessage()) {
+            $array['system_prompt'] = (string) $system->getContent();
+        }
+
+        return $array;
+    }
+
+    protected function supportedDataClass(): string
+    {
+        return MessageBag::class;
+    }
+
+    protected function supportsModel(Model $model): bool
+    {
+        return $model instanceof Codex;
+    }
+}

--- a/src/platform/src/Bridge/Codex/Exception/CliNotFoundException.php
+++ b/src/platform/src/Bridge/Codex/Exception/CliNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex\Exception;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class CliNotFoundException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('The "codex" CLI binary was not found. Please install it via "npm install -g @openai/codex" or provide the path to the binary.');
+    }
+}

--- a/src/platform/src/Bridge/Codex/LICENSE
+++ b/src/platform/src/Bridge/Codex/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/platform/src/Bridge/Codex/ModelCatalog.php
+++ b/src/platform/src/Bridge/Codex/ModelCatalog.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex;
+
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\ModelCatalog\AbstractModelCatalog;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelCatalog extends AbstractModelCatalog
+{
+    /**
+     * @param array<string, array{class: string, capabilities: list<Capability>}> $additionalModels
+     */
+    public function __construct(array $additionalModels = [])
+    {
+        $capabilities = [
+            Capability::INPUT_MESSAGES,
+            Capability::INPUT_TEXT,
+            Capability::OUTPUT_TEXT,
+            Capability::OUTPUT_STREAMING,
+        ];
+
+        $defaultModels = [
+            'gpt-5.4' => [
+                'class' => Codex::class,
+                'capabilities' => $capabilities,
+            ],
+            'gpt-5.4-mini' => [
+                'class' => Codex::class,
+                'capabilities' => $capabilities,
+            ],
+            'gpt-5.3-codex' => [
+                'class' => Codex::class,
+                'capabilities' => $capabilities,
+            ],
+            'gpt-5.3-codex-spark' => [
+                'class' => Codex::class,
+                'capabilities' => $capabilities,
+            ],
+            'gpt-5.2-codex' => [
+                'class' => Codex::class,
+                'capabilities' => $capabilities,
+            ],
+            'gpt-5.1-codex' => [
+                'class' => Codex::class,
+                'capabilities' => $capabilities,
+            ],
+            'gpt-5-codex' => [
+                'class' => Codex::class,
+                'capabilities' => $capabilities,
+            ],
+            'gpt-5-codex-mini' => [
+                'class' => Codex::class,
+                'capabilities' => $capabilities,
+            ],
+        ];
+
+        $this->models = array_merge($defaultModels, $additionalModels);
+    }
+}

--- a/src/platform/src/Bridge/Codex/ModelClient.php
+++ b/src/platform/src/Bridge/Codex/ModelClient.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\AI\Platform\Bridge\Codex\Exception\CliNotFoundException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * Spawns the Codex CLI as a subprocess and returns the result.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelClient implements ModelClientInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    private const OPTION_FLAG_MAP = [
+        'tools' => '--allowedTools',
+        'allowed_tools' => '--allowedTools',
+    ];
+
+    /**
+     * @param array<string, string> $environment
+     */
+    public function __construct(
+        private readonly ?string $cliBinary = null,
+        private readonly ?string $workingDirectory = null,
+        private readonly ?float $timeout = 300,
+        private readonly array $environment = [],
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Codex;
+    }
+
+    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface
+    {
+        if (!isset($options['model'])) {
+            $options['model'] = $model->getName();
+        }
+
+        $prompt = $this->extractPrompt($payload);
+
+        // Merge payload fields (e.g. system_prompt from the normalizer) into
+        // options, giving explicit options priority.
+        if (\is_array($payload)) {
+            $options = array_merge($payload, $options);
+            unset($options['prompt']);
+        }
+
+        // Codex CLI has no --system-prompt flag, prepend to prompt instead.
+        if (isset($options['system_prompt']) && '' !== $options['system_prompt']) {
+            $prompt = \sprintf("[System]\n%s\n\n[User]\n%s", $options['system_prompt'], $prompt);
+        }
+
+        $cwd = $options['cwd'] ?? $this->workingDirectory;
+        unset($options['cwd'], $options['stream'], $options['system_prompt']);
+
+        if (!isset($options['sandbox'])) {
+            $options['sandbox'] = 'read-only';
+        }
+
+        $command = $this->buildCommand($prompt, $options);
+
+        $this->logger->info('Spawning Codex CLI subprocess.', [
+            'command' => implode(' ', array_map('escapeshellarg', $command)),
+            'cwd' => $cwd,
+        ]);
+
+        $process = new Process($command, $cwd, $this->environment, null, $this->timeout);
+        $process->start();
+
+        return new RawProcessResult($process);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return string[]
+     */
+    public function buildCommand(string $prompt, array $options = []): array
+    {
+        $command = [$this->getCliBinary(), '--ask-for-approval', 'never', 'exec', '--json'];
+
+        foreach ($options as $key => $value) {
+            $flag = self::OPTION_FLAG_MAP[$key] ?? '--'.str_replace('_', '-', $key);
+
+            if (\is_array($value)) {
+                foreach ($value as $item) {
+                    $command[] = $flag;
+                    $command[] = (string) $item;
+                }
+            } elseif (true === $value) {
+                $command[] = $flag;
+            } elseif (false !== $value) {
+                $command[] = $flag;
+                $command[] = (string) $value;
+            }
+        }
+
+        $command[] = $prompt;
+
+        return $command;
+    }
+
+    private function getCliBinary(): string
+    {
+        $binary = $this->cliBinary ?? (new ExecutableFinder())->find('codex');
+
+        if (null === $binary || !is_executable($binary)) {
+            throw new CliNotFoundException();
+        }
+
+        return $binary;
+    }
+
+    /**
+     * @param array<string|int, mixed>|string $payload
+     */
+    private function extractPrompt(array|string $payload): string
+    {
+        if (\is_string($payload)) {
+            return $payload;
+        }
+
+        return (string) ($payload['prompt'] ?? json_encode($payload, \JSON_THROW_ON_ERROR));
+    }
+}

--- a/src/platform/src/Bridge/Codex/PlatformFactory.php
+++ b/src/platform/src/Bridge/Codex/PlatformFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\AI\Platform\Bridge\Codex\Contract\CodexContract;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\Platform;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PlatformFactory
+{
+    /**
+     * @param array<string, string|false> $environment
+     */
+    public static function create(
+        ?string $cliBinary = null,
+        ?string $workingDirectory = null,
+        ?float $timeout = 300,
+        array $environment = [],
+        ModelCatalogInterface $modelCatalog = new ModelCatalog(),
+        ?Contract $contract = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+        LoggerInterface $logger = new NullLogger(),
+    ): Platform {
+        return new Platform(
+            [new ModelClient($cliBinary, $workingDirectory, $timeout, $environment, $logger)],
+            [new ResultConverter()],
+            $modelCatalog,
+            $contract ?? CodexContract::create(),
+            $eventDispatcher,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Codex/README.md
+++ b/src/platform/src/Bridge/Codex/README.md
@@ -1,0 +1,12 @@
+Codex Platform
+==============
+
+OpenAI Codex CLI platform bridge for Symfony AI.
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/ai/issues) and
+   [send Pull Requests](https://github.com/symfony/ai/pulls)
+   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/platform/src/Bridge/Codex/RawProcessResult.php
+++ b/src/platform/src/Bridge/Codex/RawProcessResult.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Wraps a Symfony Process running the Codex CLI as a RawResultInterface.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RawProcessResult implements RawResultInterface
+{
+    public function __construct(
+        private readonly Process $process,
+    ) {
+    }
+
+    /**
+     * Waits for the process to finish, parses all output lines, and returns the final
+     * agent message together with usage data.
+     *
+     * @return array<string, mixed>
+     */
+    public function getData(): array
+    {
+        $this->process->wait();
+
+        if (!$this->process->isSuccessful()) {
+            throw new RuntimeException(\sprintf('Codex CLI process failed: "%s"', $this->process->getErrorOutput()));
+        }
+
+        $output = $this->process->getOutput();
+        $lastAgentMessage = [];
+        $lastError = [];
+        $usage = [];
+
+        foreach (explode(\PHP_EOL, $output) as $line) {
+            $line = trim($line);
+
+            if ('' === $line) {
+                continue;
+            }
+
+            $decoded = json_decode($line, true);
+
+            if (null === $decoded) {
+                continue;
+            }
+
+            $type = $decoded['type'] ?? '';
+
+            if ('item.completed' === $type
+                && 'agent_message' === ($decoded['item']['type'] ?? '')
+            ) {
+                $lastAgentMessage = $decoded;
+            }
+
+            if ('error' === $type) {
+                $lastError = $decoded;
+            }
+
+            if ('turn.completed' === $type && isset($decoded['usage'])) {
+                $usage = $decoded['usage'];
+            }
+        }
+
+        if ([] !== $lastError && [] === $lastAgentMessage) {
+            return $lastError;
+        }
+
+        if ([] !== $usage && [] !== $lastAgentMessage) {
+            $lastAgentMessage['usage'] = $usage;
+        }
+
+        return $lastAgentMessage;
+    }
+
+    /**
+     * Polls the process for incremental output, yielding each complete JSON line.
+     *
+     * @return \Generator<int, array<string, mixed>>
+     */
+    public function getDataStream(): \Generator
+    {
+        $buffer = '';
+
+        while ($this->process->isRunning()) {
+            $incrementalOutput = $this->process->getIncrementalOutput();
+
+            if ('' === $incrementalOutput) {
+                usleep(10000); // 10ms polling interval
+                continue;
+            }
+
+            $buffer .= $incrementalOutput;
+            $lines = explode(\PHP_EOL, $buffer);
+
+            // Keep the last (potentially incomplete) line in the buffer
+            $buffer = array_pop($lines);
+
+            foreach ($lines as $line) {
+                $line = trim($line);
+
+                if ('' === $line) {
+                    continue;
+                }
+
+                $decoded = json_decode($line, true);
+
+                if (null !== $decoded) {
+                    yield $decoded;
+                }
+            }
+        }
+
+        // Process remaining output after process finishes
+        $buffer .= $this->process->getIncrementalOutput();
+
+        foreach (explode(\PHP_EOL, $buffer) as $line) {
+            $line = trim($line);
+
+            if ('' === $line) {
+                continue;
+            }
+
+            $decoded = json_decode($line, true);
+
+            if (null !== $decoded) {
+                yield $decoded;
+            }
+        }
+
+        if (!$this->process->isSuccessful()) {
+            throw new RuntimeException(\sprintf('Codex CLI process failed: "%s"', $this->process->getErrorOutput()));
+        }
+    }
+
+    public function getObject(): Process
+    {
+        return $this->process;
+    }
+}

--- a/src/platform/src/Bridge/Codex/ResultConverter.php
+++ b/src/platform/src/Bridge/Codex/ResultConverter.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+
+/**
+ * Converts Codex CLI JSONL output into platform result objects.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResultConverter implements ResultConverterInterface
+{
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Codex;
+    }
+
+    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    {
+        if ($options['stream'] ?? false) {
+            return new StreamResult($this->convertStream($result));
+        }
+
+        $data = $result->getData();
+
+        if ([] === $data) {
+            throw new RuntimeException('Codex CLI did not return any result.');
+        }
+
+        if ('error' === ($data['type'] ?? '')) {
+            throw new RuntimeException(\sprintf('Codex CLI error: "%s"', $data['message'] ?? 'Unknown error'));
+        }
+
+        $text = $data['item']['text'] ?? null;
+
+        if (null === $text) {
+            throw new RuntimeException('Codex CLI result does not contain a text field.');
+        }
+
+        return new TextResult($text);
+    }
+
+    public function getTokenUsageExtractor(): TokenUsageExtractorInterface
+    {
+        return new TokenUsageExtractor();
+    }
+
+    private function convertStream(RawResultInterface $result): \Generator
+    {
+        foreach ($result->getDataStream() as $data) {
+            $type = $data['type'] ?? '';
+
+            if ('item.completed' === $type
+                && 'agent_message' === ($data['item']['type'] ?? '')
+                && isset($data['item']['text'])
+            ) {
+                yield $data['item']['text'];
+            }
+        }
+    }
+}

--- a/src/platform/src/Bridge/Codex/Tests/CodexTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/CodexTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Codex\Codex;
+use Symfony\AI\Platform\Capability;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class CodexTest extends TestCase
+{
+    public function testItCreatesCodexWithDefaults()
+    {
+        $model = new Codex('gpt-5-codex');
+
+        $this->assertSame('gpt-5-codex', $model->getName());
+        $this->assertSame([], $model->getOptions());
+    }
+
+    public function testItCreatesCodexWithCapabilities()
+    {
+        $capabilities = [Capability::INPUT_TEXT, Capability::OUTPUT_TEXT];
+        $model = new Codex('gpt-5.4', $capabilities);
+
+        $this->assertSame('gpt-5.4', $model->getName());
+        $this->assertSame($capabilities, $model->getCapabilities());
+    }
+
+    public function testItCreatesCodexWithOptions()
+    {
+        $options = ['sandbox' => 'workspace-write', 'model' => 'gpt-5-codex'];
+        $model = new Codex('gpt-5-codex', [], $options);
+
+        $this->assertSame('gpt-5-codex', $model->getName());
+        $this->assertSame($options, $model->getOptions());
+    }
+}

--- a/src/platform/src/Bridge/Codex/Tests/MessageBagNormalizerTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/MessageBagNormalizerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\ClaudeCode\ClaudeCode;
+use Symfony\AI\Platform\Bridge\Codex\Codex;
+use Symfony\AI\Platform\Bridge\Codex\Contract\MessageBagNormalizer;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class MessageBagNormalizerTest extends TestCase
+{
+    public function testSupportsCodexModel()
+    {
+        $normalizer = new MessageBagNormalizer();
+
+        $this->assertTrue($normalizer->supportsNormalization(
+            new MessageBag(),
+            context: [Contract::CONTEXT_MODEL => new Codex('gpt-5-codex')],
+        ));
+    }
+
+    public function testDoesNotSupportOtherModels()
+    {
+        $normalizer = new MessageBagNormalizer();
+
+        $this->assertFalse($normalizer->supportsNormalization(
+            new MessageBag(),
+            context: [Contract::CONTEXT_MODEL => new ClaudeCode('sonnet')],
+        ));
+    }
+
+    public function testDoesNotSupportNonMessageBag()
+    {
+        $normalizer = new MessageBagNormalizer();
+
+        $this->assertFalse($normalizer->supportsNormalization(
+            'not a message bag',
+            context: [Contract::CONTEXT_MODEL => new Codex('gpt-5-codex')],
+        ));
+    }
+
+    public function testNormalizeExtractsPromptAndSystemPrompt()
+    {
+        $messageBag = new MessageBag(
+            Message::forSystem('You are a pirate.'),
+            Message::ofUser('What is PHP?'),
+        );
+
+        $result = $this->normalize($messageBag);
+
+        $this->assertSame('What is PHP?', $result['prompt']);
+        $this->assertSame('You are a pirate.', $result['system_prompt']);
+    }
+
+    public function testNormalizeWithoutSystemMessage()
+    {
+        $messageBag = new MessageBag(
+            Message::ofUser('Hello'),
+        );
+
+        $result = $this->normalize($messageBag);
+
+        $this->assertSame('Hello', $result['prompt']);
+        $this->assertArrayNotHasKey('system_prompt', $result);
+    }
+
+    public function testNormalizeUsesLastUserMessage()
+    {
+        $messageBag = new MessageBag(
+            Message::ofUser('First question'),
+            Message::ofUser('Second question'),
+        );
+
+        $result = $this->normalize($messageBag);
+
+        $this->assertSame('Second question', $result['prompt']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalize(MessageBag $messageBag): array
+    {
+        $contract = Contract::create(new MessageBagNormalizer());
+        $model = new Codex('gpt-5-codex');
+
+        return $contract->createRequestPayload($model, $messageBag);
+    }
+}

--- a/src/platform/src/Bridge/Codex/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/ModelCatalogTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex\Tests;
+
+use Symfony\AI\Platform\Bridge\Codex\Codex;
+use Symfony\AI\Platform\Bridge\Codex\ModelCatalog;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\Test\ModelCatalogTestCase;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelCatalogTest extends ModelCatalogTestCase
+{
+    public static function modelsProvider(): iterable
+    {
+        $capabilities = [Capability::INPUT_MESSAGES, Capability::INPUT_TEXT, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING];
+
+        yield 'gpt-5.4' => ['gpt-5.4', Codex::class, $capabilities];
+        yield 'gpt-5.4-mini' => ['gpt-5.4-mini', Codex::class, $capabilities];
+        yield 'gpt-5.3-codex' => ['gpt-5.3-codex', Codex::class, $capabilities];
+        yield 'gpt-5.3-codex-spark' => ['gpt-5.3-codex-spark', Codex::class, $capabilities];
+        yield 'gpt-5.2-codex' => ['gpt-5.2-codex', Codex::class, $capabilities];
+        yield 'gpt-5.1-codex' => ['gpt-5.1-codex', Codex::class, $capabilities];
+        yield 'gpt-5-codex' => ['gpt-5-codex', Codex::class, $capabilities];
+        yield 'gpt-5-codex-mini' => ['gpt-5-codex-mini', Codex::class, $capabilities];
+    }
+
+    protected function createModelCatalog(): ModelCatalogInterface
+    {
+        return new ModelCatalog();
+    }
+}

--- a/src/platform/src/Bridge/Codex/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/ModelClientTest.php
@@ -1,0 +1,245 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\ClaudeCode\ClaudeCode;
+use Symfony\AI\Platform\Bridge\Codex\Codex;
+use Symfony\AI\Platform\Bridge\Codex\Exception\CliNotFoundException;
+use Symfony\AI\Platform\Bridge\Codex\ModelClient;
+use Symfony\AI\Platform\Bridge\Codex\RawProcessResult;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelClientTest extends TestCase
+{
+    private static string $binary;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$binary = file_exists('/usr/bin/echo') ? '/usr/bin/echo' : '/bin/echo';
+    }
+
+    public function testSupportsCodex()
+    {
+        $client = new ModelClient();
+
+        $this->assertTrue($client->supports(new Codex('gpt-5-codex')));
+    }
+
+    public function testDoesNotSupportOtherModels()
+    {
+        $client = new ModelClient();
+
+        $this->assertFalse($client->supports(new ClaudeCode('sonnet')));
+    }
+
+    public function testThrowsExceptionWhenCliNotFound()
+    {
+        $client = new ModelClient('/non/existent/binary/that/does/not/exist');
+
+        $this->expectException(CliNotFoundException::class);
+        $this->expectExceptionMessage('The "codex" CLI binary was not found.');
+
+        $client->buildCommand('Hello');
+    }
+
+    public function testBuildCommandWithDefaults()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello, World!');
+
+        $this->assertSame([self::$binary, '--ask-for-approval', 'never', 'exec', '--json', 'Hello, World!'], $command);
+    }
+
+    public function testBuildCommandWithModel()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello', ['model' => 'gpt-5-codex']);
+
+        $this->assertContains('--model', $command);
+        $this->assertContains('gpt-5-codex', $command);
+    }
+
+    public function testBuildCommandWithSandbox()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello', ['sandbox' => 'workspace-write']);
+
+        $this->assertContains('--sandbox', $command);
+        $this->assertContains('workspace-write', $command);
+    }
+
+    public function testBuildCommandWithImage()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello', ['image' => '/path/to/image.png']);
+
+        $this->assertContains('--image', $command);
+        $this->assertContains('/path/to/image.png', $command);
+    }
+
+    public function testBuildCommandWithAllowedTools()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello', ['allowed_tools' => ['Bash', 'Read']]);
+
+        $this->assertSame(2, \count(array_keys($command, '--allowedTools', true)));
+        $this->assertContains('Bash', $command);
+        $this->assertContains('Read', $command);
+    }
+
+    public function testBuildCommandWithAllOptions()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello', [
+            'model' => 'gpt-5-codex',
+            'sandbox' => 'workspace-write',
+            'allowed_tools' => ['Bash'],
+        ]);
+
+        $expected = [
+            self::$binary,
+            '--ask-for-approval', 'never',
+            'exec', '--json',
+            '--model', 'gpt-5-codex',
+            '--sandbox', 'workspace-write',
+            '--allowedTools', 'Bash',
+            'Hello',
+        ];
+
+        $this->assertSame($expected, $command);
+    }
+
+    public function testBuildCommandRewritesToolsToAllowedTools()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello', ['tools' => ['Bash', 'Read']]);
+
+        $this->assertNotContains('--tools', $command);
+        $this->assertSame(2, \count(array_keys($command, '--allowedTools', true)));
+        $this->assertContains('Bash', $command);
+        $this->assertContains('Read', $command);
+    }
+
+    public function testBuildCommandPassesUnknownOptionsAsFlags()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello', ['custom_flag' => 'value']);
+
+        $this->assertContains('--custom-flag', $command);
+        $this->assertContains('value', $command);
+    }
+
+    public function testBuildCommandHandlesBooleanTrueAsFlag()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello', ['search' => true]);
+
+        $this->assertContains('--search', $command);
+    }
+
+    public function testBuildCommandSkipsBooleanFalse()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello', ['search' => false]);
+
+        $this->assertNotContains('--search', $command);
+    }
+
+    public function testRequestReturnsRawProcessResult()
+    {
+        $client = new ModelClient(self::$binary);
+        $model = new Codex('gpt-5-codex');
+
+        $result = $client->request($model, 'Hello');
+
+        $this->assertInstanceOf(RawProcessResult::class, $result);
+    }
+
+    public function testRequestPassesModelNameToCommand()
+    {
+        $client = new ModelClient(self::$binary);
+        $model = new Codex('gpt-5-codex');
+
+        $result = $client->request($model, 'Hello');
+        $commandLine = $result->getObject()->getCommandLine();
+
+        $this->assertStringContainsString('--model', $commandLine);
+        $this->assertStringContainsString('gpt-5-codex', $commandLine);
+    }
+
+    public function testRequestUsesPromptFromNormalizedPayload()
+    {
+        $client = new ModelClient(self::$binary);
+        $model = new Codex('gpt-5-codex');
+
+        $payload = ['prompt' => 'What is PHP?', 'system_prompt' => 'You are helpful.'];
+
+        $result = $client->request($model, $payload);
+        $commandLine = $result->getObject()->getCommandLine();
+
+        $this->assertStringContainsString('What is PHP?', $commandLine);
+        $this->assertStringContainsString('You are helpful.', $commandLine);
+    }
+
+    public function testRequestUsesStringPayloadDirectly()
+    {
+        $client = new ModelClient(self::$binary);
+        $model = new Codex('gpt-5-codex');
+
+        $result = $client->request($model, 'Hello, World!');
+        $commandLine = $result->getObject()->getCommandLine();
+
+        $this->assertStringContainsString('Hello, World!', $commandLine);
+    }
+
+    public function testRequestAddsDefaultSandbox()
+    {
+        $client = new ModelClient(self::$binary);
+        $model = new Codex('gpt-5-codex');
+
+        $result = $client->request($model, 'Hello');
+        $commandLine = $result->getObject()->getCommandLine();
+
+        $this->assertStringContainsString('--sandbox', $commandLine);
+        $this->assertStringContainsString('read-only', $commandLine);
+    }
+
+    public function testRequestPrependsSystemPromptToPrompt()
+    {
+        $client = new ModelClient(self::$binary);
+        $model = new Codex('gpt-5-codex');
+
+        $payload = ['prompt' => 'What is PHP?', 'system_prompt' => 'You are a pirate.'];
+        $result = $client->request($model, $payload);
+        $commandLine = $result->getObject()->getCommandLine();
+
+        $this->assertStringContainsString('[System]', $commandLine);
+        $this->assertStringContainsString('You are a pirate.', $commandLine);
+        $this->assertStringContainsString('[User]', $commandLine);
+        $this->assertStringContainsString('What is PHP?', $commandLine);
+        // system_prompt should not be passed as a flag
+        $this->assertStringNotContainsString('--system-prompt', $commandLine);
+    }
+}

--- a/src/platform/src/Bridge/Codex/Tests/RawProcessResultTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/RawProcessResultTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Codex\RawProcessResult;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RawProcessResultTest extends TestCase
+{
+    public function testGetDataReturnsLastAgentMessage()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            json_encode(['type' => 'thread.started', 'thread_id' => 'test-123']),
+            json_encode(['type' => 'turn.started']),
+            json_encode(['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'Hello, World!']]),
+            json_encode(['type' => 'turn.completed', 'usage' => ['input_tokens' => 100, 'output_tokens' => 50, 'cached_input_tokens' => 80]]),
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $data = $rawResult->getData();
+
+        $this->assertSame('item.completed', $data['type']);
+        $this->assertSame('agent_message', $data['item']['type']);
+        $this->assertSame('Hello, World!', $data['item']['text']);
+        $this->assertSame(100, $data['usage']['input_tokens']);
+        $this->assertSame(50, $data['usage']['output_tokens']);
+        $this->assertSame(80, $data['usage']['cached_input_tokens']);
+    }
+
+    public function testGetDataReturnsLastAgentMessageFromMultiple()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            json_encode(['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'First message']]),
+            json_encode(['type' => 'item.completed', 'item' => ['type' => 'command_execution', 'command' => 'ls']]),
+            json_encode(['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'Final answer']]),
+            json_encode(['type' => 'turn.completed', 'usage' => ['input_tokens' => 200, 'output_tokens' => 100]]),
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $data = $rawResult->getData();
+
+        $this->assertSame('Final answer', $data['item']['text']);
+    }
+
+    public function testGetDataReturnsEmptyArrayWhenNoAgentMessage()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            json_encode(['type' => 'thread.started', 'thread_id' => 'test-123']),
+            json_encode(['type' => 'turn.completed', 'usage' => ['input_tokens' => 10, 'output_tokens' => 0]]),
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+
+        $this->assertSame([], $rawResult->getData());
+    }
+
+    public function testGetDataReturnsErrorEventWhenNoAgentMessage()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            json_encode(['type' => 'thread.started', 'thread_id' => 'test-123']),
+            json_encode(['type' => 'error', 'message' => 'Something went wrong']),
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $data = $rawResult->getData();
+
+        $this->assertSame('error', $data['type']);
+        $this->assertSame('Something went wrong', $data['message']);
+    }
+
+    public function testGetDataPrefersAgentMessageOverError()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            json_encode(['type' => 'error', 'message' => 'Recoverable error']),
+            json_encode(['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'Final answer']]),
+            json_encode(['type' => 'turn.completed', 'usage' => ['input_tokens' => 50, 'output_tokens' => 20]]),
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $data = $rawResult->getData();
+
+        $this->assertSame('item.completed', $data['type']);
+        $this->assertSame('Final answer', $data['item']['text']);
+    }
+
+    public function testGetDataThrowsOnProcessFailure()
+    {
+        $process = new Process(['php', '-r', 'fwrite(STDERR, "error"); exit(1);']);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Codex CLI process failed');
+
+        $rawResult->getData();
+    }
+
+    public function testGetDataStreamYieldsJsonLines()
+    {
+        $lines = [
+            json_encode(['type' => 'thread.started', 'thread_id' => 'test-123']),
+            json_encode(['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'Hi']]),
+            json_encode(['type' => 'turn.completed', 'usage' => ['input_tokens' => 10, 'output_tokens' => 5]]),
+        ];
+
+        $phpCode = 'foreach ('.var_export($lines, true).' as $line) { echo $line.PHP_EOL; usleep(1000); }';
+        $process = new Process(['php', '-r', $phpCode]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $collected = [];
+
+        foreach ($rawResult->getDataStream() as $data) {
+            $collected[] = $data;
+        }
+
+        $this->assertCount(3, $collected);
+        $this->assertSame('thread.started', $collected[0]['type']);
+        $this->assertSame('item.completed', $collected[1]['type']);
+        $this->assertSame('turn.completed', $collected[2]['type']);
+    }
+
+    public function testGetDataStreamSkipsEmptyAndInvalidLines()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            '',
+            'not json',
+            json_encode(['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'done']]),
+            '',
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $collected = [];
+
+        foreach ($rawResult->getDataStream() as $data) {
+            $collected[] = $data;
+        }
+
+        $this->assertCount(1, $collected);
+        $this->assertSame('item.completed', $collected[0]['type']);
+    }
+
+    public function testGetDataStreamThrowsOnProcessFailure()
+    {
+        $process = new Process(['php', '-r', 'fwrite(STDERR, "stream error"); exit(1);']);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Codex CLI process failed');
+
+        foreach ($rawResult->getDataStream() as $data) {
+        }
+    }
+
+    public function testGetObjectReturnsProcess()
+    {
+        $process = new Process(['php', '-r', 'echo "test";']);
+
+        $rawResult = new RawProcessResult($process);
+
+        $this->assertSame($process, $rawResult->getObject());
+    }
+}

--- a/src/platform/src/Bridge/Codex/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/ResultConverterTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\ClaudeCode\ClaudeCode;
+use Symfony\AI\Platform\Bridge\Codex\Codex;
+use Symfony\AI\Platform\Bridge\Codex\ResultConverter;
+use Symfony\AI\Platform\Bridge\Codex\TokenUsageExtractor;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResultConverterTest extends TestCase
+{
+    public function testSupportsCodex()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertTrue($converter->supports(new Codex('gpt-5-codex')));
+    }
+
+    public function testDoesNotSupportOtherModels()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertFalse($converter->supports(new ClaudeCode('sonnet')));
+    }
+
+    public function testConvertTextResult()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult([
+            'type' => 'item.completed',
+            'item' => ['type' => 'agent_message', 'text' => 'Hello, World!'],
+        ]);
+
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello, World!', $result->getContent());
+    }
+
+    public function testConvertThrowsOnEmptyData()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult([]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Codex CLI did not return any result.');
+
+        $converter->convert($rawResult);
+    }
+
+    public function testConvertThrowsOnErrorResult()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult([
+            'type' => 'error',
+            'message' => 'Something went wrong',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Codex CLI error: "Something went wrong"');
+
+        $converter->convert($rawResult);
+    }
+
+    public function testConvertThrowsOnMissingTextField()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult([
+            'type' => 'item.completed',
+            'item' => ['type' => 'agent_message'],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Codex CLI result does not contain a text field.');
+
+        $converter->convert($rawResult);
+    }
+
+    public function testConvertStreamingReturnsStreamResult()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'Hello']],
+                ['type' => 'turn.completed', 'usage' => ['input_tokens' => 10, 'output_tokens' => 5]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertSame(['Hello'], $chunks);
+    }
+
+    public function testConvertStreamingYieldsMultipleAgentMessages()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'First part.']],
+                ['type' => 'item.completed', 'item' => ['type' => 'command_execution', 'command' => 'ls']],
+                ['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'Second part.']],
+                ['type' => 'turn.completed', 'usage' => ['input_tokens' => 50, 'output_tokens' => 20]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertSame(['First part.', 'Second part.'], $chunks);
+    }
+
+    public function testConvertStreamingIgnoresNonAgentEvents()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['type' => 'thread.started', 'thread_id' => 'test-123'],
+                ['type' => 'turn.started'],
+                ['type' => 'item.started', 'item' => ['type' => 'command_execution', 'status' => 'in_progress']],
+                ['type' => 'item.completed', 'item' => ['type' => 'command_execution', 'command' => 'ls']],
+                ['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'Hello']],
+                ['type' => 'turn.completed', 'usage' => ['input_tokens' => 10, 'output_tokens' => 5]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertSame(['Hello'], $chunks);
+    }
+
+    public function testGetTokenUsageExtractor()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertInstanceOf(TokenUsageExtractor::class, $converter->getTokenUsageExtractor());
+    }
+}

--- a/src/platform/src/Bridge/Codex/Tests/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/TokenUsageExtractorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Codex\TokenUsageExtractor;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class TokenUsageExtractorTest extends TestCase
+{
+    public function testExtractReturnsTokenUsage()
+    {
+        $extractor = new TokenUsageExtractor();
+        $rawResult = new InMemoryRawResult([
+            'type' => 'item.completed',
+            'item' => ['type' => 'agent_message', 'text' => 'Hello'],
+            'usage' => [
+                'input_tokens' => 100,
+                'output_tokens' => 50,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($rawResult);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(100, $tokenUsage->getPromptTokens());
+        $this->assertSame(50, $tokenUsage->getCompletionTokens());
+        $this->assertNull($tokenUsage->getCachedTokens());
+    }
+
+    public function testExtractWithCachedTokens()
+    {
+        $extractor = new TokenUsageExtractor();
+        $rawResult = new InMemoryRawResult([
+            'type' => 'item.completed',
+            'item' => ['type' => 'agent_message', 'text' => 'Hello'],
+            'usage' => [
+                'input_tokens' => 100,
+                'output_tokens' => 50,
+                'cached_input_tokens' => 80,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($rawResult);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(100, $tokenUsage->getPromptTokens());
+        $this->assertSame(50, $tokenUsage->getCompletionTokens());
+        $this->assertSame(80, $tokenUsage->getCachedTokens());
+    }
+
+    public function testExtractReturnsNullForStreaming()
+    {
+        $extractor = new TokenUsageExtractor();
+        $rawResult = new InMemoryRawResult([
+            'type' => 'item.completed',
+            'usage' => ['input_tokens' => 100, 'output_tokens' => 50],
+        ]);
+
+        $this->assertNull($extractor->extract($rawResult, ['stream' => true]));
+    }
+
+    public function testExtractReturnsNullWhenNoUsageField()
+    {
+        $extractor = new TokenUsageExtractor();
+        $rawResult = new InMemoryRawResult([
+            'type' => 'item.completed',
+            'item' => ['type' => 'agent_message', 'text' => 'Hello'],
+        ]);
+
+        $this->assertNull($extractor->extract($rawResult));
+    }
+}

--- a/src/platform/src/Bridge/Codex/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/Codex/TokenUsageExtractor.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Codex;
+
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
+
+/**
+ * Extracts token usage information from Codex CLI results.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class TokenUsageExtractor implements TokenUsageExtractorInterface
+{
+    public function extract(RawResultInterface $rawResult, array $options = []): ?TokenUsageInterface
+    {
+        if ($options['stream'] ?? false) {
+            return null;
+        }
+
+        $content = $rawResult->getData();
+
+        if (!\array_key_exists('usage', $content)) {
+            return null;
+        }
+
+        $usage = $content['usage'];
+
+        return new TokenUsage(
+            promptTokens: $usage['input_tokens'] ?? null,
+            completionTokens: $usage['output_tokens'] ?? null,
+            cachedTokens: $usage['cached_input_tokens'] ?? null,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Codex/composer.json
+++ b/src/platform/src/Bridge/Codex/composer.json
@@ -1,0 +1,56 @@
+{
+    "name": "symfony/ai-codex-platform",
+    "description": "OpenAI Codex CLI platform bridge for Symfony AI",
+    "license": "MIT",
+    "type": "symfony-ai-platform",
+    "keywords": [
+        "ai",
+        "bridge",
+        "codex",
+        "openai",
+        "cli",
+        "platform"
+    ],
+    "authors": [
+        {
+            "name": "Johannes Wachter",
+            "email": "johannes@sulu.io"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/ai-platform": "^0.6",
+        "symfony/process": "^7.3|^8.0"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.5.53"
+    },
+    "minimum-stability": "dev",
+    "autoload": {
+        "psr-4": {
+            "Symfony\\AI\\Platform\\Bridge\\Codex\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\AI\\PHPStan\\": "../../../../../.phpstan/",
+            "Symfony\\AI\\Platform\\Bridge\\Codex\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ai",
+            "url": "https://github.com/symfony/ai"
+        }
+    }
+}

--- a/src/platform/src/Bridge/Codex/phpstan.dist.neon
+++ b/src/platform/src/Bridge/Codex/phpstan.dist.neon
@@ -1,0 +1,29 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../../../../../.phpstan/extension.neon
+
+parameters:
+    level: 6
+    paths:
+        - .
+        - Tests/
+    excludePaths:
+        - vendor/
+    treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+            reportUnmatched: false
+        -
+            message: '#^Call to( static)? method PHPUnit\\Framework\\Assert::.* will always evaluate to true\.$#'
+            reportUnmatched: false
+        -
+            identifier: 'symfonyAi.forbidNativeException'
+            path: Tests/*
+            reportUnmatched: false
+
+services:
+    - # Conditionally enabled by bleeding edge in phpstan/phpstan-phpunit 2.x
+        class: PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension
+        tags:
+            - phpstan.ignoreErrorExtension

--- a/src/platform/src/Bridge/Codex/phpunit.xml.dist
+++ b/src/platform/src/Bridge/Codex/phpunit.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         executionOrder="random"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony AI Codex Platform Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Adds a new platform bridge for OpenAI's Codex CLI (`src/platform/src/Bridge/Codex/`), following the same process-based architecture as the existing ClaudeCode bridge.

## Overview

The bridge spawns `codex exec --json` as a subprocess and parses the JSONL event stream (`item.completed`, `turn.completed`, `error`) to extract agent messages and token usage.

**Key adaptations for the Codex CLI:**
- Command structure: `codex --ask-for-approval never exec --json` (global flags before subcommand, prompt as positional argument)
- JSONL events instead of Claude's `stream_event`/`content_block_delta` format
- System prompt prepended to user prompt (Codex has no `--system-prompt` flag)
- Default `--sandbox read-only` for safe non-interactive execution
- Token usage from `turn.completed` events (`cached_input_tokens` instead of Claude's split cache fields)

**Models registered:** `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2-codex`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`

## Files

**Bridge** (`src/platform/src/Bridge/Codex/`):
- 10 production classes (Model, ModelClient, RawProcessResult, ResultConverter, TokenUsageExtractor, ModelCatalog, PlatformFactory, Contract, MessageBagNormalizer, CliNotFoundException)
- 7 test files (63 tests, 220 assertions)
- Scaffolding (composer.json, phpunit.xml.dist, phpstan.dist.neon, etc.)
- Monorepo integration (splitsh.json, deptrac.yaml)

**Examples** (`examples/codex/`):
- `chat.php` — basic chat invocation with token usage
- `stream.php` — streaming response
- `token-metadata.php` — token usage metadata
- `code-generation.php` — prompts Codex to generate and execute a PHP file

## Usage

```php
use Symfony\AI\Platform\Bridge\Codex\PlatformFactory;

$platform = PlatformFactory::create(workingDirectory: '/path/to/project');

$result = $platform->invoke('gpt-5-codex', 'Explain the architecture of this project');
echo $result->asText();
```