### PR TITLE
[AI Bundle] Patch profiler template for Template system messages and URL content

### DIFF
--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -133,10 +133,15 @@
                                                                     {{ item.text|nl2br }}
                                                                 {% elseif item.format is defined and item.format starts with 'image/'  %}
                                                                     <img src="{{ item.asDataUrl }}" style="max-width: 100%;"/>
-                                                                {% elseif item.asDataUrl  %}
+                                                                {% elseif item.asDataUrl is defined %}
                                                                     <a href="{{ item.asDataUrl }}" download="{{ item.filename ?? 'View File' }}">{{ item.filename ?? 'View File' }}</a>
+                                                                {% elseif item.url is defined %}{# ImageUrl, DocumentUrl #}
+                                                                    <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.url }}</a>
                                                                 {% endif %}
                                                             {% endfor %}
+                                                        {% elseif message.content.template is defined %}{# SystemMessage holding a Template #}
+                                                            {{ message.content.template|nl2br }}
+                                                            <small><i>(template type: {{ message.content.type }})</i></small>
                                                         {% else %}
                                                             {{ message.content|nl2br }}
                                                         {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Two pre-existing edge cases in `@Ai/data_collector.html.twig` that don't crash today only because the inputs are uncommon:

- **System message holding a `Template`** — `SystemMessage::getContent()` returns `string|Template`. The fallthrough branch hit `{{ message.content|nl2br }}`, which fails with `nl2br(): Argument #1 must be of type string, object given` when the content is a `Template` object. Handled explicitly: render `message.content.template|nl2br` plus a small note about the template type.
- **User content with `ImageUrl` / `DocumentUrl`** — those classes only expose `getUrl()` (no `text`, `format`, or `asDataUrl`) so they were silently dropped from the rendering loop. Added a fallback branch that renders the URL as a link.

Also tightened the third user-content branch from `{% elseif item.asDataUrl %}` (truthiness, calls the getter) to `{% elseif item.asDataUrl is defined %}` (existence test) so the discrimination from the new `item.url` branch is unambiguous.
