### PR TITLE
[Mate] Allow Symfony profiler capabilities without a data provider

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
+ * Allow Symfony profiler capabilities (`ProfilerResourceTemplate` and `ProfilerTool`) to be instantiated without a `ProfilerDataProvider`, throwing a clear `RuntimeException` when invoked in workspaces without profiler support
 
 0.7
 ---

--- a/src/mate/src/Bridge/Symfony/Capability/ProfilerResourceTemplate.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ProfilerResourceTemplate.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Mate\Bridge\Symfony\Capability;
 use Mcp\Capability\Attribute\McpResourceTemplate;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
 use Symfony\AI\Mate\Encoding\ResponseEncoder;
+use Symfony\AI\Mate\Exception\RuntimeException;
 
 /**
  * MCP resource templates for accessing Symfony profiler data.
@@ -29,7 +30,7 @@ use Symfony\AI\Mate\Encoding\ResponseEncoder;
 final class ProfilerResourceTemplate
 {
     public function __construct(
-        private readonly ProfilerDataProvider $dataProvider,
+        private readonly ?ProfilerDataProvider $dataProvider = null,
     ) {
     }
 
@@ -43,7 +44,8 @@ final class ProfilerResourceTemplate
     )]
     public function getProfileResource(string $token): array
     {
-        $profileData = $this->dataProvider->findProfile($token);
+        $dataProvider = $this->getDataProvider();
+        $profileData = $dataProvider->findProfile($token);
         if (null === $profileData) {
             return [
                 'uri' => "symfony-profiler://profile/{$token}",
@@ -53,7 +55,7 @@ final class ProfilerResourceTemplate
         }
 
         $profile = $profileData->getProfile();
-        $collectors = $this->dataProvider->listAvailableCollectors($token);
+        $collectors = $dataProvider->listAvailableCollectors($token);
 
         $collectorResources = [];
         foreach ($collectors as $collectorName) {
@@ -96,7 +98,7 @@ final class ProfilerResourceTemplate
     public function getCollectorResource(string $token, string $collector): array
     {
         try {
-            $data = $this->dataProvider->getCollectorData($token, $collector);
+            $data = $this->getDataProvider()->getCollectorData($token, $collector);
 
             return [
                 'uri' => "symfony-profiler://profile/{$token}/{$collector}",
@@ -110,5 +112,14 @@ final class ProfilerResourceTemplate
                 'text' => ResponseEncoder::encode(['error' => $e->getMessage()]),
             ];
         }
+    }
+
+    private function getDataProvider(): ProfilerDataProvider
+    {
+        if (null === $this->dataProvider) {
+            throw new RuntimeException('Symfony profiler resources are not available in this Mate workspace.');
+        }
+
+        return $this->dataProvider;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Capability/ProfilerTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ProfilerTool.php
@@ -16,6 +16,7 @@ use Symfony\AI\Mate\Bridge\Symfony\Profiler\Model\ProfileIndex;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
 use Symfony\AI\Mate\Encoding\ResponseEncoder;
 use Symfony\AI\Mate\Exception\InvalidArgumentException;
+use Symfony\AI\Mate\Exception\RuntimeException;
 
 /**
  * MCP tools for accessing Symfony profiler data.
@@ -25,7 +26,7 @@ use Symfony\AI\Mate\Exception\InvalidArgumentException;
 final class ProfilerTool
 {
     public function __construct(
-        private readonly ProfilerDataProvider $dataProvider,
+        private readonly ?ProfilerDataProvider $dataProvider = null,
     ) {
     }
 
@@ -50,6 +51,7 @@ final class ProfilerTool
         ?string $from = null,
         ?string $to = null,
     ): string {
+        $dataProvider = $this->getDataProvider();
         $criteria = [
             'context' => $context,
             'method' => $method,
@@ -60,7 +62,7 @@ final class ProfilerTool
             'to' => $to,
         ];
 
-        $profiles = $this->dataProvider->searchProfiles(array_filter($criteria), $limit);
+        $profiles = $dataProvider->searchProfiles(array_filter($criteria), $limit);
 
         return ResponseEncoder::encode([
             'profiles' => array_values(array_map(
@@ -76,7 +78,7 @@ final class ProfilerTool
     #[McpTool('symfony-profiler-get', 'Get a specific profiler profile by its token. Returns detailed profile data including available collectors and resource_uri for accessing collector-specific data.')]
     public function getProfile(string $token): string
     {
-        $profileData = $this->dataProvider->findProfile($token);
+        $profileData = $this->getDataProvider()->findProfile($token);
 
         if (null === $profileData) {
             throw new InvalidArgumentException(\sprintf('Profile with token "%s" not found', $token));
@@ -100,5 +102,14 @@ final class ProfilerTool
         }
 
         return ResponseEncoder::encode($data);
+    }
+
+    private function getDataProvider(): ProfilerDataProvider
+    {
+        if (null === $this->dataProvider) {
+            throw new RuntimeException('Symfony profiler tools are not available in this Mate workspace.');
+        }
+
+        return $this->dataProvider;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ProfilerResourceTemplateTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ProfilerResourceTemplateTest.php
@@ -134,4 +134,16 @@ final class ProfilerResourceTemplateTest extends TestCase
         $this->assertIsArray($data);
         $this->assertArrayHasKey('error', $data);
     }
+
+    public function testResourcesReturnAvailabilityErrorWhenProfilerSupportIsUnavailable()
+    {
+        $template = new ProfilerResourceTemplate();
+
+        $resource = $template->getCollectorResource('abc123', 'request');
+
+        $this->assertSame('symfony-profiler://profile/abc123/request', $resource['uri']);
+        $data = Toon::decode($resource['text']);
+        $this->assertIsArray($data);
+        $this->assertSame('Symfony profiler resources are not available in this Mate workspace.', $data['error']);
+    }
 }

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ProfilerToolTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ProfilerToolTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ProfilerTool;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
+use Symfony\AI\Mate\Exception\RuntimeException;
 
 /**
  * @author Johannes Wachter <johannes@sulu.io>
@@ -140,5 +141,15 @@ final class ProfilerToolTest extends TestCase
         $this->assertArrayHasKey('profiles', $result);
         $keys = array_keys($result['profiles']);
         $this->assertSame([0, 1, 2], $keys);
+    }
+
+    public function testProfilerToolsFailClearlyWhenProfilerSupportIsUnavailable()
+    {
+        $tool = new ProfilerTool();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Symfony profiler tools are not available in this Mate workspace.');
+
+        $tool->listProfiles();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Make the `ProfilerDataProvider` constructor argument optional on the `ProfilerResourceTemplate` and `ProfilerTool` MCP capabilities. When a Mate workspace doesn't provide one — e.g. because the host project has no Symfony profiler bundle wired up — the capabilities now throw a clear `Mate\Exception\RuntimeException` from a new `getDataProvider()` accessor instead of failing late on the first call.

This lets installations that don't ship the profiler still register the capabilities (e.g. through DI auto-configuration) without a hard requirement on `ProfilerDataProvider`.
