### PR TITLE
[Chat] Fix MessageNormalizer round-trip for AssistantMessage with tool calls

### DIFF
--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * [BC BREAK] Rename service ID `ai.agent.response_format_factory` to `ai.platform.response_format_factory`
  * The `collection` option for `ChromaDb` is now optional.
  * Update `DataCollector` to use `getCalls()` and `getResultCache()` getter methods on Traceable* classes
+ * Register `ToolCallNormalizer` as a `serializer.normalizer` service so `MessageNormalizer` can round-trip `AssistantMessage`/`ToolCallMessage` payloads containing tool calls
 
 0.7
 ---

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
  * [BC BREAK] Rename service ID `ai.agent.response_format_factory` to `ai.platform.response_format_factory`
  * The `collection` option for `ChromaDb` is now optional.
  * Update `DataCollector` to use `getCalls()` and `getResultCache()` getter methods on Traceable* classes
+ * Register `ToolCallNormalizer` as a `serializer.normalizer` service so `MessageNormalizer` can round-trip `AssistantMessage`/`ToolCallMessage` payloads containing tool calls
 
 0.7
 ---

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -25,6 +25,7 @@ use Symfony\AI\AiBundle\Security\EventListener\IsGrantedToolAttributeListener;
 use Symfony\AI\Chat\Command\DropStoreCommand as DropMessageStoreCommand;
 use Symfony\AI\Chat\Command\SetupStoreCommand as SetupMessageStoreCommand;
 use Symfony\AI\Chat\MessageNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Result\ToolCallNormalizer;
 use Symfony\AI\Platform\Bridge\AiMlApi\ModelCatalog as AiMlApiModelCatalog;
 use Symfony\AI\Platform\Bridge\Albert\ModelCatalog as AlbertModelCatalog;
 use Symfony\AI\Platform\Bridge\AmazeeAi\ModelApiCatalog as AmazeeAiModelCatalog;
@@ -261,6 +262,8 @@ return static function (ContainerConfigurator $container): void {
 
         // serializer
         ->set('ai.chat.message_bag.normalizer', MessageNormalizer::class)
+            ->tag('serializer.normalizer')
+        ->set('ai.platform.tool_call.normalizer', ToolCallNormalizer::class)
             ->tag('serializer.normalizer')
 
         // commands

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -68,6 +68,7 @@ use Symfony\AI\Platform\Contract\JsonSchema\Describer\SerializerDescriber;
 use Symfony\AI\Platform\Contract\JsonSchema\Describer\TypeInfoDescriber;
 use Symfony\AI\Platform\Contract\JsonSchema\Describer\ValidatorConstraintsDescriber;
 use Symfony\AI\Platform\Contract\JsonSchema\Factory as SchemaFactory;
+use Symfony\AI\Platform\Contract\Normalizer\Result\ToolCallNormalizer;
 use Symfony\AI\Platform\EventListener\TemplateRendererListener;
 use Symfony\AI\Platform\Message\TemplateRenderer\ExpressionLanguageTemplateRenderer;
 use Symfony\AI\Platform\Message\TemplateRenderer\StringTemplateRenderer;
@@ -267,6 +268,8 @@ return static function (ContainerConfigurator $container): void {
 
         // serializer
         ->set('ai.chat.message_bag.normalizer', MessageNormalizer::class)
+            ->tag('serializer.normalizer')
+        ->set('ai.platform.tool_call.normalizer', ToolCallNormalizer::class)
             ->tag('serializer.normalizer')
 
         // commands

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -244,6 +244,23 @@ class AiBundleTest extends TestCase
         $this->assertTrue($container->hasDefinition('ai.chat.message_bag.normalizer'));
     }
 
+    public function testToolCallNormalizerIsRegistered()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => 'gpt-4',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.tool_call.normalizer'));
+        $definition = $container->getDefinition('ai.platform.tool_call.normalizer');
+        $this->assertArrayHasKey('serializer.normalizer', $definition->getTags());
+    }
+
     public function testResponseFormatFactoryServiceIsRegistered()
     {
         $container = $this->buildContainer($this->getFullConfig());

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -246,6 +246,23 @@ class AiBundleTest extends TestCase
         $this->assertTrue($container->hasDefinition('ai.chat.message_bag.normalizer'));
     }
 
