### PR TITLE
[Platform][Cohere] Add speech-to-text support and update model catalog

### DIFF
--- a/examples/cohere/speech-to-text.php
+++ b/examples/cohere/speech-to-text.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Cohere\PlatformFactory;
+use Symfony\AI\Platform\Message\Content\Audio;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('COHERE_API_KEY'), http_client());
+
+$result = $platform->invoke('cohere-transcribe-03-2026', Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3'), [
+    'language' => 'en',
+]);
+
+echo $result->asText().\PHP_EOL;

--- a/src/platform/src/Bridge/Cohere/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cohere/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.8
+---
+
+ * Add speech-to-text transcription support
+ * Add vision, translation, reasoning, Aya, and additional reranking models to the catalog
+
 0.7
 ---
 

--- a/src/platform/src/Bridge/Cohere/ModelCatalog.php
+++ b/src/platform/src/Bridge/Cohere/ModelCatalog.php
@@ -36,6 +36,35 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::TOOL_CALLING,
                 ],
             ],
+            'command-a-vision-07-2025' => [
+                'class' => Cohere::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            'command-a-translate-08-2025' => [
+                'class' => Cohere::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                ],
+            ],
+            'command-a-reasoning-08-2025' => [
+                'class' => Cohere::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::TOOL_CALLING,
+                    Capability::THINKING,
+                ],
+            ],
             'command-r-plus-08-2024' => [
                 'class' => Cohere::class,
                 'capabilities' => [
@@ -66,6 +95,24 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::TOOL_CALLING,
                 ],
             ],
+            // Aya models
+            'c4ai-aya-expanse-32b' => [
+                'class' => Cohere::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                ],
+            ],
+            'c4ai-aya-vision-32b' => [
+                'class' => Cohere::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                ],
+            ],
             // Embedding models
             'embed-v4.0' => [
                 'class' => Embeddings::class,
@@ -88,6 +135,14 @@ final class ModelCatalog extends AbstractModelCatalog
                 'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             // Reranking models
+            'rerank-v4.0-pro' => [
+                'class' => Reranker::class,
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::RERANKING],
+            ],
+            'rerank-v4.0-fast' => [
+                'class' => Reranker::class,
+                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::RERANKING],
+            ],
             'rerank-v3.5' => [
                 'class' => Reranker::class,
                 'capabilities' => [Capability::INPUT_MULTIPLE, Capability::RERANKING],
@@ -99,6 +154,11 @@ final class ModelCatalog extends AbstractModelCatalog
             'rerank-multilingual-v3.0' => [
                 'class' => Reranker::class,
                 'capabilities' => [Capability::INPUT_MULTIPLE, Capability::RERANKING],
+            ],
+            // Speech-to-text models
+            'cohere-transcribe-03-2026' => [
+                'class' => SpeechToText::class,
+                'capabilities' => [Capability::INPUT_AUDIO, Capability::SPEECH_TO_TEXT],
             ],
         ];
 

--- a/src/platform/src/Bridge/Cohere/PlatformFactory.php
+++ b/src/platform/src/Bridge/Cohere/PlatformFactory.php
@@ -33,10 +33,10 @@ final class PlatformFactory
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Platform(
-            [new Embeddings\ModelClient($httpClient, $apiKey), new Reranker\ModelClient($httpClient, $apiKey), new Llm\ModelClient($httpClient, $apiKey)],
-            [new Embeddings\ResultConverter(), new Reranker\ResultConverter(), new Llm\ResultConverter()],
+            [new Embeddings\ModelClient($httpClient, $apiKey), new Reranker\ModelClient($httpClient, $apiKey), new Llm\ModelClient($httpClient, $apiKey), new SpeechToText\ModelClient($httpClient, $apiKey)],
+            [new Embeddings\ResultConverter(), new Reranker\ResultConverter(), new Llm\ResultConverter(), new SpeechToText\ResultConverter()],
             $modelCatalog,
-            $contract ?? Contract::create(),
+            $contract ?? Contract::create(new SpeechToText\AudioNormalizer()),
             $eventDispatcher,
         );
     }

--- a/src/platform/src/Bridge/Cohere/SpeechToText.php
+++ b/src/platform/src/Bridge/Cohere/SpeechToText.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere;
+
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SpeechToText extends Model
+{
+}

