### PR TITLE
[Platform] Fix structured output for reasoning models

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,27 @@
 UPGRADE FROM 0.8 to 0.9
 =======================
 
+Platform
+--------
+
+ * The OpenAI Responses bridges return `MultiPartResult` instead of `ChoiceResult` for multi-item output. Iterate parts instead of treating them as alternative completions:
+
+   ```diff
+   -if ($result instanceof ChoiceResult) {
+   -    foreach ($result->getContent() as $alternative) { /* ... */ }
+   -}
+   +if ($result instanceof MultiPartResult) {
+   +    foreach ($result as $part) { /* ... */ }
+   +}
+   ```
+
+ * Reasoning summaries from OpenAI Responses bridges are exposed as one `ThinkingResult` per `summary_text` chunk instead of being folded into a `TextResult`:
+
+   ```diff
+   -$part instanceof TextResult ? $part->getContent() : null
+   +$part instanceof ThinkingResult ? $part->getContent() : null
+   ```
+
 Mate
 ----
 

--- a/examples/openai/structured-output-reasoning.php
+++ b/examples/openai/structured-output-reasoning.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\MathReasoning;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$dispatcher = new EventDispatcher();
+$dispatcher->addSubscriber(new PlatformSubscriber());
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client(), eventDispatcher: $dispatcher);
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful math tutor. Guide the user through the solution step by step.'),
+    Message::ofUser('how can I solve 8x + 7 = -23'),
+);
+
+$result = $platform->invoke('gpt-5-mini', $messages, [
+    'response_format' => MathReasoning::class,
+    'reasoning' => ['summary' => 'auto'],
+]);
+
+$converted = $result->getResult();
+assert($converted instanceof MultiPartResult);
+
+output()->writeln('<info><reasoning></info>');
+foreach ($converted as $part) {
+    if ($part instanceof ThinkingResult && null !== $part->getContent()) {
+        output()->writeln('<fg=#999999>'.$part->getContent().'</>');
+    }
+}
+output()->writeln('<info></reasoning></info>');
+
+dump($result->asObject());

--- a/src/platform/src/Bridge/Cache/ResultNormalizer.php
+++ b/src/platform/src/Bridge/Cache/ResultNormalizer.php
@@ -14,10 +14,12 @@ namespace Symfony\AI\Platform\Bridge\Cache;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\Result\VectorResult;
@@ -59,6 +61,14 @@ final class ResultNormalizer implements NormalizerInterface, DenormalizerInterfa
                     fn (ResultInterface $result): array => $this->normalize($result, $format, $context),
                     $data->getContent(),
                 ),
+                MultiPartResult::class => array_map(
+                    fn (ResultInterface $result): array => $this->normalize($result, $format, $context),
+                    $data->getContent(),
+                ),
+                ThinkingResult::class => [
+                    'content' => $data->getContent(),
+                    'signature' => $data->getSignature(),
+                ],
                 ObjectResult::class => [
                     'type' => get_debug_type($data->getContent()),
                     'content' => \is_array($data->getContent()) ? $data->getContent() : $this->objectNormalizer->normalize($data->getContent(), $format, $context),
@@ -94,6 +104,11 @@ final class ResultNormalizer implements NormalizerInterface, DenormalizerInterfa
                 fn (array $choice): ResultInterface => $this->denormalize($choice, $type, $format, $context),
                 $data['payload']
             )),
+            MultiPartResult::class => new MultiPartResult(array_map(
+                fn (array $part): ResultInterface => $this->denormalize($part, $type, $format, $context),
+                $data['payload']
+            )),
+            ThinkingResult::class => new ThinkingResult($data['payload']['content'], $data['payload']['signature']),
             ObjectResult::class => new ObjectResult('array' === $data['payload']['type'] ? $data['payload']['content'] : $this->objectNormalizer->denormalize($data['payload']['content'], $data['payload']['type'], $format, $context)),
             TextResult::class => new TextResult($data['payload']),
             ToolCallResult::class => new ToolCallResult(array_map(

--- a/src/platform/src/Bridge/Cache/Tests/ResultNormalizerTest.php
+++ b/src/platform/src/Bridge/Cache/Tests/ResultNormalizerTest.php
@@ -18,10 +18,12 @@ use Symfony\AI\Platform\Contract\Normalizer\Result\ToolCallNormalizer;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\Result\VectorResult;
@@ -120,6 +122,32 @@ final class ResultNormalizerTest extends TestCase
                         'payload' => 'bar',
                     ],
                 ],
