### PR TITLE
[Platform][Gemini] Serialize all (parallel) tool calls

### DIFF
--- a/src/platform/src/Bridge/Gemini/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Gemini/Contract/AssistantMessageNormalizer.php
@@ -37,17 +37,18 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
         }
 
         if ($data->hasToolCalls()) {
-            $toolCall = $data->getToolCalls()[0];
-            $functionCall = [
-                'id' => $toolCall->getId(),
-                'name' => $toolCall->getName(),
-            ];
+            foreach ($data->getToolCalls() as $toolCall) {
+                $functionCall = [
+                    'id' => $toolCall->getId(),
+                    'name' => $toolCall->getName(),
+                ];
 
-            if ($toolCall->getArguments()) {
-                $functionCall['args'] = $toolCall->getArguments();
+                if ($toolCall->getArguments()) {
+                    $functionCall['args'] = $toolCall->getArguments();
+                }
+
+                $normalized[] = ['functionCall' => $functionCall];
             }
-
-            $normalized[] = ['functionCall' => $functionCall];
         }
 
         return $normalized;

--- a/src/platform/src/Bridge/Gemini/Tests/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Contract/AssistantMessageNormalizerTest.php
@@ -78,5 +78,15 @@ final class AssistantMessageNormalizerTest extends TestCase
                 ['functionCall' => ['id' => 'id1', 'name' => 'name1', 'args' => ['arg1' => '123']]],
             ],
         ];
+        yield 'parallel function calls' => [
+            new AssistantMessage(toolCalls: [
+                new ToolCall('id1', 'name1', ['arg1' => '123']),
+                new ToolCall('id2', 'name2', ['arg2' => '456']),
+            ]),
+            [
+                ['functionCall' => ['id' => 'id1', 'name' => 'name1', 'args' => ['arg1' => '123']]],
+                ['functionCall' => ['id' => 'id2', 'name' => 'name2', 'args' => ['arg2' => '456']]],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
  | Q             | A                                                                             
  | ------------- | ---                                                                           
  | Bug fix?      | yes                                                                           
  | New feature?  | no                                                                            
  | Docs?         | no                                                                            
  | Issues        | —                                                                             
  | License       | MIT                                                                           
                                                                                                  
  The Gemini `AssistantMessageNormalizer` only serialized the first tool call                     
  (`$data->getToolCalls()[0]`) when an assistant message carried multiple `functionCall` parts.   
  Gemini models can (and do, especially newer ones) emit parallel function calls in a single turn;
   the current behaviour silently drops the second and later calls when the message is replayed to
   the API, leading to ToolCall/ToolResponse mismatches and `"oneof field already set"` errors on
  subsequent turns.

  This PR iterates over all tool calls, which is the pattern already used by the other bridges:   
   
  - **Anthropic** (`Bridge/Anthropic/Contract/AssistantMessageNormalizer.php`):                   
    `foreach ($data->getToolCalls() as $toolCall) { $blocks[] = [...]; }`                       
  - **OpenAI** (`Contract/Normalizer/Message/AssistantMessageNormalizer.php`):                    
    `$array['tool_calls'] = $this->normalizer->normalize($data->getToolCalls(), ...);`            
  - **open-responses**:                                                                           
    `return $this->normalizer->normalize($data->getToolCalls(), ...);`                            
                                                                                                  
  After this PR, Gemini behaves consistently with the rest of the platform.                       
   
  ### Change                                                                                      
                                                                                                
      if ($data->hasToolCalls()) {                                                                
      -    $toolCall = $data->getToolCalls()[0];                                                
      -    $functionCall = [ ... ];                                                               
      -    ...
      -    $normalized[] = ['functionCall' => $functionCall];                                     
      +    foreach ($data->getToolCalls() as $toolCall) {                                       
      +        $functionCall = [ ... ];                                                           
      +        ...
      +        $normalized[] = ['functionCall' => $functionCall];                                 
      +    }                                                                                      
      }
                                                                                                  
  ### Compatibility                                                                             

  - Single-tool-call path unchanged (foreach yields once)                                         
  - `id`, `name`, `args` keys unchanged
  - No behavior change for messages without tool calls 