### PR TITLE
[Platform] Rename #[With] attribute to #[Schema]

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -159,5 +159,12 @@ jobs:
               with:
                   working-directory: tmp/${{ matrix.bridge.component }}/src/Bridge/${{ matrix.bridge.bridge }}
 
+            - name: Re-install root dependencies
+              uses: ramsey/composer-install@v4
+
+            - name: Link local packages
+              working-directory: tmp/${{ matrix.bridge.component }}/src/Bridge/${{ matrix.bridge.bridge }}
+              run: ../../../../../link
+
             - name: Run PHPStan
               run: cd tmp/${{ matrix.bridge.component }}/src/Bridge/${{ matrix.bridge.bridge }} && vendor/bin/phpstan

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,19 @@ AI Bundle
 Platform
 --------
 
+ * The `#[With]` attribute has been renamed to `#[Schema]`. The `WithAttributeDescriber` class has been renamed to
+   `SchemaAttributeDescriber` and the related service id `ai.platform.json_schema.describer.with_attribute` to
+   `ai.platform.json_schema.describer.schema_attribute`.
+
+   ```diff
+   -use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+   +use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+   -#[With(minimum: 0, maximum: 10)]
+   +#[Schema(minimum: 0, maximum: 10)]
+    int $number,
+   ```
+
  * The constructors of `VectorResult`, `ToolCallResult`, `RerankingResult`, `ToolCallComplete`, and `ImageResult`
    (OpenAI DallE bridge) no longer accept variadic parameters. Pass an array instead:
 

--- a/demo/src/Recipe/Data/Recipe.php
+++ b/demo/src/Recipe/Data/Recipe.php
@@ -11,7 +11,7 @@
 
 namespace App\Recipe\Data;
 
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
 final class Recipe
 {
@@ -23,19 +23,19 @@ final class Recipe
     /**
      * @var int Duration in minutes
      */
-    #[With(minimum: 5, maximum: 240)]
+    #[Schema(minimum: 5, maximum: 240)]
     public int $duration;
 
     /**
      * @var string Difficulty level of the recipe
      */
-    #[With(enum: ['Beginner', 'Intermediate', 'Advanced'])]
+    #[Schema(enum: ['Beginner', 'Intermediate', 'Advanced'])]
     public string $level;
 
     /**
      * @var string Dietary preference
      */
-    #[With(enum: ['Vegetarian', 'Vegan', 'Gluten-Free', 'Keto', 'Paleo'])]
+    #[Schema(enum: ['Vegetarian', 'Vegan', 'Gluten-Free', 'Keto', 'Paleo'])]
     public string $diet;
 
     /**

--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -132,13 +132,13 @@ Symfony AI generates a JSON Schema representation for all tools in the :class:`S
 method arguments and param comments in the doc block. Additionally, JSON Schema support validation rules, which are
 partially supported by LLMs like GPT.
 
-Parameter Validation with ``#[With]`` Attribute
-...............................................
+Parameter Validation with ``#[Schema]`` Attribute
+.................................................
 
-To leverage JSON Schema validation rules, configure the :class:`Symfony\\AI\\Platform\\Contract\\JsonSchema\\Attribute\\With` attribute on the method arguments of your tool::
+To leverage JSON Schema validation rules, configure the :class:`Symfony\\AI\\Platform\\Contract\\JsonSchema\\Attribute\\Schema` attribute on the method arguments of your tool::
 
     use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
-    use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+    use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
     #[AsTool('my_tool', 'Example tool with parameters requirements.')]
     final class MyTool
@@ -149,18 +149,18 @@ To leverage JSON Schema validation rules, configure the :class:`Symfony\\AI\\Pla
          * @param array<string> $categories List of valid categories
          */
         public function __invoke(
-            #[With(pattern: '/([a-z0-1]){5}/')]
+            #[Schema(pattern: '/([a-z0-1]){5}/')]
             string $name,
-            #[With(minimum: 0, maximum: 10)]
+            #[Schema(minimum: 0, maximum: 10)]
             int $number,
-            #[With(enum: ['tech', 'business', 'science'])]
+            #[Schema(enum: ['tech', 'business', 'science'])]
             array $categories,
         ): string {
             // ...
         }
     }
 
-See attribute class :class:`Symfony\\AI\\Platform\\Contract\\JsonSchema\\Attribute\\With` for all available options.
+See attribute class :class:`Symfony\\AI\\Platform\\Contract\\JsonSchema\\Attribute\\Schema` for all available options.
 
 .. note::
 
