### PR TITLE
[Platform][Ollama] Fix streaming by handling NDJSON instead of SSE

### DIFF
--- a/src/platform/src/Bridge/Ollama/OllamaClient.php
+++ b/src/platform/src/Bridge/Ollama/OllamaClient.php
@@ -16,6 +16,8 @@ use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\Stream\NdjsonStream;
 use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -79,10 +81,12 @@ final class OllamaClient implements ModelClientInterface
 
         $options = $this->normalizeOllamaOptions($options, self::CHAT_TOP_LEVEL_KEYS);
 
-        return new RawHttpResult($this->httpClient->request('POST', '/api/chat', [
+        $response = $this->httpClient->request('POST', '/api/chat', [
             'headers' => ['Content-Type' => 'application/json'],
             'json' => array_merge($options, $payload),
-        ]));
+        ]);
+
+        return new RawHttpResult($response, new NdjsonStream());
     }
 
     /**

--- a/src/platform/src/Bridge/Ollama/Tests/OllamaClientTest.php
+++ b/src/platform/src/Bridge/Ollama/Tests/OllamaClientTest.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\Bridge\Ollama\PlatformFactory;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\NdjsonStream;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -96,18 +97,16 @@ final class OllamaClientTest extends TestCase
             new JsonMockResponse([
                 'capabilities' => ['completion'],
             ]),
-            new MockResponse('data: '.json_encode([
-                'model' => 'llama3.2',
-                'created_at' => '2025-08-23T10:00:00Z',
-                'message' => ['role' => 'assistant', 'content' => 'Hello world'],
-                'done' => true,
-                'prompt_eval_count' => 10,
-                'eval_count' => 10,
-            ])."\n\n", [
-                'response_headers' => [
-                    'content-type' => 'text/event-stream',
-                ],
-            ]),
+            new MockResponse(
+                json_encode([
+                    'model' => 'llama3.2',
+                    'created_at' => '2025-08-23T10:00:00Z',
+                    'message' => ['role' => 'assistant', 'content' => 'Hello world'],
+                    'done' => true,
+                    'prompt_eval_count' => 10,
+                    'eval_count' => 10,
+                ])."\n",
+            ),
         ], 'http://127.0.0.1:1234');
 
         $platform = PlatformFactory::create('http://127.0.0.1:1234', httpClient: $httpClient);
@@ -132,29 +131,25 @@ final class OllamaClientTest extends TestCase
 
     public function testStreamingConverterWithDirectResponse()
     {
-        $streamingData = 'data: '.json_encode([
+        $streamingData = json_encode([
             'model' => 'llama3.2',
             'created_at' => '2025-08-23T10:00:00Z',
             'message' => ['role' => 'assistant', 'content' => 'Hello'],
             'done' => false,
-        ])."\n\n".
-        'data: '.json_encode([
+        ])."\n".
+        json_encode([
             'model' => 'llama3.2',
             'created_at' => '2025-08-23T10:00:01Z',
             'message' => ['role' => 'assistant', 'content' => ' world'],
             'done' => true,
-        ])."\n\n";
+        ])."\n";
 
         $mockHttpClient = new MockHttpClient([
-            new MockResponse($streamingData, [
-                'response_headers' => [
-                    'content-type' => 'text/event-stream',
-                ],
-            ]),
+            new MockResponse($streamingData),
         ]);
 
         $mockResponse = $mockHttpClient->request('GET', 'http://test.example');
-        $rawResult = new RawHttpResult($mockResponse);
+        $rawResult = new RawHttpResult($mockResponse, new NdjsonStream($mockHttpClient));
         $converter = new OllamaResultConverter();
 
         $result = $converter->convert($rawResult, ['stream' => true]);
@@ -171,7 +166,7 @@ final class OllamaClientTest extends TestCase
         ]);
 
         $regularMockResponse = $regularMockHttpClient->request('GET', 'http://test.example');
-        $regularRawResult = new RawHttpResult($regularMockResponse);
+        $regularRawResult = new RawHttpResult($regularMockResponse, new NdjsonStream($regularMockHttpClient));
         $regularResult = $converter->convert($regularRawResult, ['stream' => false]);
 
         $this->assertNotInstanceOf(StreamResult::class, $regularResult);

--- a/src/platform/src/Result/RawHttpResult.php
+++ b/src/platform/src/Result/RawHttpResult.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\AI\Platform\Result;
 
-use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
-use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\AI\Platform\Result\Stream\HttpStreamInterface;
+use Symfony\AI\Platform\Result\Stream\SseStream;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -22,6 +22,7 @@ final class RawHttpResult implements RawResultInterface
 {
     public function __construct(
         private readonly ResponseInterface $response,
+        private readonly HttpStreamInterface $httpStream = new SseStream(),
     ) {
     }
 
@@ -32,33 +33,7 @@ final class RawHttpResult implements RawResultInterface
 
     public function getDataStream(): iterable
     {
-        foreach ((new EventSourceHttpClient())->stream($this->response) as $chunk) {
-            if ($chunk->isFirst() || $chunk->isLast() || ($chunk instanceof ServerSentEvent && '[DONE]' === $chunk->getData())) {
-                continue;
-            }
-
-            $jsonDelta = $chunk instanceof ServerSentEvent ? $chunk->getData() : $chunk->getContent();
-
-            // Remove leading/trailing brackets
-            if (str_starts_with($jsonDelta, '[') || str_starts_with($jsonDelta, ',')) {
-                $jsonDelta = substr($jsonDelta, 1);
-            }
-            if (str_ends_with($jsonDelta, ']')) {
-                $jsonDelta = substr($jsonDelta, 0, -1);
-            }
-
-            // Split in case of multiple JSON objects
-            $deltas = explode(",\r\n", $jsonDelta);
-
-            foreach ($deltas as $delta) {
-                // lines starting with a colon identify as comment
-                if ('' === trim($delta) || str_starts_with($delta, ':')) {
-                    continue;
-                }
-
-                yield json_decode($delta, true, flags: \JSON_THROW_ON_ERROR);
-            }
-        }
+        return $this->httpStream->stream($this->response);
     }
 
     public function getObject(): ResponseInterface

--- a/src/platform/src/Result/Stream/HttpStreamInterface.php
+++ b/src/platform/src/Result/Stream/HttpStreamInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Stream;
+
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Interface for streaming HTTP responses.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+interface HttpStreamInterface
+{
+    /**
+     * Streams and decodes the HTTP response.
+     *
+     * @return iterable<mixed>
+     */
+    public function stream(ResponseInterface $response): iterable;
+}

