### PR TITLE
[Platform] Rework `AssistantMessage`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,6 +26,56 @@ Mate
 
    After updating, run `composer dump-autoload`.
 
+Chat
+----
+
+ * `MessageNormalizer` now emits an ordered `parts` field for `AssistantMessage` to preserve the sequence
+   of `Text`, `Thinking`, and `ToolCall` blocks. Payloads stored under the previous format (only `content`
+   and `toolsCalls`) still denormalize, but the ordering between text and tool calls is not reconstructed.
+   Re-normalize stored chat history to upgrade it to the new format.
+
+Platform
+--------
+
+ * `AssistantMessage` now takes a variadic list of `ContentInterface` parts instead of a single string
+   content plus separate `toolCalls`/`thinkingContent`/`thinkingSignature` arguments. A new
+   `Symfony\AI\Platform\Message\Content\Thinking` class represents thinking/reasoning blocks, and
+   `Symfony\AI\Platform\Result\ToolCall` now implements `ContentInterface` so it can be passed directly
+   as an assistant part:
+
+   ```diff
+   -new AssistantMessage(
+   -    content: 'Hello',
+   -    toolCalls: [new ToolCall('id1', 'fn', ['a' => 1])],
+   -    thinkingContent: 'reasoning',
+   -    thinkingSignature: 'sig',
+   -);
+   +new AssistantMessage(
+   +    new Thinking('reasoning', 'sig'),
+   +    new Text('Hello'),
+   +    new ToolCall('id1', 'fn', ['a' => 1]),
+   +);
+   ```
+
+   `AssistantMessage::getContent()` now returns `ContentInterface[]` (symmetric with `UserMessage`).
+   Use `AssistantMessage::asText()` to get the concatenated text. `getToolCalls()` returns a (possibly
+   empty) array of `ToolCall`s — no longer `?array`. `getThinking()` returns a (possibly empty) array of
+   `Thinking` parts and replaces `hasThinkingContent()`/`getThinkingContent()`/`getThinkingSignature()`.
+
+ * `Message::ofAssistant()` is now variadic and accepts `string`, `ContentInterface`, or `ResultInterface`
+   arguments. Strings and `TextResult` become `Text`; `ThinkingResult` becomes `Thinking`; `ToolCallResult`
+   is unwrapped to its inner `ToolCall`s; `MultiPartResult` is recursively mapped. Structured outputs
+   (`ObjectResult`, `BinaryResult`, …) are not auto-mapped and must be stringified by the caller:
+
+   ```diff
+   -Message::ofAssistant($objectResult);
+   +Message::ofAssistant($objectResult->getContent()->toString());
+   ```
+
+ * `MessageInterface::getContent()` return type no longer includes `ResultInterface`. Any custom
+   implementation of `MessageInterface` that previously declared `ResultInterface` in its union return
+   type must be updated accordingly.
+
 UPGRADE FROM 0.7 to 0.8
 =======================
 

--- a/demo/src/Blog/Chat.php
+++ b/demo/src/Blog/Chat.php
@@ -14,7 +14,6 @@ namespace App\Blog;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -41,9 +40,7 @@ final class Chat
         $messages->add(Message::ofUser($message));
         $result = $this->agent->call($messages);
 
-        \assert($result instanceof TextResult);
-
-        $messages->add(Message::ofAssistant($result->getContent()));
+        $messages->add(Message::ofAssistant($result));
 
         $this->saveMessages($messages);
     }

--- a/demo/src/Recipe/Chat.php
+++ b/demo/src/Recipe/Chat.php
@@ -61,7 +61,7 @@ final class Chat
         \assert($recipe instanceof Recipe);
 
         $assistantMessage = Message::ofAssistant($recipe->toString());
-        $assistantMessage->getMetadata()->add('recipe', $result->getContent());
+        $assistantMessage->getMetadata()->add('recipe', $recipe);
         $messages->add($assistantMessage);
 
         $this->saveMessages($messages);

--- a/demo/src/Wikipedia/Chat.php
+++ b/demo/src/Wikipedia/Chat.php
@@ -14,7 +14,6 @@ namespace App\Wikipedia;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -41,9 +40,7 @@ final class Chat
         $messages->add(Message::ofUser($message));
         $result = $this->agent->call($messages);
 
-        \assert($result instanceof TextResult);
-
-        $response = Message::ofAssistant($result->getContent());
+        $response = Message::ofAssistant($result);
         $response->getMetadata()->add('sources', $result->getMetadata()->get('sources', []));
         $messages->add($response);
 

--- a/demo/templates/_message.html.twig
+++ b/demo/templates/_message.html.twig
@@ -1,5 +1,7 @@
 {% if message.role.value == 'assistant' %}
-    {{ _self.bot(message.content, latest: latest) }}
+    {% for content in message.content %}
+        {{ content.text is defined ? _self.bot(content.text, latest: latest) }}
+    {% endfor %}
 {% else %}
     {{ _self.user(message.content) }}
 {% endif %}

--- a/demo/tests/Blog/ChatTest.php
+++ b/demo/tests/Blog/ChatTest.php
@@ -66,7 +66,7 @@ final class ChatTest extends TestCase
         // Check assistant message
         $assistantMessage = $messageList[1];
         $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
-        $this->assertSame('Symfony is a PHP web framework for building web applications and APIs.', $assistantMessage->getContent());
+        $this->assertSame('Symfony is a PHP web framework for building web applications and APIs.', $assistantMessage->asText());
     }
 
     public function testSubmitMessageWithUnknownQueryUsesDefaultResponse()
@@ -87,7 +87,8 @@ final class ChatTest extends TestCase
 
         // Check assistant used default response
         $assistantMessage = $messageList[1];
-        $this->assertSame('I can help you with Symfony-related questions!', $assistantMessage->getContent());
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('I can help you with Symfony-related questions!', $assistantMessage->asText());
     }
 
     public function testMultipleMessagesAreTrackedCorrectly()
@@ -169,7 +170,8 @@ final class ChatTest extends TestCase
         $this->assertCount(1, $messages[0]->getContent());
         $this->assertInstanceOf(Text::class, $messages[0]->getContent()[0]);
         $this->assertSame('What is Symfony?', $messages[0]->getContent()[0]->getText()); // user1
-        $this->assertSame('Symfony is a PHP web framework for building web applications and APIs.', $messages[1]->getContent()); // assistant1
+        $this->assertInstanceOf(AssistantMessage::class, $messages[1]);
+        $this->assertSame('Symfony is a PHP web framework for building web applications and APIs.', $messages[1]->asText()); // assistant1
         $this->assertInstanceOf(UserMessage::class, $messages[2]);
         $this->assertCount(1, $messages[2]->getContent());
         $this->assertInstanceOf(Text::class, $messages[2]->getContent()[0]);

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -514,15 +514,16 @@ Multi-Turn Conversations with Thinking
 When using thinking in multi-turn conversations, Anthropic requires that
 thinking blocks from previous assistant turns be included in the conversation
 history. The :class:`Symfony\\AI\\Platform\\Message\\AssistantMessage` supports
-this through its ``$thinkingContent`` and ``$thinkingSignature`` parameters::
+this through :class:`Symfony\\AI\\Platform\\Result\\ThinkingResult`::
 
     use Symfony\AI\Platform\Message\AssistantMessage;
+    use Symfony\AI\Platform\Result\TextResult;
+    use Symfony\AI\Platform\Result\ThinkingResult;
 
     // Include the model's thinking from a previous turn
     $assistant = new AssistantMessage(
-        content: 'The answer is 42.',
-        thinkingContent: 'Let me work through this step by step...',
-        thinkingSignature: 'sig_abc123...',
+        new ThinkingResult('Let me work through this step by step...', 'sig_abc123...'),
+        new TextResult('The answer is 42.'),
     );
 
     $messages = new MessageBag(

--- a/examples/chat/persistent-chat-cache.php
+++ b/examples/chat/persistent-chat-cache.php
@@ -35,4 +35,4 @@ $chat->initiate($messages);
 $chat->submit(Message::ofUser('My name is Christopher.'));
 $message = $chat->submit(Message::ofUser('What is my name?'));
 
-echo $message->getContent().\PHP_EOL;
+echo $message->asText().\PHP_EOL;

--- a/examples/chat/persistent-chat-cloudflare.php
+++ b/examples/chat/persistent-chat-cloudflare.php
@@ -39,4 +39,4 @@ $chat->initiate($messages);
 $chat->submit(Message::ofUser('My name is Christopher.'));
 $message = $chat->submit(Message::ofUser('What is my name?'));
 
-echo $message->getContent().\PHP_EOL;
+echo $message->asText().\PHP_EOL;

--- a/examples/chat/persistent-chat-doctrine-dbal.php
+++ b/examples/chat/persistent-chat-doctrine-dbal.php
@@ -37,4 +37,4 @@ $chat->initiate($messages);
 $chat->submit(Message::ofUser('My name is Christopher.'));
 $message = $chat->submit(Message::ofUser('What is my name?'));
 
-echo $message->getContent().\PHP_EOL;
+echo $message->asText().\PHP_EOL;

--- a/examples/chat/persistent-chat-meilisearch.php
+++ b/examples/chat/persistent-chat-meilisearch.php
@@ -35,4 +35,4 @@ $chat->initiate($messages);
 $chat->submit(Message::ofUser('My name is Christopher.'));
 $message = $chat->submit(Message::ofUser('What is my name?'));
 
-echo $message->getContent().\PHP_EOL;
+echo $message->asText().\PHP_EOL;

--- a/examples/chat/persistent-chat-mongodb.php
+++ b/examples/chat/persistent-chat-mongodb.php
@@ -39,4 +39,4 @@ $chat->initiate($messages);
 $chat->submit(Message::ofUser('My name is Christopher.'));
 $message = $chat->submit(Message::ofUser('What is my name?'));
 
-echo $message->getContent().\PHP_EOL;
+echo $message->asText().\PHP_EOL;

--- a/examples/chat/persistent-chat-pogocache.php
+++ b/examples/chat/persistent-chat-pogocache.php
@@ -34,4 +34,4 @@ $chat->initiate($messages);
 $chat->submit(Message::ofUser('My name is Christopher.'));
 $message = $chat->submit(Message::ofUser('What is my name?'));
 
-echo $message->getContent().\PHP_EOL;
+echo $message->asText().\PHP_EOL;

--- a/examples/chat/persistent-chat-redis.php
+++ b/examples/chat/persistent-chat-redis.php
@@ -39,4 +39,4 @@ $chat->initiate($messages);
 $chat->submit(Message::ofUser('My name is Christopher.'));
 $message = $chat->submit(Message::ofUser('What is my name?'));
 
-echo $message->getContent().\PHP_EOL;
+echo $message->asText().\PHP_EOL;

--- a/examples/chat/persistent-chat-session.php
+++ b/examples/chat/persistent-chat-session.php
@@ -44,4 +44,4 @@ $chat->initiate($messages);
 $chat->submit(Message::ofUser('My name is Christopher.'));
 $message = $chat->submit(Message::ofUser('What is my name?'));
 
-echo $message->getContent().\PHP_EOL;
+echo $message->asText().\PHP_EOL;

--- a/examples/chat/persistent-chat-surrealdb.php
+++ b/examples/chat/persistent-chat-surrealdb.php
@@ -42,4 +42,4 @@ $chat->initiate($messages);
 $chat->submit(Message::ofUser('My name is Christopher.'));
 $message = $chat->submit(Message::ofUser('What is my name?'));
 
-echo $message->getContent().\PHP_EOL;
+echo $message->asText().\PHP_EOL;

--- a/examples/chat/persistent-chat.php
+++ b/examples/chat/persistent-chat.php
@@ -31,4 +31,4 @@ $chat->initiate($messages);
 $chat->submit(Message::ofUser('My name is Christopher.'));
 $message = $chat->submit(Message::ofUser('What is my name?'));
 
-echo $message->getContent().\PHP_EOL;
+echo $message->asText().\PHP_EOL;

--- a/src/agent/src/Toolbox/AgentProcessor.php
+++ b/src/agent/src/Toolbox/AgentProcessor.php
@@ -111,7 +111,7 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
         ++$this->nestingLevel;
         $messages = $this->excludeToolMessages ? clone $output->getMessageBag() : $output->getMessageBag();
 
-        if (null !== $streamedAssistantResponse && '' !== $streamedAssistantResponse->getContent()) {
+        if (null !== $streamedAssistantResponse && [] !== $streamedAssistantResponse->getContent()) {
             $messages->add($streamedAssistantResponse);
         }
 
@@ -123,7 +123,7 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
                 }
 
                 $toolCalls = $result->getContent();
-                $messages->add(Message::ofAssistant(toolCalls: $toolCalls));
+                $messages->add(Message::ofAssistant(...$toolCalls));
 
                 $results = [];
                 foreach ($toolCalls as $toolCall) {

--- a/src/agent/tests/Toolbox/StreamListenerTest.php
+++ b/src/agent/tests/Toolbox/StreamListenerTest.php
@@ -78,7 +78,7 @@ final class StreamListenerTest extends TestCase
         $this->assertInstanceOf(TextDelta::class, $result[2]);
         $this->assertSame('Tool response', $result[2]->getText());
         $this->assertNotNull($capturedAssistantMessage);
-        $this->assertSame('Initial content ', $capturedAssistantMessage->getContent());
+        $this->assertSame('Initial content ', $capturedAssistantMessage->asText());
         $this->assertNotNull($capturedToolCallResult);
         $this->assertInstanceOf(ToolCallResult::class, $capturedToolCallResult);
         $this->assertSame('test-id', $capturedToolCallResult->getContent()[0]->getId());
@@ -104,7 +104,7 @@ final class StreamListenerTest extends TestCase
         $this->assertInstanceOf(TextDelta::class, $result[0]);
         $this->assertSame('Immediate tool response', $result[0]->getText());
         $this->assertNotNull($capturedAssistantMessage);
-        $this->assertSame('', $capturedAssistantMessage->getContent());
+        $this->assertSame('', $capturedAssistantMessage->asText());
     }
 
     public function testGetContentWithToolCallCompleteReturningGenerator()
@@ -136,7 +136,7 @@ final class StreamListenerTest extends TestCase
         $this->assertSame('Part 2', $result[2]->getText());
         $this->assertInstanceOf(TextDelta::class, $result[3]);
         $this->assertSame('Part 3', $result[3]->getText());
-        $this->assertSame('Start', $capturedAssistantMessage->getContent());
+        $this->assertSame('Start', $capturedAssistantMessage->asText());
     }
 
     public function testGetContentStopsAfterToolCallComplete()

