### PR TITLE
[Platform] Add AssistantMessage replay regression tests

### DIFF
--- a/examples/anthropic/toolcall-roundtrip.php
+++ b/examples/anthropic/toolcall-roundtrip.php
@@ -13,17 +13,17 @@ use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\Bridge\Clock\Clock;
 use Symfony\AI\Agent\Toolbox\AgentProcessor;
 use Symfony\AI\Agent\Toolbox\Toolbox;
-use Symfony\AI\Platform\Bridge\Gemini\Factory;
+use Symfony\AI\Platform\Bridge\Anthropic\Factory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 
 require_once dirname(__DIR__).'/bootstrap.php';
 
-$platform = Factory::createPlatform(env('GEMINI_API_KEY'), http_client());
+$platform = Factory::createPlatform(env('ANTHROPIC_API_KEY'), httpClient: http_client());
 
 $toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gemini-2.5-flash', [$processor], [$processor]);
+$agent = new Agent($platform, 'claude-sonnet-4-5-20250929', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
@@ -33,15 +33,16 @@ $messages = new MessageBag(
 $messages->add(Message::ofUser('What is the capital of France?'));
 $result = $agent->call($messages);
 echo 'Turn 1: '.$result->getContent().\PHP_EOL;
-$messages->add(Message::ofAssistant($result->getContent()));
+$messages->add(Message::ofAssistant($result));
 
 // tool call
 $messages->add(Message::ofUser('What time is it right now?'));
 $result = $agent->call($messages);
 echo 'Turn 2: '.$result->getContent().\PHP_EOL;
-$messages->add(Message::ofAssistant($result->getContent()));
+$messages->add(Message::ofAssistant($result));
 
-// another chat with tool result in MessageBag
+// another chat - the previous assistant turn (tool call + final answer) must be replayed via the
+// Anthropic AssistantMessageNormalizer, including any tool_use / tool_result / thinking blocks.
 $messages->add(Message::ofUser('What was the first question I asked you?'));
 $result = $agent->call($messages);
 echo 'Turn 3: '.$result->getContent().\PHP_EOL;

--- a/src/platform/src/Bridge/Anthropic/Tests/AssistantReplayTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/AssistantReplayTest.php
@@ -1,0 +1,289 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Anthropic\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Anthropic\Claude;
+use Symfony\AI\Platform\Bridge\Anthropic\Contract\AnthropicContract;
+use Symfony\AI\Platform\Bridge\Anthropic\ResultConverter;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+/**
+ * End-to-end replay test: feed a fixture provider response into ResultConverter,
+ * build an assistant message via Message::ofAssistant($result), append the next
+ * user/tool turn, and assert the byte-shape of the request that would be sent
+ * back to the provider on turn 2.
+ *
+ * Catches regressions in the round-trip path that AssistantMessageNormalizer
+ * tests in isolation cannot: ordering preservation across the bag, signature
+ * survival, tool-call id pairing, empty-content handling.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class AssistantReplayTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $providerResponse
+     * @param array<string, mixed> $expectedReplayPayload
+     */
+    #[DataProvider('provideReplayScenarios')]
+    public function testRoundTrip(array $providerResponse, callable $bagBuilder, array $expectedReplayPayload)
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse($providerResponse));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $bag = $bagBuilder($result);
+        $payload = AnthropicContract::create()->createRequestPayload(new Claude(Claude::SONNET_4_0), $bag);
+
+        $this->assertEquals($expectedReplayPayload, $payload);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>, 1: callable, 2: array<string, mixed>}>
+     */
+    public static function provideReplayScenarios(): iterable
+    {
+        yield 'text-only assistant turn replays as plain string content' => [
+            [
+                'content' => [
+                    ['type' => 'text', 'text' => 'Hi there!'],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Hello'),
+                Message::ofAssistant($result),
+                Message::ofUser('Tell me more.'),
+            ),
+            [
+                'messages' => [
+                    ['role' => 'user', 'content' => 'Hello'],
+                    ['role' => 'assistant', 'content' => 'Hi there!'],
+                    ['role' => 'user', 'content' => 'Tell me more.'],
+                ],
+                'model' => 'claude-sonnet-4-0',
+            ],
+        ];
+
+        yield 'text + tool_use assistant turn preserves order and ids' => [
+            [
+                'content' => [
+                    ['type' => 'text', 'text' => "I'll look that up."],
+                    [
+                        'type' => 'tool_use',
+                        'id' => 'toolu_abc',
+                        'name' => 'wikipedia',
+                        'input' => ['query' => 'Symfony'],
+                    ],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What is Symfony?'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('toolu_abc', 'wikipedia', ['query' => 'Symfony']), 'Symfony is a PHP framework.'),
+            ),
+            [
+                'messages' => [
+                    ['role' => 'user', 'content' => 'What is Symfony?'],
+                    [
+                        'role' => 'assistant',
+                        'content' => [
+                            ['type' => 'text', 'text' => "I'll look that up."],
+                            [
+                                'type' => 'tool_use',
+                                'id' => 'toolu_abc',
+                                'name' => 'wikipedia',
+                                'input' => ['query' => 'Symfony'],
+                            ],
+                        ],
+                    ],
+                    [
+                        'role' => 'user',
+                        'content' => [
+                            [
+                                'type' => 'tool_result',
+                                'tool_use_id' => 'toolu_abc',
+                                'content' => 'Symfony is a PHP framework.',
+                            ],
+                        ],
+                    ],
+                ],
+                'model' => 'claude-sonnet-4-0',
+            ],
+        ];
+
+        yield 'thinking + text + tool_use assistant turn preserves signature and ordering' => [
+            [
+                'content' => [
+                    [
+                        'type' => 'thinking',
+                        'thinking' => 'Let me think about which tool to use.',
+                        'signature' => 'sig_xyz',
+                    ],
+                    ['type' => 'text', 'text' => "I'll search Wikipedia."],
+                    [
+                        'type' => 'tool_use',
+                        'id' => 'toolu_def',
+                        'name' => 'wikipedia',
+                        'input' => ['query' => 'Symfony'],
+                    ],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What is Symfony?'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('toolu_def', 'wikipedia', ['query' => 'Symfony']), 'Symfony is a PHP framework.'),
+            ),
+            [
+                'messages' => [
+                    ['role' => 'user', 'content' => 'What is Symfony?'],
+                    [
+                        'role' => 'assistant',
+                        'content' => [
+                            [
+                                'type' => 'thinking',
+                                'thinking' => 'Let me think about which tool to use.',
+                                'signature' => 'sig_xyz',
+                            ],
+                            ['type' => 'text', 'text' => "I'll search Wikipedia."],
+                            [
+                                'type' => 'tool_use',
+                                'id' => 'toolu_def',
+                                'name' => 'wikipedia',
+                                'input' => ['query' => 'Symfony'],
+                            ],
+                        ],
+                    ],
+                    [
+                        'role' => 'user',
+                        'content' => [
+                            [
+                                'type' => 'tool_result',
+                                'tool_use_id' => 'toolu_def',
+                                'content' => 'Symfony is a PHP framework.',
+                            ],
+                        ],
+                    ],
+                ],
+                'model' => 'claude-sonnet-4-0',
+            ],
+        ];
+
+        yield 'thinking-only response replays as a thinking block' => [
+            [
+                'content' => [
+                    [
+                        'type' => 'thinking',
+                        'thinking' => 'Reasoning only...',
+                        'signature' => 'sig_t1',
+                    ],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Think about this.'),
+                Message::ofAssistant($result),
+                Message::ofUser('Now answer.'),
+            ),
+            [
+                'messages' => [
+                    ['role' => 'user', 'content' => 'Think about this.'],
+                    [
+                        'role' => 'assistant',
+                        'content' => [
+                            [
+                                'type' => 'thinking',
+                                'thinking' => 'Reasoning only...',
+                                'signature' => 'sig_t1',
+                            ],
+                        ],
+                    ],
+                    ['role' => 'user', 'content' => 'Now answer.'],
+                ],
+                'model' => 'claude-sonnet-4-0',
+            ],
+        ];
+
+        yield 'tool_use without preceding text replays as a single block' => [
+            [
+                'content' => [
+                    [
+                        'type' => 'tool_use',
+                        'id' => 'toolu_123',
+                        'name' => 'clock',
+                        'input' => [],
+                    ],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What time is it?'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('toolu_123', 'clock', []), '2026-05-09T12:00:00Z'),
+            ),
+            [
+                'messages' => [
+                    ['role' => 'user', 'content' => 'What time is it?'],
+                    [
+                        'role' => 'assistant',
+                        'content' => [
+                            [
+                                'type' => 'tool_use',
+                                'id' => 'toolu_123',
+                                'name' => 'clock',
+                                'input' => new \stdClass(),
+                            ],
+                        ],
+                    ],
+                    [
+                        'role' => 'user',
+                        'content' => [
+                            [
+                                'type' => 'tool_result',
+                                'tool_use_id' => 'toolu_123',
+                                'content' => '2026-05-09T12:00:00Z',
+                            ],
+                        ],
+                    ],
+                ],
+                'model' => 'claude-sonnet-4-0',
+            ],
+        ];
+
+        yield 'system message lifts to system field' => [
+            [
+                'content' => [
+                    ['type' => 'text', 'text' => 'Aye!'],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::forSystem('You are a pirate.'),
+                Message::ofUser('Greet me.'),
+                Message::ofAssistant($result),
+                Message::ofUser('Again!'),
+            ),
+            [
+                'messages' => [
+                    ['role' => 'user', 'content' => 'Greet me.'],
+                    ['role' => 'assistant', 'content' => 'Aye!'],
+                    ['role' => 'user', 'content' => 'Again!'],
+                ],
+                'system' => 'You are a pirate.',
+                'model' => 'claude-sonnet-4-0',
+            ],
+        ];
+    }
+}

--- a/src/platform/src/Bridge/Bedrock/Tests/Nova/AssistantReplayTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/Nova/AssistantReplayTest.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Bedrock\Tests\Nova;
+
+use AsyncAws\BedrockRuntime\Result\InvokeModelResponse;
+use AsyncAws\Core\Test\ResultMockFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Bedrock\Nova\Contract\AssistantMessageNormalizer;
+use Symfony\AI\Platform\Bridge\Bedrock\Nova\Contract\MessageBagNormalizer;
+use Symfony\AI\Platform\Bridge\Bedrock\Nova\Contract\ToolCallMessageNormalizer;
+use Symfony\AI\Platform\Bridge\Bedrock\Nova\Contract\ToolNormalizer;
+use Symfony\AI\Platform\Bridge\Bedrock\Nova\Contract\UserMessageNormalizer;
+use Symfony\AI\Platform\Bridge\Bedrock\Nova\Nova;
+use Symfony\AI\Platform\Bridge\Bedrock\Nova\NovaResultConverter;
+use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\ToolCall;
+
+/**
+ * End-to-end replay test: feed a fixture Bedrock Nova response into NovaResultConverter,
+ * build an assistant message via Message::ofAssistant($result), append the next
+ * user/tool turn, and assert the byte-shape of the request that would be sent
+ * back to Bedrock on turn 2.
+ *
+ * Pins the current converse-style shape (`messages: [{role, content: [...blocks]}]`,
+ * `system: [{text}]`) and the current "tool-or-text" branching in the assistant
+ * normalizer — if either changes, this test will fail and the new shape needs to
+ * be confirmed against the actual Bedrock Converse API.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class AssistantReplayTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $providerResponse
+     * @param array<string, mixed> $expectedReplayPayload
+     */
+    #[DataProvider('provideReplayScenarios')]
+    public function testRoundTrip(array $providerResponse, callable $bagBuilder, array $expectedReplayPayload)
+    {
+        $invokeResponse = ResultMockFactory::create(InvokeModelResponse::class, [
+            'body' => json_encode($providerResponse),
+        ]);
+        $result = (new NovaResultConverter())->convert(new RawBedrockResult($invokeResponse));
+
+        $contract = Contract::create([
+            new AssistantMessageNormalizer(),
+            new MessageBagNormalizer(),
+            new ToolCallMessageNormalizer(),
+            new ToolNormalizer(),
+            new UserMessageNormalizer(),
+        ]);
+
+        $bag = $bagBuilder($result);
+        $payload = $contract->createRequestPayload(new Nova('nova-pro'), $bag);
+
+        $this->assertEquals($expectedReplayPayload, $payload);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>, 1: callable, 2: array<string, mixed>}>
+     */
+    public static function provideReplayScenarios(): iterable
+    {
+        yield 'plain text turn replays as a single text content block' => [
+            [
+                'output' => ['message' => ['content' => [
+                    ['text' => 'Paris.'],
+                ]]],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What is the capital of France?'),
+                Message::ofAssistant($result),
+                Message::ofUser('And of Germany?'),
+            ),
+            [
+                'messages' => [
+                    ['role' => 'user', 'content' => [['text' => 'What is the capital of France?']]],
+                    ['role' => 'assistant', 'content' => [['text' => 'Paris.']]],
+                    ['role' => 'user', 'content' => [['text' => 'And of Germany?']]],
+                ],
+            ],
+        ];
+
+        yield 'tool_use response replays as a toolUse block paired with toolResult' => [
+            [
+                'output' => ['message' => ['content' => [
+                    ['text' => 'Calling the clock tool.'],
+                    ['toolUse' => [
+                        'toolUseId' => 'tooluse_abc',
+                        'name' => 'clock',
+                        'input' => ['tz' => 'UTC'],
+                    ]],
+                ]]],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What time is it?'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('tooluse_abc', 'clock', ['tz' => 'UTC']), '12:00:00Z'),
+            ),
+            [
+                'messages' => [
+                    ['role' => 'user', 'content' => [['text' => 'What time is it?']]],
+                    [
+                        'role' => 'assistant',
+                        'content' => [
+                            [
+                                'toolUse' => [
+                                    'toolUseId' => 'tooluse_abc',
+                                    'name' => 'clock',
+                                    'input' => ['tz' => 'UTC'],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'role' => 'user',
+                        'content' => [
+                            [
+                                'toolResult' => [
+                                    'toolUseId' => 'tooluse_abc',
+                                    'content' => [['json' => '12:00:00Z']],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'tool_use without arguments emits empty input object' => [
+            [
+                'output' => ['message' => ['content' => [
+                    ['text' => 'Calling.'],
+                    ['toolUse' => [
+                        'toolUseId' => 'tooluse_xyz',
+                        'name' => 'clock',
+                        'input' => [],
+                    ]],
+                ]]],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Time?'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('tooluse_xyz', 'clock', []), '12:00:00Z'),
+            ),
+            [
+                'messages' => [
+                    ['role' => 'user', 'content' => [['text' => 'Time?']]],
+                    [
+                        'role' => 'assistant',
+                        'content' => [
+                            [
+                                'toolUse' => [
+                                    'toolUseId' => 'tooluse_xyz',
+                                    'name' => 'clock',
+                                    'input' => new \stdClass(),
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'role' => 'user',
+                        'content' => [
+                            [
+                                'toolResult' => [
+                                    'toolUseId' => 'tooluse_xyz',
+                                    'content' => [['json' => '12:00:00Z']],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'system message lifts to system field' => [
+            [
+                'output' => ['message' => ['content' => [
+                    ['text' => 'Aye!'],
+                ]]],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::forSystem('You are a pirate.'),
+                Message::ofUser('Greet me.'),
+                Message::ofAssistant($result),
+                Message::ofUser('Again!'),
+            ),
+            [
+                'system' => [['text' => 'You are a pirate.']],
+                'messages' => [
+                    ['role' => 'user', 'content' => [['text' => 'Greet me.']]],
+                    ['role' => 'assistant', 'content' => [['text' => 'Aye!']]],
+                    ['role' => 'user', 'content' => [['text' => 'Again!']]],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/platform/src/Bridge/Gemini/Tests/AssistantReplayTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/AssistantReplayTest.php
@@ -1,0 +1,226 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Gemini\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Gemini\Contract\GeminiContract;
+use Symfony\AI\Platform\Bridge\Gemini\Gemini;
+use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+/**
+ * End-to-end replay test: feed a fixture provider response into ResultConverter,
+ * build an assistant message via Message::ofAssistant($result), append the next
+ * user/tool turn, and assert the byte-shape of the request that would be sent
+ * back to Gemini on turn 2.
+ *
+ * Particularly important for Gemini because of `thoughtSignature` round-tripping
+ * — every assistant part (text, thought, functionCall) may carry a signature
+ * that has to survive the conversion → message → normalize loop intact.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class AssistantReplayTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $providerResponse
+     * @param array<string, mixed> $expectedReplayPayload
+     */
+    #[DataProvider('provideReplayScenarios')]
+    public function testRoundTrip(array $providerResponse, callable $bagBuilder, array $expectedReplayPayload)
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse($providerResponse));
+        $httpResponse = $httpClient->request('POST', 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent');
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $bag = $bagBuilder($result);
+        $payload = GeminiContract::create()->createRequestPayload(new Gemini('gemini-2.5-flash'), $bag);
+
+        $this->assertEquals($expectedReplayPayload, $payload);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>, 1: callable, 2: array<string, mixed>}>
+     */
+    public static function provideReplayScenarios(): iterable
+    {
+        yield 'plain text turn replays as a single text part' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [['text' => 'Paris.']]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What is the capital of France?'),
+                Message::ofAssistant($result),
+                Message::ofUser('And of Germany?'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'What is the capital of France?']]],
+                    ['role' => 'model', 'parts' => [['text' => 'Paris.']]],
+                    ['role' => 'user', 'parts' => [['text' => 'And of Germany?']]],
+                ],
+            ],
+        ];
+
+        yield 'text + functionCall preserves order and ids' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => "I'll check the time."],
+                        ['functionCall' => ['id' => 'call_1', 'name' => 'clock', 'args' => []]],
+                    ]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What time is it?'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('call_1', 'clock', []), '12:00'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'What time is it?']]],
+                    ['role' => 'model', 'parts' => [
+                        ['text' => "I'll check the time."],
+                        ['functionCall' => ['id' => 'call_1', 'name' => 'clock']],
+                    ]],
+                    ['role' => 'user', 'parts' => [
+                        ['functionResponse' => [
+                            'id' => 'call_1',
+                            'name' => 'clock',
+                            'response' => ['rawResponse' => '12:00'],
+                        ]],
+                    ]],
+                ],
+            ],
+        ];
+
+        yield 'thought + text round-trips signature on each part' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'Reasoning step.', 'thought' => true, 'thoughtSignature' => 'sig_thought'],
+                        ['text' => 'Final answer.', 'thoughtSignature' => 'sig_text'],
+                    ]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Solve it.'),
+                Message::ofAssistant($result),
+                Message::ofUser('Now another.'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'Solve it.']]],
+                    ['role' => 'model', 'parts' => [
+                        ['text' => 'Reasoning step.', 'thought' => true, 'thoughtSignature' => 'sig_thought'],
+                        ['text' => 'Final answer.', 'thoughtSignature' => 'sig_text'],
+                    ]],
+                    ['role' => 'user', 'parts' => [['text' => 'Now another.']]],
+                ],
+            ],
+        ];
+
+        yield 'signed functionCall round-trips signature' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['functionCall' => ['id' => 'call_2', 'name' => 'search', 'args' => ['q' => 'symfony']], 'thoughtSignature' => 'sig_call'],
+                    ]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Search for symfony.'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('call_2', 'search', ['q' => 'symfony']), 'PHP framework.'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'Search for symfony.']]],
+                    ['role' => 'model', 'parts' => [
+                        ['functionCall' => ['id' => 'call_2', 'name' => 'search', 'args' => ['q' => 'symfony']], 'thoughtSignature' => 'sig_call'],
+                    ]],
+                    ['role' => 'user', 'parts' => [
+                        ['functionResponse' => [
+                            'id' => 'call_2',
+                            'name' => 'search',
+                            'response' => ['rawResponse' => 'PHP framework.'],
+                        ]],
+                    ]],
+                ],
+            ],
+        ];
+
+        yield 'thought + text + functionCall with mixed signatures preserves order' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'First thought.', 'thought' => true, 'thoughtSignature' => 'sig_t1'],
+                        ['text' => 'Plain visible text.'],
+                        ['functionCall' => ['id' => 'call_3', 'name' => 'lookup', 'args' => ['q' => 'x']], 'thoughtSignature' => 'sig_call3'],
+                    ]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Do work.'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('call_3', 'lookup', ['q' => 'x']), 'ok'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'Do work.']]],
+                    ['role' => 'model', 'parts' => [
+                        ['text' => 'First thought.', 'thought' => true, 'thoughtSignature' => 'sig_t1'],
+                        ['text' => 'Plain visible text.'],
+                        ['functionCall' => ['id' => 'call_3', 'name' => 'lookup', 'args' => ['q' => 'x']], 'thoughtSignature' => 'sig_call3'],
+                    ]],
+                    ['role' => 'user', 'parts' => [
+                        ['functionResponse' => [
+                            'id' => 'call_3',
+                            'name' => 'lookup',
+                            'response' => ['rawResponse' => 'ok'],
+                        ]],
+                    ]],
+                ],
+            ],
+        ];
+
+        yield 'system message lifts to system_instruction' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [['text' => 'Hello!']]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::forSystem('You are friendly.'),
+                Message::ofUser('Greet me.'),
+                Message::ofAssistant($result),
+                Message::ofUser('Again.'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'Greet me.']]],
+                    ['role' => 'model', 'parts' => [['text' => 'Hello!']]],
+                    ['role' => 'user', 'parts' => [['text' => 'Again.']]],
+                ],
+                'system_instruction' => ['parts' => [['text' => 'You are friendly.']]],
+            ],
+        ];
+    }
+}

