### PR TITLE
[Platform] Add `ref` to `#[With]` attribute

### DIFF
--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -166,6 +166,29 @@ See attribute class :class:`Symfony\\AI\\Platform\\Contract\\JsonSchema\\Attribu
 
     Please be aware, that this is only converted in a JSON Schema for the LLM to respect, but not validated by Symfony AI itself.
 
+Defining Schema from File
+.........................
+
+If you already have a JSON Schema defined in a file, you can reference it using the ``ref`` argument::
+
+    use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+    use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+
+    #[AsTool('my_tool', 'Example tool with external schema.')]
+    final class MyTool
+    {
+        public function __invoke(
+            #[With(ref: __DIR__.'/schema.json')]
+            array $data,
+        ): string {
+            // ...
+        }
+    }
+
+.. note::
+
+    When using ``ref``, other arguments on the ``#[With]`` attribute are not allowed as the entire schema is loaded from the file.
+
 Automatic Enum Validation
 .........................
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `MultiPartResult` for exposing the parts inside a message
  * Add `ExecutableCodeResult`, `CodeExecutionResult` for exposing the executed code blocks and results
  * [BC BREAK] Replace variadic constructor parameters with array parameters in `VectorResult`, `ToolCallResult`, `RerankingResult`, `ToolCallComplete`, and `ImageResult` (OpenAI DallE bridge)
+ * Add `ref` property to `#[With]` attribute to allow providing schema as file
 
 0.7
 ---

