### PR TITLE
[Demo] Configure ux_icons.yaml with aliases for cleaner templates

### DIFF
--- a/demo/config/packages/ux_icons.yaml
+++ b/demo/config/packages/ux_icons.yaml
@@ -1,0 +1,37 @@
+ux_icons:
+    # Default icon size
+    default_icon_attributes:
+        height: 20px
+        width: 20px
+
+    # Icon aliases for cleaner templates
+    aliases:
+        # Navigation icons
+        youtube: bi:youtube
+        recipe: mdi:cook
+        wikipedia: mdi:wikipedia
+        symfony: mdi:symfony
+        crop: material-symbols:crop
+        microphone: iconoir:microphone-solid
+        video: tabler:video-filled
+        turbo: mdi:car-turbocharger
+        github: mdi:github
+
+        # UI icons
+        cancel: material-symbols:cancel
+        send: mingcute:send-fill
+        bot: fluent:bot-24-filled
+        user: solar:user-bold
+        code: solar:code-linear
+
+        # Recipe specific icons
+        clock: mdi:clock
+        difficulty: mdi:signal-variant
+        vegetarian: mdi:leaf
+        ingredients: mdi:format-list-checkbox
+        steps: mdi:clipboard-list
+        email: mdi:email-send
+
+        # Speech specific icons
+        microphone-mute: iconoir:microphone-mute-solid
+        timer: iconoir:timer-solid

--- a/demo/templates/_message.html.twig
+++ b/demo/templates/_message.html.twig
@@ -7,7 +7,7 @@
 {% macro bot(content, loading = false, latest = false, contentId = null, messageId = null) %}
     <div class="d-flex align-items-baseline mb-4"{% if messageId %} id="{{ messageId }}"{% endif %}>
         <div class="bot avatar rounded-3 shadow-sm">
-            {{ ux_icon('fluent:bot-24-filled', { height: '45px', width: '45px' }) }}
+            {{ ux_icon('bot', { height: '45px', width: '45px' }) }}
         </div>
         <div class="ps-2">
             {% if loading %}
@@ -47,7 +47,7 @@
             {% endfor %}
         </div>
         <div class="user avatar rounded-3 shadow-sm">
-            {{ ux_icon('solar:user-bold', { width: '45px', height: '45px' }) }}
+            {{ ux_icon('user', { width: '45px', height: '45px' }) }}
         </div>
     </div>
 {% endmacro %}

--- a/demo/templates/base.html.twig
+++ b/demo/templates/base.html.twig
@@ -17,38 +17,38 @@
         <nav class="navbar bg-white shadow-lg navbar-expand">
             <div class="container">
                 <a class="navbar-brand ms-2 p-0" href="{{ path('index') }}">
