### PR TITLE
[Platform][Cache] Add CachePlatform::lookup() and content-based MessageBag hashing

### DIFF
--- a/src/platform/src/Bridge/Cache/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cache/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-0.4
+0.9
 ---
 
  * Hash `MessageBag` inputs by content rather than by per-instance UUID, so two bags carrying the same conversation hit the same cache entry

--- a/src/platform/src/Bridge/Cache/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cache/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.4
+---
+
+ * Hash `MessageBag` inputs by content rather than by per-instance UUID, so two bags carrying the same conversation hit the same cache entry
+ * Add `CachePlatform::lookup()` to retrieve a cached result without invoking the underlying platform on a miss
+
 0.3
 ---
 

--- a/src/platform/src/Bridge/Cache/CachePlatform.php
+++ b/src/platform/src/Bridge/Cache/CachePlatform.php
@@ -12,7 +12,10 @@
 namespace Symfony\AI\Platform\Bridge\Cache;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\ContentInterface;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\MessageInterface;
+use Symfony\AI\Platform\Message\Template;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\PlatformInterface;
@@ -64,19 +67,7 @@ final class CachePlatform implements PlatformInterface
             return $this->platform->invoke($model, $input, $options);
         }
 
-        $normalizedInput = match (true) {
-            \is_string($input) => md5($input),
-            \is_array($input) => json_encode($input),
-            $input instanceof MessageBag => $input->getId()->toString(),
-            default => throw new InvalidArgumentException(\sprintf('Unsupported input type: %s', get_debug_type($input))),
-        };
-
-        $cacheKey = (new UnicodeString())->join([
-            $options['prompt_cache_key'] ?? $this->cacheKey,
-            (new UnicodeString($model))->camel(),
-            $normalizedInput,
-        ]);
-
+        $cacheKey = $this->buildCacheKey($model, $input, $options);
         $ttl = $options['prompt_cache_ttl'] ?? $this->cacheTtl;
 
         unset($options['prompt_cache_key'], $options['prompt_cache_ttl']);
@@ -101,6 +92,111 @@ final class CachePlatform implements PlatformInterface
             ];
         });
 