--- a/src/platform/src/Contract/JsonSchema/Attribute/With.php
+++ b/src/platform/src/Contract/JsonSchema/Attribute/With.php
@@ -22,6 +22,7 @@ final class With
     /**
      * @param list<int|float|string|null>|null $enum
      * @param string|int|string[]|null         $const
+     * @param string|null                      $ref   A path to external schema file. This is mutually exclusive with all the other arguments.
      */
     public function __construct(
         // can be used by many types
@@ -53,7 +54,22 @@ final class With
         public readonly ?int $minProperties = null,
         public readonly ?int $maxProperties = null,
         public readonly ?bool $dependentRequired = null,
+
+        // a reference to a schema file
+        public readonly ?string $ref = null,
     ) {
+        if ($this->ref) {
+            if (\count(array_filter((array) $this, static fn (mixed $value) => null !== $value)) > 1) {
+                throw new InvalidArgumentException('When "ref" is defined, no other arguments are allowed.');
+            }
+
+            if (!is_readable($this->ref)) {
+                throw new InvalidArgumentException(\sprintf('The provided schema file "%s" is not readable', $this->ref));
+            }
+
+            return;
+        }
+
         if (\is_array($enum)) {
             /* @phpstan-ignore-next-line function.alreadyNarrowedType */
             if (array_filter($enum, static fn (mixed $item) => null === $item || \is_int($item) || \is_float($item) || \is_string($item)) !== $enum) {

--- a/src/platform/src/Contract/JsonSchema/Describer/WithAttributeDescriber.php
+++ b/src/platform/src/Contract/JsonSchema/Describer/WithAttributeDescriber.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Contract\JsonSchema\Describer;
 use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
 use Symfony\AI\Platform\Contract\JsonSchema\Factory;
 use Symfony\AI\Platform\Contract\JsonSchema\Subject\PropertySubject;
+use Symfony\AI\Platform\Exception\IOException;
 
 /**
  * @phpstan-import-type JsonSchema from Factory
@@ -23,7 +24,17 @@ final class WithAttributeDescriber implements PropertyDescriberInterface
     public function describeProperty(PropertySubject $subject, ?array &$schema): void
     {
         foreach ($subject->getAttributes(With::class) as $attribute) {
-            $schema = array_replace_recursive($schema ?? [], array_filter((array) $attribute, static fn ($value) => null !== $value));
+            if ($attribute->ref) {
+                try {
+                    $with = json_decode(file_get_contents($attribute->ref), true, flags: \JSON_THROW_ON_ERROR);
+                } catch (\JsonException $e) {
+                    throw new IOException(\sprintf('Failed to load the schema from "%s"', $attribute->ref), 0, $e);
+                }
+            } else {
+                $with = array_filter((array) $attribute, static fn ($value) => null !== $value);
+            }
+
+            $schema = array_replace_recursive($schema ?? [], $with);
         }
     }
 }

--- a/src/platform/tests/Contract/JsonSchema/Describer/WithAttributeDescriberTest.php
+++ b/src/platform/tests/Contract/JsonSchema/Describer/WithAttributeDescriberTest.php
@@ -16,7 +16,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithObjectAccessors;
 use Symfony\AI\Platform\Contract\JsonSchema\Describer\WithAttributeDescriber;
 use Symfony\AI\Platform\Contract\JsonSchema\Subject\PropertySubject;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Exception\IOException;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\ExampleDto;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\WithAttributeRefDto;
 
 final class WithAttributeDescriberTest extends TestCase
 {
@@ -27,6 +30,7 @@ final class WithAttributeDescriberTest extends TestCase
     #[TestWith([['const' => 42], new PropertySubject('value2', new \ReflectionParameter([ToolWithObjectAccessors::class, 'setValue2'], 0))], 'setter')]
     #[TestWith([['pattern' => '^foo$'], new PropertySubject('value3', new \ReflectionParameter([ToolWithObjectAccessors::class, '__construct'], 'value3'))], 'constructor')]
     #[TestWith([['description' => 'The quantity of the ingredient', 'example' => '2 cups'], new PropertySubject('quantity', new \ReflectionParameter([ExampleDto::class, '__construct'], 'quantity'))], 'example')]
+    #[TestWith([['type' => 'string', 'description' => 'This is a test schema from a ref file.'], new PropertySubject('schemaFromFile', new \ReflectionParameter([WithAttributeRefDto::class, '__construct'], 'schemaFromFile'))], 'schema from file')]
     public function testDescribeProperty(array $expectedSchema, PropertySubject $property)
     {
         $describer = new WithAttributeDescriber();
@@ -35,5 +39,25 @@ final class WithAttributeDescriberTest extends TestCase
         $describer->describeProperty($property, $schema);
 
         $this->assertSame($expectedSchema, $schema);
+    }
+
+    public function testDescribePropertyWithNonExistentFile()
+    {
+        $describer = new WithAttributeDescriber();
+        $property = new PropertySubject('nonExistentSchema', new \ReflectionParameter([WithAttributeRefDto::class, '__construct'], 'nonExistentSchema'));
+        $schema = null;
+
+        $this->expectException(InvalidArgumentException::class);
+        $describer->describeProperty($property, $schema);
+    }
+
+    public function testDescribePropertyWithInvalidJson()
+    {
+        $describer = new WithAttributeDescriber();
+        $property = new PropertySubject('nonJsonSchema', new \ReflectionParameter([WithAttributeRefDto::class, '__construct'], 'nonJsonSchema'));
+        $schema = null;
+
+        $this->expectException(IOException::class);
+        $describer->describeProperty($property, $schema);
     }
 }

--- a/src/platform/tests/Fixtures/StructuredOutput/WithAttributeRefDto.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/WithAttributeRefDto.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput;
+
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+
+class WithAttributeRefDto
+{
+    public function __construct(
+        #[With(ref: __DIR__.'/../json_schema_ref.json')]
+        public ?string $schemaFromFile = null,
+
+        #[With(ref: __DIR__.'/../non_existent.json')]
+        public ?string $nonExistentSchema = null,
+
+        #[With(ref: __FILE__)]
+        public ?string $nonJsonSchema = null,
+    ) {
+    }
+}

--- a/src/platform/tests/Fixtures/json_schema_ref.json
+++ b/src/platform/tests/Fixtures/json_schema_ref.json
@@ -1,0 +1,4 @@
+{
+    "type": "string",
+    "description": "This is a test schema from a ref file."
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1736
| License       | MIT

Allow reading parameter/property schema from a file, e.g. `#[With(ref: 'config.schema.json')] array $config`.