--- a/src/ai-bundle/src/Command/AgentCallCommand.php
+++ b/src/ai-bundle/src/Command/AgentCallCommand.php
@@ -163,7 +163,7 @@ final class AgentCallCommand extends Command
                     $io->writeln($result->getContent());
                     $io->newLine();
 
-                    $messages->add(Message::ofAssistant($result->getContent()));
+                    $messages->add(Message::ofAssistant($result));
                 } else {
                     $io->error('Unexpected response type from agent');
                 }

--- a/src/chat/CHANGELOG.md
+++ b/src/chat/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.9
+---
+
+* [BC BREAK] `MessageNormalizer` now serializes assistant messages with an ordered `parts` field to preserve the sequence of `Text`, `Thinking`, and `ToolCall` blocks across round-trips. Legacy payloads (no `parts`, only `content` + `toolsCalls`) still denormalize, but ordering is no longer guaranteed for them.
+
 0.8
 ---
 

--- a/src/chat/src/MessageNormalizer.php
+++ b/src/chat/src/MessageNormalizer.php
@@ -21,6 +21,7 @@ use Symfony\AI\Platform\Message\Content\File;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Message\MessageInterface;
 use Symfony\AI\Platform\Message\SystemMessage;
 use Symfony\AI\Platform\Message\ToolCallMessage;
@@ -54,14 +55,7 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
 
         $message = match ($type) {
             SystemMessage::class => new SystemMessage($content),
-            AssistantMessage::class => new AssistantMessage($content, array_map(
-                static fn (array $toolsCall): ToolCall => new ToolCall(
-                    $toolsCall['id'],
-                    $toolsCall['function']['name'],
-                    json_decode($toolsCall['function']['arguments'], true)
-                ),
-                $data['toolsCalls'],
-            )),
+            AssistantMessage::class => new AssistantMessage(...self::denormalizeAssistantParts($data)),
             UserMessage::class => new UserMessage(...array_map(
                 static fn (array $contentAsBase64): ContentInterface => \in_array($contentAsBase64['type'], [File::class, Image::class, Audio::class], true)
                     ? $contentAsBase64['type']::fromDataUrl($contentAsBase64['content'])
@@ -108,19 +102,26 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
         }
 
         $toolsCalls = [];
+        $parts = [];
+        $content = '';
 
-        if ($data instanceof AssistantMessage && $data->hasToolCalls()) {
-            $toolsCalls = $this->normalizer->normalize($data->getToolCalls(), $format, $context);
-        }
-
-        if ($data instanceof ToolCallMessage) {
+        if ($data instanceof AssistantMessage) {
+            $content = $data->asText() ?? '';
+            $parts = $this->normalizeAssistantParts($data, $format, $context);
+            if ($data->hasToolCalls()) {
+                $toolsCalls = $this->normalizer->normalize($data->getToolCalls(), $format, $context);
+            }
+        } elseif ($data instanceof SystemMessage) {
+            $content = $data->getContent();
+        } elseif ($data instanceof ToolCallMessage) {
+            $content = $data->getContent();
             $toolsCalls = $this->normalizer->normalize($data->getToolCall(), $format, $context);
         }
 
         return [
             $context['identifier'] ?? 'id' => $data->getId()->toRfc4122(),
             'type' => $data::class,
-            'content' => ($data instanceof SystemMessage || $data instanceof AssistantMessage || $data instanceof ToolCallMessage) ? $data->getContent() : '',
+            'content' => $content,
             'contentAsBase64' => ($data instanceof UserMessage && [] !== $data->getContent()) ? array_map(
                 static fn (ContentInterface $content) => [
                     'type' => $content::class,
@@ -138,6 +139,7 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
                 $data->getContent(),
             ) : [],
             'toolsCalls' => $toolsCalls,
+            'parts' => $parts,
             'metadata' => $data->getMetadata()->all(),
             'addedAt' => (new \DateTimeImmutable())->getTimestamp(),
         ];
@@ -153,5 +155,69 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
         return [
             MessageInterface::class => true,
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeAssistantParts(AssistantMessage $message, ?string $format, array $context): array
+    {
+        $parts = [];
+        foreach ($message->getContent() as $part) {
+            if ($part instanceof Text) {
+                $parts[] = ['type' => Text::class, 'text' => $part->getText()];
+            } elseif ($part instanceof Thinking) {
+                $parts[] = ['type' => Thinking::class, 'content' => $part->getContent(), 'signature' => $part->getSignature()];
+            } elseif ($part instanceof ToolCall) {
+                $parts[] = ['type' => ToolCall::class, 'toolCall' => $this->normalizer->normalize($part, $format, $context)];
+            }
+        }
+
+        return $parts;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return list<ContentInterface>
+     */
+    private static function denormalizeAssistantParts(array $data): array
+    {
+        if (isset($data['parts']) && [] !== $data['parts']) {
+            $parts = [];
+            foreach ($data['parts'] as $part) {
+                $parts[] = match ($part['type']) {
+                    Text::class => new Text($part['text']),
+                    Thinking::class => new Thinking($part['content'] ?? '', $part['signature'] ?? null),
+                    ToolCall::class => new ToolCall(
+                        $part['toolCall']['id'],
+                        $part['toolCall']['function']['name'],
+                        json_decode($part['toolCall']['function']['arguments'], true),
+                    ),
+                    default => throw new LogicException(\sprintf('Unknown assistant part type "%s".', $part['type'])),
+                };
+            }
+
+            return $parts;
+        }
+
+        // Legacy format: content + toolsCalls (no ordering preserved).
+        $parts = [];
+        $content = $data['content'] ?? '';
+        if ('' !== $content) {
+            $parts[] = new Text($content);
+        }
+
+        foreach ($data['toolsCalls'] ?? [] as $toolCall) {
+            $parts[] = new ToolCall(
+                $toolCall['id'],
+                $toolCall['function']['name'],
+                json_decode($toolCall['function']['arguments'], true),
+            );
+        }
+
+        return $parts;
     }
 }

--- a/src/chat/tests/ChatStreamListenerTest.php
+++ b/src/chat/tests/ChatStreamListenerTest.php
@@ -46,7 +46,7 @@ final class ChatStreamListenerTest extends TestCase
 
         $assistantMessage = $stored->getMessages()[1];
         $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
-        $this->assertSame('I am doing well!', $assistantMessage->getContent());
+        $this->assertSame('I am doing well!', $assistantMessage->asText());
     }
 
     public function testItIgnoresNonStringChunks()
@@ -69,7 +69,7 @@ final class ChatStreamListenerTest extends TestCase
         $stored = $store->load();
         $assistantMessage = $stored->getMessages()[1];
         $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
-        $this->assertSame('Hello World', $assistantMessage->getContent());
+        $this->assertSame('Hello World', $assistantMessage->asText());
     }
 
     public function testItMergesMetadataOntoAssistantMessage()
@@ -119,6 +119,6 @@ final class ChatStreamListenerTest extends TestCase
 
         $assistantMessage = $stored->getMessages()[1];
         $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
-        $this->assertSame('chunk1chunk2', $assistantMessage->getContent());
+        $this->assertSame('chunk1chunk2', $assistantMessage->asText());
     }
 }

--- a/src/chat/tests/ChatTest.php
+++ b/src/chat/tests/ChatTest.php
@@ -60,7 +60,7 @@ final class ChatTest extends TestCase
         $result = $this->chat->submit($userMessage);
 
         $this->assertInstanceOf(AssistantMessage::class, $result);
-        $this->assertSame($assistantContent, $result->getContent());
+        $this->assertSame($assistantContent, $result->asText());
         $this->assertSame($assistantSources, $result->getMetadata()->get('sources', []));
         $this->assertCount(2, $this->store->load());
 
@@ -87,7 +87,7 @@ final class ChatTest extends TestCase
         $result = $this->chat->submit($newUserMessage);
 
         $this->assertInstanceOf(AssistantMessage::class, $result);
-        $this->assertSame($newAssistantContent, $result->getContent());
+        $this->assertSame($newAssistantContent, $result->asText());
         $this->assertCount(4, $this->store->load());
 
         $this->agent->assertCallCount(1);
@@ -104,7 +104,7 @@ final class ChatTest extends TestCase
         $result = $this->chat->submit($userMessage);
 
         $this->assertInstanceOf(AssistantMessage::class, $result);
-        $this->assertSame($assistantContent, $result->getContent());
+        $this->assertSame($assistantContent, $result->asText());
         $this->assertCount(2, $this->store->load());
 
         $this->agent->assertCallCount(1);
@@ -136,7 +136,7 @@ final class ChatTest extends TestCase
 
         $assistantMessage = $stored->getMessages()[1];
         $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
-        $this->assertSame('I am doing well!', $assistantMessage->getContent());
+        $this->assertSame('I am doing well!', $assistantMessage->asText());
     }
 
     public function testItStreamsAndPreservesExistingConversation()
