### PR TITLE
[Platform] Add token usage extraction for embeddings

### DIFF
--- a/examples/dockermodelrunner/embeddings.php
+++ b/examples/dockermodelrunner/embeddings.php
@@ -14,10 +14,14 @@ use Symfony\AI\Platform\Bridge\DockerModelRunner\PlatformFactory;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = PlatformFactory::create(env('DOCKER_MODEL_RUNNER_HOST_URL'), http_client());
-$response = $platform->invoke('ai/nomic-embed-text-v1.5', <<<TEXT
+$result = $platform->invoke('ai/nomic-embed-text-v1.5', <<<TEXT
     Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.
     The people of Japan were very kind and hardworking. They loved their country very much and took care of it. The
     country was very peaceful and prosperous. The people lived happily ever after.
     TEXT);
 
-print_vectors($response);
+print_vectors($result);
+
+echo \PHP_EOL;
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/openai/embeddings.php
+++ b/examples/openai/embeddings.php
@@ -22,3 +22,7 @@ $result = $platform->invoke('text-embedding-3-small', <<<TEXT
     TEXT);
 
 print_vectors($result);
+
+echo \PHP_EOL;
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/scaleway/embeddings.php
+++ b/examples/scaleway/embeddings.php
@@ -22,3 +22,7 @@ $result = $platform->invoke('bge-multilingual-gemma2', <<<TEXT
     TEXT);
 
 print_vectors($result);
+
+echo \PHP_EOL;
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/vertexai/embeddings.php
+++ b/examples/vertexai/embeddings.php
@@ -22,3 +22,7 @@ $result = $platform->invoke('gemini-embedding-001', <<<TEXT
     TEXT);
 
 print_vectors($result);
+
+echo \PHP_EOL;
+
+print_token_usage($result->getMetadata()->get('token_usage'));

--- a/src/platform/src/Bridge/DockerModelRunner/CHANGELOG.md
+++ b/src/platform/src/Bridge/DockerModelRunner/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.7
 ---
 
+ * Add token usage extraction for embeddings responses
  * [BC BREAK] Streaming completion responses now yield typed deltas from the Generic completions converter (`TextDelta`, `ThinkingDelta`, `ThinkingComplete`, `ToolCallStart`, `ToolInputDelta`, `ToolCallComplete`, `TokenUsage`)
 
 0.1

--- a/src/platform/src/Bridge/DockerModelRunner/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Embeddings/ResultConverter.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 use Symfony\AI\Platform\Vector\Vector;
 
 /**
@@ -51,8 +52,8 @@ final class ResultConverter implements ResultConverterInterface
         );
     }
 
-    public function getTokenUsageExtractor(): null
+    public function getTokenUsageExtractor(): TokenUsageExtractorInterface
     {
-        return null;
+        return new TokenUsageExtractor();
     }
 }

--- a/src/platform/src/Bridge/DockerModelRunner/Embeddings/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Embeddings/TokenUsageExtractor.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\DockerModelRunner\Embeddings;
+
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
+
+/**
+ * @author Pascal Cescon <pascal.cescon@gmail.com>
+ */
+final class TokenUsageExtractor implements TokenUsageExtractorInterface
+{
+    public function extract(RawResultInterface $rawResult, array $options = []): ?TokenUsageInterface
+    {
+        $content = $rawResult->getData();
+
+        if (!\array_key_exists('usage', $content)) {
+            return null;
+        }
+
+        return new TokenUsage(
+            promptTokens: $content['usage']['prompt_tokens'] ?? null,
+            totalTokens: $content['usage']['total_tokens'] ?? null,
+        );
+    }
+}

--- a/src/platform/src/Bridge/DockerModelRunner/Tests/Embeddings/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Tests/Embeddings/TokenUsageExtractorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\DockerModelRunner\Tests\Embeddings;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\DockerModelRunner\Embeddings\TokenUsageExtractor;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+final class TokenUsageExtractorTest extends TestCase
+{
+    public function testItReturnsNullWithoutUsageData()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $this->assertNull($extractor->extract(new InMemoryRawResult(['some' => 'data'])));
+    }
+
+    public function testItExtractsTokenUsage()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 12,
+                'total_tokens' => 12,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(12, $tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getCompletionTokens());
+        $this->assertSame(12, $tokenUsage->getTotalTokens());
+    }
+
+    public function testItHandlesMissingUsageFields()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 7,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(7, $tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getTotalTokens());
+    }
+}