+            ],
+        ];
+        yield MultiPartResult::class => [
+            new MultiPartResult([
+                new ThinkingResult('thinking…'),
+                new TextResult('answer'),
+            ]),
+            [
+                'class' => MultiPartResult::class,
+                'payload' => [
+                    [
+                        'class' => ThinkingResult::class,
+                        'payload' => ['content' => 'thinking…', 'signature' => null],
+                    ],
+                    [
+                        'class' => TextResult::class,
+                        'payload' => 'answer',
+                    ],
+                ],
+            ],
+        ];
+        yield ThinkingResult::class => [
+            new ThinkingResult('reasoning summary', 'sig_abc'),
+            [
+                'class' => ThinkingResult::class,
+                'payload' => ['content' => 'reasoning summary', 'signature' => 'sig_abc'],
             ],
         ];
         yield ObjectResult::class.'-array' => [

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
-use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -29,6 +29,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
@@ -41,7 +42,7 @@ use Symfony\AI\Platform\ResultConverterInterface;
  * @phpstan-type OutputText array{type: 'output_text', text: string}
  * @phpstan-type Refusal array{type: 'refusal', refusal: string}
  * @phpstan-type FunctionCall array{id: string, arguments: string, call_id: string, name: string, type: 'function_call'}
- * @phpstan-type Reasoning array{summary: array{text?: string}, id: string}
+ * @phpstan-type Thinking array{summary: list<array{type: string, text?: string}>, id: string}
  * @phpstan-type Error array{code?: string|null, type?: string|null, param?: string|null, message?: string|null}
  */
 final class ResultConverter implements ResultConverterInterface
@@ -96,7 +97,7 @@ final class ResultConverter implements ResultConverterInterface
 
         $results = $this->convertOutputArray($data[self::KEY_OUTPUT]);
 
-        return 1 === \count($results) ? array_pop($results) : new ChoiceResult($results);
+        return 1 === \count($results) ? array_pop($results) : new MultiPartResult(array_values($results));
     }
 
     public function getTokenUsageExtractor(): TokenUsageExtractor
@@ -105,7 +106,7 @@ final class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param array<OutputMessage|FunctionCall|Reasoning> $output
+     * @param array<OutputMessage|FunctionCall|Thinking> $output
      *
      * @return ResultInterface[]
      */
