### PR TITLE
[Platform][Gemini] Strip the JSON-Schema $schema meta-key from tool parameters

### DIFF
--- a/src/platform/src/Bridge/Gemini/Contract/ToolNormalizer.php
+++ b/src/platform/src/Bridge/Gemini/Contract/ToolNormalizer.php
@@ -56,6 +56,7 @@ final class ToolNormalizer extends ModelContractNormalizer
      * Normalizes a JSON Schema for Gemini compatibility.
      *
      * - Removes 'additionalProperties' (not supported by Gemini)
+     * - Removes '$schema' (Gemini's strict OpenAPI-flavored parser rejects this JSON-Schema meta-key)
      * - Converts array-style nullable types ['string', 'null'] to ['type' => 'string', 'nullable' => true]
      *
      * @template T of array
@@ -66,7 +67,7 @@ final class ToolNormalizer extends ModelContractNormalizer
      */
     private function normalizeSchema(array $data): array
     {
-        unset($data['additionalProperties']);
+        unset($data['additionalProperties'], $data['$schema']);
 
         // Convert array-style nullable types to Gemini format
         if (isset($data['type']) && \is_array($data['type'])) {

--- a/src/platform/src/Bridge/Gemini/Tests/Contract/ToolNormalizerTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Contract/ToolNormalizerTest.php
@@ -163,6 +163,58 @@ final class ToolNormalizerTest extends TestCase
             ],
         ];
 
+        yield 'call with $schema meta-key' => [
+            new Tool(
+                new ExecutionReference(ToolRequiredParams::class, 'bar'),
+                'tool_with_schema_meta_key',
+                'A tool whose schema carries the JSON-Schema $schema meta-key (e.g. produced by an MCP server)',
+                // @phpstan-ignore argument.type (testing JSON-Schema meta-keys that get stripped)
+                [
+                    '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                            'description' => 'Name parameter',
+                        ],
+                        'nested' => [
+                            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+                            'type' => 'object',
+                            'properties' => [
+                                'inner' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'required' => ['name'],
+                    'additionalProperties' => false,
+                ],
+            ),
+            [
+                'description' => 'A tool whose schema carries the JSON-Schema $schema meta-key (e.g. produced by an MCP server)',
+                'name' => 'tool_with_schema_meta_key',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                            'description' => 'Name parameter',
+                        ],
+                        'nested' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'inner' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'required' => ['name'],
+                ],
+            ],
+        ];
+
         yield 'call with nested nullable parameter' => [
             new Tool(
                 new ExecutionReference(ToolRequiredParams::class, 'bar'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no 
| Issues        | Fix https://github.com/symfony/ai/issues/2037
| License       | MIT


More information on the issue : https://github.com/symfony/ai/issues/2037

TLDR: Gemini have a strict validation and was returning an exception when it got the `$schema` field

Returning an excetion :

```
Invalid JSON payload received. Unknown name "$schema" at 'tools[0].function_declarations[9].parameters': Cannot find field.
```