### PR TITLE
[Mate] Update version constraint in RST docs via bump script

### DIFF
--- a/bump
+++ b/bump
@@ -184,6 +184,20 @@ use Symfony\Component\Finder\Finder;
             }
         }
 
+        $rstPath = __DIR__.'/docs/components/mate/creating-extensions.rst';
+        $rstContent = $filesystem->readFile($rstPath);
+        $newRstContent = preg_replace(
+            '/("symfony\/ai-mate":\s*")[^"]+(")/',
+            \sprintf('$1%s$2', $composerConstraint),
+            $rstContent,
+            -1,
+            $rstReplacements,
+        );
+        if ($rstReplacements > 0) {
+            $filesystem->dumpFile($rstPath, $newRstContent);
+            $io->writeln(' <info>✓</info> Saved "docs/components/mate/creating-extensions.rst" with %d change');
+        }
+
         $io->newLine();
         $io->success(\sprintf('Successfully bumped version to %s and updated %d dependency constraints in %d files to "%s".', $newVersion, $totalUpdates, $finder->count(), $composerConstraint));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The ``docs/components/mate/creating-extensions.rst`` file contains a ``symfony/ai-mate`` version constraint in a JSON example (``"symfony/ai-mate": "^0.1"``) that was not updated by the ``./bump`` script. This extends the script to rewrite that constraint alongside the ``composer.json`` files so docs stay in sync with releases.