### PR TITLE
 OpenAI reasoning in stream

### DIFF
--- a/src/platform/src/Bridge/OpenAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenAi/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `gpt-5.4-mini` and `gpt-5.4-nano` to `ModelCatalog`
+ * Streaming reasoning summaries are now exposed as `ThinkingContent` objects when using models with `reasoning[summary]` enabled
  * [BC BREAK] GPT streaming responses now yield `TextDelta`, `ToolCallComplete`, and streamed `TokenUsage` deltas instead of raw strings and `ToolCallResult`
 
 0.3

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -23,6 +23,7 @@ use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -134,6 +135,8 @@ final class ResultConverter implements ResultConverterInterface
 
     private function convertStream(RawResultInterface|RawHttpResult $result): \Generator
     {
+        $checkReasoningWhenComplete = true;
+
         foreach ($result->getDataStream() as $event) {
             $type = $event['type'] ?? '';
 
@@ -149,16 +152,82 @@ final class ResultConverter implements ResultConverterInterface
                 yield new TextDelta($event['delta']);
             }
 
+            $reasoningDelta = $this->extractReasoningDelta($event, $type);
+            if (null !== $reasoningDelta) {
+                // used to prevent duplicate reasoning output when the stream is complete
+                $checkReasoningWhenComplete = false;
+                yield new ThinkingDelta($reasoningDelta);
+            }
+
             if (!str_contains($type, 'completed')) {
                 continue;
             }
 
-            [$toolCallResult] = $this->extractFunctionCalls($event['response'][self::KEY_OUTPUT] ?? []);
+            $output = $event['response'][self::KEY_OUTPUT] ?? [];
+
+            if ($checkReasoningWhenComplete) {
+                foreach ($this->extractReasoningFromOutput($output) as $reasoningText) {
+                    yield new ThinkingDelta($reasoningText);
+                }
+            }
+
+            [$toolCallResult] = $this->extractFunctionCalls($output);
 
             if ($toolCallResult && 'response.completed' === $type) {
                 yield new ToolCallComplete(...$toolCallResult->getContent());
             }
         }