+    public function testToolCallNormalizerIsRegistered()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => 'gpt-4',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.tool_call.normalizer'));
+        $definition = $container->getDefinition('ai.platform.tool_call.normalizer');
+        $this->assertArrayHasKey('serializer.normalizer', $definition->getTags());
+    }
+
     public function testResponseFormatFactoryServiceIsRegistered()
     {
         $container = $this->buildContainer($this->getFullConfig());

--- a/src/chat/CHANGELOG.md
+++ b/src/chat/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * [BC BREAK] Change `public array $calls` to `private array $calls` in `TraceableChat` and `TraceableMessageStore` - use `getCalls()` instead
+ * Fix `MessageNormalizer::denormalize()` crash on `AssistantMessage`/`ToolCallMessage` payloads containing tool calls when the outer serializer chain does not include `ToolCallNormalizer`; denormalization now accepts both the OpenAI-style wrapped shape and the flat shape produced by the default `ObjectNormalizer` fallback
 
 0.7
 ---

--- a/src/chat/CHANGELOG.md
+++ b/src/chat/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 ---
 
  * [BC BREAK] Change `public array $calls` to `private array $calls` in `TraceableChat` and `TraceableMessageStore` - use `getCalls()` instead
+ * Fix `MessageNormalizer::denormalize()` crash on `AssistantMessage`/`ToolCallMessage` payloads containing tool calls when the outer serializer chain does not include `ToolCallNormalizer`; denormalization now accepts both the OpenAI-style wrapped shape and the flat shape produced by the default `ObjectNormalizer` fallback
 
 0.7
 ---

--- a/src/chat/src/MessageNormalizer.php
+++ b/src/chat/src/MessageNormalizer.php
@@ -55,11 +55,7 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
         $message = match ($type) {
             SystemMessage::class => new SystemMessage($content),
             AssistantMessage::class => new AssistantMessage($content, array_map(
-                static fn (array $toolsCall): ToolCall => new ToolCall(
-                    $toolsCall['id'],
-                    $toolsCall['function']['name'],
-                    json_decode($toolsCall['function']['arguments'], true)
-                ),
+                self::toolCallFromPayload(...),
                 $data['toolsCalls'],
             )),
             UserMessage::class => new UserMessage(...array_map(
@@ -69,11 +65,7 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
                 $contentAsBase64,
             )),
             ToolCallMessage::class => new ToolCallMessage(
-                new ToolCall(
-                    $data['toolsCalls']['id'],
-                    $data['toolsCalls']['function']['name'],
-                    json_decode($data['toolsCalls']['function']['arguments'], true)
-                ),
+                self::toolCallFromPayload($data['toolsCalls']),
                 $content
             ),
             default => throw new LogicException(\sprintf('Unknown message type "%s".', $type)),
@@ -153,5 +145,33 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
         return [
             MessageInterface::class => true,
         ];
+    }
+
+    /**
+     * Builds a ToolCall from either the OpenAI-style wrapped payload
+     * (`{id, function: {name, arguments: JSON string}}`, produced when the
+     * outer serializer chain includes {@see \Symfony\AI\Platform\Contract\Normalizer\Result\ToolCallNormalizer})
+     * or the flat payload (`{id, name, arguments: array}`) produced by the
+     * default ObjectNormalizer fallback. The latter shape allows restoring
+     * conversations stored before the ToolCallNormalizer was wired into the
+     * ai-bundle configuration.
+     *
+     * @param array<string, mixed> $payload
+     */
+    private static function toolCallFromPayload(array $payload): ToolCall
+    {
+        if (isset($payload['function'])) {
+            return new ToolCall(
+                $payload['id'],
+                $payload['function']['name'],
+                json_decode($payload['function']['arguments'], true) ?? [],
+            );
+        }
+
+        return new ToolCall(
+            $payload['id'],
+            $payload['name'],
+            $payload['arguments'] ?? [],
+        );
     }
 }