--- a/src/platform/src/Bridge/Generic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Generic/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.7
 ---
 
+ * Add token usage extraction for embeddings responses
  * [BC BREAK] OpenAI-compatible completion streams now yield `TextDelta`, `ThinkingDelta`, `ThinkingComplete`, `ToolCallStart`, `ToolInputDelta`, `ToolCallComplete`, and streamed `TokenUsage` deltas
 
 0.4

--- a/src/platform/src/Bridge/Generic/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Generic/Embeddings/ResultConverter.php
@@ -68,8 +68,8 @@ class ResultConverter implements ResultConverterInterface
         );
     }
 
-    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    public function getTokenUsageExtractor(): TokenUsageExtractorInterface
     {
-        return null;
+        return new TokenUsageExtractor();
     }
 }

--- a/src/platform/src/Bridge/Generic/Embeddings/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/Generic/Embeddings/TokenUsageExtractor.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Generic\Embeddings;
+
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
+
+/**
+ * @author Pascal Cescon <pascal.cescon@gmail.com>
+ */
+final class TokenUsageExtractor implements TokenUsageExtractorInterface
+{
+    public function extract(RawResultInterface $rawResult, array $options = []): ?TokenUsageInterface
+    {
+        $content = $rawResult->getData();
+
+        if (!\array_key_exists('usage', $content)) {
+            return null;
+        }
+
+        return new TokenUsage(
+            promptTokens: $content['usage']['prompt_tokens'] ?? null,
+            totalTokens: $content['usage']['total_tokens'] ?? null,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Generic/Tests/Embeddings/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Embeddings/TokenUsageExtractorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Generic\Tests\Embeddings;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Generic\Embeddings\TokenUsageExtractor;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+final class TokenUsageExtractorTest extends TestCase
+{
+    public function testItReturnsNullWithoutUsageData()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $this->assertNull($extractor->extract(new InMemoryRawResult(['some' => 'data'])));
+    }
+
+    public function testItExtractsTokenUsage()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 20,
+                'total_tokens' => 20,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(20, $tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getCompletionTokens());
+        $this->assertSame(20, $tokenUsage->getTotalTokens());
+    }
+
+    public function testItHandlesMissingUsageFields()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 5,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(5, $tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getTotalTokens());
+    }
+}

--- a/src/platform/src/Bridge/OpenAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenAi/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.7
 ---
 
+ * Add token usage extraction for embeddings responses
  * Add `gpt-5.4-mini` and `gpt-5.4-nano` to `ModelCatalog`
  * [BC BREAK] GPT streaming responses now yield `TextDelta`, `ToolCallComplete`, and streamed `TokenUsage` deltas instead of raw strings and `ToolCallResult`
 

--- a/src/platform/src/Bridge/OpenAi/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings/ResultConverter.php
@@ -51,8 +51,8 @@ final class ResultConverter implements ResultConverterInterface
         );
     }
 
-    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    public function getTokenUsageExtractor(): TokenUsageExtractorInterface
     {
-        return null;
+        return new TokenUsageExtractor();
     }
 }

--- a/src/platform/src/Bridge/OpenAi/Embeddings/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings/TokenUsageExtractor.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
+
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
+
+/**
+ * @author Pascal Cescon <pascal.cescon@gmail.com>
+ */
+final class TokenUsageExtractor implements TokenUsageExtractorInterface
+{
+    public function extract(RawResultInterface $rawResult, array $options = []): ?TokenUsageInterface
+    {
+        $content = $rawResult->getData();
+
+        if (!\array_key_exists('usage', $content)) {
+            return null;
+        }
+
+        return new TokenUsage(
+            promptTokens: $content['usage']['prompt_tokens'] ?? null,
+            totalTokens: $content['usage']['total_tokens'] ?? null,
+        );
+    }
+}