+    }
+
+    /**
+     * @param array<string, mixed> $event
+     */
+    private function extractReasoningDelta(array $event, string $type): ?string
+    {
+        if (!str_contains($type, 'reasoning')) {
+            return null;
+        }
+
+        if (isset($event['delta']) && \is_string($event['delta']) && '' !== trim($event['delta'])) {
+            return $event['delta'];
+        }
+
+        if (isset($event['text']) && \is_string($event['text']) && '' !== trim($event['text'])) {
+            return $event['text'];
+        }
+
+        if (isset($event['summary']['text']) && \is_string($event['summary']['text']) && '' !== trim($event['summary']['text'])) {
+            return $event['summary']['text'];
+        }
+
+        if (isset($event['item']['summary']['text']) && \is_string($event['item']['summary']['text']) && '' !== trim($event['item']['summary']['text'])) {
+            return $event['item']['summary']['text'];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $output
+     *
+     * @return list<string>
+     */
+    private function extractReasoningFromOutput(array $output): array
+    {
+        $reasoningTexts = [];
+
+        foreach ($output as $item) {
+            if ('reasoning' !== ($item['type'] ?? null)) {
+                continue;
+            }
+
+            $summary = $item['summary']['text'] ?? null;
+            if (\is_string($summary) && '' !== trim($summary)) {
+                $reasoningTexts[] = $summary;
+            }
+        }
+
+        return $reasoningTexts;
     }
 
     /**

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -21,6 +21,7 @@ use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -278,6 +279,129 @@ class ResultConverterTest extends TestCase
         $this->assertSame(2, $chunks[2]->getThinkingTokens());
         $this->assertSame(3, $chunks[2]->getCachedTokens());
         $this->assertSame(18, $chunks[2]->getTotalTokens());
+    }
+
+    public function testStreamReasoningSummaryViaDeltaEvents()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $events = [
+            [
+                'type' => 'response.reasoning_summary_text.delta',
+                'delta' => 'First reasoning chunk',
+            ],
+            [
+                'type' => 'response.reasoning_summary_text.delta',
+                'delta' => ' and more reasoning',
+            ],
+            [
+                'type' => 'message.delta.output_text.delta',
+                'delta' => 'Hello',
+            ],
+            [
+                'type' => 'response.completed',
+                'response' => [
+                    'output' => [],
+                ],
+            ],
+        ];
+
+        $raw = new InMemoryRawResult([], $events, $httpResponse);
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $streamResult);
+
+        $chunks = iterator_to_array($streamResult->getContent(), false);
+
+        $this->assertInstanceOf(ThinkingDelta::class, $chunks[0]);
+        $this->assertSame('First reasoning chunk', $chunks[0]->getThinking());
+        $this->assertInstanceOf(ThinkingDelta::class, $chunks[1]);
+        $this->assertSame(' and more reasoning', $chunks[1]->getThinking());
+        $this->assertInstanceOf(TextDelta::class, $chunks[2]);
+        $this->assertSame('Hello', $chunks[2]->getText());
+    }
+
+    public function testStreamReasoningFallbackFromCompletedOutput()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $events = [
+            [
+                'type' => 'message.delta.output_text.delta',
+                'delta' => 'Result text',
+            ],
+            [
+                'type' => 'response.completed',
+                'response' => [
+                    'output' => [
+                        [
+                            'type' => 'reasoning',
+                            'id' => 'rs_abc123',
+                            'summary' => ['text' => 'The model thought carefully about this.'],
+                        ],
+                        [
+                            'type' => 'message',
+                            'role' => 'assistant',
+                            'content' => [['type' => 'output_text', 'text' => 'Result text']],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $raw = new InMemoryRawResult([], $events, $httpResponse);
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $streamResult);
+
+        $chunks = iterator_to_array($streamResult->getContent(), false);
+
+        $this->assertInstanceOf(TextDelta::class, $chunks[0]);
+        $this->assertSame('Result text', $chunks[0]->getText());
+        $this->assertInstanceOf(ThinkingDelta::class, $chunks[1]);
+        $this->assertSame('The model thought carefully about this.', $chunks[1]->getThinking());
+    }
+
+    public function testStreamFallbackReasoningSkippedWhenDeltasAlreadyEmitted()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $events = [
+            [
+                'type' => 'response.reasoning_summary_text.delta',
+                'delta' => 'Streamed reasoning',
+            ],
+            [
+                'type' => 'response.completed',
+                'response' => [
+                    'output' => [
+                        [
+                            'type' => 'reasoning',
+                            'id' => 'rs_abc123',
+                            'summary' => ['text' => 'Full reasoning summary'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $raw = new InMemoryRawResult([], $events, $httpResponse);
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $chunks = iterator_to_array($streamResult->getContent(), false);
+
+        $thinkingChunks = array_filter($chunks, static fn ($c) => $c instanceof ThinkingDelta);
+        $this->assertCount(1, $thinkingChunks);
+        $this->assertSame('Streamed reasoning', array_values($thinkingChunks)[0]->getThinking());
     }
 
     public function testStreamYieldsToolCallComplete()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT

Adds support for streaming reasoning summaries in the OpenAI Responses API (models with `reasoning[summary]` enabled).

When a model emits reasoning summary events during a stream, the `ResultConverter` now captures them and yields `ThinkingDelta` objects alongside the regular `TextDelta` text chunks.

Two strategies are handled:
- **Delta events** (`response.reasoning_summary_text.delta`) — reasoning is streamed incrementally as it arrives.
- **Fallback from `response.completed`** — when no delta events were emitted, the full reasoning summary from the final response output is yielded at the end. A `$checkReasoningWhenComplete` flag prevents double-emission if both occur.