### PR TITLE
 Minor doc fixes

### DIFF
--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -456,7 +456,7 @@ Message Template Support
 The Platform's feature for using message templates is set up by the bundle, and conditionally also registers the
 expression language support if the `symfony/expression-language` package is installed.
 
-More about message templates can be found in the :doc:`Platform documentation <components/platform>`.
+More about message templates can be found in the :doc:`Platform documentation </components/platform>`.
 
 Memory Provider Configuration
 -----------------------------
@@ -1062,9 +1062,7 @@ index documents directly in your code without loading them from external sources
                 vectorizer: 'ai.vectorizer.openai_small'
                 store: 'ai.store.chromadb.documents'
 
-The resulting service accepts documents directly:
-
-.. code-block::
+The resulting service accepts documents directly::
 
     use Symfony\AI\Store\Document\TextDocument;
     use Symfony\AI\Store\IndexerInterface;

--- a/docs/components/store/supabase.rst
+++ b/docs/components/store/supabase.rst
@@ -5,8 +5,8 @@ The Supabase bridge provides vector storage capabilities using `pgvector`_ exten
 
 .. note::
 
-Unlike the Postgres Store, the Supabase Store requires manual setup of the database schema because Supabase doesn't
-allow arbitrary SQL execution via REST API.
+    Unlike the Postgres Store, the Supabase Store requires manual setup of the
+    database schema because Supabase doesn't allow arbitrary SQL execution via REST API.
 
 Requirements
 ~~~~~~~~~~~~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

It fixes these errors:

```
Build errors from "2026-04-27 03:17:24"
Error while processing "code-block" directive: "Unsupported code block language "". Added it in SymfonyDocsBuilder\Renderers\CodeNodeRenderer" in file "bundles/ai-bundle" at line 1088
Error while processing "note" directive: "Content expected, none found." in file "components/store/supabase" at line 9
Found invalid reference "components/platform" in file "bundles/ai-bundle"
Found invalid reference "components/platform" in file "bundles/ai-bundle"
```