### PR TITLE
[MCP Bundle][Mate] Bump mcp/sdk to ^0.5

### DIFF
--- a/src/mate/composer.json
+++ b/src/mate/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "mcp/sdk": "^0.4",
+        "mcp/sdk": "^0.5",
         "psr/log": "^2.0|^3.0",
         "symfony/config": "^5.4|^6.4|^7.3|^8.0",
         "symfony/console": "^5.4|^6.4|^7.3|^8.0",

--- a/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
+++ b/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
@@ -38,7 +38,7 @@ final class LogSearchTool
      * @param string|null $to          End date filter, any PHP-parseable date string
      * @param int         $limit       Maximum number of entries to return
      */
-    #[McpTool('monolog-search', 'Search log entries by text or regex pattern. Supports filtering by log level, channel, environment, and date range. Use empty string for term to match all entries when using filters only.')]
+    #[McpTool(name: 'monolog-search', title: 'Log Search', description: 'Search log entries by text or regex pattern. Supports filtering by log level, channel, environment, and date range. Use empty string for term to match all entries when using filters only.')]
     public function search(
         string $term,
         bool $regex = false,
@@ -84,7 +84,7 @@ final class LogSearchTool
      * @param string|null $environment Filter by Symfony environment (e.g. dev, prod, test)
      * @param int         $limit       Maximum number of entries to return
      */
-    #[McpTool('monolog-context-search', 'Search log entries by structured context data. Finds entries where a specific context key contains the given value.')]
+    #[McpTool(name: 'monolog-context-search', title: 'Log Context Search', description: 'Search log entries by structured context data. Finds entries where a specific context key contains the given value.')]
     public function searchContext(
         string $key,
         string $value,
@@ -107,7 +107,7 @@ final class LogSearchTool
      * @param string|null $level       Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
      * @param string|null $environment Filter by Symfony environment (e.g. dev, prod, test)
      */
-    #[McpTool('monolog-tail', 'Get the most recent log entries. Reads from the end of log files, optionally filtered by level and environment.')]
+    #[McpTool(name: 'monolog-tail', title: 'Log Tail', description: 'Get the most recent log entries. Reads from the end of log files, optionally filtered by level and environment.')]
     public function tail(int $lines = 50, ?string $level = null, ?string $environment = null): string
     {
         $entries = $this->reader->tail($lines, $level, $environment);
@@ -118,7 +118,7 @@ final class LogSearchTool
     /**
      * @param string|null $environment Filter log files by Symfony environment (e.g. dev, prod, test)
      */
-    #[McpTool('monolog-list-files', 'List available log files with metadata (name, path, size, last modified). Use to discover which logs exist before searching.')]
+    #[McpTool(name: 'monolog-list-files', title: 'List Log Files', description: 'List available log files with metadata (name, path, size, last modified). Use to discover which logs exist before searching.')]
     public function listFiles(?string $environment = null): string
     {
         $files = null !== $environment
@@ -138,7 +138,7 @@ final class LogSearchTool
         return ResponseEncoder::encode(['files' => $result]);
     }
 
-    #[McpTool('monolog-list-channels', 'List all unique Monolog channel names found across log files (e.g. app, security, doctrine).')]
+    #[McpTool(name: 'monolog-list-channels', title: 'List Log Channels', description: 'List all unique Monolog channel names found across log files (e.g. app, security, doctrine).')]
     public function listChannels(): string
     {
         return ResponseEncoder::encode(['channels' => $this->reader->getUniqueChannels()]);

--- a/src/mate/src/Bridge/Symfony/Capability/ProfilerTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ProfilerTool.php
@@ -39,7 +39,7 @@ final class ProfilerTool
      * @param string|null $from       Start date filter for profile creation time
      * @param string|null $to         End date filter for profile creation time
      */
-    #[McpTool('symfony-profiler-list', 'List and filter Symfony profiler profiles by HTTP method, URL, IP, status code, date range, or context. Profiles are sorted by most recent first, so limit=1 returns the latest profile. Returns summary data with resource_uri for fetching full details via the resource template.')]
+    #[McpTool(name: 'symfony-profiler-list', title: 'Symfony Profiler List', description: 'List and filter Symfony profiler profiles by HTTP method, URL, IP, status code, date range, or context. Profiles are sorted by most recent first, so limit=1 returns the latest profile. Returns summary data with resource_uri for fetching full details via the resource template.')]
     public function listProfiles(
         int $limit = 20,
         ?string $method = null,
@@ -73,7 +73,7 @@ final class ProfilerTool
     /**
      * @param string $token The unique profiler token identifying the profile
      */
-    #[McpTool('symfony-profiler-get', 'Get a specific profiler profile by its token. Returns detailed profile data including available collectors and resource_uri for accessing collector-specific data.')]
+    #[McpTool(name: 'symfony-profiler-get', title: 'Symfony Profiler Get', description: 'Get a specific profiler profile by its token. Returns detailed profile data including available collectors and resource_uri for accessing collector-specific data.')]
     public function getProfile(string $token): string
     {
         $profileData = $this->dataProvider->findProfile($token);

--- a/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
@@ -30,7 +30,7 @@ class ServiceTool
     /**
      * @param string|null $query Filter services by ID or class name (case-insensitive partial match)
      */
-    #[McpTool('symfony-services', 'Search Symfony dependency injection container services. Optionally filter by service ID or class name. Returns a map of service IDs to their class names.')]
+    #[McpTool(name: 'symfony-services', title: 'Symfony Services', description: 'Search Symfony dependency injection container services. Optionally filter by service ID or class name. Returns a map of service IDs to their class names.')]
     public function getServices(?string $query = null): string
     {
         $container = $this->readContainer();

--- a/src/mate/src/Capability/ServerInfo.php
+++ b/src/mate/src/Capability/ServerInfo.php
@@ -20,7 +20,7 @@ use Symfony\AI\Mate\Encoding\ResponseEncoder;
  */
 class ServerInfo
 {
-    #[McpTool('server-info', 'Get PHP runtime environment details: version, OS, OS family, and loaded extensions')]
+    #[McpTool(name: 'server-info', title: 'Server Info', description: 'Get PHP runtime environment details: version, OS, OS family, and loaded extensions')]
     public function getInfo(): string
     {
         return ResponseEncoder::encode([

--- a/src/mate/tests/Discovery/FilteredDiscoveryLoaderTest.php
+++ b/src/mate/tests/Discovery/FilteredDiscoveryLoaderTest.php
@@ -33,8 +33,8 @@ final class FilteredDiscoveryLoaderTest extends TestCase
 {
     public function testLoadWithEnabledFeatures()
     {
-        $tool1 = new ToolReference(new Tool('tool1', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method1', false);
-        $tool2 = new ToolReference(new Tool('tool2', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method2', false);
+        $tool1 = new ToolReference(new Tool(name: 'tool1', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method1', false);
+        $tool2 = new ToolReference(new Tool(name: 'tool2', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method2', false);
 
         $discoveryState = new DiscoveryState(
             tools: ['tool1' => $tool1, 'tool2' => $tool2],
@@ -75,8 +75,8 @@ final class FilteredDiscoveryLoaderTest extends TestCase
 
     public function testLoadWithDisabledFeatures()
     {
-        $tool1 = new ToolReference(new Tool('tool1', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method1', false);
-        $tool2 = new ToolReference(new Tool('tool2', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method2', false);
+        $tool1 = new ToolReference(new Tool(name: 'tool1', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method1', false);
+        $tool2 = new ToolReference(new Tool(name: 'tool2', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method2', false);
 
         $discoveryState = new DiscoveryState(
             tools: ['tool1' => $tool1, 'tool2' => $tool2],
@@ -123,9 +123,9 @@ final class FilteredDiscoveryLoaderTest extends TestCase
 
     public function testLoadWithMixedEnabledDisabledFeatures()
     {
-        $tool1 = new ToolReference(new Tool('tool1', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method1', false);
-        $tool2 = new ToolReference(new Tool('tool2', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method2', false);
-        $tool3 = new ToolReference(new Tool('tool3', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method3', false);
+        $tool1 = new ToolReference(new Tool(name: 'tool1', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method1', false);
+        $tool2 = new ToolReference(new Tool(name: 'tool2', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method2', false);
+        $tool3 = new ToolReference(new Tool(name: 'tool3', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method3', false);
 
         $discoveryState = new DiscoveryState(
             tools: ['tool1' => $tool1, 'tool2' => $tool2, 'tool3' => $tool3],
@@ -315,7 +315,7 @@ final class FilteredDiscoveryLoaderTest extends TestCase
 
     public function testLoadWithEmptyFiltersConfiguration()
     {
-        $tool = new ToolReference(new Tool('tool1', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method1', false);
+        $tool = new ToolReference(new Tool(name: 'tool1', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method1', false);
 
         $discoveryState = new DiscoveryState(
             tools: ['tool1' => $tool],
@@ -355,8 +355,8 @@ final class FilteredDiscoveryLoaderTest extends TestCase
 
     public function testLoadWithMultiplePackages()
     {
-        $tool1 = new ToolReference(new Tool('tool1', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method1', false);
-        $tool2 = new ToolReference(new Tool('tool2', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method2', false);
+        $tool1 = new ToolReference(new Tool(name: 'tool1', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method1', false);
+        $tool2 = new ToolReference(new Tool(name: 'tool2', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method2', false);
 
         $discoveryStateA = new DiscoveryState(tools: ['tool1' => $tool1]);
         $discoveryStateB = new DiscoveryState(tools: ['tool2' => $tool2]);
@@ -399,7 +399,7 @@ final class FilteredDiscoveryLoaderTest extends TestCase
 
     public function testLoadFiltersNonExistentFeatures()
     {
-        $tool = new ToolReference(new Tool('tool1', ['type' => 'object', 'properties' => [], 'required' => []], 'description', null), 'method1', false);
+        $tool = new ToolReference(new Tool(name: 'tool1', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => []], description: 'description', annotations: null), 'method1', false);
 
         $discoveryState = new DiscoveryState(
             tools: ['tool1' => $tool],

--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -14,11 +14,12 @@
         }
     ],
     "require": {
-        "mcp/sdk": "^0.4",
+        "mcp/sdk": "^0.5",
         "php-http/discovery": "^1.20",
         "symfony/config": "^7.3|^8.0",
         "symfony/console": "^7.3|^8.0",
         "symfony/dependency-injection": "^7.3|^8.0",
+        "symfony/finder": "^7.3|^8.0",
         "symfony/framework-bundle": "^7.3|^8.0",
         "symfony/http-foundation": "^7.3|^8.0",
         "symfony/http-kernel": "^7.3|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Bumps `mcp/sdk` from `^0.4` to `^0.5` in `symfony/mcp-bundle` and `symfony/ai-mate`.

The fix for modelcontextprotocol/php-sdk#273 (`Session::save()` crashes when `$data` is never initialized) is included in `mcp/sdk` v0.5.

Changes required by the `mcp/sdk` 0.5 BC breaks:
   - Add `symfony/finder` as an explicit dependency of `symfony/mcp-bundle` (previously provided transitively by `mcp/sdk`)
   - Migrate `#[McpTool]` and `Tool::__construct()` usages in `symfony/ai-mate` to named arguments (`$title` parameter was inserted between `$name` and `$description`/`$inputSchema`)