### PR TITLE
[Mate] Drop `symfony/ai-mate-composer-plugin` from `symfony/ai-mate` require

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,6 +26,26 @@ Mate
 
    After updating, run `composer dump-autoload`.
 
+ * Automatic refresh of discovered extensions on `composer install` / `composer update`
+   is now expected to run via the `symfony/ai-mate` Symfony Flex recipe, which wires
+   `vendor/bin/mate discover --composer --ignore-missing-file` into `auto-scripts`.
+   Projects using Symfony Flex don't need to do anything — the recipe handles it.
+
+   Projects **without** Symfony Flex must wire the script manually in their own
+   `composer.json`:
+
+   ```diff
+    {
+        "scripts": {
+   +        "auto-scripts": {
+   +            "vendor/bin/mate discover --composer --ignore-missing-file": "script"
+   +        },
+   +        "post-install-cmd": ["@auto-scripts"],
+   +        "post-update-cmd": ["@auto-scripts"]
+        }
+    }
+   ```
+
 UPGRADE FROM 0.7 to 0.8
 =======================
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,29 @@
+UPGRADE FROM 0.11 to 0.12
+=========================
+
+Mate
+----
+
+ * Automatic refresh of discovered extensions on `composer install` / `composer update`
+   is now expected to run via the `symfony/ai-mate` Symfony Flex recipe, which wires
+   `vendor/bin/mate discover --composer --ignore-missing-file` into `auto-scripts`.
+   Projects using Symfony Flex don't need to do anything — the recipe handles it.
+
+   Projects **without** Symfony Flex must wire the script manually in their own
+   `composer.json`:
+
+   ```diff
+    {
+        "scripts": {
+   +        "auto-scripts": {
+   +            "vendor/bin/mate discover --composer --ignore-missing-file": "script"
+   +        },
+   +        "post-install-cmd": ["@auto-scripts"],
+   +        "post-update-cmd": ["@auto-scripts"]
+        }
+    }
+   ```
+
 UPGRADE FROM 0.10 to 0.11
 =========================
 

--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -81,18 +81,30 @@ After running ``mate init``, update your autoloader:
 Automatic Discovery
 -------------------
 
-The ``symfony/ai-mate`` package installs the optional Composer plugin
-``symfony/ai-mate-composer-plugin``. After your project has been initialized and
-``mate/extensions.php`` exists, Composer automatically runs::
+When using Symfony Flex, the ``symfony/ai-mate`` recipe wires
+``vendor/bin/mate discover --composer --ignore-missing-file`` into ``auto-scripts``,
+so Composer automatically refreshes discovered extensions and regenerates the managed
+instruction artifacts after ``composer install`` and ``composer update``.
 
-    $ vendor/bin/mate discover --composer
+The ``--ignore-missing-file`` flag makes the command exit successfully without doing any
+work as long as ``mate/extensions.php`` is missing, so installing ``symfony/ai-mate`` in a
+fresh project does not produce noise. Once you run ``vendor/bin/mate init`` and
+``mate/extensions.php`` exists, subsequent ``composer install`` / ``composer update`` runs
+will refresh discovery transparently.
 
-after ``composer install`` and ``composer update``. This refreshes discovered extensions and
-regenerates the managed instruction artifacts.
+Projects **without** Symfony Flex must wire the script manually:
 
-Before initialization, the Composer plugin does not modify your project. It only prints a hint to run::
+.. code-block:: diff
 
-    $ vendor/bin/mate init
+     {
+         "scripts": {
+    +        "auto-scripts": {
+    +            "vendor/bin/mate discover --composer --ignore-missing-file": "script"
+    +        },
+    +        "post-install-cmd": ["@auto-scripts"],
+    +        "post-update-cmd": ["@auto-scripts"]
+         }
+     }
 
 Use ``vendor/bin/mate discover`` whenever you want to refresh extensions manually after changing
 Mate configuration, adding instructions, or working on local extensions.

--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -87,18 +87,30 @@ After running ``mate init``, update your autoloader:
 Automatic Discovery
 -------------------
 
-The ``symfony/ai-mate`` package installs the optional Composer plugin
-``symfony/ai-mate-composer-plugin``. After your project has been initialized and
-``mate/extensions.php`` exists, Composer automatically runs::
+When using Symfony Flex, the ``symfony/ai-mate`` recipe wires
+``vendor/bin/mate discover --composer --ignore-missing-file`` into ``auto-scripts``,
+so Composer automatically refreshes discovered extensions and regenerates the managed
+instruction artifacts after ``composer install`` and ``composer update``.
 
