### PR TITLE
[Mate] Add TimeCollectorFormatter for Symfony profiler time collector

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `tag` filter parameter to `symfony-services` MCP tool to filter services by DI tag name (e.g. `kernel.event_listener`, `twig.extension`)
  * Add `channel` filter parameter to `monolog-tail` MCP tool for consistency with `monolog-search`
+ * Add `TimeCollectorFormatter` for the Symfony profiler `time` collector, exposing request duration, initialization time, and stopwatch events sorted by duration
  * Add `ResourcesReadCommand` (`mcp:resources:read`) to read MCP resources by URI from the CLI
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
  * Allow Symfony profiler capabilities (`ProfilerResourceTemplate` and `ProfilerTool`) to be instantiated without a `ProfilerDataProvider`, throwing a clear `RuntimeException` when invoked in workspaces without profiler support

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/TimeCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/TimeCollectorFormatter.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
+
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
+
+/**
+ * Formats time collector data for AI consumption.
+ *
+ * Exposes total request duration, initialization time, and individual
+ * stopwatch events to help diagnose slow requests.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ *
+ * @implements CollectorFormatterInterface<TimeDataCollector>
+ */
+final class TimeCollectorFormatter implements CollectorFormatterInterface
+{
+    public function getName(): string
+    {
+        return 'time';
+    }
+
+    public function format(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof TimeDataCollector);
+
+        $events = [];
+        foreach ($collector->getEvents() as $name => $event) {
+            if ('__section__' === $name) {
+                continue;
+            }
+            $events[] = [
+                'name' => $name,
+                'category' => $event->getCategory(),
+                'duration_ms' => round($event->getDuration(), 2),
+                'memory' => $event->getMemory(),
+            ];
+        }
+
+        usort($events, static fn (array $a, array $b) => $b['duration_ms'] <=> $a['duration_ms']);
+
+        return [
+            'duration_ms' => round($collector->getDuration(), 2),
+            'init_time_ms' => round($collector->getInitTime(), 2),
+            'stopwatch_installed' => $collector->isStopwatchInstalled(),
+            'events' => $events,
+        ];
+    }
+
+    public function getSummary(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof TimeDataCollector);
+
+        return [
+            'duration_ms' => round($collector->getDuration(), 2),
+            'init_time_ms' => round($collector->getInitTime(), 2),
+        ];
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/TimeCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/TimeCollectorFormatterTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\TimeCollectorFormatter;
+use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
+use Symfony\Component\Stopwatch\StopwatchEvent;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class TimeCollectorFormatterTest extends TestCase
+{
+    private TimeCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new TimeCollectorFormatter();
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('time', $this->formatter->getName());
+    }
+
+    public function testFormat()
+    {
+        $event = $this->createMock(StopwatchEvent::class);
+        $event->method('getCategory')->willReturn('section');
+        $event->method('getDuration')->willReturn(42.5);
+        $event->method('getMemory')->willReturn(1024 * 1024);
+
+        $collector = $this->createMock(TimeDataCollector::class);
+        $collector->method('getDuration')->willReturn(120.0);
+        $collector->method('getInitTime')->willReturn(15.3);
+        $collector->method('isStopwatchInstalled')->willReturn(true);
+        $collector->method('getEvents')->willReturn(['kernel.handle' => $event]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(120.0, $result['duration_ms']);
+        $this->assertSame(15.3, $result['init_time_ms']);
+        $this->assertTrue($result['stopwatch_installed']);
+        $this->assertCount(1, $result['events']);
+        $this->assertSame('kernel.handle', $result['events'][0]['name']);
+        $this->assertSame('section', $result['events'][0]['category']);
+        $this->assertSame(42.5, $result['events'][0]['duration_ms']);
+        $this->assertSame(1024 * 1024, $result['events'][0]['memory']);
+    }
+
+    public function testFormatExcludesSectionWrapper()
+    {
+        $sectionEvent = $this->createMock(StopwatchEvent::class);
+        $sectionEvent->method('getCategory')->willReturn('default');
+        $sectionEvent->method('getDuration')->willReturn(200.0);
+        $sectionEvent->method('getMemory')->willReturn(0);
+
+        $realEvent = $this->createMock(StopwatchEvent::class);
+        $realEvent->method('getCategory')->willReturn('section');
+        $realEvent->method('getDuration')->willReturn(50.0);
+        $realEvent->method('getMemory')->willReturn(0);
+
+        $collector = $this->createMock(TimeDataCollector::class);
+        $collector->method('getDuration')->willReturn(200.0);
+        $collector->method('getInitTime')->willReturn(5.0);
+        $collector->method('isStopwatchInstalled')->willReturn(true);
+        $collector->method('getEvents')->willReturn([
+            '__section__' => $sectionEvent,
+            'kernel.handle' => $realEvent,
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertCount(1, $result['events']);
+        $this->assertSame('kernel.handle', $result['events'][0]['name']);
+    }
+
+    public function testFormatSortsEventsByDurationDescending()
+    {
+        $fastEvent = $this->createMock(StopwatchEvent::class);
+        $fastEvent->method('getCategory')->willReturn('section');
+        $fastEvent->method('getDuration')->willReturn(10.0);
+        $fastEvent->method('getMemory')->willReturn(0);
+
+        $slowEvent = $this->createMock(StopwatchEvent::class);
+        $slowEvent->method('getCategory')->willReturn('section');
+        $slowEvent->method('getDuration')->willReturn(80.0);
+        $slowEvent->method('getMemory')->willReturn(0);
+
+        $collector = $this->createMock(TimeDataCollector::class);
+        $collector->method('getDuration')->willReturn(100.0);
+        $collector->method('getInitTime')->willReturn(10.0);
+        $collector->method('isStopwatchInstalled')->willReturn(true);
+        $collector->method('getEvents')->willReturn([
+            'kernel.response' => $fastEvent,
+            'kernel.handle' => $slowEvent,
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame('kernel.handle', $result['events'][0]['name']);
+        $this->assertSame('kernel.response', $result['events'][1]['name']);
+    }
+
+    public function testFormatWithNoEvents()
+    {
+        $collector = $this->createMock(TimeDataCollector::class);
+        $collector->method('getDuration')->willReturn(0.0);
+        $collector->method('getInitTime')->willReturn(0.0);
+        $collector->method('isStopwatchInstalled')->willReturn(false);
+        $collector->method('getEvents')->willReturn([]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(0.0, $result['duration_ms']);
+        $this->assertFalse($result['stopwatch_installed']);
+        $this->assertSame([], $result['events']);
+    }
+
+    public function testGetSummary()
+    {
+        $collector = $this->createMock(TimeDataCollector::class);
+        $collector->method('getDuration')->willReturn(98.76);
+        $collector->method('getInitTime')->willReturn(12.34);
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertSame(98.76, $result['duration_ms']);
+        $this->assertSame(12.34, $result['init_time_ms']);
+        $this->assertArrayNotHasKey('events', $result);
+        $this->assertArrayNotHasKey('stopwatch_installed', $result);
+    }
+}

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -40,6 +40,7 @@
         "phpunit/phpunit": "^11.5.53",
         "symfony/http-kernel": "^7.3|^8.0",
         "symfony/mailer": "^7.3|^8.0",
+        "symfony/stopwatch": "^7.3|^8.0",
         "symfony/translation": "^7.3|^8.0",
         "symfony/var-dumper": "^7.3|^8.0",
         "symfony/web-profiler-bundle": "^7.3|^8.0"

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -17,6 +17,7 @@ use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorF
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MailerCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RequestCollectorFormatter;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\TimeCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\TranslationCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
@@ -74,6 +75,10 @@ return static function (ContainerConfigurator $configurator) {
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(DoctrineCollectorFormatter::class)
+            ->lazy()
+            ->tag('ai_mate.profiler_collector_formatter');
+
+        $services->set(TimeCollectorFormatter::class)
             ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix part of #1440
| License       | MIT

Adds a `TimeCollectorFormatter` for the Symfony profiler `time` collector to the Symfony bridge.

The formatter exposes:
- Total request duration (`duration_ms`)
- Initialization time (`init_time_ms`)
- Whether Stopwatch is installed (`stopwatch_installed`)
- Individual Stopwatch events sorted by duration descending, each with `name`, `category`, `duration_ms`, and `memory`

The `__section__` wrapper event is excluded. `getSummary()` returns only duration and init time for compact profiler overviews.