### PR TITLE
[Agent] Fix denormalization of float properties

### DIFF
--- a/src/agent/src/Toolbox/ToolCallArgumentResolver.php
+++ b/src/agent/src/Toolbox/ToolCallArgumentResolver.php
@@ -90,8 +90,8 @@ final class ToolCallArgumentResolver implements ToolCallArgumentResolverInterfac
 
             $parameterType .= $dimensions;
 
-            if ($this->denormalizer->supportsDenormalization($value, $parameterType)) {
-                $value = $this->denormalizer->denormalize($value, $parameterType);
+            if ($this->denormalizer->supportsDenormalization($value, $parameterType, 'json')) {
+                $value = $this->denormalizer->denormalize($value, $parameterType, 'json');
             }
 
             $arguments[$name] = $value;

--- a/src/agent/tests/Fixtures/Tool/ToolObjectFloat.php
+++ b/src/agent/tests/Fixtures/Tool/ToolObjectFloat.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+
+#[AsTool('tool_object_float', 'A tool with object parameter with float property')]
+final class ToolObjectFloat
+{
+    public float $height;
+
+    public function __invoke(self $person): string
+    {
+        return \sprintf('Height: %.2fm', $person->height);
+    }
+}

--- a/src/agent/tests/Toolbox/ToolCallArgumentResolverTest.php
+++ b/src/agent/tests/Toolbox/ToolCallArgumentResolverTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolArray;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolArrayMultidimensional;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolDate;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolNoParams;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolObjectFloat;
 use Symfony\AI\Agent\Toolbox\ToolCallArgumentResolver;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\SomeStructure;
@@ -84,5 +85,17 @@ class ToolCallArgumentResolverTest extends TestCase
         ]);
 
         $this->assertSame([], $resolver->resolveArguments($metadata, $toolCall));
+    }
+
+    public function testIntCastToFloat()
+    {
+        $resolver = new ToolCallArgumentResolver();
+
+        $metadata = new Tool(new ExecutionReference(ToolObjectFloat::class, '__invoke'), 'tool_object_float', 'A tool with object');
+        $toolCall = new ToolCall('tool_id_1234', 'tool_object_float', ['person' => ['height' => 1]]);
+
+        $personArgument = $resolver->resolveArguments($metadata, $toolCall)['person'];
+        $this->assertInstanceOf(ToolObjectFloat::class, $personArgument);
+        $this->assertSame(1.0, $personArgument->height);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #2011
| License       | MIT

Pass `'json'` as `format` when denormalizing the arguments