--- a/src/platform/src/Result/Stream/NdjsonStream.php
+++ b/src/platform/src/Result/Stream/NdjsonStream.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Stream;
+
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Handles NDJSON (Newline Delimited JSON) streaming responses.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class NdjsonStream implements HttpStreamInterface
+{
+    public function stream(ResponseInterface $response): iterable
+    {
+        $buffer = '';
+
+        foreach ((new EventSourceHttpClient())->stream($response) as $chunk) {
+            if ($chunk->isFirst() || $chunk->isLast()) {
+                continue;
+            }
+
+            $buffer .= $chunk->getContent();
+
+            while (false !== ($pos = strpos($buffer, "\n"))) {
+                $line = substr($buffer, 0, $pos);
+                $buffer = substr($buffer, $pos + 1);
+                $line = trim($line);
+
+                if ('' === $line) {
+                    continue;
+                }
+
+                yield json_decode($line, true, flags: \JSON_THROW_ON_ERROR);
+            }
+        }
+
+        $buffer = trim($buffer);
+
+        if ('' !== $buffer) {
+            yield json_decode($buffer, true, flags: \JSON_THROW_ON_ERROR);
+        }
+    }
+}

--- a/src/platform/src/Result/Stream/SseStream.php
+++ b/src/platform/src/Result/Stream/SseStream.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Stream;
+
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Handles SSE (Server-Sent Events) streaming responses.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SseStream implements HttpStreamInterface
+{
+    public function stream(ResponseInterface $response): iterable
+    {
+        $buffer = '';
+
+        foreach ((new EventSourceHttpClient())->stream($response) as $chunk) {
+            if ($chunk->isFirst() || $chunk->isLast()) {
+                continue;
+            }
+
+            $buffer .= $chunk->getContent();
+
+            while (false !== ($pos = strpos($buffer, "\n\n"))) {
+                $event = substr($buffer, 0, $pos);
+                $buffer = substr($buffer, $pos + 2);
+
+                $data = null;
+                foreach (explode("\n", $event) as $line) {
+                    // Comments start with ":"
+                    if ('' === $line || str_starts_with($line, ':')) {
+                        continue;
+                    }
+
+                    if (str_starts_with($line, 'data: ')) {
+                        $data = substr($line, 6);
+                    }
+                }
+
+                if (null === $data || '[DONE]' === $data) {
+                    continue;
+                }
+
+                // Remove leading/trailing brackets
+                if (str_starts_with($data, '[') || str_starts_with($data, ',')) {
+                    $data = substr($data, 1);
+                }
+                if (str_ends_with($data, ']')) {
+                    $data = substr($data, 0, -1);
+                }
+
+                // Split in case of multiple JSON objects
+                $deltas = explode(",\r\n", $data);
+
+                foreach ($deltas as $delta) {
+                    if ('' === trim($delta)) {
+                        continue;
+                    }
+
+                    yield json_decode($delta, true, flags: \JSON_THROW_ON_ERROR);
+                }
+            }
+        }
+    }
+}

