### PR TITLE
[Examples] Include AssistantMessage usage in chat examples

### DIFF
--- a/examples/aimlapi/chat.php
+++ b/examples/aimlapi/chat.php
@@ -24,14 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('gemini-2.5-flash', $messages, [
     'max_tokens' => 500, // specific options just for this call
 ]);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('gemini-2.5-flash', $messages, [
     'max_tokens' => 500,
 ]);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/aimlapi/chat.php
+++ b/examples/aimlapi/chat.php
@@ -26,3 +26,12 @@ $result = $platform->invoke('gemini-2.5-flash', $messages, [
 ]);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('gemini-2.5-flash', $messages, [
+    'max_tokens' => 500,
+]);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/albert/chat.php
+++ b/examples/albert/chat.php
@@ -42,3 +42,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('openweight-small', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And what is the budget allocated to this strategy?'));
+$result = $platform->invoke('openweight-small', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/albert/chat.php
+++ b/examples/albert/chat.php
@@ -40,12 +40,8 @@ $messages = new MessageBag(
 );
 
 $result = $platform->invoke('openweight-small', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And what is the budget allocated to this strategy?'));
 $result = $platform->invoke('openweight-small', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/amazeeai/chat.php
+++ b/examples/amazeeai/chat.php
@@ -24,3 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('claude-3-5-sonnet', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('claude-3-5-sonnet', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/amazeeai/chat.php
+++ b/examples/amazeeai/chat.php
@@ -22,12 +22,8 @@ $messages = new MessageBag(
     Message::ofUser('What is the Symfony framework?'),
 );
 $result = $platform->invoke('claude-3-5-sonnet', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('claude-3-5-sonnet', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/anthropic/chat.php
+++ b/examples/anthropic/chat.php
@@ -22,12 +22,8 @@ $messages = new MessageBag(
     Message::ofUser('What is the Symfony framework?'),
 );
 $result = $platform->invoke('claude-sonnet-4-5-20250929', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('claude-sonnet-4-5-20250929', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/anthropic/chat.php
+++ b/examples/anthropic/chat.php
@@ -24,3 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('claude-sonnet-4-5-20250929', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('claude-sonnet-4-5-20250929', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -14,6 +14,8 @@ use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\Exception\ExceptionInterface as AgentException;
 use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
 use Symfony\AI\Platform\Exception\ExceptionInterface as PlatformException;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\TokenUsage\TokenUsageAggregation;
 use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
@@ -150,6 +152,16 @@ function print_token_usage(?TokenUsageInterface $tokenUsage): void
     if ($tokenUsage instanceof TokenUsageAggregation) {
         output()->writeln(sprintf('<comment>Aggregated token usage from %d calls.</comment>', $tokenUsage->count()));
     }
+}
+
+/**
+ * Echoes the assistant's reply and appends it back to the message bag so a
+ * subsequent user turn keeps the assistant context.
+ */
+function continue_chat(MessageBag $messages, string $content): void
+{
+    echo $content.\PHP_EOL;
+    $messages->add(Message::ofAssistant($content));
 }
 
 function print_vectors(DeferredResult $result): void

--- a/examples/cerebras/chat.php
+++ b/examples/cerebras/chat.php
@@ -22,12 +22,8 @@ $messages = new MessageBag(
     Message::ofUser('What is the capital of Japan?'),
 );
 $result = $platform->invoke('llama3.1-8b', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('What is its population?'));
 $result = $platform->invoke('llama3.1-8b', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/cerebras/chat.php
+++ b/examples/cerebras/chat.php
@@ -24,3 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('llama3.1-8b', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('What is its population?'));
+$result = $platform->invoke('llama3.1-8b', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/claude-code/chat.php
+++ b/examples/claude-code/chat.php
@@ -28,15 +28,11 @@ $result = $platform->invoke('sonnet', $messages, [
     'permission_mode' => 'plan',
     'max_turns' => 3,
 ]);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('Which directory would you start with to understand the test setup?'));
 $result = $platform->invoke('sonnet', $messages, [
     'permission_mode' => 'plan',
     'max_turns' => 3,
 ]);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/claude-code/chat.php
+++ b/examples/claude-code/chat.php
@@ -30,3 +30,13 @@ $result = $platform->invoke('sonnet', $messages, [
 ]);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('Which directory would you start with to understand the test setup?'));
+$result = $platform->invoke('sonnet', $messages, [
+    'permission_mode' => 'plan',
+    'max_turns' => 3,
+]);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/codex/chat.php
+++ b/examples/codex/chat.php
@@ -27,16 +27,12 @@ $messages = new MessageBag(
 $result = $platform->invoke('gpt-5.4', $messages, [
     'sandbox' => 'read-only',
 ]);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('Which directory would you start with to understand the test setup?'));
 $result = $platform->invoke('gpt-5.4', $messages, [
     'sandbox' => 'read-only',
 ]);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());
 
 print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/codex/chat.php
+++ b/examples/codex/chat.php
@@ -30,4 +30,13 @@ $result = $platform->invoke('gpt-5.4', $messages, [
 
 echo $result->asText().\PHP_EOL;
 
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('Which directory would you start with to understand the test setup?'));
+$result = $platform->invoke('gpt-5.4', $messages, [
+    'sandbox' => 'read-only',
+]);
+
+echo $result->asText().\PHP_EOL;
+
 print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/cohere/chat.php
+++ b/examples/cohere/chat.php
@@ -24,4 +24,13 @@ $result = $platform->invoke('command-a-03-2025', $messages, [
 
 echo $result->asText().\PHP_EOL;
 
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('What is its deepest known point?'));
+$result = $platform->invoke('command-a-03-2025', $messages, [
+    'temperature' => 0.7,
+]);
+
+echo $result->asText().\PHP_EOL;
+
 print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/cohere/chat.php
+++ b/examples/cohere/chat.php
@@ -21,16 +21,12 @@ $messages = new MessageBag(Message::ofUser('What is the largest ocean on Earth?'
 $result = $platform->invoke('command-a-03-2025', $messages, [
     'temperature' => 0.7,
 ]);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('What is its deepest known point?'));
 $result = $platform->invoke('command-a-03-2025', $messages, [
     'temperature' => 0.7,
 ]);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());
 
 print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/deepseek/chat.php
+++ b/examples/deepseek/chat.php
@@ -22,12 +22,8 @@ $messages = new MessageBag(
     Message::ofUser('Yesterday I had a Déjà vu. It is a funny feeling, no?'),
 );
 $result = $platform->invoke('deepseek-chat', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('Could it have been a glitch in the Matrix?'));
 $result = $platform->invoke('deepseek-chat', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/deepseek/chat.php
+++ b/examples/deepseek/chat.php
@@ -24,3 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('deepseek-chat', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('Could it have been a glitch in the Matrix?'));
+$result = $platform->invoke('deepseek-chat', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/dockermodelrunner/chat.php
+++ b/examples/dockermodelrunner/chat.php
@@ -25,3 +25,9 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 echo $result->getContent().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->getContent()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $agent->call($messages);
+echo $result->getContent().\PHP_EOL;

--- a/examples/dockermodelrunner/chat.php
+++ b/examples/dockermodelrunner/chat.php
@@ -24,10 +24,8 @@ $messages = new MessageBag(
     Message::ofUser('What is the Symfony framework?'),
 );
 $result = $agent->call($messages);
-echo $result->getContent().\PHP_EOL;
+continue_chat($messages, $result->getContent());
 
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->getContent()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $agent->call($messages);
-echo $result->getContent().\PHP_EOL;
+continue_chat($messages, $result->getContent());

--- a/examples/gemini/chat.php
+++ b/examples/gemini/chat.php
@@ -24,3 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('gemini-2.5-flash', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('gemini-2.5-flash', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/gemini/chat.php
+++ b/examples/gemini/chat.php
@@ -22,12 +22,8 @@ $messages = new MessageBag(
     Message::ofUser('What is the Symfony framework?'),
 );
 $result = $platform->invoke('gemini-2.5-flash', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('gemini-2.5-flash', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/github-copilot/chat.php
+++ b/examples/github-copilot/chat.php
@@ -54,17 +54,13 @@ $messages = new MessageBag(
 $result = $platform->invoke('openai/gpt-4.1', $messages, [
     'max_tokens' => 500,
 ]);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('openai/gpt-4.1', $messages, [
     'max_tokens' => 500,
 ]);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());
 
 $tokenUsage = $result->getMetadata()->get('token_usage');
 if (null !== $tokenUsage) {

--- a/examples/github-copilot/chat.php
+++ b/examples/github-copilot/chat.php
@@ -57,6 +57,15 @@ $result = $platform->invoke('openai/gpt-4.1', $messages, [
 
 echo $result->asText().\PHP_EOL;
 
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('openai/gpt-4.1', $messages, [
+    'max_tokens' => 500,
+]);
+
+echo $result->asText().\PHP_EOL;
+
 $tokenUsage = $result->getMetadata()->get('token_usage');
 if (null !== $tokenUsage) {
     print_token_usage($tokenUsage);

--- a/examples/litellm/chat.php
+++ b/examples/litellm/chat.php
@@ -49,6 +49,15 @@ $result = $platform->invoke('mistral-small-latest', $messages, [
 
 echo $result->asText().\PHP_EOL;
 
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('mistral-small-latest', $messages, [
+    'max_tokens' => 500,
+]);
+
+echo $result->asText().\PHP_EOL;
+
 print_token_usage($result->getMetadata()->get('token_usage'));
 
 echo \PHP_EOL;

--- a/examples/litellm/chat.php
+++ b/examples/litellm/chat.php
@@ -46,17 +46,13 @@ $messages = new MessageBag(
 $result = $platform->invoke('mistral-small-latest', $messages, [
     'max_tokens' => 500, // specific options just for this call
 ]);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('mistral-small-latest', $messages, [
     'max_tokens' => 500,
 ]);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());
 
 print_token_usage($result->getMetadata()->get('token_usage'));
 

--- a/examples/lmstudio/chat.php
+++ b/examples/lmstudio/chat.php
@@ -24,14 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('gemma-3-4b-it-qat', $messages, [
     'max_tokens' => 500, // specific options just for this call
 ]);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('gemma-3-4b-it-qat', $messages, [
     'max_tokens' => 500,
 ]);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/lmstudio/chat.php
+++ b/examples/lmstudio/chat.php
@@ -26,3 +26,12 @@ $result = $platform->invoke('gemma-3-4b-it-qat', $messages, [
 ]);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('gemma-3-4b-it-qat', $messages, [
+    'max_tokens' => 500,
+]);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/mistral/chat.php
+++ b/examples/mistral/chat.php
@@ -21,14 +21,10 @@ $messages = new MessageBag(Message::ofUser('What is the best French cheese?'));
 $result = $platform->invoke('mistral-large-latest', $messages, [
     'temperature' => 0.7,
 ]);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('Which one pairs best with red wine?'));
 $result = $platform->invoke('mistral-large-latest', $messages, [
     'temperature' => 0.7,
 ]);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/mistral/chat.php
+++ b/examples/mistral/chat.php
@@ -23,3 +23,12 @@ $result = $platform->invoke('mistral-large-latest', $messages, [
 ]);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('Which one pairs best with red wine?'));
+$result = $platform->invoke('mistral-large-latest', $messages, [
+    'temperature' => 0.7,
+]);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/models-dev/chat.php
+++ b/examples/models-dev/chat.php
@@ -29,3 +29,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('claude-haiku-4-5', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('claude-haiku-4-5', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/models-dev/chat.php
+++ b/examples/models-dev/chat.php
@@ -27,12 +27,8 @@ $messages = new MessageBag(
 );
 
 $result = $platform->invoke('claude-haiku-4-5', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('claude-haiku-4-5', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/openai/chat.php
+++ b/examples/openai/chat.php
@@ -24,14 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('gpt-4o-mini', $messages, [
     'max_output_tokens' => 500, // specific options just for this call
 ]);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('gpt-4o-mini', $messages, [
     'max_output_tokens' => 500,
 ]);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/openai/chat.php
+++ b/examples/openai/chat.php
@@ -26,3 +26,12 @@ $result = $platform->invoke('gpt-4o-mini', $messages, [
 ]);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('gpt-4o-mini', $messages, [
+    'max_output_tokens' => 500,
+]);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/ovh/chat.php
+++ b/examples/ovh/chat.php
@@ -22,12 +22,8 @@ $messages = new MessageBag(
     Message::ofUser('What is the Symfony framework?'),
 );
 $result = $platform->invoke('gpt-oss-120b', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('gpt-oss-120b', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/ovh/chat.php
+++ b/examples/ovh/chat.php
@@ -24,3 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('gpt-oss-120b', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('gpt-oss-120b', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/perplexity/chat.php
+++ b/examples/perplexity/chat.php
@@ -19,12 +19,8 @@ $platform = Factory::createPlatform(env('PERPLEXITY_API_KEY'), http_client());
 
 $messages = new MessageBag(Message::ofUser('What is the best French cheese?'));
 $result = $platform->invoke('sonar', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('Which region of France produces it?'));
 $result = $platform->invoke('sonar', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/perplexity/chat.php
+++ b/examples/perplexity/chat.php
@@ -21,3 +21,10 @@ $messages = new MessageBag(Message::ofUser('What is the best French cheese?'));
 $result = $platform->invoke('sonar', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('Which region of France produces it?'));
+$result = $platform->invoke('sonar', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/scaleway/chat.php
+++ b/examples/scaleway/chat.php
@@ -22,12 +22,8 @@ $messages = new MessageBag(
     Message::ofUser('What is the Symfony framework?'),
 );
 $result = $platform->invoke('gpt-oss-120b', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And which versions are LTS?'));
 $result = $platform->invoke('gpt-oss-120b', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());

--- a/examples/scaleway/chat.php
+++ b/examples/scaleway/chat.php
@@ -24,3 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('gpt-oss-120b', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And which versions are LTS?'));
+$result = $platform->invoke('gpt-oss-120b', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/vertexai/chat.php
+++ b/examples/vertexai/chat.php
@@ -24,3 +24,10 @@ $messages = new MessageBag(
 $result = $platform->invoke('gemini-2.5-flash', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
+$messages->add(Message::ofAssistant($result->asText()));
+$messages->add(Message::ofUser('And what is its elevation?'));
+$result = $platform->invoke('gemini-2.5-flash', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/vertexai/chat.php
+++ b/examples/vertexai/chat.php
@@ -22,12 +22,8 @@ $messages = new MessageBag(
     Message::ofUser('Where is Mount Fuji?'),
 );
 $result = $platform->invoke('gemini-2.5-flash', $messages);
+continue_chat($messages, $result->asText());
 
-echo $result->asText().\PHP_EOL;
-
-// Multi-turn: feed the assistant's reply back into the bag and ask a follow-up.
-$messages->add(Message::ofAssistant($result->asText()));
 $messages->add(Message::ofUser('And what is its elevation?'));
 $result = $platform->invoke('gemini-2.5-flash', $messages);
-
-echo $result->asText().\PHP_EOL;
+continue_chat($messages, $result->asText());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1969
| License       | MIT

Adds a multi-turn follow-up to every \`examples/<bridge>/chat.php\`: the
assistant's reply is fed back into the \`MessageBag\` via
\`Message::ofAssistant()\`, then a context-dependent user follow-up is
sent.

This addresses #1969 — the chat examples now exercise \`AssistantMessage\`
normalization across all bridges, making it possible to smoke-test
changes against the actual provider APIs.

Notes:
- Pattern consistent across the 21 examples; pre-existing options
  (\`max_tokens\`, \`temperature\`, \`permission_mode\`, …) preserved on
  the second invocation.
- For agent-based bridges (\`docker-model-runner\`, \`claude-code\`,
  \`codex\`) the example still demonstrates the \`MessageBag\` shape with
  the assistant turn fed back in.