### PR TITLE
[Platform][Gemini] Add `MultiPartResult`

### DIFF
--- a/examples/gemini/server-tools-code-execution.php
+++ b/examples/gemini/server-tools-code-execution.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = PlatformFactory::create(env('GEMINI_API_KEY'), http_client());
+
+$toolbox = new Toolbox([], logger: logger());
+$processor = new AgentProcessor($toolbox);
+$agent = new Agent($platform, 'gemini-3.1-pro-preview', [$processor], [$processor]);
+
+$messages = new MessageBag(
+    Message::ofUser('Calculate total cost of a mortgage with 1% interest on 100k€ principal with 25 year maturity'),
+);
+
+$result = $agent->call($messages, [
+    'server_tools' => ['code_execution' => true],
+]);
+
+assert($result instanceof MultiPartResult);
+
+foreach ($result as $part) {
+    echo match (true) {
+        $part instanceof ExecutableCodeResult => "<code>\n".$part->getContent()."\n</code>\n\n",
+        default => $part->getContent()."\n",
+    };
+}

--- a/src/agent/src/Toolbox/AgentProcessor.php
+++ b/src/agent/src/Toolbox/AgentProcessor.php
@@ -22,6 +22,7 @@ use Symfony\AI\Agent\Toolbox\Event\ToolCallsExecuted;
 use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
@@ -84,6 +85,10 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
             );
 
             return;
+        }
+
+        if ($result instanceof MultiPartResult) {
+            $result = array_find($result->getContent(), static fn (ResultInterface $part) => $part instanceof ToolCallResult);
         }
 
         if (!$result instanceof ToolCallResult) {

--- a/src/agent/tests/Toolbox/AgentProcessorTest.php
+++ b/src/agent/tests/Toolbox/AgentProcessorTest.php
@@ -29,6 +29,7 @@ use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -133,6 +134,60 @@ class AgentProcessorTest extends TestCase
         $processor->processOutput($output);
 
         $this->assertCount(0, $messageBag);
+    }
+
+    public function testProcessOutputWithMultiPartResultContainingToolCall()
+    {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Test response'));
+
+        $messageBag = new MessageBag();
+        $toolCallResult = new ToolCallResult($toolCall);
+        $result = new MultiPartResult([
+            new TextResult('Some text before tool call'),
+            $toolCallResult,
+        ]);
+
+        $agent = $this->createStub(AgentInterface::class);
+        $agent->method('call')->willReturn(new TextResult('Final response'));
+
+        $processor = new AgentProcessor($toolbox);
+        $processor->setAgent($agent);
+
+        $output = new Output('gpt-4', $result, $messageBag);
+
+        $processor->processOutput($output);
+
+        $this->assertInstanceOf(TextResult::class, $output->getResult());
+        $this->assertSame('Final response', $output->getResult()->getContent());
+    }
+
+    public function testProcessOutputWithMultiPartResultNotContainingToolCall()
+    {
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox->expects($this->never())->method('execute');
+
+        $messageBag = new MessageBag();
+        $result = new MultiPartResult([
+            new TextResult('Some text'),
+            new TextResult('More text'),
+        ]);
+
+        $agent = $this->createMock(AgentInterface::class);
+        $agent->expects($this->never())->method('call');
+
+        $processor = new AgentProcessor($toolbox);
+        $processor->setAgent($agent);
+
+        $output = new Output('gpt-4', $result, $messageBag);
+
+        $processor->processOutput($output);
+
+        $this->assertSame($result, $output->getResult());
     }
 
     public function testSourcesEndUpInResultMetadataWithSettingOn()

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.8
+---
+
+* Add `MultiPartResult` for exposing the parts inside a message
+* Add `ExecutableCodeResult`, `CodeExecutionResult` for exposing the executed code blocks and results
+
 0.7
 ---
 

