### PR TITLE
[Platform][ClaudeCode] surface tool-use deltas in the stream-result protocol

### DIFF
--- a/examples/claude-code/toolcall-stream.php
+++ b/examples/claude-code/toolcall-stream.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\ClaudeCode\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(
+    workingDirectory: dirname(__DIR__, 2),
+    environment: ['CLAUDECODE' => false], // To enable Claude Code to execute the example
+    logger: logger(),
+);
+
+$messages = new MessageBag(
+    Message::ofUser('Read the top-level README.md and summarize it in two sentences. Tell me which tool you plan to use before calling it.'),
+);
+$result = $platform->invoke('sonnet', $messages, [
+    'stream' => true,
+    'permission_mode' => 'plan',
+    'max_turns' => 2,
+]);
+
+foreach ($result->asStream() as $delta) {
+    if ($delta instanceof TextDelta) {
+        echo $delta;
+        continue;
+    }
+    if ($delta instanceof ToolCallStart) {
+        output()->writeln(\PHP_EOL.'<info>[tool-call started: '.$delta->getName().']</info>');
+        continue;
+    }
+    if ($delta instanceof ToolInputDelta) {
+        output()->write('<fg=#999999>'.$delta->getPartialJson().'</>');
+        continue;
+    }
+    if ($delta instanceof ToolCallComplete) {
+        output()->writeln(\PHP_EOL.'<info>[tool-calls ready: '.count($delta->getToolCalls()).']</info>');
+    }
+}
+
+echo \PHP_EOL;

--- a/src/platform/src/Bridge/ClaudeCode/CHANGELOG.md
+++ b/src/platform/src/Bridge/ClaudeCode/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.9
+---
+
+ * Add `ToolCallStart`, `ToolInputDelta` and `ToolCallComplete` deltas to streaming responses
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/ClaudeCode/ResultConverter.php
+++ b/src/platform/src/Bridge/ClaudeCode/ResultConverter.php
@@ -16,8 +16,12 @@ use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 
@@ -63,6 +67,10 @@ final class ResultConverter implements ResultConverterInterface
 
     private function convertStream(RawResultInterface $result): \Generator
     {
+        $toolCalls = [];
+        $currentToolCall = null;
+        $currentToolCallJson = '';
+
         foreach ($result->getDataStream() as $data) {
             $type = $data['type'] ?? '';
 
@@ -72,6 +80,57 @@ final class ResultConverter implements ResultConverterInterface
                 && 'text_delta' === ($data['event']['delta']['type'] ?? '')
             ) {
                 yield new TextDelta($data['event']['delta']['text']);
+            }
+
+            // Handle tool_use content block start
+            if ('stream_event' === $type
+                && 'content_block_start' === ($data['event']['type'] ?? '')
+                && 'tool_use' === ($data['event']['content_block']['type'] ?? '')
+            ) {
+                $currentToolCall = [
+                    'id' => $data['event']['content_block']['id'],
+                    'name' => $data['event']['content_block']['name'],
+                ];
+                $currentToolCallJson = '';
+                yield new ToolCallStart($currentToolCall['id'], $currentToolCall['name']);
+            }
+
+            // Handle tool_use input JSON deltas
+            if ('stream_event' === $type
+                && 'content_block_delta' === ($data['event']['type'] ?? '')
+                && 'input_json_delta' === ($data['event']['delta']['type'] ?? '')
+            ) {
+                $partialJson = $data['event']['delta']['partial_json'] ?? '';
+                $currentToolCallJson .= $partialJson;
+                if (null !== $currentToolCall) {
+                    yield new ToolInputDelta($currentToolCall['id'], $currentToolCall['name'], $partialJson);
+                }
+            }
+
+            // Handle content block stop - finalize current tool call
+            if ('stream_event' === $type
+                && 'content_block_stop' === ($data['event']['type'] ?? '')
+                && null !== $currentToolCall
+            ) {
+                $input = '' !== $currentToolCallJson
+                    ? json_decode($currentToolCallJson, true, flags: \JSON_THROW_ON_ERROR)
+                    : [];
+                $toolCalls[] = new ToolCall(
+                    $currentToolCall['id'],
+                    $currentToolCall['name'],
+                    $input
+                );
+                $currentToolCall = null;
+                $currentToolCallJson = '';
+            }
+
+            // Handle message stop - yield tool calls if any were collected
+            if ('stream_event' === $type
+                && 'message_stop' === ($data['event']['type'] ?? '')
+                && [] !== $toolCalls
+            ) {
+                yield new ToolCallComplete($toolCalls);
+                $toolCalls = [];
             }
         }
     }

--- a/src/platform/src/Bridge/ClaudeCode/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/ClaudeCode/Tests/ResultConverterTest.php
@@ -19,6 +19,9 @@ use Symfony\AI\Platform\Bridge\ClaudeCode\TokenUsageExtractor;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 
@@ -172,6 +175,147 @@ final class ResultConverterTest extends TestCase
         $this->assertCount(1, $chunks);
         $this->assertInstanceOf(TextDelta::class, $chunks[0]);
         $this->assertSame('Hello', $chunks[0]->getText());