--- a/src/platform/tests/Result/RawHttpResultTest.php
+++ b/src/platform/tests/Result/RawHttpResultTest.php
@@ -13,7 +13,7 @@ namespace Symfony\AI\Platform\Tests\Result;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Result\RawHttpResult;
-use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\AI\Platform\Result\Stream\SseStream;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -87,10 +87,9 @@ final class RawHttpResultTest extends TestCase
         $response = new MockResponse(': OPENROUTER PROCESSING, data: {"foo": "bar"}');
 
         $httpClient = new MockHttpClient($response);
-        $client = new EventSourceHttpClient($httpClient);
-        $actualResponse = $client->request('GET', 'https://example.com');
+        $actualResponse = $httpClient->request('GET', 'https://example.com');
 
-        $rawResult = new RawHttpResult($actualResponse);
+        $rawResult = new RawHttpResult($actualResponse, new SseStream($httpClient));
 
         $results = iterator_to_array($rawResult->getDataStream());
 

--- a/src/platform/tests/Result/Stream/NdjsonStreamTest.php
+++ b/src/platform/tests/Result/Stream/NdjsonStreamTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result\Stream;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\Stream\NdjsonStream;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class NdjsonStreamTest extends TestCase
+{
+    public function testStreamWithSingleLine()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse(json_encode(['message' => 'hello', 'done' => true])."\n"),
+        ]);
+        $response = $httpClient->request('GET', 'https://example.com');
+
+        $stream = new NdjsonStream($httpClient);
+        $results = iterator_to_array($stream->stream($response));
+
+        $this->assertCount(1, $results);
+        $this->assertSame(['message' => 'hello', 'done' => true], $results[0]);
+    }
+
+    public function testStreamWithMultipleLines()
+    {
+        $ndjson = json_encode(['model' => 'llama3.2', 'message' => ['content' => 'Hello'], 'done' => false])."\n"
+            .json_encode(['model' => 'llama3.2', 'message' => ['content' => ' world'], 'done' => false])."\n"
+            .json_encode(['model' => 'llama3.2', 'message' => ['content' => ''], 'done' => true])."\n";
+
+        $httpClient = new MockHttpClient([
+            new MockResponse($ndjson),
+        ]);
+        $response = $httpClient->request('GET', 'https://example.com');
+
+        $stream = new NdjsonStream($httpClient);
+        $results = iterator_to_array($stream->stream($response));
+
+        $this->assertCount(3, $results);
+        $this->assertSame('Hello', $results[0]['message']['content']);
+        $this->assertFalse($results[0]['done']);
+        $this->assertSame(' world', $results[1]['message']['content']);
+        $this->assertFalse($results[1]['done']);
+        $this->assertSame('', $results[2]['message']['content']);
+        $this->assertTrue($results[2]['done']);
+    }
+
+    public function testStreamHandlesChunkBoundaryMidObject()
+    {
+        $line1 = json_encode(['model' => 'llama3.2', 'message' => ['content' => 'Hello'], 'done' => false]);
+        $line2 = json_encode(['model' => 'llama3.2', 'message' => ['content' => ' world'], 'done' => true]);
+
+        $splitPoint = (int) (\strlen($line1) / 2);
+        $chunk1 = substr($line1, 0, $splitPoint);
+        $chunk2 = substr($line1, $splitPoint)."\n".$line2."\n";
+
+        $httpClient = new MockHttpClient([
+            new MockResponse([$chunk1, $chunk2]),
+        ]);
+        $response = $httpClient->request('GET', 'https://example.com');
+
+        $stream = new NdjsonStream($httpClient);
+        $results = iterator_to_array($stream->stream($response));
+
+        $this->assertCount(2, $results);
+        $this->assertSame('Hello', $results[0]['message']['content']);
+        $this->assertFalse($results[0]['done']);
+        $this->assertSame(' world', $results[1]['message']['content']);
+        $this->assertTrue($results[1]['done']);
+    }
+
+    public function testStreamIgnoresEmptyLines()
+    {
+        $ndjson = json_encode(['done' => false])."\n\n\n".json_encode(['done' => true])."\n";
+
+        $httpClient = new MockHttpClient([
+            new MockResponse($ndjson),
+        ]);
+        $response = $httpClient->request('GET', 'https://example.com');
+
+        $stream = new NdjsonStream($httpClient);
+        $results = iterator_to_array($stream->stream($response));
+
+        $this->assertCount(2, $results);
+        $this->assertFalse($results[0]['done']);
+        $this->assertTrue($results[1]['done']);
+    }
+
+    public function testStreamHandlesLastLineWithoutTrailingNewline()
+    {
+        $ndjson = json_encode(['message' => 'hello', 'done' => true]);
+
+        $httpClient = new MockHttpClient([
+            new MockResponse($ndjson),
+        ]);
+        $response = $httpClient->request('GET', 'https://example.com');
+
+        $stream = new NdjsonStream($httpClient);
+        $results = iterator_to_array($stream->stream($response));
+
+        $this->assertCount(1, $results);
+        $this->assertSame('hello', $results[0]['message']);
+    }
+}

