### PR TITLE
[Platform][VertexAi] Yield TokenUsage from Gemini stream chunks

### DIFF
--- a/examples/vertexai/stream-token-metadata.php
+++ b/examples/vertexai/stream-token-metadata.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Platform\Bridge\VertexAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+
+require_once __DIR__.'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('GOOGLE_CLOUD_LOCATION'), env('GOOGLE_CLOUD_PROJECT'), httpClient: adc_aware_http_client());
+
+$agent = new Agent($platform, 'gemini-2.5-flash');
+$messages = new MessageBag(
+    Message::forSystem('You are an expert assistant in animal study.'),
+    Message::ofUser('What does a cat usually eat?'),
+);
+$result = $agent->call($messages, [
+    'stream' => true,
+]);
+
+foreach ($result->getContent() as $delta) {
+    if ($delta instanceof TextDelta) {
+        echo $delta;
+    }
+}
+
+echo \PHP_EOL;
+
+print_token_usage($result->getMetadata()->get('token_usage'));
+
+echo \PHP_EOL;

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -94,6 +94,10 @@ final class ResultConverter implements ResultConverterInterface
     private function convertStream(RawResultInterface $result): \Generator
     {
         foreach ($result->getDataStream() as $data) {
+            if (isset($data['usageMetadata']['totalTokenCount']) && 0 < $data['usageMetadata']['totalTokenCount']) {
+                yield $this->getTokenUsageExtractor()->fromUsageMetadata($data['usageMetadata']);
+            }
+
             $choices = array_values(array_filter(array_map($this->convertChoice(...), $data['candidates'] ?? [])));
 
             if (!$choices) {

--- a/src/platform/src/Bridge/VertexAi/Gemini/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/TokenUsageExtractor.php
@@ -34,7 +34,7 @@ final class TokenUsageExtractor implements TokenUsageExtractorInterface
             return null;
         }
 
-        return $this->extractUsageMetadata($content['usageMetadata']);
+        return $this->fromUsageMetadata($content['usageMetadata']);
     }
 
     /**
@@ -46,7 +46,7 @@ final class TokenUsageExtractor implements TokenUsageExtractorInterface
      *     totalTokenCount?: int
      * } $usage
      */
-    private function extractUsageMetadata(array $usage): TokenUsage
+    public function fromUsageMetadata(array $usage): TokenUsage
     {
         return new TokenUsage(
             promptTokens: $usage['promptTokenCount'] ?? null,

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
@@ -28,6 +28,7 @@ use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class ResultConverterTest extends TestCase
@@ -328,5 +329,102 @@ final class ResultConverterTest extends TestCase
                 ],
             ],
         ], ChoiceDelta::class];
+    }
+
+    public function testStreamingYieldsTokenUsageWhenUsageMetadataIsPresent()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createStub(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($response);
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => 'Hello']]],
+                ]],
+            ];
+            yield [
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => ' world']]],
+                ]],
+                'usageMetadata' => [
+                    'promptTokenCount' => 15,
+                    'candidatesTokenCount' => 25,
+                    'thoughtsTokenCount' => 3,
+                    'totalTokenCount' => 43,
+                ],
+            ];
+        })());
+
+        $result = (new ResultConverter())->convert($rawResult, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $items = iterator_to_array($result->getContent(), false);
+
+        $this->assertCount(3, $items);
+        $this->assertInstanceOf(TextDelta::class, $items[0]);
+        $this->assertSame('Hello', $items[0]->getText());
+
+        $this->assertInstanceOf(TokenUsageInterface::class, $items[1]);
+        $this->assertSame(15, $items[1]->getPromptTokens());
+        $this->assertSame(25, $items[1]->getCompletionTokens());
+        $this->assertSame(3, $items[1]->getThinkingTokens());
+        $this->assertSame(43, $items[1]->getTotalTokens());
+
+        $this->assertInstanceOf(TextDelta::class, $items[2]);
+        $this->assertSame(' world', $items[2]->getText());
+    }
+
+    public function testStreamingSkipsEmptyOrPartialUsageMetadataChunks()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createStub(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($response);
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => 'Hello']]],
+                ]],
+                'usageMetadata' => [],
+            ];
+            yield [
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => ' world']]],
+                ]],
+                'usageMetadata' => [
+                    'promptTokenCount' => 15,
+                ],
+            ];
+            yield [
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => '!']]],
+                ]],
+                'usageMetadata' => [
+                    'promptTokenCount' => 15,
+                    'candidatesTokenCount' => 25,
+                    'totalTokenCount' => 40,
+                ],
+            ];
+        })());
+
+        $result = (new ResultConverter())->convert($rawResult, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $items = iterator_to_array($result->getContent(), false);
+
+        $this->assertCount(4, $items);
+        $this->assertInstanceOf(TextDelta::class, $items[0]);
+        $this->assertSame('Hello', $items[0]->getText());
+        $this->assertInstanceOf(TextDelta::class, $items[1]);
+        $this->assertSame(' world', $items[1]->getText());
+        $this->assertInstanceOf(TokenUsageInterface::class, $items[2]);
+        $this->assertSame(40, $items[2]->getTotalTokens());
+        $this->assertInstanceOf(TextDelta::class, $items[3]);
+        $this->assertSame('!', $items[3]->getText());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #972
| License       | MIT

The streaming token extraction was disabled in #1267 because the previous implementation re-iterated the response generator, which conflicted with the agent already consuming it (the `Generator passed to yield from was aborted` error reported by @franzwilding in #972). The workaround stopped the crash but silently dropped token usage on every streaming Gemini call.

This PR aligns Gemini with the OpenAi (`Gpt\\ResultConverter::convertStream`) and Ollama (`OllamaResultConverter::convertStream`) pattern: yield `TokenUsage` directly from the converter's stream whenever a chunk carries `usageMetadata`, so the value is delivered through the same generator that produces the deltas — no second iteration needed.

`TokenUsageExtractor::extractUsageMetadata()` is renamed to `fromUsageMetadata()` and made public so the converter can reuse it, mirroring `OpenAi\\Gpt\\TokenUsageExtractor::fromDataArray()`. The non-stream `extract()` path is unchanged.

Test coverage:
- new `testStreamingYieldsTokenUsageWhenUsageMetadataIsPresent` asserts that a stream emitting `usageMetadata` mid-flight produces a `TokenUsageInterface` delta interleaved with the regular `TextDelta`s, with the right `prompt`/`completion`/`thinking`/`total` token counts
- existing stream and non-stream tests still pass (504/597 ✓, 1 unrelated skipped)

`TokenUsageExtractor::extract()` continues to return `null` for streams, since the new path now delivers the usage through the converter — the extractor is only invoked on non-stream calls or by external code that may still want to attempt stream extraction without going through the converter.