### PR TITLE
[Agent][Platform] Mutate the message bag in place in SystemPromptInputProcessor / MemoryInputProcessor

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,18 @@
 UPGRADE FROM 0.9 to 0.10
 ========================
 
+Agent
+-----
+
+ * `SystemPromptInputProcessor` and `MemoryInputProcessor` now modify the message bag in place
+   instead of replacing it with a clone, so injected system messages and messages appended during
+   the agent run (e.g. tool calls) end up in the caller's bag. To keep your bag untouched:
+
+   ```diff
+   -$agent->call($messages);
+   +$agent->call(clone $messages);
+   ```
+
 Platform
 --------
 

--- a/src/agent/src/InputProcessor/SystemPromptInputProcessor.php
+++ b/src/agent/src/InputProcessor/SystemPromptInputProcessor.php
@@ -85,6 +85,6 @@ final class SystemPromptInputProcessor implements InputProcessorInterface
                 PROMPT;
         }
 
-        $input->setMessageBag($messages->withSystemMessage(Message::forSystem($message)));
+        $messages->prepend(Message::forSystem($message));
     }
 }

--- a/src/agent/src/InputProcessor/SystemPromptInputProcessor.php
+++ b/src/agent/src/InputProcessor/SystemPromptInputProcessor.php
@@ -90,6 +90,6 @@ final class SystemPromptInputProcessor implements InputProcessorInterface
                 PROMPT;
         }
 
-        $input->setMessageBag($messages->withSystemMessage(Message::forSystem($message)));
+        $messages->prepend(Message::forSystem($message));
     }
 }

--- a/src/agent/src/Memory/MemoryInputProcessor.php
+++ b/src/agent/src/Memory/MemoryInputProcessor.php
@@ -73,9 +73,8 @@ final class MemoryInputProcessor implements InputProcessorInterface
             $combinedMessage .= \PHP_EOL.\PHP_EOL.'# System Prompt'.\PHP_EOL.\PHP_EOL.$systemMessage;
         }
 
-        $messages = $input->getMessageBag()
-            ->withSystemMessage(Message::forSystem($combinedMessage));
-
-        $input->setMessageBag($messages);
+        $messages = $input->getMessageBag();
+        $messages->removeSystemMessage();
+        $messages->prepend(Message::forSystem($combinedMessage));
     }
 }

--- a/src/agent/src/Memory/MemoryInputProcessor.php
+++ b/src/agent/src/Memory/MemoryInputProcessor.php
@@ -20,6 +20,13 @@ use Symfony\AI\Platform\Message\Message;
  */
 final class MemoryInputProcessor implements InputProcessorInterface
 {
+    /**
+     * Metadata key on the combined system message that preserves the original
+     * system prompt, so repeated runs on the same message bag recombine from
+     * the original instead of nesting the memory prompt into itself.
+     */
+    private const ORIGINAL_SYSTEM_PROMPT_KEY = 'memory_original_system_prompt';
+
     private const MEMORY_PROMPT_MESSAGE = <<<MARKDOWN
         # Conversation Memory
         This is the memory I have found for this conversation. The memory has more weight to answer user input,
@@ -66,16 +73,22 @@ final class MemoryInputProcessor implements InputProcessorInterface
             return;
         }
 
-        $systemMessage = $input->getMessageBag()->getSystemMessage()?->getContent() ?? '';
-
-        $combinedMessage = self::MEMORY_PROMPT_MESSAGE.$memory;
-        if ('' !== $systemMessage) {
-            $combinedMessage .= \PHP_EOL.\PHP_EOL.'# System Prompt'.\PHP_EOL.\PHP_EOL.$systemMessage;
+        $systemMessage = $input->getMessageBag()->getSystemMessage();
+        $originalSystemPrompt = $systemMessage?->getMetadata()->get(self::ORIGINAL_SYSTEM_PROMPT_KEY);
+        if (!\is_string($originalSystemPrompt)) {
+            $originalSystemPrompt = $systemMessage?->getContent() ?? '';
         }
 
-        $messages = $input->getMessageBag()
-            ->withSystemMessage(Message::forSystem($combinedMessage));
+        $combinedMessage = self::MEMORY_PROMPT_MESSAGE.$memory;
+        if ('' !== $originalSystemPrompt) {
+            $combinedMessage .= \PHP_EOL.\PHP_EOL.'# System Prompt'.\PHP_EOL.\PHP_EOL.$originalSystemPrompt;
+        }
 
-        $input->setMessageBag($messages);
+        $combinedSystemMessage = Message::forSystem($combinedMessage);
+        $combinedSystemMessage->getMetadata()->add(self::ORIGINAL_SYSTEM_PROMPT_KEY, $originalSystemPrompt);
+
+        $messages = $input->getMessageBag();
+        $messages->removeSystemMessage();
+        $messages->prepend($combinedSystemMessage);
     }
 }

