### PR TITLE
[Platform][OpenAI] Add reasoning content streaming support

### DIFF
--- a/examples/openai/reasoning-stream.php
+++ b/examples/openai/reasoning-stream.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('OPENAI_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant.'),
+    Message::ofUser('What is 25 * 17?'),
+);
+
+$result = $platform->invoke('o3-mini', $messages, [
+    'stream' => true,
+    'reasoning' => ['summary' => 'auto'],
+]);
+
+foreach ($result->asStream() as $delta) {
+    if ($delta instanceof ThinkingDelta) {
+        echo '[Thinking] '.$delta->getThinking().\PHP_EOL;
+    }
+    if ($delta instanceof TextDelta) {
+        echo $delta;
+    }
+}
+echo \PHP_EOL;

--- a/src/platform/src/Bridge/OpenAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenAi/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `gpt-5.4-mini` and `gpt-5.4-nano` to `ModelCatalog`
  * [BC BREAK] GPT streaming responses now yield `TextDelta`, `ToolCallComplete`, and streamed `TokenUsage` deltas instead of raw strings and `ToolCallResult`
+ * Add reasoning content streaming support via `ThinkingDelta`
 
 0.3
 ---

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -23,6 +23,7 @@ use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -147,6 +148,10 @@ final class ResultConverter implements ResultConverterInterface
 
             if (str_contains($type, 'output_text') && isset($event['delta'])) {
                 yield new TextDelta($event['delta']);
+            }
+
+            if (str_contains($type, 'reasoning_summary_text') && isset($event['delta'])) {
+                yield new ThinkingDelta($event['delta']);
             }
 
             if (!str_contains($type, 'completed')) {

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -21,6 +21,7 @@ use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -345,5 +346,50 @@ class ResultConverterTest extends TestCase
         foreach ($streamResult->getContent() as $part) {
             // Iterate to trigger the generator
         }
+    }
+
+    public function testStreamWithReasoningContent()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $events = [
+            [
+                'type' => 'response.reasoning_summary_text.delta',
+                'delta' => 'Let me think',
+            ],
+            [
+                'type' => 'response.reasoning_summary_text.delta',
+                'delta' => ' about this...',
+            ],
+            [
+                'type' => 'response.output_text.delta',
+                'delta' => 'The answer is 42.',
+            ],
+            [
+                'type' => 'response.completed',
+                'response' => [
+                    'output' => [],
+                ],
+            ],
+        ];
+
+        $raw = new InMemoryRawResult([], $events, $httpResponse);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $streamResult);
+
+        $chunks = iterator_to_array($streamResult->getContent());
+
+        $this->assertCount(3, $chunks);
+        $this->assertInstanceOf(ThinkingDelta::class, $chunks[0]);
+        $this->assertSame('Let me think', $chunks[0]->getThinking());
+        $this->assertInstanceOf(ThinkingDelta::class, $chunks[1]);
+        $this->assertSame(' about this...', $chunks[1]->getThinking());
+        $this->assertInstanceOf(TextDelta::class, $chunks[2]);
+        $this->assertSame('The answer is 42.', $chunks[2]->getText());
     }
 }

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * [BC BREAK] Streaming responses now yield `TextDelta`, `ToolCallComplete`, and streamed `TokenUsage` deltas instead of raw strings and `ToolCallResult`
+ * Add reasoning content streaming support via `ThinkingDelta`
 
 0.4
 ---

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -22,6 +22,7 @@ use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -135,6 +136,10 @@ final class ResultConverter implements ResultConverterInterface
 
             if (str_contains($type, 'output_text') && isset($event['delta'])) {
                 yield new TextDelta($event['delta']);
+            }
+
+            if (str_contains($type, 'reasoning_summary_text') && isset($event['delta'])) {
+                yield new ThinkingDelta($event['delta']);
             }
 
             if (!str_contains($type, 'completed')) {

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -19,9 +19,11 @@ use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -385,5 +387,50 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('call_456', $toolCalls[0]->getId());
         $this->assertSame('get_weather', $toolCalls[0]->getName());
         $this->assertSame(['city' => 'Berlin'], $toolCalls[0]->getArguments());
+    }
+
+    public function testStreamWithReasoningContent()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $events = [
+            [
+                'type' => 'response.reasoning_summary_text.delta',
+                'delta' => 'Let me think',
+            ],
+            [
+                'type' => 'response.reasoning_summary_text.delta',
+                'delta' => ' about this...',
+            ],
+            [
+                'type' => 'response.output_text.delta',
+                'delta' => 'The answer is 42.',
+            ],
+            [
+                'type' => 'response.completed',
+                'response' => [
+                    'output' => [],
+                ],
+            ],
+        ];
+
+        $raw = new InMemoryRawResult([], $events, $httpResponse);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $streamResult);
+
+        $chunks = iterator_to_array($streamResult->getContent());
+
+        $this->assertCount(3, $chunks);
+        $this->assertInstanceOf(ThinkingDelta::class, $chunks[0]);
+        $this->assertSame('Let me think', $chunks[0]->getThinking());
+        $this->assertInstanceOf(ThinkingDelta::class, $chunks[1]);
+        $this->assertSame(' about this...', $chunks[1]->getThinking());
+        $this->assertInstanceOf(TextDelta::class, $chunks[2]);
+        $this->assertSame('The answer is 42.', $chunks[2]->getText());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1830
| License       | MIT

Add support for streaming reasoning traces via `ThinkingDelta` in both OpenAi/Gpt and OpenResponses bridges.

Previously, only `output_text` deltas and tool calls were streamed, missing the reasoning content which can be useful for debugging and understanding model behavior.

The fix adds handling for `reasoning_summary_text` event types in the `convertStream()` method of both ResultConverters.