### PR TITLE
[Platform][Bedrock] Fix Anthropic Claude model ID mapping

### DIFF
--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
@@ -24,10 +24,42 @@ use Symfony\AI\Platform\ModelClientInterface;
  */
 final class ClaudeModelClient implements ModelClientInterface
 {
+    /**
+     * Bedrock model identifiers differ from Anthropic API names — some require version suffixes,
+     * others don't. See https://platform.claude.com/docs/en/about-claude/models/overview for details.
+     *
+     * @var array<string, string>
+     */
+    private const MODEL_MAP = [
+        'claude-opus-4-7' => 'claude-opus-4-7',
+        'claude-sonnet-4-6' => 'claude-sonnet-4-6',
+        'claude-opus-4-6' => 'claude-opus-4-6-v1',
+        'claude-haiku-4-5-20251001' => 'claude-haiku-4-5-20251001-v1:0',
+        'claude-sonnet-4-5-20250929' => 'claude-sonnet-4-5-20250929-v1:0',
+        'claude-opus-4-5-20251101' => 'claude-opus-4-5-20251101-v1:0',
+        'claude-opus-4-1-20250805' => 'claude-opus-4-1-20250805-v1:0',
+        'claude-sonnet-4-20250514' => 'claude-sonnet-4-20250514-v1:0',
+        'claude-opus-4-20250514' => 'claude-opus-4-20250514-v1:0',
+        'claude-3-sonnet-20240229' => 'claude-3-sonnet-20240229-v1:0',
+        'claude-3-haiku-20240307' => 'claude-3-haiku-20240307-v1:0',
+        'claude-3-5-haiku-20241022' => 'claude-3-5-haiku-20241022-v1:0',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private readonly array $modelMap;
+
+    /**
+     * @param array<string, string> $modelOverrides additional or overriding entries for the model ID map,
+     *                                              keyed by Anthropic model name with Bedrock model ID as value
+     */
     public function __construct(
         private readonly BedrockRuntimeClient $bedrockRuntimeClient,
         private readonly string $version = '2023-05-31',
+        array $modelOverrides = [],
     ) {
+        $this->modelMap = array_replace(self::MODEL_MAP, $modelOverrides);
     }
 
     public function supports(Model $model): bool
@@ -72,9 +104,9 @@ final class ClaudeModelClient implements ModelClientInterface
 
     private function getModelId(Model $model): string
     {
-        $configuredRegion = $this->bedrockRuntimeClient->getConfiguration()->get('region');
-        $regionPrefix = substr((string) $configuredRegion, 0, 2);
+        $regionPrefix = substr((string) $this->bedrockRuntimeClient->getConfiguration()->get('region'), 0, 2);
+        $name = $model->getName();
 
-        return $regionPrefix.'.anthropic.'.$model->getName().'-v1:0';
+        return $regionPrefix.'.anthropic.'.($this->modelMap[$name] ?? $name);
     }
 }

--- a/src/platform/src/Bridge/Bedrock/ModelCatalog.php
+++ b/src/platform/src/Bridge/Bedrock/ModelCatalog.php
@@ -157,6 +157,17 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::TOOL_CALLING,
                 ],
             ],