@@ -113,7 +114,12 @@ final class ResultConverter implements ResultConverterInterface
     {
         [$toolCallResult, $output] = $this->extractFunctionCalls($output);
 
-        $results = array_filter(array_map($this->processOutputItem(...), $output));
+        $results = [];
+        foreach ($output as $item) {
+            foreach ($this->processOutputItem($item) as $result) {
+                $results[] = $result;
+            }
+        }
         if ($toolCallResult) {
             $results[] = $toolCallResult;
         }
@@ -122,9 +128,11 @@ final class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param OutputMessage|Reasoning $item
+     * @param OutputMessage|Thinking $item
+     *
+     * @return iterable<ResultInterface>
      */
-    private function processOutputItem(array $item): ?ResultInterface
+    private function processOutputItem(array $item): iterable
     {
         $type = $item['type'] ?? null;
 
@@ -181,9 +189,9 @@ final class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param array<OutputMessage|FunctionCall|Reasoning> $output
+     * @param array<OutputMessage|FunctionCall|Thinking> $output
      *
-     * @return list<ToolCallResult|array<OutputMessage|Reasoning>|null>
+     * @return list<ToolCallResult|array<OutputMessage|Thinking>|null>
      */
     private function extractFunctionCalls(array $output): array
     {
@@ -204,20 +212,24 @@ final class ResultConverter implements ResultConverterInterface
 
     /**
      * @param OutputMessage $output
+     *
+     * @return \Generator<TextResult>
      */
-    private function convertOutputMessage(array $output): ?TextResult
+    private function convertOutputMessage(array $output): \Generator
     {
         $content = $output['content'] ?? [];
         if ([] === $content) {
-            return null;
+            return;
         }
 
         $content = array_pop($content);
         if ('refusal' === $content['type']) {
-            return new TextResult(\sprintf('Model refused to generate output: %s', $content['refusal']));
+            yield new TextResult(\sprintf('Model refused to generate output: %s', $content['refusal']));
+
+            return;
         }
 
-        return new TextResult($content['text']);
+        yield new TextResult($content['text']);
     }
 
     /**
@@ -253,14 +265,18 @@ final class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param Reasoning $item
+     * @param Thinking $item
+     *
+     * @return \Generator<ThinkingResult>
      */
-    private function convertReasoning(array $item): ?ResultInterface
+    private function convertReasoning(array $item): \Generator
     {
         // Reasoning is sometimes missing if it exceeds the context limit.
-        $summary = $item['summary']['text'] ?? null;
-
-        return $summary ? new TextResult($summary) : null;
+        foreach ($item['summary'] ?? [] as $entry) {
+            if ('' !== ($entry['text'] ?? '')) {
+                yield new ThinkingResult($entry['text']);
+            }
+        }
     }
 
     /**

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -17,8 +17,8 @@ use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\RuntimeException;
-use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
@@ -27,6 +27,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\TokenUsage\TokenUsage;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
@@ -82,7 +83,7 @@ class ResultConverterTest extends TestCase
         $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->getArguments());
     }
 
-    public function testConvertMultipleChoices()
+    public function testConvertMultipleMessagesIntoMultiPartResult()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
@@ -93,14 +94,14 @@ class ResultConverterTest extends TestCase
                     'type' => 'message',
                     'content' => [[
                         'type' => 'output_text',
-                        'text' => 'Choice 1',
+                        'text' => 'Part 1',
                     ]],
                 ],
                 [
                     'role' => 'assistant',
                     'content' => [[
                         'type' => 'output_text',
-                        'text' => 'Choice 2',
+                        'text' => 'Part 2',
                     ]],
                     'type' => 'message',
                 ],
@@ -109,11 +110,115 @@ class ResultConverterTest extends TestCase
 
         $result = $converter->convert(new RawHttpResult($httpResponse));
 
-        $this->assertInstanceOf(ChoiceResult::class, $result);
+        $this->assertInstanceOf(MultiPartResult::class, $result);
         $output = $result->getContent();
         $this->assertCount(2, $output);
-        $this->assertSame('Choice 1', $output[0]->getContent());
-        $this->assertSame('Choice 2', $output[1]->getContent());
+        $this->assertSame('Part 1', $output[0]->getContent());
+        $this->assertSame('Part 2', $output[1]->getContent());
+    }
+
+    public function testConvertReasoningPlusMessageIntoMultiPartResult()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'reasoning',
+                    'id' => 'rs_1',
+                    'summary' => [
+                        ['type' => 'summary_text', 'text' => 'Let me work through this.'],
+                    ],
+                ],
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => '{"answer": 42}',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(ThinkingResult::class, $parts[0]);
+        $this->assertSame('Let me work through this.', $parts[0]->getContent());
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('{"answer": 42}', $parts[1]->getContent());
+    }
+
+    public function testConvertReasoningEmitsOneThinkingResultPerSummaryChunk()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'reasoning',
+                    'id' => 'rs_1',
+                    'summary' => [
+                        ['type' => 'summary_text', 'text' => 'First, I subtract 7.'],
+                        ['type' => 'summary_text', 'text' => 'Then I divide by 8.'],
+                    ],
+                ],
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'x = -3.75',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(3, $parts);
+        $this->assertInstanceOf(ThinkingResult::class, $parts[0]);
+        $this->assertSame('First, I subtract 7.', $parts[0]->getContent());
+        $this->assertInstanceOf(ThinkingResult::class, $parts[1]);
+        $this->assertSame('Then I divide by 8.', $parts[1]->getContent());
+        $this->assertInstanceOf(TextResult::class, $parts[2]);
+        $this->assertSame('x = -3.75', $parts[2]->getContent());
+    }
+
+    public function testConvertReasoningWithoutSummaryIsDropped()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'reasoning',
+                    'id' => 'rs_1',
+                    'summary' => [],
+                ],
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'final',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('final', $result->getContent());
     }
 
     public function testContentFilterException()

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
-use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -28,6 +28,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
@@ -39,7 +40,7 @@ use Symfony\AI\Platform\ResultConverterInterface;
  * @phpstan-type OutputText array{type: 'output_text', text: string}
  * @phpstan-type Refusal array{type: 'refusal', refusal: string}
  * @phpstan-type FunctionCall array{id: string, arguments: string, call_id: string, name: string, type: 'function_call'}
- * @phpstan-type Reasoning array{summary: array{text?: string}, id: string}
+ * @phpstan-type Thinking array{summary: list<array{type: string, text?: string}>, id: string}
  */
 final class ResultConverter implements ResultConverterInterface
 {
@@ -88,7 +89,7 @@ final class ResultConverter implements ResultConverterInterface
 
         $results = $this->convertOutputArray($data[self::KEY_OUTPUT]);
 
-        return 1 === \count($results) ? array_pop($results) : new ChoiceResult($results);
+        return 1 === \count($results) ? array_pop($results) : new MultiPartResult(array_values($results));
     }
 
     public function getTokenUsageExtractor(): TokenUsageExtractor
@@ -97,7 +98,7 @@ final class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param array<OutputMessage|FunctionCall|Reasoning> $output
+     * @param array<OutputMessage|FunctionCall|Thinking> $output
      *
      * @return ResultInterface[]
      */
@@ -105,7 +106,12 @@ final class ResultConverter implements ResultConverterInterface
     {
         [$toolCallResult, $output] = $this->extractFunctionCalls($output);
 
-        $results = array_filter(array_map($this->processOutputItem(...), $output));
+        $results = [];
+        foreach ($output as $item) {
+            foreach ($this->processOutputItem($item) as $result) {
+                $results[] = $result;
+            }
+        }
         if ($toolCallResult) {
             $results[] = $toolCallResult;
         }
@@ -114,9 +120,11 @@ final class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param OutputMessage|Reasoning $item
+     * @param OutputMessage|Thinking $item
+     *
+     * @return iterable<ResultInterface>
      */
-    private function processOutputItem(array $item): ?ResultInterface
+    private function processOutputItem(array $item): iterable
     {
         $type = $item['type'] ?? null;
 
@@ -169,9 +177,9 @@ final class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param array<OutputMessage|FunctionCall|Reasoning> $output
+     * @param array<OutputMessage|FunctionCall|Thinking> $output
      *
-     * @return list<ToolCallResult|array<OutputMessage|Reasoning>|null>
+     * @return list<ToolCallResult|array<OutputMessage|Thinking>|null>
      */
     private function extractFunctionCalls(array $output): array
     {
@@ -192,20 +200,24 @@ final class ResultConverter implements ResultConverterInterface
 
     /**
      * @param OutputMessage $output
+     *
+     * @return \Generator<TextResult>
      */
-    private function convertOutputMessage(array $output): ?TextResult
+    private function convertOutputMessage(array $output): \Generator
     {
         $content = $output['content'] ?? [];
         if ([] === $content) {
-            return null;
+            return;
         }
 
         $content = array_pop($content);
         if ('refusal' === $content['type']) {
-            return new TextResult(\sprintf('Model refused to generate output: %s', $content['refusal']));
+            yield new TextResult(\sprintf('Model refused to generate output: %s', $content['refusal']));
+
+            return;
         }
 
-        return new TextResult($content['text']);
+        yield new TextResult($content['text']);
     }
 
     /**
@@ -221,12 +233,16 @@ final class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param Reasoning $item
+     * @param Thinking $item
+     *
+     * @return \Generator<ThinkingResult>
      */
-    private function convertReasoning(array $item): ?ResultInterface
+    private function convertReasoning(array $item): \Generator
     {
-        $summary = $item['summary']['text'] ?? null;
-
-        return $summary ? new TextResult($summary) : null;
+        foreach ($item['summary'] ?? [] as $entry) {
+            if ('' !== ($entry['text'] ?? '')) {
+                yield new ThinkingResult($entry['text']);
+            }
+        }
     }
 }

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -18,8 +18,8 @@ use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
-use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
@@ -29,6 +29,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\TokenUsage\TokenUsage;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
@@ -84,7 +85,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->getArguments());
     }
 
-    public function testConvertMultipleChoices()
+    public function testConvertMultipleMessagesIntoMultiPartResult()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
@@ -95,14 +96,14 @@ final class ResultConverterTest extends TestCase
                     'type' => 'message',
                     'content' => [[
                         'type' => 'output_text',
-                        'text' => 'Choice 1',
+                        'text' => 'Part 1',
                     ]],
                 ],
                 [
                     'role' => 'assistant',
                     'content' => [[
                         'type' => 'output_text',
-                        'text' => 'Choice 2',
+                        'text' => 'Part 2',
                     ]],
                     'type' => 'message',
                 ],
@@ -111,11 +112,115 @@ final class ResultConverterTest extends TestCase
 
         $result = $converter->convert(new RawHttpResult($httpResponse));
 
-        $this->assertInstanceOf(ChoiceResult::class, $result);
+        $this->assertInstanceOf(MultiPartResult::class, $result);
         $output = $result->getContent();
         $this->assertCount(2, $output);
-        $this->assertSame('Choice 1', $output[0]->getContent());
-        $this->assertSame('Choice 2', $output[1]->getContent());
+        $this->assertSame('Part 1', $output[0]->getContent());
+        $this->assertSame('Part 2', $output[1]->getContent());
+    }
+
+    public function testConvertReasoningPlusMessageIntoMultiPartResult()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'reasoning',
+                    'id' => 'rs_1',
+                    'summary' => [
+                        ['type' => 'summary_text', 'text' => 'Let me work through this.'],
+                    ],
+                ],
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => '{"answer": 42}',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(ThinkingResult::class, $parts[0]);
+        $this->assertSame('Let me work through this.', $parts[0]->getContent());
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('{"answer": 42}', $parts[1]->getContent());
+    }
+
+    public function testConvertReasoningEmitsOneThinkingResultPerSummaryChunk()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'reasoning',
+                    'id' => 'rs_1',
+                    'summary' => [
+                        ['type' => 'summary_text', 'text' => 'First, I subtract 7.'],
+                        ['type' => 'summary_text', 'text' => 'Then I divide by 8.'],
+                    ],
+                ],
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'x = -3.75',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(3, $parts);
+        $this->assertInstanceOf(ThinkingResult::class, $parts[0]);
+        $this->assertSame('First, I subtract 7.', $parts[0]->getContent());
+        $this->assertInstanceOf(ThinkingResult::class, $parts[1]);
+        $this->assertSame('Then I divide by 8.', $parts[1]->getContent());
+        $this->assertInstanceOf(TextResult::class, $parts[2]);
+        $this->assertSame('x = -3.75', $parts[2]->getContent());
+    }
+
+    public function testConvertReasoningWithoutSummaryIsDropped()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'reasoning',
+                    'id' => 'rs_1',
+                    'summary' => [],
+                ],
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'final',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('final', $result->getContent());
     }
 
     public function testContentFilterException()

