### PR TITLE
[Store][AzureSearch] Improve error handling and update example configuration

### DIFF
--- a/examples/.env
+++ b/examples/.env
@@ -198,6 +198,11 @@ REDIS_HOST=localhost
 # Manticore Search (store)
 MANTICORESEARCH_HOST=http://127.0.0.1:9308
 
+# Azure Search (store)
+AZURE_SEARCH_ENDPOINT=
+AZURE_SEARCH_API_KEY=
+AZURE_SEARCH_API_VERSION=2024-07-01
+
 # Elasticsearch (store)
 ELASTICSEARCH_ENDPOINT=http://127.0.0.1:9201
 

--- a/examples/rag/azuresearch.php
+++ b/examples/rag/azuresearch.php
@@ -29,7 +29,13 @@ use Symfony\Component\Uid\Uuid;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 // initialize the store
-$store = StoreFactory::create('movies');
+$store = StoreFactory::create(
+    indexName: 'movies',
+    endpoint: env('AZURE_SEARCH_ENDPOINT'),
+    apiKey: env('AZURE_SEARCH_API_KEY'),
+    apiVersion: env('AZURE_SEARCH_API_VERSION'),
+    httpClient: http_client(),
+);
 
 // create embeddings and documents
 $documents = [];

--- a/src/store/src/Bridge/AzureSearch/SearchStore.php
+++ b/src/store/src/Bridge/AzureSearch/SearchStore.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\Query\QueryInterface;
 use Symfony\AI\Store\Query\VectorQuery;
@@ -107,11 +108,15 @@ final class SearchStore implements StoreInterface
      */
     private function request(string $endpoint, array $payload): array
     {
-        $result = $this->httpClient->request('POST', \sprintf('indexes/%s/docs/%s', $this->indexName, $endpoint), [
+        $response = $this->httpClient->request('POST', \sprintf('indexes/%s/docs/%s', $this->indexName, $endpoint), [
             'json' => $payload,
         ]);
 
-        return $result->toArray();
+        if ($response->getStatusCode() >= 400) {
+            throw new RuntimeException(\sprintf('Azure Search request failed: "%s"', $response->getContent(false)));
+        }
+
+        return $response->toArray();
     }
 
     /**

--- a/src/store/src/Bridge/AzureSearch/Tests/SearchStoreTest.php
+++ b/src/store/src/Bridge/AzureSearch/Tests/SearchStoreTest.php
@@ -17,8 +17,8 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\AzureSearch\SearchStore;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Query\VectorQuery;
-use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\Uid\Uuid;
@@ -107,9 +107,8 @@ final class SearchStoreTest extends TestCase
         $uuid = Uuid::v4();
         $document = new VectorDocument($uuid, new Vector([0.1, 0.2, 0.3]));
 
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('HTTP 400 returned');
-        $this->expectExceptionCode(400);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Azure Search request failed:');
 
         $store->add($document);
     }
@@ -205,9 +204,8 @@ final class SearchStoreTest extends TestCase
 
         $store = new SearchStore($httpClient, 'test-index');
 
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('HTTP 400 returned');
-        $this->expectExceptionCode(400);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Azure Search request failed:');
 
         iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3]))));
     }
@@ -351,9 +349,8 @@ final class SearchStoreTest extends TestCase
 
         $store = new SearchStore($httpClient, 'test-index');
 
-        $this->expectException(ClientException::class);
-        $this->expectExceptionMessage('HTTP 404 returned');
-        $this->expectExceptionCode(404);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Azure Search request failed:');
 
         $store->remove('nonexistent-doc');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

- The `SearchStore::request()` method now explicitly checks for HTTP error status codes and throws a `Symfony\AI\Store\Exception\RuntimeException` instead of letting Symfony HttpClient's `ClientException` bubble up. This keeps error handling consistent with the rest of the Store component.
- The Azure Search example now uses explicit connection parameters (`endpoint`, `apiKey`, `apiVersion`, `httpClient`) instead of relying on `StoreFactory` defaults.
- Added `AZURE_SEARCH_ENDPOINT`, `AZURE_SEARCH_API_KEY`, and `AZURE_SEARCH_API_VERSION` to the example `.env` template.