### PR TITLE
[Platform] Follow-up fixes for AssistantMessage rework

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -37,11 +37,10 @@ Chat
 Platform
 --------
 
- * `AssistantMessage` now takes a variadic list of `ContentInterface` parts instead of a single string
-   content plus separate `toolCalls`/`thinkingContent`/`thinkingSignature` arguments. A new
-   `Symfony\AI\Platform\Message\Content\Thinking` class represents thinking/reasoning blocks, and
-   `Symfony\AI\Platform\Result\ToolCall` now implements `ContentInterface` so it can be passed directly
-   as an assistant part:
+ * `AssistantMessage` takes a variadic list of `ContentInterface` parts instead of separate
+   `content`/`toolCalls`/`thinkingContent`/`thinkingSignature` arguments. New content classes:
+   `Message\Content\Thinking`, `Message\Content\ExecutableCode`, `Message\Content\CodeExecution`.
+   `Result\ToolCall` now implements `ContentInterface` and can be passed directly:
 
    ```diff
    -new AssistantMessage(
@@ -57,24 +56,24 @@ Platform
    +);
    ```
 
-   `AssistantMessage::getContent()` now returns `ContentInterface[]` (symmetric with `UserMessage`).
-   Use `AssistantMessage::asText()` to get the concatenated text. `getToolCalls()` returns a (possibly
-   empty) array of `ToolCall`s — no longer `?array`. `getThinking()` returns a (possibly empty) array of
-   `Thinking` parts and replaces `hasThinkingContent()`/`getThinkingContent()`/`getThinkingSignature()`.
+   `getContent()` returns `ContentInterface[]`; use `asText()` for the concatenated text.
+   `getToolCalls()` returns `ToolCall[]` (no longer `?array`). `getThinking()` returns `Thinking[]` and
+   replaces `hasThinkingContent()`/`getThinkingContent()`/`getThinkingSignature()`.
 
- * `Message::ofAssistant()` is now variadic and accepts `string`, `ContentInterface`, or `ResultInterface`
-   arguments. Strings and `TextResult` become `Text`; `ThinkingResult` becomes `Thinking`; `ToolCallResult`
-   is unwrapped to its inner `ToolCall`s; `MultiPartResult` is recursively mapped. Structured outputs
-   (`ObjectResult`, `BinaryResult`, …) are not auto-mapped and must be stringified by the caller:
+ * `Message::ofAssistant()` is variadic and accepts `string`, `ContentInterface`, or `ResultInterface`
+   arguments — `TextResult`/`ThinkingResult`/`ToolCallResult`/`ExecutableCodeResult`/`CodeExecutionResult`
+   map to their content equivalents and `MultiPartResult` is unwrapped recursively. Result types without
+   a known mapping (e.g. `BinaryResult`, `ObjectResult`) throw `InvalidArgumentException` so unhandled
+   cases surface; stringify them in the caller before passing them in:
 
    ```diff
    -Message::ofAssistant($objectResult);
    +Message::ofAssistant($objectResult->getContent()->toString());
    ```
 
- * `MessageInterface::getContent()` return type no longer includes `ResultInterface`. Any custom
-   implementation of `MessageInterface` that previously declared `ResultInterface` in its union return
-   type must be updated accordingly.
+ * Anthropic `ResultConverter` returns a `ThinkingResult` (or a `MultiPartResult` containing one) for
+   responses with `thinking` blocks. A thinking-only response previously raised `RuntimeException`. Update
+   any `try`/`catch` and any code that assumed the converter only returned `TextResult` or `ToolCallResult`.
 
 UPGRADE FROM 0.7 to 0.8
 =======================

--- a/demo/templates/_message.html.twig
+++ b/demo/templates/_message.html.twig
@@ -1,7 +1,8 @@
 {% if message.role.value == 'assistant' %}
-    {% for content in message.content %}
-        {{ content.text is defined ? _self.bot(content.text, latest: latest) }}
-    {% endfor %}
+    {% set text = message.asText %}
+    {% if text is not null %}
+        {{ _self.bot(text, latest: latest) }}
+    {% endif %}
 {% else %}
     {{ _self.user(message.content) }}
 {% endif %}

