### PR TITLE
[Platform][Generic] fix handler for optional api_key and model_catalog

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -653,9 +653,9 @@ final class AiBundle extends AbstractBundle
                     ->addTag('proxy', ['interface' => PlatformInterface::class])
                     ->setArguments([
                         $config['base_url'],
-                        $config['api_key'],
+                        $config['api_key'] ?? null,
                         new Reference($config['http_client'], ContainerInterface::NULL_ON_INVALID_REFERENCE),
-                        new Reference($config['model_catalog'], ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                        isset($config['model_catalog']) ? new Reference($config['model_catalog'], ContainerInterface::NULL_ON_INVALID_REFERENCE) : null,
                         null,
                         new Reference('event_dispatcher'),
                         $config['supports_completions'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Follows #1594 
| License       | MIT

- Fix generic platform handler with optional api_key
- Relates to the recipes PR https://github.com/symfony/recipes/pull/1527

Required by https://github.com/symfony/ai/pull/1686