--- a/src/platform/src/Bridge/Gemini/CHANGELOG.md
+++ b/src/platform/src/Bridge/Gemini/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.8
+---
+
+* [BC BREAK] `ResultConverter` now returns a `MultiPartResult` when there are multiple `parts` in a `candidate`
+* [BC BREAK] `ResultConverter` now `ExecutableCodeResult` and `CodeExecutionResult` parts when using `code_execution` server tool
+* [BC BREAK] Throwing when code execution server tool fails is replaced with `CodeExecutionResult::isSucceeded()`
+
 0.7
 ---
 

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -17,6 +17,9 @@ use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\CodeExecutionResult;
+use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -32,6 +35,14 @@ use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 
 /**
+ * @phpstan-type Part array{
+ *     functionCall?: array{id?: string, name: string, args: mixed[]},
+ *     text?: string,
+ *     inlineData?: array{data: string, mimeType: string},
+ *     executableCode?: array{language: string, code: string},
+ *     codeExecutionResult?: array{id?: string, outcome: self::OUTCOME_*, output: string},
+ * }
+ *
  * @author Roy Garrido
  */
 final class ResultConverter implements ResultConverterInterface
@@ -108,26 +119,11 @@ final class ResultConverter implements ResultConverterInterface
      * @param array{
      *     finishReason?: string,
      *     content?: array{
-     *         parts: array{
-     *             functionCall?: array{
-     *                 id: string,
-     *                 name: string,
-     *                 args: mixed[]
-     *             },
-     *             text?: string,
-     *             executableCode?: array{
-     *                 language?: string,
-     *                 code?: string
-     *             },
-     *             codeExecutionResult?: array{
-     *                 outcome: self::OUTCOME_*,
-     *                 output: string
-     *             }
-     *         }[]
+     *         parts: list<Part>
      *     }
      * } $choice
      */
-    private function convertChoice(array $choice): ToolCallResult|TextResult|BinaryResult|null
+    private function convertChoice(array $choice): ToolCallResult|TextResult|BinaryResult|ExecutableCodeResult|CodeExecutionResult|MultiPartResult|null
     {
         if (!isset($choice['content']['parts'])) {
             return null;
@@ -135,46 +131,33 @@ final class ResultConverter implements ResultConverterInterface
 
         $contentParts = $choice['content']['parts'];
 
-        // If any part is a function call, return it immediately and ignore all other parts.
-        foreach ($contentParts as $contentPart) {
-            if (isset($contentPart['functionCall'])) {
-                return new ToolCallResult($this->convertToolCall($contentPart['functionCall']));
-            }
-        }
+        return match (\count($contentParts)) {
+            1 => $this->convertPart($contentParts[0]),
+            default => new MultiPartResult(array_values(array_filter(array_map($this->convertPart(...), $contentParts)))),
+        };
+    }
 
-        if (1 === \count($contentParts)) {
-            $contentPart = $contentParts[0];
-
-            if (isset($contentPart['text'])) {
-                return new TextResult($contentPart['text']);
-            }
-
-            if (isset($contentPart['inlineData'])) {
-                return BinaryResult::fromBase64($contentPart['inlineData']['data'], $contentPart['inlineData']['mimeType'] ?? null);
-            }
-
-            throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finishReason']));
-        }
-
-        $content = '';
-        $successfulCodeExecutionDetected = false;
-        foreach ($contentParts as $contentPart) {
-            if ($this->isSuccessfulCodeExecution($contentPart)) {
-                $successfulCodeExecutionDetected = true;
-                continue;
-            }
-
-            if ($successfulCodeExecutionDetected) {
-                $content .= $contentPart['text'];
-            }
-        }
-
-        if ('' !== $content) {
-            return new TextResult($content);
-        }
-
-        // TODO: see https://github.com/symfony/ai/issues/1053
-        throw new RuntimeException('Choice conversion failed. Potentially due to multiple content parts.');
+    /**
+     * @param Part $contentPart
+     */
+    private function convertPart(array $contentPart): ToolCallResult|TextResult|BinaryResult|ExecutableCodeResult|CodeExecutionResult|null
+    {
+        return match (true) {
+            isset($contentPart['functionCall']) => new ToolCallResult($this->convertToolCall($contentPart['functionCall'])),
+            isset($contentPart['text']) => new TextResult($contentPart['text']),
+            isset($contentPart['inlineData']) => BinaryResult::fromBase64($contentPart['inlineData']['data'], $contentPart['inlineData']['mimeType'] ?? null),
+            isset($contentPart['executableCode']) => new ExecutableCodeResult(
+                $contentPart['executableCode']['code'],
+                $contentPart['executableCode']['language'],
+                $contentPart['executableCode']['id'] ?? null,
+            ),
+            isset($contentPart['codeExecutionResult']) => new CodeExecutionResult(
+                self::OUTCOME_OK === $contentPart['codeExecutionResult']['outcome'],
+                $contentPart['codeExecutionResult']['output'],
+                $contentPart['codeExecutionResult']['id'] ?? null,
+            ),
+            default => null,
+        };
     }
 
     /**
@@ -187,24 +170,5 @@ final class ResultConverter implements ResultConverterInterface
     private function convertToolCall(array $toolCall): ToolCall
     {
         return new ToolCall($toolCall['id'] ?? '', $toolCall['name'], $toolCall['args']);
-    }
-
-    /**
-     * @param array{
-     *     codeExecutionResult?: array{
-     *         outcome: self::OUTCOME_*,
-     *         output: string
-     *     }
-     * } $contentPart
-     */
-    private function isSuccessfulCodeExecution(array $contentPart): bool
-    {
-        if (!isset($contentPart['codeExecutionResult'])) {
-            return false;
-        }
-
-        $result = $contentPart['codeExecutionResult'];
-
-        return self::OUTCOME_OK === $result['outcome'];
     }
 }

