### PR TITLE
[Mate][Symfony] Add security profiler collector formatter

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/SecurityCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/SecurityCollectorFormatter.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
+
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
+use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+
+/**
+ * Formats security collector data.
+ *
+ * Reports authentication state, roles, voter decisions, and firewall configuration.
+ * Sensitive fields (token, logout URL) are intentionally excluded.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ *
+ * @implements CollectorFormatterInterface<SecurityDataCollector>
+ */
+final class SecurityCollectorFormatter implements CollectorFormatterInterface
+{
+    private const MAX_ACCESS_DECISION_LOG = 50;
+
+    public function getName(): string
+    {
+        return 'security';
+    }
+
+    public function format(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof SecurityDataCollector);
+
+        $log = $this->extractArray($collector->getAccessDecisionLog());
+        $truncated = \count($log) > self::MAX_ACCESS_DECISION_LOG;
+        $log = \array_slice($log, 0, self::MAX_ACCESS_DECISION_LOG);
+
+        return [
+            'enabled' => $collector->isEnabled(),
+            'authenticated' => $collector->isAuthenticated(),
+            'user' => $collector->getUser(),
+            'roles' => $this->extractStringArray($collector->getRoles()),
+            'inherited_roles' => $this->extractStringArray($collector->getInheritedRoles()),
+            'supports_role_hierarchy' => $collector->supportsRoleHierarchy(),
+            'impersonated' => $collector->isImpersonated(),
+            'impersonator_user' => $collector->getImpersonatorUser(),
+            'voter_strategy' => $collector->getVoterStrategy(),
+            'voters' => $this->extractStringArray($collector->getVoters()),
+            'access_decision_log' => $this->formatAccessDecisionLog($log),
+            'access_decision_log_truncated' => $truncated,
+            'firewall' => $this->extractNullableArray($collector->getFirewall()),
+        ];
+    }
+
+    public function getSummary(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof SecurityDataCollector);
+
+        return [
+            'enabled' => $collector->isEnabled(),
+            'authenticated' => $collector->isAuthenticated(),
+            'user' => $collector->getUser(),
+            'roles' => $this->extractStringArray($collector->getRoles()),
+            'impersonated' => $collector->isImpersonated(),
+        ];
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function extractArray(mixed $data): array
+    {
+        if (\is_object($data) && method_exists($data, 'getValue')) {
+            $data = $data->getValue(true);
+        }
+
+        return \is_array($data) ? $data : [];
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    private function extractNullableArray(mixed $data): ?array
+    {
+        if (null === $data) {
+            return null;
+        }
+
+        return $this->extractArray($data);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function extractStringArray(mixed $data): array
+    {
+        $data = $this->extractArray($data);
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $v): mixed => \is_string($v) ? $v : null,
+            $data,
+        )));
+    }
+
+    /**
+     * @param array<mixed> $log
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function formatAccessDecisionLog(array $log): array
+    {
+        $formatted = [];
+        foreach ($log as $entry) {
+            if (\is_object($entry) && method_exists($entry, 'getValue')) {
+                $entry = $entry->getValue(true);
+            }
+
+            if (!\is_array($entry)) {
+                continue;
+            }
+
+            $object = $entry['object'] ?? null;
+            if (\is_object($object) && method_exists($object, 'getValue')) {
+                $object = $object->getValue(true);
+            }
+
+            $voterDetails = $entry['voter_details'] ?? [];
+            if (\is_object($voterDetails) && method_exists($voterDetails, 'getValue')) {
+                $voterDetails = $voterDetails->getValue(true);
+            }
+
+            $formatted[] = [
+                'attribute' => $entry['attribute'] ?? null,
+                'object' => \is_object($object) ? $object::class : (\is_string($object) ? $object : null),
+                'result' => isset($entry['result']) ? (bool) $entry['result'] : null,
+                'voter_details' => \is_array($voterDetails) ? $voterDetails : [],
+            ];
+        }
+
+        return $formatted;
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/SecurityCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/SecurityCollectorFormatterTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\SecurityCollectorFormatter;
+use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SecurityCollectorFormatterTest extends TestCase
+{
+    private SecurityCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new SecurityCollectorFormatter();
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('security', $this->formatter->getName());
+    }
+
+    public function testFormatWhenDisabled()
+    {
+        $collector = $this->createMock(SecurityDataCollector::class);
+        $collector->method('isEnabled')->willReturn(false);
+        $collector->method('isAuthenticated')->willReturn(false);
+        $collector->method('getUser')->willReturn('');
+        $collector->method('getRoles')->willReturn([]);
+        $collector->method('getInheritedRoles')->willReturn([]);
+        $collector->method('supportsRoleHierarchy')->willReturn(false);
+        $collector->method('isImpersonated')->willReturn(false);
+        $collector->method('getImpersonatorUser')->willReturn(null);
+        $collector->method('getVoterStrategy')->willReturn('');
+        $collector->method('getVoters')->willReturn([]);
+        $collector->method('getAccessDecisionLog')->willReturn([]);
+        $collector->method('getFirewall')->willReturn(null);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertFalse($result['enabled']);
+        $this->assertFalse($result['authenticated']);
+        $this->assertNull($result['firewall']);
+        $this->assertFalse($result['access_decision_log_truncated']);
+        $this->assertArrayNotHasKey('token', $result);
+        $this->assertArrayNotHasKey('logout_url', $result);
+    }
+
+    public function testFormatWhenAuthenticated()
+    {
+        $collector = $this->createMock(SecurityDataCollector::class);
+        $collector->method('isEnabled')->willReturn(true);
+        $collector->method('isAuthenticated')->willReturn(true);
+        $collector->method('getUser')->willReturn('admin@example.com');
+        $collector->method('getRoles')->willReturn(['ROLE_ADMIN', 'ROLE_USER']);
+        $collector->method('getInheritedRoles')->willReturn(['ROLE_USER']);
+        $collector->method('supportsRoleHierarchy')->willReturn(true);
+        $collector->method('isImpersonated')->willReturn(false);
+        $collector->method('getImpersonatorUser')->willReturn(null);
+        $collector->method('getVoterStrategy')->willReturn('affirmative');
+        $collector->method('getVoters')->willReturn(['App\\Security\\Voter\\PostVoter']);
+        $collector->method('getAccessDecisionLog')->willReturn([]);
+        $collector->method('getFirewall')->willReturn(['name' => 'main', 'security' => true]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertTrue($result['enabled']);
+        $this->assertTrue($result['authenticated']);
+        $this->assertSame('admin@example.com', $result['user']);
+        $this->assertSame(['ROLE_ADMIN', 'ROLE_USER'], $result['roles']);
+        $this->assertSame(['ROLE_USER'], $result['inherited_roles']);
+        $this->assertTrue($result['supports_role_hierarchy']);
+        $this->assertFalse($result['impersonated']);
+        $this->assertNull($result['impersonator_user']);
+        $this->assertSame('affirmative', $result['voter_strategy']);
+        $this->assertSame(['App\\Security\\Voter\\PostVoter'], $result['voters']);
+        $this->assertSame(['name' => 'main', 'security' => true], $result['firewall']);
+    }
+
+    public function testFormatHandlesDataObjectsForRolesAndVoters()
+    {
+        $rolesData = $this->createMock(Data::class);
+        $rolesData->method('getValue')->with(true)->willReturn(['ROLE_USER']);
+
+        $inheritedRolesData = $this->createMock(Data::class);
+        $inheritedRolesData->method('getValue')->with(true)->willReturn([]);
+
+        $votersData = $this->createMock(Data::class);
+        $votersData->method('getValue')->with(true)->willReturn(['App\\Security\\Voter\\MyVoter']);
+
+        $firewallData = $this->createMock(Data::class);
+        $firewallData->method('getValue')->with(true)->willReturn(['name' => 'main']);
+
+        $collector = $this->createMock(SecurityDataCollector::class);
+        $collector->method('isEnabled')->willReturn(true);
+        $collector->method('isAuthenticated')->willReturn(true);
+        $collector->method('getUser')->willReturn('user');
+        $collector->method('getRoles')->willReturn($rolesData);
+        $collector->method('getInheritedRoles')->willReturn($inheritedRolesData);
+        $collector->method('supportsRoleHierarchy')->willReturn(true);
+        $collector->method('isImpersonated')->willReturn(false);
+        $collector->method('getImpersonatorUser')->willReturn(null);
+        $collector->method('getVoterStrategy')->willReturn('unanimous');
+        $collector->method('getVoters')->willReturn($votersData);
+        $collector->method('getAccessDecisionLog')->willReturn([]);
+        $collector->method('getFirewall')->willReturn($firewallData);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(['ROLE_USER'], $result['roles']);
+        $this->assertSame(['App\\Security\\Voter\\MyVoter'], $result['voters']);
+        $this->assertSame(['name' => 'main'], $result['firewall']);
+    }
+
+    public function testFormatWhenImpersonated()
+    {
+        $collector = $this->createMock(SecurityDataCollector::class);
+        $collector->method('isEnabled')->willReturn(true);
+        $collector->method('isAuthenticated')->willReturn(true);
+        $collector->method('getUser')->willReturn('target_user');
+        $collector->method('getRoles')->willReturn([]);
+        $collector->method('getInheritedRoles')->willReturn([]);
+        $collector->method('supportsRoleHierarchy')->willReturn(false);
+        $collector->method('isImpersonated')->willReturn(true);
+        $collector->method('getImpersonatorUser')->willReturn('admin@example.com');
+        $collector->method('getVoterStrategy')->willReturn('affirmative');
+        $collector->method('getVoters')->willReturn([]);
+        $collector->method('getAccessDecisionLog')->willReturn([]);
+        $collector->method('getFirewall')->willReturn(null);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertTrue($result['impersonated']);
+        $this->assertSame('admin@example.com', $result['impersonator_user']);
+    }
+
+    public function testFormatTruncatesAccessDecisionLogAt50()
+    {
+        $log = [];
+        for ($i = 0; $i < 51; ++$i) {
+            $log[] = ['attribute' => 'ROLE_ADMIN', 'object' => null, 'result' => true, 'voter_details' => []];
+        }
+
+        $collector = $this->createMock(SecurityDataCollector::class);
+        $collector->method('isEnabled')->willReturn(true);
+        $collector->method('isAuthenticated')->willReturn(true);
+        $collector->method('getUser')->willReturn('user');
+        $collector->method('getRoles')->willReturn([]);
+        $collector->method('getInheritedRoles')->willReturn([]);
+        $collector->method('supportsRoleHierarchy')->willReturn(false);
+        $collector->method('isImpersonated')->willReturn(false);
+        $collector->method('getImpersonatorUser')->willReturn(null);
+        $collector->method('getVoterStrategy')->willReturn('affirmative');
+        $collector->method('getVoters')->willReturn([]);
+        $collector->method('getAccessDecisionLog')->willReturn($log);
+        $collector->method('getFirewall')->willReturn(null);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertCount(50, $result['access_decision_log']);
+        $this->assertTrue($result['access_decision_log_truncated']);
+    }
+
+    public function testFormatDoesNotExposeTokenOrLogoutUrl()
+    {
+        $collector = $this->createMock(SecurityDataCollector::class);
+        $collector->method('isEnabled')->willReturn(true);
+        $collector->method('isAuthenticated')->willReturn(true);
+        $collector->method('getUser')->willReturn('user');
+        $collector->method('getRoles')->willReturn([]);
+        $collector->method('getInheritedRoles')->willReturn([]);
+        $collector->method('supportsRoleHierarchy')->willReturn(false);
+        $collector->method('isImpersonated')->willReturn(false);
+        $collector->method('getImpersonatorUser')->willReturn(null);
+        $collector->method('getVoterStrategy')->willReturn('affirmative');
+        $collector->method('getVoters')->willReturn([]);
+        $collector->method('getAccessDecisionLog')->willReturn([]);
+        $collector->method('getFirewall')->willReturn(null);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertArrayNotHasKey('token', $result);
+        $this->assertArrayNotHasKey('token_class', $result);
+        $this->assertArrayNotHasKey('logout_url', $result);
+    }
+
+    public function testGetSummary()
+    {
+        $collector = $this->createMock(SecurityDataCollector::class);
+        $collector->method('isEnabled')->willReturn(true);
+        $collector->method('isAuthenticated')->willReturn(true);
+        $collector->method('getUser')->willReturn('admin');
+        $collector->method('getRoles')->willReturn(['ROLE_ADMIN']);
+        $collector->method('isImpersonated')->willReturn(false);
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertTrue($result['enabled']);
+        $this->assertTrue($result['authenticated']);
+        $this->assertSame('admin', $result['user']);
+        $this->assertSame(['ROLE_ADMIN'], $result['roles']);
+        $this->assertFalse($result['impersonated']);
+        $this->assertArrayNotHasKey('voters', $result);
+        $this->assertArrayNotHasKey('firewall', $result);
+        $this->assertArrayNotHasKey('access_decision_log', $result);
+    }
+}

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -40,6 +40,7 @@
         "phpunit/phpunit": "^11.5.53",
         "symfony/http-kernel": "^7.3|^8.0",
         "symfony/mailer": "^7.3|^8.0",
+        "symfony/security-bundle": "^7.3|^8.0",
         "symfony/translation": "^7.3|^8.0",
         "symfony/var-dumper": "^7.3|^8.0",
         "symfony/web-profiler-bundle": "^7.3|^8.0"
@@ -48,6 +49,7 @@
         "doctrine/doctrine-bundle": "Required for Doctrine database profiler formatter",
         "symfony/http-kernel": "Required for profiler data access tools",
         "symfony/mailer": "Required for mailer profiler formatter",
+        "symfony/security-bundle": "Required for Security profiler formatter",
         "symfony/translation": "Required for translation profiler collector formatter",
         "symfony/web-profiler-bundle": "Required for profiler data access tools"
     },

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -17,9 +17,11 @@ use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorF
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MailerCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RequestCollectorFormatter;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\SecurityCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\TranslationCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
+use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
@@ -76,6 +78,12 @@ return static function (ContainerConfigurator $configurator) {
         $services->set(DoctrineCollectorFormatter::class)
             ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
+
+        if (class_exists(SecurityDataCollector::class)) {
+            $services->set(SecurityCollectorFormatter::class)
+                ->lazy()
+                ->tag('ai_mate.profiler_collector_formatter');
+        }
 
         // MCP Capabilities
         $services->set(ProfilerTool::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | n/a
| License       | MIT

Adds `SecurityCollectorFormatter` which formats `SecurityDataCollector` data for the Symfony Mate profiler MCP tool. Registered conditionally via `class_exists(SecurityDataCollector::class)` since `symfony/security-bundle` is optional.

`getSummary()` returns `enabled`, `authenticated`, `user`, `roles`, and `impersonated`. `format()` adds voter strategy, voter list, access decision log (capped at 50), and firewall config.

Sensitive fields — `getToken()`, `getTokenClass()`, `getLogoutUrl()` — are intentionally excluded. Adds `symfony/security-bundle` to `require-dev` and `suggest`.