+        return $this->buildDeferredResultFromCache($cached, $options);
+    }
+
+    /**
+     * Returns the cached result for the given input without invoking the
+     * underlying platform, or null when there is no cache hit.
+     *
+     * Useful for UI flows where a cache miss should not trigger a costly
+     * model invocation — e.g. show the cached answer if any, otherwise let
+     * the user decide to (re)generate one.
+     *
+     * @param array<string, mixed> $options Must contain a non-empty
+     *                                      `prompt_cache_key`, like
+     *                                      {@see self::invoke()} does.
+     */
+    public function lookup(string $model, array|string|object $input, array $options = []): ?DeferredResult
+    {
+        if (null === $this->cache || !\array_key_exists('prompt_cache_key', $options) || '' === $options['prompt_cache_key']) {
+            return null;
+        }
+
+        $cacheKey = $this->buildCacheKey($model, $input, $options);
+
+        $item = $this->cache->getItem($cacheKey);
+        if (!$item->isHit()) {
+            return null;
+        }
+
+        unset($options['prompt_cache_key'], $options['prompt_cache_ttl']);
+
+        return $this->buildDeferredResultFromCache($item->get(), $options);
+    }
+
+    public function getModelCatalog(): ModelCatalogInterface
+    {
+        return $this->platform->getModelCatalog();
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function buildCacheKey(string $model, array|string|object $input, array $options): string
+    {
+        return (new UnicodeString())->join([
+            $options['prompt_cache_key'] ?? $this->cacheKey,
+            (new UnicodeString($model))->camel(),
+            $this->hashInput($input),
+        ]);
+    }
+
+    private function hashInput(array|string|object $input): string
+    {
+        return match (true) {
+            \is_string($input) => md5($input),
+            \is_array($input) => md5(json_encode($input, \JSON_THROW_ON_ERROR)),
+            $input instanceof MessageBag => $this->hashMessageBag($input),
+            default => throw new InvalidArgumentException(\sprintf('Unsupported input type: %s', get_debug_type($input))),
+        };
+    }
+
+    private function hashMessageBag(MessageBag $bag): string
+    {
+        // Build a content-only payload so two MessageBag instances with the
+        // same conversation produce the same cache key. The bag's UUID and
+        // each message's UUID are intentionally excluded — they are
+        // per-instance state, not part of the conversation identity.
+        $payload = array_map(
+            fn (MessageInterface $message): array => [
+                'role' => $message->getRole()->value,
+                'content' => $this->normalizeContentForHash($message->getContent()),
+            ],
+            $bag->getMessages(),
+        );
+
+        return md5(json_encode($payload, \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param string|Template|ContentInterface[]|null $content
+     */
+    private function normalizeContentForHash(string|Template|array|null $content): mixed
+    {
+        if (null === $content || \is_string($content)) {
+            return $content;
+        }
+
+        if ($content instanceof Template) {
+            return ['template' => $content->getTemplate(), 'type' => $content->getType()];
+        }
+
+        return array_map(
+            // ContentInterface implementations are simple value objects with
+            // readonly properties — serialize() gives a stable, content-based
+            // fingerprint without including any UUID.
+            static fn (ContentInterface $item): array => ['class' => $item::class, 'fingerprint' => md5(serialize($item))],
+            $content,
+        );
+    }
+
+    /**
+     * @param array{result: mixed, raw_data: array<string, mixed>, metadata: array<string, mixed>, cached_at: int, cache_key: string} $cached
+     * @param array<string, mixed>                                                                                                    $options
+     */
+    private function buildDeferredResultFromCache(array $cached, array $options): DeferredResult
+    {
         $restoredResult = $this->serializer->denormalize($cached['result'], ResultInterface::class);
 
         $restoredResult->getMetadata()->set([
@@ -119,10 +215,5 @@ final class CachePlatform implements PlatformInterface
         $result->getMetadata()->merge($restoredResult->getMetadata());
 
         return $result;
-    }
-
-    public function getModelCatalog(): ModelCatalogInterface
-    {
-        return $this->platform->getModelCatalog();
     }
 }

--- a/src/platform/src/Bridge/Cache/CachePlatform.php
+++ b/src/platform/src/Bridge/Cache/CachePlatform.php
@@ -11,11 +11,17 @@
 
 namespace Symfony\AI\Platform\Bridge\Cache;
 
+use Symfony\AI\Platform\Contract\Normalizer\Message\AssistantMessageNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\AudioNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\ImageNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\ImageUrlNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\Content\TextNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\MessageBagNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\SystemMessageNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\ToolCallMessageNormalizer;
+use Symfony\AI\Platform\Contract\Normalizer\Message\UserMessageNormalizer;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
-use Symfony\AI\Platform\Message\Content\ContentInterface;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\AI\Platform\Message\MessageInterface;
-use Symfony\AI\Platform\Message\Template;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\PlatformInterface;
@@ -51,6 +57,15 @@ final class CachePlatform implements PlatformInterface
         private readonly ClockInterface $clock = new MonotonicClock(),
         private readonly (CacheInterface&TagAwareAdapterInterface)|null $cache = null,
         private readonly SerializerInterface&NormalizerInterface&DenormalizerInterface $serializer = new Serializer([
+            new MessageBagNormalizer(),
+            new AssistantMessageNormalizer(),
+            new SystemMessageNormalizer(),
+            new ToolCallMessageNormalizer(),
+            new UserMessageNormalizer(),
+            new AudioNormalizer(),
+            new ImageNormalizer(),
+            new ImageUrlNormalizer(),
+            new TextNormalizer(),
             new ResultNormalizer(new ObjectNormalizer(
                 propertyTypeExtractor: new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]),
                 classDiscriminatorResolver: new ClassDiscriminatorFromClassMetadata(new ClassMetadataFactory(new AttributeLoader())),
@@ -147,48 +162,13 @@ final class CachePlatform implements PlatformInterface
         return match (true) {
             \is_string($input) => md5($input),
             \is_array($input) => md5(json_encode($input, \JSON_THROW_ON_ERROR)),
-            $input instanceof MessageBag => $this->hashMessageBag($input),
+            // MessageBag is normalized through the platform's Message/Content
+            // normalizers, which expose the conversation content only —
+            // per-instance UUIDs are not part of the output, so two bags
+            // carrying the same conversation hash to the same key.
+            $input instanceof MessageBag => md5($this->serializer->serialize($input, 'json')),
             default => throw new InvalidArgumentException(\sprintf('Unsupported input type: %s', get_debug_type($input))),
         };
-    }
-
-    private function hashMessageBag(MessageBag $bag): string
-    {
-        // Build a content-only payload so two MessageBag instances with the
-        // same conversation produce the same cache key. The bag's UUID and
-        // each message's UUID are intentionally excluded — they are
-        // per-instance state, not part of the conversation identity.
-        $payload = array_map(
-            fn (MessageInterface $message): array => [
-                'role' => $message->getRole()->value,
-                'content' => $this->normalizeContentForHash($message->getContent()),
-            ],
-            $bag->getMessages(),
-        );
-
-        return md5(json_encode($payload, \JSON_THROW_ON_ERROR));
-    }
-
-    /**
-     * @param string|Template|ContentInterface[]|null $content
-     */
-    private function normalizeContentForHash(string|Template|array|null $content): mixed
-    {
-        if (null === $content || \is_string($content)) {
-            return $content;
-        }
-
-        if ($content instanceof Template) {
-            return ['template' => $content->getTemplate(), 'type' => $content->getType()];
-        }
-
-        return array_map(
-            // ContentInterface implementations are simple value objects with
-            // readonly properties — serialize() gives a stable, content-based
-            // fingerprint without including any UUID.
-            static fn (ContentInterface $item): array => ['class' => $item::class, 'fingerprint' => md5(serialize($item))],
-            $content,
-        );
     }
 
     /**

--- a/src/platform/src/Bridge/Cache/Tests/CachePlatformTest.php
+++ b/src/platform/src/Bridge/Cache/Tests/CachePlatformTest.php
@@ -78,8 +78,7 @@ final class CachePlatformTest extends TestCase
         ]);
 
         $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
+         $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
         $this->assertSame('test content', $deferredResult->getResult()->getContent());
 
         $secondDeferredResult = $cachedPlatform->invoke('foo', $messageBag, [
@@ -87,71 +86,118 @@ final class CachePlatformTest extends TestCase
         ]);
 
         $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
         $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
         $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
         $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
     }
 
-    public function testPlatformCanReturnCachedResultWhenCalledTwiceWithSeparateMessageBag()
+    public function testPlatformReturnsCachedResultForSeparateMessageBagsWithSameContent()
+    {
+        // Two MessageBag instances with the same conversation must hit the
+        // same cache entry — see #1245. The bag's UUID is per-instance state
+        // and is intentionally excluded from the cache key.
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $deferredResult = $cachedPlatform->invoke('foo', new MessageBag(Message::ofUser('Hello there')), [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('test content', $deferredResult->getResult()->getContent());
+        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
+        $cachedAt = $deferredResult->getMetadata()->get('cached_at');
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', new MessageBag(Message::ofUser('Hello there')), [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
+        $this->assertSame($cachedAt, $secondDeferredResult->getMetadata()->get('cached_at'));
+    }
+
+    public function testPlatformDistinguishesMessageBagsWithDifferentContent()
     {
         $platform = $this->createMock(PlatformInterface::class);
         $platform->expects($this->exactly(2))->method('invoke')->willReturn(new DeferredResult(
             new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
         ));
 
-        $adapter = new ArrayAdapter();
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
+        );
+
+        $cachedPlatform->invoke('foo', new MessageBag(Message::ofUser('Hello there')), [
+            'prompt_cache_key' => 'symfony',
+        ]);
+
+        // Different user message → cache miss → second underlying invocation.
+        $cachedPlatform->invoke('foo', new MessageBag(Message::ofUser('Hello world')), [
+            'prompt_cache_key' => 'symfony',
+        ]);
+    }
+
+    public function testLookupReturnsNullOnCacheMiss()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->never())->method('invoke');
 
         $cachedPlatform = new CachePlatform(
             $platform,
-            cache: new TagAwareAdapter($adapter),
+            cache: new TagAwareAdapter(new ArrayAdapter()),
         );
 
-        $messageBag = new MessageBag(
-            Message::ofUser('Hello there'),
+        $this->assertNull($cachedPlatform->lookup('foo', new MessageBag(Message::ofUser('Hello there')), [
+            'prompt_cache_key' => 'symfony',
+        ]));
+    }
+
+    public function testLookupReturnsCachedResultOnCacheHitWithoutInvokingPlatform()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
         );
 
-        $deferredResult = $cachedPlatform->invoke('foo', $messageBag, [
+        $cachedPlatform->invoke('foo', new MessageBag(Message::ofUser('Hello there')), [
             'prompt_cache_key' => 'symfony',
         ]);
 
-        $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
-        $this->assertSame('test content', $deferredResult->getResult()->getContent());
-
-        $secondDeferredResult = $cachedPlatform->invoke('foo', $messageBag, [
+        // A second `invoke()` here would also hit the cache, but `lookup()`
+        // must not even attempt to invoke the underlying platform.
+        $cached = $cachedPlatform->lookup('foo', new MessageBag(Message::ofUser('Hello there')), [
             'prompt_cache_key' => 'symfony',
         ]);
 
-        $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
-        $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
-        $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+        $this->assertNotNull($cached);
+        $this->assertSame('test content', $cached->getResult()->getContent());
+        $this->assertTrue($cached->getMetadata()->has('cached_at'));
+    }
 
-        $secondMessageBag = new MessageBag(
-            Message::ofUser('Hello there'),
+    public function testLookupReturnsNullWhenCacheKeyIsMissing()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->never())->method('invoke');
+
+        $cachedPlatform = new CachePlatform(
+            $platform,
+            cache: new TagAwareAdapter(new ArrayAdapter()),
         );
 
-        $deferredResult = $cachedPlatform->invoke('foo', $secondMessageBag, [
-            'prompt_cache_key' => 'symfony',
-        ]);
-
-        $this->assertCount(5, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $secondMessageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
-        $this->assertSame('test content', $deferredResult->getResult()->getContent());
-
-        $secondDeferredResult = $cachedPlatform->invoke('foo', $secondMessageBag, [
-            'prompt_cache_key' => 'symfony',
-        ]);
-
-        $this->assertCount(5, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $secondMessageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
-        $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
-        $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+        $this->assertNull($cachedPlatform->lookup('foo', 'bar'));
+        $this->assertNull($cachedPlatform->lookup('foo', 'bar', ['prompt_cache_key' => '']));
     }
 
     public function testPlatformCannotReturnCachedResultWhenCalledTwiceWhileUsingShortCustomTtl()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1245
| License       | MIT

Tackles the two pain points raised in #1245:

1. **Lookup-only semantics**, requested by @marco-jouwweb. Adds `CachePlatform::lookup(string $model, $input, $options): ?DeferredResult`, which returns the cached result if any or `null` on a miss, **without ever invoking the underlying platform**. This is the UI-friendly path the issue describes ("show cached answer immediately, or surface a regenerate button").

2. **Cache actually caching**, the side observation by @chr-hertel ("the implementation currently has also some functionality issues"). The cache key for `MessageBag` inputs was derived from the bag's per-instance UUID (`$input->getId()->toString()`), so two `MessageBag` instances carrying the same conversation produced two different cache entries. The key is now derived from the conversation content (role + `getContent()` per message), which is what users expect when they pass a stable `prompt_cache_key`. Per-message UUIDs and metadata are intentionally excluded from the hash for the same reason.

`CachePlatform` is also refactored a bit to share the cache-key construction and the deferred-result rebuild between `invoke()` and `lookup()`.

The previous test that documented the per-instance-UUID behaviour as intentional (`testPlatformCanReturnCachedResultWhenCalledTwiceWithSeparateMessageBag`) is split into two:
- `testPlatformReturnsCachedResultForSeparateMessageBagsWithSameContent` — same conversation, single underlying invocation, cache hit
- `testPlatformDistinguishesMessageBagsWithDifferentContent` — different conversation, two underlying invocations

Plus three new tests for `lookup()`: miss, hit-without-invoke, missing/empty cache key.