--- a/src/platform/src/Bridge/VertexAi/Tests/AssistantReplayTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/AssistantReplayTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\VertexAi\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\VertexAi\Contract\GeminiContract;
+use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
+use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ResultConverter;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+/**
+ * End-to-end replay test: feed a fixture provider response into Vertex AI's
+ * ResultConverter, build an assistant message via Message::ofAssistant($result),
+ * append the next user/tool turn, and assert the byte-shape of the request that
+ * would be sent back to Vertex on turn 2.
+ *
+ * Vertex shares the Gemini Part schema but diverges in two places that this
+ * test pins down: `systemInstruction` (camelCase) vs Gemini's `system_instruction`,
+ * and `functionResponse` / `functionCall` without the `id` field.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class AssistantReplayTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $providerResponse
+     * @param array<string, mixed> $expectedReplayPayload
+     */
+    #[DataProvider('provideReplayScenarios')]
+    public function testRoundTrip(array $providerResponse, callable $bagBuilder, array $expectedReplayPayload)
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse($providerResponse));
+        $httpResponse = $httpClient->request('POST', 'https://aiplatform.googleapis.com/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-pro:generateContent');
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $bag = $bagBuilder($result);
+        $payload = GeminiContract::create()->createRequestPayload(new Model('gemini-2.5-pro'), $bag);
+
+        $this->assertEquals($expectedReplayPayload, $payload);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>, 1: callable, 2: array<string, mixed>}>
+     */
+    public static function provideReplayScenarios(): iterable
+    {
+        yield 'plain text turn replays as a single text part' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [['text' => 'Paris.']]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What is the capital of France?'),
+                Message::ofAssistant($result),
+                Message::ofUser('And of Germany?'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'What is the capital of France?']]],
+                    ['role' => 'model', 'parts' => [['text' => 'Paris.']]],
+                    ['role' => 'user', 'parts' => [['text' => 'And of Germany?']]],
+                ],
+            ],
+        ];
+
+        yield 'text + functionCall preserves order, drops id on replay' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => "I'll check the time."],
+                        ['functionCall' => ['id' => 'call_1', 'name' => 'clock', 'args' => []]],
+                    ]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What time is it?'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('call_1', 'clock', []), '12:00'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'What time is it?']]],
+                    ['role' => 'model', 'parts' => [
+                        ['text' => "I'll check the time."],
+                        ['functionCall' => ['name' => 'clock']],
+                    ]],
+                    ['role' => 'user', 'parts' => [
+                        ['functionResponse' => [
+                            'name' => 'clock',
+                            'response' => ['rawResponse' => '12:00'],
+                        ]],
+                    ]],
+                ],
+            ],
+        ];
+
+        yield 'thought + text round-trips signature on each part' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'Reasoning step.', 'thought' => true, 'thoughtSignature' => 'sig_thought'],
+                        ['text' => 'Final answer.', 'thoughtSignature' => 'sig_text'],
+                    ]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Solve it.'),
+                Message::ofAssistant($result),
+                Message::ofUser('Now another.'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'Solve it.']]],
+                    ['role' => 'model', 'parts' => [
+                        ['text' => 'Reasoning step.', 'thought' => true, 'thoughtSignature' => 'sig_thought'],
+                        ['text' => 'Final answer.', 'thoughtSignature' => 'sig_text'],
+                    ]],
+                    ['role' => 'user', 'parts' => [['text' => 'Now another.']]],
+                ],
+            ],
+        ];
+
+        yield 'signed functionCall round-trips signature' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['functionCall' => ['id' => 'call_2', 'name' => 'search', 'args' => ['q' => 'symfony']], 'thoughtSignature' => 'sig_call'],
+                    ]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Search for symfony.'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('call_2', 'search', ['q' => 'symfony']), 'PHP framework.'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'Search for symfony.']]],
+                    ['role' => 'model', 'parts' => [
+                        ['functionCall' => ['name' => 'search', 'args' => ['q' => 'symfony']], 'thoughtSignature' => 'sig_call'],
+                    ]],
+                    ['role' => 'user', 'parts' => [
+                        ['functionResponse' => [
+                            'name' => 'search',
+                            'response' => ['rawResponse' => 'PHP framework.'],
+                        ]],
+                    ]],
+                ],
+            ],
+        ];
+
+        yield 'thought + signed text + signed functionCall preserves ordering and signatures' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'First thought.', 'thought' => true, 'thoughtSignature' => 'sig_t1'],
+                        ['text' => 'Plain visible text.'],
+                        ['functionCall' => ['id' => 'call_3', 'name' => 'lookup', 'args' => ['q' => 'x']], 'thoughtSignature' => 'sig_call3'],
+                    ]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Do work.'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('call_3', 'lookup', ['q' => 'x']), 'ok'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'Do work.']]],
+                    ['role' => 'model', 'parts' => [
+                        ['text' => 'First thought.', 'thought' => true, 'thoughtSignature' => 'sig_t1'],
+                        ['text' => 'Plain visible text.'],
+                        ['functionCall' => ['name' => 'lookup', 'args' => ['q' => 'x']], 'thoughtSignature' => 'sig_call3'],
+                    ]],
+                    ['role' => 'user', 'parts' => [
+                        ['functionResponse' => [
+                            'name' => 'lookup',
+                            'response' => ['rawResponse' => 'ok'],
+                        ]],
+                    ]],
+                ],
+            ],
+        ];
+
+        yield 'system message lifts to systemInstruction (camelCase)' => [
+            [
+                'candidates' => [
+                    ['content' => ['parts' => [['text' => 'Hello!']]]],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::forSystem('You are friendly.'),
+                Message::ofUser('Greet me.'),
+                Message::ofAssistant($result),
+                Message::ofUser('Again.'),
+            ),
+            [
+                'contents' => [
+                    ['role' => 'user', 'parts' => [['text' => 'Greet me.']]],
+                    ['role' => 'model', 'parts' => [['text' => 'Hello!']]],
+                    ['role' => 'user', 'parts' => [['text' => 'Again.']]],
+                ],
+                'systemInstruction' => ['parts' => [['text' => 'You are friendly.']]],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Follow-up to #1853.

The `AssistantMessage` rework introduced a non-trivial replay path: provider response → `ResultConverter` → `Message::ofAssistant($result)` → `MessageBag` → `Contract::createRequestPayload()` → request bytes for the next turn. The existing per-component tests (normalizers in isolation, converters in isolation) cover the endpoints of that pipeline but not the round-trip, which is exactly where regressions during the rework surfaced (signature drops, ordering swaps, empty-content shapes, tool-call id pairing).

This PR adds:

- Per-bridge `AssistantReplayTest` that pins the byte-shape of the turn-2 request for representative response patterns:
  - **Anthropic** (6 scenarios): text-only string-content shortcut, text + tool_use, thinking + text + tool_use, thinking-only, tool_use-only with empty `input` as `\stdClass`, system message lift.
  - **Gemini** (6 scenarios): plain text, text + functionCall, thought + text with `thoughtSignature` round-trip, signed functionCall, mixed thought + signed text + signed functionCall, `system_instruction` lift.
  - **Vertex AI** (6 scenarios): same six as Gemini, verifying Vertex's divergence — `systemInstruction` (camelCase) and `functionCall` / `functionResponse` without `id`.
  - **Bedrock Nova** (4 scenarios): text-only converse blocks, tool_use replay, tool_use with empty `input` as `\stdClass`, `system: [{text}]` lift. Pins the current "tool-or-text" branching — when an interleave fix lands, this test will signal and need updating.

- `examples/anthropic/toolcall-roundtrip.php` — mirrors the existing `examples/gemini/toolcall-roundtrip.php` and exercises `Message::ofAssistant($result)` across three turns. Lives under `run-examples.yaml` so it doubles as a live integration check that Anthropic still accepts our `tool_use` block ordering.

22 mocked unit tests (run under the existing `platform-bridges` CI matrix) + 1 live example.