### PR TITLE
[Platform][Gemini][VertexAI] Remove redundant EventSourceHttpClient wrapping

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
@@ -17,7 +17,6 @@ use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
-use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -26,13 +25,10 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
-    private readonly EventSourceHttpClient $httpClient;
-
     public function __construct(
-        HttpClientInterface $httpClient,
+        private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
     ) {
-        $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/Gemini/PlatformFactory.php
+++ b/src/platform/src/Bridge/Gemini/PlatformFactory.php
@@ -19,7 +19,7 @@ use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter as GeminiResultConv
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
-use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -35,7 +35,7 @@ final class PlatformFactory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
     ): Platform {
-        $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $httpClient = $httpClient ?? HttpClient::create();
 
         return new Platform(
             [new EmbeddingsModelClient($httpClient, $apiKey), new GeminiModelClient($httpClient, $apiKey)],

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ModelClientTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Gemini\Tests\Gemini;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Gemini\Gemini;
+use Symfony\AI\Platform\Bridge\Gemini\Gemini\ModelClient;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelClientTest extends TestCase
+{
+    public function testItSupportsGeminiModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertTrue($client->supports(new Gemini('gemini-2.0-flash')));
+    }
+
+    public function testItDoesNotSupportOtherModels()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertFalse($client->supports(new Model('any-model')));
+    }
+
+    public function testItSendsExpectedRequest()
+    {
+        $payload = [
+            'contents' => [
+                ['parts' => [['text' => 'Hello, world!']]],
+            ],
+        ];
+        $expectedResponse = [
+            'candidates' => [$payload],
+        ];
+
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use ($expectedResponse): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent', $url);
+            $this->assertContains('x-goog-api-key: test-key', $options['headers']);
+
+            return new MockResponse(json_encode($expectedResponse));
+        });
+
+        $client = new ModelClient($httpClient, 'test-key');
+        $result = $client->request(new Gemini('gemini-2.0-flash'), $payload);
+
+        $this->assertSame($expectedResponse, $result->getData());
+    }
+
+    public function testItSendsStreamRequest()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertStringContainsString('streamGenerateContent', $url);
+
+            return new MockResponse('{}');
+        });
+
+        $client = new ModelClient($httpClient, 'test-key');
+        $client->request(new Gemini('gemini-2.0-flash'), [
+            'contents' => [['parts' => [['text' => 'Hello']]]],
+        ], ['stream' => true]);
+    }
+
+    public function testStringPayloadThrowsException()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Payload must be an array, but a string was given');
+
+        $client->request(new Gemini('gemini-2.0-flash'), 'string payload');
+    }
+}

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -26,6 +26,9 @@ use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -306,5 +309,31 @@ final class ResultConverterTest extends TestCase
                 ],
             ],
         ], ChoiceDelta::class, []];
+    }
+
+    public function testStreamingWithRawHttpResult()
+    {
+        $sseData = "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}]}}]}\n\n"
+            ."data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" world\"}]}}]}\n\n"
+            ."data: [DONE]\n\n";
+
+        $mockHttpClient = new MockHttpClient([
+            new MockResponse($sseData, ['response_headers' => ['content-type' => 'text/event-stream']]),
+        ]);
+        $response = (new EventSourceHttpClient($mockHttpClient))->request('POST', 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:streamGenerateContent');
+        $rawResult = new RawHttpResult($response);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $items = iterator_to_array($result->getContent());
+
+        $this->assertCount(2, $items);
+        $this->assertInstanceOf(TextDelta::class, $items[0]);
+        $this->assertSame('Hello', $items[0]->getText());
+        $this->assertInstanceOf(TextDelta::class, $items[1]);
+        $this->assertSame(' world', $items[1]->getText());
     }
 }

--- a/src/platform/src/Bridge/Gemini/Tests/PlatformFactoryTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/PlatformFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Gemini\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Gemini\PlatformFactory;
+use Symfony\AI\Platform\Platform;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PlatformFactoryTest extends TestCase
+{
+    public function testItCreatesPlatformWithDefaultSettings()
+    {
+        $platform = PlatformFactory::create('test-api-key');
+
+        $this->assertInstanceOf(Platform::class, $platform);
+    }
+
+    public function testItCreatesPlatformWithCustomHttpClient()
+    {
+        $httpClient = new MockHttpClient();
+        $platform = PlatformFactory::create('test-api-key', $httpClient);
+
+        $this->assertInstanceOf(Platform::class, $platform);
+    }
+}

--- a/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
@@ -15,7 +15,6 @@ use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
-use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -24,15 +23,12 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
-    private readonly EventSourceHttpClient $httpClient;
-
     public function __construct(
-        HttpClientInterface $httpClient,
+        private readonly HttpClientInterface $httpClient,
         private readonly ?string $location = null,
         private readonly ?string $projectId = null,
         #[\SensitiveParameter] private readonly ?string $apiKey = null,
     ) {
-        $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
     }
 
     public function supports(BaseModel $model): bool

--- a/src/platform/src/Bridge/VertexAi/PlatformFactory.php
+++ b/src/platform/src/Bridge/VertexAi/PlatformFactory.php
@@ -22,7 +22,7 @@ use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Platform;
-use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -52,7 +52,7 @@ final class PlatformFactory
             throw new RuntimeException('For using the project-scoped Vertex AI endpoint, google/auth package is required for authentication via application default credentials. Try running "composer require google/auth".');
         }
 
-        $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $httpClient = $httpClient ?? HttpClient::create();
 
         return new Platform(
             [new GeminiModelClient($httpClient, $location, $projectId, $apiKey), new EmbeddingsModelClient($httpClient, $location, $projectId, $apiKey)],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

The `SseStream` class introduced in #1827 internally creates its own `EventSourceHttpClient` for streaming. This makes the explicit `EventSourceHttpClient` wrapping in the Gemini and VertexAI `ModelClient` constructors and `PlatformFactory` classes redundant.

This PR:
- Removes `EventSourceHttpClient` wrapping from `Gemini\Gemini\ModelClient` and `VertexAi\Gemini\ModelClient`, accepting plain `HttpClientInterface` instead
- Replaces `EventSourceHttpClient` wrapping in both `PlatformFactory` classes with `$httpClient ?? HttpClient::create()`
- Adds missing `ModelClientTest` and `PlatformFactoryTest` for the Gemini bridge
- Adds a streaming integration test to `ResultConverterTest` that verifies end-to-end SSE streaming through `RawHttpResult` → `SseStream` → `ResultConverter`