### PR TITLE
[Platform][Codex] Align model catalog with official docs

### DIFF
--- a/examples/codex/chat.php
+++ b/examples/codex/chat.php
@@ -24,7 +24,7 @@ $platform = Factory::createPlatform(
 $messages = new MessageBag(
     Message::ofUser('Explain the architecture of this project in 3 sentences.'),
 );
-$result = $platform->invoke('gpt-5-codex', $messages, [
+$result = $platform->invoke('gpt-5.4', $messages, [
     'sandbox' => 'read-only',
 ]);
 

--- a/examples/codex/code-generation.php
+++ b/examples/codex/code-generation.php
@@ -30,7 +30,7 @@ $platform = Factory::createPlatform(
 $messages = new MessageBag(
     Message::ofUser('Create a file called hello.php that prints "Hello, World!" to the console.'),
 );
-$result = $platform->invoke('gpt-5-codex', $messages, [
+$result = $platform->invoke('gpt-5.4', $messages, [
     'sandbox' => 'workspace-write',
 ]);
 

--- a/examples/codex/stream.php
+++ b/examples/codex/stream.php
@@ -24,7 +24,7 @@ $platform = Factory::createPlatform(
 $messages = new MessageBag(
     Message::ofUser('What is Symfony? Explain in 3 sentences.'),
 );
-$result = $platform->invoke('gpt-5-codex', $messages, [
+$result = $platform->invoke('gpt-5.4', $messages, [
     'stream' => true,
     'sandbox' => 'read-only',
 ]);

--- a/examples/codex/token-metadata.php
+++ b/examples/codex/token-metadata.php
@@ -24,7 +24,7 @@ $platform = Factory::createPlatform(
 $messages = new MessageBag(
     Message::ofUser('What testing framework does this project use? Answer in one sentence.'),
 );
-$result = $platform->invoke('gpt-5-codex', $messages, [
+$result = $platform->invoke('gpt-5.4', $messages, [
     'sandbox' => 'read-only',
 ]);
 

--- a/src/platform/src/Bridge/Codex/CHANGELOG.md
+++ b/src/platform/src/Bridge/Codex/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.9
+---
+
+ * [BC BREAK] Align `ModelCatalog` with the official OpenAI Codex models list (https://developers.openai.com/codex/models): add `gpt-5.2` and remove `gpt-5.2-codex`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Codex/ModelCatalog.php
+++ b/src/platform/src/Bridge/Codex/ModelCatalog.php
@@ -15,6 +15,10 @@ use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\AbstractModelCatalog;
 
 /**
+ * Default model catalog for the Codex CLI bridge.
+ *
+ * @see https://developers.openai.com/codex/models
+ *
  * @author Johannes Wachter <johannes@sulu.io>
  */
 final class ModelCatalog extends AbstractModelCatalog
@@ -48,19 +52,7 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => Codex::class,
                 'capabilities' => $capabilities,
             ],
-            'gpt-5.2-codex' => [
-                'class' => Codex::class,
-                'capabilities' => $capabilities,
-            ],
-            'gpt-5.1-codex' => [
-                'class' => Codex::class,
-                'capabilities' => $capabilities,
-            ],
-            'gpt-5-codex' => [
-                'class' => Codex::class,
-                'capabilities' => $capabilities,
-            ],
-            'gpt-5-codex-mini' => [
+            'gpt-5.2' => [
                 'class' => Codex::class,
                 'capabilities' => $capabilities,
             ],

--- a/src/platform/src/Bridge/Codex/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/ModelCatalogTest.php
@@ -30,10 +30,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'gpt-5.4-mini' => ['gpt-5.4-mini', Codex::class, $capabilities];
         yield 'gpt-5.3-codex' => ['gpt-5.3-codex', Codex::class, $capabilities];
         yield 'gpt-5.3-codex-spark' => ['gpt-5.3-codex-spark', Codex::class, $capabilities];
-        yield 'gpt-5.2-codex' => ['gpt-5.2-codex', Codex::class, $capabilities];
-        yield 'gpt-5.1-codex' => ['gpt-5.1-codex', Codex::class, $capabilities];
-        yield 'gpt-5-codex' => ['gpt-5-codex', Codex::class, $capabilities];
-        yield 'gpt-5-codex-mini' => ['gpt-5-codex-mini', Codex::class, $capabilities];
+        yield 'gpt-5.2' => ['gpt-5.2', Codex::class, $capabilities];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The Codex `ModelCatalog` listed several models that the Codex CLI no longer accepts with a ChatGPT account — calling them returns:

```
The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.
```

This surfaced while trying to run the bundled `examples/codex/*.php` scripts, all four of which hardcoded `gpt-5-codex` and therefore failed end-to-end.

Aligning the catalog with the official list at https://developers.openai.com/codex/models:

- Keep: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`
- Add: `gpt-5.2`
- Remove: `gpt-5.2-codex`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`

Also:

- Adds a `@see https://developers.openai.com/codex/models` link to the `ModelCatalog` PHPDoc header so the source of truth is easy to find.
- Switches the four examples from `gpt-5-codex` to `gpt-5.4` (the currently recommended default). All four now run successfully (verified against a local Codex CLI 0.122.0 install).
- Updates the `ModelCatalogTest` data provider to match.