--- a/src/chat/src/MessageNormalizer.php
+++ b/src/chat/src/MessageNormalizer.php
@@ -63,11 +63,7 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
                 $contentAsBase64,
             )),
             ToolCallMessage::class => new ToolCallMessage(
-                new ToolCall(
-                    $data['toolsCalls']['id'],
-                    $data['toolsCalls']['function']['name'],
-                    json_decode($data['toolsCalls']['function']['arguments'], true)
-                ),
+                self::toolCallFromPayload($data['toolsCalls']),
                 $content
             ),
             default => throw new LogicException(\sprintf('Unknown message type "%s".', $type)),
@@ -191,11 +187,7 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
                 $parts[] = match ($part['type']) {
                     Text::class => new Text($part['text']),
                     Thinking::class => new Thinking($part['content'] ?? '', $part['signature'] ?? null),
-                    ToolCall::class => new ToolCall(
-                        $part['toolCall']['id'],
-                        $part['toolCall']['function']['name'],
-                        json_decode($part['toolCall']['function']['arguments'], true),
-                    ),
+                    ToolCall::class => self::toolCallFromPayload($part['toolCall']),
                     default => throw new LogicException(\sprintf('Unknown assistant part type "%s".', $part['type'])),
                 };
             }
@@ -211,13 +203,37 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
         }
 
         foreach ($data['toolsCalls'] ?? [] as $toolCall) {
-            $parts[] = new ToolCall(
-                $toolCall['id'],
-                $toolCall['function']['name'],
-                json_decode($toolCall['function']['arguments'], true),
-            );
+            $parts[] = self::toolCallFromPayload($toolCall);
         }
 
         return $parts;
+    }
+
+    /**
+     * Builds a ToolCall from either the OpenAI-style wrapped payload
+     * (`{id, function: {name, arguments: JSON string}}`, produced when the
+     * outer serializer chain includes {@see \Symfony\AI\Platform\Contract\Normalizer\Result\ToolCallNormalizer})
+     * or the flat payload (`{id, name, arguments: array}`) produced by the
+     * default ObjectNormalizer fallback. The latter shape allows restoring
+     * conversations stored before the ToolCallNormalizer was wired into the
+     * ai-bundle configuration.
+     *
+     * @param array<string, mixed> $payload
+     */
+    private static function toolCallFromPayload(array $payload): ToolCall
+    {
+        if (isset($payload['function'])) {
+            return new ToolCall(
+                $payload['id'],
+                $payload['function']['name'],
+                json_decode($payload['function']['arguments'], true) ?? [],
+            );
+        }
+
+        return new ToolCall(
+            $payload['id'],
+            $payload['name'],
+            $payload['arguments'] ?? [],
+        );
     }
 }

--- a/src/chat/tests/MessageNormalizerTest.php
+++ b/src/chat/tests/MessageNormalizerTest.php
@@ -177,4 +177,73 @@ final class MessageNormalizerTest extends TestCase
         $this->assertSame('get_weather', $denormalized->getToolCall()->getName());
         $this->assertSame(['city' => 'Paris'], $denormalized->getToolCall()->getArguments());
     }
