### PR TITLE
[Platform][Gemini] Expose API errors for better Developer Experience

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `ExecutableCodeResult`, `CodeExecutionResult` for exposing the executed code blocks and results
  * [BC BREAK] Replace variadic constructor parameters with array parameters in `VectorResult`, `ToolCallResult`, `RerankingResult`, `ToolCallComplete`, and `ImageResult` (OpenAI DallE bridge)
  * Add `ref` property to `#[With]` attribute to allow providing schema as file
+ * [Gemini] Expose API errors in LLM and Embeddings result converters through `AuthenticationException`, `BadRequestException`, and `RateLimitExceededException`
 
 0.7
 ---

--- a/src/platform/src/Bridge/Gemini/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings/ResultConverter.php
@@ -12,8 +12,12 @@
 namespace Symfony\AI\Platform\Bridge\Gemini\Embeddings;
 
 use Symfony\AI\Platform\Bridge\Gemini\Embeddings;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\ResultConverterInterface;
@@ -29,8 +33,25 @@ final class ResultConverter implements ResultConverterInterface
         return $model instanceof Embeddings;
     }
 
-    public function convert(RawResultInterface $result, array $options = []): VectorResult
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): VectorResult
     {
+        if ($result instanceof RawHttpResult) {
+            $httpResponse = $result->getObject();
+
+            if (401 === $httpResponse->getStatusCode()) {
+                throw new AuthenticationException($this->extractErrorMessage($httpResponse->getContent(false)) ?? 'Unauthorized');
+            }
+
+            if (400 === $httpResponse->getStatusCode()) {
+                throw new BadRequestException($this->extractErrorMessage($httpResponse->getContent(false)) ?? 'Bad Request');
+            }
+
+            if (429 === $httpResponse->getStatusCode()) {
+                $retryAfter = $httpResponse->getHeaders(false)['retry-after'][0] ?? null;
+                throw new RateLimitExceededException($retryAfter ? (int) $retryAfter : null);
+            }
+        }
+
         $data = $result->getData();
 
         if (!isset($data['embeddings'])) {
@@ -48,5 +69,19 @@ final class ResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): null
     {
         return null;
+    }
+
+    private function extractErrorMessage(string $body): ?string
+    {
+        if ('' === $body) {
+            return null;
+        }
+
+        $data = json_decode($body, true);
+        if (!\is_array($data)) {
+            return null;
+        }
+
+        return $data['error']['message'] ?? $data['message'] ?? null;
     }
 }

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -12,6 +12,8 @@
 namespace Symfony\AI\Platform\Bridge\Gemini\Gemini;
 
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -60,8 +62,17 @@ final class ResultConverter implements ResultConverterInterface
     {
         $response = $result->getObject();
 
+        if (401 === $response->getStatusCode()) {
+            throw new AuthenticationException($this->extractErrorMessage($response->getContent(false)) ?? 'Unauthorized');
+        }
+
+        if (400 === $response->getStatusCode()) {
+            throw new BadRequestException($this->extractErrorMessage($response->getContent(false)) ?? 'Bad Request');
+        }
+
         if (429 === $response->getStatusCode()) {
-            throw new RateLimitExceededException();
+            $retryAfter = $response->getHeaders(false)['retry-after'][0] ?? null;
+            throw new RateLimitExceededException($retryAfter ? (int) $retryAfter : null);
         }
 
         if ($options['stream'] ?? false) {
@@ -170,5 +181,19 @@ final class ResultConverter implements ResultConverterInterface
     private function convertToolCall(array $toolCall): ToolCall
     {
         return new ToolCall($toolCall['id'] ?? '', $toolCall['name'], $toolCall['args']);
+    }
+
+    private function extractErrorMessage(string $body): ?string
+    {
+        if ('' === $body) {
+            return null;
+        }
+
+        $data = json_decode($body, true);
+        if (!\is_array($data)) {
+            return null;
+        }
+
+        return $data['error']['message'] ?? $data['message'] ?? null;
     }
 }

--- a/src/platform/src/Bridge/Gemini/Tests/Embeddings/ResultConverterHttpStatusTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Embeddings/ResultConverterHttpStatusTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Gemini\Tests\Embeddings;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Gemini\Embeddings\ResultConverter;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ResultConverterHttpStatusTest extends TestCase
+{
+    public function testThrowsAuthenticationExceptionOnInvalidApiKey()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(401);
+        $httpResponse->method('getContent')->with(false)->willReturn(json_encode([
+            'error' => [
+                'code' => 401,
+                'message' => 'API key not valid. Please pass a valid API key.',
+                'status' => 'UNAUTHENTICATED',
+            ],
+        ]));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('API key not valid. Please pass a valid API key.');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsAuthenticationExceptionWithFallbackMessage()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(401);
+        $httpResponse->method('getContent')->with(false)->willReturn('');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthorized');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsBadRequestExceptionOnBadRequestResponse()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->with(false)->willReturn(json_encode([
+            'error' => [
+                'code' => 400,
+                'message' => 'Invalid request',
+                'status' => 'INVALID_ARGUMENT',
+            ],
+        ]));
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Invalid request');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsBadRequestExceptionWithFallbackMessage()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->with(false)->willReturn('');
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Bad Request');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+}

