### PR TITLE
[Platform][DeepSeek] Expose API errors for better Developer Experience

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `ExecutableCodeResult`, `CodeExecutionResult` for exposing the executed code blocks and results
  * [BC BREAK] Replace variadic constructor parameters with array parameters in `VectorResult`, `ToolCallResult`, `RerankingResult`, `ToolCallComplete`, and `ImageResult` (OpenAI DallE bridge)
  * Add `ref` property to `#[With]` attribute to allow providing schema as file
+ * [DeepSeek] Expose API errors through `AuthenticationException`, `BadRequestException`, and `RateLimitExceededException`
 
 0.7
 ---

--- a/src/platform/src/Bridge/DeepSeek/ResultConverter.php
+++ b/src/platform/src/Bridge/DeepSeek/ResultConverter.php
@@ -12,11 +12,15 @@
 namespace Symfony\AI\Platform\Bridge\DeepSeek;
 
 use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\InvalidRequestException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -35,8 +39,25 @@ final class ResultConverter implements ResultConverterInterface
         return $model instanceof DeepSeek;
     }
 
-    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if ($result instanceof RawHttpResult) {
+            $httpResponse = $result->getObject();
+
+            if (401 === $httpResponse->getStatusCode()) {
+                throw new AuthenticationException($this->extractErrorMessage($httpResponse->getContent(false)) ?? 'Unauthorized');
+            }
+
+            if (400 === $httpResponse->getStatusCode()) {
+                throw new BadRequestException($this->extractErrorMessage($httpResponse->getContent(false)) ?? 'Bad Request');
+            }
+
+            if (429 === $httpResponse->getStatusCode()) {
+                $retryAfter = $httpResponse->getHeaders(false)['retry-after'][0] ?? null;
+                throw new RateLimitExceededException($retryAfter ? (int) $retryAfter : null);
+            }
+        }
+
         if ($options['stream'] ?? false) {
             return new StreamResult($this->convertStream($result));
         }
@@ -71,5 +92,19 @@ final class ResultConverter implements ResultConverterInterface
     protected function convertStreamUsage(array $usage): TokenUsage
     {
         return $this->getTokenUsageExtractor()->extractFromArray($usage);
+    }
+
+    private function extractErrorMessage(string $body): ?string
+    {
+        if ('' === $body) {
+            return null;
+        }
+
+        $data = json_decode($body, true);
+        if (!\is_array($data)) {
+            return null;
+        }
+
+        return $data['error']['message'] ?? $data['message'] ?? null;
     }
 }

--- a/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterHttpStatusTest.php
+++ b/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterHttpStatusTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\DeepSeek\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\DeepSeek\ResultConverter;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ResultConverterHttpStatusTest extends TestCase
+{
+    public function testThrowsAuthenticationExceptionOnInvalidApiKey()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(401);
+        $httpResponse->method('getContent')->with(false)->willReturn(json_encode([
+            'error' => [
+                'message' => 'Authentication Fails, Your api key: ****XXXX is invalid',
+            ],
+        ]));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Authentication Fails, Your api key: ****XXXX is invalid');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsAuthenticationExceptionWithFallbackMessage()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(401);
+        $httpResponse->method('getContent')->with(false)->willReturn('');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthorized');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsBadRequestExceptionOnBadRequestResponse()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->with(false)->willReturn(json_encode([
+            'error' => [
+                'message' => 'Invalid request body',
+            ],
+        ]));
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Invalid request body');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsBadRequestExceptionWithFallbackMessage()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->with(false)->willReturn('');
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Bad Request');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+}

--- a/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterRateLimitTest.php
+++ b/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterRateLimitTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\DeepSeek\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\DeepSeek\ResultConverter;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ResultConverterRateLimitTest extends TestCase
+{
+    public function testRateLimitExceededThrowsException()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"error":{"message":"You have exceeded your rate limit"}}', [
+                'http_code' => 429,
+                'response_headers' => [
+                    'retry-after' => '45',
+                ],
+            ]),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://api.deepseek.com/chat/completions');
+        $converter = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded');
+
+        try {
+            $converter->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $this->assertSame(45, $e->getRetryAfter());
+            throw $e;
+        }
+    }
+
+    public function testRateLimitExceededWithoutRetryAfter()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"error":{"message":"You have exceeded your rate limit"}}', [
+                'http_code' => 429,
+            ]),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://api.deepseek.com/chat/completions');
+        $converter = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded');
+
+        try {
+            $converter->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $this->assertNull($e->getRetryAfter());
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #528
| License       | MIT

The DeepSeek bridge result converter only inspected the response body for logical errors (`content_filter`, `invalid_request_error`) and ignored the HTTP status code entirely. As a result, authentication failures and rate limits surfaced as PHP errors on a missing `choices` key rather than meaningful exceptions. This aligns DeepSeek with the Anthropic, OpenAI GPT and Mistral bridges.

The result converter now throws dedicated exceptions:

 - `401` → `AuthenticationException`
 - `400` → `BadRequestException`
 - `429` → `RateLimitExceededException` (with `retry-after` header propagated)

Error messages are extracted from the response body, supporting both the top-level `message` shape and the nested `error.message` shape.

```php
try {
    $platform->invoke(new DeepSeek('deepseek-chat'), $messages);
} catch (RateLimitExceededException $e) {
    sleep($e->getRetryAfter() ?? 60);
    // retry...
} catch (AuthenticationException $e) {
    // invalid API key -> message from the API is now exposed
}
```

HTTP status handling is guarded behind an `instanceof RawHttpResult` branch so the existing in-memory streaming tests (`InMemoryRawResult`) keep working untouched.

Part of the effort to address #528 across Platform bridges. Previous step: #1961 (Mistral).