--- a/src/platform/src/Bridge/Cohere/SpeechToText/AudioNormalizer.php
+++ b/src/platform/src/Bridge/Cohere/SpeechToText/AudioNormalizer.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
+
+use Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class AudioNormalizer implements NormalizerInterface
+{
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Audio && $context[Contract::CONTEXT_MODEL] instanceof SpeechToText;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            Audio::class => true,
+        ];
+    }
+
+    /**
+     * @param Audio $data
+     *
+     * @return array{model: string, file: resource}
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        return [
+            'model' => $context[Contract::CONTEXT_MODEL]->getName(),
+            'file' => $data->asResource(),
+        ];
+    }
+}

--- a/src/platform/src/Bridge/Cohere/SpeechToText/ModelClient.php
+++ b/src/platform/src/Bridge/Cohere/SpeechToText/ModelClient.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
+
+use Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelClient implements ModelClientInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        #[\SensitiveParameter] private readonly string $apiKey,
+    ) {
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof SpeechToText;
+    }
+
+    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    {
+        if (\is_string($payload)) {
+            throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
+        }
+
+        $body = array_merge($options, $payload, ['model' => $model->getName()]);
+
+        return new RawHttpResult($this->httpClient->request('POST', 'https://api.cohere.com/v2/audio/transcriptions', [
+            'auth_bearer' => $this->apiKey,
+            'headers' => ['Content-Type' => 'multipart/form-data'],
+            'body' => $body,
+        ]));
+    }
+}

--- a/src/platform/src/Bridge/Cohere/SpeechToText/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/SpeechToText/ResultConverter.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
+
+use Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResultConverter implements ResultConverterInterface
+{
+    public function supports(Model $model): bool
+    {
+        return $model instanceof SpeechToText;
+    }
+
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): TextResult
+    {
+        $httpResponse = $result->getObject();
+
+        if (200 !== $httpResponse->getStatusCode()) {
+            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $httpResponse->getStatusCode(), $httpResponse->getContent(false)));
+        }
+
+        $data = $result->getData();
+
+        if (!isset($data['text'])) {
+            throw new RuntimeException('Response does not contain transcription text.');
+        }
+
+        return new TextResult($data['text']);
+    }
+
+    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    {
+        return null;
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/ModelCatalogTest.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Bridge\Cohere\Cohere;
 use Symfony\AI\Platform\Bridge\Cohere\Embeddings;
 use Symfony\AI\Platform\Bridge\Cohere\ModelCatalog;
 use Symfony\AI\Platform\Bridge\Cohere\Reranker;
+use Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Test\ModelCatalogTestCase;
@@ -25,9 +26,16 @@ final class ModelCatalogTest extends ModelCatalogTestCase
     {
         // Chat models
         yield 'command-a-03-2025' => ['command-a-03-2025', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
+        yield 'command-a-vision-07-2025' => ['command-a-vision-07-2025', Cohere::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
+        yield 'command-a-translate-08-2025' => ['command-a-translate-08-2025', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
+        yield 'command-a-reasoning-08-2025' => ['command-a-reasoning-08-2025', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::THINKING]];
         yield 'command-r-plus-08-2024' => ['command-r-plus-08-2024', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
         yield 'command-r-08-2024' => ['command-r-08-2024', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
         yield 'command-r7b-12-2024' => ['command-r7b-12-2024', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
+
+        // Aya models
+        yield 'c4ai-aya-expanse-32b' => ['c4ai-aya-expanse-32b', Cohere::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
+        yield 'c4ai-aya-vision-32b' => ['c4ai-aya-vision-32b', Cohere::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
 
         // Embedding models
         yield 'embed-v4.0' => ['embed-v4.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::INPUT_MULTIMODAL, Capability::EMBEDDINGS]];
@@ -37,9 +45,14 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'embed-multilingual-light-v3.0' => ['embed-multilingual-light-v3.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
 
         // Reranking models
+        yield 'rerank-v4.0-pro' => ['rerank-v4.0-pro', Reranker::class, [Capability::INPUT_MULTIPLE, Capability::RERANKING]];
+        yield 'rerank-v4.0-fast' => ['rerank-v4.0-fast', Reranker::class, [Capability::INPUT_MULTIPLE, Capability::RERANKING]];
         yield 'rerank-v3.5' => ['rerank-v3.5', Reranker::class, [Capability::INPUT_MULTIPLE, Capability::RERANKING]];
         yield 'rerank-english-v3.0' => ['rerank-english-v3.0', Reranker::class, [Capability::INPUT_MULTIPLE, Capability::RERANKING]];
         yield 'rerank-multilingual-v3.0' => ['rerank-multilingual-v3.0', Reranker::class, [Capability::INPUT_MULTIPLE, Capability::RERANKING]];
+
+        // Speech-to-text models
+        yield 'cohere-transcribe-03-2026' => ['cohere-transcribe-03-2026', SpeechToText::class, [Capability::INPUT_AUDIO, Capability::SPEECH_TO_TEXT]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/Cohere/Tests/SpeechToText/ModelClientTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/SpeechToText/ModelClientTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests\SpeechToText;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Cohere;
+use Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
+use Symfony\AI\Platform\Bridge\Cohere\SpeechToText\ModelClient;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ModelClientTest extends TestCase
+{
+    public function testItSupportsSpeechToTextModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertTrue($client->supports(new SpeechToText('cohere-transcribe-03-2026')));
+    }
+
+    public function testItDoesNotSupportCohereModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertFalse($client->supports(new Cohere('command-a-03-2025')));
+    }
+
+    public function testItSendsExpectedRequest()
+    {
+        $httpClient = new MockHttpClient([function (
+            string $method,
+            string $url,
+            array $options,
+        ): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.cohere.com/v2/audio/transcriptions', $url);
+            $this->assertStringContainsString('Bearer test-key', $options['normalized_headers']['authorization'][0]);
+            $this->assertStringContainsString('multipart/form-data', $options['normalized_headers']['content-type'][0]);
+
+            return new MockResponse('{"text": "Hello world"}');
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key');
+
+        $client->request(new SpeechToText('cohere-transcribe-03-2026'), ['file' => 'audio-data', 'language' => 'en']);
+    }
+
+    public function testStringPayloadThrowsException()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Payload must be an array, but a string was given');
+
+        $client->request(new SpeechToText('cohere-transcribe-03-2026'), 'string payload');
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/SpeechToText/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/SpeechToText/ResultConverterTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests\SpeechToText;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
+use Symfony\AI\Platform\Bridge\Cohere\SpeechToText\ResultConverter;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ResultConverterTest extends TestCase
+{
+    public function testItSupportsSpeechToTextModel()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertTrue($converter->supports(new SpeechToText('cohere-transcribe-03-2026')));
+    }
+
+    public function testItThrowsExceptionOnNon200StatusCode()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(500);
+        $response->method('getContent')->willReturn('Internal Server Error');
+
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testItConvertsResponseToTextResult()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'text' => 'Hello, this is a transcription test.',
+        ]);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello, this is a transcription test.', $result->getContent());
+    }
+
+    public function testItThrowsExceptionWhenResponseDoesNotContainText()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn(['invalid' => 'response']);
+
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Response does not contain transcription text.');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testItReturnsNullTokenUsageExtractor()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertNull($converter->getTokenUsageExtractor());
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Tests/SpeechToTextTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/SpeechToTextTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
+use Symfony\AI\Platform\Model;
+
+final class SpeechToTextTest extends TestCase
+{
+    public function testItExtendsModel()
+    {
+        $model = new SpeechToText('cohere-transcribe-03-2026');
+
+        $this->assertInstanceOf(Model::class, $model);
+        $this->assertSame('cohere-transcribe-03-2026', $model->getName());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

### Summary

Add speech-to-text transcription support and update the model catalog for the Cohere bridge.

#### Speech-to-Text

Adds transcription support using Cohere's `POST /v2/audio/transcriptions` endpoint with model `cohere-transcribe-03-2026`.

```php
$platform = PlatformFactory::create($apiKey);

$result = $platform->invoke('cohere-transcribe-03-2026', Audio::fromFile('/path/to/audio.mp3'), [
    'language' => 'en',
]);

echo $result->asText();
```

New classes:
- `SpeechToText` — Model class
- `SpeechToText\ModelClient` — Sends multipart/form-data requests
- `SpeechToText\ResultConverter` — Converts `{"text": "..."}` to `TextResult`
- `SpeechToText\AudioNormalizer` — Normalizes `Audio` content for the contract

#### Model Catalog Updates

Added missing models:
- **Chat**: `command-a-vision-07-2025` (vision), `command-a-translate-08-2025` (translation), `command-a-reasoning-08-2025` (thinking)
- **Aya**: `c4ai-aya-expanse-32b`, `c4ai-aya-vision-32b`
- **Reranking**: `rerank-v4.0-pro`, `rerank-v4.0-fast`
- **Speech-to-text**: `cohere-transcribe-03-2026`