### PR TITLE
[Platform] Fix JSONSchema generation with CPP & `@var`

### DIFF
--- a/src/platform/src/Contract/JsonSchema/Describer/TypeInfoDescriber.php
+++ b/src/platform/src/Contract/JsonSchema/Describer/TypeInfoDescriber.php
@@ -130,10 +130,9 @@ final class TypeInfoDescriber implements ObjectDescriberInterface, PropertyDescr
             case $type->isIdentifiedBy(TypeIdentifier::ARRAY):
                 \assert($type instanceof CollectionType);
 
-                return [
-                    'type' => 'array',
-                    'items' => $this->getTypeSchema($type->getCollectionValueType()),
-                ];
+                $items = $this->getTypeSchema($type->getCollectionValueType());
+
+                return ['type' => 'array'] + ($items ? ['items' => $items] : []);
 
             case $type->isIdentifiedBy(TypeIdentifier::OBJECT):
                 if ($type instanceof BuiltinType) {
@@ -150,9 +149,9 @@ final class TypeInfoDescriber implements ObjectDescriberInterface, PropertyDescr
             case $type->isIdentifiedBy(TypeIdentifier::NULL):
                 return ['type' => 'null'];
             case $type->isIdentifiedBy(TypeIdentifier::STRING):
-            default:
-                // Fallback to string for any unhandled types
                 return ['type' => 'string'];
+            default:
+                return [];
         }
     }
 

--- a/src/platform/tests/Contract/JsonSchema/Describer/DescriberTest.php
+++ b/src/platform/tests/Contract/JsonSchema/Describer/DescriberTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Contract\JsonSchema\Describer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Contract\JsonSchema\Describer\Describer;
+use Symfony\AI\Platform\Contract\JsonSchema\Subject\ObjectSubject;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\CPPWithAtVarDocFixture;
+
+final class DescriberTest extends TestCase
+{
+    public function testDescribeObject()
+    {
+        $describer = new Describer();
+        $describer->describeObject(new ObjectSubject(CPPWithAtVarDocFixture::class, new \ReflectionClass(CPPWithAtVarDocFixture::class)), $actual);
+
+        $this->assertSame([
+            'type' => 'object',
+            'properties' => [
+                'steps' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'explanation' => [
+                                'type' => 'string',
+                            ],
+                            'output' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'required' => ['explanation', 'output'],
+                        'additionalProperties' => false,
+                    ],
+                ],
+            ],
+            'required' => ['steps'],
+            'additionalProperties' => false,
+        ], $actual);
+    }
+}

--- a/src/platform/tests/Contract/JsonSchema/FactoryTest.php
+++ b/src/platform/tests/Contract/JsonSchema/FactoryTest.php
@@ -107,7 +107,6 @@ final class FactoryTest extends TestCase
                 ],
                 'products' => [
                     'type' => 'array',
-                    'items' => ['type' => 'string'],
                     'description' => 'The products given to the tool',
                     'minItems' => 1,
                     'maxItems' => 10,

--- a/src/platform/tests/Fixtures/StructuredOutput/CPPWithAtVarDocFixture.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/CPPWithAtVarDocFixture.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput;
+
+final class CPPWithAtVarDocFixture
+{
+    public function __construct(
+        /** @var Step[] */
+        public array $steps = [],
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

PR #1683 broke JSON Schema generation when using constructor property promotion with `@var` annotations.

For example, given the following class:

```php
final class CPPWithAtVarDocFixture
{
    public function __construct(
        /** @var Step[] */
        public array $steps = [],
    ) {
    }
}
```

The generated schema has changed unexpectedly. The diff between the previous and current output is:

```diff
{
    "type": "object",
    "properties": {
        "steps": {
            "type": "array",
            "items": {
-               "type": "object",
+               "type": "string",
                "properties": {
                    "explanation": {
                        "type": "string"
                    },
                    "output": {
                        "type": "string"
                    }
                },
                "required": [
                    "explanation",
                    "output"
                ],
                "additionalProperties": false
            }
        }
    },
    "required": [
        "steps"
    ],
    "additionalProperties": false
}
```

I'm not sure what the best approach is to fix this. I'm open to suggestions.