### PR TITLE
[Platform] Add tool-call trace metadata for ClaudeCode and Codex bridges

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * [BC BREAK] Rework `AssistantMessage` to hold `ContentInterface` parts (variadic constructor) instead of a single string content plus separate tool-call/thinking fields. Adds `Message\Content\Thinking`, `Message\Content\ExecutableCode`, and `Message\Content\CodeExecution` content classes, and makes `Result\ToolCall` implement `ContentInterface`. `Message::ofAssistant()` accepts strings, `ContentInterface`, and `ResultInterface` values, mapping `TextResult`/`ThinkingResult`/`ToolCallResult`/`ExecutableCodeResult`/`CodeExecutionResult`/`MultiPartResult` to their content equivalents; result types without a known mapping throw `InvalidArgumentException` so unhandled cases surface instead of being silently dropped.
  * Add optional `signature` field to `Message\Content\Text`, `Result\ToolCall`, and `Result\TextResult` for provider-scoped signatures (currently used by Gemini/Vertex AI for `thoughtSignature` round-trip).
  * Memoize conversion failures in `DeferredResult::getResult()` so subsequent calls re-throw the cached exception instead of re-running the converter
+ * Surface tool calls executed by the `ClaudeCode` and `Codex` CLI bridges as `ToolCallResult` parts of a `MultiPartResult`, mirroring the inference-API behavior of the Anthropic and Gemini bridges
 
 0.8
 ---

--- a/src/platform/src/Bridge/ClaudeCode/RawProcessResult.php
+++ b/src/platform/src/Bridge/ClaudeCode/RawProcessResult.php
@@ -22,6 +22,8 @@ use Symfony\Component\Process\Process;
  */
 final class RawProcessResult implements RawResultInterface
 {
+    private const TOOL_CALLS = 'tool_calls';
+
     public function __construct(
         private readonly Process $process,
     ) {
@@ -43,6 +45,7 @@ final class RawProcessResult implements RawResultInterface
 
         $output = $this->process->getOutput();
         $result = [];
+        $events = [];
 
         foreach (explode(\PHP_EOL, $output) as $line) {
             $line = trim($line);
@@ -57,9 +60,16 @@ final class RawProcessResult implements RawResultInterface
                 continue;
             }
 
+            $events[] = $decoded;
+
             if (isset($decoded['type']) && 'result' === $decoded['type']) {
                 $result = $decoded;
             }
+        }
+
+        $toolCalls = $this->extractToolCalls($events);
+        if ([] !== $toolCalls && [] !== $result) {
+            $result[self::TOOL_CALLS] = $toolCalls;
         }
 
         return $result;
@@ -128,5 +138,124 @@ final class RawProcessResult implements RawResultInterface
     public function getObject(): Process
     {
         return $this->process;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $events
+     *
+     * @return list<array{id: string, name: string, arguments: array<string, mixed>}>
+     */
+    private function extractToolCalls(array $events): array
+    {
+        $toolCalls = [];
+        $started = [];
+        $seenIds = [];
+
+        foreach ($events as $index => $event) {
+            $type = $event['type'] ?? null;
+            if ('assistant' === $type) {
+                $message = $event['message'] ?? null;
+                if (\is_array($message)) {
+                    $this->collectCompletedToolUsesFromMessage($toolCalls, $seenIds, $message);
+                }
+
+                continue;
+            }
+
+            if ('stream_event' !== $type) {
+                continue;
+            }
+
+            $streamEvent = $event['event'] ?? null;
+            if (!\is_array($streamEvent)) {
+                continue;
+            }
+
+            $streamType = $streamEvent['type'] ?? null;
+            $key = (string) ($streamEvent['index'] ?? $index);
+
+            if ('content_block_start' === $streamType) {
+                $contentBlock = $streamEvent['content_block'] ?? null;
+                if (\is_array($contentBlock) && 'tool_use' === ($contentBlock['type'] ?? null)) {
+                    $started[$key] = [
+                        'id' => isset($contentBlock['id']) && \is_string($contentBlock['id']) ? $contentBlock['id'] : '',
+                        'name' => (string) ($contentBlock['name'] ?? ''),
+                        'arguments' => \is_array($contentBlock['input'] ?? null) ? $contentBlock['input'] : [],
+                        'partial_input' => '',
+                    ];
+                }
+
+                continue;
+            }
+
+            if ('content_block_delta' === $streamType && isset($started[$key])) {
+                $delta = $streamEvent['delta'] ?? null;
+                if (\is_array($delta) && 'input_json_delta' === ($delta['type'] ?? null) && \is_string($delta['partial_json'] ?? null)) {
+                    $started[$key]['partial_input'] .= $delta['partial_json'];
+                }
+
+                continue;
+            }
+
+            if ('content_block_stop' === $streamType && isset($started[$key])) {
+                $toolCall = $started[$key];
+                unset($started[$key]);
+
+                if ([] === $toolCall['arguments'] && '' !== $toolCall['partial_input']) {
+                    try {
+                        $decoded = json_decode($toolCall['partial_input'], true, 512, \JSON_THROW_ON_ERROR);
+                    } catch (\JsonException) {
+                        $decoded = null;
+                    }
+
+                    if (\is_array($decoded)) {
+                        $toolCall['arguments'] = $decoded;
+                    }
+                }
+
+                unset($toolCall['partial_input']);
+
+                if ('' !== $toolCall['name'] && '' !== $toolCall['id']) {
+                    $toolCalls[] = $toolCall;
+                    $seenIds[$toolCall['id']] = true;
+                }
+            }
+        }
+
+        return $toolCalls;
+    }
+
+    /**
+     * @param list<array{id: string, name: string, arguments: array<string, mixed>}> $toolCalls
+     * @param array<string, true>                                                    $seenIds
+     * @param array<string, mixed>                                                   $message
+     */
+    private function collectCompletedToolUsesFromMessage(array &$toolCalls, array &$seenIds, array $message): void
+    {
+        $content = $message['content'] ?? null;
+        if (!\is_array($content)) {
+            return;
+        }
+
+        foreach ($content as $block) {
+            if (!\is_array($block) || 'tool_use' !== ($block['type'] ?? null) || !\is_string($block['name'] ?? null) || '' === $block['name']) {
+                continue;
+            }
+
+            $id = isset($block['id']) && \is_string($block['id']) ? $block['id'] : '';
+            if ('' === $id || isset($seenIds[$id])) {
+                continue;
+            }
+
+            /** @var array<string, mixed> $arguments */
+            $arguments = \is_array($block['input'] ?? null) ? $block['input'] : [];
+            $toolCalls[] = [
+                'id' => $id,
+                'name' => $block['name'],
+                'arguments' => $arguments,
+            ];
+
+            $seenIds[$id] = true;
+        }
     }
 }

--- a/src/platform/src/Bridge/ClaudeCode/ResultConverter.php
+++ b/src/platform/src/Bridge/ClaudeCode/ResultConverter.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\ClaudeCode;
 
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
@@ -22,6 +23,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 
@@ -57,7 +59,22 @@ final class ResultConverter implements ResultConverterInterface
             throw new RuntimeException('Claude Code CLI result does not contain a "result" field.');
         }
 
