### PR TITLE
[MCP Bundle] Add PSR-15 middleware registration via service tag

### DIFF
--- a/src/mcp-bundle/src/Controller/McpController.php
+++ b/src/mcp-bundle/src/Controller/McpController.php
@@ -15,20 +15,27 @@ use Mcp\Server;
 use Mcp\Server\Transport\StreamableHttpTransport;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 final class McpController
 {
+    /**
+     * @param iterable<MiddlewareInterface> $middleware
+     */
     public function __construct(
         private readonly Server $server,
         private readonly HttpMessageFactoryInterface $httpMessageFactory,
         private readonly HttpFoundationFactoryInterface $httpFoundationFactory,
         private readonly ResponseFactoryInterface $responseFactory,
         private readonly StreamFactoryInterface $streamFactory,
+        #[AutowireIterator('mcp.middleware')]
+        private readonly iterable $middleware = [],
         private readonly ?LoggerInterface $logger = null,
     ) {
     }
@@ -40,6 +47,7 @@ final class McpController
             $this->responseFactory,
             $this->streamFactory,
             logger: $this->logger,
+            middleware: $this->middleware,
         );
 
         $psrResponse = $this->server->run($transport);

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -22,6 +22,7 @@ use Mcp\Server\Handler\Request\RequestHandlerInterface;
 use Mcp\Server\Session\FileSessionStore;
 use Mcp\Server\Session\InMemorySessionStore;
 use Mcp\Server\Session\Psr16SessionStore;
+use Psr\Http\Server\MiddlewareInterface;
 use Symfony\AI\McpBundle\Command\McpCommand;
 use Symfony\AI\McpBundle\Controller\McpController;
 use Symfony\AI\McpBundle\DependencyInjection\McpPass;
@@ -32,6 +33,7 @@ use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -73,6 +75,9 @@ final class McpBundle extends AbstractBundle
 
         $builder->registerForAutoconfiguration(NotificationHandlerInterface::class)
             ->addTag('mcp.notification_handler');
+
+        $builder->registerForAutoconfiguration(MiddlewareInterface::class)
+            ->addTag('mcp.middleware');
 
         if ($builder->getParameter('kernel.debug')) {
             $traceableRegistry = (new Definition('mcp.traceable_registry'))
@@ -161,6 +166,7 @@ final class McpBundle extends AbstractBundle
                     new Reference('mcp.http_foundation_factory'),
                     new Reference('mcp.psr17_factory'),
                     new Reference('mcp.psr17_factory'),
+                    new TaggedIteratorArgument('mcp.middleware'),
                     new Reference('logger'),
                 ])
                 ->setPublic(true)

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -23,6 +23,7 @@ use Mcp\Server\Session\InMemorySessionStore;
 use Mcp\Server\Session\Psr16SessionStore;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\MiddlewareInterface;
 use Symfony\AI\McpBundle\McpBundle;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -510,6 +511,33 @@ class McpBundleTest extends TestCase
         $this->assertArrayHasKey(NotificationHandlerInterface::class, $autoconfigured);
         $definition = $autoconfigured[NotificationHandlerInterface::class];
         $this->assertTrue($definition->hasTag('mcp.notification_handler'));
+    }
+
+    public function testMiddlewareInterfaceAutoconfiguration()
+    {
+        $container = $this->buildContainer([]);
+        $autoconfigured = $container->getAutoconfiguredInstanceof();
+        $this->assertArrayHasKey(MiddlewareInterface::class, $autoconfigured);
+        $definition = $autoconfigured[MiddlewareInterface::class];
+        $this->assertTrue($definition->hasTag('mcp.middleware'));
+    }
+
+    public function testMiddlewareInjectedIntoController()
+    {
+        $container = $this->buildContainer([
+            'mcp' => [
+                'client_transports' => [
+                    'http' => true,
+                ],
+            ],
+        ]);
+
+        $controllerDefinition = $container->getDefinition('mcp.server.controller');
+        $arguments = $controllerDefinition->getArguments();
+
+        $middlewareArgument = $arguments[5];
+        $this->assertInstanceOf(TaggedIteratorArgument::class, $middlewareArgument);
+        $this->assertSame('mcp.middleware', $middlewareArgument->getTag());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| License       | MIT

## Summary

Add support for PSR-15 middleware in the MCP HTTP transport pipeline.

- Autoconfigure `MiddlewareInterface` implementations with `mcp.middleware` tag
- Inject tagged middleware into `McpController` via `TaggedIteratorArgument`
- Pass middleware to `StreamableHttpTransport`
- Execution order controlled via standard Symfony tag priorities

This is extracted from #1791 as requested by @chr-hertel to reduce scope. It provides the middleware registration mechanism only — no security, OAuth, or session changes.

### Usage

Any service implementing `Psr\Http\Server\MiddlewareInterface` is auto-discovered and injected into the HTTP transport:

```php
use Psr\Http\Server\MiddlewareInterface;

class RateLimitMiddleware implements MiddlewareInterface
{
    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
    {
        // pre-processing
        return $handler->handle($request);
    }
}
```

For explicit priority control:

```yaml
services:
    App\Middleware\RateLimitMiddleware:
        tags:
            - { name: 'mcp.middleware', priority: 50 }
```

### Tests

- `testMiddlewareInterfaceAutoconfiguration`: verifies `MiddlewareInterface` is autoconfigured with `mcp.middleware` tag
- `testMiddlewareInjectedIntoController`: verifies `TaggedIteratorArgument('mcp.middleware')` is passed to the controller

### Tested in

Tested in a real Symfony application with the MCP SDK's OAuth middleware stack registered via service tags — works as expected.