### PR TITLE
[Platform] Add Support for Multiple System Messages

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `ValidatorSubscriber` to validate structured output using Symfony Validator
+ * Add support for multiple system messages in `MessageBag`
 
 0.8
 ---

--- a/src/platform/src/Message/MessageBag.php
+++ b/src/platform/src/Message/MessageBag.php
@@ -57,15 +57,27 @@ class MessageBag implements \Countable, \IteratorAggregate
         return $this->messages;
     }
 
-    public function getSystemMessage(): ?SystemMessage
+    public function getSystemMessage(string $separator = \PHP_EOL.\PHP_EOL): ?SystemMessage
     {
-        foreach ($this->messages as $message) {
-            if ($message instanceof SystemMessage) {
-                return $message;
-            }
+        $systemMessages = array_values(array_filter(
+            $this->messages,
+            static fn (MessageInterface $message): bool => $message instanceof SystemMessage,
+        ));
+
+        if ([] === $systemMessages) {
+            return null;
         }
 
-        return null;
+        if (1 === \count($systemMessages)) {
+            return $systemMessages[0];
+        }
+
+        $content = implode($separator, array_map(
+            static fn (SystemMessage $message): string => (string) $message->getContent(),
+            $systemMessages,
+        ));
+
+        return new SystemMessage($content);
     }
 
     public function getUserMessage(): ?UserMessage

--- a/src/platform/tests/Message/MessageBagTest.php
+++ b/src/platform/tests/Message/MessageBagTest.php
@@ -40,6 +40,21 @@ final class MessageBagTest extends TestCase
         $this->assertSame('My amazing system prompt.', $systemMessage->getContent());
     }
 
+    public function testGetSystemMessageWithMultipleSystemMessages()
+    {
+        $messageBag = new MessageBag(
+            Message::forSystem('First system prompt.'),
+            Message::ofAssistant('It is time to sleep.'),
+            Message::forSystem('Second system prompt.'),
+            Message::ofUser('Hello, world!'),
+            Message::forSystem('Third system prompt.'),
+        );
+
+        $systemMessage = $messageBag->getSystemMessage();
+
+        $this->assertSame('First system prompt.'.\PHP_EOL.\PHP_EOL.'Second system prompt.'.\PHP_EOL.\PHP_EOL.'Third system prompt.', $systemMessage->getContent());
+    }
+
     public function testGetSystemMessageWithoutSystemMessage()
     {
         $messageBag = new MessageBag(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| License       | MIT

From Slack conversation: https://symfony-devs.slack.com/archives/C09BAPA9BJP/p1775161627809229

My initial approach is to concatenate system messages (appended by two break lines). I think it's worse to return only the first declared system message.

The next step would be to fully support multiple system messages by introducing a `getSystemMessages()` method and updating all providers (Anthropic, OpenAI, etc) 
