### PR TITLE
[Platform][Anthropic] Add missing Claude models to ModelCatalog

### DIFF
--- a/src/platform/src/Bridge/Anthropic/ModelCatalog.php
+++ b/src/platform/src/Bridge/Anthropic/ModelCatalog.php
@@ -179,6 +179,54 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::TOOL_CALLING,
                 ],
             ],
+            'claude-opus-4-5-20251101' => [
+                'class' => Claude::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::THINKING,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            'claude-opus-4-6' => [
+                'class' => Claude::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::THINKING,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            'claude-sonnet-4-6' => [
+                'class' => Claude::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::THINKING,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            'claude-opus-4-7' => [
+                'class' => Claude::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::THINKING,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
         ];
 
         $this->models = array_merge($defaultModels, $additionalModels);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

---

## Summary

The Anthropic `ModelCatalog` was missing several models. This PR adds them based on
the response of `GET /v1/models` (checked 2026-05-06).

### Added

- `claude-opus-4-5-20251101` (Claude Opus 4.5)
- `claude-opus-4-6` (Claude Opus 4.6)
- `claude-sonnet-4-6` (Claude Sonnet 4.6)
- `claude-opus-4-7` (Claude Opus 4.7)

## Open question: handling of older models

`GET /v1/models` currently returns only Claude 4.x models (`has_more: false`).
The following entries in the catalog are no longer listed by the API — they may be
deprecated but could still be callable:

- `claude-3-haiku-20240307`
- `claude-3-opus-20240229`
- `claude-3-5-haiku-latest`
- `claude-3-5-haiku-20241022`
- `claude-3-7-sonnet-latest`
- `claude-3-7-sonnet-20250219`

They have been kept as-is to avoid any BC break. Should we remove them, deprecate them,
or keep them indefinitely? Happy to follow up in a separate PR based on your preference.
