### PR TITLE
[Docs] Fix outdated references in HuggingFace READMEs

### DIFF
--- a/.claude/skills/docs-check/SKILL.md
+++ b/.claude/skills/docs-check/SKILL.md
@@ -42,10 +42,21 @@ For each reference, verify the class/interface/method actually exists at that na
 
 Scan these locations for documentation files:
 - `docs/**/*.rst` - Main Sphinx documentation
-- `src/*/README.md` - Component READMEs
-- `src/*/CHANGELOG.md` - Component changelogs (check recent entries only)
-- `UPGRADE.md` - Upgrade guide
+- `README.md` - Root repository README
 - `CONTRIBUTING.md` - Contributing guide
+- `src/*/README.md` - Component READMEs (platform, agent, store, chat, mate, ai-bundle, mcp-bundle)
+- `src/*/src/Bridge/*/README.md` - Bridge READMEs (e.g. `src/platform/src/Bridge/HuggingFace/README.md`, `src/store/src/Bridge/Qdrant/README.md`, `src/agent/src/Bridge/Tavily/README.md`, `src/chat/src/Bridge/Doctrine/README.md`)
+- `src/mate/INSTRUCTIONS.md` and `src/mate/src/Bridge/*/INSTRUCTIONS.md` - Mate extension instructions
+- `examples/README.md` and `examples/*/README.md` - Example-suite READMEs
+- `demo/README.md` - Demo application README
+
+Explicitly exclude the following from scans:
+- All `CHANGELOG.md` and `UPGRADE.md` files — these intentionally document historical state (old class names, removed APIs, before/after diffs) so references that no longer exist in the code are expected, not bugs
+- Anything under `vendor/`, `node_modules/`, `.git/`, `.symfony-docs/`, or `**/cache/`
+- `fixtures/**` and `**/tests/**/Fixtures/**` (test data, not documentation)
+- `.github/**` templates and `.claude/**` (harness configuration, not project docs)
+- `CLAUDE.md`, `AGENTS.md`, `AGENT_INSTRUCTIONS.md` (assistant instructions, not user-facing docs)
+- `ai.symfony.com/public/**` (generated artifacts)
 
 ## How to Work
 

--- a/examples/huggingface/README.md
+++ b/examples/huggingface/README.md
@@ -44,7 +44,7 @@ This can happen due to preselected models in the examples not being available an
 Hugging Face's side. You can change the model used in the examples by updating the model name in the example script.
 
 To find available models for a specific task, you can check out the [Hugging Face Model Hub](https://huggingface.co/models)
-and filter by the desired task, or you can use the `huggingface/_model-listing.php` script.
+and filter by the desired task, or you can use the `huggingface/_model.php` script.
 
 ### Listing Available Models
 
@@ -98,7 +98,7 @@ php huggingface/_model.php ai:huggingface:model-list --warm --task=text-generati
 
 ### Model Information
 
-To get detailed information about a specific model, you can use the `huggingface/_model-info.php` script:
+To get detailed information about a specific model, you can use the `huggingface/_model.php` script:
 
 ```bash
 php huggingface/_model.php ai:huggingface:model-info google/vit-base-patch16-224

--- a/src/platform/src/Bridge/HuggingFace/README.md
+++ b/src/platform/src/Bridge/HuggingFace/README.md
@@ -31,10 +31,10 @@ composer require symfony/ai-platform
 ### Initialize the Platform
 
 ```php
-use Symfony\AI\Platform\Bridge\HuggingFace\PlatformFactory;
+use Symfony\AI\Platform\Bridge\HuggingFace\Factory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Provider;
 
-$platform = PlatformFactory::create(
+$platform = Factory::createPlatform(
     apiKey: 'hf_your_api_key_here',
     provider: Provider::CEREBRAS, // or other providers
     httpClient: $httpClient  // optional, uses default if not provided
@@ -95,9 +95,10 @@ the [`Provider` interface](./Provider.php).
 Specify a provider when creating the platform:
 
 ```php
+use Symfony\AI\Platform\Bridge\HuggingFace\Factory;
 use Symfony\AI\Platform\Bridge\HuggingFace\Provider;
 
-$platform = PlatformFactory::create(
+$platform = Factory::createPlatform(
     apiKey: 'your_api_key',
     provider: Provider::GROQ,
 );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

Two outdated references in HuggingFace-related documentation:

- `src/platform/src/Bridge/HuggingFace/README.md`: the quick-start and providers snippets referenced a non-existent `PlatformFactory::create(...)`. The class is `Factory` with `createPlatform()`, matching the other platform bridges. Also adds the missing `use Factory` import in the providers snippet.
- `examples/huggingface/README.md`: two references to non-existent scripts `huggingface/_model-listing.php` and `huggingface/_model-info.php`. The actual file is `huggingface/_model.php` (the commands below those lines already use the correct name).