### PR TITLE
 Add reasoning_content serialization to AssistantMessageNormalizer

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Add `description` and `example` properties to `#[With]` attribute
  * Generate JSON schema from Symfony Validator constraints when available
  * Add `asTextStream()` method to `DeferredResult` to get a stream of `TextDelta` objects only
+ * Add `reasoning_content` serialization in shared `AssistantMessageNormalizer` for OpenAI-compatible endpoints
 
 0.6
 ---

--- a/src/platform/src/Contract/Normalizer/Message/AssistantMessageNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Message/AssistantMessageNormalizer.php
@@ -38,7 +38,7 @@ final class AssistantMessageNormalizer implements NormalizerInterface, Normalize
     /**
      * @param AssistantMessage $data
      *
-     * @return array{role: 'assistant', content: string|null, tool_calls?: array<array<string, mixed>>}
+     * @return array{role: 'assistant', content: string|null, tool_calls?: array<array<string, mixed>>, reasoning_content?: string}
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
@@ -49,6 +49,10 @@ final class AssistantMessageNormalizer implements NormalizerInterface, Normalize
 
         if ($data->hasToolCalls()) {
             $array['tool_calls'] = $this->normalizer->normalize($data->getToolCalls(), $format, $context);
+        }
+
+        if ($data->hasThinkingContent()) {
+            $array['reasoning_content'] = $data->getThinkingContent();
         }
 
         return $array;

--- a/src/platform/tests/Contract/Normalizer/Message/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Message/AssistantMessageNormalizerTest.php
@@ -100,4 +100,50 @@ final class AssistantMessageNormalizerTest extends TestCase
         $this->assertNull($result['content']);
         $this->assertSame($expectedToolCalls, $result['tool_calls']);
     }
+
+    public function testNormalizeWithThinkingContent()
+    {
+        $message = new AssistantMessage('The answer is 42.', null, 'Let me think about this...');
+
+        $expected = [
+            'role' => 'assistant',
+            'content' => 'The answer is 42.',
+            'reasoning_content' => 'Let me think about this...',
+        ];
+
+        $this->assertSame($expected, $this->normalizer->normalize($message));
+    }
+
+    public function testNormalizeWithoutThinkingContentDoesNotEmitReasoningContent()
+    {
+        $message = new AssistantMessage('Just a normal response');
+
+        $result = $this->normalizer->normalize($message);
+
+        $this->assertArrayNotHasKey('reasoning_content', $result);
+        $this->assertSame('Just a normal response', $result['content']);
+    }
+
+    public function testNormalizeWithThinkingContentAndToolCalls()
+    {
+        $toolCalls = [new ToolCall('id1', 'function1', ['param' => 'value'])];
+        $message = new AssistantMessage('Content', $toolCalls, 'Reasoning about tool usage');
+
+        $expectedToolCalls = [['id' => 'id1', 'function' => 'function1', 'arguments' => ['param' => 'value']]];
+
+        $innerNormalizer = $this->createMock(NormalizerInterface::class);
+        $innerNormalizer->expects($this->once())
+            ->method('normalize')
+            ->with($message->getToolCalls(), null, [])
+            ->willReturn($expectedToolCalls);
+
+        $this->normalizer->setNormalizer($innerNormalizer);
+
+        $result = $this->normalizer->normalize($message);
+
+        $this->assertSame('assistant', $result['role']);
+        $this->assertSame('Content', $result['content']);
+        $this->assertSame($expectedToolCalls, $result['tool_calls']);
+        $this->assertSame('Reasoning about tool usage', $result['reasoning_content']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #1854 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Emit `reasoning_content` in the shared `AssistantMessageNormalizer` when `AssistantMessage` has thinking content, so reasoning is preserved across conversation turns for OpenAI-compatible endpoints (DeepSeek, Z.AI, llama.cpp etc.).

In theory we should also parse it with non-streaming response I guess, but there is no clear way to put it further (maybe in Metadata?), so I decided to keep this PR small and focused.

