### PR TITLE
[Platform][Gemini] Gemini call after a tool action fail

### DIFF
--- a/src/platform/src/Bridge/Gemini/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Gemini/Contract/AssistantMessageNormalizer.php
@@ -24,28 +24,33 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
     /**
      * @param AssistantMessage $data
      *
-     * @return array{array{text: string}}
+     * @return list<array{text: string}|array{functionCall: array{id: string, name: string, args?: mixed}}>
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         $normalized = [];
 
+        // text and functionCall are separate oneof fields in Gemini's
+        // they must be emitted as distinct parts, never merged into one.
         if (null !== $data->getContent()) {
-            $normalized['text'] = $data->getContent();
+            $normalized[] = ['text' => $data->getContent()];
         }
 
         if ($data->hasToolCalls()) {
-            $normalized['functionCall'] = [
-                'id' => $data->getToolCalls()[0]->getId(),
-                'name' => $data->getToolCalls()[0]->getName(),
+            $toolCall = $data->getToolCalls()[0];
+            $functionCall = [
+                'id' => $toolCall->getId(),
+                'name' => $toolCall->getName(),
             ];
 
-            if ($data->getToolCalls()[0]->getArguments()) {
-                $normalized['functionCall']['args'] = $data->getToolCalls()[0]->getArguments();
+            if ($toolCall->getArguments()) {
+                $functionCall['args'] = $toolCall->getArguments();
             }
+
+            $normalized[] = ['functionCall' => $functionCall];
         }
 
-        return [$normalized];
+        return $normalized;
     }
 
     protected function supportedDataClass(): string

--- a/src/platform/src/Bridge/Gemini/Tests/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Contract/AssistantMessageNormalizerTest.php
@@ -68,5 +68,15 @@ final class AssistantMessageNormalizerTest extends TestCase
             new AssistantMessage(toolCalls: [new ToolCall('id1', 'name1')]),
             [['functionCall' => ['id' => 'id1', 'name' => 'name1']]],
         ];
+        yield 'text with function call' => [
+            new AssistantMessage(
+                'I\'ll look that up for you.',
+                [new ToolCall('id1', 'name1', ['arg1' => '123'])],
+            ),
+            [
+                ['text' => 'I\'ll look that up for you.'],
+                ['functionCall' => ['id' => 'id1', 'name' => 'name1', 'args' => ['arg1' => '123']]],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix, see below
| License       | MIT

While working on a chat integration, after doing some test with Gemini (Gemini 2.5 flash).

I got the following exception

```
Error "400" - "INVALID_ARGUMENT": "Invalid value at 'contents[5].parts[0]' (oneof), oneof field 'data' is already set. Cannot set 'functionCall'".
```

I was able to reproduce it every-time by doing the following:

1. Send a chat message
2. Send a chat message using a tool
3. Send a regular chat message -> It fail and return the previous exception message