### PR TITLE
[Platform][Gemini] Fix function calling with JSON response and add thoughtSignature support

### DIFF
--- a/src/agent/src/Toolbox/AgentProcessor.php
+++ b/src/agent/src/Toolbox/AgentProcessor.php
@@ -117,7 +117,13 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
             }
 
             $toolCalls = $result->getContent();
-            $messages->add(Message::ofAssistant(toolCalls: $toolCalls));
+            $thinkingContent = $result->getMetadata()->get('thinkingContent');
+            $thinkingSignature = $result->getMetadata()->get('thinkingSignature');
+            $messages->add(Message::ofAssistant(
+                toolCalls: $toolCalls,
+                thinkingContent: $thinkingContent,
+                thinkingSignature: $thinkingSignature,
+            ));
 
             $results = [];
             foreach ($toolCalls as $toolCall) {

--- a/src/platform/src/Bridge/Gemini/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Gemini/Contract/AssistantMessageNormalizer.php
@@ -24,28 +24,47 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
     /**
      * @param AssistantMessage $data
      *
-     * @return array{array{text: string}}
+     * @return list<array<string, mixed>>
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        $normalized = [];
+        $parts = [];
+
+        // Add thoughtSignature as first part if present (required for Gemini 3+ thinking models)
+        if (null !== $data->getThinkingSignature()) {
+            $thinkingPart = ['thoughtSignature' => $data->getThinkingSignature()];
+            if (null !== $data->getThinkingContent()) {
+                $thinkingPart['thought'] = true;
+                $thinkingPart['text'] = $data->getThinkingContent();
+            }
+            $parts[] = $thinkingPart;
+        }
 
         if (null !== $data->getContent()) {
-            $normalized['text'] = $data->getContent();
+            $parts[] = ['text' => $data->getContent()];
         }
 
         if ($data->hasToolCalls()) {
-            $normalized['functionCall'] = [
-                'id' => $data->getToolCalls()[0]->getId(),
-                'name' => $data->getToolCalls()[0]->getName(),
-            ];
+            foreach ($data->getToolCalls() as $toolCall) {
+                $functionCall = [
+                    'id' => $toolCall->getId(),
+                    'name' => $toolCall->getName(),
+                ];
 
-            if ($data->getToolCalls()[0]->getArguments()) {
-                $normalized['functionCall']['args'] = $data->getToolCalls()[0]->getArguments();
+                if ([] !== $toolCall->getArguments()) {
+                    $functionCall['args'] = $toolCall->getArguments();
+                }
+
+                $parts[] = ['functionCall' => $functionCall];
             }
         }
 
-        return [$normalized];
+        // If no parts were added, return empty text part
+        if ([] === $parts) {
+            return [['text' => '']];
+        }
+
+        return $parts;
     }
 
     protected function supportedDataClass(): string

--- a/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
@@ -55,7 +55,14 @@ final class ModelClient implements ModelClientInterface
             $options['stream'] ?? false ? 'streamGenerateContent' : 'generateContent',
         );
 
-        if (isset($options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema'])) {
+        $hasJsonResponseFormat = isset($options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema']);
+        $hasTools = isset($options['tools']) && [] !== $options['tools'];
+
+        if ($hasJsonResponseFormat && $hasTools) {
+            throw new InvalidArgumentException('The Gemini API does not support function calling with JSON response format. Please use one or the other, but not both. See https://ai.google.dev/gemini-api/docs/structured-output for more information.');
+        }
+
+        if ($hasJsonResponseFormat) {
             $options['responseMimeType'] = 'application/json';
             $options['responseJsonSchema'] = $options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema'];
             unset($options[PlatformSubscriber::RESPONSE_FORMAT]);

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -101,6 +101,8 @@ final class ResultConverter implements ResultConverterInterface
      *                 args: mixed[]
      *             },
      *             text?: string,
+     *             thought?: bool,
+     *             thoughtSignature?: string,
      *             executableCode?: array{
      *                 language?: string,
      *                 code?: string
@@ -121,10 +123,30 @@ final class ResultConverter implements ResultConverterInterface
 
         $contentParts = $choice['content']['parts'];
 
-        // If any part is a function call, return it immediately and ignore all other parts.
+        // Extract thoughtSignature if present (for Gemini 3+ thinking models)
+        $thoughtSignature = null;
+        $thinkingContent = null;
+        foreach ($contentParts as $contentPart) {
+            if (isset($contentPart['thoughtSignature'])) {
+                $thoughtSignature = $contentPart['thoughtSignature'];
+            }
+            if (isset($contentPart['thought']) && true === $contentPart['thought'] && isset($contentPart['text'])) {
+                $thinkingContent = $contentPart['text'];
+            }
+        }
+
+        // If any part is a function call, return it with thoughtSignature metadata.
         foreach ($contentParts as $contentPart) {
             if (isset($contentPart['functionCall'])) {
-                return new ToolCallResult($this->convertToolCall($contentPart['functionCall']));
+                $result = new ToolCallResult($this->convertToolCall($contentPart['functionCall']));
+                if (null !== $thoughtSignature) {
+                    $result->getMetadata()->add('thinkingSignature', $thoughtSignature);
+                }
+                if (null !== $thinkingContent) {
+                    $result->getMetadata()->add('thinkingContent', $thinkingContent);
+                }
+
+                return $result;
             }
         }
 

--- a/src/platform/src/Bridge/Gemini/Tests/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Contract/AssistantMessageNormalizerTest.php
@@ -52,7 +52,7 @@ final class AssistantMessageNormalizerTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{AssistantMessage, array{text?: string, functionCall?: array{id: string, name: string, args?: mixed}}[]}>
+     * @return iterable<string, array{AssistantMessage, list<array<string, mixed>>}>
      */
     public static function normalizeDataProvider(): iterable
     {
@@ -67,6 +67,41 @@ final class AssistantMessageNormalizerTest extends TestCase
         yield 'function call without parameters' => [
             new AssistantMessage(toolCalls: [new ToolCall('id1', 'name1')]),
             [['functionCall' => ['id' => 'id1', 'name' => 'name1']]],
+        ];
+        yield 'function call with thought signature' => [
+            new AssistantMessage(
+                toolCalls: [new ToolCall('id1', 'get_weather', ['city' => 'Paris'])],
+                thinkingContent: 'Let me check the weather for Paris.',
+                thinkingSignature: 'sig-abc123',
+            ),
+            [
+                ['thoughtSignature' => 'sig-abc123', 'thought' => true, 'text' => 'Let me check the weather for Paris.'],
+                ['functionCall' => ['id' => 'id1', 'name' => 'get_weather', 'args' => ['city' => 'Paris']]],
+            ],
+        ];
+        yield 'function call with thought signature only (no thinking content)' => [
+            new AssistantMessage(
+                toolCalls: [new ToolCall('id1', 'search', ['query' => 'test'])],
+                thinkingSignature: 'sig-xyz789',
+            ),
+            [
+                ['thoughtSignature' => 'sig-xyz789'],
+                ['functionCall' => ['id' => 'id1', 'name' => 'search', 'args' => ['query' => 'test']]],
+            ],
+        ];
+        yield 'multiple function calls' => [
+            new AssistantMessage(toolCalls: [
+                new ToolCall('id1', 'get_weather', ['city' => 'Paris']),
+                new ToolCall('id2', 'get_weather', ['city' => 'London']),
+            ]),
+            [
+                ['functionCall' => ['id' => 'id1', 'name' => 'get_weather', 'args' => ['city' => 'Paris']]],
+                ['functionCall' => ['id' => 'id2', 'name' => 'get_weather', 'args' => ['city' => 'London']]],
+            ],
+        ];
+        yield 'empty message' => [
+            new AssistantMessage(),
+            [['text' => '']],
         ];
     }
 }

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ModelClientTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Gemini\Tests\Gemini;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Gemini\Gemini;
+use Symfony\AI\Platform\Bridge\Gemini\Gemini\ModelClient;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+final class ModelClientTest extends TestCase
+{
+    public function testItInvokesTheTextModelsSuccessfully()
+    {
+        $payload = [
+            'contents' => [
+                ['parts' => [['text' => 'Hello, world!']]],
+            ],
+        ];
+        $expectedResponse = [
+            'candidates' => [$payload],
+        ];
+        $httpClient = new MockHttpClient(
+            new JsonMockResponse($expectedResponse),
+        );
+
+        $client = new ModelClient($httpClient, 'test-api-key');
+
+        $result = $client->request(new Gemini('gemini-2.0-flash'), $payload);
+        $data = $result->getData();
+        $info = $result->getObject()->getInfo();
+
+        $this->assertNotEmpty($data);
+        $this->assertNotEmpty($info);
+        $this->assertSame('POST', $info['http_method']);
+        $this->assertSame(
+            'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent',
+            $info['url'],
+        );
+        $this->assertSame($expectedResponse, $data);
+    }
+
+    public function testItThrowsExceptionWhenCombiningToolsWithJsonResponseFormat()
+    {
+        $httpClient = new MockHttpClient();
+        $client = new ModelClient($httpClient, 'test-api-key');
+
+        $payload = [
+            'contents' => [
+                ['parts' => [['text' => 'Hello']]],
+            ],
+        ];
+
+        $options = [
+            'tools' => [
+                ['name' => 'get_weather', 'description' => 'Get weather'],
+            ],
+            PlatformSubscriber::RESPONSE_FORMAT => [
+                'json_schema' => [
+                    'schema' => ['type' => 'object'],
+                ],
+            ],
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The Gemini API does not support function calling with JSON response format');
+
+        $client->request(new Gemini('gemini-2.0-flash'), $payload, $options);
+    }
+
+    public function testItAllowsToolsWithoutJsonResponseFormat()
+    {
+        $httpClient = new MockHttpClient(
+            new JsonMockResponse(['candidates' => []]),
+        );
+        $client = new ModelClient($httpClient, 'test-api-key');
+
+        $payload = [
+            'contents' => [
+                ['parts' => [['text' => 'Hello']]],
+            ],
+        ];
+
+        $options = [
+            'tools' => [
+                ['name' => 'get_weather', 'description' => 'Get weather'],
+            ],
+        ];
+
+        $result = $client->request(new Gemini('gemini-2.0-flash'), $payload, $options);
+
+        $this->assertNotNull($result);
+    }
+
+    public function testItAllowsJsonResponseFormatWithoutTools()
+    {
+        $httpClient = new MockHttpClient(
+            new JsonMockResponse(['candidates' => []]),
+        );
+        $client = new ModelClient($httpClient, 'test-api-key');
+
+        $payload = [
+            'contents' => [
+                ['parts' => [['text' => 'Hello']]],
+            ],
+        ];
+
+        $options = [
+            PlatformSubscriber::RESPONSE_FORMAT => [
+                'json_schema' => [
+                    'schema' => ['type' => 'object'],
+                ],
+            ],
+        ];
+
+        $result = $client->request(new Gemini('gemini-2.0-flash'), $payload, $options);
+
+        $this->assertNotNull($result);
+    }
+}

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -185,4 +185,72 @@ final class ResultConverterTest extends TestCase
         $this->assertCount(1, $items);
         $this->assertSame('Hello', $items[0]);
     }