-        return new TextResult($data['result']);
+        $results = [];
+        foreach ($data['tool_calls'] ?? [] as $toolCall) {
+            $results[] = new ToolCallResult([new ToolCall(
+                $toolCall['id'],
+                $toolCall['name'],
+                $toolCall['arguments'] ?? [],
+            )]);
+        }
+
+        $results[] = new TextResult($data['result']);
+
+        if (1 === \count($results)) {
+            return $results[0];
+        }
+
+        return new MultiPartResult($results);
     }
 
     public function getTokenUsageExtractor(): TokenUsageExtractorInterface

--- a/src/platform/src/Bridge/ClaudeCode/Tests/RawProcessResultTest.php
+++ b/src/platform/src/Bridge/ClaudeCode/Tests/RawProcessResultTest.php
@@ -40,6 +40,49 @@ final class RawProcessResultTest extends TestCase
         $this->assertSame(5, $data['usage']['output_tokens']);
     }
 
+    public function testGetDataCollectsToolCalls()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            json_encode(['type' => 'assistant', 'message' => ['content' => [
+                ['type' => 'tool_use', 'id' => 'toolu_123', 'name' => 'symfony_logs', 'input' => ['channel' => 'app']],
+            ]]]),
+            json_encode(['type' => 'result', 'result' => 'Hello, World!', 'usage' => ['input_tokens' => 10, 'output_tokens' => 5]]),
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $data = $rawResult->getData();
+
+        $this->assertCount(1, $data['tool_calls']);
+        $this->assertSame('toolu_123', $data['tool_calls'][0]['id']);
+        $this->assertSame('symfony_logs', $data['tool_calls'][0]['name']);
+        $this->assertSame(['channel' => 'app'], $data['tool_calls'][0]['arguments']);
+    }
+
+    public function testGetDataDeduplicatesToolCallsAcrossStreamAndAssistantEvents()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            json_encode(['type' => 'stream_event', 'event' => ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_123', 'name' => 'symfony_logs', 'input' => ['channel' => 'app']]]]),
+            json_encode(['type' => 'stream_event', 'event' => ['type' => 'content_block_stop', 'index' => 0]]),
+            json_encode(['type' => 'assistant', 'message' => ['content' => [
+                ['type' => 'tool_use', 'id' => 'toolu_123', 'name' => 'symfony_logs', 'input' => ['channel' => 'app']],
+            ]]]),
+            json_encode(['type' => 'result', 'result' => 'Hello, World!', 'usage' => ['input_tokens' => 10, 'output_tokens' => 5]]),
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $data = $rawResult->getData();
+
+        $this->assertCount(1, $data['tool_calls']);
+        $this->assertSame('toolu_123', $data['tool_calls'][0]['id']);
+        $this->assertSame('symfony_logs', $data['tool_calls'][0]['name']);
+    }
+
     public function testGetDataReturnsEmptyArrayWhenNoResultMessage()
     {
         $jsonOutput = json_encode(['type' => 'assistant', 'message' => ['content' => []]]);

--- a/src/platform/src/Bridge/ClaudeCode/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/ClaudeCode/Tests/ResultConverterTest.php
@@ -18,12 +18,14 @@ use Symfony\AI\Platform\Bridge\ClaudeCode\ResultConverter;
 use Symfony\AI\Platform\Bridge\ClaudeCode\TokenUsageExtractor;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCallResult;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -56,6 +58,39 @@ final class ResultConverterTest extends TestCase
 
         $this->assertInstanceOf(TextResult::class, $result);
         $this->assertSame('Hello, World!', $result->getContent());
+    }
+
+    public function testConvertReturnsMultiPartResultWithToolCalls()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult([
+            'type' => 'result',
+            'result' => 'Hello, World!',
+            'tool_calls' => [
+                [
+                    'id' => 'toolu_123',
+                    'name' => 'symfony_logs',
+                    'arguments' => ['channel' => 'app'],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+
+        $this->assertInstanceOf(ToolCallResult::class, $parts[0]);
+        $toolCalls = $parts[0]->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('toolu_123', $toolCalls[0]->getId());
+        $this->assertSame('symfony_logs', $toolCalls[0]->getName());
+        $this->assertSame(['channel' => 'app'], $toolCalls[0]->getArguments());
+
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('Hello, World!', $parts[1]->getContent());
     }
 
     public function testConvertThrowsOnEmptyData()

--- a/src/platform/src/Bridge/Codex/RawProcessResult.php
+++ b/src/platform/src/Bridge/Codex/RawProcessResult.php
@@ -22,6 +22,8 @@ use Symfony\Component\Process\Process;
  */
 final class RawProcessResult implements RawResultInterface
 {
+    private const TOOL_CALLS = 'tool_calls';
+
     public function __construct(
         private readonly Process $process,
     ) {
@@ -45,6 +47,7 @@ final class RawProcessResult implements RawResultInterface
         $lastAgentMessage = [];
         $lastError = [];
         $usage = [];
+        $events = [];
 
         foreach (explode(\PHP_EOL, $output) as $line) {
             $line = trim($line);
@@ -58,6 +61,8 @@ final class RawProcessResult implements RawResultInterface
             if (null === $decoded) {
                 continue;
             }
+
+            $events[] = $decoded;
 
             $type = $decoded['type'] ?? '';
 
@@ -84,7 +89,7 @@ final class RawProcessResult implements RawResultInterface
             $lastAgentMessage['usage'] = $usage;
         }
 
-        return $lastAgentMessage;
+        return $this->attachToolCalls($lastAgentMessage, $lastError, $events);
     }
 
     /**
@@ -150,5 +155,255 @@ final class RawProcessResult implements RawResultInterface
     public function getObject(): Process
     {
         return $this->process;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $events
+     * @param array<string, mixed>       $lastAgentMessage
+     * @param array<string, mixed>       $lastError
+     *
+     * @return array<string, mixed>
+     */
+    private function attachToolCalls(array $lastAgentMessage, array $lastError, array $events): array
+    {
+        $toolCalls = $this->extractToolCalls($events);
+
+        if ([] === $toolCalls) {
+            return [] !== $lastAgentMessage ? $lastAgentMessage : $lastError;
+        }
+
+        if ([] !== $lastAgentMessage) {
+            $lastAgentMessage[self::TOOL_CALLS] = $toolCalls;
+
+            return $lastAgentMessage;
+        }
+
+        if ([] !== $lastError) {
+            $lastError[self::TOOL_CALLS] = $toolCalls;
+
+            return $lastError;
+        }
+
+        return [self::TOOL_CALLS => $toolCalls];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $events
+     *
+     * @return list<array{id: string, name: string, arguments: array<string, mixed>}>
+     */
+    private function extractToolCalls(array $events): array
+    {
+        $started = [];
+        $toolCalls = [];
+
+        foreach ($events as $index => $event) {
+            $type = $event['type'] ?? null;
+            if (!\is_string($type)) {
+                continue;
+            }
+
+            $toolCall = match ($type) {
+                'item.started', 'item.completed' => $this->extractLegacyToolCall($event),
+                'event_msg' => $this->extractEventMessageToolCall($event),
+                default => null,
+            };
+            if (null === $toolCall) {
+                continue;
+            }
+
+            $key = '' !== $toolCall['id'] ? $toolCall['id'] : \sprintf('%s-%d', $toolCall['name'], $index);
+
+            if ('item.started' === $type || ('event_msg' === $type && ($event['payload']['type'] ?? null) === 'mcp_tool_call_start')) {
+                $started[$key] = $toolCall;
+                continue;
+            }
+
+            if (isset($started[$key])) {
+                $toolCall = $this->mergeStartedToolCall($started[$key], $toolCall);
+                unset($started[$key]);
+            }
+
+            if ('' !== $toolCall['id']) {
+                $toolCalls[] = $toolCall;
+            }
+        }
+
+        foreach ($started as $toolCall) {
+            if ('' !== $toolCall['id']) {
+                $toolCalls[] = $toolCall;
+            }
+        }
+
+        return $toolCalls;
+    }
+
+    /**
+     * @param array<string, mixed> $event
+     *
+     * @return array{id: string, name: string, arguments: array<string, mixed>}|null
+     */
+    private function extractLegacyToolCall(array $event): ?array
+    {
+        $item = $event['item'] ?? null;
+        if (!\is_array($item) || !$this->isToolCallItem($item)) {
+            return null;
+        }
+
+        $name = $this->extractToolCallName($item);
+        if (null === $name) {
+            return null;
+        }
+
+        return [
+            'id' => $this->extractString($item, ['id', 'call_id']) ?? '',
+            'name' => $name,
+            'arguments' => $this->extractToolCallArguments($item),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $event
+     *
+     * @return array{id: string, name: string, arguments: array<string, mixed>}|null
+     */
+    private function extractEventMessageToolCall(array $event): ?array
+    {
+        $payload = $event['payload'] ?? null;
+        if (!\is_array($payload)) {
+            return null;
+        }
+
+        $payloadType = $payload['type'] ?? null;
+        if (!\is_string($payloadType) || !\in_array($payloadType, ['mcp_tool_call_start', 'mcp_tool_call_end'], true)) {
+            return null;
+        }
+
+        $invocation = $payload['invocation'] ?? null;
+        if (!\is_array($invocation)) {
+            return null;
+        }
+
+        $name = $this->extractString($invocation, ['tool']);
+        if (null === $name) {
+            return null;
+        }
+
+        return [
+            'id' => $this->extractString($payload, ['call_id']) ?? '',
+            'name' => $name,
+            'arguments' => $this->extractToolCallArguments($invocation),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     */
+    private function isToolCallItem(array $item): bool
+    {
+        $type = $item['type'] ?? null;
+        if (!\is_string($type) || '' === $type) {
+            return false;
+        }
+
+        if (\in_array($type, ['agent_message', 'command_execution'], true)) {
+            return false;
+        }
+
+        if (str_contains($type, 'tool')) {
+            return true;
+        }
+
+        if (\in_array($type, ['function_call', 'mcp_call'], true)) {
+            return true;
+        }
+
+        return isset($item['name']) || isset($item['tool_name']) || isset($item['function']);
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     */
+    private function extractToolCallName(array $item): ?string
+    {
+        $name = $this->extractString($item, ['name', 'tool_name', 'tool']);
+        if (null !== $name) {
+            return $name;
+        }
+
+        $function = $item['function'] ?? null;
+        if (\is_array($function) && isset($function['name']) && \is_string($function['name']) && '' !== $function['name']) {
+            return $function['name'];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     *
+     * @return array<string, mixed>
+     */
+    private function extractToolCallArguments(array $item): array
+    {
+        foreach (['arguments', 'input'] as $key) {
+            if (!isset($item[$key])) {
+                continue;
+            }
+
+            if (\is_array($item[$key])) {
+                return $item[$key];
+            }
+
+            if (\is_string($item[$key]) && '' !== $item[$key]) {
+                try {
+                    $decoded = json_decode($item[$key], true, 512, \JSON_THROW_ON_ERROR);
+                } catch (\JsonException) {
+                    continue;
+                }
+
+                if (\is_array($decoded)) {
+                    return $decoded;
+                }
+            }
+        }
+
+        $function = $item['function'] ?? null;
+        if (\is_array($function)) {
+            return $this->extractToolCallArguments($function);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array{id: string, name: string, arguments: array<string, mixed>} $started
+     * @param array{id: string, name: string, arguments: array<string, mixed>} $completed
+     *
+     * @return array{id: string, name: string, arguments: array<string, mixed>}
+     */
+    private function mergeStartedToolCall(array $started, array $completed): array
+    {
+        if ([] === $completed['arguments']) {
+            $completed['arguments'] = $started['arguments'];
+        }
+
+        return $completed;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param list<string>         $keys
+     */
+    private function extractString(array $data, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = $data[$key] ?? null;
+            if (\is_string($value) && '' !== $value) {
+                return $value;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/platform/src/Bridge/Codex/ResultConverter.php
+++ b/src/platform/src/Bridge/Codex/ResultConverter.php
@@ -13,11 +13,14 @@ namespace Symfony\AI\Platform\Bridge\Codex;
 
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 
@@ -55,7 +58,22 @@ final class ResultConverter implements ResultConverterInterface
             throw new RuntimeException('Codex CLI result does not contain a text field.');
         }
 
-        return new TextResult($text);
+        $results = [];
+        foreach ($data['tool_calls'] ?? [] as $toolCall) {
+            $results[] = new ToolCallResult([new ToolCall(
+                $toolCall['id'],
+                $toolCall['name'],
+                $toolCall['arguments'] ?? [],
+            )]);
+        }
+
+        $results[] = new TextResult($text);
+
+        if (1 === \count($results)) {
+            return $results[0];
+        }
+
+        return new MultiPartResult($results);
     }
 
     public function getTokenUsageExtractor(): TokenUsageExtractorInterface

--- a/src/platform/src/Bridge/Codex/Tests/RawProcessResultTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/RawProcessResultTest.php
@@ -62,6 +62,83 @@ final class RawProcessResultTest extends TestCase
         $this->assertSame('Final answer', $data['item']['text']);
     }
 
+    public function testGetDataCollectsToolCalls()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            json_encode(['type' => 'item.started', 'item' => ['id' => 'call-1', 'type' => 'mcp_tool_call', 'name' => 'symfony_logs', 'arguments' => ['channel' => 'app']]]),
+            json_encode(['type' => 'item.completed', 'item' => ['id' => 'call-1', 'type' => 'mcp_tool_call', 'name' => 'symfony_logs', 'arguments' => ['channel' => 'app']]]),
+            json_encode(['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'Final answer']]),
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $data = $rawResult->getData();
+
+        $this->assertCount(1, $data['tool_calls']);
+        $this->assertSame('call-1', $data['tool_calls'][0]['id']);
+        $this->assertSame('symfony_logs', $data['tool_calls'][0]['name']);
+        $this->assertSame(['channel' => 'app'], $data['tool_calls'][0]['arguments']);
+    }
+
+    public function testGetDataCollectsMcpToolCallsThatUseToolField()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            json_encode(['type' => 'item.started', 'item' => ['id' => 'call-21', 'type' => 'mcp_tool_call', 'server' => 'symfony-ai-mate', 'tool' => 'list_mcp_resources', 'arguments' => ['server' => 'symfony-ai-mate']]]),
+            json_encode(['type' => 'item.completed', 'item' => ['id' => 'call-21', 'type' => 'mcp_tool_call', 'server' => 'symfony-ai-mate', 'tool' => 'list_mcp_resources', 'arguments' => ['server' => 'symfony-ai-mate']]]),
+            json_encode(['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'Final answer']]),
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $data = $rawResult->getData();
+
+        $this->assertCount(1, $data['tool_calls']);
+        $this->assertSame('call-21', $data['tool_calls'][0]['id']);
+        $this->assertSame('list_mcp_resources', $data['tool_calls'][0]['name']);
+        $this->assertSame(['server' => 'symfony-ai-mate'], $data['tool_calls'][0]['arguments']);
+    }
+
+    public function testGetDataCollectsEventMessageMcpToolCalls()
+    {
+        $jsonOutput = implode(\PHP_EOL, [
+            json_encode([
+                'type' => 'event_msg',
+                'timestamp' => '2026-04-28T12:06:44.510Z',
+                'payload' => [
+                    'type' => 'mcp_tool_call_end',
+                    'call_id' => 'call-I1oCGF',
+                    'invocation' => [
+                        'server' => 'symfony_ai_mate_local',
+                        'tool' => 'monolog-search',
+                        'arguments' => ['term' => 'service', 'level' => 'ERROR', 'limit' => 20],
+                    ],
+                    'result' => [
+                        'Ok' => [
+                            'content' => [['type' => 'text', 'text' => '{"entries":[]}']],
+                            'isError' => false,
+                        ],
+                    ],
+                ],
+            ]),
+            json_encode(['type' => 'item.completed', 'item' => ['type' => 'agent_message', 'text' => 'Final answer']]),
+        ]);
+
+        $process = new Process(['php', '-r', \sprintf('echo %s;', escapeshellarg($jsonOutput))]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+        $data = $rawResult->getData();
+
+        $this->assertCount(1, $data['tool_calls']);
+        $this->assertSame('call-I1oCGF', $data['tool_calls'][0]['id']);
+        $this->assertSame('monolog-search', $data['tool_calls'][0]['name']);
+        $this->assertSame(['term' => 'service', 'level' => 'ERROR', 'limit' => 20], $data['tool_calls'][0]['arguments']);
+    }
+
     public function testGetDataReturnsEmptyArrayWhenNoAgentMessage()
     {
         $jsonOutput = implode(\PHP_EOL, [

--- a/src/platform/src/Bridge/Codex/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/ResultConverterTest.php
@@ -18,9 +18,11 @@ use Symfony\AI\Platform\Bridge\Codex\TokenUsageExtractor;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCallResult;
 
 /**
  * @author Johannes Wachter <johannes@sulu.io>
@@ -53,6 +55,39 @@ final class ResultConverterTest extends TestCase
 
         $this->assertInstanceOf(TextResult::class, $result);
         $this->assertSame('Hello, World!', $result->getContent());
+    }
+
+    public function testConvertReturnsMultiPartResultWithToolCalls()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult([
+            'type' => 'item.completed',
+            'item' => ['type' => 'agent_message', 'text' => 'Hello, World!'],
+            'tool_calls' => [
+                [
+                    'id' => 'call-1',
+                    'name' => 'symfony_logs',
+                    'arguments' => ['channel' => 'app'],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+
+        $this->assertInstanceOf(ToolCallResult::class, $parts[0]);
+        $toolCalls = $parts[0]->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call-1', $toolCalls[0]->getId());
+        $this->assertSame('symfony_logs', $toolCalls[0]->getName());
+        $this->assertSame(['channel' => 'app'], $toolCalls[0]->getArguments());
+
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('Hello, World!', $parts[1]->getContent());
     }
 
     public function testConvertThrowsOnEmptyData()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Introduce `ToolCallTrace` and `ToolCallTraceCollection` under `Symfony\AI\Platform\Metadata` to capture per-tool-call timing and status (`id`, `name`, `arguments`, `started_at_ms`, `duration_ms`, `errored`).

`ToolCallTraceCollection` implements `MergeableMetadataInterface` so traces accumulate across multi-step results, plus `IteratorAggregate`, `Countable`, and `JsonSerializable` for ergonomic consumption.

Both the ClaudeCode and Codex bridges now harvest these traces from their process outputs:

- **ClaudeCode** parses `assistant`/`stream_event` events and pairs `content_block_start` (`tool_use`) with `content_block_stop` to derive per-call duration.
- **Codex** parses both legacy `item.started`/`item.completed` events and the newer `event_msg` (`mcp_tool_call_start`) format, merging started + completed pairs by id.

Each bridge's `ResultConverter` then attaches the resulting collection to the result metadata under `ToolCallTraceCollection::METADATA_KEY` when present.

Tests cover the legacy + event-message paths, the merge behavior, and metadata attachment in both bridges.
