### PR TITLE
[Platform] Expose API errors uniformly across bridges through a shared trait

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Add `ModelRouterInterface` with `CatalogBasedModelRouter` as default strategy, and `CompositeModelCatalog` merging provider catalogs
  * Add `ModelRoutingEvent` dispatched by `Platform` before resolution, allowing listeners to observe/modify routing or short-circuit it by setting a provider
  * [BC BREAK] `Platform` constructor signature changed from `(modelClients, resultConverters, modelCatalog, contract, eventDispatcher)` to `(providers, modelRouter, eventDispatcher)`
+ * Add `HttpStatusErrorHandlingTrait` and expose API errors (`AuthenticationException`, `BadRequestException`, `RateLimitExceededException`) across the Mistral, DeepSeek, Cerebras, Perplexity, Cohere, Gemini and OpenAI (Embeddings, DallE, TextToSpeech) bridges
 
 0.7
 ---

--- a/src/platform/src/Bridge/Cerebras/ResultConverter.php
+++ b/src/platform/src/Bridge/Cerebras/ResultConverter.php
@@ -15,6 +15,8 @@ use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -27,14 +29,19 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 final class ResultConverter implements ResultConverterInterface
 {
     use CompletionsConversionTrait;
+    use HttpStatusErrorHandlingTrait;
 
     public function supports(BaseModel $model): bool
     {
         return $model instanceof Model;
     }
 
-    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if ($result instanceof RawHttpResult) {
+            $this->throwOnHttpError($result->getObject());
+        }
+
         if ($options['stream'] ?? false) {
             return new StreamResult($this->convertStream($result));
         }

--- a/src/platform/src/Bridge/Cohere/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Embeddings/ResultConverter.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Bridge\Cohere\Embeddings;
 use Symfony\AI\Platform\Bridge\Cohere\MetaBilledUnitsTokenUsageExtractor;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\VectorResult;
@@ -27,6 +28,8 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Embeddings;
@@ -35,6 +38,8 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): VectorResult
     {
         $httpResponse = $result->getObject();
+
+        $this->throwOnHttpError($httpResponse);
 
         if (200 !== $httpResponse->getStatusCode()) {
             throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $httpResponse->getStatusCode(), $httpResponse->getContent(false)));

--- a/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Cohere\Llm;
 use Symfony\AI\Platform\Bridge\Cohere\Cohere;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -31,6 +32,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Cohere;
@@ -43,8 +46,12 @@ final class ResultConverter implements ResultConverterInterface
     {
         $httpResponse = $result->getObject();
 
-        if ($httpResponse instanceof ResponseInterface && 200 !== $code = $httpResponse->getStatusCode()) {
-            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $httpResponse->getContent(false)));
+        if ($httpResponse instanceof ResponseInterface) {
+            $this->throwOnHttpError($httpResponse);
+
+            if (200 !== $code = $httpResponse->getStatusCode()) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $httpResponse->getContent(false)));
+            }
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/Cohere/Reranker/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Reranker/ResultConverter.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\Cohere\Reranker;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Reranking\RerankingEntry;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\RerankingResult;
@@ -27,6 +28,8 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Reranker;
@@ -35,6 +38,8 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): RerankingResult
     {
         $httpResponse = $result->getObject();
+
+        $this->throwOnHttpError($httpResponse);
 
         if (200 !== $httpResponse->getStatusCode()) {
             throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $httpResponse->getStatusCode(), $httpResponse->getContent(false)));

--- a/src/platform/src/Bridge/Cohere/SpeechToText/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/SpeechToText/ResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
 use Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
@@ -25,6 +26,8 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof SpeechToText;
@@ -33,6 +36,8 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): TextResult
     {
         $httpResponse = $result->getObject();
+
+        $this->throwOnHttpError($httpResponse);
 
         if (200 !== $httpResponse->getStatusCode()) {
             throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $httpResponse->getStatusCode(), $httpResponse->getContent(false)));