--- a/examples/anthropic/server-tools-code-execution-roundtrip.php
+++ b/examples/anthropic/server-tools-code-execution-roundtrip.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Platform\Bridge\Anthropic\Factory;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('ANTHROPIC_API_KEY'), httpClient: http_client());
+
+$agent = new Agent($platform, 'claude-sonnet-4-5-20250929');
+
+$tools = [
+    ['type' => 'code_execution_20250825', 'name' => 'code_execution'],
+];
+
+$messages = new MessageBag(
+    Message::ofUser('Compute the 10th Fibonacci number using a short Python snippet.'),
+);
+
+$result = $agent->call($messages, ['tools' => $tools]);
+$messages->add($assistant = Message::ofAssistant($result));
+
+output()->writeln('<info>====== Turn 1 ======</info>');
+foreach ($assistant->getContent() as $part) {
+    if ($part instanceof Text) {
+        output()->writeln('<comment>Assistant:</comment> '.$part->getText());
+    } elseif ($part instanceof ExecutableCode) {
+        output()->writeln('<comment>Code:</comment> '.\PHP_EOL.$part->getCode());
+    } elseif ($part instanceof CodeExecution) {
+        output()->writeln('<comment>Result:</comment> '.$part->getOutput());
+    }
+}
+
+echo \PHP_EOL;
+
+output()->writeln('<info>====== Turn 2 ======</info>');
+$messages->add(Message::ofUser('What number did your snippet print? Answer with the number only.'));
+$result = $agent->call($messages, ['tools' => $tools]);
+output()->writeln('<comment>Assistant:</comment> '.$result->getContent());

--- a/examples/gemini/server-tools-code-execution-roundtrip.php
+++ b/examples/gemini/server-tools-code-execution-roundtrip.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Gemini\Factory;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('GEMINI_API_KEY'), http_client());
+
+$toolbox = new Toolbox([], logger: logger());
+$processor = new AgentProcessor($toolbox);
+$agent = new Agent($platform, 'gemini-3.1-pro-preview', [$processor], [$processor]);
+
+$options = ['server_tools' => ['code_execution' => true]];
+
+$messages = new MessageBag(
+    Message::ofUser('Compute the 10th Fibonacci number using a short Python snippet.'),
+);
+
+$result = $agent->call($messages, $options);
+$messages->add($assistant = Message::ofAssistant($result));
+
+output()->writeln('<info>====== Turn 1 ======</info>');
+foreach ($assistant->getContent() as $part) {
+    if ($part instanceof Text) {
+        output()->writeln('<comment>Assistant:</comment> '.$part->getText());
+    } elseif ($part instanceof ExecutableCode) {
+        output()->writeln('<comment>Code:</comment> '.\PHP_EOL.$part->getCode());
+    } elseif ($part instanceof CodeExecution) {
+        output()->writeln('<comment>Result:</comment> '.$part->getOutput());
+    }
+}
+
+echo \PHP_EOL;
+
+output()->writeln('<info>====== Turn 2 ======</info>');
+$messages->add(Message::ofUser('What number did your snippet print? Answer with the number only.'));
+$result = $agent->call($messages, $options);
+output()->writeln('<comment>Assistant:</comment> '.$result->getContent());

--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -122,8 +122,21 @@
                                                 {% for message in call.input.messages %}
                                                     <li>
                                                         <strong>{{ message.role.value|title }}:</strong>