-                    {{ ux_icon('fluent:bot-24-filled', { height: '40px', width: '40px' }) }}
+                    {{ ux_icon('bot', { height: '40px', width: '40px' }) }}
                     <strong>Symfony AI</strong> Demo
                 </a>
                 <div class="collapse navbar-collapse">
                     <ul class="navbar-nav ms-auto me-2 mb-0 small">
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ path('youtube') }}">{{ ux_icon('bi:youtube', { height: '20px', width: '20px' }) }} YouTube</a>
+                            <a class="nav-link" href="{{ path('youtube') }}">{{ ux_icon('youtube') }} YouTube</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ path('recipe') }}">{{ ux_icon('mdi:cook', { height: '20px', width: '20px' }) }} Recipe</a>
+                            <a class="nav-link" href="{{ path('recipe') }}">{{ ux_icon('recipe') }} Recipe</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ path('wikipedia') }}">{{ ux_icon('mdi:wikipedia', { height: '20px', width: '20px' }) }} Wikipedia</a>
+                            <a class="nav-link" href="{{ path('wikipedia') }}">{{ ux_icon('wikipedia') }} Wikipedia</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ path('blog') }}">{{ ux_icon('mdi:symfony', { height: '20px', width: '20px' }) }} Symfony Blog</a>
+                            <a class="nav-link" href="{{ path('blog') }}">{{ ux_icon('symfony') }} Symfony Blog</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ path('crop') }}">{{ ux_icon('material-symbols:crop', { height: '20px', width: '20px' }) }} Smart Crop</a>
+                            <a class="nav-link" href="{{ path('crop') }}">{{ ux_icon('crop') }} Smart Crop</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ path('speech') }}">{{ ux_icon('iconoir:microphone-solid', { height: '20px', width: '20px' }) }} Speech</a>
+                            <a class="nav-link" href="{{ path('speech') }}">{{ ux_icon('microphone') }} Speech</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ path('video') }}">{{ ux_icon('tabler:video-filled', { height: '20px', width: '20px' }) }} Video</a>
+                            <a class="nav-link" href="{{ path('video') }}">{{ ux_icon('video') }} Video</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ path('stream') }}">{{ ux_icon('mdi:car-turbocharger', { height: '20px', width: '20px' }) }} Turbo Stream</a>
+                            <a class="nav-link" href="{{ path('stream') }}">{{ ux_icon('turbo') }} Turbo Stream</a>
                         </li>
                         <li class="nav-item"><span class="nav-link">|</span></li>
                         <li class="nav-item">
-                            <a class="nav-link" href="https://github.com/symfony/ai" target="_blank">{{ ux_icon('mdi:github', { height: '20px', width: '20px' }) }} GitHub</a>
+                            <a class="nav-link" href="https://github.com/symfony/ai" target="_blank">{{ ux_icon('github') }} GitHub</a>
                         </li>
                     </ul>
                 </div>

--- a/demo/templates/components/blog.html.twig
+++ b/demo/templates/components/blog.html.twig
@@ -2,16 +2,16 @@
 
 <div class="card mx-auto shadow-lg" {{ attributes.defaults(stimulus_controller('blog')) }}>
     <div class="card-header p-2">
-            {{ ux_icon('mdi:symfony', { height: '32px', width: '32px' }) }}
+            {{ ux_icon('symfony', { height: '32px', width: '32px' }) }}
             <strong class="ms-1 pt-1 d-inline-block">Symfony Blog Bot</strong>
-        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('material-symbols:cancel') }} Reset Chat</button>
+        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('cancel') }} Reset Chat</button>
     </div>
     <div id="chat-body" class="card-body p-4 overflow-auto">
         {% for message in this.messages %}
             {% include '_message.html.twig' with { message, latest: loop.last } %}
         {% else %}
             <div id="welcome" class="text-center mt-5 py-5 bg-white rounded-5 shadow-sm w-75 mx-auto">
-                {{ ux_icon('mdi:symfony', { height: '200px', width: '200px' }) }}
+                {{ ux_icon('symfony', { height: '200px', width: '200px' }) }}
                 <h4 class="mt-5">Retrieval Augmented Generation based on the Symfony blog</h4>
                 <span class="text-muted">Please use the text input at the bottom to start chatting.</span>
             </div>
@@ -27,7 +27,7 @@
                    data-model="norender|message"
                    type="text" class="form-control border-0" placeholder="Write a message ...">
             <button class="btn btn-outline-secondary border-0">
-                {{ ux_icon('mingcute:send-fill', { height: '25px', width: '25px' }) }} Submit
+                {{ ux_icon('send', { height: '25px', width: '25px' }) }} Submit
             </button>
         </form>
     </div>

--- a/demo/templates/components/crop.html.twig
+++ b/demo/templates/components/crop.html.twig
@@ -1,6 +1,6 @@
 <div id="crop-component" class="card mx-auto shadow-lg" {{ attributes }}>
     <div class="card-header p-2">