+            'claude-opus-4-7' => [
+                'class' => Claude::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
             'llama-3.2-1b-instruct' => [
                 'class' => Llama::class,
                 'capabilities' => [

--- a/src/platform/src/Bridge/Bedrock/Tests/Anthropic/ClaudeModelClientTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/Anthropic/ClaudeModelClientTest.php
@@ -31,7 +31,7 @@ final class ClaudeModelClientTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->model = new Claude('claude-sonnet-4-5-20250929');
+        $this->model = new Claude('claude-sonnet-4-6');
         $this->bedrockClient = $this->getMockBuilder(BedrockRuntimeClient::class)
             ->setConstructorArgs([
                 Configuration::create([Configuration::OPTION_REGION => Configuration::DEFAULT_REGION]),
@@ -40,13 +40,13 @@ final class ClaudeModelClientTest extends TestCase
             ->getMock();
     }
 
-    public function testPassesModelId()
+    public function testPassesModelIdWithoutSuffix()
     {
         $this->bedrockClient->expects($this->once())
             ->method('invokeModel')
             ->with($this->callback(function ($arg) {
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
-                $this->assertSame('us.anthropic.claude-sonnet-4-5-20250929-v1:0', $arg->getModelId());
+                $this->assertSame('us.anthropic.claude-sonnet-4-6', $arg->getModelId());
                 $this->assertSame('application/json', $arg->getContentType());
                 $this->assertTrue(json_validate($arg->getBody()));
 
@@ -57,6 +57,82 @@ final class ClaudeModelClientTest extends TestCase
         $this->modelClient = new ClaudeModelClient($this->bedrockClient, self::VERSION);
 
         $response = $this->modelClient->request($this->model, ['message' => 'test']);
+        $this->assertInstanceOf(RawBedrockResult::class, $response);
+    }
+
+    public function testPassesModelIdWithVersionSuffix()
+    {
+        $this->bedrockClient->expects($this->once())
+            ->method('invokeModel')
+            ->with($this->callback(function ($arg) {
+                $this->assertInstanceOf(InvokeModelRequest::class, $arg);
+                $this->assertSame('us.anthropic.claude-sonnet-4-5-20250929-v1:0', $arg->getModelId());
+
+                return true;
+            }))
+            ->willReturn($this->createMock(InvokeModelResponse::class));
+
+        $this->modelClient = new ClaudeModelClient($this->bedrockClient, self::VERSION);
+
+        $response = $this->modelClient->request(new Claude('claude-sonnet-4-5-20250929'), ['message' => 'test']);
+        $this->assertInstanceOf(RawBedrockResult::class, $response);
+    }
+
+    public function testPassesModelIdWithV1Suffix()
+    {
+        $this->bedrockClient->expects($this->once())
+            ->method('invokeModel')
+            ->with($this->callback(function ($arg) {
+                $this->assertInstanceOf(InvokeModelRequest::class, $arg);
+                $this->assertSame('us.anthropic.claude-opus-4-6-v1', $arg->getModelId());
+
+                return true;
+            }))
+            ->willReturn($this->createMock(InvokeModelResponse::class));
+
+        $this->modelClient = new ClaudeModelClient($this->bedrockClient, self::VERSION);
+
+        $response = $this->modelClient->request(new Claude('claude-opus-4-6'), ['message' => 'test']);
+        $this->assertInstanceOf(RawBedrockResult::class, $response);
+    }
+
+    public function testPassesModelIdWithCustomOverride()
+    {
+        $this->bedrockClient->expects($this->once())
+            ->method('invokeModel')
+            ->with($this->callback(function ($arg) {
+                $this->assertInstanceOf(InvokeModelRequest::class, $arg);
+                $this->assertSame('us.anthropic.claude-custom-model-v2:0', $arg->getModelId());
+
+                return true;
+            }))
+            ->willReturn($this->createMock(InvokeModelResponse::class));
+
+        $this->modelClient = new ClaudeModelClient(
+            $this->bedrockClient,
+            self::VERSION,
+            ['claude-custom-model' => 'claude-custom-model-v2:0']
+        );
+
+        $response = $this->modelClient->request(new Claude('claude-custom-model'), ['message' => 'test']);
+        $this->assertInstanceOf(RawBedrockResult::class, $response);
+    }
+
+    public function testPassesUnknownModelNameAsIs()
+    {
+        $this->bedrockClient->expects($this->once())
+            ->method('invokeModel')
+            ->with($this->callback(function ($arg) {
+                $this->assertInstanceOf(InvokeModelRequest::class, $arg);
+                $this->assertSame('us.anthropic.claude-unknown-model', $arg->getModelId());
+
+                return true;
+            }))
+            ->willReturn($this->createMock(InvokeModelResponse::class));
+
+        $this->modelClient = new ClaudeModelClient($this->bedrockClient, self::VERSION);
+
+        $response = $this->modelClient->request(new Claude('claude-unknown-model'), ['message' => 'test']);
         $this->assertInstanceOf(RawBedrockResult::class, $response);
     }
 

--- a/src/platform/src/Bridge/Bedrock/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/ModelCatalogTest.php
@@ -39,6 +39,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'claude-opus-4-5-20251101' => ['claude-opus-4-5-20251101', Claude::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
         yield 'claude-sonnet-4-6' => ['claude-sonnet-4-6', Claude::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
         yield 'claude-opus-4-6' => ['claude-opus-4-6', Claude::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
+        yield 'claude-opus-4-7' => ['claude-opus-4-7', Claude::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::TOOL_CALLING]];
         yield 'llama-3.2-1b-instruct' => ['llama-3.2-1b-instruct', Llama::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]];
         yield 'llama-3.2-3b-instruct' => ['llama-3.2-3b-instruct', Llama::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | no
| License       | MIT

Bedrock model identifiers for Anthropic Claude models follow inconsistent naming conventions - some require version suffixes like `-v1:0` or `-v1`, while others (such as the new Claude Opus 4.7) require none.

This change introduces a model map to correctly resolve Bedrock IDs based on the Anthropic model name, allows for constructor overrides, and adds support for `claude-opus-4-7`, `claude-sonnet-4-6` and `claude-opus-4-6`.