### PR TITLE
[Mate] Make json-input argument optional in mcp:tools:call

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
  * Allow Symfony profiler capabilities (`ProfilerResourceTemplate` and `ProfilerTool`) to be instantiated without a `ProfilerDataProvider`, throwing a clear `RuntimeException` when invoked in workspaces without profiler support
  * Add `--ignore-missing-file` option to the `discover` command that exits successfully without doing any work when `mate/extensions.php` does not exist (intended for unconditional invocation from Composer scripts wired by the Symfony Flex recipe)
+ * Make `json-input` argument optional in `mcp:tools:call` command (defaults to `{}`)
 
 0.7
 ---

--- a/src/mate/src/Command/ToolsCallCommand.php
+++ b/src/mate/src/Command/ToolsCallCommand.php
@@ -66,7 +66,7 @@ class ToolsCallCommand extends Command
     {
         $this
             ->addArgument('tool-name', InputArgument::REQUIRED, 'Name of the tool to execute')
-            ->addArgument('json-input', InputArgument::REQUIRED, 'JSON object with tool parameters')
+            ->addArgument('json-input', InputArgument::OPTIONAL, 'JSON object with tool parameters', '{}')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (json, pretty, toon)', 'pretty')
             ->setHelp(
                 <<<'HELP'
@@ -77,11 +77,14 @@ The <info>%command.name%</info> command executes MCP tools with JSON input param
   <comment># Execute a tool with parameters</comment>
   %command.full_name% search-logs '{"query": "error", "level": "error"}'
 
+  <comment># Execute tool without parameters (defaults to '{}')</comment>
+  %command.full_name% server-info
+
   <comment># Execute tool with empty parameters</comment>
-  %command.full_name% php-version '{}'
+  %command.full_name% server-info '{}'
 
   <comment># JSON output format</comment>
-  %command.full_name% php-version '{}' --format=json
+  %command.full_name% server-info --format=json
 
   <comment># For a list of available tools, use:</comment>
   bin/mate.php mcp:tools:list

--- a/src/mate/tests/Command/ToolsCallCommandTest.php
+++ b/src/mate/tests/Command/ToolsCallCommandTest.php
@@ -50,6 +50,27 @@ final class ToolsCallCommandTest extends TestCase
         $this->assertStringContainsString(\PHP_VERSION, $output);
     }
 
+    public function testExecuteWithoutJsonInputUsesDefault()
+    {
+        $rootDir = __DIR__.'/../..';
+        $extensions = [
+            '_custom' => ['dirs' => ['src/Capability'], 'includes' => []],
+        ];
+
+        $command = $this->createCommand($rootDir, $extensions);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'tool-name' => 'server-info',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Executing Tool: server-info', $output);
+        $this->assertStringContainsString('Result', $output);
+        $this->assertStringContainsString(\PHP_VERSION, $output);
+    }
+
     public function testExecuteWithJsonFormat()
     {
         $rootDir = __DIR__.'/../..';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Defaults the `json-input` argument of the `mcp:tools:call` command to `'{}'`, so tools that don't require parameters can be invoked without explicitly passing an empty JSON object.

Before:

```bash
vendor/bin/mate mcp:tools:call sulu-info '{}'
```

After (both still work):

```bash
vendor/bin/mate mcp:tools:call sulu-info
vendor/bin/mate mcp:tools:call sulu-info '{}'
```