### PR TITLE
[AI Bundle] Data Collector - Fix bug that re-throws Exception

### DIFF
--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Validate structured output using `symfony/validator` when available
  * Make `ai:platform:invoke` arguments optional and prompt for them interactively when missing
+ * Visualize failed calls with `result_type: 'error'` in profiler
 
 0.8
 ---

--- a/src/ai-bundle/src/Profiler/DataCollector.php
+++ b/src/ai-bundle/src/Profiler/DataCollector.php
@@ -41,8 +41,9 @@ use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
  *     input: array<mixed>|string|object,
  *     options: array<string, mixed>,
  *     result: string|iterable<mixed>|object|null,
- *     result_type: 'tool_calls'|'vectors'|'text',
+ *     result_type: 'tool_calls'|'vectors'|'text'|'error',
  *     metadata: Metadata,
+ *     error?: array{class: class-string, message: string},
  * }
  */
 final class DataCollector extends AbstractDataCollector implements LateDataCollectorInterface
@@ -214,22 +215,30 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
         $calls = $platform->getCalls();
         $resultCache = $platform->getResultCache();
         foreach ($calls as $key => $call) {
-            $result = $call['result']->getResult();
+            try {
+                $result = $call['result']->getResult();
 
-            if (isset($resultCache[$result])) {
-                $call['result'] = $resultCache[$result];
-                $call['result_type'] = 'text';
-            } else {
-                $content = $result->getContent();
-                $call['result'] = $content instanceof \Generator ? null : $content;
-                $call['result_type'] = match (true) {
-                    $result instanceof ToolCallResult => 'tool_calls',
-                    $result instanceof VectorResult => 'vectors',
-                    default => 'text',
-                };
+                if (isset($resultCache[$result])) {
+                    $call['result'] = $resultCache[$result];
+                    $call['result_type'] = 'text';
+                } else {
+                    $content = $result->getContent();
+                    $call['result'] = $content instanceof \Generator ? null : $content;
+                    $call['result_type'] = match (true) {
+                        $result instanceof ToolCallResult => 'tool_calls',
+                        $result instanceof VectorResult => 'vectors',
+                        default => 'text',
+                    };
+                }
+
+                $call['metadata'] = $result->getMetadata();
+            } catch (\Throwable $exception) {
+                // Recording instead of re-throwing prevents replacing the user's response with a 500 during kernel.response.
+                $call['result'] = null;
+                $call['result_type'] = 'error';
+                $call['metadata'] = new Metadata();
+                $call['error'] = ['class' => $exception::class, 'message' => $exception->getMessage()];
             }
-
-            $call['metadata'] = $result->getMetadata();
 
             $calls[$key] = $call;
         }

--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -203,6 +203,9 @@
                                                     <li>Vector with <strong>{{ vector.dimensions }}</strong> dimensions</li>
                                                 {% endfor %}
                                             </ol>
+                                        {% elseif call.result_type == 'error' %}
+                                            <strong class="status-error">Failed:</strong>
+                                            <code>{{ call.error.class }}</code>: {{ call.error.message }}
                                         {% else %}
                                             {{ dump(call.result) }}
                                         {% endif %}

--- a/src/ai-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/ai-bundle/tests/Profiler/DataCollectorTest.php
@@ -23,10 +23,12 @@ use Symfony\AI\Chat\Chat;
 use Symfony\AI\Chat\InMemory\Store as InMemoryStore;
 use Symfony\AI\Chat\TraceableChat;
 use Symfony\AI\Chat\TraceableMessageStore;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Metadata\Metadata;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -38,6 +40,7 @@ use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\Tool\ExecutionReference;
 use Symfony\AI\Platform\Tool\Tool;
 use Symfony\AI\Platform\TraceablePlatform;
@@ -160,6 +163,43 @@ class DataCollectorTest extends TestCase
 
         $this->assertCount(1, $dataCollector->getPlatformCalls());
         $this->assertSame('vectors', $dataCollector->getPlatformCalls()[0]['result_type']);
+    }
+
+    public function testRecordsErrorWhenResultConversionFails()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $traceablePlatform = new TraceablePlatform($platform);
+        $messageBag = new MessageBag(Message::ofUser(new Text('Hello')));
+        $exception = new RateLimitExceededException();
+
+        $failingConverter = $this->createMock(ResultConverterInterface::class);
+        $failingConverter->method('convert')->willThrowException($exception);
+        $failingConverter->method('getTokenUsageExtractor')->willReturn(null);
+
+        $platform->method('invoke')->willReturn(
+            new DeferredResult($failingConverter, $this->createStub(RawResultInterface::class))
+        );
+
+        $deferred = $traceablePlatform->invoke('gpt-4o', $messageBag, ['stream' => false]);
+
+        try {
+            $deferred->getResult();
+            $this->fail('Expected RateLimitExceededException to be thrown.');
+        } catch (RateLimitExceededException) {
+        }
+
+        // lateCollect() must not re-throw, otherwise it would replace the user's response with a 500.
+        $dataCollector = new DataCollector([$traceablePlatform], [], [], [], [], []);
+        $dataCollector->lateCollect();
+
+        $calls = $dataCollector->getPlatformCalls();
+        $this->assertCount(1, $calls);
+        $this->assertSame('error', $calls[0]['result_type']);
+        $this->assertNull($calls[0]['result']);
+        $this->assertInstanceOf(Metadata::class, $calls[0]['metadata']);
+        $this->assertArrayHasKey('error', $calls[0]);
+        $this->assertSame(RateLimitExceededException::class, $calls[0]['error']['class']);
+        $this->assertSame('Rate limit exceeded.', $calls[0]['error']['message']);
     }
 
     public function testCollectsDataForObjectResult()

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add support for multiple system messages in `MessageBag`
  * [BC BREAK] Rework `AssistantMessage` to hold `ContentInterface` parts (variadic constructor) instead of a single string content plus separate tool-call/thinking fields. Adds `Message\Content\Thinking`, `Message\Content\ExecutableCode`, and `Message\Content\CodeExecution` content classes, and makes `Result\ToolCall` implement `ContentInterface`. `Message::ofAssistant()` accepts strings, `ContentInterface`, and `ResultInterface` values, mapping `TextResult`/`ThinkingResult`/`ToolCallResult`/`ExecutableCodeResult`/`CodeExecutionResult`/`MultiPartResult` to their content equivalents; result types without a known mapping throw `InvalidArgumentException` so unhandled cases surface instead of being silently dropped.
  * Add optional `signature` field to `Message\Content\Text`, `Result\ToolCall`, and `Result\TextResult` for provider-scoped signatures (currently used by Gemini/Vertex AI for `thoughtSignature` round-trip).