@@ -169,6 +169,6 @@ final class ChatTest extends TestCase
 
         $assistantMessage = $stored->getMessages()[3];
         $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
-        $this->assertSame('Yes, I can!', $assistantMessage->getContent());
+        $this->assertSame('Yes, I can!', $assistantMessage->asText());
     }
 }

--- a/src/chat/tests/InMemory/StoreTest.php
+++ b/src/chat/tests/InMemory/StoreTest.php
@@ -109,7 +109,7 @@ final class StoreTest extends TestCase
         $store = new Store();
         $store->setup();
         $store->save(new MessageBag(new UserMessage(new Text('Hello'))));
-        $store->save(new MessageBag(new UserMessage(new Text('Hello')), new AssistantMessage('Hi')));
+        $store->save(new MessageBag(new UserMessage(new Text('Hello')), new AssistantMessage(new Text('Hi'))));
 
         $this->assertCount(2, $store->load());
 

--- a/src/chat/tests/MessageNormalizerTest.php
+++ b/src/chat/tests/MessageNormalizerTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Chat\MessageNormalizer;
 use Symfony\AI\Platform\Contract\Normalizer\Result\ToolCallNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageInterface;
 use Symfony\AI\Platform\Message\Role;
@@ -107,9 +108,9 @@ final class MessageNormalizerTest extends TestCase
             new MessageNormalizer(),
         ], [new JsonEncoder()]);
 
-        $message = new AssistantMessage('', [
+        $message = new AssistantMessage(
             new ToolCall('call-1', 'get_weather', ['city' => 'Paris']),
-        ]);
+        );
 
         $payload = $serializer->normalize($message);
 
@@ -129,10 +130,10 @@ final class MessageNormalizerTest extends TestCase
             new MessageNormalizer(),
         ], [new JsonEncoder()]);
 
-        $message = new AssistantMessage('', [
+        $message = new AssistantMessage(
             new ToolCall('call-1', 'get_weather', ['city' => 'Paris']),
             new ToolCall('call-2', 'get_time', []),
-        ]);
+        );
 
         $payload = $serializer->normalize($message);
         $denormalized = $serializer->denormalize($payload, MessageInterface::class);
@@ -148,6 +149,42 @@ final class MessageNormalizerTest extends TestCase
         $this->assertSame('call-2', $toolCalls[1]->getId());
         $this->assertSame('get_time', $toolCalls[1]->getName());
         $this->assertSame([], $toolCalls[1]->getArguments());
+    }
+
+    public function testItPreservesAssistantPartOrderingAcrossRoundtrip()
+    {
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new ToolCallNormalizer(),
+            new MessageNormalizer(),
+        ], [new JsonEncoder()]);
+
+        $message = new AssistantMessage(
+            new Thinking('First thought.', 'sig_1'),
+            new Text('Intermediate text.'),
+            new ToolCall('call-1', 'run', ['x' => 1]),
+            new Thinking('Second thought.', 'sig_2'),
+            new Text('Trailing text.'),
+        );
+
+        $payload = $serializer->normalize($message);
+        /** @var AssistantMessage $denormalized */
+        $denormalized = $serializer->denormalize($payload, MessageInterface::class);
+
+        $parts = $denormalized->getContent();
+        $this->assertCount(5, $parts);
+        $this->assertInstanceOf(Thinking::class, $parts[0]);
+        $this->assertSame('First thought.', $parts[0]->getContent());
+        $this->assertSame('sig_1', $parts[0]->getSignature());
+        $this->assertInstanceOf(Text::class, $parts[1]);
+        $this->assertSame('Intermediate text.', $parts[1]->getText());
+        $this->assertInstanceOf(ToolCall::class, $parts[2]);
+        $this->assertSame('call-1', $parts[2]->getId());
+        $this->assertInstanceOf(Thinking::class, $parts[3]);
+        $this->assertSame('Second thought.', $parts[3]->getContent());
+        $this->assertSame('sig_2', $parts[3]->getSignature());
+        $this->assertInstanceOf(Text::class, $parts[4]);
+        $this->assertSame('Trailing text.', $parts[4]->getText());
     }
 
     public function testItCanNormalizeAndDenormalizeToolCallMessage()

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add `ValidatorSubscriber` to validate structured output using Symfony Validator
  * Add support for multiple system messages in `MessageBag`
+ * [BC BREAK] Rework `AssistantMessage` to hold `ContentInterface` parts (variadic constructor) instead of a single string content plus separate tool-call/thinking fields. Introduces `Message\Content\Thinking` as a first-class content block and makes `Result\ToolCall` implement `ContentInterface`. `Message::ofAssistant()` accepts strings, `ContentInterface` instances, and `ResultInterface` values (mapping `TextResult`, `ThinkingResult`, `ToolCallResult` and `MultiPartResult` to their content equivalents).
+ * Add `thought`/`thoughtSignature` round-trip in Gemini and VertexAI bridges: `ResultConverter` emits a `ThinkingResult` for a part with `thought: true`, and `AssistantMessageNormalizer` sends `Thinking` content parts back with `thought: true` (and `thoughtSignature` when set). Signatures attached to non-thought `text` or `functionCall` parts are also preserved by adding an optional `signature` field to `Message\Content\Text`, `Result\ToolCall`, and `Result\TextResult`.
 
 0.8
 ---

--- a/src/platform/src/Bridge/AiMlApi/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/AiMlApi/Contract/AssistantMessageNormalizer.php
@@ -12,6 +12,9 @@
 namespace Symfony\AI\Platform\Bridge\AiMlApi\Contract;
 
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -42,17 +45,31 @@ final class AssistantMessageNormalizer implements NormalizerInterface, Normalize
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        $array = [
-            'role' => $data->getRole()->value,
-            'content' => $data->getContent() ?? '',
-        ];
+        $text = '';
+        $reasoning = '';
+        $toolCalls = [];
 