-                                                        {% if 'assistant' == message.role.value and message.hasToolCalls%}
-                                                            {{ _self.tool_calls(message.toolCalls) }}
+                                                        {% if 'assistant' == message.role.value %}
+                                                            {% for part in message.content %}
+                                                                {% if part.text is defined %}{# Text #}
+                                                                    {{ part.text|nl2br }}
+                                                                {% elseif part.code is defined %}{# ExecutableCode #}
+                                                                    <pre><code>{{ part.code }}</code></pre>
+                                                                {% elseif part.output is defined %}{# CodeExecution #}
+                                                                    <pre>{{ part.output }}</pre>
+                                                                {% elseif part.arguments is defined %}{# ToolCall #}
+                                                                    <strong>{{ part.name }}({{ part.arguments|map((value, key) => "#{key}: #{value|json_encode}")|join(', ') }})</strong>
+                                                                    <i>(ID: {{ part.id }})</i>
+                                                                {% elseif part.content is defined %}{# Thinking #}
+                                                                    <details><summary><i>Thinking</i></summary>{{ part.content|nl2br }}</details>
+                                                                {% endif %}
+                                                            {% endfor %}
                                                         {% elseif 'tool' == message.role.value %}
                                                             <i>Result of tool call with ID {{ message.toolCall.id }}</i><br />
                                                             {{ message.content|nl2br }}

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -6,8 +6,8 @@ CHANGELOG
 
  * Add `ValidatorSubscriber` to validate structured output using Symfony Validator
  * Add support for multiple system messages in `MessageBag`
- * [BC BREAK] Rework `AssistantMessage` to hold `ContentInterface` parts (variadic constructor) instead of a single string content plus separate tool-call/thinking fields. Introduces `Message\Content\Thinking` as a first-class content block and makes `Result\ToolCall` implement `ContentInterface`. `Message::ofAssistant()` accepts strings, `ContentInterface` instances, and `ResultInterface` values (mapping `TextResult`, `ThinkingResult`, `ToolCallResult` and `MultiPartResult` to their content equivalents).
- * Add `thought`/`thoughtSignature` round-trip in Gemini and VertexAI bridges: `ResultConverter` emits a `ThinkingResult` for a part with `thought: true`, and `AssistantMessageNormalizer` sends `Thinking` content parts back with `thought: true` (and `thoughtSignature` when set). Signatures attached to non-thought `text` or `functionCall` parts are also preserved by adding an optional `signature` field to `Message\Content\Text`, `Result\ToolCall`, and `Result\TextResult`.
+ * [BC BREAK] Rework `AssistantMessage` to hold `ContentInterface` parts (variadic constructor) instead of a single string content plus separate tool-call/thinking fields. Adds `Message\Content\Thinking`, `Message\Content\ExecutableCode`, and `Message\Content\CodeExecution` content classes, and makes `Result\ToolCall` implement `ContentInterface`. `Message::ofAssistant()` accepts strings, `ContentInterface`, and `ResultInterface` values, mapping `TextResult`/`ThinkingResult`/`ToolCallResult`/`ExecutableCodeResult`/`CodeExecutionResult`/`MultiPartResult` to their content equivalents; result types without a known mapping throw `InvalidArgumentException` so unhandled cases surface instead of being silently dropped.
+ * Add optional `signature` field to `Message\Content\Text`, `Result\ToolCall`, and `Result\TextResult` for provider-scoped signatures (currently used by Gemini/Vertex AI for `thoughtSignature` round-trip).
 
 0.8
 ---

--- a/src/platform/src/Bridge/Anthropic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Anthropic/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.9
+---
+
+ * [BC BREAK] `ResultConverter` now emits `ThinkingResult` for `thinking` content blocks. A thinking-only response previously raised `RuntimeException`; it now returns a `ThinkingResult` (or `MultiPartResult` combined with text/tool calls).
+ * `AssistantMessageNormalizer` emits `thinking`, `text`, `tool_use`, `server_tool_use`, and `*_code_execution_tool_result` blocks in their original order so multi-turn replays of thinking and code-execution conversations round-trip end-to-end.
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Anthropic/Contract/AssistantMessageNormalizer.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Platform\Bridge\Anthropic\Contract;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Model;
@@ -30,10 +32,12 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
      * @return array{
      *     role: 'assistant',
      *     content: string|list<array{
-     *         type: 'thinking'|'text'|'tool_use',
+     *         type: 'thinking'|'text'|'tool_use'|'server_tool_use'|'bash_code_execution_tool_result'|'text_editor_code_execution_tool_result',
      *         id?: string,
+     *         tool_use_id?: string,
      *         name?: string,
      *         input?: array<string, mixed>,
+     *         content?: array<string, mixed>,
      *         text?: string,
      *         thinking?: string,
      *         signature?: string
@@ -44,6 +48,13 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
     {
         $parts = $data->getContent();
 
+        if ([] === $parts) {
+            return [
+                'role' => 'assistant',
+                'content' => '',
+            ];
+        }
+
         if (1 === \count($parts) && $parts[0] instanceof Text) {
             return [
                 'role' => 'assistant',
@@ -52,6 +63,7 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
         }
 
         $blocks = [];
+        $executedAsBash = [];
         foreach ($parts as $part) {
             if ($part instanceof Thinking) {
                 $block = [
@@ -77,6 +89,41 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
                     'name' => $part->getName(),
                     'input' => [] !== $part->getArguments() ? $part->getArguments() : new \stdClass(),
                 ];
+                continue;
+            }
+
+            if ($part instanceof ExecutableCode) {
+                // ResultConverter sets language='bash' for bash_code_execution and null for text_editor_code_execution.
+                $isBash = 'bash' === $part->getLanguage();
+                $block = [
+                    'type' => 'server_tool_use',
+                    'name' => $isBash ? 'bash_code_execution' : 'text_editor_code_execution',
+                    'input' => $isBash ? ['command' => $part->getCode()] : ['file_text' => $part->getCode()],
+                ];
+                if (null !== $part->getId()) {
+                    $block['id'] = $part->getId();
+                    $executedAsBash[$part->getId()] = $isBash;
+                }
+                $blocks[] = $block;
+                continue;
+            }
+
+            if ($part instanceof CodeExecution) {
+                $isBash = $executedAsBash[$part->getId() ?? ''] ?? true;
+                $block = ['type' => $isBash ? 'bash_code_execution_tool_result' : 'text_editor_code_execution_tool_result'];
+                if (null !== $part->getId()) {
+                    $block['tool_use_id'] = $part->getId();
+                }
+                if ($isBash) {
+                    $block['content'] = [
+                        'type' => 'bash_code_execution_result',
+                        'stdout' => $part->getOutput() ?? '',
+                        'stderr' => '',
+                        'return_code' => $part->isSucceeded() ? 0 : 1,
+                        'content' => [],
+                    ];
+                }
+                $blocks[] = $block;
             }
         }
 

--- a/src/platform/src/Bridge/Bedrock/CHANGELOG.md
+++ b/src/platform/src/Bridge/Bedrock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.9
+---
+
+ * Nova `AssistantMessageNormalizer` interleaves `text` and `toolUse` blocks in their original order instead of dropping text whenever tool calls are present.
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Bedrock/Nova/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/Contract/AssistantMessageNormalizer.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Bedrock\Nova\Contract;
 use Symfony\AI\Platform\Bridge\Bedrock\Nova\Nova;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ToolCall;
 
@@ -39,24 +40,31 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        if ($data->hasToolCalls()) {
-            return [
-                'role' => 'assistant',
-                'content' => array_map(static function (ToolCall $toolCall) {
-                    return [
-                        'toolUse' => [
-                            'toolUseId' => $toolCall->getId(),
-                            'name' => $toolCall->getName(),
-                            'input' => [] !== $toolCall->getArguments() ? $toolCall->getArguments() : new \stdClass(),
-                        ],
-                    ];
-                }, $data->getToolCalls()),
-            ];
+        $blocks = [];
+        foreach ($data->getContent() as $part) {
+            if ($part instanceof Text) {
+                $blocks[] = ['text' => $part->getText()];
+                continue;
+            }
+
+            if ($part instanceof ToolCall) {
+                $blocks[] = [
+                    'toolUse' => [
+                        'toolUseId' => $part->getId(),
+                        'name' => $part->getName(),
+                        'input' => [] !== $part->getArguments() ? $part->getArguments() : new \stdClass(),
+                    ],
+                ];
+            }
+        }
+
+        if ([] === $blocks) {
+            $blocks[] = ['text' => ''];
         }
 
         return [
             'role' => 'assistant',
-            'content' => [['text' => $data->asText() ?? '']],
+            'content' => $blocks,
         ];
     }
 

--- a/src/platform/src/Bridge/Bedrock/Tests/Nova/ContractTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/Nova/ContractTest.php
@@ -20,6 +20,7 @@ use Symfony\AI\Platform\Bridge\Bedrock\Nova\Contract\ToolNormalizer;
 use Symfony\AI\Platform\Bridge\Bedrock\Nova\Contract\UserMessageNormalizer;
 use Symfony\AI\Platform\Bridge\Bedrock\Nova\Nova;
 use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -82,6 +83,50 @@ final class ContractTest extends TestCase
                 'system' => [['text' => 'You are a cat. Your name is Neko.']],
                 'messages' => [
                     ['role' => 'user', 'content' => [['text' => 'Hello there']]],
+                ],
+            ],
+        ];
+
+        yield 'with text and tool use interleaved' => [
+            new MessageBag(
+                Message::ofUser('Hello there, what is the time?'),
+                Message::ofAssistant(
+                    new Text('Let me check.'),
+                    new ToolCall('123456', 'clock', []),
+                ),
+                Message::ofToolCall(new ToolCall('123456', 'clock', []), '2023-10-01T10:00:00+00:00'),
+                Message::ofAssistant('It is 10:00 AM.'),
+            ),
+            [
+                'messages' => [
+                    ['role' => 'user', 'content' => [['text' => 'Hello there, what is the time?']]],
+                    [
+                        'role' => 'assistant',
+                        'content' => [
+                            ['text' => 'Let me check.'],
+                            [
+                                'toolUse' => [
+                                    'toolUseId' => '123456',
+                                    'name' => 'clock',
+                                    'input' => new \stdClass(),
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'role' => 'user',
+                        'content' => [
+                            [
+                                'toolResult' => [
+                                    'toolUseId' => '123456',
+                                    'content' => [
+                                        ['json' => '2023-10-01T10:00:00+00:00'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    ['role' => 'assistant', 'content' => [['text' => 'It is 10:00 AM.']]],
                 ],
             ],
         ];

--- a/src/platform/src/Bridge/Gemini/CHANGELOG.md
+++ b/src/platform/src/Bridge/Gemini/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.9
+---
+
+ * Add `thoughtSignature` round-trip: `ResultConverter` emits `ThinkingResult` for parts with `thought: true` and preserves `thoughtSignature` on `text`/`functionCall`/thought parts; `AssistantMessageNormalizer` sends them back on replay.
+ * `AssistantMessageNormalizer` emits `executableCode` and `codeExecutionResult` parts for `Message\Content\ExecutableCode` and `Message\Content\CodeExecution` content so multi-turn code-execution conversations replay end-to-end.
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Gemini/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Gemini/Contract/AssistantMessageNormalizer.php
@@ -15,6 +15,8 @@ use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Model;
@@ -70,6 +72,30 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
                     $toolPart['thoughtSignature'] = $part->getSignature();
                 }
                 $normalized[] = $toolPart;
+                continue;
+            }
+
+            if ($part instanceof ExecutableCode) {
+                $executableCode = [
+                    'language' => $part->getLanguage() ?? 'PYTHON',
+                    'code' => $part->getCode(),
+                ];
+                if (null !== $part->getId()) {
+                    $executableCode['id'] = $part->getId();
+                }
+                $normalized[] = ['executableCode' => $executableCode];
+                continue;
+            }
+
+            if ($part instanceof CodeExecution) {
+                $codeExecutionResult = [
+                    'outcome' => $part->isSucceeded() ? ResultConverter::OUTCOME_OK : ResultConverter::OUTCOME_FAILED,
+                    'output' => $part->getOutput() ?? '',
+                ];
+                if (null !== $part->getId()) {
+                    $codeExecutionResult['id'] = $part->getId();
+                }
+                $normalized[] = ['codeExecutionResult' => $codeExecutionResult];
             }
         }
 

--- a/src/platform/src/Bridge/Gemini/Tests/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Contract/AssistantMessageNormalizerTest.php
@@ -17,6 +17,8 @@ use Symfony\AI\Platform\Bridge\Gemini\Contract\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -116,6 +118,40 @@ final class AssistantMessageNormalizerTest extends TestCase
             new AssistantMessage(new ToolCall('id1', 'run', ['x' => 1], 'sig_call')),
             [
                 ['functionCall' => ['id' => 'id1', 'name' => 'run', 'args' => ['x' => 1]], 'thoughtSignature' => 'sig_call'],
+            ],
+        ];
+        yield 'executable code with explicit language' => [
+            new AssistantMessage(new ExecutableCode('print(1)', 'PYTHON', 'exec_1')),
+            [
+                ['executableCode' => ['language' => 'PYTHON', 'code' => 'print(1)', 'id' => 'exec_1']],
+            ],
+        ];
+        yield 'executable code defaults language to PYTHON' => [
+            new AssistantMessage(new ExecutableCode('print(1)')),
+            [
+                ['executableCode' => ['language' => 'PYTHON', 'code' => 'print(1)']],
+            ],
+        ];
+        yield 'code execution result success' => [
+            new AssistantMessage(new CodeExecution(true, '1', 'exec_1')),
+            [
+                ['codeExecutionResult' => ['outcome' => 'OUTCOME_OK', 'output' => '1', 'id' => 'exec_1']],
+            ],
+        ];
+        yield 'code execution result failure' => [
+            new AssistantMessage(new CodeExecution(false, 'oops')),
+            [
+                ['codeExecutionResult' => ['outcome' => 'OUTCOME_FAILED', 'output' => 'oops']],
+            ],
+        ];
+        yield 'paired executable code and result' => [
+            new AssistantMessage(
+                new ExecutableCode('print(1)', 'PYTHON', 'exec_1'),
+                new CodeExecution(true, '1', 'exec_1'),
+            ),
+            [
+                ['executableCode' => ['language' => 'PYTHON', 'code' => 'print(1)', 'id' => 'exec_1']],
+                ['codeExecutionResult' => ['outcome' => 'OUTCOME_OK', 'output' => '1', 'id' => 'exec_1']],
             ],
         ];
     }

--- a/src/platform/src/Bridge/VertexAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/VertexAi/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.9
+---
+
+ * Add `thoughtSignature` round-trip: `ResultConverter` emits `ThinkingResult` for parts with `thought: true` and preserves `thoughtSignature` on `text`/`functionCall`/thought parts; `AssistantMessageNormalizer` sends them back on replay.
+ * `AssistantMessageNormalizer` emits `executableCode` and `codeExecutionResult` parts for `Message\Content\ExecutableCode` and `Message\Content\CodeExecution` content so multi-turn code-execution conversations replay end-to-end.
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/VertexAi/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/VertexAi/Contract/AssistantMessageNormalizer.php
@@ -15,6 +15,8 @@ use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ResultConverter;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Model as BaseModel;
@@ -69,6 +71,30 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer
                     $toolPart['thoughtSignature'] = $part->getSignature();
                 }
                 $normalized[] = $toolPart;
+                continue;
+            }
+
+            if ($part instanceof ExecutableCode) {
+                $executableCode = [
+                    'language' => $part->getLanguage() ?? 'PYTHON',
+                    'code' => $part->getCode(),
+                ];
+                if (null !== $part->getId()) {
+                    $executableCode['id'] = $part->getId();
+                }
+                $normalized[] = ['executableCode' => $executableCode];
+                continue;
+            }
+
+            if ($part instanceof CodeExecution) {
+                $codeExecutionResult = [
+                    'outcome' => $part->isSucceeded() ? ResultConverter::OUTCOME_OK : ResultConverter::OUTCOME_FAILED,
+                    'output' => $part->getOutput() ?? '',
+                ];
+                if (null !== $part->getId()) {
+                    $codeExecutionResult['id'] = $part->getId();
+                }
+                $normalized[] = ['codeExecutionResult' => $codeExecutionResult];
             }
         }
 

--- a/src/platform/src/Bridge/VertexAi/Tests/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Contract/AssistantMessageNormalizerTest.php
@@ -17,6 +17,8 @@ use Symfony\AI\Platform\Bridge\VertexAi\Contract\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -109,6 +111,22 @@ final class AssistantMessageNormalizerTest extends TestCase
             new AssistantMessage(new ToolCall('id1', 'run', ['x' => 1], 'sig_call')),
             [
                 ['functionCall' => ['name' => 'run', 'args' => ['x' => 1]], 'thoughtSignature' => 'sig_call'],
+            ],
+        ];
+        yield 'paired executable code and result' => [
+            new AssistantMessage(
+                new ExecutableCode('print(1)', 'PYTHON', 'exec_1'),
+                new CodeExecution(true, '1', 'exec_1'),
+            ),
+            [
+                ['executableCode' => ['language' => 'PYTHON', 'code' => 'print(1)', 'id' => 'exec_1']],
+                ['codeExecutionResult' => ['outcome' => 'OUTCOME_OK', 'output' => '1', 'id' => 'exec_1']],
+            ],
+        ];
+        yield 'code execution result failure without id' => [
+            new AssistantMessage(new CodeExecution(false, 'oops')),
+            [
+                ['codeExecutionResult' => ['outcome' => 'OUTCOME_FAILED', 'output' => 'oops']],
             ],
         ];
     }

--- a/src/platform/src/Message/Content/CodeExecution.php
+++ b/src/platform/src/Message/Content/CodeExecution.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message\Content;
+
+final class CodeExecution implements ContentInterface
+{
+    public function __construct(
+        private readonly bool $succeeded,
+        private readonly ?string $output = null,
+        private readonly ?string $id = null,
+    ) {
+    }
+
+    public function getOutput(): ?string
+    {
+        return $this->output;
+    }
+
+    public function isSucceeded(): bool
+    {
+        return $this->succeeded;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/src/platform/src/Message/Content/ExecutableCode.php
+++ b/src/platform/src/Message/Content/ExecutableCode.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message\Content;
+
+final class ExecutableCode implements ContentInterface
+{
+    public function __construct(
+        private readonly string $code,
+        private readonly ?string $language = null,
+        private readonly ?string $id = null,
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getLanguage(): ?string
+    {
+        return $this->language;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/src/platform/src/Message/Message.php
+++ b/src/platform/src/Message/Message.php
@@ -12,9 +12,13 @@
 namespace Symfony\AI\Platform\Message;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
 use Symfony\AI\Platform\Message\Content\ContentInterface;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Result\CodeExecutionResult;
+use Symfony\AI\Platform\Result\ExecutableCodeResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
@@ -96,6 +100,14 @@ final class Message
             return array_values($part->getContent());
         }
 
+        if ($part instanceof ExecutableCodeResult) {
+            return [new ExecutableCode($part->getContent(), $part->getLanguage(), $part->getId())];
+        }
+
+        if ($part instanceof CodeExecutionResult) {
+            return [new CodeExecution($part->isSucceeded(), $part->getContent(), $part->getId())];
+        }
+
         if ($part instanceof MultiPartResult) {
             $content = [];
             foreach ($part->getContent() as $inner) {
@@ -105,6 +117,11 @@ final class Message
             return $content;
         }
 
+        // Aggressive on purpose: we'd rather fail loudly than silently drop a part
+        // and leave the next turn's request missing context. If you hit this with a
+        // legitimate response, please open an issue at https://github.com/symfony/ai
+        // with a minimal reproducer (model, request, raw provider response) so we
+        // can add a mapping.
         throw new InvalidArgumentException(\sprintf('Unsupported assistant message part of type "%s".', $part::class));
     }
 }

--- a/src/platform/tests/Bridge/Anthropic/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/tests/Bridge/Anthropic/Contract/AssistantMessageNormalizerTest.php
@@ -16,6 +16,8 @@ use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Bridge\Anthropic\Contract\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -57,13 +59,13 @@ final class AssistantMessageNormalizerTest extends TestCase
         ], $this->normalizer->normalize($message));
     }
 
-    public function testNormalizeWithEmptyMessageProducesEmptyBlocks()
+    public function testNormalizeWithEmptyMessageProducesEmptyString()
     {
         $message = new AssistantMessage();
 
         $this->assertSame([
             'role' => 'assistant',
-            'content' => [],
+            'content' => '',
         ], $this->normalizer->normalize($message));
     }
 
@@ -136,6 +138,92 @@ final class AssistantMessageNormalizerTest extends TestCase
                     'signature' => 'sig-abc',
                 ],
                 ['type' => 'text', 'text' => 'The answer is 42.'],
+            ],
+        ], $this->normalizer->normalize($message));
+    }
+
+    public function testNormalizeWithBashCodeExecutionAndResult()
+    {
+        $message = new AssistantMessage(
+            new ExecutableCode('echo hi', 'bash', 'srvtoolu_1'),
+            new CodeExecution(true, 'hi', 'srvtoolu_1'),
+        );
+
+        $this->assertSame([
+            'role' => 'assistant',
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'name' => 'bash_code_execution',
+                    'input' => ['command' => 'echo hi'],
+                    'id' => 'srvtoolu_1',
+                ],
+                [
+                    'type' => 'bash_code_execution_tool_result',
+                    'tool_use_id' => 'srvtoolu_1',
+                    'content' => [
+                        'type' => 'bash_code_execution_result',
+                        'stdout' => 'hi',
+                        'stderr' => '',
+                        'return_code' => 0,
+                        'content' => [],
+                    ],
+                ],
+            ],
+        ], $this->normalizer->normalize($message));
+    }
+
+    public function testNormalizeWithTextEditorCodeExecutionAndResult()
+    {
+        $message = new AssistantMessage(
+            new ExecutableCode("print('x')", null, 'srvtoolu_2'),
+            new CodeExecution(true, null, 'srvtoolu_2'),
+        );
+
+        $this->assertSame([
+            'role' => 'assistant',
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'name' => 'text_editor_code_execution',
+                    'input' => ['file_text' => "print('x')"],
+                    'id' => 'srvtoolu_2',
+                ],
+                [
+                    'type' => 'text_editor_code_execution_tool_result',
+                    'tool_use_id' => 'srvtoolu_2',
+                ],
+            ],
+        ], $this->normalizer->normalize($message));
+    }
+
+    public function testNormalizeWithFailedBashExecution()
+    {
+        $message = new AssistantMessage(
+            new ExecutableCode('false', 'bash', 'srvtoolu_3'),
+            new CodeExecution(false, 'oops', 'srvtoolu_3'),
+        );
+
+        $this->assertSame([
+            'role' => 'assistant',
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'name' => 'bash_code_execution',
+                    'input' => ['command' => 'false'],
+                    'id' => 'srvtoolu_3',
+                ],
+                [
+                    'type' => 'bash_code_execution_tool_result',
+                    'tool_use_id' => 'srvtoolu_3',
+                    'content' => [
+                        'type' => 'bash_code_execution_result',
+                        'stdout' => 'oops',
+                        'stderr' => '',
+                        'return_code' => 1,
+                        'content' => [],
+                    ],
+                ],
             ],
         ], $this->normalizer->normalize($message));
     }

