### PR TITLE
[Platform][Cerebras] Expose API errors for better Developer Experience

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `ExecutableCodeResult`, `CodeExecutionResult` for exposing the executed code blocks and results
  * [BC BREAK] Replace variadic constructor parameters with array parameters in `VectorResult`, `ToolCallResult`, `RerankingResult`, `ToolCallComplete`, and `ImageResult` (OpenAI DallE bridge)
  * Add `ref` property to `#[With]` attribute to allow providing schema as file
+ * [Cerebras] Expose API errors through `AuthenticationException`, `BadRequestException`, and `RateLimitExceededException`
 
 0.7
 ---

--- a/src/platform/src/Bridge/Cerebras/ResultConverter.php
+++ b/src/platform/src/Bridge/Cerebras/ResultConverter.php
@@ -12,9 +12,13 @@
 namespace Symfony\AI\Platform\Bridge\Cerebras;
 
 use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -33,8 +37,25 @@ final class ResultConverter implements ResultConverterInterface
         return $model instanceof Model;
     }
 
-    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if ($result instanceof RawHttpResult) {
+            $httpResponse = $result->getObject();
+
+            if (401 === $httpResponse->getStatusCode()) {
+                throw new AuthenticationException($this->extractErrorMessage($httpResponse->getContent(false)) ?? 'Unauthorized');
+            }
+
+            if (400 === $httpResponse->getStatusCode()) {
+                throw new BadRequestException($this->extractErrorMessage($httpResponse->getContent(false)) ?? 'Bad Request');
+            }
+
+            if (429 === $httpResponse->getStatusCode()) {
+                $retryAfter = $httpResponse->getHeaders(false)['retry-after'][0] ?? null;
+                throw new RateLimitExceededException($retryAfter ? (int) $retryAfter : null);
+            }
+        }
+
         if ($options['stream'] ?? false) {
             return new StreamResult($this->convertStream($result));
         }
@@ -57,5 +78,19 @@ final class ResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
     {
         return null;
+    }
+
+    private function extractErrorMessage(string $body): ?string
+    {
+        if ('' === $body) {
+            return null;
+        }
+
+        $data = json_decode($body, true);
+        if (!\is_array($data)) {
+            return null;
+        }
+
+        return $data['error']['message'] ?? $data['message'] ?? null;
     }
 }

--- a/src/platform/src/Bridge/Cerebras/Tests/ResultConverterHttpStatusTest.php
+++ b/src/platform/src/Bridge/Cerebras/Tests/ResultConverterHttpStatusTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cerebras\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cerebras\ResultConverter;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ResultConverterHttpStatusTest extends TestCase
+{
+    public function testThrowsAuthenticationExceptionOnInvalidApiKey()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(401);
+        $httpResponse->method('getContent')->with(false)->willReturn(json_encode([
+            'message' => 'Wrong API Key',
+            'type' => 'invalid_request_error',
+        ]));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Wrong API Key');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsAuthenticationExceptionWithFallbackMessage()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(401);
+        $httpResponse->method('getContent')->with(false)->willReturn('');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthorized');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsBadRequestExceptionOnBadRequestResponse()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->with(false)->willReturn(json_encode([
+            'message' => 'Invalid request: model not supported',
+        ]));
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Invalid request: model not supported');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsBadRequestExceptionWithFallbackMessage()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->with(false)->willReturn('');
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Bad Request');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+}

--- a/src/platform/src/Bridge/Cerebras/Tests/ResultConverterRateLimitTest.php
+++ b/src/platform/src/Bridge/Cerebras/Tests/ResultConverterRateLimitTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cerebras\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cerebras\ResultConverter;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ResultConverterRateLimitTest extends TestCase
+{
+    public function testRateLimitExceededThrowsException()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"message":"Too many requests"}', [
+                'http_code' => 429,
+                'response_headers' => [
+                    'retry-after' => '10',
+                ],
+            ]),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://api.cerebras.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded');
+
+        try {
+            $converter->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $this->assertSame(10, $e->getRetryAfter());
+            throw $e;
+        }
+    }
+
+    public function testRateLimitExceededWithoutRetryAfter()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"message":"Too many requests"}', [
+                'http_code' => 429,
+            ]),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://api.cerebras.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded');
+
+        try {
+            $converter->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $this->assertNull($e->getRetryAfter());
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #528
| License       | MIT

The Cerebras bridge result converter only threw a generic `RuntimeException` when the response did not match the expected shape, which meant auth failures and rate limits were indistinguishable from other errors. This aligns Cerebras with the Anthropic, OpenAI GPT, Mistral and DeepSeek bridges.

The result converter now throws dedicated exceptions:

 - `401` → `AuthenticationException`
 - `400` → `BadRequestException`
 - `429` → `RateLimitExceededException` (with `retry-after` header propagated)

Error messages are extracted from the response body, supporting both the top-level `message` shape and the nested `error.message` shape.

```php
try {
    $platform->invoke(new Model('gpt-oss-120b'), $messages);
} catch (RateLimitExceededException $e) {
    sleep($e->getRetryAfter() ?? 60);
    // retry...
} catch (AuthenticationException $e) {
    // invalid API key -> message from the API is now exposed
}
```

HTTP status handling is guarded behind an \`instanceof RawHttpResult\` branch to keep fake-result testing paths working.

Part of the effort to address #528 across Platform bridges. Previous steps: #1961 (Mistral), #1962 (DeepSeek).