### PR TITLE
[Mate][Symfony] Add logger profiler collector formatter

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `tag` filter parameter to `symfony-services` MCP tool to filter services by DI tag name (e.g. `kernel.event_listener`, `twig.extension`)
  * Add `channel` filter parameter to `monolog-tail` MCP tool for consistency with `monolog-search`
  * Add `TimeCollectorFormatter` for the Symfony profiler `time` collector, exposing request duration, initialization time, and stopwatch events sorted by duration
+ * Add `LoggerCollectorFormatter` for the Symfony profiler `logger` collector, exposing error/warning/deprecation/scream counts and individual log entries
  * Add `MemoryCollectorFormatter` for the Symfony profiler `memory` collector, exposing peak memory usage, memory limit, and usage percentage
  * Add `symfony-service-detail` MCP tool to retrieve full details of a single DI container service by its exact ID (class, tags, method calls, factory)
  * Add `ResourcesReadCommand` (`mcp:resources:read`) to read MCP resources by URI from the CLI

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/LoggerCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/LoggerCollectorFormatter.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
+
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
+
+/**
+ * Formats logger collector data.
+ *
+ * Reports log counts by severity and individual log entries (capped at MAX_LOGS)
+ * with message and context extracted from VarDumper Data objects.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ *
+ * @implements CollectorFormatterInterface<LoggerDataCollector>
+ */
+final class LoggerCollectorFormatter implements CollectorFormatterInterface
+{
+    private const MAX_LOGS = 100;
+
+    public function getName(): string
+    {
+        return 'logger';
+    }
+
+    public function format(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof LoggerDataCollector);
+
+        $processedLogs = $collector->getProcessedLogs();
+        $truncated = \count($processedLogs) > self::MAX_LOGS;
+        $processedLogs = \array_slice($processedLogs, 0, self::MAX_LOGS);
+
+        return [
+            'error_count' => $collector->countErrors(),
+            'warning_count' => $collector->countWarnings(),
+            'deprecation_count' => $collector->countDeprecations(),
+            'scream_count' => $collector->countScreams(),
+            'logs' => $this->formatLogs($processedLogs),
+            'logs_truncated' => $truncated,
+        ];
+    }
+
+    public function getSummary(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof LoggerDataCollector);
+
+        return [
+            'error_count' => $collector->countErrors(),
+            'warning_count' => $collector->countWarnings(),
+            'deprecation_count' => $collector->countDeprecations(),
+            'scream_count' => $collector->countScreams(),
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $logs
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function formatLogs(array $logs): array
+    {
+        $formatted = [];
+        foreach ($logs as $log) {
+            $message = $log['message'] ?? null;
+            if (\is_object($message) && method_exists($message, 'getValue')) {
+                $message = $message->getValue();
+            }
+
+            $context = $log['context'] ?? null;
+            if (\is_object($context) && method_exists($context, 'getValue')) {
+                $context = $context->getValue(true);
+            }
+
+            $formatted[] = [
+                'type' => $log['type'] ?? null,
+                'timestamp' => $log['timestamp'] ?? null,
+                'priority' => $log['priority'] ?? null,
+                'priority_name' => $log['priorityName'] ?? null,
+                'channel' => $log['channel'] ?? null,
+                'message' => $message,
+                'context' => $context,
+                'error_count' => $log['errorCount'] ?? null,
+            ];
+        }
+
+        return $formatted;
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/LoggerCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/LoggerCollectorFormatterTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\LoggerCollectorFormatter;
+use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class LoggerCollectorFormatterTest extends TestCase
+{
+    private LoggerCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new LoggerCollectorFormatter();
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('logger', $this->formatter->getName());
+    }
+
+    public function testGetSummary()
+    {
+        $collector = $this->createMock(LoggerDataCollector::class);
+        $collector->method('countErrors')->willReturn(2);
+        $collector->method('countWarnings')->willReturn(3);
+        $collector->method('countDeprecations')->willReturn(1);
+        $collector->method('countScreams')->willReturn(0);
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertSame(2, $result['error_count']);
+        $this->assertSame(3, $result['warning_count']);
+        $this->assertSame(1, $result['deprecation_count']);
+        $this->assertSame(0, $result['scream_count']);
+        $this->assertArrayNotHasKey('logs', $result);
+    }
+
+    public function testFormatWithNoLogs()
+    {
+        $collector = $this->createMock(LoggerDataCollector::class);
+        $collector->method('countErrors')->willReturn(0);
+        $collector->method('countWarnings')->willReturn(0);
+        $collector->method('countDeprecations')->willReturn(0);
+        $collector->method('countScreams')->willReturn(0);
+        $collector->method('getProcessedLogs')->willReturn([]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(0, $result['error_count']);
+        $this->assertSame(0, $result['warning_count']);
+        $this->assertSame(0, $result['deprecation_count']);
+        $this->assertSame(0, $result['scream_count']);
+        $this->assertSame([], $result['logs']);
+        $this->assertFalse($result['logs_truncated']);
+    }
+
+    public function testFormatExtractsDataObjects()
+    {
+        $message = $this->createMock(Data::class);
+        $message->method('getValue')->with()->willReturn('Something went wrong');
+
+        $context = $this->createMock(Data::class);
+        $context->method('getValue')->with(true)->willReturn(['key' => 'value']);
+
+        $collector = $this->createMock(LoggerDataCollector::class);
+        $collector->method('countErrors')->willReturn(1);
+        $collector->method('countWarnings')->willReturn(0);
+        $collector->method('countDeprecations')->willReturn(0);
+        $collector->method('countScreams')->willReturn(0);
+        $collector->method('getProcessedLogs')->willReturn([
+            [
+                'type' => 'error',
+                'timestamp' => 1234567890.0,
+                'priority' => 400,
+                'priorityName' => 'ERROR',
+                'channel' => 'app',
+                'message' => $message,
+                'context' => $context,
+                'errorCount' => 1,
+            ],
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertCount(1, $result['logs']);
+        $log = $result['logs'][0];
+        $this->assertSame('error', $log['type']);
+        $this->assertSame('ERROR', $log['priority_name']);
+        $this->assertSame('app', $log['channel']);
+        $this->assertSame('Something went wrong', $log['message']);
+        $this->assertSame(['key' => 'value'], $log['context']);
+        $this->assertFalse($result['logs_truncated']);
+    }
+
+    public function testFormatTruncatesAt100Logs()
+    {
+        $logs = [];
+        for ($i = 0; $i < 101; ++$i) {
+            $logs[] = [
+                'type' => 'debug',
+                'timestamp' => 1234567890.0,
+                'priority' => 100,
+                'priorityName' => 'DEBUG',
+                'channel' => 'app',
+                'message' => 'msg '.$i,
+                'context' => [],
+                'errorCount' => 0,
+            ];
+        }
+
+        $collector = $this->createMock(LoggerDataCollector::class);
+        $collector->method('countErrors')->willReturn(0);
+        $collector->method('countWarnings')->willReturn(0);
+        $collector->method('countDeprecations')->willReturn(0);
+        $collector->method('countScreams')->willReturn(0);
+        $collector->method('getProcessedLogs')->willReturn($logs);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertCount(100, $result['logs']);
+        $this->assertTrue($result['logs_truncated']);
+    }
+}

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -15,6 +15,7 @@ use Symfony\AI\Mate\Bridge\Symfony\Capability\ServiceTool;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\LoggerCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MailerCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MemoryCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RequestCollectorFormatter;
@@ -80,6 +81,10 @@ return static function (ContainerConfigurator $configurator) {
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(TimeCollectorFormatter::class)
+            ->lazy()
+            ->tag('ai_mate.profiler_collector_formatter');
+
+        $services->set(LoggerCollectorFormatter::class)
             ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | n/a
| License       | MIT

Adds `LoggerCollectorFormatter` which formats `LoggerDataCollector` data for the Symfony Mate profiler MCP tool.

`getSummary()` returns only the four severity counts (`error_count`, `warning_count`, `deprecation_count`, `scream_count`) so the AI can triage quickly. `format()` adds individual log entries (capped at 100) with `message` and `context` properly extracted from VarDumper `Data` objects.