### PR TITLE
[Mate][Symfony] Add router profiler collector formatter

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `tag` filter parameter to `symfony-services` MCP tool to filter services by DI tag name (e.g. `kernel.event_listener`, `twig.extension`)
  * Add `channel` filter parameter to `monolog-tail` MCP tool for consistency with `monolog-search`
+ * Add `RouterCollectorFormatter` for the Symfony profiler `router` collector, exposing redirect status, target URL, and target route
  * Add `ResourcesReadCommand` (`mcp:resources:read`) to read MCP resources by URI from the CLI
  * Change default user namespace scaffolded by `mate init` from `App\Mate\` to `Mate\`
  * Allow Symfony profiler capabilities (`ProfilerResourceTemplate` and `ProfilerTool`) to be instantiated without a `ProfilerDataProvider`, throwing a clear `RuntimeException` when invoked in workspaces without profiler support

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/RouterCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/RouterCollectorFormatter.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
+
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\RouterDataCollector;
+
+/**
+ * Formats router collector data.
+ *
+ * Reports redirect information: whether the response was a redirect,
+ * the target URL, and the guessed target route name.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ *
+ * @implements CollectorFormatterInterface<RouterDataCollector>
+ */
+final class RouterCollectorFormatter implements CollectorFormatterInterface
+{
+    public function getName(): string
+    {
+        return 'router';
+    }
+
+    public function format(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof RouterDataCollector);
+
+        return [
+            'redirect' => $collector->getRedirect(),
+            'target_url' => $collector->getTargetUrl(),
+            'target_route' => $collector->getTargetRoute(),
+        ];
+    }
+
+    public function getSummary(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof RouterDataCollector);
+
+        return [
+            'redirect' => $collector->getRedirect(),
+            'target_route' => $collector->getTargetRoute(),
+        ];
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/RouterCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/RouterCollectorFormatterTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RouterCollectorFormatter;
+use Symfony\Component\HttpKernel\DataCollector\RouterDataCollector;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RouterCollectorFormatterTest extends TestCase
+{
+    private RouterCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new RouterCollectorFormatter();
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('router', $this->formatter->getName());
+    }
+
+    public function testFormatWithNoRedirect()
+    {
+        $collector = $this->createMock(RouterDataCollector::class);
+        $collector->method('getRedirect')->willReturn(false);
+        $collector->method('getTargetUrl')->willReturn(null);
+        $collector->method('getTargetRoute')->willReturn(null);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertFalse($result['redirect']);
+        $this->assertNull($result['target_url']);
+        $this->assertNull($result['target_route']);
+    }
+
+    public function testFormatWithRedirect()
+    {
+        $collector = $this->createMock(RouterDataCollector::class);
+        $collector->method('getRedirect')->willReturn(true);
+        $collector->method('getTargetUrl')->willReturn('/dashboard');
+        $collector->method('getTargetRoute')->willReturn('app_dashboard');
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertTrue($result['redirect']);
+        $this->assertSame('/dashboard', $result['target_url']);
+        $this->assertSame('app_dashboard', $result['target_route']);
+    }
+
+    public function testGetSummaryWithNoRedirect()
+    {
+        $collector = $this->createMock(RouterDataCollector::class);
+        $collector->method('getRedirect')->willReturn(false);
+        $collector->method('getTargetRoute')->willReturn(null);
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertFalse($result['redirect']);
+        $this->assertNull($result['target_route']);
+        $this->assertArrayNotHasKey('target_url', $result);
+    }
+
+    public function testGetSummaryWithRedirect()
+    {
+        $collector = $this->createMock(RouterDataCollector::class);
+        $collector->method('getRedirect')->willReturn(true);
+        $collector->method('getTargetRoute')->willReturn('app_login');
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertTrue($result['redirect']);
+        $this->assertSame('app_login', $result['target_route']);
+        $this->assertArrayNotHasKey('target_url', $result);
+    }
+}

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -17,6 +17,7 @@ use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorF
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MailerCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RequestCollectorFormatter;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RouterCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\TranslationCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
@@ -74,6 +75,10 @@ return static function (ContainerConfigurator $configurator) {
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(DoctrineCollectorFormatter::class)
+            ->lazy()
+            ->tag('ai_mate.profiler_collector_formatter');
+
+        $services->set(RouterCollectorFormatter::class)
             ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | n/a
| License       | MIT

Adds `RouterCollectorFormatter` which formats `RouterDataCollector` data for the Symfony Mate profiler MCP tool.

The formatter is intentionally thin — the router collector only tracks redirect information. `format()` returns `redirect`, `target_url`, and `target_route`. `getSummary()` omits `target_url` as the route name is sufficient for triage.