### PR TITLE
[Platform][Anthropic] Fix tool calls dropped

### DIFF
--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -83,16 +83,10 @@ class ResultConverter implements ResultConverterInterface
         }
 
         $results = [];
-        $toolCalls = [];
         foreach ($data['content'] as $content) {
             if ('tool_use' === $content['type']) {
-                $toolCalls[] = new ToolCall($content['id'], $content['name'], $content['input']);
+                $results[] = new ToolCallResult([new ToolCall($content['id'], $content['name'], $content['input'])]);
                 continue;
-            }
-
-            if ([] !== $toolCalls) {
-                $results[] = new ToolCallResult($toolCalls);
-                $toolCalls = [];
             }
 
             if ('text' === $content['type']) {
@@ -115,10 +109,6 @@ class ResultConverter implements ResultConverterInterface
         }
 
         if ([] === $results) {
-            if ($toolCalls) {
-                return new ToolCallResult($toolCalls);
-            }
-
             throw new RuntimeException('Response content does not contain any supported content.');
         }
 

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -403,6 +403,42 @@ final class ResultConverterTest extends TestCase
         $this->assertNull($thinkingCompletes[0]->getSignature());
     }
 
+    public function testConvertWithTextPreambleBeforeToolCallYieldsMultiPartResult()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => 'Let me look that up for you.',
+                ],
+                [
+                    'type' => 'tool_use',
+                    'id' => 'toolu_01ABC123',
+                    'name' => 'get_weather',
+                    'input' => ['location' => 'Berlin'],
+                ],
+            ],
+        ]));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+        $converter = new ResultConverter();
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+
+        $this->assertInstanceOf(TextResult::class, $parts[0]);
+        $this->assertSame('Let me look that up for you.', $parts[0]->getContent());
+
+        $this->assertInstanceOf(ToolCallResult::class, $parts[1]);
+        $toolCalls = $parts[1]->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('toolu_01ABC123', $toolCalls[0]->getId());
+        $this->assertSame('get_weather', $toolCalls[0]->getName());
+        $this->assertSame(['location' => 'Berlin'], $toolCalls[0]->getArguments());
+    }
+
     public function testNonStreamingResponseWithThinkingAndTextContent()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | No ticket
| License       | MIT

Fix tools calls dropped when Anthropic returns text before tool_use

When the model generates a text preamble before calling a tool, the API response content array is [text_block, tool_use_block]. The converter flushed accumulated $toolCalls to $results only when a non-tool_use block appeared *after* them; tool calls at the end of the array were never flushed, causing them to be silently dropped and only the text returned.

Add a post-loop flush so any remaining $toolCalls are always appended to $results before the final return, regardless of content ordering.