--- a/src/platform/src/StructuredOutput/ResultConverter.php
+++ b/src/platform/src/StructuredOutput/ResultConverter.php
@@ -13,6 +13,8 @@ namespace Symfony\AI\Platform\StructuredOutput;
 
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -42,10 +44,28 @@ final class ResultConverter implements ResultConverterInterface
     {
         $innerResult = $this->innerConverter->convert($result, $options);
 
-        if (!$innerResult instanceof TextResult) {
-            return $innerResult;
+        if ($innerResult instanceof TextResult) {
+            return $this->convertTextToObject($innerResult, $result);
         }
 
+        if ($innerResult instanceof MultiPartResult) {
+            return $this->convertMultiPart($innerResult, $result);
+        }
+
+        if ($innerResult instanceof ChoiceResult) {
+            return $this->convertChoice($innerResult, $result);
+        }
+
+        return $innerResult;
+    }
+
+    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    {
+        return $this->innerConverter->getTokenUsageExtractor();
+    }
+
+    private function convertTextToObject(TextResult $textResult, RawResultInterface $result): ObjectResult
+    {
         try {
             $context = [];
             if (null !== $this->objectToPopulate) {
@@ -53,9 +73,9 @@ final class ResultConverter implements ResultConverterInterface
             }
 
             $structure = null === $this->outputType
-                ? json_decode($innerResult->getContent(), true, flags: \JSON_THROW_ON_ERROR)
+                ? json_decode($textResult->getContent(), true, flags: \JSON_THROW_ON_ERROR)
                 : $this->serializer->deserialize(
-                    $innerResult->getContent(),
+                    $textResult->getContent(),
                     $this->outputType,
                     'json',
                     $context
@@ -68,13 +88,79 @@ final class ResultConverter implements ResultConverterInterface
 
         $objectResult = new ObjectResult($structure);
         $objectResult->setRawResult($result);
-        $objectResult->getMetadata()->set($innerResult->getMetadata()->all());
+        $objectResult->getMetadata()->set($textResult->getMetadata()->all());
+
+        // Preserve the provider-scoped signature (Vertex/Gemini) alongside the metadata so
+        // it survives the swap from TextResult to ObjectResult and can still be replayed.
+        if (null !== $signature = $textResult->getSignature()) {
+            $objectResult->getMetadata()->add('signature', $signature);
+        }
 
         return $objectResult;
     }
 
-    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    private function convertMultiPart(MultiPartResult $multiPart, RawResultInterface $result): MultiPartResult
     {
-        return $this->innerConverter->getTokenUsageExtractor();
+        $parts = $multiPart->getContent();
+        $converted = false;
+        $newParts = [];
+
+        foreach ($parts as $part) {
+            if (!$converted && $part instanceof TextResult) {
+                $newParts[] = $this->convertTextToObject($part, $result);
+                $converted = true;
+
+                continue;
+            }
+
+            $newParts[] = $part;
+        }
+
+        if (!$converted) {
+            return $multiPart;
+        }
+
+        $rebuilt = new MultiPartResult($newParts);
+        $rebuilt->setRawResult($result);
+        $rebuilt->getMetadata()->set($multiPart->getMetadata()->all());
+
+        return $rebuilt;
+    }
+
+    private function convertChoice(ChoiceResult $choices, RawResultInterface $result): ChoiceResult
+    {
+        $newChoices = [];
+        $converted = false;
+
+        foreach ($choices->getContent() as $choice) {
+            if ($choice instanceof TextResult) {
+                $newChoices[] = $this->convertTextToObject($choice, $result);
+                $converted = true;
+
+                continue;
+            }
+
+            if ($choice instanceof MultiPartResult) {
+                $convertedChoice = $this->convertMultiPart($choice, $result);
+                if ($convertedChoice !== $choice) {
+                    $converted = true;
+                }
+                $newChoices[] = $convertedChoice;
+
+                continue;
+            }
+
+            $newChoices[] = $choice;
+        }
+
+        if (!$converted) {
+            return $choices;
+        }
+
+        $rebuilt = new ChoiceResult($newChoices);
+        $rebuilt->setRawResult($result);
+        $rebuilt->getMetadata()->set($choices->getMetadata()->all());
+
+        return $rebuilt;
     }
 }

--- a/src/platform/tests/Result/ThinkingResultTest.php
+++ b/src/platform/tests/Result/ThinkingResultTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\ThinkingResult;
+
+final class ThinkingResultTest extends TestCase
+{
+    public function testGetContentAndSignature()
+    {
+        $result = new ThinkingResult('Thinking step by step…', 'sig_abc');
+
+        $this->assertSame('Thinking step by step…', $result->getContent());
+        $this->assertSame('sig_abc', $result->getSignature());
+    }
+
+    public function testDefaultsToNullContentAndSignature()
+    {
+        $result = new ThinkingResult();
+
+        $this->assertNull($result->getContent());
+        $this->assertNull($result->getSignature());
+    }
+}

--- a/src/platform/tests/StructuredOutput/ResultConverterTest.php
+++ b/src/platform/tests/StructuredOutput/ResultConverterTest.php
@@ -14,9 +14,12 @@ namespace Symfony\AI\Platform\Tests\StructuredOutput;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\PlainConverter;
+use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\StructuredOutput\ResultConverter;
 use Symfony\AI\Platform\StructuredOutput\Serializer;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\City;
@@ -134,6 +137,19 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('test_value', $result->getMetadata()->get('test_key'));
     }
 
+    public function testConvertPreservesTextResultSignatureInMetadata()
+    {
+        $textResult = new TextResult('{"some": "data"}', 'sig_replay_token');
+
+        $innerConverter = new PlainConverter($textResult);
+        $converter = new ResultConverter($innerConverter, new Serializer(), SomeStructure::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertTrue($result->getMetadata()->has('signature'));
+        $this->assertSame('sig_replay_token', $result->getMetadata()->get('signature'));
+    }
+
     public function testConvertSetsRawResultOnObjectResult()
     {
         $innerConverter = new PlainConverter(new TextResult('{"some": "data"}'));
@@ -165,5 +181,118 @@ final class ResultConverterTest extends TestCase
         $this->assertInstanceOf(ObjectResult::class, $result);
         $this->assertInstanceOf(UserWithAccessors::class, $result->getContent());
         $this->assertSame(10, $result->getContent()->getAge());
+    }
+
+    public function testConvertMultiPartResultWithReasoningAndMessage()
+    {
+        $reasoning = new ThinkingResult('Thinking step by step…');
+        $textResult = new TextResult('{"some": "data"}');
+        $multiPart = new MultiPartResult([$reasoning, $textResult]);
+
+        $innerConverter = new PlainConverter($multiPart);
+        $converter = new ResultConverter($innerConverter, new Serializer(), SomeStructure::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertSame($reasoning, $parts[0]);
+        $this->assertInstanceOf(ObjectResult::class, $parts[1]);
+        $this->assertInstanceOf(SomeStructure::class, $parts[1]->getContent());
+        $this->assertSame('data', $parts[1]->getContent()->some);
+    }
+
+    public function testConvertMultiPartResultWithoutTextResultIsUntouched()
+    {
+        $reasoning = new ThinkingResult('Just thinking, no answer.');
+        $multiPart = new MultiPartResult([$reasoning, $reasoning]);
+
+        $innerConverter = new PlainConverter($multiPart);
+        $converter = new ResultConverter($innerConverter, new Serializer(), SomeStructure::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertSame($multiPart, $result);
+    }
+
+    public function testConvertChoiceResultOfTextResults()
+    {
+        $choices = new ChoiceResult([
+            new TextResult('{"some": "first"}'),
+            new TextResult('{"some": "second"}'),
+        ]);
+
+        $innerConverter = new PlainConverter($choices);
+        $converter = new ResultConverter($innerConverter, new Serializer(), SomeStructure::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(ChoiceResult::class, $result);
+
+        $entries = $result->getContent();
+        $this->assertCount(2, $entries);
+        $this->assertInstanceOf(ObjectResult::class, $entries[0]);
+        $this->assertInstanceOf(ObjectResult::class, $entries[1]);
+
+        $first = $entries[0]->getContent();
+        $second = $entries[1]->getContent();
+        $this->assertInstanceOf(SomeStructure::class, $first);
+        $this->assertInstanceOf(SomeStructure::class, $second);
+        $this->assertSame('first', $first->some);
+        $this->assertSame('second', $second->some);
+    }
+
+    public function testConvertChoiceResultOfMultiPartResultsWithReasoning()
+    {
+        $reasoningA = new ThinkingResult('Thinking about choice A.');
+        $reasoningB = new ThinkingResult('Thinking about choice B.');
+
+        $choices = new ChoiceResult([
+            new MultiPartResult([$reasoningA, new TextResult('{"some": "a"}')]),
+            new MultiPartResult([$reasoningB, new TextResult('{"some": "b"}')]),
+        ]);
+
+        $innerConverter = new PlainConverter($choices);
+        $converter = new ResultConverter($innerConverter, new Serializer(), SomeStructure::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(ChoiceResult::class, $result);
+
+        $entries = $result->getContent();
+        $this->assertCount(2, $entries);
+
+        $this->assertInstanceOf(MultiPartResult::class, $entries[0]);
+        $partsA = $entries[0]->getContent();
+        $this->assertSame($reasoningA, $partsA[0]);
+        $this->assertInstanceOf(ObjectResult::class, $partsA[1]);
+        $contentA = $partsA[1]->getContent();
+        $this->assertInstanceOf(SomeStructure::class, $contentA);
+        $this->assertSame('a', $contentA->some);
+
+        $this->assertInstanceOf(MultiPartResult::class, $entries[1]);
+        $partsB = $entries[1]->getContent();
+        $this->assertSame($reasoningB, $partsB[0]);
+        $this->assertInstanceOf(ObjectResult::class, $partsB[1]);
+        $contentB = $partsB[1]->getContent();
+        $this->assertInstanceOf(SomeStructure::class, $contentB);
+        $this->assertSame('b', $contentB->some);
+    }
+
+    public function testConvertChoiceResultWithoutAnyConvertibleEntryIsUntouched()
+    {
+        $reasoningOnly = new MultiPartResult([new ThinkingResult('No answer here.')]);
+        $objectChoice = new ObjectResult(['already' => 'converted']);
+
+        $choices = new ChoiceResult([$reasoningOnly, $objectChoice]);
+
+        $innerConverter = new PlainConverter($choices);
+        $converter = new ResultConverter($innerConverter, new Serializer(), SomeStructure::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertSame($choices, $result);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Reasoning models (e.g. `gpt-5`) emit a reasoning summary alongside the assistant message. The Responses-API converters wrapped both into a `ChoiceResult`, which the structured-output converter could not unwrap — so `response_format` threw `UnexpectedResultTypeException` on any reasoning model. `ChoiceResult` is also semantically wrong here (it represents `n>1` alternatives, not heterogeneous parts of one response).
Important to know: Responses API doesn't support returning multiple choices.

## Fix

- New `Result\ThinkingResult` exposes reasoning summaries as `non-empty-list<string>` with `asText(string $separator = PHP_EOL.PHP_EOL)`. Naming matches the existing `Thinking*` stream deltas.
- `Bridge\OpenAi\Gpt` and `Bridge\OpenResponses` converters return `MultiPartResult` instead of `ChoiceResult`, and now read the reasoning summary from the `summary[]` list of `summary_text` entries (was reading `summary['text']` and silently dropping reasoning on real responses).
- `StructuredOutput\ResultConverter` recurses into `MultiPartResult` and `ChoiceResult`, swapping the inner `TextResult` for an `ObjectResult` while preserving the surrounding parts.
- `Bridge\Cache\ResultNormalizer` (de)normalizes `MultiPartResult` and `ThinkingResult`.
- New example `examples/openai/structured-output-reasoning.php` exercises the full path against `gpt-5-mini`.

## BC break

Responses-API bridges return `MultiPartResult` instead of `ChoiceResult` for multi-item output; reasoning is `ThinkingResult` instead of `TextResult`. Documented in `UPGRADE.md`.

## Test plan

- [x] Platform PHPUnit (540) + PHPStan (level 6) clean
- [x] Live `gpt-5-mini` run confirms reasoning summary + structured object both surface