--- a/src/platform/src/Bridge/OpenAi/Tests/Embeddings/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Embeddings/TokenUsageExtractorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenAi\Tests\Embeddings;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\OpenAi\Embeddings\TokenUsageExtractor;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+final class TokenUsageExtractorTest extends TestCase
+{
+    public function testItReturnsNullWithoutUsageData()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $this->assertNull($extractor->extract(new InMemoryRawResult(['some' => 'data'])));
+    }
+
+    public function testItExtractsTokenUsage()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 15,
+                'total_tokens' => 15,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(15, $tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getCompletionTokens());
+        $this->assertSame(15, $tokenUsage->getTotalTokens());
+    }
+
+    public function testItHandlesMissingUsageFields()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 10,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(10, $tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getTotalTokens());
+    }
+}

--- a/src/platform/src/Bridge/Scaleway/CHANGELOG.md
+++ b/src/platform/src/Bridge/Scaleway/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.7
 ---
 
+ * Add token usage extraction for embeddings responses
  * [BC BREAK] Streaming completion responses now yield typed deltas from the Generic completions converter (`TextDelta`, `ThinkingDelta`, `ThinkingComplete`, `ToolCallStart`, `ToolInputDelta`, `ToolCallComplete`, `TokenUsage`)
 
 0.1

--- a/src/platform/src/Bridge/Scaleway/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Scaleway/Embeddings/ResultConverter.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 use Symfony\AI\Platform\Vector\Vector;
 
 /**
@@ -50,8 +51,8 @@ final class ResultConverter implements ResultConverterInterface
         );
     }
 
-    public function getTokenUsageExtractor(): null
+    public function getTokenUsageExtractor(): TokenUsageExtractorInterface
     {
-        return null;
+        return new TokenUsageExtractor();
     }
 }

--- a/src/platform/src/Bridge/Scaleway/Embeddings/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/Scaleway/Embeddings/TokenUsageExtractor.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Scaleway\Embeddings;
+
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
+
+/**
+ * @author Pascal Cescon <pascal.cescon@gmail.com>
+ */
+final class TokenUsageExtractor implements TokenUsageExtractorInterface
+{
+    public function extract(RawResultInterface $rawResult, array $options = []): ?TokenUsageInterface
+    {
+        $content = $rawResult->getData();
+
+        if (!\array_key_exists('usage', $content)) {
+            return null;
+        }
+
+        return new TokenUsage(
+            promptTokens: $content['usage']['prompt_tokens'] ?? null,
+            totalTokens: $content['usage']['total_tokens'] ?? null,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Scaleway/Tests/Embeddings/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Embeddings/TokenUsageExtractorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Scaleway\Tests\Embeddings;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Scaleway\Embeddings\TokenUsageExtractor;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+final class TokenUsageExtractorTest extends TestCase
+{
+    public function testItReturnsNullWithoutUsageData()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $this->assertNull($extractor->extract(new InMemoryRawResult(['some' => 'data'])));
+    }
+
+    public function testItExtractsTokenUsage()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 25,
+                'total_tokens' => 25,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(25, $tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getCompletionTokens());
+        $this->assertSame(25, $tokenUsage->getTotalTokens());
+    }
+
+    public function testItHandlesMissingUsageFields()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 8,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(8, $tokenUsage->getPromptTokens());
+        $this->assertNull($tokenUsage->getTotalTokens());
+    }
+}

--- a/src/platform/src/Bridge/VertexAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/VertexAi/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.7
 ---
 
+ * Add token usage extraction for embeddings responses
  * [BC BREAK] Gemini streaming responses now yield `TextDelta`, `BinaryDelta`, `ToolCallComplete`, and `ChoiceDelta` instead of result objects and raw strings
 
 0.6

