### PR TITLE
[Store] Implement ManagedStoreInterface in TraceableStore

### DIFF
--- a/src/ai-bundle/src/Profiler/TraceableStore.php
+++ b/src/ai-bundle/src/Profiler/TraceableStore.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\AiBundle\Profiler;
 
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\Query\QueryInterface;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\Component\Clock\ClockInterface;
@@ -30,7 +31,7 @@ use Symfony\Contracts\Service\ResetInterface;
  *     called_at: \DateTimeImmutable,
  * }
  */
-final class TraceableStore implements StoreInterface, ResetInterface
+final class TraceableStore implements StoreInterface, ManagedStoreInterface, ResetInterface
 {
     /**
      * @var StoreData[]
@@ -41,6 +42,13 @@ final class TraceableStore implements StoreInterface, ResetInterface
         private readonly StoreInterface $store,
         private readonly ClockInterface $clock = new MonotonicClock(),
     ) {
+    }
+
+    public function setup(array $options = []): void
+    {
+        if ($this->store instanceof ManagedStoreInterface) {
+            $this->store->setup($options);
+        }
     }
 
     public function add(VectorDocument|array $documents): void
@@ -81,6 +89,13 @@ final class TraceableStore implements StoreInterface, ResetInterface
     public function supports(string $queryClass): bool
     {
         return $this->store->supports($queryClass);
+    }
+
+    public function drop(array $options = []): void
+    {
+        if ($this->store instanceof ManagedStoreInterface) {
+            $this->store->drop($options);
+        }
     }
 
     public function reset(): void

--- a/src/ai-bundle/tests/Profiler/TraceableStoreTest.php
+++ b/src/ai-bundle/tests/Profiler/TraceableStoreTest.php
@@ -16,7 +16,10 @@ use Symfony\AI\AiBundle\Profiler\TraceableStore;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\InMemory\Store;
+use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\QueryInterface;
 use Symfony\AI\Store\Query\VectorQuery;
+use Symfony\AI\Store\StoreInterface;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Uid\Uuid;
 
@@ -79,5 +82,115 @@ final class TraceableStoreTest extends TestCase
                 'called_at' => $clock->now(),
             ],
         ], $traceableStore->calls);
+    }
+
+    public function testSetupDelegatesToManagedStore()
+    {
+        $innerStore = new class implements StoreInterface, ManagedStoreInterface {
+            public bool $setupCalled = false;
+            /** @var array<mixed> */
+            public array $setupOptions = [];
+
+            public function setup(array $options = []): void
+            {
+                $this->setupCalled = true;
+                $this->setupOptions = $options;
+            }
+
+            public function drop(array $options = []): void
+            {
+            }
+
+            public function add(VectorDocument|array $documents): void
+            {
+            }
+
+            public function query(QueryInterface $query, array $options = []): iterable
+            {
+                return [];
+            }
+
+            public function remove(array|string $ids, array $options = []): void
+            {
+            }
+
+            public function supports(string $queryClass): bool
+            {
+                return false;
+            }
+        };
+
+        $traceableStore = new TraceableStore($innerStore);
+
+        $traceableStore->setup(['foo' => 'bar']);
+
+        $this->assertTrue($innerStore->setupCalled);
+        $this->assertSame(['foo' => 'bar'], $innerStore->setupOptions);
+    }
+
+    public function testSetupDoesNothingWhenInnerStoreIsNotManaged()
+    {
+        $innerStore = $this->createMock(StoreInterface::class);
+
+        $traceableStore = new TraceableStore($innerStore);
+
+        $traceableStore->setup();
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testDropDelegatesToManagedStore()
+    {
+        $innerStore = new class implements StoreInterface, ManagedStoreInterface {
+            public bool $dropCalled = false;
+            /** @var array<mixed> */
+            public array $dropOptions = [];
+
+            public function setup(array $options = []): void
+            {
+            }
+
+            public function drop(array $options = []): void
+            {
+                $this->dropCalled = true;
+                $this->dropOptions = $options;
+            }
+
+            public function add(VectorDocument|array $documents): void
+            {
+            }
+
+            public function query(QueryInterface $query, array $options = []): iterable
+            {
+                return [];
+            }
+
+            public function remove(array|string $ids, array $options = []): void
+            {
+            }
+
+            public function supports(string $queryClass): bool
+            {
+                return false;
+            }
+        };
+
+        $traceableStore = new TraceableStore($innerStore);
+
+        $traceableStore->drop(['foo' => 'bar']);
+
+        $this->assertTrue($innerStore->dropCalled);
+        $this->assertSame(['foo' => 'bar'], $innerStore->dropOptions);
+    }
+
+    public function testDropDoesNothingWhenInnerStoreIsNotManaged()
+    {
+        $innerStore = $this->createMock(StoreInterface::class);
+
+        $traceableStore = new TraceableStore($innerStore);
+
+        $traceableStore->drop();
+
+        $this->addToAssertionCount(1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        |
| License       | MIT

In dev mode, all stores are wrapped in `TraceableStore`, which only implements `StoreInterface`. The `ai:store:setup` and `ai:store:drop` commands check for `ManagedStoreInterface`, so they fail with:

> The "ai.store.sqlite.memory_store" store does not support setup.

This works fine in prod where `TraceableStore` is not used.

`TraceableStore` now implements `ManagedStoreInterface` and conditionally delegates `setup()` and `drop()` to the inner store when it supports it. If the inner store does not implement `ManagedStoreInterface`, the methods are no-ops.