### PR TITLE
[Agent] Add responseDescription to AsTool attribute

### DIFF
--- a/examples/toolbox/clock.php
+++ b/examples/toolbox/clock.php
@@ -23,7 +23,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
 
 $metadataFactory = (new MemoryToolFactory())
-    ->addTool(Clock::class, 'clock', 'Get the current date and time', 'now');
+    ->addTool(Clock::class, 'clock', 'Get the current date and time', 'now', 'Returns a DatePoint object with the current date and time');
 $toolbox = new Toolbox([new Clock()], $metadataFactory, logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);

--- a/src/agent/src/Toolbox/Attribute/AsTool.php
+++ b/src/agent/src/Toolbox/Attribute/AsTool.php
@@ -21,6 +21,7 @@ final class AsTool
         public readonly string $name,
         public readonly string $description,
         public readonly string $method = '__invoke',
+        public readonly ?string $responseDescription = null,
     ) {
     }
 }

--- a/src/agent/src/Toolbox/ToolFactory/MemoryToolFactory.php
+++ b/src/agent/src/Toolbox/ToolFactory/MemoryToolFactory.php
@@ -33,7 +33,7 @@ final class MemoryToolFactory implements ToolFactoryInterface
     ) {
     }
 
-    public function addTool(string|object $class, string $name, string $description, string $method = '__invoke'): self
+    public function addTool(string|object $class, string $name, string $description, string $method = '__invoke', ?string $responseDescription = null): self
     {
         $className = \is_object($class) ? $class::class : $class;
         $key = \is_object($class) ? (string) spl_object_id($class) : $className;
@@ -44,6 +44,7 @@ final class MemoryToolFactory implements ToolFactoryInterface
                 $name,
                 $description,
                 $this->factory->buildParameters($className, $method),
+                $responseDescription,
             );
         } catch (\ReflectionException $e) {
             throw ToolConfigurationException::invalidMethod($className, $method, $e);

--- a/src/agent/src/Toolbox/ToolFactory/ReflectionToolFactory.php
+++ b/src/agent/src/Toolbox/ToolFactory/ReflectionToolFactory.php
@@ -55,6 +55,7 @@ final class ReflectionToolFactory implements ToolFactoryInterface
                     $asTool->name,
                     $asTool->description,
                     $this->factory->buildParameters($className, $asTool->method),
+                    $asTool->responseDescription,
                 );
             } catch (\ReflectionException $e) {
                 throw ToolConfigurationException::invalidMethod($className, $asTool->method, $e);

--- a/src/agent/tests/Fixtures/Tool/ToolWithResponseDescription.php
+++ b/src/agent/tests/Fixtures/Tool/ToolWithResponseDescription.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+
+#[AsTool('tool_with_response', 'A tool that searches for items', method: 'search', responseDescription: 'Returns a list of matching items with name and score')]
+final class ToolWithResponseDescription
+{
+    /**
+     * @param string $query The search query
+     *
+     * @return array<string, mixed>
+     */
+    public function search(string $query): array
+    {
+        return [];
+    }
+}

--- a/src/agent/tests/Toolbox/Attribute/AsToolTest.php
+++ b/src/agent/tests/Toolbox/Attribute/AsToolTest.php
@@ -25,5 +25,19 @@ final class AsToolTest extends TestCase
 
         $this->assertSame('name', $attribute->name);
         $this->assertSame('description', $attribute->description);
+        $this->assertNull($attribute->responseDescription);
+    }
+
+    public function testCanBeConstructedWithResponseDescription()
+    {
+        $attribute = new AsTool(
+            name: 'name',
+            description: 'description',
+            responseDescription: 'Returns a list of items',
+        );
+
+        $this->assertSame('name', $attribute->name);
+        $this->assertSame('description', $attribute->description);
+        $this->assertSame('Returns a list of items', $attribute->responseDescription);
     }
 }

--- a/src/agent/tests/Toolbox/MetadataFactory/ReflectionFactoryTest.php
+++ b/src/agent/tests/Toolbox/MetadataFactory/ReflectionFactoryTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Agent\Tests\Toolbox\MetadataFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolMultiple;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolRequiredParams;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithResponseDescription;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWrong;
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 use Symfony\AI\Agent\Toolbox\Exception\ToolException;
@@ -126,6 +127,19 @@ final class ReflectionFactoryTest extends TestCase
                 'required' => ['text', 'number'],
                 'additionalProperties' => false,
             ],