-        {{ ux_icon('material-symbols:crop', { height: '32px', width: '32px' }) }}
+        {{ ux_icon('crop', { height: '32px', width: '32px' }) }}
         <strong class="ms-1 pt-1 d-inline-block">Smart Image Cropping</strong>
     </div>
     <div id="chat-body" class="card-body p-4">
@@ -26,7 +26,7 @@
                 </div>
                 <div class="text-center">
                     <button class="btn btn-primary">
-                        {{ ux_icon('material-symbols:crop', { height: '20px', width: '20px' }) }}
+                        {{ ux_icon('crop') }}
                         Crop My Image!
                     </button>
                 </div>

--- a/demo/templates/components/recipe.html.twig
+++ b/demo/templates/components/recipe.html.twig
@@ -1,8 +1,8 @@
 <div class="card mx-auto shadow-lg" {{ attributes.defaults(stimulus_controller('recipe')) }}>
     <div class="card-header p-2">
-            {{ ux_icon('mdi:cook', { height: '32px', width: '32px' }) }}
+            {{ ux_icon('recipe', { height: '32px', width: '32px' }) }}
             <strong class="ms-1 pt-1 d-inline-block">Recipe Bot</strong>
-        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('material-symbols:cancel') }} Reset Chat</button>
+        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('cancel') }} Reset Chat</button>
     </div>
     <div id="chat-body" class="card-body p-4 overflow-auto">
         {% if this.recipe %}
@@ -14,7 +14,7 @@
                         <div class="row">
                             <div class="col-md-4">
                                 <div class="info-box p-2 bg-light rounded">
-                                    {{ ux_icon('mdi:clock', { height: '24px', width: '24px', class: 'text-primary' }) }}
+                                    {{ ux_icon('clock', { height: '24px', width: '24px', class: 'text-primary' }) }}
                                     <p class="mb-0 mt-2 small">
                                         <strong>{{ recipe.duration }}</strong><br>
                                         <span class="text-muted">minutes</span>
@@ -23,7 +23,7 @@
                             </div>
                             <div class="col-md-4">
                                 <div class="info-box p-2 bg-light rounded">
-                                    {{ ux_icon('mdi:signal-variant', { height: '24px', width: '24px', class: 'text-warning' }) }}
+                                    {{ ux_icon('difficulty', { height: '24px', width: '24px', class: 'text-warning' }) }}
                                     <p class="mb-0 mt-2 small">
                                         <strong>{{ recipe.level }}</strong><br>
                                         <span class="text-muted">difficulty</span>
@@ -32,7 +32,7 @@
                             </div>
                             <div class="col-md-4">
                                 <div class="info-box p-2 bg-light rounded">
-                                    {{ ux_icon('mdi:leaf', { height: '24px', width: '24px', class: 'text-success' }) }}
+                                    {{ ux_icon('vegetarian', { height: '24px', width: '24px', class: 'text-success' }) }}
                                     <p class="mb-0 mt-2 small">
                                         <strong>{{ recipe.diet }}</strong><br>
                                         <span class="text-muted">diet</span>
@@ -44,7 +44,7 @@
                         <!-- Ingredients Section -->
                         <div class="mb-4 text-start mt-4">
                             <h5 class="mb-3">
-                                {{ ux_icon('mdi:format-list-checkbox', { height: '20px', width: '20px', class: 'me-2' }) }}
+                                {{ ux_icon('ingredients', { class: 'me-2' }) }}
                                 Ingredients
                             </h5>
                             <div class="d-flex flex-wrap gap-2">
@@ -59,7 +59,7 @@
                     </div>
                     <div class="col-md-8 text-start">
                         <h5 class="mb-3">
-                            {{ ux_icon('mdi:clipboard-list', { height: '20px', width: '20px', class: 'me-2' }) }}
+                            {{ ux_icon('steps', { class: 'me-2' }) }}
                             Instructions
                         </h5>
                         <div class="">