--- a/src/platform/src/Bridge/Gemini/Tests/CodeExecution/Fixtures/code_execution_outcome_ok.json
+++ b/src/platform/src/Bridge/Gemini/Tests/CodeExecution/Fixtures/code_execution_outcome_ok.json
@@ -4,7 +4,7 @@
             "content": {
                 "parts": [
                     {
-                        "text": "First text"
+                        "text": "First text\n"
                     },
                     {
                         "executableCode": {

--- a/src/platform/src/Bridge/Gemini/Tests/CodeExecution/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/CodeExecution/ResultConverterTest.php
@@ -13,6 +13,9 @@ namespace Symfony\AI\Platform\Bridge\Gemini\Tests\CodeExecution;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter;
+use Symfony\AI\Platform\Result\CodeExecutionResult;
+use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -31,12 +34,22 @@ final class ResultConverterTest extends TestCase
         $converter = new ResultConverter();
 
         $result = $converter->convert(new RawHttpResult($response));
-        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertInstanceOf(MultiPartResult::class, $result);
 
-        $this->assertEquals("Second text\nThird text\nFourth text", $result->getContent());
+        $parts = [
+            new TextResult("First text\n"),
+            new ExecutableCodeResult("print('Hello, World!')", 'PYTHON'),
+            new CodeExecutionResult(true, 'Hello, World!'),
+            new TextResult("Second text\n"),
+            new TextResult("Third text\n"),
+            new TextResult('Fourth text'),
+        ];
+
+        $this->assertEquals($parts, $result->getContent());
+        $this->assertEquals("First text\nSecond text\nThird text\nFourth text", $result->asText());
     }
 
-    public function testItThrowsExceptionOnFailure()
+    public function testItDoesNotSucceedOnFailure()
     {
         $response = $this->createStub(ResponseInterface::class);
         $responseContent = file_get_contents(__DIR__.'/Fixtures/code_execution_outcome_failed.json');
@@ -47,11 +60,20 @@ final class ResultConverterTest extends TestCase
 
         $converter = new ResultConverter();
 
-        $this->expectException(\RuntimeException::class);
-        $converter->convert(new RawHttpResult($response));
+        $result = $converter->convert(new RawHttpResult($response));
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+
+        $parts = [
+            new TextResult('First text'),
+            new ExecutableCodeResult("print('Hello, World!')", 'PYTHON'),
+            new CodeExecutionResult(false, 'An error occurred during code execution.'),
+            new TextResult('Last text'),
+        ];
+
+        $this->assertEquals($parts, $result->getContent());
     }
 
-    public function testItThrowsExceptionOnTimeout()
+    public function testItDoesNotSucceedOnTimeout()
     {
         $response = $this->createStub(ResponseInterface::class);
         $responseContent = file_get_contents(__DIR__.'/Fixtures/code_execution_outcome_deadline_exceeded.json');
@@ -62,7 +84,16 @@ final class ResultConverterTest extends TestCase
 
         $converter = new ResultConverter();
 
-        $this->expectException(\RuntimeException::class);
-        $converter->convert(new RawHttpResult($response));
+        $result = $converter->convert(new RawHttpResult($response));
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+
+        $parts = [
+            new TextResult('First text'),
+            new ExecutableCodeResult("print('Hello, World!')", 'PYTHON'),
+            new CodeExecutionResult(false, 'An error occurred during code execution.'),
+            new TextResult('Last text'),
+        ];
+
+        $this->assertEquals($parts, $result->getContent());
     }
 }

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\BinaryDelta;
@@ -52,7 +53,7 @@ final class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
-    public function testReturnsToolCallEvenIfMultipleContentPartsAreGiven()
+    public function testReturnsMultiPartIfMultipleContentPartsAreGiven()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
@@ -79,9 +80,10 @@ final class ResultConverterTest extends TestCase
         ]);
 
         $result = $converter->convert(new RawHttpResult($httpResponse));
