### PR TITLE
[Mate][Symfony] Return raw collector data when no formatter is registered

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.7
 ---
 
+ * Add raw data fallback for profiler collectors without a registered formatter
  * Add Codex wrapper generation (`bin/codex`, `bin/codex.bat`) to `mate init`
  * Add AGENT instruction artifact materialization to `mate discover` (`mate/AGENT_INSTRUCTIONS.md` and managed `AGENTS.md` block)
  * Merge `php-version`, `operating-system`, `operating-system-family`, and `php-extensions` tools into a single `server-info` tool

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/ProfilerDataProvider.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/ProfilerDataProvider.php
@@ -15,7 +15,10 @@ use Symfony\AI\Mate\Bridge\Symfony\Profiler\Exception\InvalidCollectorException;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Exception\ProfileNotFoundException;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Model\ProfileData;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Model\ProfileIndex;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * Reads and parses profiler data files.
@@ -176,7 +179,7 @@ final class ProfilerDataProvider
         if (null === $formatter) {
             return [
                 'name' => $collectorName,
-                'data' => [],
+                'data' => ['raw' => $this->extractRawData($collectorData)],
                 'summary' => [],
             ];
         }
@@ -212,6 +215,50 @@ final class ProfilerDataProvider
         $profiles = $this->readIndex(1);
 
         return $profiles[0] ?? null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function extractRawData(DataCollectorInterface $collector): array
+    {
+        if (!$collector instanceof DataCollector) {
+            return [];
+        }
+
+        $class = new \ReflectionClass(DataCollector::class);
+        $property = $class->getProperty('data');
+        $data = $property->getValue($collector);
+
+        if ($data instanceof Data) {
+            $raw = $data->getValue(true);
+
+            return \is_array($raw) ? $raw : [];
+        }
+
+        if (\is_array($data)) {
+            return $this->convertDataObjects($data);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    private function convertDataObjects(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if ($value instanceof Data) {
+                $data[$key] = $value->getValue(true);
+            } elseif (\is_array($value)) {
+                $data[$key] = $this->convertDataObjects($value);
+            }
+        }
+
+        return $data;
     }
 
     /**

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/ProfilerDataProviderTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/ProfilerDataProviderTest.php
@@ -142,7 +142,7 @@ final class ProfilerDataProviderTest extends TestCase
         $this->provider->getCollectorData('abc123', 'nonexistent');
     }
 
-    public function testGetCollectorDataReturnsFormattedData()
+    public function testGetCollectorDataReturnsRawDataWithoutFormatter()
     {
         $data = $this->provider->getCollectorData('abc123', 'request');
 
@@ -151,6 +151,10 @@ final class ProfilerDataProviderTest extends TestCase
         $this->assertArrayHasKey('data', $data);
         $this->assertArrayHasKey('summary', $data);
         $this->assertSame('request', $data['name']);
+        $this->assertSame([], $data['summary']);
+        $this->assertArrayHasKey('raw', $data['data']);
+        $this->assertSame('GET', $data['data']['raw']['method']);
+        $this->assertSame('/api/users', $data['data']['raw']['path']);
     }
 
     public function testListAvailableCollectorsThrowsExceptionForNonExistentProfile()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1441
| License       | MIT

When a profiler collector has no registered `CollectorFormatterInterface`, the `ProfilerDataProvider` previously returned empty `data` and `summary` arrays. This made collectors like `time`, `memory`, `logger`, `router`, `cache`, `twig`, `http_client`, and others return useless empty responses to AI assistants.

This PR extracts the raw data from the collector via reflection as a fallback, handling both VarDumper `Data` objects and plain arrays. The raw data is returned under a `['raw' => ...]` key to clearly indicate it's unformatted.