### PR TITLE
[Mate][Symfony] Add messenger profiler collector formatter

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/MessengerCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/MessengerCollectorFormatter.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
+
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\Messenger\DataCollector\MessengerDataCollector;
+
+/**
+ * Formats messenger collector data.
+ *
+ * Reports dispatched messages per bus with stamp types and exception presence.
+ * Message payload values are intentionally excluded to avoid exposing PII or secrets.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ *
+ * @implements CollectorFormatterInterface<MessengerDataCollector>
+ */
+final class MessengerCollectorFormatter implements CollectorFormatterInterface
+{
+    private const MAX_MESSAGES = 50;
+
+    public function getName(): string
+    {
+        return 'messenger';
+    }
+
+    public function format(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof MessengerDataCollector);
+
+        $buses = $collector->getBuses();
+        $rawMessages = $collector->getMessages(null);
+        $truncated = \count($rawMessages) > self::MAX_MESSAGES;
+        $rawMessages = \array_slice($rawMessages, 0, self::MAX_MESSAGES);
+
+        return [
+            'bus_count' => \count($buses),
+            'buses' => $buses,
+            'message_count' => \count($collector->getMessages(null)),
+            'exception_count' => $collector->getExceptionsCount(null),
+            'messages' => $this->formatMessages($rawMessages),
+            'messages_truncated' => $truncated,
+        ];
+    }
+
+    public function getSummary(DataCollectorInterface $collector): array
+    {
+        \assert($collector instanceof MessengerDataCollector);
+
+        return [
+            'buses' => $collector->getBuses(),
+            'message_count' => \count($collector->getMessages(null)),
+            'exception_count' => $collector->getExceptionsCount(null),
+        ];
+    }
+
+    /**
+     * @param array<mixed> $messages
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function formatMessages(array $messages): array
+    {
+        $formatted = [];
+        foreach ($messages as $message) {
+            if (\is_object($message) && method_exists($message, 'getValue')) {
+                $message = $message->getValue(true);
+            }
+
+            if (!\is_array($message)) {
+                continue;
+            }
+
+            $messageEntry = $message['message'] ?? [];
+            if (\is_object($messageEntry) && method_exists($messageEntry, 'getValue')) {
+                $messageEntry = $messageEntry->getValue(true);
+            }
+
+            $messageType = null;
+            if (\is_array($messageEntry)) {
+                $type = $messageEntry['type'] ?? null;
+                $messageType = \is_object($type) ? (string) $type : (\is_string($type) ? $type : null);
+            }
+
+            $stamps = $message['stamps'] ?? [];
+            if (\is_object($stamps) && method_exists($stamps, 'getValue')) {
+                $stamps = $stamps->getValue(true);
+            }
+            $stampTypes = \is_array($stamps) ? array_keys($stamps) : [];
+
+            $caller = $message['caller'] ?? [];
+            if (\is_object($caller) && method_exists($caller, 'getValue')) {
+                $caller = $caller->getValue(true);
+            }
+
+            $exception = $message['exception'] ?? null;
+            if (\is_object($exception) && method_exists($exception, 'getValue')) {
+                $exception = $exception->getValue(true);
+            }
+
+            $exceptionType = null;
+            if (\is_array($exception)) {
+                $type = $exception['type'] ?? null;
+                $exceptionType = \is_object($type) ? (string) $type : (\is_string($type) ? $type : null);
+            }
+
+            $formatted[] = [
+                'bus' => $message['bus'] ?? null,
+                'message_type' => $messageType,
+                'caller_name' => \is_array($caller) ? ($caller['name'] ?? null) : null,
+                'caller_file' => \is_array($caller) ? ($caller['file'] ?? null) : null,
+                'caller_line' => \is_array($caller) ? ($caller['line'] ?? null) : null,
+                'stamp_count' => \count($stampTypes),
+                'stamps' => $stampTypes,
+                'has_exception' => null !== $exception && false !== $exception,
+                'exception_type' => $exceptionType,
+            ];
+        }
+
+        return $formatted;
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/MessengerCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/MessengerCollectorFormatterTest.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MessengerCollectorFormatter;
+use Symfony\Component\Messenger\DataCollector\MessengerDataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class MessengerCollectorFormatterTest extends TestCase
+{
+    private MessengerCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new MessengerCollectorFormatter();
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('messenger', $this->formatter->getName());
+    }
+
+    public function testFormatWithNoMessages()
+    {
+        $collector = $this->createMock(MessengerDataCollector::class);
+        $collector->method('getBuses')->willReturn(['messenger.default_bus']);
+        $collector->method('getMessages')->with(null)->willReturn([]);
+        $collector->method('getExceptionsCount')->with(null)->willReturn(0);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(1, $result['bus_count']);
+        $this->assertSame(['messenger.default_bus'], $result['buses']);
+        $this->assertSame(0, $result['message_count']);
+        $this->assertSame(0, $result['exception_count']);
+        $this->assertSame([], $result['messages']);
+        $this->assertFalse($result['messages_truncated']);
+    }
+
+    public function testFormatSingleMessage()
+    {
+        $messageData = [
+            'bus' => 'messenger.default_bus',
+            'caller' => ['name' => 'MyController::dispatch', 'file' => '/app/Controller.php', 'line' => 42],
+            'message' => ['type' => 'App\\Message\\SendEmail', 'value' => 'HIDDEN'],
+            'stamps' => [
+                'Symfony\\Component\\Messenger\\Stamp\\DelayStamp' => [['delay' => 5000]],
+            ],
+            'exception' => null,
+        ];
+
+        $collector = $this->createMock(MessengerDataCollector::class);
+        $collector->method('getBuses')->willReturn(['messenger.default_bus']);
+        $collector->method('getMessages')->with(null)->willReturn([$messageData]);
+        $collector->method('getExceptionsCount')->with(null)->willReturn(0);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertCount(1, $result['messages']);
+        $msg = $result['messages'][0];
+
+        $this->assertSame('messenger.default_bus', $msg['bus']);
+        $this->assertSame('App\\Message\\SendEmail', $msg['message_type']);
+        $this->assertSame('MyController::dispatch', $msg['caller_name']);
+        $this->assertSame('/app/Controller.php', $msg['caller_file']);
+        $this->assertSame(42, $msg['caller_line']);
+        $this->assertSame(1, $msg['stamp_count']);
+        $this->assertSame(['Symfony\\Component\\Messenger\\Stamp\\DelayStamp'], $msg['stamps']);
+        $this->assertFalse($msg['has_exception']);
+        $this->assertNull($msg['exception_type']);
+        $this->assertArrayNotHasKey('value', $msg);
+    }
+
+    public function testFormatMessageWithException()
+    {
+        $messageData = [
+            'bus' => 'messenger.default_bus',
+            'caller' => ['name' => 'App\\Handler\\Handler::__invoke', 'file' => '/app/Handler.php', 'line' => 10],
+            'message' => ['type' => 'App\\Message\\FailingMessage', 'value' => 'HIDDEN'],
+            'stamps' => [],
+            'exception' => ['type' => 'RuntimeException', 'message' => 'Something failed'],
+        ];
+
+        $collector = $this->createMock(MessengerDataCollector::class);
+        $collector->method('getBuses')->willReturn(['messenger.default_bus']);
+        $collector->method('getMessages')->with(null)->willReturn([$messageData]);
+        $collector->method('getExceptionsCount')->with(null)->willReturn(1);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(1, $result['exception_count']);
+        $msg = $result['messages'][0];
+        $this->assertTrue($msg['has_exception']);
+        $this->assertSame('RuntimeException', $msg['exception_type']);
+    }
+
+    public function testFormatHandlesDataObjects()
+    {
+        $messageType = new class {
+            public function __toString(): string
+            {
+                return 'App\\Message\\WrappedMessage';
+            }
+        };
+
+        $messageEntry = $this->createMock(Data::class);
+        $messageEntry->method('getValue')->with(true)->willReturn([
+            'type' => $messageType,
+            'value' => 'HIDDEN',
+        ]);
+
+        $stampsData = $this->createMock(Data::class);
+        $stampsData->method('getValue')->with(true)->willReturn([
+            'Symfony\\Component\\Messenger\\Stamp\\HandledStamp' => [],
+        ]);
+
+        $messageData = $this->createMock(Data::class);
+        $messageData->method('getValue')->with(true)->willReturn([
+            'bus' => 'messenger.default_bus',
+            'caller' => ['name' => 'TestCaller', 'file' => '/test.php', 'line' => 1],
+            'message' => $messageEntry,
+            'stamps' => $stampsData,
+            'exception' => null,
+        ]);
+
+        $collector = $this->createMock(MessengerDataCollector::class);
+        $collector->method('getBuses')->willReturn(['messenger.default_bus']);
+        $collector->method('getMessages')->with(null)->willReturn([$messageData]);
+        $collector->method('getExceptionsCount')->with(null)->willReturn(0);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertCount(1, $result['messages']);
+        $msg = $result['messages'][0];
+        $this->assertSame('App\\Message\\WrappedMessage', $msg['message_type']);
+        $this->assertSame(['Symfony\\Component\\Messenger\\Stamp\\HandledStamp'], $msg['stamps']);
+    }
+
+    public function testFormatTruncatesAt50Messages()
+    {
+        $messages = [];
+        for ($i = 0; $i < 51; ++$i) {
+            $messages[] = [
+                'bus' => 'messenger.default_bus',
+                'caller' => ['name' => 'caller', 'file' => '/f.php', 'line' => 1],
+                'message' => ['type' => 'App\\Message\\Msg', 'value' => 'HIDDEN'],
+                'stamps' => [],
+                'exception' => null,
+            ];
+        }
+
+        $collector = $this->createMock(MessengerDataCollector::class);
+        $collector->method('getBuses')->willReturn(['messenger.default_bus']);
+        $collector->method('getMessages')->with(null)->willReturn($messages);
+        $collector->method('getExceptionsCount')->with(null)->willReturn(0);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertCount(50, $result['messages']);
+        $this->assertTrue($result['messages_truncated']);
+    }
+
+    public function testFormatDoesNotExposeMessageValue()
+    {
+        $messageData = [
+            'bus' => 'messenger.default_bus',
+            'caller' => ['name' => 'caller', 'file' => '/f.php', 'line' => 1],
+            'message' => ['type' => 'App\\Message\\Msg', 'value' => 'SECRET_DTO_CONTENT'],
+            'stamps' => [],
+            'exception' => null,
+        ];
+
+        $collector = $this->createMock(MessengerDataCollector::class);
+        $collector->method('getBuses')->willReturn(['messenger.default_bus']);
+        $collector->method('getMessages')->with(null)->willReturn([$messageData]);
+        $collector->method('getExceptionsCount')->with(null)->willReturn(0);
+
+        $result = $this->formatter->format($collector);
+
+        $msg = $result['messages'][0];
+        $this->assertArrayNotHasKey('value', $msg);
+        $encoded = json_encode($result);
+        $this->assertIsString($encoded);
+        $this->assertStringNotContainsString('SECRET_DTO_CONTENT', $encoded);
+    }
+
+    public function testGetSummary()
+    {
+        $collector = $this->createMock(MessengerDataCollector::class);
+        $collector->method('getBuses')->willReturn(['messenger.default_bus', 'messenger.async_bus']);
+        $collector->method('getMessages')->with(null)->willReturn([[], []]);
+        $collector->method('getExceptionsCount')->with(null)->willReturn(1);
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertSame(['messenger.default_bus', 'messenger.async_bus'], $result['buses']);
+        $this->assertSame(2, $result['message_count']);
+        $this->assertSame(1, $result['exception_count']);
+        $this->assertArrayNotHasKey('messages', $result);
+        $this->assertArrayNotHasKey('bus_count', $result);
+    }
+}

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -40,6 +40,7 @@
         "phpunit/phpunit": "^11.5.53",
         "symfony/http-kernel": "^7.3|^8.0",
         "symfony/mailer": "^7.3|^8.0",
+        "symfony/messenger": "^7.3|^8.0",
         "symfony/translation": "^7.3|^8.0",
         "symfony/var-dumper": "^7.3|^8.0",
         "symfony/web-profiler-bundle": "^7.3|^8.0"
@@ -48,6 +49,7 @@
         "doctrine/doctrine-bundle": "Required for Doctrine database profiler formatter",
         "symfony/http-kernel": "Required for profiler data access tools",
         "symfony/mailer": "Required for mailer profiler formatter",
+        "symfony/messenger": "Required for Messenger profiler formatter",
         "symfony/translation": "Required for translation profiler collector formatter",
         "symfony/web-profiler-bundle": "Required for profiler data access tools"
     },

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -16,12 +16,14 @@ use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MailerCollectorFormatter;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\MessengerCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RequestCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\TranslationCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Component\Messenger\DataCollector\MessengerDataCollector;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
@@ -76,6 +78,12 @@ return static function (ContainerConfigurator $configurator) {
         $services->set(DoctrineCollectorFormatter::class)
             ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
+
+        if (class_exists(MessengerDataCollector::class)) {
+            $services->set(MessengerCollectorFormatter::class)
+                ->lazy()
+                ->tag('ai_mate.profiler_collector_formatter');
+        }
 
         // MCP Capabilities
         $services->set(ProfilerTool::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | n/a
| License       | MIT

Adds `MessengerCollectorFormatter` which formats `MessengerDataCollector` data for the Symfony Mate profiler MCP tool. Registered conditionally via `class_exists(MessengerDataCollector::class)` since `symfony/messenger` is optional.

`getSummary()` returns bus names, message count, and exception count. `format()` adds per-message details: bus, message type, caller info, stamp types, and exception presence (capped at 50 messages).

Message payload values are intentionally excluded to avoid exposing PII or secrets. Adds `symfony/messenger` to `require-dev` and `suggest`.