--- a/src/platform/tests/Message/MessageTest.php
+++ b/src/platform/tests/Message/MessageTest.php
@@ -12,11 +12,22 @@
 namespace Symfony\AI\Platform\Tests\Message;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\CodeExecution;
 use Symfony\AI\Platform\Message\Content\ContentInterface;
+use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\CodeExecutionResult;
+use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
 
 final class MessageTest extends TestCase
 {
@@ -114,6 +125,55 @@ final class MessageTest extends TestCase
         );
 
         $this->assertCount(4, $message->getContent());
+    }
+
+    public function testCreateAssistantMessageFromMultiPartResultMapsKnownResultTypes()
+    {
+        $result = new MultiPartResult([
+            new ThinkingResult('Reasoning...', 'sig'),
+            new TextResult('Visible answer.'),
+            new ToolCallResult([new ToolCall('id1', 'fn', ['x' => 1])]),
+            new ExecutableCodeResult('echo hi', 'bash', 'srvtoolu_1'),
+            new CodeExecutionResult(true, 'hi', 'srvtoolu_1'),
+        ]);
+
+        $message = Message::ofAssistant($result);
+
+        $parts = $message->getContent();
+        $this->assertCount(5, $parts);
+        $this->assertInstanceOf(Thinking::class, $parts[0]);
+        $this->assertInstanceOf(Text::class, $parts[1]);
+        $this->assertInstanceOf(ToolCall::class, $parts[2]);
+        $this->assertInstanceOf(ExecutableCode::class, $parts[3]);
+        $this->assertSame('echo hi', $parts[3]->getCode());
+        $this->assertSame('bash', $parts[3]->getLanguage());
+        $this->assertSame('srvtoolu_1', $parts[3]->getId());
+        $this->assertInstanceOf(CodeExecution::class, $parts[4]);
+        $this->assertTrue($parts[4]->isSucceeded());
+        $this->assertSame('hi', $parts[4]->getOutput());
+        $this->assertSame('srvtoolu_1', $parts[4]->getId());
+    }
+
+    public function testCreateAssistantMessageFromUnsupportedResultThrows()
+    {
+        $result = BinaryResult::fromBase64(base64_encode('binary'), 'image/png');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('Unsupported assistant message part of type "%s".', $result::class));
+
+        Message::ofAssistant($result);
+    }
+
+    public function testCreateAssistantMessageFromMultiPartResultThrowsOnUnsupportedInnerPart()
+    {
+        $result = new MultiPartResult([
+            new TextResult('Visible answer.'),
+            BinaryResult::fromBase64(base64_encode('binary'), 'image/png'),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        Message::ofAssistant($result);
     }
 
     public function testCreateToolCallMessage()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes <!-- ExecutableCode / CodeExecution content classes -->
| Docs?         | yes <!-- UPGRADE.md, CHANGELOG.md, vendor bridge changelogs -->
| Issues        | -
| License       | MIT

Follow-up to #1853.

Findings from a post-merge review of the `AssistantMessage` rework, addressed in one branch.

## Correctness fixes

- **Anthropic empty `AssistantMessage`** serializes to `content: ''` instead of `content: []`. The Anthropic Messages API rejects empty `content` arrays on the assistant role; the original PR introduced that shape on `new AssistantMessage()` (no parts). Restored to a string fallback.
- **Bedrock Nova `AssistantMessageNormalizer`** now interleaves `text` and `toolUse` blocks in their original order. Previously it short-circuited to tool-only output whenever any tool call was present, dropping the assistant's accompanying text.
- **AI Bundle profiler template** rendered `nl2br(message.content)` for assistant messages without tool calls, but `AssistantMessage::getContent()` is now `ContentInterface[]`. The template now iterates parts and renders each by type (Text / Thinking / ToolCall / ExecutableCode / CodeExecution), which also fixes a latent issue where assistant messages with both text and tool calls only showed the tool calls.
- **`Message::ofAssistant()`** throws `InvalidArgumentException` for `ResultInterface` types without a known mapping, so unhandled cases surface instead of being silently dropped. Direct readers to open an issue with a reproducer when they hit it.

## Replayable code execution

This is the architectural piece the rework left open. Anthropic and Gemini explicitly accept `executableCode` / code-execution result blocks on the assistant role for replay (verified in their public docs); silently dropping them would break multi-turn code-execution conversations.

- New `Message\Content\ExecutableCode` and `Message\Content\CodeExecution` content classes.
- `Message::ofAssistant()` maps `ExecutableCodeResult` → `ExecutableCode` and `CodeExecutionResult` → `CodeExecution`.
- **Anthropic** `AssistantMessageNormalizer` emits `server_tool_use` blocks (with `bash_code_execution` / `text_editor_code_execution` based on `language`) and matching `bash_code_execution_tool_result` / `text_editor_code_execution_tool_result` blocks paired by `tool_use_id`. Inner `bash_code_execution_result` content carries the discriminator `type` and required `content: []` field expected by Anthropic on input — caught by running the live roundtrip example end-to-end.
- **Gemini** and **Vertex AI** `AssistantMessageNormalizer`s emit `executableCode` and `codeExecutionResult` parts with provider-specific outcome enums.

## Examples

- `examples/anthropic/server-tools-code-execution-roundtrip.php` and `examples/gemini/server-tools-code-execution-roundtrip.php` — two-turn live demos: turn 1 runs Python via the server tool, turn 2 asks the model to recall its prior output. Both providers correctly answer "55" on turn 2, proving the replay path is intact end-to-end. Run by CI under `run-examples.yaml`.

## Doc fixes

- `UPGRADE.md` — replaced the misleading `MessageInterface::getContent()` note (the interface signature didn't actually change in the rework); tightened the rework block; added entries for the new throw behavior and the Anthropic `ResultConverter` thinking BC.
- `src/platform/CHANGELOG.md` — only platform-level entries; vendor-specific changes live in the respective bridge changelogs (`src/platform/src/Bridge/{Anthropic,Gemini,VertexAi,Bedrock}/CHANGELOG.md`) for 0.9.
- `demo/templates/_message.html.twig` — uses `message.asText` once instead of looping per-text-part, so a multi-part assistant reply doesn't fire the typewriter animation per bubble.
- Removed class-level docblocks from the new content classes (they restated what names + constructor signatures already convey).

## Tests

7 new unit tests across `Message`, Anthropic / Gemini / Vertex AI normalizers, and Bedrock Nova `ContractTest` — covering bash/text-editor pairing, interleaved replay, success/failure code-execution outcomes, and `Message::ofAssistant` round-tripping a `MultiPartResult` of mixed types plus throw behavior on unknown ones. The replay tests added in #2059 continue to pass alongside these changes.