@@ -75,7 +75,7 @@
                         <div class="mt-4 border-top pt-3 d-flex align-items-center justify-content-between">
                             <div class="fw-semibold text-muted">Share this recipe</div>
                             <button class="btn btn-outline-secondary" {{ live_action('openShare') }}>
-                                {{ ux_icon('mdi:email-send', { height: '20px', width: '20px', class: 'me-1' }) }}
+                                {{ ux_icon('email', { class: 'me-1' }) }}
                                 Share
                             </button>
                         </div>
@@ -84,7 +84,7 @@
             </div>
         {% else %}
             <div data-loading="hide" class="text-center mt-5 py-5 bg-white rounded-5 shadow-sm w-75 mx-auto">
-                {{ ux_icon('mdi:cook', { height: '200px', width: '200px' }) }}
+                {{ ux_icon('recipe', { height: '200px', width: '200px' }) }}
                 <h4 class="mt-5">Cooking Recipes</h4>
                 <span class="text-muted">Please provide your preferences for a recipe.</span>
             </div>
@@ -103,7 +103,7 @@
         <div class="share-panel">
             <button class="share-close" {{ live_action('closeShare') }} aria-label="Close">×</button>
             <h4 class="mb-2">
-                {{ ux_icon('mdi:email-send', { height: '22px', width: '22px', class: 'me-2' }) }}
+                {{ ux_icon('email', { height: '22px', width: '22px', class: 'me-2' }) }}
                 Share this recipe
             </h4>
             <p class="text-muted mb-3">Send the recipe to an email address.</p>
@@ -126,7 +126,7 @@
                    data-model="norender|message"
                    type="text" class="form-control border-0" placeholder="Write a message ...">
             <button class="btn btn-outline-secondary border-0">
-                {{ ux_icon('mingcute:send-fill', { height: '25px', width: '25px' }) }} Submit
+                {{ ux_icon('send', { height: '25px', width: '25px' }) }} Submit
             </button>
         </form>
     </div>

--- a/demo/templates/components/speech.html.twig
+++ b/demo/templates/components/speech.html.twig
@@ -2,9 +2,9 @@
 
 <div class="card mx-auto shadow-lg" {{ attributes.defaults(stimulus_controller('speech')) }}>
     <div class="card-header p-2">
-        {{ ux_icon('iconoir:microphone-solid', { height: '32px', width: '32px' }) }}
+        {{ ux_icon('microphone', { height: '32px', width: '32px' }) }}
         <strong class="ms-1 pt-1 d-inline-block">Speech Bot</strong>
-        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('material-symbols:cancel') }} Reset Chat</button>
+        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('cancel') }} Reset Chat</button>
     </div>
     <div id="chat-body" class="card-body p-4 overflow-auto">
         {% for message in this.messages %}
@@ -13,7 +13,7 @@
             {% else %}
                 <div class="d-flex align-items-baseline mb-4">
                     <div class="bot avatar rounded-3 shadow-sm">
-                        {{ ux_icon('fluent:bot-24-filled', { height: '45px', width: '45px' }) }}
+                        {{ ux_icon('bot', { height: '45px', width: '45px' }) }}
                     </div>
                     <div class="ps-2">
                         <audio class="pt-3" controls {{ loop.last ? 'autoplay' }} src="{{ message.metadata.get('speech') }}"></audio>
@@ -22,7 +22,7 @@
             {% endif %}
         {% else %}
             <div id="welcome" class="text-center mt-5 py-5 bg-white rounded-5 shadow-sm w-75 mx-auto">
-                {{ ux_icon('iconoir:microphone-solid', { height: '200px', width: '200px' }) }}
+                {{ ux_icon('microphone', { height: '200px', width: '200px' }) }}
                 <h4 class="mt-5">Speech Bot</h4>
                 <span class="text-muted">Please hit the button below to start talking and again to stop</span>
             </div>
@@ -34,15 +34,15 @@
     </div>
     <div class="card-footer p-2 text-center">
         <button id="micro-start" class="btn btn-primary" type="button">
