### PR TITLE
[Mate] Make Symfony model DTOs readonly

### DIFF
--- a/src/mate/src/Bridge/Monolog/Model/LogEntry.php
+++ b/src/mate/src/Bridge/Monolog/Model/LogEntry.php
@@ -34,15 +34,61 @@ final class LogEntry
      * @param array<string, mixed> $extra
      */
     public function __construct(
-        public readonly \DateTimeImmutable $datetime,
-        public readonly string $channel,
-        public readonly string $level,
-        public readonly string $message,
-        public readonly array $context = [],
-        public readonly array $extra = [],
-        public readonly ?string $sourceFile = null,
-        public readonly ?int $lineNumber = null,
+        private readonly \DateTimeImmutable $datetime,
+        private readonly string $channel,
+        private readonly string $level,
+        private readonly string $message,
+        private readonly array $context = [],
+        private readonly array $extra = [],
+        private readonly ?string $sourceFile = null,
+        private readonly ?int $lineNumber = null,
     ) {
+    }
+
+    public function getDatetime(): \DateTimeImmutable
+    {
+        return $this->datetime;
+    }
+
+    public function getChannel(): string
+    {
+        return $this->channel;
+    }
+
+    public function getLevel(): string
+    {
+        return $this->level;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getExtra(): array
+    {
+        return $this->extra;
+    }
+
+    public function getSourceFile(): ?string
+    {
+        return $this->sourceFile;
+    }
+
+    public function getLineNumber(): ?int
+    {
+        return $this->lineNumber;
     }
 
     /**

--- a/src/mate/src/Bridge/Monolog/Model/SearchCriteria.php
+++ b/src/mate/src/Bridge/Monolog/Model/SearchCriteria.php
@@ -19,34 +19,84 @@ namespace Symfony\AI\Mate\Bridge\Monolog\Model;
 final class SearchCriteria
 {
     public function __construct(
-        public readonly ?string $term = null,
-        public readonly ?string $regex = null,
-        public readonly ?string $level = null,
-        public readonly ?string $channel = null,
-        public readonly ?\DateTimeInterface $from = null,
-        public readonly ?\DateTimeInterface $to = null,
-        public readonly ?string $contextKey = null,
-        public readonly ?string $contextValue = null,
-        public readonly int $limit = 100,
-        public readonly int $offset = 0,
+        private readonly ?string $term = null,
+        private readonly ?string $regex = null,
+        private readonly ?string $level = null,
+        private readonly ?string $channel = null,
+        private readonly ?\DateTimeInterface $from = null,
+        private readonly ?\DateTimeInterface $to = null,
+        private readonly ?string $contextKey = null,
+        private readonly ?string $contextValue = null,
+        private readonly int $limit = 100,
+        private readonly int $offset = 0,
     ) {
+    }
+
+    public function getTerm(): ?string
+    {
+        return $this->term;
+    }
+
+    public function getRegex(): ?string
+    {
+        return $this->regex;
+    }
+
+    public function getLevel(): ?string
+    {
+        return $this->level;
+    }
+
+    public function getChannel(): ?string
+    {
+        return $this->channel;
+    }
+
+    public function getFrom(): ?\DateTimeInterface
+    {
+        return $this->from;
+    }
+
+    public function getTo(): ?\DateTimeInterface
+    {
+        return $this->to;
+    }
+
+    public function getContextKey(): ?string
+    {
+        return $this->contextKey;
+    }
+
+    public function getContextValue(): ?string
+    {
+        return $this->contextValue;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
     }
 
     public function matches(LogEntry $entry): bool
     {
-        if (null !== $this->level && strtoupper($this->level) !== strtoupper($entry->level)) {
+        if (null !== $this->level && strtoupper($this->level) !== strtoupper($entry->getLevel())) {
             return false;
         }
 
-        if (null !== $this->channel && strtolower($this->channel) !== strtolower($entry->channel)) {
+        if (null !== $this->channel && strtolower($this->channel) !== strtolower($entry->getChannel())) {
             return false;
         }
 
-        if (null !== $this->from && $entry->datetime < $this->from) {
+        if (null !== $this->from && $entry->getDatetime() < $this->from) {
             return false;
         }
 
-        if (null !== $this->to && $entry->datetime > $this->to) {
+        if (null !== $this->to && $entry->getDatetime() > $this->to) {
             return false;
         }
 

--- a/src/mate/src/Bridge/Monolog/Service/LogReader.php
+++ b/src/mate/src/Bridge/Monolog/Service/LogReader.php
@@ -103,8 +103,8 @@ final class LogReader
     public function readFiles(array $files, ?SearchCriteria $criteria = null): \Generator
     {
         $count = 0;
-        $limit = null !== $criteria ? $criteria->limit : \PHP_INT_MAX;
-        $offset = null !== $criteria ? $criteria->offset : 0;
+        $limit = null !== $criteria ? $criteria->getLimit() : \PHP_INT_MAX;
+        $offset = null !== $criteria ? $criteria->getOffset() : 0;
         $skipped = 0;
 
         foreach ($files as $file) {
@@ -184,7 +184,7 @@ final class LogReader
         $channels = [];
 
         foreach ($this->readAll() as $entry) {
-            $channels[$entry->channel] = true;
+            $channels[$entry->getChannel()] = true;
         }
 
         return array_keys($channels);
@@ -222,7 +222,7 @@ final class LogReader
                     continue;
                 }
 
-                if (null !== $level && strtoupper($level) !== $entry->level) {
+                if (null !== $level && strtoupper($level) !== $entry->getLevel()) {
                     continue;
                 }
 

--- a/src/mate/src/Bridge/Monolog/Tests/Service/LogParserTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Service/LogParserTest.php
@@ -33,13 +33,13 @@ final class LogParserTest extends TestCase
         $entry = $this->parser->parse($line);
 
         $this->assertNotNull($entry);
-        $this->assertSame('2024-01-15', $entry->datetime->format('Y-m-d'));
-        $this->assertSame('10:30:45', $entry->datetime->format('H:i:s'));
-        $this->assertSame('app', $entry->channel);
-        $this->assertSame('ERROR', $entry->level);
-        $this->assertSame('Database connection failed', $entry->message);
-        $this->assertSame(['exception' => 'PDOException'], $entry->context);
-        $this->assertSame(['retry' => 3], $entry->extra);
+        $this->assertSame('2024-01-15', $entry->getDatetime()->format('Y-m-d'));
+        $this->assertSame('10:30:45', $entry->getDatetime()->format('H:i:s'));
+        $this->assertSame('app', $entry->getChannel());
+        $this->assertSame('ERROR', $entry->getLevel());
+        $this->assertSame('Database connection failed', $entry->getMessage());
+        $this->assertSame(['exception' => 'PDOException'], $entry->getContext());
+        $this->assertSame(['retry' => 3], $entry->getExtra());
     }
 
     public function testParseLineFormatWithoutContext()
@@ -49,11 +49,11 @@ final class LogParserTest extends TestCase
         $entry = $this->parser->parse($line);
 
         $this->assertNotNull($entry);
-        $this->assertSame('app', $entry->channel);
-        $this->assertSame('INFO', $entry->level);
-        $this->assertSame('Simple message', $entry->message);
-        $this->assertSame([], $entry->context);
-        $this->assertSame([], $entry->extra);
+        $this->assertSame('app', $entry->getChannel());
+        $this->assertSame('INFO', $entry->getLevel());
+        $this->assertSame('Simple message', $entry->getMessage());
+        $this->assertSame([], $entry->getContext());
+        $this->assertSame([], $entry->getExtra());
     }
 
     public function testParseJsonFormat()
@@ -63,12 +63,12 @@ final class LogParserTest extends TestCase
         $entry = $this->parser->parse($line);
 
         $this->assertNotNull($entry);
-        $this->assertSame('2024-01-15', $entry->datetime->format('Y-m-d'));
-        $this->assertSame('app', $entry->channel);
-        $this->assertSame('INFO', $entry->level);
-        $this->assertSame('Test message', $entry->message);
-        $this->assertSame(['key' => 'value'], $entry->context);
-        $this->assertSame([], $entry->extra);
+        $this->assertSame('2024-01-15', $entry->getDatetime()->format('Y-m-d'));
+        $this->assertSame('app', $entry->getChannel());
+        $this->assertSame('INFO', $entry->getLevel());
+        $this->assertSame('Test message', $entry->getMessage());
+        $this->assertSame(['key' => 'value'], $entry->getContext());
+        $this->assertSame([], $entry->getExtra());
     }
 
     public function testParseJsonFormatWithNumericLevel()
@@ -78,7 +78,7 @@ final class LogParserTest extends TestCase
         $entry = $this->parser->parse($line);
 
         $this->assertNotNull($entry);
-        $this->assertSame('ERROR', $entry->level);
+        $this->assertSame('ERROR', $entry->getLevel());
     }
 
     public function testParseEmptyLine()
@@ -109,8 +109,8 @@ final class LogParserTest extends TestCase
         $entry = $this->parser->parse($line, 'dev.log', 42);
 
         $this->assertNotNull($entry);
-        $this->assertSame('dev.log', $entry->sourceFile);
-        $this->assertSame(42, $entry->lineNumber);
+        $this->assertSame('dev.log', $entry->getSourceFile());
+        $this->assertSame(42, $entry->getLineNumber());
     }
 
     public function testParseLineFormatWithTimezone()
@@ -120,8 +120,8 @@ final class LogParserTest extends TestCase
         $entry = $this->parser->parse($line);
 
         $this->assertNotNull($entry);
-        $this->assertSame('app', $entry->channel);
-        $this->assertSame('INFO', $entry->level);
+        $this->assertSame('app', $entry->getChannel());
+        $this->assertSame('INFO', $entry->getLevel());
     }
 
     public function testParseLineFormatWithMilliseconds()
@@ -131,6 +131,6 @@ final class LogParserTest extends TestCase
         $entry = $this->parser->parse($line);
 
         $this->assertNotNull($entry);
-        $this->assertSame('DEBUG', $entry->level);
+        $this->assertSame('DEBUG', $entry->getLevel());
     }
 }

--- a/src/mate/src/Bridge/Monolog/Tests/Service/LogReaderTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Service/LogReaderTest.php
@@ -63,7 +63,7 @@ final class LogReaderTest extends TestCase
         // 1 ERROR in sample.log + 1 ERROR in sample.json.log = 2 total
         $this->assertCount(2, $entries);
         foreach ($entries as $entry) {
-            $this->assertSame('ERROR', $entry->level);
+            $this->assertSame('ERROR', $entry->getLevel());
         }
     }
 
@@ -75,7 +75,7 @@ final class LogReaderTest extends TestCase
         // 1 in sample.log + 1 in sample.json.log = 2 total
         $this->assertCount(2, $entries);
         foreach ($entries as $entry) {
-            $this->assertSame('security', $entry->channel);
+            $this->assertSame('security', $entry->getChannel());
         }
     }
 
@@ -85,7 +85,7 @@ final class LogReaderTest extends TestCase
         $entries = iterator_to_array($this->reader->readAll($criteria));
 
         $this->assertCount(1, $entries);
-        $this->assertStringContainsString('Database', $entries[0]->message);
+        $this->assertStringContainsString('Database', $entries[0]->getMessage());
     }
 
     public function testReadFile()
@@ -108,7 +108,7 @@ final class LogReaderTest extends TestCase
 
         // Only ERROR entries should be returned
         foreach ($entries as $entry) {
-            $this->assertSame('ERROR', $entry->level);
+            $this->assertSame('ERROR', $entry->getLevel());
         }
     }
 

--- a/src/mate/src/Bridge/Symfony/Capability/ProfilerResourceTemplate.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ProfilerResourceTemplate.php
@@ -52,7 +52,7 @@ final class ProfilerResourceTemplate
             ];
         }
 
-        $profile = $profileData->profile;
+        $profile = $profileData->getProfile();
         $collectors = $this->dataProvider->listAvailableCollectors($token);
 
         $collectorResources = [];
@@ -74,8 +74,8 @@ final class ProfilerResourceTemplate
             'collectors' => $collectorResources,
         ];
 
-        if (null !== $profileData->context) {
-            $data['context'] = $profileData->context;
+        if (null !== $profileData->getContext()) {
+            $data['context'] = $profileData->getContext();
         }
 
         return [

--- a/src/mate/src/Bridge/Symfony/Capability/ProfilerTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ProfilerTool.php
@@ -82,7 +82,7 @@ final class ProfilerTool
             throw new InvalidArgumentException(\sprintf('Profile with token "%s" not found', $token));
         }
 
-        $profile = $profileData->profile;
+        $profile = $profileData->getProfile();
         $data = [
             'token' => $profile->getToken(),
             'ip' => $profile->getIp(),
@@ -95,8 +95,8 @@ final class ProfilerTool
             'resource_uri' => \sprintf('symfony-profiler://profile/%s', $profile->getToken()),
         ];
 
-        if (null !== $profileData->context) {
-            $data['context'] = $profileData->context;
+        if (null !== $profileData->getContext()) {
+            $data['context'] = $profileData->getContext();
         }
 
         return ResponseEncoder::encode($data);

--- a/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
@@ -39,15 +39,15 @@ class ServiceTool
         }
 
         $output = [];
-        foreach ($container->services as $service) {
+        foreach ($container->getServices() as $service) {
             if (null !== $query && '' !== $query) {
-                $matches = str_contains(strtolower($service->id), strtolower($query))
-                    || (null !== $service->class && str_contains(strtolower($service->class), strtolower($query)));
+                $matches = str_contains(strtolower($service->getId()), strtolower($query))
+                    || (null !== $service->getClass() && str_contains(strtolower($service->getClass()), strtolower($query)));
                 if (!$matches) {
                     continue;
                 }
             }
-            $output[$service->id] = $service->class;
+            $output[$service->getId()] = $service->getClass();
         }
 
         return ResponseEncoder::encode($output);

--- a/src/mate/src/Bridge/Symfony/Model/Container.php
+++ b/src/mate/src/Bridge/Symfony/Model/Container.php
@@ -22,7 +22,15 @@ class Container
      * @param array<string, ServiceDefinition> $services
      */
     public function __construct(
-        public array $services,
+        private readonly array $services,
     ) {
+    }
+
+    /**
+     * @return array<string, ServiceDefinition>
+     */
+    public function getServices(): array
+    {
+        return $this->services;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Model/ServiceDefinition.php
+++ b/src/mate/src/Bridge/Symfony/Model/ServiceDefinition.php
@@ -26,12 +26,54 @@ class ServiceDefinition
      * @param array{0: string|null, 1: string} $constructor
      */
     public function __construct(
-        public string $id,
-        public ?string $class,
-        public ?string $alias,
-        public array $calls,
-        public array $tags,
-        public array $constructor,
+        private readonly string $id,
+        private readonly ?string $class,
+        private readonly ?string $alias,
+        private readonly array $calls,
+        private readonly array $tags,
+        private readonly array $constructor,
     ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return ?class-string
+     */
+    public function getClass(): ?string
+    {
+        return $this->class;
+    }
+
+    public function getAlias(): ?string
+    {
+        return $this->alias;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCalls(): array
+    {
+        return $this->calls;
+    }
+
+    /**
+     * @return ServiceTag[]
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @return array{0: string|null, 1: string}
+     */
+    public function getConstructor(): array
+    {
+        return $this->constructor;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Model/ServiceTag.php
+++ b/src/mate/src/Bridge/Symfony/Model/ServiceTag.php
@@ -22,8 +22,21 @@ class ServiceTag
      * @param array<string, string> $attributes
      */
     public function __construct(
-        public string $name,
-        public array $attributes = [],
+        private readonly string $name,
+        private readonly array $attributes = [],
     ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Profiler/Model/CollectorData.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Model/CollectorData.php
@@ -23,9 +23,30 @@ class CollectorData
      * @param array<string, mixed> $summary
      */
     public function __construct(
-        public readonly string $name,
-        public readonly array $data,
-        public readonly array $summary,
+        private readonly string $name,
+        private readonly array $data,
+        private readonly array $summary,
     ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSummary(): array
+    {
+        return $this->summary;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Profiler/Model/ProfileData.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Model/ProfileData.php
@@ -23,8 +23,18 @@ use Symfony\Component\HttpKernel\Profiler\Profile;
 class ProfileData
 {
     public function __construct(
-        public readonly Profile $profile,
-        public readonly ?string $context = null,
+        private readonly Profile $profile,
+        private readonly ?string $context = null,
     ) {
+    }
+
+    public function getProfile(): Profile
+    {
+        return $this->profile;
+    }
+
+    public function getContext(): ?string
+    {
+        return $this->context;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Profiler/Model/ProfileIndex.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Model/ProfileIndex.php
@@ -32,16 +32,61 @@ namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Model;
 class ProfileIndex
 {
     public function __construct(
-        public readonly string $token,
-        public readonly string $ip,
-        public readonly string $method,
-        public readonly string $url,
-        public readonly int $time,
-        public readonly ?int $statusCode = null,
-        public readonly ?string $parentToken = null,
-        public readonly ?string $context = null,
-        public readonly ?string $type = null,
+        private readonly string $token,
+        private readonly string $ip,
+        private readonly string $method,
+        private readonly string $url,
+        private readonly int $time,
+        private readonly ?int $statusCode = null,
+        private readonly ?string $parentToken = null,
+        private readonly ?string $context = null,
+        private readonly ?string $type = null,
     ) {
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function getIp(): string
+    {
+        return $this->ip;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getTime(): int
+    {
+        return $this->time;
+    }
+
+    public function getStatusCode(): ?int
+    {
+        return $this->statusCode;
+    }
+
+    public function getParentToken(): ?string
+    {
+        return $this->parentToken;
+    }
+
+    public function getContext(): ?string
+    {
+        return $this->context;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
     }
 
     /**

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/ProfileIndexer.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/ProfileIndexer.php
@@ -50,7 +50,7 @@ final class ProfileIndexer
     {
         return array_filter(
             $profiles,
-            static fn (ProfileIndex $profile) => strtoupper($profile->method) === strtoupper($method)
+            static fn (ProfileIndex $profile) => strtoupper($profile->getMethod()) === strtoupper($method)
         );
     }
 
@@ -63,7 +63,7 @@ final class ProfileIndexer
     {
         return array_filter(
             $profiles,
-            static fn (ProfileIndex $profile) => $profile->statusCode === $statusCode
+            static fn (ProfileIndex $profile) => $profile->getStatusCode() === $statusCode
         );
     }
 
@@ -83,7 +83,7 @@ final class ProfileIndexer
 
         return array_filter(
             $profiles,
-            static fn (ProfileIndex $profile) => $profile->time >= $fromTime && $profile->time <= $toTime
+            static fn (ProfileIndex $profile) => $profile->getTime() >= $fromTime && $profile->getTime() <= $toTime
         );
     }
 
@@ -96,7 +96,7 @@ final class ProfileIndexer
     {
         return array_filter(
             $profiles,
-            static fn (ProfileIndex $profile) => str_contains($profile->url, $urlPattern)
+            static fn (ProfileIndex $profile) => str_contains($profile->getUrl(), $urlPattern)
         );
     }
 
@@ -109,7 +109,7 @@ final class ProfileIndexer
     {
         return array_filter(
             $profiles,
-            static fn (ProfileIndex $profile) => $profile->ip === $ip
+            static fn (ProfileIndex $profile) => $profile->getIp() === $ip
         );
     }
 
@@ -122,7 +122,7 @@ final class ProfileIndexer
     {
         return array_filter(
             $profiles,
-            static fn (ProfileIndex $profile) => $profile->context === $context
+            static fn (ProfileIndex $profile) => $profile->getContext() === $context
         );
     }
 

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/ProfilerDataProvider.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/ProfilerDataProvider.php
@@ -75,7 +75,7 @@ final class ProfilerDataProvider
             }
         }
 
-        usort($allProfiles, static fn ($a, $b) => $b->time <=> $a->time);
+        usort($allProfiles, static fn ($a, $b) => $b->getTime() <=> $a->getTime());
 
         if (null !== $limit) {
             return \array_slice($allProfiles, 0, $limit);
@@ -142,7 +142,7 @@ final class ProfilerDataProvider
             }
         }
 
-        usort($allResults, static fn ($a, $b) => $b->time <=> $a->time);
+        usort($allResults, static fn ($a, $b) => $b->getTime() <=> $a->getTime());
 
         return \array_slice($allResults, 0, $limit);
     }
@@ -158,7 +158,7 @@ final class ProfilerDataProvider
             throw new ProfileNotFoundException(\sprintf('Profile not found for token: "%s"', $token));
         }
 
-        $profile = $profileData->profile;
+        $profile = $profileData->getProfile();
         $collectors = $profile->getCollectors();
 
         // Find collector by short name
@@ -202,7 +202,7 @@ final class ProfilerDataProvider
             throw new ProfileNotFoundException(\sprintf('Profile not found for token: "%s"', $token));
         }
 
-        $collectors = $profileData->profile->getCollectors();
+        $collectors = $profileData->getProfile()->getCollectors();
 
         return array_values(array_map(
             static fn ($collector) => $collector->getName(),

--- a/src/mate/src/Bridge/Symfony/Service/ContainerProvider.php
+++ b/src/mate/src/Bridge/Symfony/Service/ContainerProvider.php
@@ -97,8 +97,8 @@ class ContainerProvider
                     $constructor,
                 );
 
-                if (null === $service->alias) {
-                    $services[$service->id] = $service;
+                if (null === $service->getAlias()) {
+                    $services[$service->getId()] = $service;
                 } else {
                     $aliases[] = $service;
                 }
@@ -106,18 +106,18 @@ class ContainerProvider
         }
 
         foreach ($aliases as $service) {
-            $alias = $service->alias;
+            $alias = $service->getAlias();
             if (null === $alias || !isset($services[$alias])) {
                 continue;
             }
 
-            $services[$service->id] = new ServiceDefinition(
-                $service->id,
-                $services[$alias]->class,
+            $services[$service->getId()] = new ServiceDefinition(
+                $service->getId(),
+                $services[$alias]->getClass(),
                 null,
-                $services[$alias]->calls,
-                $services[$alias]->tags,
-                $services[$alias]->constructor,
+                $services[$alias]->getCalls(),
+                $services[$alias]->getTags(),
+                $services[$alias]->getConstructor(),
             );
         }
 

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Model/CollectorDataTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Model/CollectorDataTest.php
@@ -30,9 +30,9 @@ final class CollectorDataTest extends TestCase
             summary: $summary
         );
 
-        $this->assertSame('request', $collectorData->name);
-        $this->assertSame($data, $collectorData->data);
-        $this->assertSame($summary, $collectorData->summary);
+        $this->assertSame('request', $collectorData->getName());
+        $this->assertSame($data, $collectorData->getData());
+        $this->assertSame($summary, $collectorData->getSummary());
     }
 
     public function testDataCanBeEmpty()
@@ -43,8 +43,7 @@ final class CollectorDataTest extends TestCase
             summary: []
         );
 
-        $this->assertIsArray($collectorData->data);
-        $this->assertEmpty($collectorData->data);
+        $this->assertSame([], $collectorData->getData());
     }
 
     public function testSummaryCanBeEmpty()
@@ -55,8 +54,7 @@ final class CollectorDataTest extends TestCase
             summary: []
         );
 
-        $this->assertIsArray($collectorData->summary);
-        $this->assertEmpty($collectorData->summary);
+        $this->assertSame([], $collectorData->getSummary());
     }
 
     public function testPropertiesAreReadonly()

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Model/ProfileDataTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Model/ProfileDataTest.php
@@ -31,8 +31,8 @@ final class ProfileDataTest extends TestCase
             context: 'website'
         );
 
-        $this->assertSame($profile, $profileData->profile);
-        $this->assertSame('website', $profileData->context);
+        $this->assertSame($profile, $profileData->getProfile());
+        $this->assertSame('website', $profileData->getContext());
     }
 
     public function testContextCanBeNull()
@@ -44,8 +44,8 @@ final class ProfileDataTest extends TestCase
             context: null
         );
 
-        $this->assertSame($profile, $profileData->profile);
-        $this->assertNull($profileData->context);
+        $this->assertSame($profile, $profileData->getProfile());
+        $this->assertNull($profileData->getContext());
     }
 
     public function testContextDefaultsToNull()
@@ -56,8 +56,8 @@ final class ProfileDataTest extends TestCase
             profile: $profile
         );
 
-        $this->assertSame($profile, $profileData->profile);
-        $this->assertNull($profileData->context);
+        $this->assertSame($profile, $profileData->getProfile());
+        $this->assertNull($profileData->getContext());
     }
 
     public function testPropertiesAreReadonly()
@@ -86,9 +86,9 @@ final class ProfileDataTest extends TestCase
 
         $profileData = new ProfileData(profile: $profile);
 
-        $this->assertSame('abc123', $profileData->profile->getToken());
-        $this->assertSame('POST', $profileData->profile->getMethod());
-        $this->assertSame('/api/users', $profileData->profile->getUrl());
-        $this->assertSame('192.168.1.1', $profileData->profile->getIp());
+        $this->assertSame('abc123', $profileData->getProfile()->getToken());
+        $this->assertSame('POST', $profileData->getProfile()->getMethod());
+        $this->assertSame('/api/users', $profileData->getProfile()->getUrl());
+        $this->assertSame('192.168.1.1', $profileData->getProfile()->getIp());
     }
 }

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/ProfileIndexerTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/ProfileIndexerTest.php
@@ -42,11 +42,11 @@ final class ProfileIndexerTest extends TestCase
         $this->assertCount(3, $profiles);
 
         $first = $profiles[0];
-        $this->assertSame('abc123', $first->token);
-        $this->assertSame('127.0.0.1', $first->ip);
-        $this->assertSame('GET', $first->method);
-        $this->assertSame('/api/users', $first->url);
-        $this->assertSame(200, $first->statusCode);
+        $this->assertSame('abc123', $first->getToken());
+        $this->assertSame('127.0.0.1', $first->getIp());
+        $this->assertSame('GET', $first->getMethod());
+        $this->assertSame('/api/users', $first->getUrl());
+        $this->assertSame(200, $first->getStatusCode());
     }
 
     public function testFilterByMethod()
@@ -55,7 +55,7 @@ final class ProfileIndexerTest extends TestCase
         $filtered = $this->indexer->filterByMethod($profiles, 'POST');
 
         $this->assertCount(1, $filtered);
-        $this->assertSame('def456', array_values($filtered)[0]->token);
+        $this->assertSame('def456', array_values($filtered)[0]->getToken());
     }
 
     public function testFilterByStatusCode()
@@ -64,7 +64,7 @@ final class ProfileIndexerTest extends TestCase
         $filtered = $this->indexer->filterByStatusCode($profiles, 404);
 
         $this->assertCount(1, $filtered);
-        $this->assertSame('ghi789', array_values($filtered)[0]->token);
+        $this->assertSame('ghi789', array_values($filtered)[0]->getToken());
     }
 
     public function testFilterByUrl()

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/ProfilerDataProviderTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/ProfilerDataProviderTest.php
@@ -42,9 +42,9 @@ final class ProfilerDataProviderTest extends TestCase
         $profiles = $this->provider->readIndex();
 
         $this->assertCount(3, $profiles);
-        $this->assertSame('ghi789', $profiles[0]->token);
-        $this->assertSame('def456', $profiles[1]->token);
-        $this->assertSame('abc123', $profiles[2]->token);
+        $this->assertSame('ghi789', $profiles[0]->getToken());
+        $this->assertSame('def456', $profiles[1]->getToken());
+        $this->assertSame('abc123', $profiles[2]->getToken());
     }
 
     public function testReadIndexWithLimit()
@@ -52,8 +52,8 @@ final class ProfilerDataProviderTest extends TestCase
         $profiles = $this->provider->readIndex(2);
 
         $this->assertCount(2, $profiles);
-        $this->assertSame('ghi789', $profiles[0]->token);
-        $this->assertSame('def456', $profiles[1]->token);
+        $this->assertSame('ghi789', $profiles[0]->getToken());
+        $this->assertSame('def456', $profiles[1]->getToken());
     }
 
     public function testFindProfileReturnsProfileData()
@@ -61,9 +61,9 @@ final class ProfilerDataProviderTest extends TestCase
         $profileData = $this->provider->findProfile('abc123');
 
         $this->assertNotNull($profileData);
-        $this->assertSame('abc123', $profileData->profile->getToken());
-        $this->assertInstanceOf(Profile::class, $profileData->profile);
-        $this->assertIsArray($profileData->profile->getCollectors());
+        $this->assertSame('abc123', $profileData->getProfile()->getToken());
+        $this->assertInstanceOf(Profile::class, $profileData->getProfile());
+        $this->assertIsArray($profileData->getProfile()->getCollectors());
     }
 
     public function testFindProfileReturnsNullForNonExistentToken()
@@ -80,7 +80,7 @@ final class ProfilerDataProviderTest extends TestCase
         $profileData = $this->provider->findProfile('abc123');
 
         $this->assertNotNull($profileData);
-        $this->assertSame('abc123', $profileData->profile->getToken());
+        $this->assertSame('abc123', $profileData->getProfile()->getToken());
     }
 
     public function testSearchProfilesWithoutCriteria()
@@ -95,7 +95,7 @@ final class ProfilerDataProviderTest extends TestCase
         $profiles = $this->provider->searchProfiles(['method' => 'POST']);
 
         $this->assertCount(1, $profiles);
-        $this->assertSame('def456', $profiles[0]->token);
+        $this->assertSame('def456', $profiles[0]->getToken());
     }
 
     public function testSearchProfilesByStatusCode()
@@ -103,7 +103,7 @@ final class ProfilerDataProviderTest extends TestCase
         $profiles = $this->provider->searchProfiles(['statusCode' => 404]);
 
         $this->assertCount(1, $profiles);
-        $this->assertSame('ghi789', $profiles[0]->token);
+        $this->assertSame('ghi789', $profiles[0]->getToken());
     }
 
     public function testSearchProfilesByUrl()
@@ -201,7 +201,7 @@ final class ProfilerDataProviderTest extends TestCase
         $profile = $this->provider->getLatestProfile();
 
         $this->assertNotNull($profile);
-        $this->assertSame('ghi789', $profile->token);
+        $this->assertSame('ghi789', $profile->getToken());
     }
 
     public function testGetLatestProfileReturnsNullWhenNoProfiles()
@@ -232,6 +232,6 @@ final class ProfilerDataProviderTest extends TestCase
         $profiles = $provider->readIndex();
 
         $this->assertCount(3, $profiles);
-        $this->assertSame('context1', $profiles[0]->context);
+        $this->assertSame('context1', $profiles[0]->getContext());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1933
| License       | MIT

## Summary

Aligns all Mate DTOs with the pattern established in #1942 for HuggingFace Output classes: constructor-promoted properties are `private readonly` with explicit public getter methods, preventing external mutation and making the immutability contract explicit.

All affected classes are marked `@internal`.

### Symfony Model DTOs (`public` → `private readonly` + getters)
- `Container` → `getServices()`
- `ServiceDefinition` → `getId()`, `getClass()`, `getAlias()`, `getCalls()`, `getTags()`, `getConstructor()`
- `ServiceTag` → `getName()`, `getAttributes()`

### Profiler Model DTOs (`public readonly` → `private readonly` + getters)
- `CollectorData` → `getName()`, `getData()`, `getSummary()`
- `ProfileData` → `getProfile()`, `getContext()`
- `ProfileIndex` → `getToken()`, `getIp()`, `getMethod()`, `getUrl()`, `getTime()`, `getStatusCode()`, `getParentToken()`, `getContext()`, `getType()`

### Monolog Model DTOs (`public readonly` → `private readonly` + getters)
- `LogEntry` → `getDatetime()`, `getChannel()`, `getLevel()`, `getMessage()`, `getContext()`, `getExtra()`, `getSourceFile()`, `getLineNumber()`
- `SearchCriteria` → `getTerm()`, `getRegex()`, `getLevel()`, `getChannel()`, `getFrom()`, `getTo()`, `getContextKey()`, `getContextValue()`, `getLimit()`, `getOffset()`

### Updated call sites
All internal call sites (`ContainerProvider`, `ServiceTool`, `ProfilerResourceTemplate`, `ProfilerTool`, `ProfileIndexer`, `ProfilerDataProvider`, `LogReader`, `SearchCriteria::matches()`) and tests updated to use the new getters.

```php
// Before
$container->services;
$profileData->profile;
$entry->level;

// After
$container->getServices();
$profileData->getProfile();
$entry->getLevel();
```

## Testing

- `cd src/mate && vendor/bin/phpstan analyse` — clean
- `cd src/mate && vendor/bin/phpunit` — 95 tests, 410 assertions, all pass
- `vendor/bin/php-cs-fixer fix src/mate/ --dry-run` — no style issues in modified files

Pre-existing failures remain for tests that depend on optional Symfony packages not required in `composer.json` (`symfony/http-kernel`, `symfony/translation`, `symfony/var-dumper`) — unrelated to this change.