### PR TITLE
[AI Bundle] Fix ValidateToolCallArgumentsListener registration when a agent is not installed

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -374,6 +374,7 @@ final class AiBundle extends AbstractBundle
             $builder->removeDefinition('ai.tool_result_converter');
             $builder->removeDefinition('ai.tool_call_argument_resolver');
             $builder->removeDefinition('ai.tool.agent_processor.abstract');
+            $builder->removeDefinition('ai.tool.validate_tool_call_arguments_listener');
         }
 
         if (!ContainerBuilder::willBeAvailable('symfony/ai-store', StoreInterface::class, ['symfony/ai-bundle'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

When using `symfony/ai-bundle` with `symfony/ai-platform` and `symfony/validator` but without `symfony/ai-agent`, `lint:container` fails because `ai.tool.validate_tool_call_arguments_listener` references `Symfony\AI\Agent\Toolbox\EventListener\ValidateToolCallArgumentsListener` which only exists in `symfony/ai-agent`.

This was the only ai-agent-dependent service missing from the existing removal block in `AiBundle::loadExtension()`. Mirrors the pattern used for the other 6 services in the same condition.

### Reproducer

```bash
composer create-project symfony/skeleton:^7.4 test-bug --stability=dev
cd test-bug
composer require symfony/ai-bundle:^0.7 symfony/ai-platform:^0.7 symfony/validator:^7.4
bin/console lint:container
```

Before the fix:
```
Invalid service "ai.tool.validate_tool_call_arguments_listener":
class "...ValidateToolCallArgumentsListener" does not exist.
```

After the fix: `lint:container` passes.