-            {{ ux_icon('iconoir:microphone-solid', { height: '24px', width: '24px' }) }}
+            {{ ux_icon('microphone', { height: '24px', width: '24px' }) }}
             <strong>Say something</strong>
         </button>
         <button id="micro-stop" class="btn btn-danger d-none" type="button">
-            {{ ux_icon('iconoir:microphone-mute-solid', { height: '24px', width: '24px' }) }}
+            {{ ux_icon('microphone-mute', { height: '24px', width: '24px' }) }}
             <strong>Stop</strong>
         </button>
         <button id="bot-thinking" class="btn btn-secondary disabled d-none" type="button">
-            {{ ux_icon('iconoir:timer-solid', { height: '24px', width: '24px' }) }}
+            {{ ux_icon('timer', { height: '24px', width: '24px' }) }}
             <strong>Bot is thinking</strong>
         </button>
     </div>

--- a/demo/templates/components/stream.html.twig
+++ b/demo/templates/components/stream.html.twig
@@ -2,9 +2,9 @@
 
 <div class="card mx-auto shadow-lg" {{ attributes }}>
     <div class="card-header p-2">
-        {{ ux_icon('mdi:car-turbocharger', { height: '32px', width: '32px' }) }}
+        {{ ux_icon('turbo', { height: '32px', width: '32px' }) }}
         <strong class="ms-1 pt-1 d-inline-block">Turbo Stream Bot</strong>
-        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('material-symbols:cancel') }} Reset Chat</button>
+        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('cancel') }} Reset Chat</button>
     </div>
     <div id="chat-body" class="card-body p-4 overflow-auto">
         {% for message in this.messages %}
@@ -16,7 +16,7 @@
         {% endif %}
         {% if not this.messages|length %}
             <div id="welcome" class="text-center mt-5 py-5 bg-white rounded-5 shadow-sm w-75 mx-auto">
-                {{ ux_icon('mdi:car-turbocharger', { height: '200px', width: '200px' }) }}
+                {{ ux_icon('turbo', { height: '200px', width: '200px' }) }}
                 <h4 class="mt-5">Turbo Stream Chat</h4>
                 <span class="text-muted">Please ask the bot about the used technologies in this example.</span>
             </div>
@@ -25,7 +25,7 @@
     <div class="card-footer p-2">
         <form class="input-group" {{ live_action('submit:prevent') }}>
             <input autofocus data-model="norender|message" type="text" class="form-control border-0" placeholder="Write a message ...">
-            <button class="btn btn-outline-secondary border-0">{{ ux_icon('mingcute:send-fill', { height: '25px', width: '25px' }) }} Submit</button>
+            <button class="btn btn-outline-secondary border-0">{{ ux_icon('send', { height: '25px', width: '25px' }) }} Submit</button>
         </form>
     </div>
 </div>

--- a/demo/templates/components/video.html.twig
+++ b/demo/templates/components/video.html.twig
@@ -2,7 +2,7 @@
 
 <div class="card mx-auto shadow-lg" {{ attributes.defaults(stimulus_controller('video')) }}>
     <div class="card-header p-2">
-        {{ ux_icon('tabler:video-filled', { height: '32px', width: '32px' }) }}
+        {{ ux_icon('video', { height: '32px', width: '32px' }) }}
         <strong class="ms-1 pt-1 d-inline-block">Video Bot</strong>
     </div>
     <div id="chat-body" class="card-body p-2 overflow-auto">
@@ -20,7 +20,7 @@
                    data-model="norender|instruction"
                    type="text" class="form-control border-0" placeholder="What do you see?">
             <button class="btn btn-outline-secondary border-0">
-                {{ ux_icon('mingcute:send-fill', { height: '25px', width: '25px' }) }} Submit
+                {{ ux_icon('send', { height: '25px', width: '25px' }) }} Submit
             </button>
         </form>
     </div>