-        $this->assertInstanceOf(ToolCallResult::class, $result);
-        $this->assertCount(1, $result->getContent());
-        $toolCall = $result->getContent()[0];
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $this->assertCount(2, $result->getContent());
+        $this->assertInstanceOf(ToolCallResult::class, $result->getContent()[1]);
+        $toolCall = $result->getContent()[1]->getContent()[0];
         $this->assertInstanceOf(ToolCall::class, $toolCall);
         $this->assertSame('1234', $toolCall->getId());
     }

--- a/src/platform/src/Result/CodeExecutionResult.php
+++ b/src/platform/src/Result/CodeExecutionResult.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * @author Valtteri R <valtzu@gmail.com>
+ */
+final class CodeExecutionResult extends BaseResult
+{
+    public function __construct(
+        private readonly bool $succeeded,
+        private readonly ?string $output = null,
+        private readonly ?string $id = null,
+    ) {
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->output;
+    }
+
+    public function isSucceeded(): bool
+    {
+        return $this->succeeded;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -204,6 +204,13 @@ final class DeferredResult
     {
         $result = $this->getResult();
 
+        if ($result instanceof MultiPartResult) {
+            $parts = array_filter($result->getContent(), static fn (ResultInterface $part) => $part instanceof $type);
+            if (1 === \count($parts)) {
+                $result = array_first($parts);
+            }
+        }
+
         if (!$result instanceof $type) {
             throw new UnexpectedResultTypeException($type, $result::class);
         }

--- a/src/platform/src/Result/ExecutableCodeResult.php
+++ b/src/platform/src/Result/ExecutableCodeResult.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * @author Valtteri R <valtzu@gmail.com>
+ */
+final class ExecutableCodeResult extends BaseResult
+{
+    public function __construct(
+        private readonly string $code,
+        private readonly ?string $language = null,
+        private readonly ?string $id = null,
+    ) {
+    }
+
+    public function getContent(): string
+    {
+        return $this->code;
+    }
+
+    public function getLanguage(): ?string
+    {
+        return $this->language;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/src/platform/src/Result/MultiPartResult.php
+++ b/src/platform/src/Result/MultiPartResult.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * @phpstan-implements \IteratorAggregate<int, ResultInterface>
+ */
+final class MultiPartResult extends BaseResult implements \IteratorAggregate
+{
+    /**
+     * @param non-empty-list<ResultInterface> $results
+     */
+    public function __construct(
+        private readonly array $results,
+    ) {
+    }
+
+    /**
+     * @return non-empty-list<ResultInterface>
+     */
+    public function getContent(): array
+    {
+        return $this->results;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->results);
+    }
+
+    public function asText(): string
+    {
+        return implode('', array_map(static fn (TextResult $result) => $result->getContent(), array_filter($this->results, static fn (ResultInterface $result) => $result instanceof TextResult)));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1053
| License       | MIT

Expose the `parts` _(instead of grouping them or selecting one specific part-of-interest)_ from platform to
1. Let users do whatever they want to do with them (i.e. render nice UI where different type of parts show up differently)
2. Prepare for part-specific metadata (or part-specific raw response) since Gemini mentions in the [docs](https://ai.google.dev/gemini-api/docs/tool-combination#api-returns-parts):
   >  You must return all parts, including all the [fields](https://ai.google.dev/gemini-api/docs/tool-combination#critical-fields) they contain, back to the model on each turn to maintain context and enable tool combinations.
3. Prepare for "meta-parts", e.g. server side toolcalls
