### PR TITLE
[MCP Bundle] Add framework session store backed by SessionHandlerInterface

### DIFF
--- a/docs/bundles/mcp-bundle.rst
+++ b/docs/bundles/mcp-bundle.rst
@@ -160,14 +160,14 @@ The MCP Bundle supports two transport types for server communication:
 The HTTP transport uses the MCP SDK's ``StreamableHttpTransport`` which supports:
 
 - JSON-RPC 2.0 over HTTP POST requests
-- Session management with configurable storage (file/memory/cache)
+- Session management with configurable storage (file/memory/cache/framework)
 - CORS headers for cross-origin requests
 - Proper MCP initialization handshake
 
 Session Storage
 ...............
 
-The MCP Bundle supports three types of session storage for the HTTP transport:
+The MCP Bundle supports four types of session storage for the HTTP transport:
 
 **File Storage** (default) - Stores sessions on the filesystem:
 
@@ -224,6 +224,19 @@ To use a custom cache backend, you need to configure a PSR-16 cache service in y
 This allows you to store sessions in Redis, a SQL database via Doctrine, or any other PSR-6 cache adapter.
 See the `Symfony Cache documentation`_ for more details on configuring cache pools.
 
+**Framework Storage** - Uses Symfony's ``SessionHandlerInterface`` for session persistence::
+
+    mcp:
+        http:
+            session:
+                store: framework
+                prefix: 'mcp-' # Optional prefix for session keys
+                ttl: 3600
+
+This wraps the configured Symfony session handler (e.g. Redis, database, filesystem — whatever
+your application uses for HTTP sessions) with a JSON envelope for application-level TTL.
+Expired sessions are cleaned up lazily on read.
+
 Act as Client
 ~~~~~~~~~~~~~
 
@@ -274,7 +287,7 @@ Configuration
         http:
             path: /_mcp # HTTP endpoint path (default: /_mcp)
             session:
-                store: file # Session store type: 'file', 'memory', or 'cache' (default: file)
+                store: file # Session store type: 'file', 'memory', 'cache', or 'framework' (default: file)
                 directory: '%kernel.cache_dir%/mcp-sessions' # Directory for file store (default: cache_dir/mcp-sessions)
                 cache_pool: 'cache.mcp.sessions' # Cache pool service for cache store (default: cache.mcp.sessions)
                 prefix: 'mcp-' # Prefix for cache keys (default: 'mcp-')

--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.8
+---
+
+ * Add `framework` session store backed by Symfony's `SessionHandlerInterface`
+
 0.4
 ---
 