+        );
+    }
+
+    public function testGetDefinitionWithResponseDescription()
+    {
+        /** @var Tool[] $metadatas */
+        $metadatas = iterator_to_array($this->factory->getTool(ToolWithResponseDescription::class));
+
+        $this->assertCount(1, $metadatas);
+        $this->assertSame('tool_with_response', $metadatas[0]->getName());
+        $this->assertSame(
+            "A tool that searches for items\n\nResponse description: Returns a list of matching items with name and score",
+            $metadatas[0]->getDescription(),
         );
     }
 

--- a/src/platform/src/Tool/Tool.php
+++ b/src/platform/src/Tool/Tool.php
@@ -28,6 +28,7 @@ final class Tool
         private readonly string $name,
         private readonly string $description,
         private readonly ?array $parameters = null,
+        private readonly ?string $responseDescription = null,
     ) {
     }
 
@@ -43,7 +44,11 @@ final class Tool
 
     public function getDescription(): string
     {
-        return $this->description;
+        if (null === $this->responseDescription) {
+            return $this->description;
+        }
+
+        return $this->description."\n\nResponse description: ".$this->responseDescription;
     }
 
     /**

--- a/src/platform/tests/Contract/Normalizer/ToolNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/ToolNormalizerTest.php
@@ -153,5 +153,22 @@ class ToolNormalizerTest extends TestCase
                 ],
             ],
         ];
+
+        yield 'with response description' => [
+            new Tool(
+                new ExecutionReference(ToolNoParams::class),
+                'tool_with_response',
+                'A tool that searches',
+                null,
+                'Returns a list of items',
+            ),
+            [
+                'type' => 'function',
+                'function' => [
+                    'name' => 'tool_with_response',
+                    'description' => "A tool that searches\n\nResponse description: Returns a list of items",
+                ],
+            ],
+        ];
     }
 }

--- a/src/platform/tests/Tool/ToolTest.php
+++ b/src/platform/tests/Tool/ToolTest.php
@@ -67,4 +67,20 @@ final class ToolTest extends TestCase
 
         $this->assertNull($tool->getParameters());
     }
+
+    public function testReturnsDescriptionWithResponseDescription()
+    {
+        $reference = new ExecutionReference('MyClass');
+        $tool = new Tool($reference, 'tool_name', 'tool description', null, 'Returns a list of items');
+
+        $this->assertSame("tool description\n\nResponse description: Returns a list of items", $tool->getDescription());
+    }
+
+    public function testReturnsDescriptionWithoutResponseDescription()
+    {
+        $reference = new ExecutionReference('MyClass');
+        $tool = new Tool($reference, 'tool_name', 'tool description');
+
+        $this->assertSame('tool description', $tool->getDescription());
+    }
 }


### PR DESCRIPTION
  | Q             | A                                                                                               
  | ------------- | ---                                                                                             
  | Bug fix?      | no                                                                                              
  | New feature?  | yes                                                                                             
  | Docs?         | no                                                                                              
  | Issues        | —                                                                                               
  | License       | MIT                                                                                             
                                                                                                                    
  ## Summary                                                                                                        
                                                                                                                    
  This adds an optional `responseDescription` property to the `#[AsTool]` attribute, allowing                       
  tools to describe their response structure in a way that reaches the LLM.
                                                                                                                    
  Currently, tool definitions only send `name`, `description`, and `parameters` (input schema)                      
  to the LLM. There is no mechanism to describe what a tool **returns**.         
                                                                                                                    
  ## Usage                                                                                                          
                                                                                                                    
  ```php                                                                                                            
  #[AsTool(                                                 
      name: 'search_courses',                                                                                       
      description: 'Search for university courses.',                                                                
      method: 'searchCourses',                                                                                      
      responseDescription: 'Returns courseCount, collegeCount, an array of course results (max 40), and facet       
  aggregations across all matches.',                                                                                
  )]                                                                                                                
  class SearchCoursesTool                                                                                           
  {                                                                                                                 
      public function searchCourses(/* ... */): array { /* ... */ }
  }                                                                                                                 
  ```

                                                            
The responseDescription is appended to the tool's description in Tool::getDescription(),                          
so all existing normalizers (OpenAI, Anthropic, Gemini, VertexAI, Bedrock, Mistral) pick it
up automatically — no bridge changes needed.  