### PR TITLE
[Mate] Add `--ignore-missing-file` option to `discover` command

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
  * Allow Symfony profiler capabilities (`ProfilerResourceTemplate` and `ProfilerTool`) to be instantiated without a `ProfilerDataProvider`, throwing a clear `RuntimeException` when invoked in workspaces without profiler support
+ * Add `--ignore-missing-file` option to the `discover` command that exits successfully without doing any work when `mate/extensions.php` does not exist (intended for unconditional invocation from Composer scripts wired by the Symfony Flex recipe)
 
 0.7
 ---

--- a/src/mate/src/Command/DiscoverCommand.php
+++ b/src/mate/src/Command/DiscoverCommand.php
@@ -55,12 +55,17 @@ class DiscoverCommand extends Command
     protected function configure(): void
     {
         $this->addOption('composer', null, InputOption::VALUE_NONE, 'Compact output for Composer plugin integration');
+        $this->addOption('ignore-missing-file', null, InputOption::VALUE_NONE, 'Exit successfully without doing any work when mate/extensions.php is missing (intended for Composer scripts wired by the Symfony Flex recipe)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $composerMode = $input->getOption('composer');
+
+        if ($input->getOption('ignore-missing-file') && !$this->extensionConfigSynchronizer->extensionsFileExists()) {
+            return Command::SUCCESS;
+        }
 
         $extensions = $this->extensionDiscovery->discover();
         $rootProjectExtension = $this->extensionDiscovery->discoverRootProject();

--- a/src/mate/src/Service/ExtensionConfigSynchronizer.php
+++ b/src/mate/src/Service/ExtensionConfigSynchronizer.php
@@ -36,6 +36,11 @@ final class ExtensionConfigSynchronizer
     ) {
     }
 
+    public function extensionsFileExists(): bool
+    {
+        return file_exists($this->rootDir.'/mate/extensions.php');
+    }
+
     /**
      * @param array<string, ExtensionData> $discoveredExtensions
      *

--- a/src/mate/tests/Command/DiscoverCommandTest.php
+++ b/src/mate/tests/Command/DiscoverCommandTest.php
@@ -155,6 +155,66 @@ PHP
         }
     }
 
+    public function testIgnoreMissingFileExitsEarlyWhenExtensionsFileAbsent()
+    {
+        $tempDir = sys_get_temp_dir().'/mate-discover-test-'.uniqid();
+        mkdir($tempDir, 0755, true);
+
+        try {
+            $rootDir = $this->createConfiguration($this->fixturesDir.'/with-ai-mate-config', $tempDir);
+            $logger = new NullLogger();
+            $discoverer = new ComposerExtensionDiscovery($rootDir, $logger);
+            $synchronizer = new ExtensionConfigSynchronizer($rootDir);
+            $aggregator = new AgentInstructionsAggregator($rootDir, [], $logger);
+            $materializer = new AgentInstructionsMaterializer($rootDir, $aggregator, $logger);
+            $command = new DiscoverCommand($discoverer, $synchronizer, $materializer);
+            $tester = new CommandTester($command);
+
+            $tester->execute(['--ignore-missing-file' => true]);
+
+            $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+            $this->assertFileDoesNotExist($tempDir.'/mate/extensions.php');
+            $this->assertFileDoesNotExist($tempDir.'/mate/AGENT_INSTRUCTIONS.md');
+            $this->assertSame('', $tester->getDisplay());
+        } finally {
+            $this->removeDirectory($tempDir);
+        }
+    }
+
+    public function testIgnoreMissingFileRunsNormallyWhenExtensionsFileExists()
+    {
+        $tempDir = sys_get_temp_dir().'/mate-discover-test-'.uniqid();
+        mkdir($tempDir.'/mate', 0755, true);
+
+        try {
+            file_put_contents($tempDir.'/mate/extensions.php', <<<'PHP'
+<?php
+return [];
+PHP
+            );
+
+            $rootDir = $this->createConfiguration($this->fixturesDir.'/with-ai-mate-config', $tempDir);
+            $logger = new NullLogger();
+            $discoverer = new ComposerExtensionDiscovery($rootDir, $logger);
+            $synchronizer = new ExtensionConfigSynchronizer($rootDir);
+            $aggregator = new AgentInstructionsAggregator($rootDir, [], $logger);
+            $materializer = new AgentInstructionsMaterializer($rootDir, $aggregator, $logger);
+            $command = new DiscoverCommand($discoverer, $synchronizer, $materializer);
+            $tester = new CommandTester($command);
+
+            $tester->execute(['--ignore-missing-file' => true]);
+
+            $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+            $extensions = include $tempDir.'/mate/extensions.php';
+            $this->assertIsArray($extensions);
+            $this->assertArrayHasKey('vendor/package-a', $extensions);
+            $this->assertArrayHasKey('vendor/package-b', $extensions);
+            $this->assertFileExists($tempDir.'/mate/AGENT_INSTRUCTIONS.md');
+        } finally {
+            $this->removeDirectory($tempDir);
+        }
+    }
+
     public function testDisplaysWarningWhenNoExtensionsFound()
     {
         $tempDir = sys_get_temp_dir().'/mate-discover-test-'.uniqid();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1994 (partial)
| License       | MIT

Adds an `--ignore-missing-file` option to `mate discover` that exits `0` as a no-op when `mate/extensions.php` does not exist. Required so the upcoming `symfony/ai-mate` Symfony Flex recipe can invoke `mate discover` unconditionally from Composer scripts.

## Cross-repo PRs

| # | Repo | PR | What | Status |
|---|---|---|---|---|
| 1 | symfony/ai | [symfony/ai#2027](https://github.com/symfony/ai/pull/2027) | `mate discover --ignore-missing-file` | **this PR** |
| 2 | symfony/ai | [symfony/ai#2026](https://github.com/symfony/ai/pull/2026) | Drop `symfony/ai-mate-composer-plugin` from `symfony/ai-mate`'s require list (depends on symfony/ai#2027) | draft |
| 3 | symfony/flex | [symfony/flex#1089](https://github.com/symfony/flex/pull/1089) | Auto-wire `@auto-scripts` into `post-install-cmd` / `post-update-cmd` | draft |
| 4 | symfony/recipes | [symfony/recipes#1535](https://github.com/symfony/recipes/pull/1535) | The `symfony/ai-mate` recipe | draft |
| 5 | symfony/ai | _follow-up_ | Delete the composer plugin source | not started |

## Summary

- Adds `--ignore-missing-file` option to `mate discover`: exits `0` when `mate/extensions.php` does not exist.

## Usage

The Flex recipe (symfony/recipes#1535) wires `vendor/bin/mate discover --composer --ignore-missing-file` into `@auto-scripts`, so it runs unconditionally on every `composer install` / `composer update` — including the first one, before `mate init` has been executed.