### PR TITLE
[Mate] Add symfony-service-detail MCP tool

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `channel` filter parameter to `monolog-tail` MCP tool for consistency with `monolog-search`
  * Add `TimeCollectorFormatter` for the Symfony profiler `time` collector, exposing request duration, initialization time, and stopwatch events sorted by duration
  * Add `MemoryCollectorFormatter` for the Symfony profiler `memory` collector, exposing peak memory usage, memory limit, and usage percentage
+ * Add `symfony-service-detail` MCP tool to retrieve full details of a single DI container service by its exact ID (class, tags, method calls, factory)
  * Add `ResourcesReadCommand` (`mcp:resources:read`) to read MCP resources by URI from the CLI
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
  * Allow Symfony profiler capabilities (`ProfilerResourceTemplate` and `ProfilerTool`) to be instantiated without a `ProfilerDataProvider`, throwing a clear `RuntimeException` when invoked in workspaces without profiler support

--- a/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Mate\Bridge\Symfony\Capability;
 
 use Mcp\Capability\Attribute\McpTool;
+use Symfony\AI\Mate\Bridge\Symfony\Exception\ServiceNotFoundException;
 use Symfony\AI\Mate\Bridge\Symfony\Model\Container;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
 use Symfony\AI\Mate\Encoding\ResponseEncoder;
@@ -63,6 +64,53 @@ class ServiceTool
             }
 
             $output[$service->getId()] = $service->getClass();
+        }
+
+        return ResponseEncoder::encode($output);
+    }
+
+    /**
+     * @param string $id The exact service ID to retrieve details for
+     */
+    #[McpTool(name: 'symfony-service-detail', title: 'Symfony Service Detail', description: 'Get full details of a single Symfony DI container service by its exact ID, including class, tags, method calls, and constructor/factory information.')]
+    public function getServiceDetail(string $id): string
+    {
+        $container = $this->readContainer();
+        if (null === $container) {
+            throw new ServiceNotFoundException(\sprintf('Service "%s" not found: container could not be loaded.', $id));
+        }
+
+        $services = $container->getServices();
+        if (!isset($services[$id])) {
+            throw new ServiceNotFoundException(\sprintf('Service "%s" not found in the container.', $id));
+        }
+
+        $service = $services[$id];
+
+        $tags = [];
+        foreach ($service->getTags() as $tag) {
+            $entry = ['name' => $tag->getName()];
+            foreach ($tag->getAttributes() as $key => $value) {
+                $entry[$key] = $value;
+            }
+            $tags[] = $entry;
+        }
+
+        [$factoryClass, $factoryMethod] = $service->getConstructor();
+        $constructor = null;
+        if (null !== $factoryClass) {
+            $constructor = $factoryClass.'::'.$factoryMethod;
+        }
+
+        $output = [
+            'id' => $service->getId(),
+            'class' => $service->getClass(),
+            'tags' => $tags,
+            'calls' => $service->getCalls(),
+        ];
+
+        if (null !== $constructor) {
+            $output['factory'] = $constructor;
         }
 
         return ResponseEncoder::encode($output);

--- a/src/mate/src/Bridge/Symfony/Exception/ServiceNotFoundException.php
+++ b/src/mate/src/Bridge/Symfony/Exception/ServiceNotFoundException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Exception;
+
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
+
+/**
+ * @internal
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class ServiceNotFoundException extends InvalidArgumentException
+{
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolTest.php
@@ -15,7 +15,9 @@ use HelgeSverre\Toon\DecodeOptions;
 use HelgeSverre\Toon\Toon;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ServiceTool;
+use Symfony\AI\Mate\Bridge\Symfony\Exception\ServiceNotFoundException;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 /**
  * @author Johannes Wachter <johannes@sulu.io>
@@ -209,6 +211,69 @@ final class ServiceToolTest extends TestCase
         $this->assertArrayHasKey('app.event_listener', $services);
         $this->assertArrayNotHasKey('cache.app', $services);
         $this->assertArrayNotHasKey('logger', $services);
+    }
+
+    public function testGetServiceDetailReturnsServiceInfo()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool($this->fixturesDir, $provider);
+
+        $detail = Toon::decode($tool->getServiceDetail('cache.app'));
+
+        $this->assertSame('cache.app', $detail['id']);
+        $this->assertSame(FilesystemAdapter::class, $detail['class']);
+        $this->assertIsArray($detail['tags']);
+        $this->assertIsArray($detail['calls']);
+    }
+
+    public function testGetServiceDetailIncludesTags()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool($this->fixturesDir, $provider);
+
+        $detail = Toon::decode($tool->getServiceDetail('logger'));
+
+        $this->assertCount(1, $detail['tags']);
+        $this->assertSame('monolog.logger', $detail['tags'][0]['name']);
+        $this->assertSame('app', $detail['tags'][0]['channel']);
+    }
+
+    public function testGetServiceDetailIncludesCalls()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool($this->fixturesDir, $provider);
+
+        $detail = Toon::decode($tool->getServiceDetail('event_dispatcher'));
+
+        $this->assertContains('addListener', $detail['calls']);
+    }
+
+    public function testGetServiceDetailIncludesFactory()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool($this->fixturesDir, $provider);
+
+        $detail = Toon::decode($tool->getServiceDetail('router'));
+
+        $this->assertSame('RouterFactory::create', $detail['factory']);
+    }
+
+    public function testGetServiceDetailThrowsForUnknownService()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool($this->fixturesDir, $provider);
+
+        $this->expectException(ServiceNotFoundException::class);
+        $tool->getServiceDetail('nonexistent.service.xyz');
+    }
+
+    public function testGetServiceDetailThrowsWhenContainerNotFound()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool('/non/existent/directory', $provider);
+
+        $this->expectException(ServiceNotFoundException::class);
+        $tool->getServiceDetail('cache.app');
     }
 
     public function testGetServicesDetectsCustomKernelClassName()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

The `symfony-services` tool returns a broad map of service IDs to class names. When an AI agent needs to understand a specific service in depth (its tags, method calls, factory), it had no way to get that detail.

This PR adds a `symfony-service-detail` tool that takes an exact service ID and returns:
- `class` — the service's class name
- `tags` — all DI tags with their attributes (e.g. `kernel.event_listener` with `event` and `method`)
- `calls` — configured method calls
- `factory` — factory class and method if applicable

The `@return` array-shape docblock is included to align with the structured output pattern being introduced in #1897.