### PR TITLE
[Mate] Add mcp:resources:read command

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.9
 ---
 
+ * Add `ResourcesReadCommand` (`mcp:resources:read`) to read MCP resources by URI from the CLI
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
 
 0.7

--- a/src/mate/CLAUDE.md
+++ b/src/mate/CLAUDE.md
@@ -58,6 +58,10 @@ bin/mate mcp:tools:inspect server-info --format=json  # Output in JSON format
 # Tool execution
 bin/mate mcp:tools:call server-info '{}'    # Execute tool with parameters
 bin/mate mcp:tools:call server-info '{}' --format=json    # JSON output format
+
+# Resource reading
+bin/mate mcp:resources:read symfony-profiler://profile/abc123   # Read a resource by URI
+bin/mate mcp:resources:read symfony-profiler://profile/abc123 --format=json   # JSON output format
 ```
 
 ## Architecture
@@ -69,7 +73,7 @@ bin/mate mcp:tools:call server-info '{}' --format=json    # JSON output format
 - **FilteredDiscoveryLoader**: Loads MCP capabilities with feature filtering
 
 ### Key Directories
-- `src/Command/`: CLI commands (serve, init, discover, clear-cache, debug:capabilities, debug:extensions, mcp:tools:list, mcp:tools:inspect, mcp:tools:call)
+- `src/Command/`: CLI commands (serve, init, discover, clear-cache, debug:capabilities, debug:extensions, mcp:tools:list, mcp:tools:inspect, mcp:tools:call, mcp:resources:read)
 - `src/Container/`: DI container management
 - `src/Discovery/`: Extension discovery system
 - `src/Capability/`: Built-in MCP tools

--- a/src/mate/src/App.php
+++ b/src/mate/src/App.php
@@ -18,6 +18,7 @@ use Symfony\AI\Mate\Command\DebugCapabilitiesCommand;
 use Symfony\AI\Mate\Command\DebugExtensionsCommand;
 use Symfony\AI\Mate\Command\DiscoverCommand;
 use Symfony\AI\Mate\Command\InitCommand;
+use Symfony\AI\Mate\Command\ResourcesReadCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
 use Symfony\AI\Mate\Command\StopCommand;
 use Symfony\AI\Mate\Command\ToolsCallCommand;
@@ -52,6 +53,7 @@ final class App
             ToolsListCommand::class,
             ToolsInspectCommand::class,
             ToolsCallCommand::class,
+            ResourcesReadCommand::class,
         ];
 
         foreach ($commands as $commandClass) {

--- a/src/mate/src/Command/ResourcesReadCommand.php
+++ b/src/mate/src/Command/ResourcesReadCommand.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command;
+
+use HelgeSverre\Toon\Toon;
+use Mcp\Capability\Registry\ReferenceHandler;
+use Mcp\Capability\Registry\ResourceTemplateReference;
+use Mcp\Capability\RegistryInterface;
+use Mcp\Exception\ResourceNotFoundException;
+use Mcp\Schema\Content\BlobResourceContents;
+use Mcp\Schema\Content\ResourceContents;
+use Mcp\Schema\Content\TextResourceContents;
+use Mcp\Schema\Request\ReadResourceRequest;
+use Symfony\AI\Mate\Command\Session\CliSession;
+use Symfony\AI\Mate\Command\Trait\EnsuresToonFormatAvailabilityTrait;
+use Symfony\AI\Mate\Service\RegistryProvider;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Read MCP resources by URI.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('mcp:resources:read', 'Read MCP resources by URI')]
+class ResourcesReadCommand extends Command
+{
+    use EnsuresToonFormatAvailabilityTrait;
+
+    private RegistryInterface $registry;
+    private ReferenceHandler $referenceHandler;
+
+    public function __construct(
+        RegistryProvider $registryProvider,
+        ContainerInterface $container,
+    ) {
+        parent::__construct(self::getDefaultName());
+
+        $this->registry = $registryProvider->getRegistry();
+        $this->referenceHandler = new ReferenceHandler($container);
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'mcp:resources:read';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Read MCP resources by URI';
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('uri', InputArgument::REQUIRED, 'URI of the resource to read')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (pretty, json, toon)', 'pretty')
+            ->setHelp(
+                <<<'HELP'
+The <info>%command.name%</info> command reads an MCP resource by its URI.
+
+Both static resource URIs and URIs matching a registered resource template are supported.
+
+<info>Usage Examples:</info>
+
+  <comment># Read a static resource</comment>
+  %command.full_name% file:///path/to/resource
+
+  <comment># Read a templated resource (URI matched against registered templates)</comment>
+  %command.full_name% symfony-profiler://profile/abc123
+
+  <comment># JSON output format</comment>
+  %command.full_name% symfony-profiler://profile/abc123 --format=json
+
+  <comment># For a list of available resource templates, use:</comment>
+  bin/mate.php debug:capabilities --type=resource
+  bin/mate.php debug:capabilities --type=template
+HELP
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $verbose = $output->isVerbose();
+
+        $uri = $input->getArgument('uri');
+        \assert(\is_string($uri));
+
+        $format = $input->getOption('format');
+        \assert(\is_string($format));
+
+        if (!$this->ensureToonFormatAvailable($io, $format)) {
+            return Command::FAILURE;
+        }
+
+        try {
+            $reference = $this->registry->getResource($uri);
+        } catch (ResourceNotFoundException $e) {
+            $io->error(\sprintf('Resource "%s" not found', $uri));
+            $io->note('Use "bin/mate.php debug:capabilities --type=resource" to see all available resources');
+
+            return Command::FAILURE;
+        }
+
+        $session = new CliSession();
+        $request = new ReadResourceRequest(uri: $uri);
+
+        $arguments = [
+            'uri' => $uri,
+            '_session' => $session,
+            '_request' => $request,
+        ];
+
+        if ($reference instanceof ResourceTemplateReference) {
+            $arguments = array_merge($arguments, $reference->extractVariables($uri));
+            $mimeType = $reference->resourceTemplate->mimeType;
+            $name = $reference->resourceTemplate->name;
+            $description = $reference->resourceTemplate->description;
+        } else {
+            $mimeType = $reference->resource->mimeType;
+            $name = $reference->resource->name;
+            $description = $reference->resource->description;
+        }
+
+        if ('pretty' === $format) {
+            $io->title(\sprintf('Reading Resource: %s', $uri));
+            $io->text(\sprintf('<info>Name:</info> %s', $name));
+            if (null !== $description) {
+                $io->text($description);
+            }
+            $io->newLine();
+        }
+
+        try {
+            $result = $this->referenceHandler->handle($reference, $arguments);
+            $contents = $reference->formatResult($result, $uri, $mimeType);
+        } catch (\Throwable $e) {
+            if ($verbose) {
+                $io->error(\sprintf('Error: %s', $e->getMessage()));
+                $io->text($e->getTraceAsString());
+            } else {
+                $io->error(\sprintf('Error: %s', $e->getMessage()));
+            }
+
+            return Command::FAILURE;
+        }
+
+        if ('json' === $format) {
+            $output->writeln(json_encode($contents, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+            return Command::SUCCESS;
+        }
+
+        if ('toon' === $format) {
+            $output->writeln(Toon::encode(array_map(static fn ($item) => $item->jsonSerialize(), $contents)));
+
+            return Command::SUCCESS;
+        }
+
+        $io->section('Contents');
+        foreach ($contents as $content) {
+            $this->renderContent($content, $io);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function renderContent(ResourceContents $content, SymfonyStyle $io): void
+    {
+        $io->definitionList(
+            ['URI' => $content->uri],
+            ['MIME Type' => $content->mimeType ?? '<comment>N/A</comment>'],
+        );
+
+        if ($content instanceof TextResourceContents) {
+            $io->text($content->text);
+
+            return;
+        }
+
+        if ($content instanceof BlobResourceContents) {
+            $io->text(\sprintf('<comment>Binary blob (%d bytes, base64-encoded)</comment>', \strlen($content->blob)));
+
+            return;
+        }
+
+        $io->text('<comment>Unknown content type</comment>');
+    }
+}

--- a/src/mate/src/default.config.php
+++ b/src/mate/src/default.config.php
@@ -19,6 +19,7 @@ use Symfony\AI\Mate\Command\DebugCapabilitiesCommand;
 use Symfony\AI\Mate\Command\DebugExtensionsCommand;
 use Symfony\AI\Mate\Command\DiscoverCommand;
 use Symfony\AI\Mate\Command\InitCommand;
+use Symfony\AI\Mate\Command\ResourcesReadCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
 use Symfony\AI\Mate\Command\StopCommand;
 use Symfony\AI\Mate\Command\ToolsCallCommand;
@@ -125,6 +126,9 @@ return static function (ContainerConfigurator $container): void {
             ->public()
 
         ->set(ToolsCallCommand::class)
+            ->public()
+
+        ->set(ResourcesReadCommand::class)
             ->public()
     ;
 };

--- a/src/mate/tests/Command/Fixtures/SampleResources.php
+++ b/src/mate/tests/Command/Fixtures/SampleResources.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command\Fixtures;
+
+use Mcp\Capability\Attribute\McpResource;
+use Mcp\Capability\Attribute\McpResourceTemplate;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SampleResources
+{
+    #[McpResource(
+        uri: 'sample://greeting',
+        name: 'sample-greeting',
+        description: 'A static greeting resource for tests',
+        mimeType: 'text/plain',
+    )]
+    public function getGreeting(): string
+    {
+        return 'Hello from the Mate test fixture!';
+    }
+
+    /**
+     * @return array{uri: string, mimeType: string, text: string}
+     */
+    #[McpResourceTemplate(
+        uriTemplate: 'sample://echo/{message}',
+        name: 'sample-echo',
+        description: 'Echoes the message back as a resource',
+        mimeType: 'text/plain',
+    )]
+    public function getEcho(string $message): array
+    {
+        return [
+            'uri' => "sample://echo/{$message}",
+            'mimeType' => 'text/plain',
+            'text' => "echo: {$message}",
+        ];
+    }
+}

--- a/src/mate/tests/Command/ResourcesReadCommandTest.php
+++ b/src/mate/tests/Command/ResourcesReadCommandTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use HelgeSverre\Toon\Toon;
+use Mcp\Capability\Discovery\Discoverer;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Command\ResourcesReadCommand;
+use Symfony\AI\Mate\Discovery\FilteredDiscoveryLoader;
+use Symfony\AI\Mate\Service\RegistryProvider;
+use Symfony\AI\Mate\Tests\Command\Fixtures\SampleResources;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResourcesReadCommandTest extends TestCase
+{
+    public function testReadStaticResource()
+    {
+        $tester = new CommandTester($this->createCommand());
+
+        $tester->execute([
+            'uri' => 'sample://greeting',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Reading Resource: sample://greeting', $output);
+        $this->assertStringContainsString('Hello from the Mate test fixture!', $output);
+    }
+
+    public function testReadTemplatedResource()
+    {
+        $tester = new CommandTester($this->createCommand());
+
+        $tester->execute([
+            'uri' => 'sample://echo/world',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Reading Resource: sample://echo/world', $output);
+        $this->assertStringContainsString('echo: world', $output);
+    }
+
+    public function testReadWithJsonFormat()
+    {
+        $tester = new CommandTester($this->createCommand());
+
+        $tester->execute([
+            'uri' => 'sample://greeting',
+            '--format' => 'json',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $this->assertStringNotContainsString('Reading Resource:', $output);
+
+        $contents = json_decode($output, true);
+        $this->assertIsArray($contents);
+        $this->assertCount(1, $contents);
+        $this->assertSame('sample://greeting', $contents[0]['uri']);
+        $this->assertSame('text/plain', $contents[0]['mimeType']);
+        $this->assertSame('Hello from the Mate test fixture!', $contents[0]['text']);
+    }
+
+    public function testReadWithToonFormat()
+    {
+        $tester = new CommandTester($this->createCommand());
+
+        $tester->execute([
+            'uri' => 'sample://greeting',
+            '--format' => 'toon',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        $contents = Toon::decode($output);
+        $this->assertIsArray($contents);
+        $this->assertSame('sample://greeting', $contents[0]['uri']);
+        $this->assertSame('Hello from the Mate test fixture!', $contents[0]['text']);
+    }
+
+    public function testReadWithUnknownUri()
+    {
+        $tester = new CommandTester($this->createCommand());
+
+        $tester->execute([
+            'uri' => 'unknown://does-not-exist',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Resource "unknown://does-not-exist" not found', $output);
+    }
+
+    private function createCommand(): ResourcesReadCommand
+    {
+        $rootDir = __DIR__.'/../..';
+        $extensions = [
+            '_custom' => ['dirs' => ['tests/Command/Fixtures'], 'includes' => []],
+        ];
+
+        $logger = new NullLogger();
+        $discoverer = new Discoverer($logger);
+        $loader = new FilteredDiscoveryLoader($rootDir, $extensions, [], $discoverer, $logger);
+        $registryProvider = new RegistryProvider($loader, $logger);
+
+        $container = new ContainerBuilder();
+        $container->set(SampleResources::class, new SampleResources());
+
+        return new class($registryProvider, $container) extends ResourcesReadCommand {
+            protected function isToonFormatAvailable(): bool
+            {
+                return true;
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Adds a new `mcp:resources:read` CLI command that reads an MCP resource by its URI, complementing the existing `mcp:tools:list` / `mcp:tools:inspect` / `mcp:tools:call` commands.

The command resolves the URI through `RegistryInterface::getResource()` (which transparently handles both static resources and URI-template-matched resources), invokes the registered handler via `ReferenceHandler`, and formats the output through the reference's `formatResult()` method.

## Usage

```bash
# Read a static resource
bin/mate mcp:resources:read file:///path/to/resource

# Read a templated resource (URI matched against registered templates)
bin/mate mcp:resources:read symfony-profiler://profile/abc123

# JSON output for scripting
bin/mate mcp:resources:read symfony-profiler://profile/abc123 --format=json

# TOON output (requires helgesverre/toon)
bin/mate mcp:resources:read symfony-profiler://profile/abc123 --format=toon
```

Output formats: `pretty` (default), `json`, `toon`.

## Notes

- Renders `TextResourceContents` and `BlobResourceContents` (binary blobs are reported with their byte length rather than dumping base64 to the terminal in `pretty` mode).
- Returns a clean "Resource not found" error when no resource or matching template is registered for the given URI, pointing users at `debug:capabilities --type=resource`.
- Tests cover static resources, templated resources, all three output formats, and the not-found path (5 tests / 19 assertions).