--- a/demo/templates/components/wikipedia.html.twig
+++ b/demo/templates/components/wikipedia.html.twig
@@ -2,9 +2,9 @@
 
 <div class="card mx-auto shadow-lg" {{ attributes.defaults(stimulus_controller('wikipedia')) }}>
     <div class="card-header p-2">
-            {{ ux_icon('mdi:wikipedia', { height: '32px', width: '32px' }) }}
+            {{ ux_icon('wikipedia', { height: '32px', width: '32px' }) }}
             <strong class="ms-1 pt-1 d-inline-block">Wikipedia Research Bot</strong>
-        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('material-symbols:cancel') }} Reset Chat</button>
+        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('cancel') }} Reset Chat</button>
     </div>
     <div id="chat-body" class="card-body p-4 overflow-auto">
         {% for message in this.messages %}
@@ -21,7 +21,7 @@
             {% endif %}
         {% else %}
             <div id="welcome" class="text-center mt-5 py-5 bg-white rounded-5 shadow-sm w-75 mx-auto">
-                {{ ux_icon('mdi:wikipedia', { height: '200px', width: '200px' }) }}
+                {{ ux_icon('wikipedia', { height: '200px', width: '200px' }) }}
                 <h4 class="mt-5">Wikipedia Research</h4>
                 <span class="text-muted">Please provide the bot with a topic down below to start the research.</span>
             </div>
@@ -37,7 +37,7 @@
                    data-model="norender|message"
                    type="text" class="form-control border-0" placeholder="Write a message ...">
             <button class="btn btn-outline-secondary border-0">
-                {{ ux_icon('mingcute:send-fill', { height: '25px', width: '25px' }) }} Submit
+                {{ ux_icon('send', { height: '25px', width: '25px' }) }} Submit
             </button>
         </form>
     </div>

--- a/demo/templates/components/youtube.html.twig
+++ b/demo/templates/components/youtube.html.twig
@@ -2,9 +2,9 @@
 
 <div class="card mx-auto shadow-lg" {{ attributes.defaults(stimulus_controller('youtube')) }}>
     <div class="card-header p-2">
-        {{ ux_icon('bi:youtube', { height: '32px', width: '32px' }) }}
+        {{ ux_icon('youtube', { height: '32px', width: '32px' }) }}
         <strong class="ms-1 pt-1 d-inline-block">YouTube Transcript Bot</strong>
-        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('material-symbols:cancel') }} Reset Chat</button>
+        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('cancel') }} Reset Chat</button>
     </div>
     <div id="chat-body" class="card-body p-4 overflow-auto">
         {% set messages = this.messages %}
@@ -12,7 +12,7 @@
             {% include '_message.html.twig' with { message, latest: loop.last } %}
         {% else %}
             <div id="welcome" class="text-center mt-5 py-5 bg-white rounded-5 shadow-sm w-75 mx-auto">
-                {{ ux_icon('bi:youtube', { color: '#FF0000', height: '200px', width: '200px' }) }}
+                {{ ux_icon('youtube', { color: '#FF0000', height: '200px', width: '200px' }) }}
                 <h4 class="mt-5">Chat about a YouTube Video</h4>
                 <div class="w-75 mx-auto text-start">
                     <label for="youtube-id" class="form-label">Enter the ID of the YouTube video (e.g. <code>6uXW-ulpj0s</code>) to initialize the chat:</label>
@@ -38,7 +38,7 @@
                    type="text" class="form-control border-0" placeholder="Write a message ...">
             <button {{ messages|length == 0 ? 'disabled'}}
                 class="btn btn-outline-secondary border-0">
-                {{ ux_icon('mingcute:send-fill', { height: '25px', width: '25px' }) }} Submit
+                {{ ux_icon('send', { height: '25px', width: '25px' }) }} Submit
             </button>
         </form>
     </div>