--- a/src/mcp-bundle/config/options.php
+++ b/src/mcp-bundle/config/options.php
@@ -58,7 +58,7 @@ return static function (DefinitionConfigurator $configurator): void {
                     ->arrayNode('session')
                         ->addDefaultsIfNotSet()
                         ->children()
-                            ->enumNode('store')->values(['file', 'memory', 'cache'])->defaultValue('file')->end()
+                            ->enumNode('store')->values(['file', 'memory', 'cache', 'framework'])->defaultValue('file')->end()
                             ->scalarNode('directory')->defaultValue('%kernel.cache_dir%/mcp-sessions')->end()
                             ->scalarNode('cache_pool')->defaultValue('cache.mcp.sessions')->end()
                             ->scalarNode('prefix')->defaultValue('mcp-')->end()

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -28,6 +28,7 @@ use Symfony\AI\McpBundle\DependencyInjection\McpPass;
 use Symfony\AI\McpBundle\Profiler\DataCollector;
 use Symfony\AI\McpBundle\Profiler\TraceableRegistry;
 use Symfony\AI\McpBundle\Routing\RouteLoader;
+use Symfony\AI\McpBundle\Session\FrameworkSessionStore;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\Cache\Psr16Cache;
@@ -196,6 +197,13 @@ final class McpBundle extends AbstractBundle
             $container->register('mcp.session.store', Psr16SessionStore::class)
                 ->setArguments([
                     new Reference($sessionConfig['cache_pool']),
+                    $sessionConfig['prefix'],
+                    $sessionConfig['ttl'],
+                ]);
+        } elseif ('framework' === $sessionConfig['store']) {
+            $container->register('mcp.session.store', FrameworkSessionStore::class)
+                ->setArguments([
+                    new Reference('session.handler'),
                     $sessionConfig['prefix'],
                     $sessionConfig['ttl'],
                 ]);

--- a/src/mcp-bundle/src/Session/FrameworkSessionStore.php
+++ b/src/mcp-bundle/src/Session/FrameworkSessionStore.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Session;
+
+use Mcp\Server\Session\SessionStoreInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Simon Chrzanowski
+ */
+final class FrameworkSessionStore implements SessionStoreInterface
+{
+    public function __construct(
+        private readonly \SessionHandlerInterface $handler,
+        private readonly string $prefix = 'mcp-',
+        private readonly int $ttl = 3600,
+    ) {
+    }
+
+    public function exists(Uuid $id): bool
+    {
+        return false !== $this->read($id);
+    }
+
+    public function read(Uuid $id): string|false
+    {
+        $raw = $this->handler->read($this->getKey($id));
+        if ('' === $raw) {
+            return false;
+        }
+
+        $envelope = json_decode($raw, true);
+        if (!\is_array($envelope) || !isset($envelope['d'], $envelope['e'])) {
+            return false;
+        }
+
+        if ($envelope['e'] < time()) {
+            $this->destroy($id);
+
+            return false;
+        }
+
+        return $envelope['d'];
+    }
+
+    public function write(Uuid $id, string $data): bool
+    {
+        $envelope = json_encode(['d' => $data, 'e' => time() + $this->ttl], \JSON_THROW_ON_ERROR);
+
+        return $this->handler->write($this->getKey($id), $envelope);
+    }
+
+    public function destroy(Uuid $id): bool
+    {
+        return $this->handler->destroy($this->getKey($id));
+    }
+
+    public function gc(): array
+    {
+        // Expiry is handled lazily on read() — expired sessions are destroyed
+        // when accessed. We cannot call SessionHandlerInterface::gc() because
+        // it would affect all sessions (including framework HTTP sessions)
+        // and returns int|false, not the Uuid[] required by this interface.
+        return [];
+    }
+
+    private function getKey(Uuid $id): string
+    {
+        return $this->prefix.$id;
+    }
+}

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -24,6 +24,7 @@ use Mcp\Server\Session\Psr16SessionStore;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpBundle\McpBundle;
+use Symfony\AI\McpBundle\Session\FrameworkSessionStore;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -432,6 +433,33 @@ class McpBundleTest extends TestCase
 
         // No default cache pool definition should be created for custom cache pool
         $this->assertFalse($container->hasDefinition('cache.mcp.sessions'));
+    }
+
+    public function testSessionStoreFrameworkConfiguration()
+    {
+        $container = $this->buildContainer([
+            'mcp' => [
+                'client_transports' => [
+                    'http' => true,
+                ],
+                'http' => [
+                    'session' => [
+                        'store' => 'framework',
+                        'prefix' => 'mcp-',
+                        'ttl' => 1800,
+                    ],
+                ],
+            ],
+        ]);
+
+        $sessionStoreDefinition = $container->getDefinition('mcp.session.store');
+        $this->assertSame(FrameworkSessionStore::class, $sessionStoreDefinition->getClass());
+        $arguments = $sessionStoreDefinition->getArguments();
+
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
+        $this->assertSame('session.handler', (string) $arguments[0]);
+        $this->assertSame('mcp-', $arguments[1]);
+        $this->assertSame(1800, $arguments[2]);
     }
 
     public function testDiscoveryDefaultConfiguration()

