### PR TITLE
[Mate] Change default user namespace from App\Mate to Mate

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,31 @@
+UPGRADE FROM 0.8 to 0.9
+=======================
+
+Mate
+----
+
+ * The default user namespace scaffolded by `mate init` changed from `App\Mate\` to `Mate\`.
+   Existing projects must update their `composer.json` autoload entry and move user-defined
+   tool classes into the new namespace:
+
+   ```diff
+    {
+        "autoload-dev": {
+            "psr-4": {
+   -            "App\\Mate\\": "mate/src/"
+   +            "Mate\\": "mate/src/"
+            }
+        }
+    }
+   ```
+
+   ```diff
+   -namespace App\Mate;
+   +namespace Mate;
+   ```
+
+   After updating, run `composer dump-autoload`.
+
 UPGRADE FROM 0.7 to 0.8
 =======================
 

--- a/demo/composer.json
+++ b/demo/composer.json
@@ -90,7 +90,7 @@
     "autoload-dev": {
         "psr-4": {
             "App\\Tests\\": "tests/",
-            "App\\Mate\\": "mate/src/"
+            "Mate\\": "mate/src/"
         }
     },
     "config": {

--- a/demo/mate/config.php
+++ b/demo/mate/config.php
@@ -11,7 +11,7 @@
 
 // This file is loaded into the Symfony DI container
 
-use App\Mate\SymfonyAiFeaturesTool;
+use Mate\SymfonyAiFeaturesTool;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $container): void {

--- a/demo/mate/src/SymfonyAiFeaturesTool.php
+++ b/demo/mate/src/SymfonyAiFeaturesTool.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace App\Mate;
+namespace Mate;
 
 use Mcp\Capability\Attribute\McpTool;
 use Symfony\Component\Yaml\Yaml;

--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -56,7 +56,7 @@ It also updates your ``composer.json`` with the following configuration:
     {
         "autoload-dev": {
             "psr-4": {
-                "App\\Mate\\": "mate/src/"
+                "Mate\\": "mate/src/"
             }
         },
         "extra": {
@@ -127,7 +127,7 @@ The easiest way to add tools is to create a ``mate/src`` folder next to your ``s
 then add a class with a method using the ``#[McpTool]`` attribute::
 
     // mate/MyTool.php
-    namespace App\Mate;
+    namespace Mate;
 
     use Mcp\Capability\Attribute\McpTool;
 

--- a/docs/components/mate/troubleshooting.rst
+++ b/docs/components/mate/troubleshooting.rst
@@ -145,7 +145,7 @@ Create a simple test script::
     // test-tool.php
     require 'vendor/autoload.php';
 
-    $tool = new App\Mate\MyTool();
+    $tool = new Mate\MyTool();
     var_dump($tool->execute('test-param'));
 
 Clear Cache

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.9
+---
+
+ * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
+
 0.7
 ---
 

--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -223,12 +223,12 @@ class InitCommand extends Command
             $actions[] = ['○', 'Exists', 'extra.ai-mate configuration'];
         }
 
-        if (!isset($composerJson['autoload-dev']['psr-4']['App\\Mate\\'])) {
-            $composerJson['autoload-dev']['psr-4']['App\\Mate\\'] = 'mate/src/';
+        if (!isset($composerJson['autoload-dev']['psr-4']['Mate\\'])) {
+            $composerJson['autoload-dev']['psr-4']['Mate\\'] = 'mate/src/';
             $modified = true;
-            $actions[] = ['✓', 'Added', 'App\\Mate\\ autoloader'];
+            $actions[] = ['✓', 'Added', 'Mate\\ autoloader'];
         } else {
-            $actions[] = ['○', 'Exists', 'App\\Mate\\ autoloader'];
+            $actions[] = ['○', 'Exists', 'Mate\\ autoloader'];
         }
 
         if ($modified) {

--- a/src/mate/tests/Discovery/Fixtures/with-ai-mate-config/composer.json
+++ b/src/mate/tests/Discovery/Fixtures/with-ai-mate-config/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "autoload": {
         "psr-4": {
-            "App\\Mate\\": "mate/src"
+            "Mate\\": "mate/src"
         }
     },
     "extra": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | Fix #1995
| License       | MIT

After [discussion with @nicolas-grekas](https://github.com/symfony/ai/issues/1995), the default user-facing namespace scaffolded by `mate init` has been changed from `App\Mate\` to a top-level `Mate\`.

The `mate/` directory lives outside the application's `src/` folder and is not really part of the `App\` namespace — it is project-local tooling. Using a top-level `Mate\` namespace makes that separation explicit, avoids colliding with user application code, and is shorter.

### Scope

Only the **user-facing** namespace changes. The internal component namespace `Symfony\AI\Mate\` is unchanged.

### Migration for existing users

Existing projects that already ran `mate init` keep `App\Mate\` in their `composer.json`; the upgrade note walks them through updating the autoload entry and the namespace of their user-defined tool classes, followed by `composer dump-autoload`.