### PR TITLE
[Platform][VertexAi] Fix binary result handling

### DIFF
--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -141,7 +141,7 @@ final class ResultConverter implements ResultConverterInterface
             }
 
             if (isset($contentPart['inlineData'])) {
-                return new BinaryResult($contentPart['inlineData']['data'], $contentPart['inlineData']['mimeType'] ?? null);
+                return BinaryResult::fromBase64($contentPart['inlineData']['data'], $contentPart['inlineData']['mimeType'] ?? null);
             }
 
             throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finishReason']));

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
@@ -145,8 +145,8 @@ final class ResultConverterTest extends TestCase
                             'parts' => [
                                 [
                                     'inlineData' => [
-                                        'mimeType' => 'image/png',
-                                        'data' => 'base64EncodedImageData',
+                                        'mimeType' => 'text/plain',
+                                        'data' => 'SGVsbG8=',
                                     ],
                                 ],
                             ],
@@ -160,8 +160,8 @@ final class ResultConverterTest extends TestCase
         $result = $resultConverter->convert(new RawHttpResult($response));
 
         $this->assertInstanceOf(BinaryResult::class, $result);
-        $this->assertSame('base64EncodedImageData', $result->getContent());
-        $this->assertSame('image/png', $result->getMimeType());
+        $this->assertSame('Hello', $result->getContent());
+        $this->assertSame('text/plain', $result->getMimeType());
     }
 
     public function testConvertsInlineDataWithoutMimeTypeToBinaryResult()
@@ -176,7 +176,7 @@ final class ResultConverterTest extends TestCase
                             'parts' => [
                                 [
                                     'inlineData' => [
-                                        'data' => 'base64EncodedData',
+                                        'data' => 'SGVsbG8=',
                                     ],
                                 ],
                             ],
@@ -190,7 +190,7 @@ final class ResultConverterTest extends TestCase
         $result = $resultConverter->convert(new RawHttpResult($response));
 
         $this->assertInstanceOf(BinaryResult::class, $result);
-        $this->assertSame('base64EncodedData', $result->getContent());
+        $this->assertSame('Hello', $result->getContent());
         $this->assertNull($result->getMimeType());
     }
 
@@ -223,8 +223,8 @@ final class ResultConverterTest extends TestCase
         }
 
         if ($items[0] instanceof BinaryDelta) {
-            $this->assertSame('base64EncodedImageData', $items[0]->getData());
-            $this->assertSame('image/png', $items[0]->getMimeType());
+            $this->assertSame('Hello', $items[0]->getData());
+            $this->assertSame('text/plain', $items[0]->getMimeType());
         }
 
         if ($items[0] instanceof ToolCallComplete) {
@@ -256,8 +256,8 @@ final class ResultConverterTest extends TestCase
                 'content' => [
                     'parts' => [[
                         'inlineData' => [
-                            'mimeType' => 'image/png',
-                            'data' => 'base64EncodedImageData',
+                            'mimeType' => 'text/plain',
+                            'data' => 'SGVsbG8=',
                         ],
                     ]],
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT

Fix Vertex binary result handling; it was missing base64 decoding. I have manually verified that Vertex returns base64-encoded content, just like Gemini API, despite [the docs](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#parts) mentioning "Inline data in raw bytes.".