+
+    public function testExtractsThoughtSignatureFromToolCallResponse()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            [
+                                'thought' => true,
+                                'text' => 'Let me search for that information.',
+                                'thoughtSignature' => 'encrypted-signature-abc123',
+                            ],
+                            [
+                                'functionCall' => [
+                                    'id' => 'call-123',
+                                    'name' => 'search',
+                                    'args' => ['query' => 'test'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $this->assertSame('encrypted-signature-abc123', $result->getMetadata()->get('thinkingSignature'));
+        $this->assertSame('Let me search for that information.', $result->getMetadata()->get('thinkingContent'));
+    }
+
+    public function testExtractsThoughtSignatureWithoutThinkingContent()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            [
+                                'thoughtSignature' => 'sig-xyz',
+                            ],
+                            [
+                                'functionCall' => [
+                                    'id' => 'call-456',
+                                    'name' => 'get_data',
+                                    'args' => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $this->assertSame('sig-xyz', $result->getMetadata()->get('thinkingSignature'));
+        $this->assertNull($result->getMetadata()->get('thinkingContent'));
+    }
 }

--- a/src/platform/src/Message/Message.php
+++ b/src/platform/src/Message/Message.php
@@ -38,9 +38,9 @@ final class Message
     /**
      * @param ?ToolCall[] $toolCalls
      */
-    public static function ofAssistant(?string $content = null, ?array $toolCalls = null): AssistantMessage
+    public static function ofAssistant(?string $content = null, ?array $toolCalls = null, ?string $thinkingContent = null, ?string $thinkingSignature = null): AssistantMessage
     {
-        return new AssistantMessage($content, $toolCalls);
+        return new AssistantMessage($content, $toolCalls, $thinkingContent, $thinkingSignature);
     }
 
     public static function ofUser(\Stringable|string|ContentInterface ...$content): UserMessage


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1777, Fix #1539
| License       | MIT

## Summary

This PR addresses two related issues with the Gemini bridge for better compatibility across Gemini model versions.

### 1. Incompatibility Detection (Gemini 2.x)

The Gemini API does not support combining function calling with JSON response format (`response_mime_type: application/json`). This is a known limitation documented in:
- https://discuss.ai.google.dev/t/function-calling-with-a-response-mime-type-application-json-is-unsupported/105093
- https://github.com/googleapis/python-genai/issues/867

**Changes:**
- Added early detection in `ModelClient` to throw a clear `InvalidArgumentException` when both features are requested
- This prevents confusing API errors and guides developers to choose one or the other

### 2. ThoughtSignature Support (Gemini 3.x)

Gemini 3 "thinking" models (e.g., `gemini-3-pro-preview`) require the `thoughtSignature` to be passed back in subsequent requests during function calling. Without this, the API returns a 400 error.

**Changes:**
- `ResultConverter`: Extracts `thoughtSignature` and `thinkingContent` from API responses and stores them in result metadata
- `AssistantMessageNormalizer`: Includes `thoughtSignature` as the first part before `functionCall` in requests
- `Message::ofAssistant()`: Added `thinkingContent` and `thinkingSignature` parameters
- `AgentProcessor`: Propagates thinking metadata through the tool call flow

## Version Compatibility Strategy

| Gemini Version | Function Calling | JSON Response | Both Combined |
|----------------|------------------|---------------|---------------|
| 2.x (flash, pro) | ✅ | ✅ | ❌ Exception thrown |
| 3.x (preview) | ✅ with thoughtSignature | ✅ | ⚠️ Unstable per Google |

## Test Plan

- [x] Added `ModelClientTest` for incompatibility detection
- [x] Added tests for `thoughtSignature` extraction in `ResultConverterTest`
- [x] Added tests for `thoughtSignature` normalization in `AssistantMessageNormalizerTest`
- [x] Verified existing tests still pass
- [x] PHPStan analysis passes

🤖 Generated with [Claude Code](https://claude.ai/code)