+    }
+
+    public function testConvertStreamingYieldsToolCallDeltas()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['type' => 'stream_event', 'event' => ['type' => 'message_start']],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_01ABC123', 'name' => 'get_weather']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'input_json_delta', 'partial_json' => '{"loc']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'input_json_delta', 'partial_json' => 'ation": "']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'input_json_delta', 'partial_json' => 'Berlin"}']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_stop', 'index' => 0]],
+                ['type' => 'stream_event', 'event' => ['type' => 'message_stop']],
+                ['type' => 'result', 'result' => ''],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(5, $chunks);
+
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertSame('toolu_01ABC123', $chunks[0]->getId());
+        $this->assertSame('get_weather', $chunks[0]->getName());
+
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[1]);
+        $this->assertSame('toolu_01ABC123', $chunks[1]->getId());
+        $this->assertSame('{"loc', $chunks[1]->getPartialJson());
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[2]);
+        $this->assertSame('ation": "', $chunks[2]->getPartialJson());
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[3]);
+        $this->assertSame('Berlin"}', $chunks[3]->getPartialJson());
+
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[4]);
+        $toolCalls = $chunks[4]->getToolCalls();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('toolu_01ABC123', $toolCalls[0]->getId());
+        $this->assertSame('get_weather', $toolCalls[0]->getName());
+        $this->assertSame(['location' => 'Berlin'], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertStreamingYieldsToolCallWithEmptyInput()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_empty', 'name' => 'list_files']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_stop', 'index' => 0]],
+                ['type' => 'stream_event', 'event' => ['type' => 'message_stop']],
+                ['type' => 'result', 'result' => ''],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(2, $chunks);
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[1]);
+        $toolCalls = $chunks[1]->getToolCalls();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('toolu_empty', $toolCalls[0]->getId());
+        $this->assertSame([], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertStreamingInterleavesTextAndToolCallDeltas()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'text_delta', 'text' => 'Let me check.']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_start', 'index' => 1, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_01XYZ789', 'name' => 'get_weather']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_delta', 'index' => 1, 'delta' => ['type' => 'input_json_delta', 'partial_json' => '{"location":"Paris"}']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_stop', 'index' => 1]],
+                ['type' => 'stream_event', 'event' => ['type' => 'message_stop']],
+                ['type' => 'result', 'result' => 'Let me check.'],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(4, $chunks);
+        $this->assertInstanceOf(TextDelta::class, $chunks[0]);
+        $this->assertSame('Let me check.', $chunks[0]->getText());
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[1]);
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[2]);
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[3]);
+        $this->assertSame(['location' => 'Paris'], $chunks[3]->getToolCalls()[0]->getArguments());
+    }
+
+    public function testConvertStreamingYieldsMultipleToolCallsInOrder()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_a', 'name' => 'first']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'input_json_delta', 'partial_json' => '{"x":1}']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_stop', 'index' => 0]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_start', 'index' => 1, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_b', 'name' => 'second']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_delta', 'index' => 1, 'delta' => ['type' => 'input_json_delta', 'partial_json' => '{"y":2}']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_stop', 'index' => 1]],
+                ['type' => 'stream_event', 'event' => ['type' => 'message_stop']],
+                ['type' => 'result', 'result' => ''],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $toolCallComplete = $chunks[\count($chunks) - 1];
+        $this->assertInstanceOf(ToolCallComplete::class, $toolCallComplete);
+        $toolCalls = $toolCallComplete->getToolCalls();
+        $this->assertCount(2, $toolCalls);
+        $this->assertSame('toolu_a', $toolCalls[0]->getId());
+        $this->assertSame(['x' => 1], $toolCalls[0]->getArguments());
+        $this->assertSame('toolu_b', $toolCalls[1]->getId());
+        $this->assertSame(['y' => 2], $toolCalls[1]->getArguments());
     }
 
     public function testGetTokenUsageExtractor()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

The ClaudeCode bridge's stream converter currently yields only `TextDelta` events. The underlying CLI's stream-json output also emits `content_block_start`, `content_block_delta`, `content_block_stop` and `message_stop` events for tool-use blocks, but those are filtered out, so consumers iterating a `StreamResult` see no signal between "the model decided to call a tool" and "the tool's result came back". For progress UIs around long-running tool-using dialogues, that gap is the entire perceptible wait.

This PR widens `ClaudeCode\ResultConverter::convertStream()` to yield the existing `ToolCallStart`, `ToolInputDelta` and `ToolCallComplete` deltas, mirroring `Anthropic\ResultConverter`. The CLI emits the same Anthropic content-block events, just nested one level deeper inside `stream_event.event.*`. No new public API.

This is parity, not a regression: `StreamResult` consumers that already type-check deltas (the documented pattern, used by the Anthropic bridge) keep working unchanged. Consumers iterating without type checks may now see new types, the same situation as the Anthropic bridge today.

Tests cover: isolated tool call, interleaved with text, multiple tool calls in order, and an empty-input call (start + stop with no `input_json_delta`). A new `examples/claude-code/toolcall-stream.php` mirrors `examples/anthropic/toolcall-stream.php` to demonstrate consumption.

### Adjacent, non-overlapping work

#2015 attaches `ToolCallTrace` *metadata* to the final result for timing observability. Different consumer surface (final-result metadata vs. real-time stream deltas) and complementary.

### Out of scope

* Other bridges with the same gap. Codex (sibling CLI bridge, different JSON event shape) and the OpenAI-compat group (Cerebras, DeepSeek, Perplexity, DockerModelRunner, Generic via `CompletionsConversionTrait`) each need their own per-provider PR.
* `is_error` asymmetry. `convert()`'s non-stream path throws `RuntimeException` on a final `result` event with `is_error: true`; the stream path silently ends. Worth fixing, but it is an orthogonal behaviour change (throwing from a generator mid-iteration) and best handled separately.