### PR TITLE
[AI Bundle] Prompt for missing arguments in `ai:platform:invoke`

### DIFF
--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Validate structured output using `symfony/validator` when available
+ * Make `ai:platform:invoke` arguments optional and prompt for them interactively when missing
 
 0.8
 ---

--- a/src/ai-bundle/src/Command/PlatformInvokeCommand.php
+++ b/src/ai-bundle/src/Command/PlatformInvokeCommand.php
@@ -35,10 +35,6 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 )]
 final class PlatformInvokeCommand extends Command
 {
-    private string $message;
-    private PlatformInterface $platform;
-    private string $model;
-
     /**
      * @param ServiceLocator<PlatformInterface> $platforms
      */
@@ -58,9 +54,9 @@ final class PlatformInvokeCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('platform', InputArgument::REQUIRED, 'The name of the configured platform to invoke')
-            ->addArgument('model', InputArgument::REQUIRED, 'The model to use for the request')
-            ->addArgument('message', InputArgument::REQUIRED, 'The message to send to the AI platform')
+            ->addArgument('platform', InputArgument::OPTIONAL, 'The name of the configured platform to invoke')
+            ->addArgument('model', InputArgument::OPTIONAL, 'The model to use for the request')
+            ->addArgument('message', InputArgument::OPTIONAL, 'The message to send to the AI platform')
             ->setHelp(
                 <<<'HELP'
                 The <info>%command.name%</info> command allows you to invoke configured AI platforms with a message.
@@ -72,33 +68,48 @@ final class PlatformInvokeCommand extends Command
                   <info>%command.full_name% openai gpt-4o-mini "Hello, world!"</info>
                   <info>%command.full_name% anthropic claude-3-5-sonnet-20241022 "Explain quantum physics"</info>
 
+                Any missing argument will be prompted for in interactive mode.
+
                 Available platforms depend on your configuration in config/packages/ai.yaml
                 HELP
             );
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output): void
+    protected function interact(InputInterface $input, OutputInterface $output): void
     {
+        $io = new SymfonyStyle($input, $output);
+
+        if (null === $input->getArgument('platform')) {
+            $input->setArgument('platform', $io->choice('Select a platform', array_keys($this->platforms->getProvidedServices())));
+        }
+
+        if (null === $input->getArgument('model')) {
+            $input->setArgument('model', $io->ask('Which model do you want to use?'));
+        }
+
+        if (null === $input->getArgument('message')) {
+            $input->setArgument('message', $io->ask('Enter the message to send'));
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
         $platformName = trim((string) $input->getArgument('platform'));
 
         if (!$this->platforms->has($platformName)) {
             throw new InvalidArgumentException(\sprintf('Platform "%s" not found. Available platforms: "%s"', $platformName, implode(', ', array_keys($this->platforms->getProvidedServices()))));
         }
 
-        $this->platform = $this->platforms->get($platformName);
-        $this->model = trim((string) $input->getArgument('model'));
-        $this->message = trim((string) $input->getArgument('message'));
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
+        $platform = $this->platforms->get($platformName);
+        $model = trim((string) $input->getArgument('model'));
+        $message = trim((string) $input->getArgument('message'));
 
         try {
             $messages = new MessageBag();
-            $messages->add(Message::ofUser($this->message));
+            $messages->add(Message::ofUser($message));
 
-            $result = $this->platform->invoke($this->model, $messages)->getResult();
+            $result = $platform->invoke($model, $messages)->getResult();
 
             if ($result instanceof TextResult) {
                 $io->writeln('<info>Response:</info> '.$result->getContent());

--- a/src/ai-bundle/tests/Command/PlatformInvokeCommandTest.php
+++ b/src/ai-bundle/tests/Command/PlatformInvokeCommandTest.php
@@ -73,4 +73,35 @@ final class PlatformInvokeCommandTest extends TestCase
             'message' => 'Test message',
         ]);
     }
+
+    public function testExecuteInteractivelyPromptsForMissingArguments()
+    {
+        $textResult = new TextResult('Hello! How can I assist you?');
+        $rawResult = new InMemoryRawResult([]);
+        $promise = new DeferredResult(new PlainConverter($textResult), $rawResult);
+
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->method('invoke')
+            ->with('gpt-4o-mini', $this->anything())
+            ->willReturn($promise);
+
+        $platforms = $this->createMock(ServiceLocator::class);
+        $platforms->method('getProvidedServices')->willReturn(['openai' => 'service_class', 'anthropic' => 'service_class']);
+        $platforms->method('has')->with('openai')->willReturn(true);
+        $platforms->method('get')->with('openai')->willReturn($platform);
+
+        $command = new PlatformInvokeCommand($platforms);
+        $commandTester = new CommandTester($command);
+
+        $commandTester->setInputs(['openai', 'gpt-4o-mini', 'Hello!']);
+
+        $exitCode = $commandTester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $display = $commandTester->getDisplay();
+        $this->assertStringContainsString('Select a platform', $display);
+        $this->assertStringContainsString('Which model do you want to use?', $display);
+        $this->assertStringContainsString('Enter the message to send', $display);
+        $this->assertStringContainsString('Hello! How can I assist you?', $display);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1924
| License       | MIT

As suggested by @chr-hertel in #1924, this improves the DX of `ai:platform:invoke` by making all three arguments optional and prompting for them interactively when missing.

### Behavior

- `platform` → `ChoiceQuestion` populated from the configured `ServiceLocator` of platforms
- `model` → free-text prompt
- `message` → free-text prompt

Existing non-interactive usage (`bin/console ai:platform:invoke openai gpt-4o-mini "Hello"`) is unchanged. Shell completion for `platform` (already present) is preserved.

### Example

```console
$ bin/console ai:platform:invoke

 Select a platform:
  [0] openai
  [1] anthropic
 > 0

 Which model do you want to use?:
 > gpt-4o-mini

 Enter the message to send:
 > Hello!

 Response: Hi there!
```

### Notes

- `initialize()` was removed and its validation moved to `execute()` because `Command::run()` calls `initialize()` *before* `interact()`, which would cause the empty platform name to be validated before the prompt could fill it.
- Per-provider model autocompletion and a `--prompt-file` option (also mentioned in #1924) are intentionally left out to keep this PR focused — happy to follow up on either.