--- a/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
@@ -45,6 +45,22 @@ final class SystemPromptInputProcessorTest extends TestCase
         $this->assertSame('This is a system prompt', $messages[0]->getContent());
     }
 
+    public function testProcessInputMutatesTheCallerMessageBagInPlace()
+    {
+        $processor = new SystemPromptInputProcessor('This is a system prompt');
+
+        $bag = new MessageBag(Message::ofUser('This is a user message'));
+        $input = new Input('gpt-4o', $bag);
+        $processor->processInput($input);
+
+        // Caller's bag must reflect the injected system message so downstream
+        // processors (e.g. tool-call output processors) can append messages
+        // visible to the caller's reference. See #1726.
+        $this->assertSame($bag, $input->getMessageBag());
+        $this->assertCount(2, $bag);
+        $this->assertInstanceOf(SystemMessage::class, $bag->getMessages()[0]);
+    }
+
     public function testProcessInputDoesNotAddSystemMessageWhenOneExists()
     {
         $processor = new SystemPromptInputProcessor('This is a system prompt');

--- a/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
@@ -60,6 +60,22 @@ final class SystemPromptInputProcessorTest extends TestCase
         $this->assertSame('This is a system prompt', $messages[0]->getContent());
     }
 
+    public function testProcessInputMutatesTheCallerMessageBagInPlace()
+    {
+        $processor = new SystemPromptInputProcessor('This is a system prompt');
+
+        $bag = new MessageBag(Message::ofUser('This is a user message'));
+        $input = new Input('gpt-4o', $bag);
+        $processor->processInput($input);
+
+        // Caller's bag must reflect the injected system message so downstream
+        // processors (e.g. tool-call output processors) can append messages
+        // visible to the caller's reference. See #1726.
+        $this->assertSame($bag, $input->getMessageBag());
+        $this->assertCount(2, $bag);
+        $this->assertInstanceOf(SystemMessage::class, $bag->getMessages()[0]);
+    }
+
     public function testProcessInputDoesNotAddSystemMessageWhenOneExists()
     {
         $processor = new SystemPromptInputProcessor('This is a system prompt');

--- a/src/agent/tests/Memory/MemoryInputProcessorTest.php
+++ b/src/agent/tests/Memory/MemoryInputProcessorTest.php
@@ -153,4 +153,24 @@ final class MemoryInputProcessorTest extends TestCase
         $this->assertArrayNotHasKey('use_memory', $input->getOptions());
         $this->assertNull($input->getMessageBag()->getSystemMessage()?->getContent());
     }
+
+    public function testItMutatesTheCallerMessageBagInPlace()
+    {
+        $memoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $memoryProvider->expects($this->once())
+            ->method('load')
+            ->willReturn([new Memory('Some memory content')]);
+
+        $memoryInputProcessor = new MemoryInputProcessor([$memoryProvider]);
+
+        $bag = new MessageBag(Message::forSystem('You are a helpful assistant.'));
+        $memoryInputProcessor->processInput($input = new Input('gpt-4', $bag, []));
+
+        // Caller's bag must reflect the combined system message so downstream
+        // processors can append messages visible to the caller's reference.
+        // See #1726.
+        $this->assertSame($bag, $input->getMessageBag());
+        $this->assertCount(1, $bag);
+        $this->assertStringContainsString('Some memory content', $bag->getSystemMessage()->getContent());
+    }
 }

--- a/src/agent/tests/Memory/MemoryInputProcessorTest.php
+++ b/src/agent/tests/Memory/MemoryInputProcessorTest.php
@@ -153,4 +153,116 @@ final class MemoryInputProcessorTest extends TestCase
         $this->assertArrayNotHasKey('use_memory', $input->getOptions());
         $this->assertNull($input->getMessageBag()->getSystemMessage()?->getContent());
     }