--- a/src/mcp-bundle/tests/Session/FrameworkSessionStoreTest.php
+++ b/src/mcp-bundle/tests/Session/FrameworkSessionStoreTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\Session;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\Session\FrameworkSessionStore;
+use Symfony\Component\Uid\Uuid;
+
+final class FrameworkSessionStoreTest extends TestCase
+{
+    private const PREFIX = 'mcp-';
+
+    public function testWriteAndReadRoundTrip()
+    {
+        $id = Uuid::v4();
+        $store = new FrameworkSessionStore($this->createInMemoryHandler(), self::PREFIX);
+
+        $this->assertTrue($store->write($id, 'session-data'));
+        $this->assertSame('session-data', $store->read($id));
+    }
+
+    public function testReadReturnsFalseForEmptyString()
+    {
+        $handler = $this->createStub(\SessionHandlerInterface::class);
+        $handler->method('read')->willReturn('');
+
+        $store = new FrameworkSessionStore($handler, self::PREFIX);
+
+        $this->assertFalse($store->read(Uuid::v4()));
+    }
+
+    public function testReadReturnsFalseForInvalidEnvelope()
+    {
+        $handler = $this->createStub(\SessionHandlerInterface::class);
+        $handler->method('read')->willReturn('not-json');
+
+        $store = new FrameworkSessionStore($handler, self::PREFIX);
+
+        $this->assertFalse($store->read(Uuid::v4()));
+    }
+
+    public function testReadReturnsFalseAndDestroysExpiredSession()
+    {
+        $id = Uuid::v4();
+        $expired = json_encode(['d' => 'old-data', 'e' => time() - 1]);
+
+        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler->method('read')->willReturn($expired);
+        $handler->expects($this->once())->method('destroy')->with(self::PREFIX.$id);
+
+        $store = new FrameworkSessionStore($handler, self::PREFIX);
+
+        $this->assertFalse($store->read($id));
+    }
+
+    public function testDestroyDelegatesToHandler()
+    {
+        $id = Uuid::v4();
+        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler->expects($this->once())
+            ->method('destroy')
+            ->with(self::PREFIX.$id)
+            ->willReturn(true);
+
+        $store = new FrameworkSessionStore($handler, self::PREFIX);
+
+        $this->assertTrue($store->destroy($id));
+    }
+
+    public function testExistsReturnsTrueForValidSession()
+    {
+        $envelope = json_encode(['d' => 'data', 'e' => time() + 3600]);
+
+        $handler = $this->createStub(\SessionHandlerInterface::class);
+        $handler->method('read')->willReturn($envelope);
+
+        $store = new FrameworkSessionStore($handler, self::PREFIX);
+
+        $this->assertTrue($store->exists(Uuid::v4()));
+    }
+
+    public function testExistsReturnsFalseForMissingSession()
+    {
+        $handler = $this->createStub(\SessionHandlerInterface::class);
+        $handler->method('read')->willReturn('');
+
+        $store = new FrameworkSessionStore($handler, self::PREFIX);
+
+        $this->assertFalse($store->exists(Uuid::v4()));
+    }
+
+    public function testExistsReturnsFalseForExpiredSession()
+    {
+        $expired = json_encode(['d' => 'data', 'e' => time() - 1]);
+
+        $handler = $this->createStub(\SessionHandlerInterface::class);
+        $handler->method('read')->willReturn($expired);
+
+        $store = new FrameworkSessionStore($handler, self::PREFIX);
+
+        $this->assertFalse($store->exists(Uuid::v4()));
+    }
+
+    public function testGcReturnsEmptyArray()
+    {
+        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler->expects($this->never())->method('gc');
+
+        $store = new FrameworkSessionStore($handler, self::PREFIX);
+
+        $this->assertSame([], $store->gc());
+    }
+
+    public function testCustomPrefix()
+    {
+        $id = Uuid::v4();
+        $envelope = json_encode(['d' => 'data', 'e' => time() + 3600]);
+
+        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler->expects($this->once())
+            ->method('read')
+            ->with('custom_'.$id)
+            ->willReturn($envelope);
+
+        $store = new FrameworkSessionStore($handler, 'custom_');
+
+        $this->assertSame('data', $store->read($id));
+    }
+
+    public function testTtlIsRespected()
+    {
+        $id = Uuid::v4();
+
+        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler->expects($this->once())
+            ->method('write')
+            ->with(self::PREFIX.$id, $this->callback(static function (string $raw): bool {
+                $envelope = json_decode($raw, true);
+
+                return \is_array($envelope) && $envelope['e'] <= time() + 60;
+            }))
+            ->willReturn(true);
+
+        $store = new FrameworkSessionStore($handler, self::PREFIX, 60);
+
+        $store->write($id, 'data');
+    }
+
+    private function createInMemoryHandler(): \SessionHandlerInterface
+    {
+        return new class implements \SessionHandlerInterface {
+            /** @var array<string, string> */
+            private array $data = [];
+
+            public function open(string $path, string $name): bool
+            {
+                return true;
+            }
+
+            public function close(): bool
+            {
+                return true;
+            }
+
+            public function read(string $id): string
+            {
+                return $this->data[$id] ?? '';
+            }
+
+            public function write(string $id, string $data): bool
+            {
+                $this->data[$id] = $data;
+
+                return true;
+            }
+
+            public function destroy(string $id): bool
+            {
+                unset($this->data[$id]);
+
+                return true;
+            }
+
+            public function gc(int $max_lifetime): int
+            {
+                return 0;
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| License       | MIT

## Summary

Add a `framework` session store option that wraps Symfony's `SessionHandlerInterface` for MCP session persistence.

Extracted from #1791 as requested by @chr-hertel.

### FrameworkSessionStore

- Wraps `SessionHandlerInterface` with a JSON envelope containing data and expiration timestamp
- Application-level TTL with lazy expiry on read (expired sessions destroyed when accessed)
- Does not call `SessionHandlerInterface::gc()` to avoid affecting framework HTTP sessions
- Configurable prefix (default: `mcp-`) and TTL (default: 3600s)

### Configuration

```yaml
mcp:
    http:
        session:
            store: framework
            prefix: mcp-
            ttl: 3600
```

### Tests

- `FrameworkSessionStoreTest`: 11 tests covering read/write round-trip, TTL expiry, invalid envelope handling, destroy delegation, gc no-op, custom prefix, exists checks
- `McpBundleTest::testSessionStoreFrameworkConfiguration`: verifies DI wiring with `session.handler` reference

### Tested in

Tested in a real Symfony application with the framework session store — works as expected.