### PR TITLE
[Mate] Simplify post-init next steps output

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -78,6 +78,7 @@ return (new PhpCsFixer\Config())
 
                     if (
                         str_contains($relativePathname, '/Tests/') // don't touch test files, as massive change with little benefit - as outside of public contract anyway
+                        || str_contains($relativePathname, '/tests/') // lowercase top-level test dirs (e.g. src/<component>/tests/) follow the same rule
                         || str_contains($relativePathname, '/Test/') // public namespace not following the rule, do not mistake it with `/Tests/`
                     ) {
                         return false;

--- a/src/mate/src/Command/DiscoverCommand.php
+++ b/src/mate/src/Command/DiscoverCommand.php
@@ -151,7 +151,6 @@ class DiscoverCommand extends Command
         $io->comment([
             'Next steps:',
             '  • Edit mate/extensions.php to enable/disable specific extensions',
-            '  • Run "vendor/bin/mate serve" to start the MCP server',
         ]);
 
         return Command::SUCCESS;

--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -133,25 +133,13 @@ class InitCommand extends Command
 
         $io->comment([
             'Next steps:',
-            '  1. Run "composer dump-autoload" to update the autoloader',
-            '  2. Run "vendor/bin/mate discover" to find MCP extensions and refresh AGENT instructions',
-            '  3. Add your custom MCP tools/resources/prompts to the mate/src/ directory',
-            '  4. Run "vendor/bin/mate serve" to start the MCP server',
-            '  5. Run "./bin/codex" to start Codex with project-local Mate MCP integration',
-        ]);
-
-        $io->note([
-            'By default, "extension: false" is set in composer.json to prevent this package',
-            'from being discovered as a Mate extension when installed in other projects.',
-            'If you want this package to BE a Mate extension, set "extension: true" or remove',
-            'the "extension" field from extra.ai-mate configuration.',
+            '  1. Run "composer dump-autoload" to register the Mate\\ autoloader',
+            '  2. Add custom MCP tools/resources/prompts to mate/src/',
+            '  3. Run your preferred coding agent (e.g. Claude Code) — it picks up the generated mcp.json; for Codex, use "./bin/codex"',
         ]);
 
         if (!class_exists(Toon::class)) {
-            $io->note([
-                'For reduced token consumption in tool responses, consider installing the "helgesverre/toon" package:',
-                '  composer require helgesverre/toon',
-            ]);
+            $io->note('Tip: install "helgesverre/toon" (composer require helgesverre/toon) to reduce tokens in tool responses.');
         }
 
         return Command::SUCCESS;

--- a/src/mate/tests/Command/InitCommandTest.php
+++ b/src/mate/tests/Command/InitCommandTest.php
@@ -76,7 +76,7 @@ final class InitCommandTest extends TestCase
         $this->assertStringContainsString('AI Mate Initialization', $output);
         $this->assertStringContainsString('extensions.php', $output);
         $this->assertStringContainsString('config.php', $output);
-        $this->assertStringContainsString('vendor/bin/mate discover', $output);
+        $this->assertStringContainsString('composer dump-autoload', $output);
         $this->assertStringContainsString('./bin/codex', $output);
         $this->assertStringContainsString('Summary', $output);
         $this->assertStringContainsString('Created', $output);
@@ -160,11 +160,6 @@ final class InitCommandTest extends TestCase
         $this->assertArrayHasKey('ai-mate', $composerJson['extra']);
         $this->assertArrayHasKey('extension', $composerJson['extra']['ai-mate']);
         $this->assertFalse($composerJson['extra']['ai-mate']['extension']);
-
-        // Verify note is displayed
-        $output = $tester->getDisplay();
-        $this->assertStringContainsString('extension: false', $output);
-        $this->assertStringContainsString('By default', $output);
     }
 
     private function createCommand(): InitCommand


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The `Next steps` list printed after `bin/mate init` contained items that don't reflect how Mate is actually used:

- **`Run "vendor/bin/mate serve"`** — misleading. `serve` is a stdio MCP server that clients spawn automatically. The generated `mcp.json` (for Claude Code and similar) already does this, and the generated `bin/codex` execs `codex` with that spawn wired up. Users should not start it manually.
- **`Run "vendor/bin/mate discover"`** — partially redundant. `InitCommand` already calls the instructions materializer, so AGENTS.md is already refreshed. Discovery only matters after composer extensions are actually added/removed.
- **`extension: false` note** — a four-line paragraph relevant only to package authors publishing Mate extensions; noisy for ordinary app users running `init`.

### After

```
Next steps:
  1. Run "composer dump-autoload" to register the App\Mate\ autoloader
  2. Add custom MCP tools/resources/prompts to mate/src/
  3. Run "./bin/codex" to start Codex — other MCP clients can use the generated mcp.json
```

Plus the existing `helgesverre/toon` tip, collapsed to a single line.

The same misleading `Run "vendor/bin/mate serve"` bullet is removed from `DiscoverCommand`'s trailing comment too. Existing tests were updated accordingly (composer.json structural assertions in `testSetsExtensionFalseByDefault` are preserved; only the removed-note display assertions are dropped).