### PR TITLE
 [Platform] Handle structured output decoding correctly, when model is returning it markdown code encapsulated

### DIFF
--- a/src/platform/src/StructuredOutput/ResultConverter.php
+++ b/src/platform/src/StructuredOutput/ResultConverter.php
@@ -52,10 +52,17 @@ final class ResultConverter implements ResultConverterInterface
                 $context[AbstractNormalizer::OBJECT_TO_POPULATE] = $this->objectToPopulate;
             }
 
+            $content = $innerResult->getContent();
+
+            //Some models encapsulate the structured output in a json code block, so try to extract it before decoding/deserializing
+            if (str_starts_with($content, '```json') && str_ends_with($content, '```')) {
+                $content = substr($content, 7, -3);
+            }
+
             $structure = null === $this->outputType
-                ? json_decode($innerResult->getContent(), true, flags: \JSON_THROW_ON_ERROR)
+                ? json_decode($content, true, flags: \JSON_THROW_ON_ERROR)
                 : $this->serializer->deserialize(
-                    $innerResult->getContent(),
+                    $content,
                     $this->outputType,
                     'json',
                     $context

--- a/src/platform/tests/StructuredOutput/ResultConverterTest.php
+++ b/src/platform/tests/StructuredOutput/ResultConverterTest.php
@@ -166,4 +166,16 @@ final class ResultConverterTest extends TestCase
         $this->assertInstanceOf(UserWithAccessors::class, $result->getContent());
         $this->assertSame(10, $result->getContent()->getAge());
     }
+
+    public function testConvertWithMarkdownEncapsulation()
+    {
+        $innerConverter = new PlainConverter(new TextResult("```json\n{\"key\": \"value\"}\n```"));
+        $converter = new ResultConverter($innerConverter, new Serializer());
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(ObjectResult::class, $result);
+        $this->assertIsArray($result->getContent());
+        $this->assertSame(['key' => 'value'], $result->getContent());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  no
| Docs?         | no
| Issues        | None
| License       | MIT

Some models like "google/gemini-2.5-flash-lite" (under openrouter provider), return not raw json as output, but encapsulate it into a markdown code block like
````
```json
{}
```
````

Retrieving structured output fails then with an json decode error.

This PR modifies the StructuredOutput ResultConverter to properly handle that cases, by removing the encapsulation.

Alternatively that could be implemented in its own inner result converter, or handled by the models themselves, but not sure if that is worth the effort and complexity. This change not affects anything without markdown code encapsulation