--- a/demo/templates/index.html.twig
+++ b/demo/templates/index.html.twig
@@ -16,7 +16,7 @@
             <div class="col-md-3">
                 <div class="card youtube bg-body shadow-sm">
                     <div class="card-img-top py-2">
-                        {{ ux_icon('bi:youtube', { height: '150px', width: '150px' }) }}
+                        {{ ux_icon('youtube', { height: '150px', width: '150px' }) }}
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">YouTube Transcript Bot</h5>
@@ -26,7 +26,7 @@
                     {# Profiler route only available in dev #}
                     {% if 'dev' == app.environment %}
                         <div class="card-footer">
-                            {{ ux_icon('solar:code-linear', { height: '20px', width: '20px' }) }}
+                            {{ ux_icon('code') }}
                             <a href="{{ path('_profiler_open_file', { file: 'src/YouTube/Chat.php', line: 21 }) }}">See Implementation</a>
                         </div>
                     {% endif %}
@@ -35,7 +35,7 @@
             <div class="col-md-3">
                 <div class="card recipe bg-body shadow-sm">
                     <div class="card-img-top py-2">
-                        {{ ux_icon('mdi:cook', { height: '150px', width: '150px' }) }}
+                        {{ ux_icon('recipe', { height: '150px', width: '150px' }) }}
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">Recipe Bot</h5>
@@ -45,7 +45,7 @@
                     {# Profiler route only available in dev #}
                     {% if 'dev' == app.environment %}
                         <div class="card-footer">
-                            {{ ux_icon('solar:code-linear', { height: '20px', width: '20px' }) }}
+                            {{ ux_icon('code') }}
                             <a href="{{ path('_profiler_open_file', { file: 'src/Recipe/Chat.php', line: 22 }) }}">See Implementation</a>
                         </div>
                     {% endif %}
@@ -54,7 +54,7 @@
             <div class="col-md-3">
                 <div class="card wikipedia bg-body shadow-sm">
                     <div class="card-img-top py-2">
-                        {{ ux_icon('mdi:wikipedia', { height: '150px', width: '150px' }) }}
+                        {{ ux_icon('wikipedia', { height: '150px', width: '150px' }) }}
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">Wikipedia Research Bot</h5>
@@ -64,7 +64,7 @@
                     {# Profiler route only available in dev #}
                     {% if 'dev' == app.environment %}
                         <div class="card-footer">
-                            {{ ux_icon('solar:code-linear', { height: '20px', width: '20px' }) }}
+                            {{ ux_icon('code') }}
                             <a href="{{ path('_profiler_open_file', { file: 'src/Wikipedia/Chat.php', line: 21 }) }}">See Implementation</a>
                         </div>
                     {% endif %}
@@ -73,7 +73,7 @@
             <div class="col-md-3">
                 <div class="card blog bg-body shadow-sm">
                     <div class="card-img-top py-2">
-                        {{ ux_icon('mdi:symfony', { height: '150px', width: '150px' }) }}
+                        {{ ux_icon('symfony', { height: '150px', width: '150px' }) }}
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">Symfony Blog Bot</h5>
@@ -83,7 +83,7 @@
                     {# Profiler route only available in dev #}
                     {% if 'dev' == app.environment %}
                         <div class="card-footer">
-                            {{ ux_icon('solar:code-linear', { height: '20px', width: '20px' }) }}
+                            {{ ux_icon('code') }}
                             <a href="{{ path('_profiler_open_file', { file: 'src/Blog/Chat.php', line: 21 }) }}">See Implementation</a>
                         </div>
                     {% endif %}
@@ -94,7 +94,7 @@
             <div class="col-md-3">
                 <div class="card speech bg-body shadow-sm">
                     <div class="card-img-top py-2">
-                        {{ ux_icon('iconoir:microphone-solid', { height: '150px', width: '150px' }) }}
+f                        {{ ux_icon('microphone', { height: '150px', width: '150px' }) }}
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">Speech Bot + Subagent</h5>
@@ -104,7 +104,7 @@
                     {# Profiler route only available in dev #}
                     {% if 'dev' == app.environment %}
                         <div class="card-footer">
-                            {{ ux_icon('solar:code-linear', { height: '20px', width: '20px' }) }}
+                            {{ ux_icon('code') }}
                             <a href="{{ path('_profiler_open_file', { file: 'src/Speech/Chat.php', line: 25 }) }}">See Implementation</a>
                         </div>
                     {% endif %}
@@ -113,7 +113,7 @@
             <div class="col-md-3">
                 <div class="card video bg-body shadow-sm">
                     <div class="card-img-top py-2">
-                        {{ ux_icon('tabler:video-filled', { height: '150px', width: '150px' }) }}
+                        {{ ux_icon('video', { height: '150px', width: '150px' }) }}
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">Video Bot</h5>
@@ -123,7 +123,7 @@
                     {# Profiler route only available in dev #}
                     {% if 'dev' == app.environment %}
                         <div class="card-footer">
-                            {{ ux_icon('solar:code-linear', { height: '20px', width: '20px' }) }}
+                            {{ ux_icon('code') }}
                             <a href="{{ path('_profiler_open_file', { file: 'src/Video/TwigComponent.php', line: 41 }) }}">See Implementation</a>
                         </div>
                     {% endif %}
@@ -132,7 +132,7 @@
             <div class="col-md-3">
                 <div class="card crop bg-body shadow-sm">
                     <div class="card-img-top py-2">
-                        {{ ux_icon('material-symbols:crop', { height: '150px', width: '150px' }) }}
+                        {{ ux_icon('crop', { height: '150px', width: '150px' }) }}
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">Smart Image Cropping</h5>
@@ -142,7 +142,7 @@
                     {# Profiler route only available in dev #}
                     {% if 'dev' == app.environment %}
                         <div class="card-footer">
-                            {{ ux_icon('solar:code-linear', { height: '20px', width: '20px' }) }}
+                            {{ ux_icon('code') }}
                             <a href="{{ path('_profiler_open_file', { file: 'src/Crop/Image/Analyzer.php', line: 21 }) }}">See Implementation</a>
                         </div>
                     {% endif %}
@@ -151,7 +151,7 @@
             <div class="col-md-3">
                 <div class="card stream bg-body shadow-sm">
                     <div class="card-img-top py-2">
-                        {{ ux_icon('mdi:car-turbocharger', { height: '150px', width: '150px' }) }}
+                        {{ ux_icon('turbo', { height: '150px', width: '150px' }) }}
                     </div>
                     <div class="card-body">
                         <h5 class="card-title">Turbo Stream Bot</h5>
@@ -161,7 +161,7 @@
                     {# Profiler route only available in dev #}
                     {% if 'dev' == app.environment %}
                         <div class="card-footer">
-                            {{ ux_icon('solar:code-linear', { height: '20px', width: '20px' }) }}
+                            {{ ux_icon('code') }}
                             <a href="{{ path('_profiler_open_file', { file: 'src/Stream/TwigComponent.php', line: 41 }) }}">See Implementation</a>
                         </div>
                     {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1836
| License       | MIT

Add icon configuration with default size (20px) and aliases for all icons used in the demo application.

This follows Symfony best practices as suggested in the issue - using `ux_icons.yaml` to configure icon aliases makes templates more readable:

**Before:**
```twig
{{ ux_icon('bi:youtube', { height: '20px', width: '20px' }) }}
```

**After:**
```twig
{{ ux_icon('youtube') }}
```

The configuration includes:
- Default icon size of 20px
- Aliases for navigation icons (youtube, recipe, wikipedia, symfony, etc.)
- Aliases for UI icons (cancel, send, bot, user, code)
- Aliases for component-specific icons (clock, ingredients, steps, etc.)