### PR TITLE
[Mate] Add MemoryCollectorFormatter for Symfony profiler memory collector

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `tag` filter parameter to `symfony-services` MCP tool to filter services by DI tag name (e.g. `kernel.event_listener`, `twig.extension`)
  * Add `channel` filter parameter to `monolog-tail` MCP tool for consistency with `monolog-search`
  * Add `TimeCollectorFormatter` for the Symfony profiler `time` collector, exposing request duration, initialization time, and stopwatch events sorted by duration
+ * Add `MemoryCollectorFormatter` for the Symfony profiler `memory` collector, exposing peak memory usage, memory limit, and usage percentage
  * Add `ResourcesReadCommand` (`mcp:resources:read`) to read MCP resources by URI from the CLI
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
  * Allow Symfony profiler capabilities (`ProfilerResourceTemplate` and `ProfilerTool`) to be instantiated without a `ProfilerDataProvider`, throwing a clear `RuntimeException` when invoked in workspaces without profiler support

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/MemoryCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/MemoryCollectorFormatter.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
+
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\MemoryDataCollector;
+
+/**
+ * Formats memory collector data for AI consumption.
+ *
+ * Exposes peak memory usage and the configured memory limit to help
+ * diagnose memory-intensive requests.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ *
+ * @implements CollectorFormatterInterface<MemoryDataCollector>
+ */
+final class MemoryCollectorFormatter implements CollectorFormatterInterface
+{
+    public function getName(): string
+    {
+        return 'memory';
+    }
+
+    /**
+     * @return array{
+     *     memory_bytes: int,
+     *     memory_mb: float,
+     *     memory_limit_bytes: int|float,
+     *     memory_limit_mb: float|string,
+     *     usage_percent: float|null,
+     * }
+     */
+    public function format(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof MemoryDataCollector);
+
+        $memoryBytes = $collector->getMemory();
+        $limitBytes = $collector->getMemoryLimit();
+
+        if ($limitBytes > 0) {
+            $usagePercent = round($memoryBytes / $limitBytes * 100, 2);
+            $limitMb = round($limitBytes / 1024 / 1024, 2);
+        } else {
+            $usagePercent = null;
+            $limitMb = 'unlimited';
+        }
+
+        return [
+            'memory_bytes' => $memoryBytes,
+            'memory_mb' => round($memoryBytes / 1024 / 1024, 2),
+            'memory_limit_bytes' => $limitBytes,
+            'memory_limit_mb' => $limitMb,
+            'usage_percent' => $usagePercent,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     memory_mb: float,
+     *     memory_limit_mb: float|string,
+     *     usage_percent: float|null,
+     * }
+     */
+    public function getSummary(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof MemoryDataCollector);
+
+        $memoryBytes = $collector->getMemory();
+        $limitBytes = $collector->getMemoryLimit();
+
+        if ($limitBytes > 0) {
+            $usagePercent = round($memoryBytes / $limitBytes * 100, 2);
+            $limitMb = round($limitBytes / 1024 / 1024, 2);
+        } else {
+            $usagePercent = null;
+            $limitMb = 'unlimited';
+        }
+
+        return [
+            'memory_mb' => round($memoryBytes / 1024 / 1024, 2),
+            'memory_limit_mb' => $limitMb,
+            'usage_percent' => $usagePercent,
+        ];
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/MemoryCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/MemoryCollectorFormatterTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MemoryCollectorFormatter;
+use Symfony\Component\HttpKernel\DataCollector\MemoryDataCollector;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class MemoryCollectorFormatterTest extends TestCase
+{
+    private MemoryCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new MemoryCollectorFormatter();
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('memory', $this->formatter->getName());
+    }
+
+    public function testFormat()
+    {
+        $collector = $this->createMock(MemoryDataCollector::class);
+        $collector->method('getMemory')->willReturn(16 * 1024 * 1024); // 16 MB
+        $collector->method('getMemoryLimit')->willReturn(128 * 1024 * 1024); // 128 MB
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(16 * 1024 * 1024, $result['memory_bytes']);
+        $this->assertSame(16.0, $result['memory_mb']);
+        $this->assertSame(128 * 1024 * 1024, $result['memory_limit_bytes']);
+        $this->assertSame(128.0, $result['memory_limit_mb']);
+        $this->assertSame(12.5, $result['usage_percent']);
+    }
+
+    public function testFormatWithUnlimitedMemory()
+    {
+        $collector = $this->createMock(MemoryDataCollector::class);
+        $collector->method('getMemory')->willReturn(8 * 1024 * 1024); // 8 MB
+        $collector->method('getMemoryLimit')->willReturn(-1);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(8 * 1024 * 1024, $result['memory_bytes']);
+        $this->assertSame(8.0, $result['memory_mb']);
+        $this->assertSame(-1, $result['memory_limit_bytes']);
+        $this->assertSame('unlimited', $result['memory_limit_mb']);
+        $this->assertNull($result['usage_percent']);
+    }
+
+    public function testGetSummary()
+    {
+        $collector = $this->createMock(MemoryDataCollector::class);
+        $collector->method('getMemory')->willReturn(32 * 1024 * 1024); // 32 MB
+        $collector->method('getMemoryLimit')->willReturn(256 * 1024 * 1024); // 256 MB
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertSame(32.0, $result['memory_mb']);
+        $this->assertSame(256.0, $result['memory_limit_mb']);
+        $this->assertSame(12.5, $result['usage_percent']);
+        $this->assertArrayNotHasKey('memory_bytes', $result);
+        $this->assertArrayNotHasKey('memory_limit_bytes', $result);
+    }
+
+    public function testGetSummaryWithUnlimitedMemory()
+    {
+        $collector = $this->createMock(MemoryDataCollector::class);
+        $collector->method('getMemory')->willReturn(4 * 1024 * 1024); // 4 MB
+        $collector->method('getMemoryLimit')->willReturn(-1);
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertSame(4.0, $result['memory_mb']);
+        $this->assertSame('unlimited', $result['memory_limit_mb']);
+        $this->assertNull($result['usage_percent']);
+    }
+}

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -16,6 +16,7 @@ use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MailerCollectorFormatter;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MemoryCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RequestCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\TimeCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\TranslationCollectorFormatter;
@@ -79,6 +80,10 @@ return static function (ContainerConfigurator $configurator) {
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(TimeCollectorFormatter::class)
+            ->lazy()
+            ->tag('ai_mate.profiler_collector_formatter');
+
+        $services->set(MemoryCollectorFormatter::class)
             ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix part of #1440
| License       | MIT

Adds a `MemoryCollectorFormatter` for the Symfony profiler `memory` collector to the Symfony bridge.

The formatter exposes:
- `memory_bytes` / `memory_mb` — peak memory usage during the request
- `memory_limit_bytes` / `memory_limit_mb` — configured PHP memory limit (`"unlimited"` when set to `-1`)
- `usage_percent` — percentage of memory limit consumed (`null` when unlimited)

`getSummary()` returns the same fields minus raw bytes (`memory_bytes`, `memory_limit_bytes`) for compact profiler overviews.