-        if ($data->hasToolCalls()) {
-            $array['tool_calls'] = $this->normalizer->normalize($data->getToolCalls(), $format, $context);
+        foreach ($data->getContent() as $part) {
+            if ($part instanceof Text) {
+                $text .= $part->getText();
+            } elseif ($part instanceof Thinking) {
+                $reasoning .= $part->getContent();
+            } elseif ($part instanceof ToolCall) {
+                $toolCalls[] = $part;
+            }
         }
 
-        if ($data->hasThinkingContent()) {
-            $array['reasoning_content'] = $data->getThinkingContent();
+        $array = [
+            'role' => $data->getRole()->value,
+            'content' => $text,
+        ];
+
+        if ([] !== $toolCalls) {
+            $array['tool_calls'] = $this->normalizer->normalize($toolCalls, $format, $context);
+        }
+
+        if ('' !== $reasoning) {
+            $array['reasoning_content'] = $reasoning;
         }
 
         return $array;

--- a/src/platform/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
@@ -14,17 +14,16 @@ namespace Symfony\AI\Platform\Bridge\Anthropic\Contract;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Model;
-use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
-use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\AI\Platform\Result\ToolCall;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class AssistantMessageNormalizer extends ModelContractNormalizer implements NormalizerAwareInterface
+final class AssistantMessageNormalizer extends ModelContractNormalizer
 {
-    use NormalizerAwareTrait;
-
     /**
      * @param AssistantMessage $data
      *
@@ -43,39 +42,40 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        $hasBlocks = $data->hasToolCalls() || $data->hasThinkingContent();
+        $parts = $data->getContent();
 
-        if (!$hasBlocks) {
+        if (1 === \count($parts) && $parts[0] instanceof Text) {
             return [
                 'role' => 'assistant',
-                'content' => $data->getContent() ?? '',
+                'content' => $parts[0]->getText(),
             ];
         }
 
         $blocks = [];
-
-        if ($data->hasThinkingContent()) {
-            $thinkingBlock = [
-                'type' => 'thinking',
-                'thinking' => $data->getThinkingContent(),
-            ];
-            if (null !== $data->getThinkingSignature()) {
-                $thinkingBlock['signature'] = $data->getThinkingSignature();
+        foreach ($parts as $part) {
+            if ($part instanceof Thinking) {
+                $block = [
+                    'type' => 'thinking',
+                    'thinking' => $part->getContent(),
+                ];
+                if (null !== $part->getSignature()) {
+                    $block['signature'] = $part->getSignature();
+                }
+                $blocks[] = $block;
+                continue;
             }
-            $blocks[] = $thinkingBlock;
-        }
 
-        if (null !== $data->getContent()) {
-            $blocks[] = ['type' => 'text', 'text' => $data->getContent()];
-        }
+            if ($part instanceof Text) {
+                $blocks[] = ['type' => 'text', 'text' => $part->getText()];
+                continue;
+            }
 
-        if ($data->hasToolCalls()) {
-            foreach ($data->getToolCalls() as $toolCall) {
+            if ($part instanceof ToolCall) {
                 $blocks[] = [
                     'type' => 'tool_use',
-                    'id' => $toolCall->getId(),
-                    'name' => $toolCall->getName(),
-                    'input' => [] !== $toolCall->getArguments() ? $toolCall->getArguments() : new \stdClass(),
+                    'id' => $part->getId(),
+                    'name' => $part->getName(),
+                    'input' => [] !== $part->getArguments() ? $part->getArguments() : new \stdClass(),
                 ];
             }
         }

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -32,6 +32,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
@@ -105,6 +106,8 @@ class ResultConverter implements ResultConverterInterface
                 );
             } elseif ('text_editor_code_execution_tool_result' === $content['type']) {
                 $results[] = new CodeExecutionResult(true, null, $content['tool_use_id']);
+            } elseif ('thinking' === $content['type']) {
+                $results[] = new ThinkingResult($content['thinking'], $content['signature'] ?? null);
             }
         }
 

--- a/src/platform/src/Bridge/Anthropic/Tests/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/Contract/AssistantMessageNormalizerTest.php
@@ -17,6 +17,8 @@ use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\Contract\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Result\ToolCall;
 
 final class AssistantMessageNormalizerTest extends TestCase
@@ -25,7 +27,7 @@ final class AssistantMessageNormalizerTest extends TestCase
     {
         $normalizer = new AssistantMessageNormalizer();
 
-        $this->assertTrue($normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
+        $this->assertTrue($normalizer->supportsNormalization(new AssistantMessage(new Text('Hello')), context: [
             Contract::CONTEXT_MODEL => new Claude('claude-3-5-sonnet-latest'),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not an assistant message'));
@@ -71,14 +73,14 @@ final class AssistantMessageNormalizerTest extends TestCase
     public static function normalizeDataProvider(): iterable
     {
         yield 'assistant message' => [
-            new AssistantMessage('Great to meet you. What would you like to know?'),
+            new AssistantMessage(new Text('Great to meet you. What would you like to know?')),
             [
                 'role' => 'assistant',
                 'content' => 'Great to meet you. What would you like to know?',
             ],
         ];
         yield 'function call' => [
-            new AssistantMessage(toolCalls: [new ToolCall('id1', 'name1', ['arg1' => '123'])]),
+            new AssistantMessage(new ToolCall('id1', 'name1', ['arg1' => '123'])),
             [
                 'role' => 'assistant',
                 'content' => [
@@ -92,7 +94,7 @@ final class AssistantMessageNormalizerTest extends TestCase
             ],
         ];
         yield 'function call without parameters' => [
-            new AssistantMessage(toolCalls: [new ToolCall('id1', 'name1')]),
+            new AssistantMessage(new ToolCall('id1', 'name1')),
             [
                 'role' => 'assistant',
                 'content' => [
@@ -108,8 +110,8 @@ final class AssistantMessageNormalizerTest extends TestCase
 
         yield 'text prefix with single tool call' => [
             new AssistantMessage(
-                'I\'ll look that up for you.',
-                [new ToolCall('id1', 'search', ['query' => 'symfony'])],
+                new Text('I\'ll look that up for you.'),
+                new ToolCall('id1', 'search', ['query' => 'symfony']),
             ),
             [
                 'role' => 'assistant',
@@ -122,11 +124,9 @@ final class AssistantMessageNormalizerTest extends TestCase
 
         yield 'text prefix with multiple tool calls' => [
             new AssistantMessage(
-                'Let me run both tools.',
-                [
-                    new ToolCall('id1', 'read', ['path' => '/etc/hosts']),
-                    new ToolCall('id2', 'write', ['path' => '/tmp/out', 'content' => 'ok']),
-                ],
+                new Text('Let me run both tools.'),
+                new ToolCall('id1', 'read', ['path' => '/etc/hosts']),
+                new ToolCall('id2', 'write', ['path' => '/tmp/out', 'content' => 'ok']),
             ),
             [
                 'role' => 'assistant',
@@ -140,8 +140,8 @@ final class AssistantMessageNormalizerTest extends TestCase
 
         yield 'text prefix with no-argument tool call' => [
             new AssistantMessage(
-                'Checking the current date.',
-                [new ToolCall('id1', 'get_date')],
+                new Text('Checking the current date.'),
+                new ToolCall('id1', 'get_date'),
             ),
             [
                 'role' => 'assistant',
@@ -154,10 +154,8 @@ final class AssistantMessageNormalizerTest extends TestCase
 
         yield 'thinking with text' => [
             new AssistantMessage(
-                'The answer is 42.',
-                null,
-                'Let me reason about this...',
-                'sig_abc123',
+                new Thinking('Let me reason about this...', 'sig_abc123'),
+                new Text('The answer is 42.'),
             ),
             [
                 'role' => 'assistant',
@@ -170,10 +168,9 @@ final class AssistantMessageNormalizerTest extends TestCase
 
         yield 'thinking with text and tool calls' => [
             new AssistantMessage(
-                'Let me search.',
-                [new ToolCall('id1', 'search', ['query' => 'symfony'])],
-                'I need to look this up.',
-                'sig_xyz',
+                new Thinking('I need to look this up.', 'sig_xyz'),
+                new Text('Let me search.'),
+                new ToolCall('id1', 'search', ['query' => 'symfony']),
             ),
             [
                 'role' => 'assistant',
@@ -187,9 +184,8 @@ final class AssistantMessageNormalizerTest extends TestCase
 
         yield 'thinking without signature' => [
             new AssistantMessage(
-                'Done.',
-                null,
-                'Quick thought.',
+                new Thinking('Quick thought.'),
+                new Text('Done.'),
             ),
             [
                 'role' => 'assistant',
@@ -202,10 +198,8 @@ final class AssistantMessageNormalizerTest extends TestCase
 
         yield 'thinking with tool calls but no text' => [
             new AssistantMessage(
-                null,
-                [new ToolCall('id1', 'read', ['path' => '/etc/hosts'])],
-                'I should read this file.',
-                'sig_123',
+                new Thinking('I should read this file.', 'sig_123'),
+                new ToolCall('id1', 'read', ['path' => '/etc/hosts']),
             ),
             [
                 'role' => 'assistant',

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -29,6 +29,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -460,8 +461,14 @@ final class ResultConverterTest extends TestCase
 
         $result = $converter->convert(new RawHttpResult($httpResponse));
 
-        $this->assertInstanceOf(TextResult::class, $result);
-        $this->assertSame('The answer is 42.', $result->getContent());
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(ThinkingResult::class, $parts[0]);
+        $this->assertSame('Let me reason about this...', $parts[0]->getContent());
+        $this->assertSame('sig_abc123', $parts[0]->getSignature());
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('The answer is 42.', $parts[1]->getContent());
     }
 
     public function testNonStreamingResponseWithOnlyThinkingContent()
@@ -479,10 +486,11 @@ final class ResultConverterTest extends TestCase
         $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
         $converter = new ResultConverter();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Response content does not contain any supported content.');
+        $result = $converter->convert(new RawHttpResult($httpResponse));
 
-        $converter->convert(new RawHttpResult($httpResponse));
+        $this->assertInstanceOf(ThinkingResult::class, $result);
+        $this->assertSame('Reasoning only...', $result->getContent());
+        $this->assertSame('sig_xyz', $result->getSignature());
     }
 
     /**

--- a/src/platform/src/Bridge/Bedrock/Nova/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/Contract/AssistantMessageNormalizer.php
@@ -56,7 +56,7 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
 
         return [
             'role' => 'assistant',
-            'content' => [['text' => $data->getContent()]],
+            'content' => [['text' => $data->asText() ?? '']],
         ];
     }
 

--- a/src/platform/src/Bridge/Bedrock/Tests/Nova/ContractTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/Nova/ContractTest.php
@@ -23,6 +23,7 @@ use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
 
 final class ContractTest extends TestCase
 {
@@ -88,7 +89,7 @@ final class ContractTest extends TestCase
         yield 'with tool use' => [
             new MessageBag(
                 Message::ofUser('Hello there, what is the time?'),
-                Message::ofAssistant(toolCalls: [new ToolCall('123456', 'clock', [])]),
+                Message::ofAssistant(new ToolCallResult([new ToolCall('123456', 'clock', [])])),
                 Message::ofToolCall(new ToolCall('123456', 'clock', []), '2023-10-01T10:00:00+00:00'),
                 Message::ofAssistant('It is 10:00 AM.'),
             ),

--- a/src/platform/src/Bridge/Gemini/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Gemini/Contract/AssistantMessageNormalizer.php
@@ -12,42 +12,65 @@
 namespace Symfony\AI\Platform\Bridge\Gemini\Contract;
 
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
+use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ToolCall;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
+ *
+ * @phpstan-import-type Part from ResultConverter
  */
 final class AssistantMessageNormalizer extends ModelContractNormalizer
 {
     /**
      * @param AssistantMessage $data
      *
-     * @return list<array{text: string}|array{functionCall: array{id: string, name: string, args?: mixed}}>
+     * @return list<Part>
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         $normalized = [];
 
-        // text and functionCall are separate oneof fields in Gemini's
-        // they must be emitted as distinct parts, never merged into one.
-        if (null !== $data->getContent()) {
-            $normalized[] = ['text' => $data->getContent()];
-        }
-
-        if ($data->hasToolCalls()) {
-            $toolCall = $data->getToolCalls()[0];
-            $functionCall = [
-                'id' => $toolCall->getId(),
-                'name' => $toolCall->getName(),
-            ];
-
-            if ($toolCall->getArguments()) {
-                $functionCall['args'] = $toolCall->getArguments();
+        foreach ($data->getContent() as $part) {
+            if ($part instanceof Text) {
+                $textPart = ['text' => $part->getText()];
+                if (null !== $part->getSignature()) {
+                    $textPart['thoughtSignature'] = $part->getSignature();
+                }
+                $normalized[] = $textPart;
+                continue;
             }
 
-            $normalized[] = ['functionCall' => $functionCall];
+            if ($part instanceof Thinking) {
+                $thoughtPart = ['text' => $part->getContent(), 'thought' => true];
+                if (null !== $part->getSignature()) {
+                    $thoughtPart['thoughtSignature'] = $part->getSignature();
+                }
+                $normalized[] = $thoughtPart;
+                continue;
+            }
+
+            if ($part instanceof ToolCall) {
+                $functionCall = [
+                    'id' => $part->getId(),
+                    'name' => $part->getName(),
+                ];
+
+                if ([] !== $part->getArguments()) {
+                    $functionCall['args'] = $part->getArguments();
+                }
+
+                $toolPart = ['functionCall' => $functionCall];
+                if (null !== $part->getSignature()) {
+                    $toolPart['thoughtSignature'] = $part->getSignature();
+                }
+                $normalized[] = $toolPart;
+            }
         }
 
         return $normalized;

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -30,6 +30,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
@@ -38,6 +39,8 @@ use Symfony\AI\Platform\ResultConverterInterface;
  * @phpstan-type Part array{
  *     functionCall?: array{id?: string, name: string, args: mixed[]},
  *     text?: string,
+ *     thought?: bool,
+ *     thoughtSignature?: string,
  *     inlineData?: array{data: string, mimeType: string},
  *     executableCode?: array{language: string, code: string},
  *     codeExecutionResult?: array{id?: string, outcome: self::OUTCOME_*, output: string},
@@ -140,11 +143,14 @@ final class ResultConverter implements ResultConverterInterface
     /**
      * @param Part $contentPart
      */
-    private function convertPart(array $contentPart): ToolCallResult|TextResult|BinaryResult|ExecutableCodeResult|CodeExecutionResult|null
+    private function convertPart(array $contentPart): ToolCallResult|TextResult|ThinkingResult|BinaryResult|ExecutableCodeResult|CodeExecutionResult|null
     {
+        $signature = $contentPart['thoughtSignature'] ?? null;
+
         return match (true) {
-            isset($contentPart['functionCall']) => new ToolCallResult([$this->convertToolCall($contentPart['functionCall'])]),
-            isset($contentPart['text']) => new TextResult($contentPart['text']),
+            isset($contentPart['functionCall']) => new ToolCallResult([$this->convertToolCall($contentPart['functionCall'], $signature)]),
+            true === ($contentPart['thought'] ?? false) => new ThinkingResult($contentPart['text'] ?? '', $signature),
+            isset($contentPart['text']) => new TextResult($contentPart['text'], $signature),
             isset($contentPart['inlineData']) => BinaryResult::fromBase64($contentPart['inlineData']['data'], $contentPart['inlineData']['mimeType'] ?? null),
             isset($contentPart['executableCode']) => new ExecutableCodeResult(
                 $contentPart['executableCode']['code'],
@@ -167,8 +173,8 @@ final class ResultConverter implements ResultConverterInterface
      *     args: mixed[]
      * } $toolCall
      */
-    private function convertToolCall(array $toolCall): ToolCall
+    private function convertToolCall(array $toolCall, ?string $signature = null): ToolCall
     {
-        return new ToolCall($toolCall['id'] ?? '', $toolCall['name'], $toolCall['args']);
+        return new ToolCall($toolCall['id'] ?? '', $toolCall['name'], $toolCall['args'], $signature);
     }
 }

--- a/src/platform/src/Bridge/Gemini/Tests/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Contract/AssistantMessageNormalizerTest.php
@@ -17,6 +17,8 @@ use Symfony\AI\Platform\Bridge\Gemini\Contract\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Result\ToolCall;
 
 final class AssistantMessageNormalizerTest extends TestCase
@@ -25,7 +27,7 @@ final class AssistantMessageNormalizerTest extends TestCase
     {
         $normalizer = new AssistantMessageNormalizer();
 
-        $this->assertTrue($normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
+        $this->assertTrue($normalizer->supportsNormalization(new AssistantMessage(new Text('Hello')), context: [
             Contract::CONTEXT_MODEL => new Gemini('gemini-2.0-flash'),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not an assistant message'));
@@ -57,25 +59,63 @@ final class AssistantMessageNormalizerTest extends TestCase
     public static function normalizeDataProvider(): iterable
     {
         yield 'assistant message' => [
-            new AssistantMessage('Great to meet you. What would you like to know?'),
+            new AssistantMessage(new Text('Great to meet you. What would you like to know?')),
             [['text' => 'Great to meet you. What would you like to know?']],
         ];
         yield 'function call' => [
-            new AssistantMessage(toolCalls: [new ToolCall('id1', 'name1', ['arg1' => '123'])]),
+            new AssistantMessage(new ToolCall('id1', 'name1', ['arg1' => '123'])),
             [['functionCall' => ['id' => 'id1', 'name' => 'name1', 'args' => ['arg1' => '123']]]],
         ];
         yield 'function call without parameters' => [
-            new AssistantMessage(toolCalls: [new ToolCall('id1', 'name1')]),
+            new AssistantMessage(new ToolCall('id1', 'name1')),
             [['functionCall' => ['id' => 'id1', 'name' => 'name1']]],
         ];
         yield 'text with function call' => [
             new AssistantMessage(
-                'I\'ll look that up for you.',
-                [new ToolCall('id1', 'name1', ['arg1' => '123'])],
+                new Text('I\'ll look that up for you.'),
+                new ToolCall('id1', 'name1', ['arg1' => '123']),
             ),
             [
                 ['text' => 'I\'ll look that up for you.'],
                 ['functionCall' => ['id' => 'id1', 'name' => 'name1', 'args' => ['arg1' => '123']]],
+            ],
+        ];
+        yield 'thinking with signature' => [
+            new AssistantMessage(
+                new Thinking('Let me reason about this...', 'sig_abc123'),
+                new Text('The answer is 42.'),
+            ),
+            [
+                ['text' => 'Let me reason about this...', 'thought' => true, 'thoughtSignature' => 'sig_abc123'],
+                ['text' => 'The answer is 42.'],
+            ],
+        ];
+        yield 'thinking without signature' => [
+            new AssistantMessage(new Thinking('Quick thought.')),
+            [['text' => 'Quick thought.', 'thought' => true]],
+        ];
+        yield 'multiple thinking parts with signatures' => [
+            new AssistantMessage(
+                new Thinking('First thought.', 'sig_1'),
+                new Text('Intermediate.'),
+                new Thinking('Second thought.', 'sig_2'),
+            ),
+            [
+                ['text' => 'First thought.', 'thought' => true, 'thoughtSignature' => 'sig_1'],
+                ['text' => 'Intermediate.'],
+                ['text' => 'Second thought.', 'thought' => true, 'thoughtSignature' => 'sig_2'],
+            ],
+        ];
+        yield 'signed text part (non-thought)' => [
+            new AssistantMessage(new Text('Signed visible text.', 'sig_text')),
+            [
+                ['text' => 'Signed visible text.', 'thoughtSignature' => 'sig_text'],
+            ],
+        ];
+        yield 'signed function call' => [
+            new AssistantMessage(new ToolCall('id1', 'run', ['x' => 1], 'sig_call')),
+            [
+                ['functionCall' => ['id' => 'id1', 'name' => 'run', 'args' => ['x' => 1]], 'thoughtSignature' => 'sig_call'],
             ],
         ];
     }

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -25,6 +25,8 @@ use Symfony\AI\Platform\Result\Stream\Delta\ChoiceDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -144,6 +146,75 @@ final class ResultConverterTest extends TestCase
         $this->assertInstanceOf(BinaryResult::class, $result);
         $this->assertSame($image->asBinary(), $result->getContent());
         $this->assertNull($result->getMimeType());
+    }
+
+    public function testConvertsThoughtPartToThinkingResult()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            ['text' => 'Reasoning step.', 'thought' => true, 'thoughtSignature' => 'sig_abc'],
+                            ['text' => 'Final answer.'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(ThinkingResult::class, $parts[0]);
+        $this->assertSame('Reasoning step.', $parts[0]->getContent());
+        $this->assertSame('sig_abc', $parts[0]->getSignature());
+    }
+
+    public function testConvertsSignedTextPartCarriesSignature()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                ['content' => ['parts' => [
+                    ['text' => 'Signed visible text.', 'thoughtSignature' => 'sig_text'],
+                ]]],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Signed visible text.', $result->getContent());
+        $this->assertSame('sig_text', $result->getSignature());
+    }
+
+    public function testConvertsSignedFunctionCallCarriesSignature()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                ['content' => ['parts' => [
+                    ['functionCall' => ['id' => 'id1', 'name' => 'run', 'args' => ['x' => 1]], 'thoughtSignature' => 'sig_call'],
+                ]]],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('sig_call', $toolCalls[0]->getSignature());
     }
 
     public function testStreamSkipsCandidatesWithoutContentParts()

--- a/src/platform/src/Bridge/Meta/LlamaPromptConverter.php
+++ b/src/platform/src/Bridge/Meta/LlamaPromptConverter.php
@@ -49,14 +49,15 @@ final class LlamaPromptConverter
         }
 
         if ($message instanceof AssistantMessage) {
-            if ('' === $message->getContent() || null === $message->getContent()) {
+            $text = $message->asText();
+            if (null === $text || '' === $text) {
                 return '';
             }
 
             return trim(<<<ASSISTANT
                 <|start_header_id|>{$message->getRole()->value}<|end_header_id|>
 
-                {$message->getContent()}<|eot_id|>
+                {$text}<|eot_id|>
                 ASSISTANT);
         }
 

--- a/src/platform/src/Bridge/Meta/Tests/LlamaPromptConverterTest.php
+++ b/src/platform/src/Bridge/Meta/Tests/LlamaPromptConverterTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Meta\LlamaPromptConverter;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
+use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\SystemMessage;
@@ -119,7 +120,7 @@ final class LlamaPromptConverterTest extends TestCase
 
                 I am an assistant.<|eot_id|>
                 ASSISTANT,
-            new AssistantMessage('I am an assistant.'),
+            new AssistantMessage(new Text('I am an assistant.')),
         ];
 
         yield 'AssistantMessage with null content' => [

--- a/src/platform/src/Bridge/OpenResponses/Contract/Message/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/OpenResponses/Contract/Message/AssistantMessageNormalizer.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\OpenResponses\Contract\Message;
 use Symfony\AI\Platform\Bridge\OpenResponses\ResponsesModel;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Model;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
@@ -40,10 +41,17 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
             return $this->normalizer->normalize($data->getToolCalls(), $format, $context);
         }
 
+        $text = '';
+        foreach ($data->getContent() as $part) {
+            if ($part instanceof Text) {
+                $text .= $part->getText();
+            }
+        }
+
         return [
             'role' => $data->getRole()->value,
             'type' => 'message',
-            'content' => $data->getContent(),
+            'content' => '' === $text ? null : $text,
         ];
     }
 

--- a/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/AssistantMessageNormalizerTest.php
@@ -53,7 +53,7 @@ class AssistantMessageNormalizerTest extends TestCase
 
         $toolCall = new ToolCall('some-id', 'roll-die', ['sides' => 24]);
         yield 'with tool calls' => [
-            Message::ofAssistant(null, [$toolCall]),
+            Message::ofAssistant($toolCall),
             [
                 [
                     'arguments' => json_encode($toolCall->getArguments()),

--- a/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/MessageBagNormalizerTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/MessageBagNormalizerTest.php
@@ -57,7 +57,7 @@ class MessageBagNormalizerTest extends TestCase
         $toolCallMessage = Message::ofToolCall($toolCall, 'Critical hit');
         $systemMessage = Message::forSystem('You\'re a nice bot that will not overthrow humanity.');
         $assistantMessage = Message::ofAssistant('Anything else?');
-        $toolCallAssistantMessage = Message::ofAssistant(null, [$toolCall]);
+        $toolCallAssistantMessage = Message::ofAssistant($toolCall);
 
         $messageBag = new MessageBag($message, $assistantMessage, $toolCallAssistantMessage, $toolCallMessage);
         $expected = ['input' => [
@@ -68,7 +68,7 @@ class MessageBagNormalizerTest extends TestCase
             [
                 'role' => 'assistant',
                 'type' => 'message',
-                'content' => $assistantMessage->getContent(),
+                'content' => 'Anything else?',
             ],
             [
                 'arguments' => json_encode($toolCall->getArguments()),

--- a/src/platform/src/Bridge/VertexAi/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/VertexAi/Contract/AssistantMessageNormalizer.php
@@ -12,43 +12,63 @@
 namespace Symfony\AI\Platform\Bridge\VertexAi\Contract;
 
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
+use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ResultConverter;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Model as BaseModel;
+use Symfony\AI\Platform\Result\ToolCall;
 
 /**
  * @author Junaid Farooq <ulislam.junaid125@gmail.com>
+ *
+ * @phpstan-import-type Part from ResultConverter
  */
 final class AssistantMessageNormalizer extends ModelContractNormalizer
 {
     /**
      * @param AssistantMessage $data
      *
-     * @return array{
-     *     array{
-     *         text: string,
-     *         functionCall?: array{
-     *             name: string,
-     *             args?: array<int|string, mixed>
-     *         }
-     *     }
-     * }
+     * @return list<Part>
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         $normalized = [];
 
-        if (null !== $data->getContent()) {
-            $normalized[] = ['text' => $data->getContent()];
-        }
+        foreach ($data->getContent() as $part) {
+            if ($part instanceof Text) {
+                $textPart = ['text' => $part->getText()];
+                if (null !== $part->getSignature()) {
+                    $textPart['thoughtSignature'] = $part->getSignature();
+                }
+                $normalized[] = $textPart;
+                continue;
+            }
 
-        if ($data->hasToolCalls()) {
-            $normalized['functionCall'] = [
-                'name' => $data->getToolCalls()[0]->getName(),
-            ];
+            if ($part instanceof Thinking) {
+                $thoughtPart = ['text' => $part->getContent(), 'thought' => true];
+                if (null !== $part->getSignature()) {
+                    $thoughtPart['thoughtSignature'] = $part->getSignature();
+                }
+                $normalized[] = $thoughtPart;
+                continue;
+            }
 
-            if ($data->getToolCalls()[0]->getArguments()) {
-                $normalized['functionCall']['args'] = $data->getToolCalls()[0]->getArguments();
+            if ($part instanceof ToolCall) {
+                $functionCall = [
+                    'name' => $part->getName(),
+                ];
+
+                if ([] !== $part->getArguments()) {
+                    $functionCall['args'] = $part->getArguments();
+                }
+
+                $toolPart = ['functionCall' => $functionCall];
+                if (null !== $part->getSignature()) {
+                    $toolPart['thoughtSignature'] = $part->getSignature();
+                }
+                $normalized[] = $toolPart;
             }
         }
 

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -29,6 +29,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
@@ -38,6 +39,8 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
  * @phpstan-type Part array{
  *     functionCall?: array{id?: string, name: string, args: mixed[]},
  *     text?: string,
+ *     thought?: bool,
+ *     thoughtSignature?: string,
  *     inlineData?: array{data: string, mimeType: string},
  *     executableCode?: array{id?: string, language: string, code: string},
  *     codeExecutionResult?: array{id?: string, outcome: self::OUTCOME_*, output: string},
@@ -144,11 +147,14 @@ final class ResultConverter implements ResultConverterInterface
     /**
      * @param Part $contentPart
      */
-    private function convertPart(array $contentPart): ToolCallResult|TextResult|BinaryResult|ExecutableCodeResult|CodeExecutionResult|null
+    private function convertPart(array $contentPart): ToolCallResult|TextResult|ThinkingResult|BinaryResult|ExecutableCodeResult|CodeExecutionResult|null
     {
+        $signature = $contentPart['thoughtSignature'] ?? null;
+
         return match (true) {
-            isset($contentPart['functionCall']) => new ToolCallResult([$this->convertToolCall($contentPart['functionCall'])]),
-            isset($contentPart['text']) => new TextResult($contentPart['text']),
+            isset($contentPart['functionCall']) => new ToolCallResult([$this->convertToolCall($contentPart['functionCall'], $signature)]),
+            true === ($contentPart['thought'] ?? false) => new ThinkingResult($contentPart['text'] ?? '', $signature),
+            isset($contentPart['text']) => new TextResult($contentPart['text'], $signature),
             isset($contentPart['inlineData']) => BinaryResult::fromBase64($contentPart['inlineData']['data'], $contentPart['inlineData']['mimeType'] ?? null),
             isset($contentPart['executableCode']) => new ExecutableCodeResult(
                 $contentPart['executableCode']['code'],
@@ -171,8 +177,8 @@ final class ResultConverter implements ResultConverterInterface
      *     args: mixed[]
      * } $toolCall
      */
-    private function convertToolCall(array $toolCall): ToolCall
+    private function convertToolCall(array $toolCall, ?string $signature = null): ToolCall
     {
-        return new ToolCall($toolCall['id'] ?? '', $toolCall['name'], $toolCall['args']);
+        return new ToolCall($toolCall['id'] ?? '', $toolCall['name'], $toolCall['args'], $signature);
     }
 }

--- a/src/platform/src/Bridge/VertexAi/Tests/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Contract/AssistantMessageNormalizerTest.php
@@ -17,6 +17,8 @@ use Symfony\AI\Platform\Bridge\VertexAi\Contract\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Result\ToolCall;
 
 final class AssistantMessageNormalizerTest extends TestCase
@@ -25,7 +27,7 @@ final class AssistantMessageNormalizerTest extends TestCase
     {
         $normalizer = new AssistantMessageNormalizer();
 
-        $this->assertTrue($normalizer->supportsNormalization(new AssistantMessage('Hello'), context: [
+        $this->assertTrue($normalizer->supportsNormalization(new AssistantMessage(new Text('Hello')), context: [
             Contract::CONTEXT_MODEL => new Model('gemini-2.5-pro'),
         ]));
         $this->assertFalse($normalizer->supportsNormalization('not an assistant message'));
@@ -60,16 +62,54 @@ final class AssistantMessageNormalizerTest extends TestCase
     public static function normalizeDataProvider(): iterable
     {
         yield 'assistant message' => [
-            new AssistantMessage('Great to meet you. What would you like to know?'),
+            new AssistantMessage(new Text('Great to meet you. What would you like to know?')),
             [['text' => 'Great to meet you. What would you like to know?']],
         ];
         yield 'function call' => [
-            new AssistantMessage(toolCalls: [new ToolCall('name1', 'name1', ['arg1' => '123'])]),
-            ['functionCall' => ['name' => 'name1', 'args' => ['arg1' => '123']]],
+            new AssistantMessage(new ToolCall('name1', 'name1', ['arg1' => '123'])),
+            [['functionCall' => ['name' => 'name1', 'args' => ['arg1' => '123']]]],
         ];
         yield 'function call without parameters' => [
-            new AssistantMessage(toolCalls: [new ToolCall('name1', 'name1')]),
-            ['functionCall' => ['name' => 'name1']],
+            new AssistantMessage(new ToolCall('name1', 'name1')),
+            [['functionCall' => ['name' => 'name1']]],
+        ];
+        yield 'thinking with signature' => [
+            new AssistantMessage(
+                new Thinking('Reasoning step.', 'sig_v1'),
+                new Text('Answer.'),
+            ),
+            [
+                ['text' => 'Reasoning step.', 'thought' => true, 'thoughtSignature' => 'sig_v1'],
+                ['text' => 'Answer.'],
+            ],
+        ];
+        yield 'thinking without signature' => [
+            new AssistantMessage(new Thinking('Quick thought.')),
+            [['text' => 'Quick thought.', 'thought' => true]],
+        ];
+        yield 'multiple thinking parts with signatures' => [
+            new AssistantMessage(
+                new Thinking('First thought.', 'sig_1'),
+                new Text('Intermediate.'),
+                new Thinking('Second thought.', 'sig_2'),
+            ),
+            [
+                ['text' => 'First thought.', 'thought' => true, 'thoughtSignature' => 'sig_1'],
+                ['text' => 'Intermediate.'],
+                ['text' => 'Second thought.', 'thought' => true, 'thoughtSignature' => 'sig_2'],
+            ],
+        ];
+        yield 'signed text part (non-thought)' => [
+            new AssistantMessage(new Text('Signed visible text.', 'sig_text')),
+            [
+                ['text' => 'Signed visible text.', 'thoughtSignature' => 'sig_text'],
+            ],
+        ];
+        yield 'signed function call' => [
+            new AssistantMessage(new ToolCall('id1', 'run', ['x' => 1], 'sig_call')),
+            [
+                ['functionCall' => ['name' => 'run', 'args' => ['x' => 1]], 'thoughtSignature' => 'sig_call'],
+            ],
         ];
     }
 }

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
@@ -26,6 +26,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -163,6 +164,75 @@ final class ResultConverterTest extends TestCase
         ];
 
         $this->assertEquals($parts, $result->getContent());
+    }
+
+    public function testConvertsThoughtPartToThinkingResult()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            ['text' => 'Reasoning step.', 'thought' => true, 'thoughtSignature' => 'sig_abc'],
+                            ['text' => 'Final answer.'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(ThinkingResult::class, $parts[0]);
+        $this->assertSame('Reasoning step.', $parts[0]->getContent());
+        $this->assertSame('sig_abc', $parts[0]->getSignature());
+    }
+
+    public function testConvertsSignedTextPartCarriesSignature()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                ['content' => ['parts' => [
+                    ['text' => 'Signed visible text.', 'thoughtSignature' => 'sig_text'],
+                ]]],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Signed visible text.', $result->getContent());
+        $this->assertSame('sig_text', $result->getSignature());
+    }
+
+    public function testConvertsSignedFunctionCallCarriesSignature()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                ['content' => ['parts' => [
+                    ['functionCall' => ['name' => 'run', 'args' => ['x' => 1]], 'thoughtSignature' => 'sig_call'],
+                ]]],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('sig_call', $toolCalls[0]->getSignature());
     }
 
     public function testConvertsInlineDataToBinaryResult()

--- a/src/platform/src/Contract/Normalizer/Message/AssistantMessageNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/AssistantMessageNormalizer.php
@@ -12,6 +12,9 @@
 namespace Symfony\AI\Platform\Contract\Normalizer\Message;
 
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -42,17 +45,31 @@ final class AssistantMessageNormalizer implements NormalizerInterface, Normalize
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        $array = [
-            'role' => $data->getRole()->value,
-            'content' => $data->getContent(),
-        ];
+        $text = '';
+        $reasoning = '';
+        $toolCalls = [];
 
-        if ($data->hasToolCalls()) {
-            $array['tool_calls'] = $this->normalizer->normalize($data->getToolCalls(), $format, $context);
+        foreach ($data->getContent() as $part) {
+            if ($part instanceof Text) {
+                $text .= $part->getText();
+            } elseif ($part instanceof Thinking) {
+                $reasoning .= $part->getContent();
+            } elseif ($part instanceof ToolCall) {
+                $toolCalls[] = $part;
+            }
         }
 
-        if ($data->hasThinkingContent()) {
-            $array['reasoning_content'] = $data->getThinkingContent();
+        $array = [
+            'role' => $data->getRole()->value,
+            'content' => '' === $text ? null : $text,
+        ];
+
+        if ([] !== $toolCalls) {
+            $array['tool_calls'] = $this->normalizer->normalize($toolCalls, $format, $context);
+        }
+
+        if ('' !== $reasoning) {
+            $array['reasoning_content'] = $reasoning;
         }
 
         return $array;

--- a/src/platform/src/Message/AssistantMessage.php
+++ b/src/platform/src/Message/AssistantMessage.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\AI\Platform\Message;
 
+use Symfony\AI\Platform\Message\Content\ContentInterface;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Metadata\MetadataAwareTrait;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\Component\Uid\Uuid;
@@ -24,14 +27,13 @@ final class AssistantMessage implements MessageInterface
     use MetadataAwareTrait;
 
     /**
-     * @param ?ToolCall[] $toolCalls
+     * @var ContentInterface[]
      */
-    public function __construct(
-        private readonly ?string $content = null,
-        private readonly ?array $toolCalls = null,
-        private readonly ?string $thinkingContent = null,
-        private readonly ?string $thinkingSignature = null,
-    ) {
+    private readonly array $content;
+
+    public function __construct(ContentInterface ...$content)
+    {
+        $this->content = $content;
         $this->id = Uuid::v7();
     }
 
@@ -40,36 +42,71 @@ final class AssistantMessage implements MessageInterface
         return Role::Assistant;
     }
 
-    public function hasToolCalls(): bool
-    {
-        return null !== $this->toolCalls && [] !== $this->toolCalls;
-    }
-
     /**
-     * @return ?ToolCall[]
+     * @return ContentInterface[]
      */
-    public function getToolCalls(): ?array
-    {
-        return $this->toolCalls;
-    }
-
-    public function getContent(): ?string
+    public function getContent(): array
     {
         return $this->content;
     }
 
-    public function hasThinkingContent(): bool
+    public function hasToolCalls(): bool
     {
-        return null !== $this->thinkingContent;
+        foreach ($this->content as $part) {
+            if ($part instanceof ToolCall) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
-    public function getThinkingContent(): ?string
+    /**
+     * @return ToolCall[]
+     */
+    public function getToolCalls(): array
     {
-        return $this->thinkingContent;
+        return array_values(array_filter(
+            $this->content,
+            static fn (ContentInterface $part) => $part instanceof ToolCall,
+        ));
     }
 
-    public function getThinkingSignature(): ?string
+    public function hasThinking(): bool
     {
-        return $this->thinkingSignature;
+        foreach ($this->content as $part) {
+            if ($part instanceof Thinking) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return Thinking[]
+     */
+    public function getThinking(): array
+    {
+        return array_values(array_filter(
+            $this->content,
+            static fn (ContentInterface $part) => $part instanceof Thinking,
+        ));
+    }
+
+    public function asText(): ?string
+    {
+        $textParts = [];
+        foreach ($this->content as $part) {
+            if ($part instanceof Text) {
+                $textParts[] = $part->getText();
+            }
+        }
+
+        if ([] === $textParts) {
+            return null;
+        }
+
+        return implode('', $textParts);
     }
 }

--- a/src/platform/src/Message/Content/Text.php
+++ b/src/platform/src/Message/Content/Text.php
@@ -18,11 +18,21 @@ final class Text implements ContentInterface
 {
     public function __construct(
         private readonly string $text,
+        private readonly ?string $signature = null,
     ) {
     }
 
     public function getText(): string
     {
         return $this->text;
+    }
+
+    /**
+     * Provider-scoped signature guarding this text part when replayed on a subsequent turn.
+     * Currently only Google Gemini / Vertex AI emit signatures on non-thought text parts.
+     */
+    public function getSignature(): ?string
+    {
+        return $this->signature;
     }
 }

--- a/src/platform/src/Message/Content/Thinking.php
+++ b/src/platform/src/Message/Content/Thinking.php
@@ -9,12 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\Platform\Result;
+namespace Symfony\AI\Platform\Message\Content;
 
 /**
- * @author Christopher Hertel <mail@christopher-hertel.de>
+ * Represents a thinking/reasoning block emitted by an assistant.
+ *
+ * The optional signature is used by providers such as Anthropic to verify
+ * thinking blocks when they are replayed on a subsequent turn.
  */
-final class TextResult extends BaseResult
+final class Thinking implements ContentInterface
 {
     public function __construct(
         private readonly string $content,
@@ -27,10 +30,6 @@ final class TextResult extends BaseResult
         return $this->content;
     }
 
-    /**
-     * Provider-scoped signature guarding this text part when replayed on a subsequent turn.
-     * Currently only Google Gemini / Vertex AI emit signatures on non-thought text parts.
-     */
     public function getSignature(): ?string
     {
         return $this->signature;

--- a/src/platform/src/Message/Message.php
+++ b/src/platform/src/Message/Message.php
@@ -11,9 +11,16 @@
 
 namespace Symfony\AI\Platform\Message;
 
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\Content\ContentInterface;
 use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -35,12 +42,14 @@ final class Message
         return new SystemMessage($content instanceof \Stringable ? (string) $content : $content);
     }
 
-    /**
-     * @param ?ToolCall[] $toolCalls
-     */
-    public static function ofAssistant(?string $content = null, ?array $toolCalls = null): AssistantMessage
+    public static function ofAssistant(string|ContentInterface|ResultInterface ...$parts): AssistantMessage
     {
-        return new AssistantMessage($content, $toolCalls);
+        $content = [];
+        foreach ($parts as $part) {
+            array_push($content, ...self::toContent($part));
+        }
+
+        return new AssistantMessage(...$content);
     }
 
     public static function ofUser(\Stringable|string|ContentInterface ...$content): UserMessage
@@ -60,5 +69,42 @@ final class Message
     public static function ofToolCall(ToolCall $toolCall, string $content): ToolCallMessage
     {
         return new ToolCallMessage($toolCall, $content);
+    }
+
+    /**
+     * @return list<ContentInterface>
+     */
+    private static function toContent(string|ContentInterface|ResultInterface $part): array
+    {
+        if (\is_string($part)) {
+            return [new Text($part)];
+        }
+
+        if ($part instanceof ContentInterface) {
+            return [$part];
+        }
+
+        if ($part instanceof TextResult) {
+            return [new Text($part->getContent(), $part->getSignature())];
+        }
+
+        if ($part instanceof ThinkingResult) {
+            return [new Thinking($part->getContent() ?? '', $part->getSignature())];
+        }
+
+        if ($part instanceof ToolCallResult) {
+            return array_values($part->getContent());
+        }
+
+        if ($part instanceof MultiPartResult) {
+            $content = [];
+            foreach ($part->getContent() as $inner) {
+                array_push($content, ...self::toContent($inner));
+            }
+
+            return $content;
+        }
+
+        throw new InvalidArgumentException(\sprintf('Unsupported assistant message part of type "%s".', $part::class));
     }
 }

--- a/src/platform/src/Result/ThinkingResult.php
+++ b/src/platform/src/Result/ThinkingResult.php
@@ -12,25 +12,21 @@
 namespace Symfony\AI\Platform\Result;
 
 /**
- * @author Christopher Hertel <mail@christopher-hertel.de>
+ * Represents a separate thinking block/part.
  */
-final class TextResult extends BaseResult
+final class ThinkingResult extends BaseResult
 {
     public function __construct(
-        private readonly string $content,
+        private readonly ?string $content = null,
         private readonly ?string $signature = null,
     ) {
     }
 
-    public function getContent(): string
+    public function getContent(): ?string
     {
         return $this->content;
     }
 
-    /**
-     * Provider-scoped signature guarding this text part when replayed on a subsequent turn.
-     * Currently only Google Gemini / Vertex AI emit signatures on non-thought text parts.
-     */
     public function getSignature(): ?string
     {
         return $this->signature;

--- a/src/platform/src/Result/ToolCall.php
+++ b/src/platform/src/Result/ToolCall.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\AI\Platform\Result;
 
+use Symfony\AI\Platform\Message\Content\ContentInterface;
+
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class ToolCall
+final class ToolCall implements ContentInterface
 {
     /**
      * @param array<string, mixed> $arguments
@@ -23,6 +25,7 @@ final class ToolCall
         private readonly string $id,
         private readonly string $name,
         private readonly array $arguments = [],
+        private readonly ?string $signature = null,
     ) {
     }
 
@@ -42,5 +45,15 @@ final class ToolCall
     public function getArguments(): array
     {
         return $this->arguments;
+    }
+
+    /**
+     * Provider-scoped signature guarding this tool call when replayed on a subsequent turn.
+     * Currently only Google Gemini / Vertex AI emit signatures on function-call parts (for
+     * parallel calls, only the first part carries one).
+     */
+    public function getSignature(): ?string
+    {
+        return $this->signature;
     }
 }

--- a/src/platform/tests/Bridge/Anthropic/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Anthropic/Contract/AssistantMessageNormalizerTest.php
@@ -16,6 +16,8 @@ use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\Contract\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Result\ToolCall;
 
 /**
@@ -35,8 +37,8 @@ final class AssistantMessageNormalizerTest extends TestCase
         $model = new Claude(Claude::HAIKU_35);
         $context = [Contract::CONTEXT_MODEL => $model];
 
-        $this->assertTrue($this->normalizer->supportsNormalization(new AssistantMessage('content'), null, $context));
-        $this->assertFalse($this->normalizer->supportsNormalization(new AssistantMessage('content'), null, []));
+        $this->assertTrue($this->normalizer->supportsNormalization(new AssistantMessage(new Text('content')), null, $context));
+        $this->assertFalse($this->normalizer->supportsNormalization(new AssistantMessage(new Text('content')), null, []));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass(), null, $context));
     }
 
@@ -47,7 +49,7 @@ final class AssistantMessageNormalizerTest extends TestCase
 
     public function testNormalizeWithContent()
     {
-        $message = new AssistantMessage('Hello, I am an assistant.');
+        $message = new AssistantMessage(new Text('Hello, I am an assistant.'));
 
         $this->assertSame([
             'role' => 'assistant',
@@ -55,20 +57,20 @@ final class AssistantMessageNormalizerTest extends TestCase
         ], $this->normalizer->normalize($message));
     }
 
-    public function testNormalizeWithNullContentProducesEmptyString()
+    public function testNormalizeWithEmptyMessageProducesEmptyBlocks()
     {
-        $message = new AssistantMessage(null);
+        $message = new AssistantMessage();
 
         $this->assertSame([
             'role' => 'assistant',
-            'content' => '',
+            'content' => [],
         ], $this->normalizer->normalize($message));
     }
 
     public function testNormalizeWithToolCalls()
     {
         $toolCall = new ToolCall('tool-id', 'some_tool', ['param' => 'value']);
-        $message = new AssistantMessage(null, [$toolCall]);
+        $message = new AssistantMessage($toolCall);
 
         $this->assertSame([
             'role' => 'assistant',
@@ -86,7 +88,7 @@ final class AssistantMessageNormalizerTest extends TestCase
     public function testNormalizeWithToolCallsAndContent()
     {
         $toolCall = new ToolCall('tool-id', 'some_tool', ['param' => 'value']);
-        $message = new AssistantMessage('Some text before tool use.', [$toolCall]);
+        $message = new AssistantMessage(new Text('Some text before tool use.'), $toolCall);
 
         $this->assertSame([
             'role' => 'assistant',
@@ -104,7 +106,7 @@ final class AssistantMessageNormalizerTest extends TestCase
 
     public function testNormalizeWithThinkingContent()
     {
-        $message = new AssistantMessage(null, null, 'Let me think about this...', 'sig-abc');
+        $message = new AssistantMessage(new Thinking('Let me think about this...', 'sig-abc'));
 
         $this->assertSame([
             'role' => 'assistant',
@@ -120,7 +122,10 @@ final class AssistantMessageNormalizerTest extends TestCase
 
     public function testNormalizeWithThinkingContentAndText()
     {
-        $message = new AssistantMessage('The answer is 42.', null, 'Let me think about this...', 'sig-abc');
+        $message = new AssistantMessage(
+            new Thinking('Let me think about this...', 'sig-abc'),
+            new Text('The answer is 42.'),
+        );
 
         $this->assertSame([
             'role' => 'assistant',

--- a/src/platform/tests/Contract/Normalizer/Message/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/AssistantMessageNormalizerTest.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Message;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Contract\Normalizer\Message\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -28,7 +30,7 @@ final class AssistantMessageNormalizerTest extends TestCase
 
     public function testSupportsNormalization()
     {
-        $this->assertTrue($this->normalizer->supportsNormalization(new AssistantMessage('content')));
+        $this->assertTrue($this->normalizer->supportsNormalization(new AssistantMessage(new Text('content'))));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 
@@ -39,7 +41,7 @@ final class AssistantMessageNormalizerTest extends TestCase
 
     public function testNormalizeWithContent()
     {
-        $message = new AssistantMessage('I am an assistant');
+        $message = new AssistantMessage(new Text('I am an assistant'));
 
         $expected = [
             'role' => 'assistant',
@@ -55,7 +57,7 @@ final class AssistantMessageNormalizerTest extends TestCase
             new ToolCall('id1', 'function1', ['param' => 'value']),
             new ToolCall('id2', 'function2', ['param' => 'value2']),
         ];
-        $message = new AssistantMessage('Content with tools', $toolCalls);
+        $message = new AssistantMessage(new Text('Content with tools'), ...$toolCalls);
 
         $expectedToolCalls = [
             ['id' => 'id1', 'function' => 'function1', 'arguments' => ['param' => 'value']],
@@ -81,8 +83,8 @@ final class AssistantMessageNormalizerTest extends TestCase
 
     public function testNormalizeWithNullContent()
     {
-        $toolCalls = [new ToolCall('id1', 'function1', ['param' => 'value'])];
-        $message = new AssistantMessage(null, $toolCalls);
+        $toolCall = new ToolCall('id1', 'function1', ['param' => 'value']);
+        $message = new AssistantMessage($toolCall);
 
         $expectedToolCalls = [['id' => 'id1', 'function' => 'function1', 'arguments' => ['param' => 'value']]];
 
@@ -103,7 +105,10 @@ final class AssistantMessageNormalizerTest extends TestCase
 
     public function testNormalizeWithThinkingContent()
     {
-        $message = new AssistantMessage('The answer is 42.', null, 'Let me think about this...');
+        $message = new AssistantMessage(
+            new Thinking('Let me think about this...'),
+            new Text('The answer is 42.'),
+        );
 
         $expected = [
             'role' => 'assistant',
@@ -116,7 +121,7 @@ final class AssistantMessageNormalizerTest extends TestCase
 
     public function testNormalizeWithoutThinkingContentDoesNotEmitReasoningContent()
     {
-        $message = new AssistantMessage('Just a normal response');
+        $message = new AssistantMessage(new Text('Just a normal response'));
 
         $result = $this->normalizer->normalize($message);
 
@@ -126,8 +131,12 @@ final class AssistantMessageNormalizerTest extends TestCase
 
     public function testNormalizeWithThinkingContentAndToolCalls()
     {
-        $toolCalls = [new ToolCall('id1', 'function1', ['param' => 'value'])];
-        $message = new AssistantMessage('Content', $toolCalls, 'Reasoning about tool usage');
+        $toolCall = new ToolCall('id1', 'function1', ['param' => 'value']);
+        $message = new AssistantMessage(
+            new Text('Content'),
+            new Thinking('Reasoning about tool usage'),
+            $toolCall,
+        );
 
         $expectedToolCalls = [['id' => 'id1', 'function' => 'function1', 'arguments' => ['param' => 'value']]];
 

--- a/src/platform/tests/ContractTest.php
+++ b/src/platform/tests/ContractTest.php
@@ -18,7 +18,6 @@ use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper\AudioNormalizer;
 use Symfony\AI\Platform\Contract;
-use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\Audio;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
@@ -157,7 +156,7 @@ final class ContractTest extends TestCase
                 Message::forSystem('My amazing system prompt.'),
                 Message::ofAssistant('It is time to sleep.'),
                 Message::ofUser('Hello, world!'),
-                new AssistantMessage('Hello User!'),
+                Message::ofAssistant('Hello User!'),
                 Message::ofUser('My hint for how to analyze an image.', new ImageUrl('http://image-generator.local/my-fancy-image.png')),
             ),
             'expected' => [

--- a/src/platform/tests/Message/AssistantMessageTest.php
+++ b/src/platform/tests/Message/AssistantMessageTest.php
@@ -13,6 +13,8 @@ namespace Symfony\AI\Platform\Tests\Message;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Message\Role;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tests\Helper\UuidAssertionTrait;
@@ -31,33 +33,61 @@ final class AssistantMessageTest extends TestCase
 
     public function testConstructionWithoutToolCallIsPossible()
     {
-        $message = new AssistantMessage('foo');
+        $message = new AssistantMessage(new Text('foo'));
 
-        $this->assertSame('foo', $message->getContent());
-        $this->assertNull($message->getToolCalls());
+        $this->assertSame('foo', $message->asText());
+        $this->assertSame([], $message->getToolCalls());
+        $this->assertFalse($message->hasToolCalls());
     }
 
     public function testConstructionWithoutContentIsPossible()
     {
         $toolCall = new ToolCall('foo', 'foo');
-        $message = new AssistantMessage(toolCalls: [$toolCall]);
+        $message = new AssistantMessage($toolCall);
 
-        $this->assertNull($message->getContent());
+        $this->assertNull($message->asText());
         $this->assertSame([$toolCall], $message->getToolCalls());
         $this->assertTrue($message->hasToolCalls());
     }
 
+    public function testConstructionWithThinkingIsPossible()
+    {
+        $thinking = new Thinking('reasoning', 'sig');
+        $message = new AssistantMessage($thinking, new Text('answer'));
+
+        $this->assertTrue($message->hasThinking());
+        $this->assertSame([$thinking], $message->getThinking());
+        $this->assertSame('answer', $message->asText());
+    }
+
+    public function testGetContentReturnsAllParts()
+    {
+        $thinking = new Thinking('reasoning');
+        $text = new Text('answer');
+        $toolCall = new ToolCall('id', 'name');
+        $message = new AssistantMessage($thinking, $text, $toolCall);
+
+        $this->assertSame([$thinking, $text, $toolCall], $message->getContent());
+    }
+
+    public function testAsTextConcatenatesMultipleTextParts()
+    {
+        $message = new AssistantMessage(new Text('Hello, '), new Text('world!'));
+
+        $this->assertSame('Hello, world!', $message->asText());
+    }
+
     public function testMessageHasUid()
     {
-        $message = new AssistantMessage('foo');
+        $message = new AssistantMessage(new Text('foo'));
 
         $this->assertInstanceOf(UuidV7::class, $message->getId());
     }
 
     public function testDifferentMessagesHaveDifferentUids()
     {
-        $message1 = new AssistantMessage('foo');
-        $message2 = new AssistantMessage('bar');
+        $message1 = new AssistantMessage(new Text('foo'));
+        $message2 = new AssistantMessage(new Text('bar'));
 
         $this->assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
         $this->assertIsUuidV7($message1->getId()->toRfc4122());
@@ -66,8 +96,8 @@ final class AssistantMessageTest extends TestCase
 
     public function testSameMessagesHaveDifferentUids()
     {
-        $message1 = new AssistantMessage('foo');
-        $message2 = new AssistantMessage('foo');
+        $message1 = new AssistantMessage(new Text('foo'));
+        $message2 = new AssistantMessage(new Text('foo'));
 
         $this->assertNotSame($message1->getId()->toRfc4122(), $message2->getId()->toRfc4122());
         $this->assertIsUuidV7($message1->getId()->toRfc4122());
@@ -76,7 +106,7 @@ final class AssistantMessageTest extends TestCase
 
     public function testMessageIdImplementsRequiredInterfaces()
     {
-        $message = new AssistantMessage('test');
+        $message = new AssistantMessage(new Text('test'));
 
         $this->assertInstanceOf(AbstractUid::class, $message->getId());
         $this->assertInstanceOf(TimeBasedUidInterface::class, $message->getId());

--- a/src/platform/tests/Message/MessageBagTest.php
+++ b/src/platform/tests/Message/MessageBagTest.php
@@ -83,7 +83,7 @@ final class MessageBagTest extends TestCase
         $newMessageFromBag = $newMessageBag->getMessages()[3];
 
         $this->assertInstanceOf(AssistantMessage::class, $newMessageFromBag);
-        $this->assertSame('It is time to wake up.', $newMessageFromBag->getContent());
+        $this->assertSame('It is time to wake up.', $newMessageFromBag->asText());
     }
 
     public function testMerge()
@@ -103,7 +103,7 @@ final class MessageBagTest extends TestCase
         $messageFromBag = $messageBag->getMessages()[3];
 
         $this->assertInstanceOf(AssistantMessage::class, $messageFromBag);
-        $this->assertSame('It is time to wake up.', $messageFromBag->getContent());
+        $this->assertSame('It is time to wake up.', $messageFromBag->asText());
     }
 
     public function testWithoutSystemMessage()
@@ -123,7 +123,7 @@ final class MessageBagTest extends TestCase
 
         $assistantMessage = $newMessageBag->getMessages()[0];
         $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
-        $this->assertSame('It is time to sleep.', $assistantMessage->getContent());
+        $this->assertSame('It is time to sleep.', $assistantMessage->asText());
 
         $userMessage = $newMessageBag->getMessages()[1];
         $this->assertInstanceOf(UserMessage::class, $userMessage);

--- a/src/platform/tests/Message/MessageTest.php
+++ b/src/platform/tests/Message/MessageTest.php
@@ -43,7 +43,9 @@ final class MessageTest extends TestCase
     {
         $message = Message::ofAssistant('It is time to sleep.');
 
-        $this->assertSame('It is time to sleep.', $message->getContent());
+        $this->assertCount(1, $message->getContent());
+        $this->assertInstanceOf(Text::class, $message->getContent()[0]);
+        $this->assertSame('It is time to sleep.', $message->asText());
     }
 
     public function testCreateAssistantMessageWithToolCalls()
@@ -52,7 +54,7 @@ final class MessageTest extends TestCase
             new ToolCall('call_123456', 'my_tool', ['foo' => 'bar']),
             new ToolCall('call_456789', 'my_faster_tool'),
         ];
-        $message = Message::ofAssistant(toolCalls: $toolCalls);
+        $message = Message::ofAssistant(...$toolCalls);
 
         $this->assertCount(2, $message->getToolCalls());
         $this->assertTrue($message->hasToolCalls());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | todo
| License       | MIT

Rework `AssistantMessage` to better model the APIs and
1. Allow any platform-specific content that needs to be sent back to the server on next call
2. Retain original order of blocks/parts
3. Allow attaching metadata to blocks/parts instead of just the message.
  - e.g. with Gemini, several parts in the assistant message can have `thoughtSignatures`

Before
---

```php
new AssistantMessage(
  content: 'Hello',
  toolCalls: [new ToolCall('id1', 'fn', ['a' => 1])],
  thinkingContent: 'reasoning',
  thinkingSignature: 'sig',
),
```

After
---

```php
new AssistantMessage(                                     
    new Thinking('reasoning', 'sig'),                                                                                                                                                       
    new Text('Hello'),                                    
    new ToolCall('id1', 'fn', ['a' => 1]),
); 
```