+
+    public function testItMutatesTheCallerMessageBagInPlace()
+    {
+        $memoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $memoryProvider->expects($this->once())
+            ->method('load')
+            ->willReturn([new Memory('Some memory content')]);
+
+        $memoryInputProcessor = new MemoryInputProcessor([$memoryProvider]);
+
+        $bag = new MessageBag(Message::forSystem('You are a helpful assistant.'));
+        $memoryInputProcessor->processInput($input = new Input('gpt-4', $bag, []));
+
+        // Caller's bag must reflect the combined system message so downstream
+        // processors can append messages visible to the caller's reference.
+        // See #1726.
+        $this->assertSame($bag, $input->getMessageBag());
+        $this->assertCount(1, $bag);
+        $this->assertStringContainsString('Some memory content', $bag->getSystemMessage()->getContent());
+    }
+
+    public function testItDoesNotCompoundTheMemoryPromptOnRepeatedCallsWithTheSameBag()
+    {
+        $memoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $memoryProvider->expects($this->exactly(2))
+            ->method('load')
+            ->willReturn([new Memory('User likes PHP')]);
+
+        $memoryInputProcessor = new MemoryInputProcessor([$memoryProvider]);
+
+        // Since the processor mutates the caller's bag in place, the combined
+        // system message survives the agent call. Chat::submit() persists that
+        // bag and reuses it on the next turn, so the processor runs again on
+        // its own output and must not wrap the memory prompt a second time.
+        $bag = new MessageBag(Message::forSystem('You are a helpful assistant.'));
+
+        $memoryInputProcessor->processInput(new Input('gpt-4', $bag, []));
+        $firstTurnSystemMessage = $bag->getSystemMessage()->getContent();
+
+        $memoryInputProcessor->processInput(new Input('gpt-4', $bag, []));
+        $secondTurnSystemMessage = $bag->getSystemMessage()->getContent();
+
+        $this->assertSame(1, substr_count($secondTurnSystemMessage, '# Conversation Memory'));
+        $this->assertSame($firstTurnSystemMessage, $secondTurnSystemMessage);
+    }
+
+    public function testItKeepsTheOriginalSystemPromptInTheCombinedMessageMetadata()
+    {
+        $memoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $memoryProvider->expects($this->once())
+            ->method('load')
+            ->willReturn([new Memory('Some memory content')]);
+
+        $memoryInputProcessor = new MemoryInputProcessor([$memoryProvider]);
+
+        $bag = new MessageBag(Message::forSystem('You are a helpful assistant.'));
+        $memoryInputProcessor->processInput(new Input('gpt-4', $bag, []));
+
+        // The original prompt must travel as metadata on the combined message:
+        // Chat message stores persist metadata, so idempotence survives a
+        // serialization round-trip through the store.
+        $this->assertSame(
+            'You are a helpful assistant.',
+            $bag->getSystemMessage()->getMetadata()->get('memory_original_system_prompt'),
+        );
+    }
+
+    public function testItIsIdempotentWhenThereWasNoOriginalSystemPrompt()
+    {
+        $memoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $memoryProvider->expects($this->exactly(2))
+            ->method('load')
+            ->willReturn([new Memory('Some memory content')]);
+
+        $memoryInputProcessor = new MemoryInputProcessor([$memoryProvider]);
+
+        $bag = new MessageBag(Message::ofUser('Hi'));
+
+        $memoryInputProcessor->processInput(new Input('gpt-4', $bag, []));
+        $firstTurnSystemMessage = $bag->getSystemMessage()->getContent();
+
+        $memoryInputProcessor->processInput(new Input('gpt-4', $bag, []));
+        $secondTurnSystemMessage = $bag->getSystemMessage()->getContent();
+
+        $this->assertStringNotContainsString('# System Prompt', $secondTurnSystemMessage);
+        $this->assertSame($firstTurnSystemMessage, $secondTurnSystemMessage);
+    }
+
+    public function testItRefreshesTheMemoryOnSubsequentCallsWithTheSameBag()
+    {
+        $memoryProvider = $this->createMock(MemoryProviderInterface::class);
+        $memoryProvider->expects($this->exactly(2))
+            ->method('load')
+            ->willReturnOnConsecutiveCalls(
+                [new Memory('First turn memory')],
+                [new Memory('Second turn memory')],
+            );
+
+        $memoryInputProcessor = new MemoryInputProcessor([$memoryProvider]);
+
+        $bag = new MessageBag(Message::forSystem('You are a helpful assistant.'));
+
+        $memoryInputProcessor->processInput(new Input('gpt-4', $bag, []));
+        $memoryInputProcessor->processInput(new Input('gpt-4', $bag, []));
+
+        $systemMessage = $bag->getSystemMessage()->getContent();
+
+        // Memory must be re-derived per call, while the original prompt is kept.
+        $this->assertStringContainsString('Second turn memory', $systemMessage);
+        $this->assertStringNotContainsString('First turn memory', $systemMessage);
+        $this->assertStringContainsString('You are a helpful assistant.', $systemMessage);
+    }
 }