+ * Memoize conversion failures in `DeferredResult::getResult()` so subsequent calls re-throw the cached exception instead of re-running the converter
 
 0.8
 ---

--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -30,6 +30,7 @@ final class DeferredResult
 
     private bool $isConverted = false;
     private ResultInterface $convertedResult;
+    private ?\Throwable $conversionFailure = null;
 
     /**
      * @param array<string, mixed> $options
@@ -46,7 +47,15 @@ final class DeferredResult
      */
     public function getResult(): ResultInterface
     {
-        if (!$this->isConverted) {
+        if (null !== $this->conversionFailure) {
+            throw $this->conversionFailure;
+        }
+
+        if ($this->isConverted) {
+            return $this->convertedResult;
+        }
+
+        try {
             $this->convertedResult = $this->resultConverter->convert($this->rawResult, $this->options);
 
             if (null === $this->convertedResult->getRawResult()) {
@@ -72,6 +81,9 @@ final class DeferredResult
             $this->metadata->set($metadata->all());
 
             $this->isConverted = true;
+        } catch (\Throwable $exception) {
+            $this->conversionFailure = $exception;
+            throw $exception;
         }
 
         return $this->convertedResult;

--- a/src/platform/tests/Result/DeferredResultTest.php
+++ b/src/platform/tests/Result/DeferredResultTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Tests\Result;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\Result\BaseResult;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -166,6 +167,34 @@ final class DeferredResultTest extends TestCase
 
         $this->assertInstanceOf(TokenUsageInterface::class, $tokenUsage = $converted->getMetadata()->get('token_usage'));
         $this->assertSame(123456, $tokenUsage->getPromptTokens());
+    }
+
+    public function testItSavesConversionFailureAndDoesNotRetryConvert()
+    {
+        $rawHttpResult = new RawHttpResult($this->createStub(SymfonyHttpResponse::class));
+        $exception = new RateLimitExceededException();
+
+        $resultConverter = $this->createMock(ResultConverterInterface::class);
+        $resultConverter->expects($this->once())
+            ->method('convert')
+            ->with($rawHttpResult, [])
+            ->willThrowException($exception);
+
+        $deferredResult = new DeferredResult($resultConverter, $rawHttpResult);
+
+        try {
+            $deferredResult->getResult();
+            $this->fail('Expected RateLimitExceededException on first call.');
+        } catch (RateLimitExceededException $first) {
+            $this->assertSame($exception, $first);
+        }
+
+        try {
+            $deferredResult->getResult();
+            $this->fail('Expected RateLimitExceededException on second call.');
+        } catch (RateLimitExceededException $second) {
+            $this->assertSame($exception, $second, 'Second call must re-throw the cached exception instance.');
+        }
     }
 
     public function testTokenUsageGetsPromotedToDeferredResultFromStream()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

When a platform call throws (rate limit, network error, etc.), the bundle's DataCollector re-runs the conversion during `kernel.response` to build profile data, so it throws the exception again. From the user's perspective, their `try/catch` around the agent looks broken: a 429 turns into a 500.

  Fix:

  - `DataCollector::awaitCallResults()` — wrap the per-call work in try/catch. Failed calls are recorded as result_type: 'error' with an error array (class, message), and the profiler template renders them. 
  - `DeferredResult::getResult()` — cache the exception; re-throw the same instance on subsequent calls. 

This bug only affects the development environment because the data collector only runs with `kernel.debug=true`.

BTW, Claude helped me debug the issue and find a proper solution