### PR TITLE
[Mate] Add channel filter to monolog-tail tool

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `tag` filter parameter to `symfony-services` MCP tool to filter services by DI tag name (e.g. `kernel.event_listener`, `twig.extension`)
+ * Add `channel` filter parameter to `monolog-tail` MCP tool for consistency with `monolog-search`
  * Add `ResourcesReadCommand` (`mcp:resources:read`) to read MCP resources by URI from the CLI
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
  * Allow Symfony profiler capabilities (`ProfilerResourceTemplate` and `ProfilerTool`) to be instantiated without a `ProfilerDataProvider`, throwing a clear `RuntimeException` when invoked in workspaces without profiler support

--- a/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
+++ b/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
@@ -106,11 +106,12 @@ final class LogSearchTool
      * @param int         $lines       Number of most recent log entries to return
      * @param string|null $level       Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
      * @param string|null $environment Filter by Symfony environment (e.g. dev, prod, test)
+     * @param string|null $channel     Filter by Monolog channel name (e.g. app, security, doctrine)
      */
-    #[McpTool(name: 'monolog-tail', title: 'Log Tail', description: 'Get the most recent log entries. Reads from the end of log files, optionally filtered by level and environment.')]
-    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null): string
+    #[McpTool(name: 'monolog-tail', title: 'Log Tail', description: 'Get the most recent log entries. Reads from the end of log files, optionally filtered by level, environment, and channel.')]
+    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null, ?string $channel = null): string
     {
-        $entries = $this->reader->tail($lines, $level, $environment);
+        $entries = $this->reader->tail($lines, $level, $environment, $channel);
 
         return ResponseEncoder::encode(['entries' => array_values(array_map(static fn ($entry) => $entry->toArray(), $entries))]);
     }

--- a/src/mate/src/Bridge/Monolog/Service/LogReader.php
+++ b/src/mate/src/Bridge/Monolog/Service/LogReader.php
@@ -158,7 +158,7 @@ final class LogReader
     /**
      * @return LogEntry[]
      */
-    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null): array
+    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null, ?string $channel = null): array
     {
         $files = null !== $environment
             ? $this->getLogFilesForEnvironment($environment)
@@ -173,7 +173,7 @@ final class LogReader
             return [];
         }
 
-        return $this->tailFromFile($file, $lines, $level);
+        return $this->tailFromFile($file, $lines, $level, $channel);
     }
 
     /**
@@ -193,7 +193,7 @@ final class LogReader
     /**
      * @return LogEntry[]
      */
-    private function tailFromFile(string $file, int $lines, ?string $level = null): array
+    private function tailFromFile(string $file, int $lines, ?string $level = null, ?string $channel = null): array
     {
         $handle = fopen($file, 'r');
         if (false === $handle) {
@@ -223,6 +223,10 @@ final class LogReader
                 }
 
                 if (null !== $level && strtoupper($level) !== $entry->getLevel()) {
+                    continue;
+                }
+
+                if (null !== $channel && strtolower($channel) !== strtolower($entry->getChannel())) {
                     continue;
                 }
 

--- a/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
@@ -158,6 +158,17 @@ final class LogSearchToolTest extends TestCase
         }
     }
 
+    public function testTailWithChannel()
+    {
+        $result = Toon::decode($this->tool->tail(10, channel: 'security'));
+
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertNotEmpty($result['entries']);
+        foreach ($result['entries'] as $entry) {
+            $this->assertSame('security', $entry['channel']);
+        }
+    }
+
     public function testListFiles()
     {
         $result = Toon::decode($this->tool->listFiles());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

The `monolog-tail` MCP tool previously only supported filtering by `level` and `environment`, while `monolog-search` supports `level`, `channel`, `environment`, and date range filters. This inconsistency made it awkward for an AI agent to tail logs from a specific channel (e.g. `security`, `doctrine`).

This PR adds a `channel` parameter to `monolog-tail` to bring it in line with `monolog-search`.