### PR TITLE
[Mate][Symfony] Add events profiler collector formatter

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/EventCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/EventCollectorFormatter.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
+
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\EventDataCollector;
+
+/**
+ * Formats event dispatcher collector data.
+ *
+ * Reports called, not-called, and orphaned events per dispatcher,
+ * with execution time in milliseconds.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ *
+ * @implements CollectorFormatterInterface<EventDataCollector>
+ */
+final class EventCollectorFormatter implements CollectorFormatterInterface
+{
+    public function getName(): string
+    {
+        return 'events';
+    }
+
+    public function format(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof EventDataCollector);
+
+        $data = $collector->getData();
+        if (\is_object($data) && method_exists($data, 'getValue')) {
+            $data = $data->getValue(true);
+        }
+
+        $rawDispatchers = $data['dispatchers'] ?? [];
+        if (\is_object($rawDispatchers) && method_exists($rawDispatchers, 'getValue')) {
+            $rawDispatchers = $rawDispatchers->getValue(true);
+        }
+
+        $dispatchers = [];
+        $totalCalled = 0;
+        $totalNotCalled = 0;
+        $totalOrphaned = 0;
+
+        foreach ($rawDispatchers as $name => $dispatcherData) {
+            if (\is_object($dispatcherData) && method_exists($dispatcherData, 'getValue')) {
+                $dispatcherData = $dispatcherData->getValue(true);
+            }
+
+            $calledListeners = $this->extractListeners($dispatcherData['called_listeners'] ?? [], true);
+            $notCalledListeners = $this->extractListeners($dispatcherData['not_called_listeners'] ?? [], false);
+            $orphanedEvents = $this->extractOrphanedEvents($dispatcherData['orphaned_events'] ?? []);
+
+            $totalCalled += \count($calledListeners);
+            $totalNotCalled += \count($notCalledListeners);
+            $totalOrphaned += \count($orphanedEvents);
+
+            $dispatchers[] = [
+                'name' => $name,
+                'called_listener_count' => \count($calledListeners),
+                'not_called_listener_count' => \count($notCalledListeners),
+                'orphaned_event_count' => \count($orphanedEvents),
+                'called_listeners' => $calledListeners,
+                'not_called_listeners' => $notCalledListeners,
+                'orphaned_events' => $orphanedEvents,
+            ];
+        }
+
+        return [
+            'total_called_listener_count' => $totalCalled,
+            'total_not_called_listener_count' => $totalNotCalled,
+            'total_orphaned_event_count' => $totalOrphaned,
+            'dispatchers' => $dispatchers,
+        ];
+    }
+
+    public function getSummary(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof EventDataCollector);
+
+        $data = $collector->getData();
+        if (\is_object($data) && method_exists($data, 'getValue')) {
+            $data = $data->getValue(true);
+        }
+
+        $rawDispatchers = $data['dispatchers'] ?? [];
+        if (\is_object($rawDispatchers) && method_exists($rawDispatchers, 'getValue')) {
+            $rawDispatchers = $rawDispatchers->getValue(true);
+        }
+
+        $totalCalled = 0;
+        $totalNotCalled = 0;
+        $totalOrphaned = 0;
+
+        foreach ($rawDispatchers as $dispatcherData) {
+            if (\is_object($dispatcherData) && method_exists($dispatcherData, 'getValue')) {
+                $dispatcherData = $dispatcherData->getValue(true);
+            }
+
+            $called = $dispatcherData['called_listeners'] ?? [];
+            if (\is_object($called) && method_exists($called, 'getValue')) {
+                $called = $called->getValue(true);
+            }
+
+            $notCalled = $dispatcherData['not_called_listeners'] ?? [];
+            if (\is_object($notCalled) && method_exists($notCalled, 'getValue')) {
+                $notCalled = $notCalled->getValue(true);
+            }
+
+            $orphaned = $dispatcherData['orphaned_events'] ?? [];
+            if (\is_object($orphaned) && method_exists($orphaned, 'getValue')) {
+                $orphaned = $orphaned->getValue(true);
+            }
+
+            $totalCalled += \is_array($called) ? \count($called) : 0;
+            $totalNotCalled += \is_array($notCalled) ? \count($notCalled) : 0;
+            $totalOrphaned += \is_array($orphaned) ? \count($orphaned) : 0;
+        }
+
+        return [
+            'total_called_listener_count' => $totalCalled,
+            'total_not_called_listener_count' => $totalNotCalled,
+            'total_orphaned_event_count' => $totalOrphaned,
+            'dispatcher_count' => \is_array($rawDispatchers) ? \count($rawDispatchers) : 0,
+        ];
+    }
+
+    /**
+     * @param mixed $listeners
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function extractListeners(mixed $listeners, bool $withTime): array
+    {
+        if (\is_object($listeners) && method_exists($listeners, 'getValue')) {
+            $listeners = $listeners->getValue(true);
+        }
+
+        if (!\is_array($listeners)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($listeners as $listener) {
+            if (\is_object($listener) && method_exists($listener, 'getValue')) {
+                $listener = $listener->getValue(true);
+            }
+
+            if (!\is_array($listener)) {
+                continue;
+            }
+
+            $entry = [
+                'event' => $listener['event'] ?? null,
+                'pretty' => $listener['pretty'] ?? null,
+                'priority' => $listener['priority'] ?? null,
+            ];
+
+            if ($withTime) {
+                $time = $listener['time'] ?? null;
+                $entry['time_ms'] = null !== $time ? round((float) $time * 1000, 2) : null;
+            }
+
+            $result[] = $entry;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param mixed $events
+     *
+     * @return string[]
+     */
+    private function extractOrphanedEvents(mixed $events): array
+    {
+        if (\is_object($events) && method_exists($events, 'getValue')) {
+            $events = $events->getValue(true);
+        }
+
+        if (!\is_array($events)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $e): mixed => \is_string($e) ? $e : null,
+            $events,
+        )));
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/EventCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/EventCollectorFormatterTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\EventCollectorFormatter;
+use Symfony\Component\HttpKernel\DataCollector\EventDataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class EventCollectorFormatterTest extends TestCase
+{
+    private EventCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new EventCollectorFormatter();
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('events', $this->formatter->getName());
+    }
+
+    public function testFormatWithNoDispatchers()
+    {
+        $collector = $this->createMock(EventDataCollector::class);
+        $collector->method('getData')->willReturn(['dispatchers' => []]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(0, $result['total_called_listener_count']);
+        $this->assertSame(0, $result['total_not_called_listener_count']);
+        $this->assertSame(0, $result['total_orphaned_event_count']);
+        $this->assertSame([], $result['dispatchers']);
+    }
+
+    public function testFormatWithSingleDispatcher()
+    {
+        $collector = $this->createMock(EventDataCollector::class);
+        $collector->method('getData')->willReturn([
+            'dispatchers' => [
+                'event_dispatcher' => [
+                    'called_listeners' => [
+                        ['event' => 'kernel.request', 'pretty' => 'MyListener::onRequest', 'priority' => 0, 'time' => 0.005],
+                    ],
+                    'not_called_listeners' => [
+                        ['event' => 'kernel.exception', 'pretty' => 'MyListener::onException', 'priority' => 0],
+                    ],
+                    'orphaned_events' => ['app.unused_event'],
+                ],
+            ],
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(1, $result['total_called_listener_count']);
+        $this->assertSame(1, $result['total_not_called_listener_count']);
+        $this->assertSame(1, $result['total_orphaned_event_count']);
+        $this->assertCount(1, $result['dispatchers']);
+
+        $dispatcher = $result['dispatchers'][0];
+        $this->assertSame('event_dispatcher', $dispatcher['name']);
+        $this->assertSame(1, $dispatcher['called_listener_count']);
+        $this->assertSame(1, $dispatcher['not_called_listener_count']);
+        $this->assertSame(1, $dispatcher['orphaned_event_count']);
+
+        $calledListener = $dispatcher['called_listeners'][0];
+        $this->assertSame('kernel.request', $calledListener['event']);
+        $this->assertSame('MyListener::onRequest', $calledListener['pretty']);
+        $this->assertSame(5.0, $calledListener['time_ms']);
+
+        $notCalledListener = $dispatcher['not_called_listeners'][0];
+        $this->assertSame('kernel.exception', $notCalledListener['event']);
+        $this->assertArrayNotHasKey('time_ms', $notCalledListener);
+
+        $this->assertSame(['app.unused_event'], $dispatcher['orphaned_events']);
+    }
+
+    public function testFormatSumsTotalsAcrossMultipleDispatchers()
+    {
+        $collector = $this->createMock(EventDataCollector::class);
+        $collector->method('getData')->willReturn([
+            'dispatchers' => [
+                'dispatcher_a' => [
+                    'called_listeners' => [
+                        ['event' => 'foo', 'pretty' => 'A::foo', 'priority' => 0, 'time' => 0.001],
+                    ],
+                    'not_called_listeners' => [],
+                    'orphaned_events' => [],
+                ],
+                'dispatcher_b' => [
+                    'called_listeners' => [
+                        ['event' => 'bar', 'pretty' => 'B::bar', 'priority' => 0, 'time' => 0.002],
+                        ['event' => 'baz', 'pretty' => 'B::baz', 'priority' => 0, 'time' => null],
+                    ],
+                    'not_called_listeners' => [
+                        ['event' => 'qux', 'pretty' => 'B::qux', 'priority' => 0],
+                    ],
+                    'orphaned_events' => ['x', 'y'],
+                ],
+            ],
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(3, $result['total_called_listener_count']);
+        $this->assertSame(1, $result['total_not_called_listener_count']);
+        $this->assertSame(2, $result['total_orphaned_event_count']);
+        $this->assertCount(2, $result['dispatchers']);
+
+        $dispatcherB = $result['dispatchers'][1];
+        $this->assertNull($dispatcherB['called_listeners'][1]['time_ms']);
+    }
+
+    public function testFormatHandlesDataObjects()
+    {
+        $orphanedData = $this->createMock(Data::class);
+        $orphanedData->method('getValue')->with(true)->willReturn(['kernel.finish_request']);
+
+        $notCalledData = $this->createMock(Data::class);
+        $notCalledData->method('getValue')->with(true)->willReturn([]);
+
+        $calledData = $this->createMock(Data::class);
+        $calledData->method('getValue')->with(true)->willReturn([
+            ['event' => 'kernel.response', 'pretty' => 'L::onResponse', 'priority' => 0, 'time' => 0.003],
+        ]);
+
+        $dispatcherInner = $this->createMock(Data::class);
+        $dispatcherInner->method('getValue')->with(true)->willReturn([
+            'called_listeners' => $calledData,
+            'not_called_listeners' => $notCalledData,
+            'orphaned_events' => $orphanedData,
+        ]);
+
+        $dispatchers = $this->createMock(Data::class);
+        $dispatchers->method('getValue')->with(true)->willReturn([
+            'main' => $dispatcherInner,
+        ]);
+
+        $rawData = $this->createMock(Data::class);
+        $rawData->method('getValue')->with(true)->willReturn([
+            'dispatchers' => $dispatchers,
+        ]);
+
+        $collector = $this->createMock(EventDataCollector::class);
+        $collector->method('getData')->willReturn($rawData);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(1, $result['total_called_listener_count']);
+        $this->assertSame(0, $result['total_not_called_listener_count']);
+        $this->assertSame(1, $result['total_orphaned_event_count']);
+        $this->assertSame('kernel.finish_request', $result['dispatchers'][0]['orphaned_events'][0]);
+        $this->assertSame(3.0, $result['dispatchers'][0]['called_listeners'][0]['time_ms']);
+    }
+
+    public function testGetSummaryCountsDispatchers()
+    {
+        $collector = $this->createMock(EventDataCollector::class);
+        $collector->method('getData')->willReturn([
+            'dispatchers' => [
+                'a' => ['called_listeners' => [['event' => 'e1', 'pretty' => 'L::a', 'priority' => 0, 'time' => 0.0]], 'not_called_listeners' => [], 'orphaned_events' => []],
+                'b' => ['called_listeners' => [], 'not_called_listeners' => [], 'orphaned_events' => ['x']],
+            ],
+        ]);
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertSame(1, $result['total_called_listener_count']);
+        $this->assertSame(0, $result['total_not_called_listener_count']);
+        $this->assertSame(1, $result['total_orphaned_event_count']);
+        $this->assertSame(2, $result['dispatcher_count']);
+        $this->assertArrayNotHasKey('dispatchers', $result);
+    }
+}

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -14,6 +14,7 @@ use Symfony\AI\Mate\Bridge\Symfony\Capability\ProfilerTool;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ServiceTool;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorFormatter;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\EventCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MailerCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RequestCollectorFormatter;
@@ -74,6 +75,10 @@ return static function (ContainerConfigurator $configurator) {
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(DoctrineCollectorFormatter::class)
+            ->lazy()
+            ->tag('ai_mate.profiler_collector_formatter');
+
+        $services->set(EventCollectorFormatter::class)
             ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | n/a
| License       | MIT

Adds `EventCollectorFormatter` which formats `EventDataCollector` data for the Symfony Mate profiler MCP tool.

`getSummary()` returns aggregate counts plus `dispatcher_count` — enough for the AI to decide whether event tracing is relevant. `format()` returns the full per-dispatcher breakdown: called listeners (with `time_ms`), not-called listeners, and orphaned event names. All VarDumper `Data` objects are unwrapped recursively; listener time is converted from seconds to milliseconds.