### PR TITLE
[Documentation][Platform] Update docs for reworked AssistantMessage

### DIFF
--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -492,7 +492,7 @@ confirmation system using the ``ToolCallRequested`` event.
 Excluding Tool Messages from MessageBag
 ---------------------------------------
 
-Sometimes you might wish to exclude the tool messages (:class:`Symfony\\AI\\Platform\\Message\\AssistantMessage` containing the ``toolCalls`` and :class:`Symfony\\AI\\Platform\\Message\\ToolCallMessage`
+Sometimes you might wish to exclude the tool messages (:class:`Symfony\\AI\\Platform\\Message\\AssistantMessage` containing :class:`Symfony\\AI\\Platform\\Result\\ToolCall` parts and :class:`Symfony\\AI\\Platform\\Message\\ToolCallMessage`
 containing the result) in the context. Enable the ``excludeToolMessages`` flag of the toolbox' :class:`Symfony\\AI\\Agent\\Toolbox\\AgentProcessor`
 to ensure those messages will be removed from your :class:`Symfony\\AI\\Platform\\Message\\MessageBag`::
 
@@ -592,7 +592,7 @@ and are able to mutate both on top of the :class:`Symfony\\AI\\Agent\\Input` ins
 
     use Symfony\AI\Agent\Input;
     use Symfony\AI\Agent\InputProcessorInterface;
-    use Symfony\AI\Platform\Message\AssistantMessage;
+    use Symfony\AI\Platform\Message\Message;
 
     final class MyProcessor implements InputProcessorInterface
     {
@@ -604,7 +604,7 @@ and are able to mutate both on top of the :class:`Symfony\\AI\\Agent\\Input` ins
             $input->setOptions($options);
 
             // mutate MessageBag
-            $input->getMessageBag()->append(new AssistantMessage(sprintf('Please answer using the locale %s', $this->locale)));
+            $input->getMessageBag()->append(Message::ofAssistant(sprintf('Please answer using the locale %s', $this->locale)));
         }
     }
 

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -513,17 +513,19 @@ Multi-Turn Conversations with Thinking
 
 When using thinking in multi-turn conversations, Anthropic requires that
 thinking blocks from previous assistant turns be included in the conversation
-history. The :class:`Symfony\\AI\\Platform\\Message\\AssistantMessage` supports
-this through :class:`Symfony\\AI\\Platform\\Result\\ThinkingResult`::
+history. The :class:`Symfony\\AI\\Platform\\Message\\AssistantMessage` accepts a
+variadic list of :class:`Symfony\\AI\\Platform\\Message\\Content\\ContentInterface`
+parts, including :class:`Symfony\\AI\\Platform\\Message\\Content\\Thinking` blocks
+that carry the original reasoning text and its provider-specific signature::
 
     use Symfony\AI\Platform\Message\AssistantMessage;
-    use Symfony\AI\Platform\Result\TextResult;
-    use Symfony\AI\Platform\Result\ThinkingResult;
+    use Symfony\AI\Platform\Message\Content\Text;
+    use Symfony\AI\Platform\Message\Content\Thinking;
 
     // Include the model's thinking from a previous turn
     $assistant = new AssistantMessage(
-        new ThinkingResult('Let me work through this step by step...', 'sig_abc123...'),
-        new TextResult('The answer is 42.'),
+        new Thinking('Let me work through this step by step...', 'sig_abc123...'),
+        new Text('The answer is 42.'),
     );
 
     $messages = new MessageBag(
@@ -531,6 +533,23 @@ this through :class:`Symfony\\AI\\Platform\\Result\\ThinkingResult`::
         $assistant,
         Message::ofUser('Can you elaborate?'),
     );
+
+In practice you usually do not have to build the parts yourself.
+:method:`Symfony\\AI\\Platform\\Message\\Message::ofAssistant` accepts strings,
+content parts, and result objects, and unwraps them into the matching content
+parts (including thinking blocks with their signatures). Passing the result of a
+previous invocation back into the message bag is therefore a one-liner::
+
+    use Symfony\AI\Platform\Message\Message;
+
+    $result = $platform->invoke($model, $messages)->getResult();
+
+    $messages->add(Message::ofAssistant($result));
+
+:class:`Symfony\\AI\\Platform\\Result\\MultiPartResult` is unwrapped recursively,
+so a result that contains a :class:`Symfony\\AI\\Platform\\Result\\ThinkingResult`
+followed by a :class:`Symfony\\AI\\Platform\\Result\\TextResult` (and any tool
+calls) is replayed in the same order on the next turn.
 
 Checking for Thinking Support
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

Follow-up to #1853, which reworked `AssistantMessage` to take a variadic list of `ContentInterface` parts. A few code snippets in `docs/` were left in a state that no longer compiles or that referred to removed parameters.

## Summary

- `docs/components/platform.rst` — the *Multi-Turn Conversations with Thinking* example passed `ThinkingResult` / `TextResult` (which are `ResultInterface`, not `ContentInterface`) directly into the `AssistantMessage` constructor. Switched to `Content\Thinking` / `Content\Text`, matching the upgrade notes, and added a follow-up snippet showing `Message::ofAssistant($result)` — the canonical one-liner that unwraps `MultiPartResult` recursively and preserves thinking signatures across turns.
- `docs/components/agent.rst` — the `InputProcessor` example built `new AssistantMessage(sprintf(...))` from a raw string, which no longer matches the constructor signature. Switched to `Message::ofAssistant(...)`. Also reworded the *Excluding Tool Messages* paragraph to refer to `ToolCall` parts instead of the removed `toolCalls` named argument.

`./doctor-rst` passes.