### PR TITLE
[CI] Add docs-builder build to catch broken docs in PRs

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -1,0 +1,40 @@
+name: Docs Build
+
+on:
+    pull_request:
+        paths:
+            - '**.rst'
+            - 'docs/**'
+            - '.github/workflows/docs-build.yaml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    docs-build:
+        name: docs-builder
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.5
+
+            - name: Install dependencies
+              uses: ramsey/composer-install@v4
+              with:
+                  working-directory: docs/_build
+
+            - name: Build the docs
+              working-directory: docs/_build
+              run: vendor/bin/docs-builder build:docs .. output --disable-cache --fail-on-errors --save-errors=errors.log
+
+            - name: Show build errors
+              if: failure()
+              working-directory: docs/_build
+              run: cat errors.log

--- a/docs/_build/.gitignore
+++ b/docs/_build/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+output
+vendor

--- a/docs/_build/composer.json
+++ b/docs/_build/composer.json
@@ -1,0 +1,6 @@
+{
+    "require": {
+        "symfony-tools/docs-builder": "^0.27",
+        "symfony/console": "^7.4"
+    }
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,3 @@
+{
+    "exclude": ["_build"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Suggested by @stof in #2005: add a `symfony-tools/docs-builder` build alongside the existing DOCtor-RST job, so PRs that introduce broken `:doc:` references, unsupported code-block languages, empty directives, etc. fail the check rather than breaking the website deployment after merge.

Mirrors the [symfony-docs CI layout](https://github.com/symfony/symfony-docs/blob/7.3/.github/workflows/ci.yaml), but uses the docs-builder package's own CLI directly so no wrapper script is needed:

- `docs/_build/composer.json` — pulls `symfony-tools/docs-builder ^0.27`. `symfony/console` is pinned to `^7.4` because docs-builder declares `^8.0` compat in its require but its `Application` class still calls the `Application::add()` method removed in Console 8.x.
- `docs/_build/.gitignore` — excludes `composer.lock`, `output`, `vendor`.
- `docs/docs.json` — exclude list (`_build`) for the build, picked up automatically by docs-builder.
- `.github/workflows/docs-build.yaml` — runs on `pull_request` for `**.rst`/`docs/**`. PHP 8.5, `composer install`, then `vendor/bin/docs-builder build:docs .. output --disable-cache --fail-on-errors --save-errors=errors.log`. The error log is `cat`-ed on failure so messages surface in the job output. `continue-on-error: true` to mirror symfony-docs (informational on first iteration; can be flipped to required once trusted).

### Verified locally

- Clean docs → exit 0, empty errors log.
- Injected a bad `:doc:` reference → exit 1, errors log contains:
  ```
  Build errors from "..."
  Found invalid reference "/components/does-not-exist" in file "index"
  ```