@@ -172,13 +172,13 @@ Defining Schema from File
 If you already have a JSON Schema defined in a file, you can reference it using the ``ref`` argument::
 
     use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
-    use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+    use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
     #[AsTool('my_tool', 'Example tool with external schema.')]
     final class MyTool
     {
         public function __invoke(
-            #[With(ref: __DIR__.'/schema.json')]
+            #[Schema(ref: __DIR__.'/schema.json')]
             array $data,
         ): string {
             // ...
@@ -187,12 +187,12 @@ If you already have a JSON Schema defined in a file, you can reference it using 
 
 .. note::
 
-    When using ``ref``, other arguments on the ``#[With]`` attribute are not allowed as the entire schema is loaded from the file.
+    When using ``ref``, other arguments on the ``#[Schema]`` attribute are not allowed as the entire schema is loaded from the file.
 
 Automatic Enum Validation
 .........................
 
-For PHP backed enums, automatic validation without requiring any :class:`Symfony\\AI\\Platform\\Contract\\JsonSchema\\Attribute\\With` attribute is supported::
+For PHP backed enums, automatic validation without requiring any :class:`Symfony\\AI\\Platform\\Contract\\JsonSchema\\Attribute\\Schema` attribute is supported::
 
     enum Priority: int
     {
@@ -223,12 +223,12 @@ For PHP backed enums, automatic validation without requiring any :class:`Symfony
             Priority $priority,
             ?ContentType $fallback = null,
         ): array {
-            // Enums are automatically validated - no #[With] attribute needed!
+            // Enums are automatically validated - no #[Schema] attribute needed!
             // ...
         }
     }
 
-This eliminates the need for manual ``#[With(enum: [...])]`` attributes when using PHP's native backed enum types.
+This eliminates the need for manual ``#[Schema(enum: [...])]`` attributes when using PHP's native backed enum types.
 
 Using Symfony Validator
 .......................
@@ -256,7 +256,7 @@ If you have `symfony/validator` installed, you can also use validation constrain
         }
     }
 
-This replaces the need to manually define the schema using ``#[With(...)]``, though it's possible to use both if needed.
+This replaces the need to manually define the schema using ``#[Schema(...)]``, though it's possible to use both if needed.
 
 To validate tool call arguments before invoking the actual tool, add the built-in :class:`Symfony\\AI\\Agent\\Toolbox\\EventListener\\ValidateToolCallArgumentsListener`
 to the event dispatcher that is passed to :class:`Symfony\\AI\\Agent\\Toolbox\\Toolbox`::

--- a/src/agent/src/Bridge/Brave/Brave.php
+++ b/src/agent/src/Bridge/Brave/Brave.php
@@ -15,7 +15,7 @@ use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 use Symfony\AI\Agent\Toolbox\Source\HasSourcesInterface;
 use Symfony\AI\Agent\Toolbox\Source\HasSourcesTrait;
 use Symfony\AI\Agent\Toolbox\Source\Source;
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -50,10 +50,10 @@ final class Brave implements HasSourcesInterface
      * }>
      */
     public function __invoke(
-        #[With(maxLength: 500)]
+        #[Schema(maxLength: 500)]
         string $query,
         int $count = 20,
-        #[With(minimum: 0, maximum: 9)]
+        #[Schema(minimum: 0, maximum: 9)]
         int $offset = 0,
     ): array {
         $result = $this->httpClient->request('GET', 'https://api.search.brave.com/res/v1/web/search', [

--- a/src/agent/src/Bridge/Mapbox/Mapbox.php
+++ b/src/agent/src/Bridge/Mapbox/Mapbox.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Agent\Bridge\Mapbox;
 
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -44,7 +44,7 @@ final class Mapbox
      */
     public function geocode(
         string $address,
-        #[With(minimum: 1, maximum: 10)]
+        #[Schema(minimum: 1, maximum: 10)]
         int $limit = 1,
     ): array {
         $response = $this->httpClient->request('GET', 'https://api.mapbox.com/geocoding/v5/mapbox.places/'.urlencode($address).'.json', [
@@ -101,7 +101,7 @@ final class Mapbox
     public function reverseGeocode(
         float $longitude,
         float $latitude,
-        #[With(minimum: 1, maximum: 5)]
+        #[Schema(minimum: 1, maximum: 5)]
         int $limit = 1,
     ): array {
         $response = $this->httpClient->request('GET', 'https://api.mapbox.com/search/geocode/v6/reverse', [

--- a/src/agent/src/Bridge/OpenMeteo/OpenMeteo.php
+++ b/src/agent/src/Bridge/OpenMeteo/OpenMeteo.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Agent\Bridge\OpenMeteo;
 
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -104,7 +104,7 @@ final class OpenMeteo
     public function forecast(
         float $latitude,
         float $longitude,
-        #[With(minimum: 1, maximum: 16)]
+        #[Schema(minimum: 1, maximum: 16)]
         int $days = 7,
     ): array {
         $result = $this->httpClient->request('GET', 'https://api.open-meteo.com/v1/forecast', [

--- a/src/agent/tests/Fixtures/Tool/ToolWithObjectAccessors.php
+++ b/src/agent/tests/Fixtures/Tool/ToolWithObjectAccessors.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
 
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
 class ToolWithObjectAccessors
 {
@@ -19,7 +19,7 @@ class ToolWithObjectAccessors
     private float $value2;
 
     public function __construct(
-        #[With(pattern: '^foo$')]
+        #[Schema(pattern: '^foo$')]
         private string $value3,
     ) {
     }
@@ -36,7 +36,7 @@ class ToolWithObjectAccessors
         ];
     }
 
-    public function setValue1(#[With(minimum: 1)] int $value1): void
+    public function setValue1(#[Schema(minimum: 1)] int $value1): void
     {
         $this->value1 = $value1;
     }
@@ -46,7 +46,7 @@ class ToolWithObjectAccessors
         return $this->value1;
     }
 
-    public function setValue2(#[With(const: 42)] float $value): void
+    public function setValue2(#[Schema(const: 42)] float $value): void
     {
         $this->value2 = $value;
     }

--- a/src/agent/tests/Fixtures/Tool/ToolWithToolParameterAttribute.php
+++ b/src/agent/tests/Fixtures/Tool/ToolWithToolParameterAttribute.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
 
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
 #[AsTool('tool_with_ToolParameter_attribute', 'A tool which has a parameter with described with #[ToolParameter] attribute')]
 final class ToolWithToolParameterAttribute
@@ -28,21 +28,21 @@ final class ToolWithToolParameterAttribute
      * @param string       $shippingAddress  The shipping address given to the tool
      */
     public function __invoke(
-        #[With(enum: ['dog', 'cat', 'bird'])]
+        #[Schema(enum: ['dog', 'cat', 'bird'])]
         string $animal,
-        #[With(const: 42)]
+        #[Schema(const: 42)]
         int $numberOfArticles,
-        #[With(const: 'info@example.de')]
+        #[Schema(const: 'info@example.de')]
         string $infoEmail,
-        #[With(const: ['de', 'en'])]
+        #[Schema(const: ['de', 'en'])]
         string $locales,
-        #[With(
+        #[Schema(
             pattern: '^[a-zA-Z]+$',
             minLength: 1,
             maxLength: 10,
         )]
         string $text,
-        #[With(
+        #[Schema(
             minimum: 1,
             maximum: 10,
             multipleOf: 2,
@@ -50,7 +50,7 @@ final class ToolWithToolParameterAttribute
             exclusiveMaximum: 10,
         )]
         int $number,
-        #[With(
+        #[Schema(
             minItems: 1,
             maxItems: 10,
             uniqueItems: true,
@@ -58,7 +58,7 @@ final class ToolWithToolParameterAttribute
             maxContains: 10,
         )]
         array $products,
-        #[With(
+        #[Schema(
             minProperties: 1,
             maxProperties: 10,
             dependentRequired: true,

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -63,10 +63,10 @@ use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Contract\JsonSchema\Describer\Describer;
 use Symfony\AI\Platform\Contract\JsonSchema\Describer\MethodDescriber;
 use Symfony\AI\Platform\Contract\JsonSchema\Describer\PropertyInfoDescriber;
+use Symfony\AI\Platform\Contract\JsonSchema\Describer\SchemaAttributeDescriber;
 use Symfony\AI\Platform\Contract\JsonSchema\Describer\SerializerDescriber;
 use Symfony\AI\Platform\Contract\JsonSchema\Describer\TypeInfoDescriber;
 use Symfony\AI\Platform\Contract\JsonSchema\Describer\ValidatorConstraintsDescriber;
-use Symfony\AI\Platform\Contract\JsonSchema\Describer\WithAttributeDescriber;
 use Symfony\AI\Platform\Contract\JsonSchema\Factory as SchemaFactory;
 use Symfony\AI\Platform\EventListener\TemplateRendererListener;
 use Symfony\AI\Platform\Message\TemplateRenderer\ExpressionLanguageTemplateRenderer;
@@ -184,7 +184,7 @@ return static function (ContainerConfigurator $container): void {
                 service('validator')->nullOnInvalid(),
             ])
             ->tag('ai.platform.json_schema.describer')
-        ->set('ai.platform.json_schema.describer.with_attribute', WithAttributeDescriber::class)
+        ->set('ai.platform.json_schema.describer.schema_attribute', SchemaAttributeDescriber::class)
             ->tag('ai.platform.json_schema.describer')
         ->set('ai.platform.json_schema.describer', Describer::class)
             ->args([

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -7,7 +7,8 @@ CHANGELOG
  * Add `MultiPartResult` for exposing the parts inside a message
  * Add `ExecutableCodeResult`, `CodeExecutionResult` for exposing the executed code blocks and results
  * [BC BREAK] Replace variadic constructor parameters with array parameters in `VectorResult`, `ToolCallResult`, `RerankingResult`, `ToolCallComplete`, and `ImageResult` (OpenAI DallE bridge)
- * Add `ref` property to `#[With]` attribute to allow providing schema as file
+ * [BC BREAK] Rename `#[With]` attribute to `#[Schema]` and `WithAttributeDescriber` to `SchemaAttributeDescriber`
+ * Add `ref` property to `#[Schema]` attribute to allow providing schema as file
 
 0.7
 ---

--- a/src/platform/src/Contract/JsonSchema/Attribute/Schema.php
+++ b/src/platform/src/Contract/JsonSchema/Attribute/Schema.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Exception\InvalidArgumentException;
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
 #[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
-final class With
+final class Schema
 {
     /**
      * @param list<int|float|string|null>|null $enum

--- a/src/platform/src/Contract/JsonSchema/Describer/Describer.php
+++ b/src/platform/src/Contract/JsonSchema/Describer/Describer.php
@@ -40,7 +40,7 @@ final class Describer implements ObjectDescriberInterface, PropertyDescriberInte
                 $describers[] = new ValidatorConstraintsDescriber();
             }
 
-            $describers[] = new WithAttributeDescriber();
+            $describers[] = new SchemaAttributeDescriber();
         }
 
         $objectDescribers = $propertyDescribers = [];

--- a/src/platform/src/Contract/JsonSchema/Describer/SchemaAttributeDescriber.php
+++ b/src/platform/src/Contract/JsonSchema/Describer/SchemaAttributeDescriber.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Platform\Contract\JsonSchema\Describer;
 
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 use Symfony\AI\Platform\Contract\JsonSchema\Factory;
 use Symfony\AI\Platform\Contract\JsonSchema\Subject\PropertySubject;
 use Symfony\AI\Platform\Exception\IOException;
@@ -19,22 +19,22 @@ use Symfony\AI\Platform\Exception\IOException;
 /**
  * @phpstan-import-type JsonSchema from Factory
  */
-final class WithAttributeDescriber implements PropertyDescriberInterface
+final class SchemaAttributeDescriber implements PropertyDescriberInterface
 {
     public function describeProperty(PropertySubject $subject, ?array &$schema): void
     {
-        foreach ($subject->getAttributes(With::class) as $attribute) {
+        foreach ($subject->getAttributes(Schema::class) as $attribute) {
             if ($attribute->ref) {
                 try {
-                    $with = json_decode(file_get_contents($attribute->ref), true, flags: \JSON_THROW_ON_ERROR);
+                    $attributeSchema = json_decode(file_get_contents($attribute->ref), true, flags: \JSON_THROW_ON_ERROR);
                 } catch (\JsonException $e) {
                     throw new IOException(\sprintf('Failed to load the schema from "%s"', $attribute->ref), 0, $e);
                 }
             } else {
-                $with = array_filter((array) $attribute, static fn ($value) => null !== $value);
+                $attributeSchema = array_filter((array) $attribute, static fn ($value) => null !== $value);
             }
 
-            $schema = array_replace_recursive($schema ?? [], $with);
+            $schema = array_replace_recursive($schema ?? [], $attributeSchema);
         }
     }
 }

--- a/src/platform/tests/Contract/JsonSchema/Attribute/ToolParameterTest.php
+++ b/src/platform/tests/Contract/JsonSchema/Attribute/ToolParameterTest.php
@@ -13,7 +13,7 @@ namespace Symfony\AI\Platform\Tests\Contract\JsonSchema\Attribute;
 
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 
 final class ToolParameterTest extends TestCase
@@ -21,7 +21,7 @@ final class ToolParameterTest extends TestCase
     public function testValidEnum()
     {
         $enum = ['value1', 'value2'];
-        $toolParameter = new With(enum: $enum);
+        $toolParameter = new Schema(enum: $enum);
         $this->assertSame($enum, $toolParameter->enum);
     }
 
@@ -29,13 +29,13 @@ final class ToolParameterTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $enum = ['value1', new \stdClass()];
-        new With(enum: $enum); /* @phpstan-ignore-line argument.type */
+        new Schema(enum: $enum); /* @phpstan-ignore-line argument.type */
     }
 
     public function testValidConstString()
     {
         $const = 'constant value';
-        $toolParameter = new With(const: $const);
+        $toolParameter = new Schema(const: $const);
         $this->assertSame($const, $toolParameter->const);
     }
 
@@ -43,13 +43,13 @@ final class ToolParameterTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $const = '   ';
-        new With(const: $const);
+        new Schema(const: $const);
     }
 
     public function testValidPattern()
     {
         $pattern = '/^[a-z]+$/';
-        $toolParameter = new With(pattern: $pattern);
+        $toolParameter = new Schema(pattern: $pattern);
         $this->assertSame($pattern, $toolParameter->pattern);
     }
 
@@ -57,27 +57,27 @@ final class ToolParameterTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $pattern = '   ';
-        new With(pattern: $pattern);
+        new Schema(pattern: $pattern);
     }
 
     public function testValidMinLength()
     {
         $minLength = 5;
-        $toolParameter = new With(minLength: $minLength);
+        $toolParameter = new Schema(minLength: $minLength);
         $this->assertSame($minLength, $toolParameter->minLength);
     }
 
     public function testInvalidMinLengthNegative()
     {
         $this->expectException(InvalidArgumentException::class);
-        new With(minLength: -1);
+        new Schema(minLength: -1);
     }
 
     public function testValidMinLengthAndMaxLength()
     {
         $minLength = 5;
         $maxLength = 10;
-        $toolParameter = new With(minLength: $minLength, maxLength: $maxLength);
+        $toolParameter = new Schema(minLength: $minLength, maxLength: $maxLength);
         $this->assertSame($minLength, $toolParameter->minLength);
         $this->assertSame($maxLength, $toolParameter->maxLength);
     }
@@ -85,7 +85,7 @@ final class ToolParameterTest extends TestCase
     public function testInvalidMaxLengthLessThanMinLength()
     {
         $this->expectException(InvalidArgumentException::class);
-        new With(minLength: 10, maxLength: 5);
+        new Schema(minLength: 10, maxLength: 5);
     }
 
     #[TestWith([0], 'zero')]
@@ -93,28 +93,28 @@ final class ToolParameterTest extends TestCase
     #[TestWith([-1], 'negative')]
     public function testValidMinimum(int|float $minimum)
     {
-        $toolParameter = new With(minimum: $minimum);
+        $toolParameter = new Schema(minimum: $minimum);
         $this->assertSame($minimum, $toolParameter->minimum);
     }
 
     public function testValidMultipleOf()
     {
         $multipleOf = 5;
-        $toolParameter = new With(multipleOf: $multipleOf);
+        $toolParameter = new Schema(multipleOf: $multipleOf);
         $this->assertSame($multipleOf, $toolParameter->multipleOf);
     }
 
     public function testInvalidMultipleOfNegative()
     {
         $this->expectException(InvalidArgumentException::class);
-        new With(multipleOf: -5);
+        new Schema(multipleOf: -5);
     }
 
     public function testValidExclusiveMinimumAndMaximum()
     {
         $exclusiveMinimum = 1;
         $exclusiveMaximum = 10;
-        $toolParameter = new With(exclusiveMinimum: $exclusiveMinimum, exclusiveMaximum: $exclusiveMaximum);
+        $toolParameter = new Schema(exclusiveMinimum: $exclusiveMinimum, exclusiveMaximum: $exclusiveMaximum);
         $this->assertSame($exclusiveMinimum, $toolParameter->exclusiveMinimum);
         $this->assertSame($exclusiveMaximum, $toolParameter->exclusiveMaximum);
     }
@@ -122,14 +122,14 @@ final class ToolParameterTest extends TestCase
     public function testInvalidExclusiveMaximumLessThanExclusiveMinimum()
     {
         $this->expectException(InvalidArgumentException::class);
-        new With(exclusiveMinimum: 10, exclusiveMaximum: 5);
+        new Schema(exclusiveMinimum: 10, exclusiveMaximum: 5);
     }
 
     public function testValidMinItemsAndMaxItems()
     {
         $minItems = 1;
         $maxItems = 5;
-        $toolParameter = new With(minItems: $minItems, maxItems: $maxItems);
+        $toolParameter = new Schema(minItems: $minItems, maxItems: $maxItems);
         $this->assertSame($minItems, $toolParameter->minItems);
         $this->assertSame($maxItems, $toolParameter->maxItems);
     }
@@ -137,26 +137,26 @@ final class ToolParameterTest extends TestCase
     public function testInvalidMaxItemsLessThanMinItems()
     {
         $this->expectException(InvalidArgumentException::class);
-        new With(minItems: 5, maxItems: 1);
+        new Schema(minItems: 5, maxItems: 1);
     }
 
     public function testValidUniqueItemsTrue()
     {
-        $toolParameter = new With(uniqueItems: true);
+        $toolParameter = new Schema(uniqueItems: true);
         $this->assertTrue($toolParameter->uniqueItems);
     }
 
     public function testInvalidUniqueItemsFalse()
     {
         $this->expectException(InvalidArgumentException::class);
-        new With(uniqueItems: false);
+        new Schema(uniqueItems: false);
     }
 
     public function testValidMinContainsAndMaxContains()
     {
         $minContains = 1;
         $maxContains = 3;
-        $toolParameter = new With(minContains: $minContains, maxContains: $maxContains);
+        $toolParameter = new Schema(minContains: $minContains, maxContains: $maxContains);
         $this->assertSame($minContains, $toolParameter->minContains);
         $this->assertSame($maxContains, $toolParameter->maxContains);
     }
@@ -164,14 +164,14 @@ final class ToolParameterTest extends TestCase
     public function testInvalidMaxContainsLessThanMinContains()
     {
         $this->expectException(InvalidArgumentException::class);
-        new With(minContains: 3, maxContains: 1);
+        new Schema(minContains: 3, maxContains: 1);
     }
 
     public function testValidMinPropertiesAndMaxProperties()
     {
         $minProperties = 1;
         $maxProperties = 5;
-        $toolParameter = new With(minProperties: $minProperties, maxProperties: $maxProperties);
+        $toolParameter = new Schema(minProperties: $minProperties, maxProperties: $maxProperties);
         $this->assertSame($minProperties, $toolParameter->minProperties);
         $this->assertSame($maxProperties, $toolParameter->maxProperties);
     }
@@ -179,18 +179,18 @@ final class ToolParameterTest extends TestCase
     public function testInvalidMaxPropertiesLessThanMinProperties()
     {
         $this->expectException(InvalidArgumentException::class);
-        new With(minProperties: 5, maxProperties: 1);
+        new Schema(minProperties: 5, maxProperties: 1);
     }
 
     public function testValidDependentRequired()
     {
-        $toolParameter = new With(dependentRequired: true);
+        $toolParameter = new Schema(dependentRequired: true);
         $this->assertTrue($toolParameter->dependentRequired);
     }
 
     public function testValidCombination()
     {
-        $toolParameter = new With(
+        $toolParameter = new Schema(
             enum: ['value1', 'value2'],
             const: 'constant',
             pattern: '/^[a-z]+$/',
@@ -211,12 +211,12 @@ final class ToolParameterTest extends TestCase
             dependentRequired: true
         );
 
-        $this->assertInstanceOf(With::class, $toolParameter);
+        $this->assertInstanceOf(Schema::class, $toolParameter);
     }
 
     public function testInvalidCombination()
     {
         $this->expectException(InvalidArgumentException::class);
-        new With(minLength: -1, maxLength: -2);
+        new Schema(minLength: -1, maxLength: -2);
     }
 }

--- a/src/platform/tests/Contract/JsonSchema/Describer/SchemaAttributeDescriberTest.php
+++ b/src/platform/tests/Contract/JsonSchema/Describer/SchemaAttributeDescriberTest.php
@@ -14,14 +14,14 @@ namespace Symfony\AI\Platform\Tests\Contract\JsonSchema\Describer;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithObjectAccessors;
-use Symfony\AI\Platform\Contract\JsonSchema\Describer\WithAttributeDescriber;
+use Symfony\AI\Platform\Contract\JsonSchema\Describer\SchemaAttributeDescriber;
 use Symfony\AI\Platform\Contract\JsonSchema\Subject\PropertySubject;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Exception\IOException;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\ExampleDto;
-use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\WithAttributeRefDto;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\SchemaAttributeRefDto;
 
-final class WithAttributeDescriberTest extends TestCase
+final class SchemaAttributeDescriberTest extends TestCase
 {
     /**
      * @param array<string, mixed> $expectedSchema
@@ -30,10 +30,10 @@ final class WithAttributeDescriberTest extends TestCase
     #[TestWith([['const' => 42], new PropertySubject('value2', new \ReflectionParameter([ToolWithObjectAccessors::class, 'setValue2'], 0))], 'setter')]
     #[TestWith([['pattern' => '^foo$'], new PropertySubject('value3', new \ReflectionParameter([ToolWithObjectAccessors::class, '__construct'], 'value3'))], 'constructor')]
     #[TestWith([['description' => 'The quantity of the ingredient', 'example' => '2 cups'], new PropertySubject('quantity', new \ReflectionParameter([ExampleDto::class, '__construct'], 'quantity'))], 'example')]
-    #[TestWith([['type' => 'string', 'description' => 'This is a test schema from a ref file.'], new PropertySubject('schemaFromFile', new \ReflectionParameter([WithAttributeRefDto::class, '__construct'], 'schemaFromFile'))], 'schema from file')]
+    #[TestWith([['type' => 'string', 'description' => 'This is a test schema from a ref file.'], new PropertySubject('schemaFromFile', new \ReflectionParameter([SchemaAttributeRefDto::class, '__construct'], 'schemaFromFile'))], 'schema from file')]
     public function testDescribeProperty(array $expectedSchema, PropertySubject $property)
     {
-        $describer = new WithAttributeDescriber();
+        $describer = new SchemaAttributeDescriber();
         $schema = null;
 
         $describer->describeProperty($property, $schema);
@@ -43,8 +43,8 @@ final class WithAttributeDescriberTest extends TestCase
 
     public function testDescribePropertyWithNonExistentFile()
     {
-        $describer = new WithAttributeDescriber();
-        $property = new PropertySubject('nonExistentSchema', new \ReflectionParameter([WithAttributeRefDto::class, '__construct'], 'nonExistentSchema'));
+        $describer = new SchemaAttributeDescriber();
+        $property = new PropertySubject('nonExistentSchema', new \ReflectionParameter([SchemaAttributeRefDto::class, '__construct'], 'nonExistentSchema'));
         $schema = null;
 
         $this->expectException(InvalidArgumentException::class);
@@ -53,8 +53,8 @@ final class WithAttributeDescriberTest extends TestCase
 
     public function testDescribePropertyWithInvalidJson()
     {
-        $describer = new WithAttributeDescriber();
-        $property = new PropertySubject('nonJsonSchema', new \ReflectionParameter([WithAttributeRefDto::class, '__construct'], 'nonJsonSchema'));
+        $describer = new SchemaAttributeDescriber();
+        $property = new PropertySubject('nonJsonSchema', new \ReflectionParameter([SchemaAttributeRefDto::class, '__construct'], 'nonJsonSchema'));
         $schema = null;
 
         $this->expectException(IOException::class);

--- a/src/platform/tests/Contract/JsonSchema/FactoryTest.php
+++ b/src/platform/tests/Contract/JsonSchema/FactoryTest.php
@@ -22,10 +22,10 @@ use Symfony\AI\Platform\Contract\JsonSchema\Factory;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\ExampleDto;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\MathReasoning;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType\ListOfPolymorphicTypesDto;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\SchemaAttributeValuesDto;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\Step;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\UnionType\UnionTypeDto;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\User;
-use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\WithAttributeValuesDto;
 
 final class FactoryTest extends TestCase
 {
@@ -381,7 +381,7 @@ final class FactoryTest extends TestCase
             'additionalProperties' => false,
         ];
 
-        $actual = $this->factory->buildProperties(WithAttributeValuesDto::class);
+        $actual = $this->factory->buildProperties(SchemaAttributeValuesDto::class);
 
         $this->assertSame($expected, $actual);
     }

--- a/src/platform/tests/Fixtures/StructuredOutput/ExampleDto.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/ExampleDto.php
@@ -11,15 +11,15 @@
 
 namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput;
 
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
 class ExampleDto
 {
     public function __construct(
         public string $name,
-        #[With(enum: [7, 19])] public int $taxRate,
-        #[With(enum: ['Foo', 'Bar', null])] public ?string $category,
-        #[With(description: 'The quantity of the ingredient', example: '2 cups')] public ?string $quantity = null,
+        #[Schema(enum: [7, 19])] public int $taxRate,
+        #[Schema(enum: ['Foo', 'Bar', null])] public ?string $category,
+        #[Schema(description: 'The quantity of the ingredient', example: '2 cups')] public ?string $quantity = null,
     ) {
     }
 }

--- a/src/platform/tests/Fixtures/StructuredOutput/PolymorphicType/ListItemAge.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/PolymorphicType/ListItemAge.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType;
 
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
 final class ListItemAge implements ListItemDiscriminator
 {
     public function __construct(
         public int $age,
-        #[With(pattern: '^age$')]
+        #[Schema(pattern: '^age$')]
         public string $type = 'age',
     ) {
     }

--- a/src/platform/tests/Fixtures/StructuredOutput/PolymorphicType/ListItemName.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/PolymorphicType/ListItemName.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType;
 
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
 class ListItemName implements ListItemDiscriminator
 {
     public function __construct(
         public string $name,
-        #[With(pattern: '^name$')]
+        #[Schema(pattern: '^name$')]
         public string $type = 'name',
     ) {
     }

--- a/src/platform/tests/Fixtures/StructuredOutput/SchemaAttributeRefDto.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/SchemaAttributeRefDto.php
@@ -11,18 +11,18 @@
 
 namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput;
 
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
-class WithAttributeRefDto
+class SchemaAttributeRefDto
 {
     public function __construct(
-        #[With(ref: __DIR__.'/../json_schema_ref.json')]
+        #[Schema(ref: __DIR__.'/../json_schema_ref.json')]
         public ?string $schemaFromFile = null,
 
-        #[With(ref: __DIR__.'/../non_existent.json')]
+        #[Schema(ref: __DIR__.'/../non_existent.json')]
         public ?string $nonExistentSchema = null,
 
-        #[With(ref: __FILE__)]
+        #[Schema(ref: __FILE__)]
         public ?string $nonJsonSchema = null,
     ) {
     }

--- a/src/platform/tests/Fixtures/StructuredOutput/SchemaAttributeValuesDto.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/SchemaAttributeValuesDto.php
@@ -11,15 +11,15 @@
 
 namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput;
 
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
-class WithAttributeValuesDto
+class SchemaAttributeValuesDto
 {
     /**
      * @param string $name this is the PHPDoc description
      */
     public function __construct(
-        #[With(description: 'This is the attribute description.', example: 'Attribute example')]
+        #[Schema(description: 'This is the attribute description.', example: 'Attribute example')]
         public string $name,
     ) {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        |
| License       | MIT

The `#[With]` attribute used to configure the JSON schema generated for tool-call arguments (and structured-output DTO properties) has been renamed to `#[Schema]`. The name `#[Schema(...)]` describes the intent at call sites and matches the `JsonSchema` namespace it lives in.

In lock-step with the attribute, the related describer and service id are renamed too:

- `Symfony\AI\Platform\Contract\JsonSchema\Attribute\With` → `…\Attribute\Schema`
- `Symfony\AI\Platform\Contract\JsonSchema\Describer\WithAttributeDescriber` → `…\Describer\SchemaAttributeDescriber`
- service id `ai.platform.json_schema.describer.with_attribute` → `ai.platform.json_schema.describer.schema_attribute`

All bridges, fixtures, tests, demo code and docs have been updated accordingly. A `[BC BREAK]` entry has been added to `src/platform/CHANGELOG.md` and an upgrade note to `UPGRADE.md` under `UPGRADE FROM 0.7 to 0.8` → `Platform`.

```diff
-use Symfony\AI\Platform\Contract\JsonSchema\Attribute\With;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;

-#[With(minimum: 0, maximum: 10)]
+#[Schema(minimum: 0, maximum: 10)]
 int $number,
```

cc @valtzu @OskarStark 