--- a/src/platform/tests/Result/Stream/SseStreamTest.php
+++ b/src/platform/tests/Result/Stream/SseStreamTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result\Stream;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\Stream\SseStream;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class SseStreamTest extends TestCase
+{
+    public function testStream()
+    {
+        $sse = "data: {\"foo\": \"bar\"}\n\n";
+        $response = new MockResponse($sse);
+        $httpClient = new MockHttpClient([$response]);
+        $actualResponse = $httpClient->request('GET', 'https://example.com');
+
+        $stream = new SseStream($httpClient);
+        $results = iterator_to_array($stream->stream($actualResponse));
+
+        $this->assertCount(1, $results);
+        $this->assertSame(['foo' => 'bar'], $results[0]);
+    }
+
+    public function testStreamHandlesDoneEvent()
+    {
+        $sse = "data: {\"foo\": \"bar\"}\n\ndata: [DONE]\n\n";
+        $response = new MockResponse($sse);
+        $httpClient = new MockHttpClient([$response]);
+        $actualResponse = $httpClient->request('GET', 'https://example.com');
+
+        $stream = new SseStream($httpClient);
+        $results = iterator_to_array($stream->stream($actualResponse));
+
+        $this->assertCount(1, $results);
+        $this->assertSame(['foo' => 'bar'], $results[0]);
+    }
+
+    public function testStreamHandlesEmptyColonInResponseAsCommentAndIgnore()
+    {
+        $sse = ": OPENROUTER PROCESSING\n\ndata: {\"foo\": \"bar\"}\n\n";
+        $response = new MockResponse($sse);
+        $httpClient = new MockHttpClient([$response]);
+        $actualResponse = $httpClient->request('GET', 'https://example.com');
+
+        $stream = new SseStream($httpClient);
+        $results = iterator_to_array($stream->stream($actualResponse));
+
+        $this->assertCount(1, $results);
+        $this->assertSame(['foo' => 'bar'], $results[0]);
+    }
+
+    public function testStreamHandlesBracketsAndCommas()
+    {
+        $sse = "data: [{\"foo\": \"bar\"}]\n\ndata: ,{\"baz\": \"qux\"}\n\n";
+        $response = new MockResponse($sse);
+        $httpClient = new MockHttpClient([$response]);
+        $actualResponse = $httpClient->request('GET', 'https://example.com');
+
+        $stream = new SseStream($httpClient);
+        $results = iterator_to_array($stream->stream($actualResponse));
+
+        $this->assertCount(2, $results);
+        $this->assertSame(['foo' => 'bar'], $results[0]);
+        $this->assertSame(['baz' => 'qux'], $results[1]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        |
| License       | MIT

Ollama's `/api/chat` with `stream: true` returns NDJSON (newline-delimited JSON) — one complete JSON object per line:

```
{"model":"llama3.2","message":{"role":"assistant","content":"Hello"},"done":false}\n
{"model":"llama3.2","message":{"role":"assistant","content":" world"},"done":true}\n
```

But `RawHttpResult::getDataStream()` wraps the response in `EventSourceHttpClient::stream()`, which expects SSE format (`data: {...}\n\n`). Since Ollama doesn't send SSE, chunks arrive as raw `ChunkInterface` (not `ServerSentEvent`), so `$chunk->getContent()` returns raw bytes that may contain multiple JSON objects concatenated or a JSON object split mid-object across chunk boundaries. The subsequent `json_decode()` then throws `JsonException: Syntax error`.

**Fix:**

- Add `NdjsonHttpResult` implementing `RawResultInterface` that uses `HttpClientInterface::stream()` directly (no SSE wrapper), buffers incoming bytes, and splits on `\n` boundaries before JSON-decoding — correctly handling chunk boundaries that fall mid-object.
- Update `OllamaClient` to use `NdjsonHttpResult` for chat completion requests.
- Update existing streaming tests to use NDJSON format and add dedicated `NdjsonHttpResultTest` covering single/multi-line streams, chunk boundary splits, empty lines, and missing trailing newlines.