### PR TITLE
[Store][ChromaDB] Fix document update

### DIFF
--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -75,7 +75,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $collection = $this->client->getOrCreateCollection($this->collectionName);
 
         // @phpstan-ignore argument.type (chromadb-php library has incorrect PHPDoc type for $metadatas parameter)
-        $collection->add($ids, $vectors, $metadata, $originalDocuments);
+        $collection->upsert($ids, $vectors, $metadata, $originalDocuments);
     }
 
     public function remove(string|array $ids, array $options = []): void

--- a/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
@@ -51,7 +51,7 @@ final class StoreTest extends TestCase
             ->willReturn($collection);
 
         $collection->expects($this->once())
-            ->method('add')
+            ->method('upsert')
             ->with($expectedIds, $expectedVectors, $expectedMetadata, $expectedOriginalDocuments);
 
         $store = new Store($client, 'test-collection');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | --
| License       | MIT

Fix document update in ChromaDb bridge by using `upsert` instead of `add`
