### PR TITLE
[Mate] Add tag filter to symfony-services tool

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.9
 ---
 
+ * Add `tag` filter parameter to `symfony-services` MCP tool to filter services by DI tag name (e.g. `kernel.event_listener`, `twig.extension`)
  * Add `ResourcesReadCommand` (`mcp:resources:read`) to read MCP resources by URI from the CLI
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
  * Allow Symfony profiler capabilities (`ProfilerResourceTemplate` and `ProfilerTool`) to be instantiated without a `ProfilerDataProvider`, throwing a clear `RuntimeException` when invoked in workspaces without profiler support

--- a/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
@@ -28,10 +28,11 @@ class ServiceTool
     }
 
     /**
-     * @param string|null $query Filter services by ID or class name (case-insensitive partial match)
+     * @param string|null $query Filter by service ID or class name (case-insensitive partial match)
+     * @param string|null $tag   Filter by DI tag name (e.g. kernel.event_listener, twig.extension)
      */
-    #[McpTool(name: 'symfony-services', title: 'Symfony Services', description: 'Search Symfony dependency injection container services. Optionally filter by service ID or class name. Returns a map of service IDs to their class names.')]
-    public function getServices(?string $query = null): string
+    #[McpTool(name: 'symfony-services', title: 'Symfony Services', description: 'Search Symfony dependency injection container services. Optionally filter by service ID, class name, or tag name. Returns a map of service IDs to their class names.')]
+    public function getServices(?string $query = null, ?string $tag = null): string
     {
         $container = $this->readContainer();
         if (null === $container) {
@@ -47,6 +48,20 @@ class ServiceTool
                     continue;
                 }
             }
+
+            if (null !== $tag && '' !== $tag) {
+                $hasTag = false;
+                foreach ($service->getTags() as $serviceTag) {
+                    if ($serviceTag->getName() === $tag) {
+                        $hasTag = true;
+                        break;
+                    }
+                }
+                if (!$hasTag) {
+                    continue;
+                }
+            }
+
             $output[$service->getId()] = $service->getClass();
         }
 

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolTest.php
@@ -165,6 +165,52 @@ final class ServiceToolTest extends TestCase
         $this->assertEmpty($services);
     }
 
+    public function testGetServicesFiltersByTag()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool($this->fixturesDir, $provider);
+
+        $services = Toon::decode($tool->getServices(tag: 'kernel.event_listener'));
+
+        $this->assertArrayHasKey('app.event_listener', $services);
+        $this->assertSame('App\EventListener\RequestListener', $services['app.event_listener']);
+    }
+
+    public function testGetServicesFiltersByTagReturnsOnlyMatchingServices()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool($this->fixturesDir, $provider);
+
+        $services = Toon::decode($tool->getServices(tag: 'cache.pool'));
+
+        $this->assertArrayHasKey('cache.app', $services);
+        $this->assertArrayNotHasKey('logger', $services);
+        $this->assertArrayNotHasKey('event_dispatcher', $services);
+        $this->assertArrayNotHasKey('app.event_listener', $services);
+    }
+
+    public function testGetServicesFiltersByTagWithNoMatch()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool($this->fixturesDir, $provider);
+
+        $services = Toon::decode($tool->getServices(tag: 'nonexistent.tag'), DecodeOptions::lenient());
+
+        $this->assertEmpty($services);
+    }
+
+    public function testGetServicesFiltersByTagAndQuery()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool($this->fixturesDir, $provider);
+
+        $services = Toon::decode($tool->getServices(query: 'listener', tag: 'kernel.event_listener'));
+
+        $this->assertArrayHasKey('app.event_listener', $services);
+        $this->assertArrayNotHasKey('cache.app', $services);
+        $this->assertArrayNotHasKey('logger', $services);
+    }
+
     public function testGetServicesDetectsCustomKernelClassName()
     {
         $tempDir = sys_get_temp_dir().'/symfony_ai_mate_test_'.uniqid();

--- a/src/mate/src/Bridge/Symfony/Tests/Fixtures/App_KernelDevDebugContainer.xml
+++ b/src/mate/src/Bridge/Symfony/Tests/Fixtures/App_KernelDevDebugContainer.xml
@@ -17,5 +17,8 @@
         <service id="router" class="Symfony\Component\Routing\Router">
             <factory class="RouterFactory" method="create"/>
         </service>
+        <service id="app.event_listener" class="App\EventListener\RequestListener">
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

The `symfony-services` MCP tool supports filtering by service ID or class name. Tag data (`kernel.event_listener`, `twig.extension`, `cache.pool`, etc.) is already parsed and stored in `ServiceDefinition::$tags` but was not exposed for filtering.

This PR adds a `tag` parameter so AI agents can ask "which services are tagged `kernel.event_listener`?" — a common need when exploring a Symfony application's structure.