+
+    public function testItCanDenormalizeAssistantMessageWithFlatToolCalls()
+    {
+        // Flat payloads are produced when the outer serializer chain does
+        // not include ToolCallNormalizer (as was the case before
+        // ai-bundle's config was fixed). Restoring such payloads must
+        // still work — otherwise conversations persisted before the fix
+        // become unreadable.
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new MessageNormalizer(),
+        ], [new JsonEncoder()]);
+
+        $uuid = Uuid::v7();
+        $payload = [
+            'id' => $uuid->toRfc4122(),
+            'type' => AssistantMessage::class,
+            'content' => '',
+            'contentAsBase64' => [],
+            'toolsCalls' => [
+                [
+                    'id' => 'call-1',
+                    'name' => 'get_weather',
+                    'arguments' => ['city' => 'Paris'],
+                ],
+            ],
+            'metadata' => [],
+            'addedAt' => 0,
+        ];
+
+        $denormalized = $serializer->denormalize($payload, MessageInterface::class);
+
+        $this->assertInstanceOf(AssistantMessage::class, $denormalized);
+        $toolCalls = $denormalized->getToolCalls();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call-1', $toolCalls[0]->getId());
+        $this->assertSame('get_weather', $toolCalls[0]->getName());
+        $this->assertSame(['city' => 'Paris'], $toolCalls[0]->getArguments());
+    }
+
+    public function testItCanDenormalizeToolCallMessageWithFlatToolCall()
+    {
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new MessageNormalizer(),
+        ], [new JsonEncoder()]);
+
+        $uuid = Uuid::v7();
+        $payload = [
+            'id' => $uuid->toRfc4122(),
+            'type' => ToolCallMessage::class,
+            'content' => 'Sunny, 22°C',
+            'contentAsBase64' => [],
+            'toolsCalls' => [
+                'id' => 'call-1',
+                'name' => 'get_weather',
+                'arguments' => ['city' => 'Paris'],
+            ],
+            'metadata' => [],
+            'addedAt' => 0,
+        ];
+
+        $denormalized = $serializer->denormalize($payload, MessageInterface::class);
+
+        $this->assertInstanceOf(ToolCallMessage::class, $denormalized);
+        $this->assertSame('call-1', $denormalized->getToolCall()->getId());
+        $this->assertSame('get_weather', $denormalized->getToolCall()->getName());
+        $this->assertSame(['city' => 'Paris'], $denormalized->getToolCall()->getArguments());
+    }
 }

--- a/src/chat/tests/MessageNormalizerTest.php
+++ b/src/chat/tests/MessageNormalizerTest.php
@@ -214,4 +214,120 @@ final class MessageNormalizerTest extends TestCase
         $this->assertSame('get_weather', $denormalized->getToolCall()->getName());
         $this->assertSame(['city' => 'Paris'], $denormalized->getToolCall()->getArguments());
     }
+
+    public function testItCanDenormalizeAssistantMessageWithFlatToolCalls()
+    {
+        // Flat payloads are produced when the outer serializer chain does
+        // not include ToolCallNormalizer (as was the case before
+        // ai-bundle's config was fixed). Restoring such payloads must
+        // still work — otherwise conversations persisted before the fix
+        // become unreadable.
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new MessageNormalizer(),
+        ], [new JsonEncoder()]);
+
+        $uuid = Uuid::v7();
+        $payload = [
+            'id' => $uuid->toRfc4122(),
+            'type' => AssistantMessage::class,
+            'content' => '',
+            'contentAsBase64' => [],
+            'toolsCalls' => [
+                [
+                    'id' => 'call-1',
+                    'name' => 'get_weather',
+                    'arguments' => ['city' => 'Paris'],
+                ],
+            ],
+            'metadata' => [],
+            'addedAt' => 0,
+        ];
+
+        $denormalized = $serializer->denormalize($payload, MessageInterface::class);
+
+        $this->assertInstanceOf(AssistantMessage::class, $denormalized);
+        $toolCalls = $denormalized->getToolCalls();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call-1', $toolCalls[0]->getId());
+        $this->assertSame('get_weather', $toolCalls[0]->getName());
+        $this->assertSame(['city' => 'Paris'], $toolCalls[0]->getArguments());
+    }
+
+    public function testItCanDenormalizeAssistantMessageWithFlatToolCallInParts()
+    {
+        // Same legacy concern as the flat `toolsCalls` test above, but for
+        // the v0.9 `parts` path: when the outer serializer chain does not
+        // include ToolCallNormalizer, the per-part `toolCall` sub-array
+        // gets serialized in the flat shape by ObjectNormalizer, and the
+        // denormalizer must still be able to restore it.
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new MessageNormalizer(),
+        ], [new JsonEncoder()]);
+
+        $uuid = Uuid::v7();
+        $payload = [
+            'id' => $uuid->toRfc4122(),
+            'type' => AssistantMessage::class,
+            'content' => '',
+            'contentAsBase64' => [],
+            'toolsCalls' => [],
+            'parts' => [
+                ['type' => Text::class, 'text' => 'Intermediate text.'],
+                [
+                    'type' => ToolCall::class,
+                    'toolCall' => [
+                        'id' => 'call-1',
+                        'name' => 'get_weather',
+                        'arguments' => ['city' => 'Paris'],
+                    ],
+                ],
+            ],
+            'metadata' => [],
+            'addedAt' => 0,
+        ];
+
+        $denormalized = $serializer->denormalize($payload, MessageInterface::class);
+
+        $this->assertInstanceOf(AssistantMessage::class, $denormalized);
+        $parts = $denormalized->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(Text::class, $parts[0]);
+        $this->assertSame('Intermediate text.', $parts[0]->getText());
+        $this->assertInstanceOf(ToolCall::class, $parts[1]);
+        $this->assertSame('call-1', $parts[1]->getId());
+        $this->assertSame('get_weather', $parts[1]->getName());
+        $this->assertSame(['city' => 'Paris'], $parts[1]->getArguments());
+    }
+
+    public function testItCanDenormalizeToolCallMessageWithFlatToolCall()
+    {
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new MessageNormalizer(),
+        ], [new JsonEncoder()]);
+
+        $uuid = Uuid::v7();
+        $payload = [
+            'id' => $uuid->toRfc4122(),
+            'type' => ToolCallMessage::class,
+            'content' => 'Sunny, 22°C',
+            'contentAsBase64' => [],
+            'toolsCalls' => [
+                'id' => 'call-1',
+                'name' => 'get_weather',
+                'arguments' => ['city' => 'Paris'],
+            ],
+            'metadata' => [],
+            'addedAt' => 0,
+        ];
+
+        $denormalized = $serializer->denormalize($payload, MessageInterface::class);
+
+        $this->assertInstanceOf(ToolCallMessage::class, $denormalized);
+        $this->assertSame('call-1', $denormalized->getToolCall()->getId());
+        $this->assertSame('get_weather', $denormalized->getToolCall()->getName());
+        $this->assertSame(['city' => 'Paris'], $denormalized->getToolCall()->getArguments());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1972
| License       | MIT