--- a/src/platform/src/Bridge/VertexAi/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Embeddings/ResultConverter.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 use Symfony\AI\Platform\Vector\Vector;
 
 /**
@@ -48,8 +49,8 @@ final class ResultConverter implements ResultConverterInterface
         );
     }
 
-    public function getTokenUsageExtractor(): null
+    public function getTokenUsageExtractor(): TokenUsageExtractorInterface
     {
-        return null;
+        return new TokenUsageExtractor();
     }
 }

--- a/src/platform/src/Bridge/VertexAi/Embeddings/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/VertexAi/Embeddings/TokenUsageExtractor.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\VertexAi\Embeddings;
+
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
+
+/**
+ * @author Pascal Cescon <pascal.cescon@gmail.com>
+ */
+final class TokenUsageExtractor implements TokenUsageExtractorInterface
+{
+    public function extract(RawResultInterface $rawResult, array $options = []): ?TokenUsageInterface
+    {
+        $content = $rawResult->getData();
+
+        if (!\array_key_exists('predictions', $content)) {
+            return null;
+        }
+
+        $totalTokens = 0;
+        foreach ($content['predictions'] as $prediction) {
+            if (isset($prediction['embeddings']['statistics']['token_count'])) {
+                $totalTokens += (int) $prediction['embeddings']['statistics']['token_count'];
+            }
+        }
+
+        if (0 === $totalTokens) {
+            return null;
+        }
+
+        return new TokenUsage(
+            promptTokens: $totalTokens,
+            totalTokens: $totalTokens,
+        );
+    }
+}

--- a/src/platform/src/Bridge/VertexAi/Tests/Embeddings/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Embeddings/TokenUsageExtractorTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\VertexAi\Tests\Embeddings;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\TokenUsageExtractor;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+final class TokenUsageExtractorTest extends TestCase
+{
+    public function testItReturnsNullWithoutPredictions()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $this->assertNull($extractor->extract(new InMemoryRawResult(['some' => 'data'])));
+    }
+
+    public function testItExtractsTokenUsageFromSinglePrediction()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'predictions' => [
+                [
+                    'embeddings' => [
+                        'values' => [0.1, 0.2, 0.3],
+                        'statistics' => [
+                            'token_count' => 15,
+                            'truncated' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(15, $tokenUsage->getPromptTokens());
+        $this->assertSame(15, $tokenUsage->getTotalTokens());
+    }
+
+    public function testItSumsTokenUsageFromMultiplePredictions()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'predictions' => [
+                [
+                    'embeddings' => [
+                        'values' => [0.1, 0.2],
+                        'statistics' => [
+                            'token_count' => 10,
+                            'truncated' => false,
+                        ],
+                    ],
+                ],
+                [
+                    'embeddings' => [
+                        'values' => [0.3, 0.4],
+                        'statistics' => [
+                            'token_count' => 8,
+                            'truncated' => false,
+                        ],
+                    ],
+                ],
+                [
+                    'embeddings' => [
+                        'values' => [0.5, 0.6],
+                        'statistics' => [
+                            'token_count' => 12,
+                            'truncated' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(30, $tokenUsage->getPromptTokens());
+        $this->assertSame(30, $tokenUsage->getTotalTokens());
+    }
+
+    public function testItReturnsNullWhenNoStatisticsAvailable()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'predictions' => [
+                [
+                    'embeddings' => [
+                        'values' => [0.1, 0.2, 0.3],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertNull($extractor->extract($result));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1619
| License       | MIT

## Summary

- Add `TokenUsageExtractor` for embeddings in OpenAi, Generic, Scaleway, DockerModelRunner and VertexAi bridges
- Extract token usage information from embedding API responses
- VertexAi uses a different response format with per-embedding statistics (`predictions[].embeddings.statistics.token_count`), so the extractor sums up token counts from all predictions

## Test plan

- [x] Unit tests added for all 5 bridges
- [x] PHPStan passes
- [x] PHP-CS-Fixer passes