### PR TITLE
[Mate] Improve Doctrine profiler formatter output

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/DoctrineCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/DoctrineCollectorFormatter.php
@@ -38,7 +38,7 @@ final class DoctrineCollectorFormatter implements CollectorFormatterInterface
     {
         \assert($collector instanceof DoctrineDataCollector);
 
-        $queries = $this->flattenQueries($collector);
+        $queries = $this->groupQueries($collector);
         $truncated = \count($queries) > self::MAX_QUERIES;
         $queries = \array_slice($queries, 0, self::MAX_QUERIES);
 
@@ -48,7 +48,6 @@ final class DoctrineCollectorFormatter implements CollectorFormatterInterface
             'connections' => array_keys($collector->getConnections()),
             'queries' => $queries,
             'queries_truncated' => $truncated,
-            'duplicate_queries' => $this->detectDuplicateQueries($collector),
         ];
     }
 
@@ -56,47 +55,35 @@ final class DoctrineCollectorFormatter implements CollectorFormatterInterface
     {
         \assert($collector instanceof DoctrineDataCollector);
 
+        $duplicateCount = \count(array_filter(
+            $this->groupQueries($collector),
+            static fn (array $q): bool => $q['count'] > 1,
+        ));
+
         return [
             'query_count' => $collector->getQueryCount(),
             'total_time_ms' => round($collector->getTime() * 1000, 2),
-            'duplicate_query_count' => \count($this->detectDuplicateQueries($collector)),
+            'duplicate_query_count' => $duplicateCount,
         ];
     }
 
     /**
-     * @return list<array{connection: string, sql: string, params: mixed, time_ms: float}>
+     * @return list<array{sql: string, count: int, total_time_ms: float, avg_time_ms: float, sample_params: mixed}>
      */
-    private function flattenQueries(DoctrineDataCollector $collector): array
+    private function groupQueries(DoctrineDataCollector $collector): array
     {
-        $flattened = [];
-
-        foreach ($collector->getQueries() as $connection => $queries) {
-            foreach ($queries as $query) {
-                $flattened[] = [
-                    'connection' => $connection,
-                    'sql' => $query['sql'] ?? '',
-                    'params' => $this->truncateParams($query['params'] ?? null),
-                    'time_ms' => round(($query['executionMS'] ?? 0.0) * 1000, 2),
-                ];
-            }
-        }
-
-        return $flattened;
-    }
-
-    /**
-     * @return list<array{sql: string, count: int, total_time_ms: float}>
-     */
-    private function detectDuplicateQueries(DoctrineDataCollector $collector): array
-    {
-        /** @var array<string, array{count: int, total_time_ms: float}> $grouped */
+        /** @var array<string, array{count: int, total_time_ms: float, sample_params: mixed}> $grouped */
         $grouped = [];
 
         foreach ($collector->getQueries() as $queries) {
             foreach ($queries as $query) {
                 $sql = $query['sql'] ?? '';
                 if (!isset($grouped[$sql])) {
-                    $grouped[$sql] = ['count' => 0, 'total_time_ms' => 0.0];
+                    $grouped[$sql] = [
+                        'count' => 0,
+                        'total_time_ms' => 0.0,
+                        'sample_params' => $this->truncateParams($query['params'] ?? null),
+                    ];
                 }
 
                 ++$grouped[$sql]['count'];
@@ -104,20 +91,21 @@ final class DoctrineCollectorFormatter implements CollectorFormatterInterface
             }
         }
 
-        $duplicates = [];
+        $result = [];
         foreach ($grouped as $sql => $data) {
-            if ($data['count'] <= 1) {
-                continue;
-            }
-
-            $duplicates[] = [
+            $totalTimeMs = round($data['total_time_ms'], 2);
+            $result[] = [
                 'sql' => $sql,
                 'count' => $data['count'],
-                'total_time_ms' => round($data['total_time_ms'], 2),
+                'total_time_ms' => $totalTimeMs,
+                'avg_time_ms' => round($totalTimeMs / $data['count'], 2),
+                'sample_params' => $data['sample_params'],
             ];
         }
 
-        return $duplicates;
+        usort($result, static fn (array $a, array $b): int => $b['total_time_ms'] <=> $a['total_time_ms']);
+
+        return $result;
     }
 
     private function truncateParams(mixed $params): mixed

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterIntegrationTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterIntegrationTest.php
@@ -52,11 +52,11 @@ final class DoctrineCollectorFormatterIntegrationTest extends TestCase
         $this->assertCount(2, $result['queries']);
         $this->assertFalse($result['queries_truncated']);
 
-        $this->assertSame('default', $result['queries'][0]['connection']);
-        $this->assertSame('SELECT * FROM users', $result['queries'][0]['sql']);
-        $this->assertArrayHasKey('time_ms', $result['queries'][0]);
-
-        $this->assertSame('SELECT * FROM posts WHERE user_id = ?', $result['queries'][1]['sql']);
+        $this->assertArrayHasKey('total_time_ms', $result['queries'][0]);
+        $this->assertArrayHasKey('avg_time_ms', $result['queries'][0]);
+        $this->assertArrayHasKey('sample_params', $result['queries'][0]);
+        $this->assertSame(1, $result['queries'][0]['count']);
+        $this->assertSame(1, $result['queries'][1]['count']);
     }
 
     public function testFormatDetectsDuplicatesWithRealCollector()