## Problem

When a conversation containing an `AssistantMessage` (or `ToolCallMessage`) with tool calls is persisted through `MessageNormalizer` and later restored, `denormalize()` crashes on `Undefined array key "function"`.

## Root cause

- `MessageNormalizer::denormalize()` reads the OpenAI-style **wrapped** shape: `{id, function: {name, arguments: JSON string}}`.
- `MessageNormalizer::normalize()` delegates the tool call payload to the outer `Serializer`. When `ToolCallNormalizer` is in the chain, the wrapped shape is produced; otherwise the default `ObjectNormalizer` falls back to the **flat** shape `{id, name, arguments: array}`.
- `ToolCallNormalizer` was never registered as a service in `ai-bundle`. In real Symfony apps, the outer serializer therefore produced the flat shape, and denormalize crashed. The chat component's existing round-trip tests only passed because they wire `ToolCallNormalizer` manually.

## Fix (two complementary changes)

1. **ai-bundle** — register `Symfony\AI\Platform\Contract\Normalizer\Result\ToolCallNormalizer` with the `serializer.normalizer` tag, so the outer serializer produces the wrapped shape the denormalizer expects.
2. **chat** — make `MessageNormalizer::denormalize()` tolerate **both** shapes (wrapped and flat). This lets apps restore conversations that were persisted before this fix landed (the reporter's own DB rows are in the flat form).

## Test plan

- `src/chat` — 41 tests pass, including 2 new regression tests exercising the flat-shape path without `ToolCallNormalizer` in the chain (`testItCanDenormalizeAssistantMessageWithFlatToolCalls`, `testItCanDenormalizeToolCallMessageWithFlatToolCall`).
- `src/ai-bundle` — 239 tests pass (+1 from this PR verifying the new service registration and tag), identical error count to main (8 pre-existing errors tied to the optional `symfony/ai-ovh-platform` package, unrelated to this change).
- `phpstan` clean on `src/chat`.

## Notes

- Thanks to @sjahns for the precise diagnosis in the issue — the wrapped-vs-flat asymmetry was described clearly enough that the fix direction was obvious.
- The `toolCallFromPayload()` helper centralizes the tolerance so there's a single place to revisit if we ever want to drop the flat-shape fallback later.