### PR TITLE
[Platform][Codex] Drop no-op --ask-for-approval flag from codex exec

### DIFF
--- a/src/platform/src/Bridge/Codex/ModelClient.php
+++ b/src/platform/src/Bridge/Codex/ModelClient.php
@@ -99,7 +99,12 @@ final class ModelClient implements ModelClientInterface
      */
     public function buildCommand(string $prompt, array $options = []): array
     {
-        $command = [$this->getCliBinary(), '--ask-for-approval', 'never', 'exec', '--json'];
+        if (isset($options['ask_for_approval'])) {
+            @trigger_error('The "ask_for_approval" option is ignored by "codex exec" and has no effect; remove it or use "dangerously_bypass_approvals_and_sandbox" to bypass approvals.', \E_USER_DEPRECATED);
+            unset($options['ask_for_approval']);
+        }
+
+        $command = [$this->getCliBinary(), 'exec', '--json'];
 
         foreach ($options as $key => $value) {
             $flag = self::OPTION_FLAG_MAP[$key] ?? '--'.str_replace('_', '-', $key);

--- a/src/platform/src/Bridge/Codex/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/ModelClientTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Codex\Tests;
 
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Codex\Codex;
 use Symfony\AI\Platform\Bridge\Codex\Exception\CliNotFoundException;
@@ -60,7 +61,7 @@ final class ModelClientTest extends TestCase
 
         $command = $client->buildCommand('Hello, World!');
 
-        $this->assertSame([self::$binary, '--ask-for-approval', 'never', 'exec', '--json', 'Hello, World!'], $command);
+        $this->assertSame([self::$binary, 'exec', '--json', 'Hello, World!'], $command);
     }
 
     public function testBuildCommandWithModel()
@@ -116,7 +117,6 @@ final class ModelClientTest extends TestCase
 
         $expected = [
             self::$binary,
-            '--ask-for-approval', 'never',
             'exec', '--json',
             '--model', 'gpt-5-codex',
             '--sandbox', 'workspace-write',
@@ -125,6 +125,35 @@ final class ModelClientTest extends TestCase
         ];
 
         $this->assertSame($expected, $command);
+    }
+
+    #[IgnoreDeprecations]
+    public function testBuildCommandTriggersDeprecationForAskForApproval()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $this->expectUserDeprecationMessageMatches('/ask_for_approval/');
+
+        $command = $client->buildCommand('Hello', ['ask_for_approval' => 'on-request']);
+
+        $this->assertNotContains('--ask-for-approval', $command);
+        $this->assertSame([self::$binary, 'exec', '--json', 'Hello'], $command);
+    }
+
+    public function testBuildCommandWithDangerouslyBypassApprovalsAndSandbox()
+    {
+        $client = new ModelClient(self::$binary);
+
+        $command = $client->buildCommand('Hello', [
+            'dangerously_bypass_approvals_and_sandbox' => true,
+        ]);
+
+        $this->assertSame([
+            self::$binary,
+            'exec', '--json',
+            '--dangerously-bypass-approvals-and-sandbox',
+            'Hello',
+        ], $command);
     }
 
     public function testBuildCommandRewritesToolsToAllowedTools()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The top-level `--ask-for-approval` flag is silently ignored by `codex exec` (verified against codex CLI 0.125.0): regardless of the value passed, the spawned session ends up with `approval_policy = "never"`. Hard-coding it on the command line — and accepting it as an option — gave callers a false sense that the value took effect.

This PR drops the flag from `ModelClient::buildCommand` and strips any caller-supplied `ask_for_approval` from the options array, so the bridge no longer pretends to honor a value the CLI ignores. The supported escape hatch when an exec session needs to actually run MCP tools is the existing `dangerously_bypass_approvals_and_sandbox` option, which maps to `--dangerously-bypass-approvals-and-sandbox` and is verified by an added test.

The existing `buildCommand` tests are updated to expect the trimmed argv, and two new tests cover (a) `ask_for_approval` being dropped silently and (b) `dangerously_bypass_approvals_and_sandbox` being forwarded.