### PR TITLE
 Rename 'mcp' to '_mcp' in routes configuration

### DIFF
--- a/docs/bundles/mcp-bundle.rst
+++ b/docs/bundles/mcp-bundle.rst
@@ -22,7 +22,7 @@ You also need to add few lines in the routing configuration for this bundle:
 .. code-block:: yaml
 
     # config/routes.yaml
-    mcp:
+    _mcp:
         resource: .
         type: mcp
 


### PR DESCRIPTION
Route name in `config/routes.yaml` should be equal to the configured http route (`_mcp` in example docs), otherwise server will return "tool not found".

This PR changes the documentation to use `_mcp` as name, https://github.com/symfony/ai/blob/main/docs/bundles/mcp-bundle.rst?plain=1#L25

```
_mcp:    
    resource: .
    type: mcp
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

The documentation at https://symfony.com/doc/current/ai/bundles/mcp-bundle.html tells the user to add this to `config/routes.yaml`

```
mcp:    
    resource: .
    type: mcp
```

And the default configuration has `/_mcp` as http path https://github.com/symfony/ai/blob/main/docs/bundles/mcp-bundle.rst?plain=1#L288

```
    # HTTP transport configuration (optional)
    http:
        path: /_mcp # HTTP endpoint path (default: /_mcp)
```

The MCP Server will reply to clients that the tool doesn't exist when those mismatch, this change fixes the default routes to be `_mcp` so it returns response correctly.