--- a/src/chat/tests/MessageNormalizerTest.php
+++ b/src/chat/tests/MessageNormalizerTest.php
@@ -100,6 +100,25 @@ final class MessageNormalizerTest extends TestCase
         $this->assertSame($message->getId()->toRfc4122(), $denormalized->getId()->toRfc4122());
     }
 
+    public function testItRoundTripsMessageMetadata()
+    {
+        $normalizer = new MessageNormalizer();
+
+        $message = Message::forSystem('You are a helpful assistant.');
+        $message->getMetadata()->add('memory_original_system_prompt', 'You are a helpful assistant.');
+
+        $payload = $normalizer->normalize($message);
+        $denormalized = $normalizer->denormalize($payload, MessageInterface::class);
+
+        // Input processors rely on metadata surviving store persistence,
+        // e.g. MemoryInputProcessor keeps the original system prompt there
+        // to stay idempotent across chat turns.
+        $this->assertSame(
+            'You are a helpful assistant.',
+            $denormalized->getMetadata()->get('memory_original_system_prompt'),
+        );
+    }
+
     public function testItCanNormalizeAssistantMessageWithToolCalls()
     {
         $serializer = new Serializer([

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Add support for passing a fully defined `Model` instance to `Platform::invoke()` (and `Provider::invoke()`) instead of a model name string, bypassing the model catalog; widen `ProviderInterface::supports()` to `string|Model` to route a model instance to the first provider whose model clients accept it
+ * Add in-place `MessageBag::prepend()` and `MessageBag::removeSystemMessage()`
 
 0.9
 ---

--- a/src/platform/src/Message/MessageBag.php
+++ b/src/platform/src/Message/MessageBag.php
@@ -50,6 +50,25 @@ class MessageBag implements \Countable, \IteratorAggregate
     }
 
     /**
+     * Mutable counterpart of {@see self::with()} that prepends the message in place.
+     */
+    public function prepend(MessageInterface $message): void
+    {
+        array_unshift($this->messages, $message);
+    }
+
+    /**
+     * Mutable counterpart of {@see self::withoutSystemMessage()} that removes the system message in place.
+     */
+    public function removeSystemMessage(): void
+    {
+        $this->messages = array_values(array_filter(
+            $this->messages,
+            static fn (MessageInterface $message): bool => !$message instanceof SystemMessage,
+        ));
+    }
+
+    /**
      * @return list<MessageInterface>
      */
     public function getMessages(): array

--- a/src/platform/tests/Message/MessageBagTest.php
+++ b/src/platform/tests/Message/MessageBagTest.php
@@ -135,6 +135,46 @@ final class MessageBagTest extends TestCase
         $this->assertSame('My amazing system prompt.', $newMessageBagMessage->getContent());
     }
 
+    public function testPrependMutatesInPlace()
+    {
+        $messageBag = new MessageBag(
+            Message::ofAssistant('It is time to sleep.'),
+            Message::ofUser('Hello, world!'),
+        );
+
+        $messageBag->prepend(Message::forSystem('My amazing system prompt.'));
+
+        $this->assertCount(3, $messageBag);
+
+        $first = $messageBag->getMessages()[0];
+        $this->assertInstanceOf(SystemMessage::class, $first);
+        $this->assertSame('My amazing system prompt.', $first->getContent());
+    }
+
+    public function testRemoveSystemMessageMutatesInPlace()
+    {
+        $messageBag = new MessageBag(
+            Message::forSystem('My amazing system prompt.'),
+            Message::ofAssistant('It is time to sleep.'),
+            Message::forSystem('A system prompt in the middle.'),
+            Message::ofUser('Hello, world!'),
+            Message::forSystem('Another system prompt at the end'),
+        );
+
+        $messageBag->removeSystemMessage();
+
+        $this->assertCount(2, $messageBag);
+
+        $assistantMessage = $messageBag->getMessages()[0];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('It is time to sleep.', $assistantMessage->getContent());
+
+        $userMessage = $messageBag->getMessages()[1];
+        $this->assertInstanceOf(UserMessage::class, $userMessage);
+        $this->assertInstanceOf(Text::class, $userMessage->getContent()[0]);
+        $this->assertSame('Hello, world!', $userMessage->getContent()[0]->getText());
+    }
+
     public function testContainsImageReturnsFalseWithoutImage()
     {
         $messageBag = new MessageBag(

--- a/src/platform/tests/Message/MessageBagTest.php
+++ b/src/platform/tests/Message/MessageBagTest.php
@@ -150,6 +150,46 @@ final class MessageBagTest extends TestCase
         $this->assertSame('My amazing system prompt.', $newMessageBagMessage->getContent());
     }
 
+    public function testPrependMutatesInPlace()
+    {
+        $messageBag = new MessageBag(
+            Message::ofAssistant('It is time to sleep.'),
+            Message::ofUser('Hello, world!'),
+        );
+
+        $messageBag->prepend(Message::forSystem('My amazing system prompt.'));
+
+        $this->assertCount(3, $messageBag);
+
+        $first = $messageBag->getMessages()[0];
+        $this->assertInstanceOf(SystemMessage::class, $first);
+        $this->assertSame('My amazing system prompt.', $first->getContent());
+    }
+
+    public function testRemoveSystemMessageMutatesInPlace()
+    {
+        $messageBag = new MessageBag(
+            Message::forSystem('My amazing system prompt.'),
+            Message::ofAssistant('It is time to sleep.'),
+            Message::forSystem('A system prompt in the middle.'),
+            Message::ofUser('Hello, world!'),
+            Message::forSystem('Another system prompt at the end'),
+        );
+
+        $messageBag->removeSystemMessage();
+
+        $this->assertCount(2, $messageBag);
+
+        $assistantMessage = $messageBag->getMessages()[0];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('It is time to sleep.', $assistantMessage->asText());
+
+        $userMessage = $messageBag->getMessages()[1];
+        $this->assertInstanceOf(UserMessage::class, $userMessage);
+        $this->assertInstanceOf(Text::class, $userMessage->getContent()[0]);
+        $this->assertSame('Hello, world!', $userMessage->getContent()[0]->getText());
+    }
+
     public function testContainsImageReturnsFalseWithoutImage()
     {
         $messageBag = new MessageBag(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1726
| License       | MIT

Reported by @jo-hoff in #1726: a caller passing their own `MessageBag` to `Agent::call($bag)` could not see tool-call messages later appended by output processors, because `SystemPromptInputProcessor` (and the closely related `MemoryInputProcessor`) replaced the bag in the `Input` with a fresh clone via `MessageBag::withSystemMessage()`. The agent then operated on the clone, while the caller was left holding a stale reference.

This PR adds two mutable counterparts on `MessageBag`:
- `prepend(MessageInterface)` — insert the message at index 0
- `removeSystemMessage()` — drop the system message in place

Both processors now mutate the caller's bag instead of replacing it, so downstream output processors (e.g. tool-call appending) and the caller share the same instance.

The immutable `with*()` / `without*()` API is unchanged and still used by the bridge normalizers (no BC break).

Test coverage:
- new `MessageBag::prepend()` / `removeSystemMessage()` unit tests
- new `testProcessInputMutatesTheCallerMessageBagInPlace` on `SystemPromptInputProcessor`
- new `testItMutatesTheCallerMessageBagInPlace` on `MemoryInputProcessor`
- the existing test suite still passes (the `assertSame($bag, $input->getMessageBag())` assertion was previously satisfied by accident only when the processor early-returned)