-    $ vendor/bin/mate discover --composer
+The ``--ignore-missing-file`` flag makes the command exit successfully without doing any
+work as long as ``mate/extensions.php`` is missing, so installing ``symfony/ai-mate`` in a
+fresh project does not produce noise. Once you run ``vendor/bin/mate init`` and
+``mate/extensions.php`` exists, subsequent ``composer install`` / ``composer update`` runs
+will refresh discovery transparently.
 
-after ``composer install`` and ``composer update``. This refreshes discovered extensions and
-regenerates the managed instruction artifacts.
+Projects **without** Symfony Flex must wire the script manually:
 
-Before initialization, the Composer plugin does not modify your project. It only prints a hint to run::
+.. code-block:: diff
 
-    $ vendor/bin/mate init
+     {
+         "scripts": {
+    +        "auto-scripts": {
+    +            "vendor/bin/mate discover --composer --ignore-missing-file": "script"
+    +        },
+    +        "post-install-cmd": ["@auto-scripts"],
+    +        "post-update-cmd": ["@auto-scripts"]
+         }
+     }
 
 Use ``vendor/bin/mate discover`` whenever you want to refresh extensions manually after changing
 Mate configuration, adding instructions, or working on local extensions.

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
+ * Automatic refresh of discovered extensions on `composer install` / `composer update` is now expected to run via the `symfony/ai-mate` Symfony Flex recipe
 
 0.7
 ---

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Automatic refresh of discovered extensions on `composer install` / `composer update` is now expected to run via the `symfony/ai-mate` Symfony Flex recipe
+
 0.11
 ----
 

--- a/src/mate/README.md
+++ b/src/mate/README.md
@@ -12,9 +12,8 @@ vendor/bin/mate init
 composer dump-autoload
 ```
 
-The package ships with the optional `symfony/ai-mate-composer-plugin`, which automatically
-refreshes Mate extension discovery after `composer install` and `composer update` once the
-project has been initialized.
+When using Symfony Flex, the matching recipe wires automatic Mate extension discovery
+into `composer install` and `composer update` once the project has been initialized.
 
 ## Installation
 

--- a/src/mate/composer.json
+++ b/src/mate/composer.json
@@ -36,7 +36,6 @@
         "symfony/config": "^5.4|^6.4|^7.3|^8.0",
         "symfony/console": "^5.4|^6.4|^7.3|^8.0",
         "symfony/dependency-injection": "^5.4|^6.4|^7.3|^8.0",
-        "symfony/ai-mate-composer-plugin": "^0.8",
         "symfony/finder": "^5.4|^6.4|^7.3|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1994 (partial)
| License       | MIT

Removes `symfony/ai-mate-composer-plugin` from `symfony/ai-mate`'s require list and updates the docs to point at the upcoming Flex recipe instead of the bundled plugin. **Depends on symfony/ai#2027** (the docs reference `mate discover --ignore-missing-file`, added there).

## Cross-repo PRs

| # | Repo | PR | What | Status |
|---|---|---|---|---|
| 1 | symfony/ai | [symfony/ai#2027](https://github.com/symfony/ai/pull/2027) | `mate discover --ignore-missing-file` | open |
| 2 | symfony/ai | [symfony/ai#2026](https://github.com/symfony/ai/pull/2026) | Drop `symfony/ai-mate-composer-plugin` from `symfony/ai-mate`'s require list (depends on symfony/ai#2027) | **this PR** |
| 3 | symfony/flex | [symfony/flex#1089](https://github.com/symfony/flex/pull/1089) | Auto-wire `@auto-scripts` into `post-install-cmd` / `post-update-cmd` | draft |
| 4 | symfony/recipes | [symfony/recipes#1535](https://github.com/symfony/recipes/pull/1535) | The `symfony/ai-mate` recipe | draft |
| 5 | symfony/ai | _follow-up_ | Delete the composer plugin source | not started |

## Summary

- Removes `symfony/ai-mate-composer-plugin` from `src/mate/composer.json`'s `require`.
- Updates `README.md`, `docs/components/mate.rst`, `UPGRADE.md` and `CHANGELOG.md` to point at the Flex recipe (with `--ignore-missing-file`) and document a manual `auto-scripts` wiring fallback for projects without Flex.
- Plugin source under `src/mate/composer-plugin/` is intentionally left in place for now and will be removed in a follow-up once the recipe has landed and projects have had a chance to migrate. Projects on legacy setups can still install the plugin explicitly via `composer require symfony/ai-mate-composer-plugin`.

## Usage

Once the recipe (symfony/recipes#1535) ships, automatic refresh runs through `@auto-scripts`; non-Flex projects follow the manual-wiring example added to `UPGRADE.md`.