--- a/src/platform/src/Bridge/Gemini/Tests/Embeddings/ResultConverterRateLimitTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Embeddings/ResultConverterRateLimitTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Gemini\Tests\Embeddings;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Gemini\Embeddings\ResultConverter;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ResultConverterRateLimitTest extends TestCase
+{
+    public function testRateLimitExceededThrowsException()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}', [
+                'http_code' => 429,
+            ]),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent');
+        $converter = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded');
+
+        try {
+            $converter->convert(new RawHttpResult($httpResponse));
+        } catch (RateLimitExceededException $e) {
+            $this->assertNull($e->getRetryAfter());
+            throw $e;
+        }
+    }
+}

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterHttpStatusTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterHttpStatusTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Gemini\Tests\Gemini;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ResultConverterHttpStatusTest extends TestCase
+{
+    public function testThrowsAuthenticationExceptionOnInvalidApiKey()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(401);
+        $httpResponse->method('getContent')->with(false)->willReturn(json_encode([
+            'error' => [
+                'code' => 401,
+                'message' => 'API key not valid. Please pass a valid API key.',
+                'status' => 'UNAUTHENTICATED',
+            ],
+        ]));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('API key not valid. Please pass a valid API key.');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsAuthenticationExceptionWithFallbackMessage()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(401);
+        $httpResponse->method('getContent')->with(false)->willReturn('');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthorized');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsBadRequestExceptionOnBadRequestResponse()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->with(false)->willReturn(json_encode([
+            'error' => [
+                'code' => 400,
+                'message' => 'Invalid value at generationConfig.temperature',
+                'status' => 'INVALID_ARGUMENT',
+            ],
+        ]));
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Invalid value at generationConfig.temperature');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsBadRequestExceptionWithFallbackMessage()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->with(false)->willReturn('');
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Bad Request');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+}

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -38,17 +38,17 @@ final class ResultConverterTest extends TestCase
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
-        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getStatusCode')->willReturn(500);
         $httpResponse->method('toArray')->willReturn([
             'error' => [
-                'code' => 400,
-                'status' => 'INVALID_ARGUMENT',
-                'message' => 'Invalid request: The model does not support this feature.',
+                'code' => 500,
+                'status' => 'INTERNAL',
+                'message' => 'Internal error encountered.',
             ],
         ]);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Error "400" - "INVALID_ARGUMENT": "Invalid request: The model does not support this feature.".');
+        $this->expectExceptionMessage('Error "500" - "INTERNAL": "Internal error encountered.".');
 
         $converter->convert(new RawHttpResult($httpResponse));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #528
| License       | MIT

The Gemini bridge LLM result converter already handled `429` through `RateLimitExceededException`, but auth failures (`401`) and bad requests (`400`) still surfaced as a generic `RuntimeException` with a verbose `Error "<code>" - "<status>": "<message>"` string that consumers had to parse. The Embeddings result converter did not inspect the HTTP status at all.

Both result converters now throw dedicated exceptions:

 - `401` → `AuthenticationException`
 - `400` → `BadRequestException`
 - `429` → `RateLimitExceededException` (with `retry-after` header propagated)

Error messages are extracted from Gemini's nested `error.message` shape.

```php
try {
    $platform->invoke(new Gemini('gemini-1.5-flash'), $messages);
} catch (RateLimitExceededException $e) {
    sleep($e->getRetryAfter() ?? 60);
    // retry...
} catch (AuthenticationException $e) {
    // invalid API key -> message from the API is now exposed
}
```

The existing LLM "detailed error" regression test is moved from status 400 to 500 since 400 now falls through the dedicated `BadRequestException` branch.

HTTP status handling in the Embeddings converter is guarded behind an \`instanceof RawHttpResult\` branch to preserve fake-result testing paths.

Part of the effort to address #528 across Platform bridges. Previous steps: #1961 (Mistral), #1962 (DeepSeek), #1963 (Cerebras), #1964 (Perplexity), #1965 (Cohere).