@@ -73,10 +73,11 @@ final class DoctrineCollectorFormatterIntegrationTest extends TestCase
         $result = $this->formatter->format($collector);
 
         $this->assertSame(4, $result['query_count']);
-        $this->assertCount(4, $result['queries']);
-        $this->assertCount(1, $result['duplicate_queries']);
-        $this->assertSame('SELECT * FROM users WHERE id = ?', $result['duplicate_queries'][0]['sql']);
-        $this->assertSame(3, $result['duplicate_queries'][0]['count']);
+        $this->assertCount(2, $result['queries']);
+        // sorted by total_time_ms descending — the 3× query is first
+        $this->assertSame('SELECT * FROM users WHERE id = ?', $result['queries'][0]['sql']);
+        $this->assertSame(3, $result['queries'][0]['count']);
+        $this->assertArrayHasKey('avg_time_ms', $result['queries'][0]);
     }
 
     public function testGetSummaryWithRealCollector()
@@ -113,8 +114,6 @@ final class DoctrineCollectorFormatterIntegrationTest extends TestCase
         $this->assertSame(2, $result['query_count']);
         $this->assertSame(['default', 'legacy'], $result['connections']);
         $this->assertCount(2, $result['queries']);
-        $this->assertSame('default', $result['queries'][0]['connection']);
-        $this->assertSame('legacy', $result['queries'][1]['connection']);
     }
 
     /**

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterTest.php
@@ -51,17 +51,19 @@ final class DoctrineCollectorFormatterTest extends TestCase
         $this->assertSame(['default'], $result['connections']);
         $this->assertCount(2, $result['queries']);
         $this->assertFalse($result['queries_truncated']);
-        $this->assertSame([], $result['duplicate_queries']);
+        $this->assertArrayNotHasKey('duplicate_queries', $result);
 
-        $this->assertSame('default', $result['queries'][0]['connection']);
         $this->assertSame('SELECT * FROM users', $result['queries'][0]['sql']);
-        $this->assertSame([], $result['queries'][0]['params']);
-        $this->assertSame(1.2, $result['queries'][0]['time_ms']);
+        $this->assertSame(1, $result['queries'][0]['count']);
+        $this->assertSame(1.2, $result['queries'][0]['total_time_ms']);
+        $this->assertSame(1.2, $result['queries'][0]['avg_time_ms']);
+        $this->assertSame([], $result['queries'][0]['sample_params']);
 
-        $this->assertSame('default', $result['queries'][1]['connection']);
         $this->assertSame('SELECT * FROM posts WHERE user_id = ?', $result['queries'][1]['sql']);
-        $this->assertSame([1], $result['queries'][1]['params']);
-        $this->assertSame(0.8, $result['queries'][1]['time_ms']);
+        $this->assertSame(1, $result['queries'][1]['count']);
+        $this->assertSame(0.8, $result['queries'][1]['total_time_ms']);
+        $this->assertSame(0.8, $result['queries'][1]['avg_time_ms']);
+        $this->assertSame([1], $result['queries'][1]['sample_params']);
     }
 
     public function testFormatMultipleConnections()
@@ -83,8 +85,6 @@ final class DoctrineCollectorFormatterTest extends TestCase
         $this->assertSame(2, $result['query_count']);
         $this->assertSame(['default', 'legacy'], $result['connections']);
         $this->assertCount(2, $result['queries']);
-        $this->assertSame('default', $result['queries'][0]['connection']);
-        $this->assertSame('legacy', $result['queries'][1]['connection']);
     }
 
     public function testFormatTruncatesQueries()
@@ -106,25 +106,6 @@ final class DoctrineCollectorFormatterTest extends TestCase
         $this->assertTrue($result['queries_truncated']);
     }
 
-    public function testFormatTruncatesLongParams()
-    {
-        $longParam = str_repeat('a', 150);
-
-        $collector = $this->createCollector(
-            ['default' => 'doctrine.default'],
-            [
-                'default' => [
-                    ['sql' => 'SELECT * FROM users WHERE bio = ?', 'params' => [$longParam], 'executionMS' => 0.001, 'types' => []],
-                ],
-            ],
-        );
-
-        $result = $this->formatter->format($collector);
-
-        $this->assertSame(103, \strlen($result['queries'][0]['params'][0]));
-        $this->assertStringEndsWith('...', $result['queries'][0]['params'][0]);
-    }
-
     public function testFormatDetectsDuplicateQueries()
     {
         $collector = $this->createCollector(
@@ -141,10 +122,38 @@ final class DoctrineCollectorFormatterTest extends TestCase
 
         $result = $this->formatter->format($collector);
 
-        $this->assertCount(1, $result['duplicate_queries']);
-        $this->assertSame('SELECT * FROM users WHERE id = ?', $result['duplicate_queries'][0]['sql']);
-        $this->assertSame(3, $result['duplicate_queries'][0]['count']);
-        $this->assertSame(6.0, $result['duplicate_queries'][0]['total_time_ms']);
+        $this->assertCount(2, $result['queries']);
+        // sorted by total_time_ms descending
+        $this->assertSame('SELECT * FROM users WHERE id = ?', $result['queries'][0]['sql']);
+        $this->assertSame(3, $result['queries'][0]['count']);
+        $this->assertSame(6.0, $result['queries'][0]['total_time_ms']);
+        $this->assertSame(2.0, $result['queries'][0]['avg_time_ms']);
+        $this->assertSame([1], $result['queries'][0]['sample_params']);
+        $this->assertSame('SELECT * FROM posts', $result['queries'][1]['sql']);
+        $this->assertSame(1, $result['queries'][1]['count']);
+        $this->assertSame(1.0, $result['queries'][1]['total_time_ms']);
+        $this->assertSame(1.0, $result['queries'][1]['avg_time_ms']);
+        $this->assertSame([], $result['queries'][1]['sample_params']);
+        $this->assertArrayNotHasKey('duplicate_queries', $result);
+    }
+
+    public function testFormatTruncatesLongSampleParams()
+    {
+        $longParam = str_repeat('a', 150);
+
+        $collector = $this->createCollector(
+            ['default' => 'doctrine.default'],
+            [
+                'default' => [
+                    ['sql' => 'SELECT * FROM users WHERE bio = ?', 'params' => [$longParam], 'executionMS' => 0.001, 'types' => []],
+                ],
+            ],
+        );
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(103, \strlen($result['queries'][0]['sample_params'][0]));
+        $this->assertStringEndsWith('...', $result['queries'][0]['sample_params'][0]);
     }
 
     public function testFormatNoQueries()
@@ -160,7 +169,6 @@ final class DoctrineCollectorFormatterTest extends TestCase
         $this->assertSame(0.0, $result['total_time_ms']);
         $this->assertSame([], $result['queries']);
         $this->assertFalse($result['queries_truncated']);
-        $this->assertSame([], $result['duplicate_queries']);
     }
 
     public function testGetSummary()


### PR DESCRIPTION
| | |
|---|---|
| Bug fix? | no |
| New feature? | no |
| Docs? | no |
| Issues | |
| License | MIT |

## Description

Improves the `DoctrineCollectorFormatter` to produce more useful output for AI consumption.

**Before:** every query execution was listed individually — an N+1 with 100 calls produced 100 identical rows, making the output noisy and token-wasteful.

**After:** queries are grouped by SQL with aggregated metrics, sorted by total time descending:

```json
{
    "query_count": 107,
    "total_time_ms": 45.32,
    "connections": ["default"],
    "queries": [
        {"sql": "SELECT ... FROM comment WHERE post_id = ?", "count": 100, "total_time_ms": 38.21, "avg_time_ms": 0.38, "sample_params": [42]},
        {"sql": "SELECT ... FROM user WHERE id = ?",         "count": 5,   "total_time_ms": 4.15,  "avg_time_ms": 0.83, "sample_params": [1]},
        {"sql": "SELECT ... FROM post WHERE author_id = ?",  "count": 1,   "total_time_ms": 0.84,  "avg_time_ms": 0.84, "sample_params": []}
    ],
    "queries_truncated": false
}
```

Changes:
- Group queries by SQL, replacing per-execution entries with `count` + `total_time_ms` + `avg_time_ms`
- Add `sample_params` from the first execution (truncated at 100 chars) so the AI has context about what data is being fetched without seeing repetitive identical params
- Sort by `total_time_ms` descending so worst offenders appear first
- Remove `duplicate_queries` field — redundant since `count > 1` already signals duplicates