### PR TITLE
[Platform][Gemini] Use SSE format for streaming to avoid partial-JSON parsing

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
@@ -52,7 +52,7 @@ final class ModelClient implements ModelClientInterface
         $url = \sprintf(
             'https://generativelanguage.googleapis.com/v1beta/models/%s:%s',
             $model->getName(),
-            $options['stream'] ?? false ? 'streamGenerateContent' : 'generateContent',
+            $options['stream'] ?? false ? 'streamGenerateContent?alt=sse' : 'generateContent',
         );
 
         if (isset($options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema'])) {

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ModelClientTest.php
@@ -73,7 +73,7 @@ final class ModelClientTest extends TestCase
     public function testRequestWithStreamUsesDifferentEndpoint()
     {
         $httpClient = new MockHttpClient(function (string $method, string $url) {
-            $this->assertSame('https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent', $url);
+            $this->assertSame('https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent?alt=sse', $url);
 
             return new JsonMockResponse(['candidates' => []]);
         });


### PR DESCRIPTION
                                                                     
  | Q             | A                                                                             
  | ------------- | ---                  
  | Bug fix?      | yes                                                                           
  | New feature?  | no                                                                            
  | Docs?         | no                                                                            
  | Issues        | Related to #1184, alternative to #1191  
  | License       | MIT                                                                           
   
  When streaming responses, Gemini defaults to returning a streamed JSON array over HTTP. HTTP    
  chunk boundaries are not guaranteed to align with JSON object boundaries, so a single chunk can
  split a JSON object mid-field — making incremental parsing fragile and occasionally causing     
  hard-to-reproduce failures (see #1184).                   

  Google's API natively supports SSE via the `?alt=sse` query parameter on the                    
  `streamGenerateContent` endpoint (see [Gemini API docs][1]). With `?alt=sse` the responses
  arrive as standard `data: {...}\n\n` events, which the platform's existing `SseStream` handles  
  out of the box — no custom chunk buffering needed.        

  This is an alternative to #1191, which tries to cope with the default JSON array stream by      
  buffering partial chunks at parse time. Asking Gemini for SSE directly is simpler,
  upstream-supported, and removes the need for Gemini-specific parsing workarounds.               
                                                            
  ### Change

  One-line URL change in `Gemini/ModelClient.php`:

      -    $options['stream'] ?? false ? 'streamGenerateContent' : 'generateContent',             
      +    $options['stream'] ?? false ? 'streamGenerateContent?alt=sse' : 'generateContent',
                                                                                                  
  ### Compatibility                                         
                                                                                                  
  - Non-streaming path (`stream: false`) unchanged          
  - VertexAI / custom `ModelClient` implementations unaffected (they build their own URLs)
                                                                                                  
  [1]: https://ai.google.dev/gemini-api/docs/text-generation?hl=de#rest_5
