### PR TITLE
[Platform][VertexAi] Fix model catalog referencing wrong bridge

### DIFF
--- a/src/platform/src/Bridge/VertexAi/ModelCatalog.php
+++ b/src/platform/src/Bridge/VertexAi/ModelCatalog.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\AI\Platform\Bridge\VertexAi;
 
-use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\Model as EmbeddingsModel;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model as GeminiModel;
 use Symfony\AI\Platform\Capability;
@@ -33,7 +32,7 @@ final class ModelCatalog extends AbstractModelCatalog
         $defaultModels = [
             // Gemini models
             'gemini-3-pro-preview' => [
-                'class' => Gemini::class,
+                'class' => GeminiModel::class,
                 'capabilities' => [
                     Capability::INPUT_MESSAGES,
                     Capability::INPUT_IMAGE,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT

I was scratching my head why the Gemini bridge is triggered when trying to use Vertex. This is a bug, right?

Original PR https://github.com/symfony/ai/pull/893