### PR TITLE
[Platform][Gemini] Wrap function_response in a Protobuf Struct

### DIFF
--- a/examples/gemini/toolcall-list-result.php
+++ b/examples/gemini/toolcall-list-result.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Gemini\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+#[AsTool('list_european_capitals', 'Returns the capitals of a few European countries.')]
+final class EuropeanCapitalsTool
+{
+    /**
+     * @return list<string>
+     */
+    public function __invoke(): array
+    {
+        return ['Paris', 'Berlin', 'Madrid', 'Rome'];
+    }
+}
+
+$platform = Factory::createPlatform(env('GEMINI_API_KEY'), http_client());
+
+$toolbox = new Toolbox([new EuropeanCapitalsTool()], logger: logger());
+$processor = new AgentProcessor($toolbox);
+$agent = new Agent($platform, 'gemini-2.5-flash', [$processor], [$processor]);
+
+$messages = new MessageBag(
+    Message::forSystem('Use the available tool to answer.'),
+    Message::ofUser('List a few European capitals.'),
+);
+$result = $agent->call($messages);
+
+echo $result->getContent().\PHP_EOL;

--- a/src/platform/src/Bridge/Gemini/Contract/ToolCallMessageNormalizer.php
+++ b/src/platform/src/Bridge/Gemini/Contract/ToolCallMessageNormalizer.php
@@ -26,9 +26,9 @@ final class ToolCallMessageNormalizer extends ModelContractNormalizer
      *
      * @return array{
      *      functionResponse: array{
-     *          id: string,
+     *          id?: string,
      *          name: string,
-     *          response: array<int|string, mixed>
+     *          response: array{result: array<int|string, mixed>|string}
      *      }
      *  }[]
      */
@@ -37,14 +37,20 @@ final class ToolCallMessageNormalizer extends ModelContractNormalizer
         $resultContent = json_validate($data->getContent())
             ? json_decode($data->getContent(), true) : $data->getContent();
 
+        // Gemini's API requires `response` (FunctionResponse) to be a Protobuf Struct
+        $functionResponse = [
+            'name' => $data->getToolCall()->getName(),
+            'response' => ['result' => $resultContent],
+        ];
+
+        // Gemini < 3.0 may return an empty string as the ID which is invalid
+        $id = $data->getToolCall()->getId();
+        if ('' !== $id) {
+            $functionResponse['id'] = $id;
+        }
+
         return [[
-            'functionResponse' => array_filter([
-                'id' => $data->getToolCall()->getId(),
-                'name' => $data->getToolCall()->getName(),
-                'response' => \is_array($resultContent) ? $resultContent : [
-                    'rawResponse' => $resultContent, // Gemini expects the response to be an object, but not everyone uses objects as their responses.
-                ],
-            ]),
+            'functionResponse' => $functionResponse,
         ]];
     }
 

--- a/src/platform/src/Bridge/Gemini/Tests/Contract/ToolCallMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Contract/ToolCallMessageNormalizerTest.php
@@ -43,7 +43,7 @@ final class ToolCallMessageNormalizerTest extends TestCase
     }
 
     /**
-     * @param array{functionResponse: array{id: string, name: string, response: array<int|string, mixed>}}[] $expected
+     * @param array{functionResponse: array{name: string, response: array{result: mixed}, id?: string}}[] $expected
      */
     #[DataProvider('normalizeDataProvider')]
     public function testNormalize(ToolCallMessage $message, array $expected)
@@ -67,9 +67,9 @@ final class ToolCallMessageNormalizerTest extends TestCase
             ),
             [[
                 'functionResponse' => [
-                    'id' => 'id1',
                     'name' => 'name1',
-                    'response' => ['rawResponse' => 'true'],
+                    'response' => ['result' => 'true'],
+                    'id' => 'id1',
                 ],
             ]],
         ];
@@ -81,9 +81,36 @@ final class ToolCallMessageNormalizerTest extends TestCase
             ),
             [[
                 'functionResponse' => [
-                    'id' => 'id1',
                     'name' => 'name1',
-                    'response' => ['structured' => 'response'],
+                    'response' => ['result' => ['structured' => 'response']],
+                    'id' => 'id1',
+                ],
+            ]],
+        ];
+
+        yield 'list response is wrapped as a Protobuf Struct' => [
+            new ToolCallMessage(
+                new ToolCall('id1', 'name1', ['foo' => 'bar']),
+                '["foo","bar"]',
+            ),
+            [[
+                'functionResponse' => [
+                    'name' => 'name1',
+                    'response' => ['result' => ['foo', 'bar']],
+                    'id' => 'id1',
+                ],
+            ]],
+        ];
+
+        yield 'empty id is omitted' => [
+            new ToolCallMessage(
+                new ToolCall('', 'name1', ['foo' => 'bar']),
+                '{"structured":"response"}',
+            ),
+            [[
+                'functionResponse' => [
+                    'name' => 'name1',
+                    'response' => ['result' => ['structured' => 'response']],
                 ],
             ]],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1555
| License       | MIT

After fixing these issue https://github.com/symfony/ai/pull/2038 I also had the issue reported here https://github.com/symfony/ai/issues/1555

```
Invalid JSON payload received. Unknown name "response" at 'contents[N].parts[0].function_response': Proto field is not repeating, cannot start list.
```

- Gemini doesn't always return an id for function call, making it being dropped.
- As reported by @johnnestebann Gemini a Protobuf Struct format. This issue occured when a list was returned by my MCP.