--- a/src/platform/src/Bridge/DeepSeek/ResultConverter.php
+++ b/src/platform/src/Bridge/DeepSeek/ResultConverter.php
@@ -17,6 +17,8 @@ use Symfony\AI\Platform\Exception\InvalidRequestException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -29,14 +31,19 @@ use Symfony\AI\Platform\TokenUsage\TokenUsage;
 final class ResultConverter implements ResultConverterInterface
 {
     use CompletionsConversionTrait;
+    use HttpStatusErrorHandlingTrait;
 
     public function supports(Model $model): bool
     {
         return $model instanceof DeepSeek;
     }
 
-    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if ($result instanceof RawHttpResult) {
+            $this->throwOnHttpError($result->getObject());
+        }
+
         if ($options['stream'] ?? false) {
             return new StreamResult($this->convertStream($result));
         }

--- a/src/platform/src/Bridge/Gemini/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings/ResultConverter.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Platform\Bridge\Gemini\Embeddings;
 use Symfony\AI\Platform\Bridge\Gemini\Embeddings;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\ResultConverterInterface;
@@ -24,13 +26,19 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Embeddings;
     }
 
-    public function convert(RawResultInterface $result, array $options = []): VectorResult
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): VectorResult
     {
+        if ($result instanceof RawHttpResult) {
+            $this->throwOnHttpError($result->getObject());
+        }
+
         $data = $result->getData();
 
         if (!isset($data['embeddings'])) {

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -12,13 +12,13 @@
 namespace Symfony\AI\Platform\Bridge\Gemini\Gemini;
 
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
-use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -47,6 +47,8 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public const OUTCOME_OK = 'OUTCOME_OK';
     public const OUTCOME_FAILED = 'OUTCOME_FAILED';
     public const OUTCOME_DEADLINE_EXCEEDED = 'OUTCOME_DEADLINE_EXCEEDED';
@@ -60,9 +62,7 @@ final class ResultConverter implements ResultConverterInterface
     {
         $response = $result->getObject();
 
-        if (429 === $response->getStatusCode()) {
-            throw new RateLimitExceededException();
-        }
+        $this->throwOnHttpError($response);
 
         if ($options['stream'] ?? false) {
             return new StreamResult($this->convertStream($result));

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -38,17 +38,17 @@ final class ResultConverterTest extends TestCase
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
-        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getStatusCode')->willReturn(500);
         $httpResponse->method('toArray')->willReturn([
             'error' => [
-                'code' => 400,
-                'status' => 'INVALID_ARGUMENT',
-                'message' => 'Invalid request: The model does not support this feature.',
+                'code' => 500,
+                'status' => 'INTERNAL',
+                'message' => 'Internal error encountered.',
             ],
         ]);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Error "400" - "INVALID_ARGUMENT": "Invalid request: The model does not support this feature.".');
+        $this->expectExceptionMessage('Error "500" - "INTERNAL": "Internal error encountered.".');
 
         $converter->convert(new RawHttpResult($httpResponse));
     }

--- a/src/platform/src/Bridge/Mistral/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Embeddings/ResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Mistral\Embeddings;
 use Symfony\AI\Platform\Bridge\Mistral\Embeddings;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\VectorResult;
@@ -26,6 +27,8 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Embeddings;
@@ -34,6 +37,8 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): VectorResult
     {
         $httpResponse = $result->getObject();
+
+        $this->throwOnHttpError($httpResponse);
 
         if (200 !== $httpResponse->getStatusCode()) {
             throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $httpResponse->getStatusCode(), $httpResponse->getContent(false)));

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -31,6 +32,7 @@ use Symfony\AI\Platform\ResultConverterInterface;
 final class ResultConverter implements ResultConverterInterface
 {
     use CompletionsConversionTrait;
+    use HttpStatusErrorHandlingTrait;
 
     public function supports(Model $model): bool
     {
@@ -43,6 +45,8 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
         $httpResponse = $result->getObject();
+
+        $this->throwOnHttpError($httpResponse);
 
         if ($options['stream'] ?? false) {
             return new StreamResult($this->convertStream($result));

--- a/src/platform/src/Bridge/OpenAi/DallE/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/DallE/ResultConverter.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Platform\Bridge\OpenAi\DallE;
 use Symfony\AI\Platform\Bridge\OpenAi\DallE;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\ResultConverterInterface;
@@ -27,13 +29,19 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof DallE;
     }
 
-    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if ($result instanceof RawHttpResult) {
+            $this->throwOnHttpError($result->getObject());
+        }
+
         $result = $result->getData();
 
         if (!isset($result['data'][0])) {

--- a/src/platform/src/Bridge/OpenAi/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings/ResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\VectorResult;
@@ -26,13 +27,19 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Embeddings;
     }
 
-    public function convert(RawResultInterface $result, array $options = []): VectorResult
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): VectorResult
     {
+        if ($result instanceof RawHttpResult) {
+            $this->throwOnHttpError($result->getObject());
+        }
+
         $data = $result->getData();
 
         if (!isset($data['data'])) {

--- a/src/platform/src/Bridge/OpenAi/Tests/TextToSpeech/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/TextToSpeech/ResultConverterTest.php
@@ -49,7 +49,7 @@ final class ResultConverterTest extends TestCase
         $result = $this->createStub(ResponseInterface::class);
         $result
             ->method('getStatusCode')
-            ->willReturn(400);
+            ->willReturn(500);
         $result
             ->method('getContent')
             ->willReturn('Hi Test!');

--- a/src/platform/src/Bridge/OpenAi/TextToSpeech/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/TextToSpeech/ResultConverter.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Bridge\OpenAi\TextToSpeech;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -26,6 +27,8 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof TextToSpeech;
@@ -34,6 +37,8 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
         $response = $result->getObject();
+
+        $this->throwOnHttpError($response);
 
         if (200 !== $response->getStatusCode()) {
             throw new RuntimeException(\sprintf('The OpenAI Text-to-Speech API returned an error: "%s"', $response->getContent(false)));

--- a/src/platform/src/Bridge/Perplexity/ResultConverter.php
+++ b/src/platform/src/Bridge/Perplexity/ResultConverter.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Platform\Bridge\Perplexity;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
@@ -27,13 +29,19 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Perplexity;
     }
 
-    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if ($result instanceof RawHttpResult) {
+            $this->throwOnHttpError($result->getObject());
+        }
+
         if ($options['stream'] ?? false) {
             return new StreamResult($this->convertStream($result));
         }

--- a/src/platform/src/Result/HttpStatusErrorHandlingTrait.php
+++ b/src/platform/src/Result/HttpStatusErrorHandlingTrait.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Provides shared HTTP error handling for bridge result converters.
+ *
+ * Translates the common 4xx/429 responses returned by AI providers into
+ * dedicated platform exceptions so consumers can react to auth failures,
+ * bad requests and rate limits without parsing error bodies themselves.
+ */
+trait HttpStatusErrorHandlingTrait
+{
+    private function throwOnHttpError(ResponseInterface $response): void
+    {
+        $status = $response->getStatusCode();
+
+        if (401 === $status) {
+            throw new AuthenticationException($this->extractErrorMessage($response) ?? 'Unauthorized');
+        }
+
+        if (400 === $status) {
+            throw new BadRequestException($this->extractErrorMessage($response) ?? 'Bad Request');
+        }
+
+        if (429 === $status) {
+            throw new RateLimitExceededException($this->extractRetryAfter($response));
+        }
+    }
+
+    private function extractErrorMessage(ResponseInterface $response): ?string
+    {
+        try {
+            $data = $response->toArray(false);
+        } catch (DecodingExceptionInterface) {
+            return null;
+        }
+
+        return $data['error']['message'] ?? $data['message'] ?? null;
+    }
+
+    private function extractRetryAfter(ResponseInterface $response): ?int
+    {
+        $retryAfter = $response->getHeaders(false)['retry-after'][0] ?? null;
+
+        return $retryAfter ? (int) $retryAfter : null;
+    }
+}

--- a/src/platform/tests/Result/HttpStatusErrorHandlingTraitTest.php
+++ b/src/platform/tests/Result/HttpStatusErrorHandlingTraitTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class HttpStatusErrorHandlingTraitTest extends TestCase
+{
+    public function testNoopOnSuccessfulStatusCodes()
+    {
+        $subject = $this->subject();
+
+        foreach ([200, 201, 204, 301, 302, 500, 503] as $status) {
+            $response = $this->response('', $status);
+            $subject->throwOnHttpError($response);
+            $this->assertTrue(true, \sprintf('No exception thrown for status %d.', $status));
+        }
+    }
+
+    public function testThrowsAuthenticationExceptionOn401WithNestedErrorMessage()
+    {
+        $response = $this->response(json_encode([
+            'error' => [
+                'message' => 'Invalid API key',
+            ],
+        ]), 401);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid API key');
+
+        $this->subject()->throwOnHttpError($response);
+    }
+
+    public function testThrowsAuthenticationExceptionOn401WithFlatMessage()
+    {
+        $response = $this->response(json_encode([
+            'message' => 'invalid api token',
+        ]), 401);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('invalid api token');
+
+        $this->subject()->throwOnHttpError($response);
+    }
+
+    public function testThrowsAuthenticationExceptionOn401WithEmptyBody()
+    {
+        $response = $this->response('', 401);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthorized');
+
+        $this->subject()->throwOnHttpError($response);
+    }
+
+    public function testThrowsAuthenticationExceptionOn401WithInvalidJson()
+    {
+        $response = $this->response('not json at all', 401);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthorized');
+
+        $this->subject()->throwOnHttpError($response);
+    }
+
+    public function testThrowsBadRequestExceptionOn400WithNestedErrorMessage()
+    {
+        $response = $this->response(json_encode([
+            'error' => [
+                'message' => 'Invalid request body',
+            ],
+        ]), 400);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Invalid request body');
+
+        $this->subject()->throwOnHttpError($response);
+    }
+
+    public function testThrowsBadRequestExceptionOn400WithFlatMessage()
+    {
+        $response = $this->response(json_encode([
+            'message' => 'invalid model specified',
+        ]), 400);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('invalid model specified');
+
+        $this->subject()->throwOnHttpError($response);
+    }
+
+    public function testThrowsBadRequestExceptionOn400WithEmptyBody()
+    {
+        $response = $this->response('', 400);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Bad Request');
+
+        $this->subject()->throwOnHttpError($response);
+    }
+
+    public function testThrowsRateLimitExceededExceptionOn429WithRetryAfter()
+    {
+        $response = $this->response('{"message":"Too many requests"}', 429, ['retry-after' => '42']);
+
+        try {
+            $this->subject()->throwOnHttpError($response);
+            $this->fail('Expected RateLimitExceededException.');
+        } catch (RateLimitExceededException $e) {
+            $this->assertSame(42, $e->getRetryAfter());
+        }
+    }
+
+    public function testThrowsRateLimitExceededExceptionOn429WithoutRetryAfter()
+    {
+        $response = $this->response('{"message":"Too many requests"}', 429);
+
+        try {
+            $this->subject()->throwOnHttpError($response);
+            $this->fail('Expected RateLimitExceededException.');
+        } catch (RateLimitExceededException $e) {
+            $this->assertNull($e->getRetryAfter());
+        }
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    private function response(string $body, int $statusCode, array $headers = []): ResponseInterface
+    {
+        $client = new MockHttpClient([
+            new MockResponse($body, [
+                'http_code' => $statusCode,
+                'response_headers' => $headers,
+            ]),
+        ]);
+
+        return $client->request('GET', 'https://example.test/');
+    }
+
+    private function subject(): object
+    {
+        return new class {
+            use HttpStatusErrorHandlingTrait {
+                throwOnHttpError as public;
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #528
| License       | MIT

## Origin & context

This PR consolidates the effort started with a series of per-bridge PRs (#1961 Mistral, #1962 DeepSeek, #1963 Cerebras, #1964 Perplexity, #1965 Cohere, #1966 Gemini, #1967 OpenAI) which are now **closed in favour of this one**, following feedback from:

- @OskarStark on #1965: *"Can you merge all these kind of Pr into one please?"*
- @chr-hertel on #1961:
  1. *"is a better way for avoiding the duplication here?"*
  2. *"can you help with reviewing this for providing the links to the corresponding docs?"*
  3. Inline on `extractErrorMessage`: *"can we use the `$httpResponse->toArray(false)` instead of this?"*

All three points are addressed here.

## What this PR does

### 1. New shared trait: `Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait`

Exposes `throwOnHttpError(ResponseInterface $response): void` that translates the three common AI-provider HTTP errors into dedicated exceptions:

 - `401` → `AuthenticationException`
 - `400` → `BadRequestException`
 - `429` → `RateLimitExceededException` (with `retry-after` propagated)

Error bodies are parsed via `$response->toArray(false)` wrapped in a `try { ... } catch (DecodingExceptionInterface)` so empty / non-JSON bodies fall back to default messages (`"Unauthorized"` / `"Bad Request"`). Both the top-level `message` and nested `error.message` shapes are supported, since providers split roughly 50/50 between the two.

Covered by 10 dedicated tests in `tests/Result/HttpStatusErrorHandlingTraitTest.php`.

### 2. Migrate 14 bridge result converters to the trait

One `use HttpStatusErrorHandlingTrait;` + one `$this->throwOnHttpError(...)` call per converter, replacing the previous copy-paste blocks or (where applicable) the plain "Unexpected response code X" generic `RuntimeException`:

| Bridge | Sub-clients |
|---|---|
| Mistral | LLM, Embeddings |
| DeepSeek | (single) |
| Cerebras | (single) |
| Perplexity | (single) |
| Cohere | LLM, Embeddings, Reranker, SpeechToText |
| Gemini | LLM (replaces the previous 429-only branch), Embeddings |
| OpenAI | Embeddings, DallE, TextToSpeech |

Anthropic, OpenAI/Gpt and OpenAI/Whisper already had the pattern hardcoded and are left untouched in this PR — migrating them to the trait would be a trivial follow-up if desired.

### 3. Test cleanup

- Per-converter HTTP-status and rate-limit tests that existed in the original child PRs are dropped: the trait's own test covers all extraction edge cases.
- Two pre-existing regression tests (`Gemini/Tests/Gemini/ResultConverterTest::testConvertThrowsExceptionWithDetailedErrorInformation` and `OpenAi/Tests/TextToSpeech/ResultConverterTest::testThrowsOnErrorResponse`) relied on status `400` falling through the generic path; since `400` now resolves to `BadRequestException` they are switched to status `500` (same code path, same assertion).

## Usage

```php
try {
    \$platform->invoke(\$model, \$messages);
} catch (RateLimitExceededException \$e) {
    sleep(\$e->getRetryAfter() ?? 60);
    // retry...
} catch (AuthenticationException \$e) {
    // invalid API key — message from the provider is now exposed
} catch (BadRequestException \$e) {
    // malformed request — message from the provider is now exposed
}
```

## Provider docs consulted

MockResponses are inferred from public docs + OpenAI-compat assumptions. I did not spin up real accounts for every provider — happy to validate specific ones if you consider that non-negotiable.

 - Mistral: https://docs.mistral.ai/api/
 - DeepSeek: https://api-docs.deepseek.com/
 - Cerebras: https://inference-docs.cerebras.ai/
 - Perplexity: https://docs.perplexity.ai/
 - Cohere: https://docs.cohere.com/reference
 - Gemini: https://ai.google.dev/api/rest
 - OpenAI: https://platform.openai.com/docs/api-reference

## Commits

1. `[Platform] Add HttpStatusErrorHandlingTrait for shared API error handling` — trait + 10 tests
2. `[Platform] Route bridge result converters through HttpStatusErrorHandlingTrait` — 14 converters + CHANGELOG + 2 regression-test status bumps

Thanks again @chr-hertel and @OskarStark for the reviews on the original series — the final shape is much cleaner thanks to your feedback 🙏