### PR TITLE
 issue-1845: use Tabler SVG icon

### DIFF
--- a/src/ai-bundle/templates/icon.svg
+++ b/src/ai-bundle/templates/icon.svg
@@ -1,9 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="226 13 50 50">
-    <path
-        fill="currentColor"
-        d="M253.39985,47.45406h-13.29523l-1.60193,4.55023c-.40867,1.16081-1.50535,1.93738-2.73599,1.93738h-3.3834l10.92086-30.52647c.27304-.7632.99618-1.27253,1.80675-1.27253h3.32851c.81057,0,1.53372.50932,1.80675,1.27253l10.92086,30.52647h-3.0259c-1.47233,0-2.78439-.92908-3.27331-2.31786l-1.46798-4.16975ZM251.93835,43.20509l-5.16318-14.75776-5.20802,14.75776h10.3712Z"/>
-    <path
-        fill="currentColor"
-        d="M269.87499,24.50757v27.11454c0,1.28105-1.0385,2.31955-2.31955,2.31955h-2.88949v-31.75364h2.88949c1.28105,0,2.31955,1.0385,2.31955,2.31955Z"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-ai"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M8 16v-6a2 2 0 1 1 4 0v6" /><path d="M8 13h4" /><path d="M16 8v8" /></svg>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1845
| License       | MIT

This PR uses the official Tabler icon for "AI" from https://tabler.io/icons?ref=tabler-icons-readme.

After:
<img width="254" height="572" alt="grafik" src="https://github.com/user-attachments/assets/3e834ae7-a273-497c-bc62-ecd5e646792b" />
