### PR TITLE
[Platform][Gemini] Cover list-returning tool result in roundtrip example

### DIFF
--- a/examples/gemini/toolcall-roundtrip.php
+++ b/examples/gemini/toolcall-roundtrip.php
@@ -13,6 +13,7 @@ use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\Bridge\Clock\Clock;
 use Symfony\AI\Agent\Toolbox\AgentProcessor;
 use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Fixtures\EuropeanCapitalsTool;
 use Symfony\AI\Platform\Bridge\Gemini\Factory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
@@ -21,7 +22,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = Factory::createPlatform(env('GEMINI_API_KEY'), http_client());
 
-$toolbox = new Toolbox([new Clock()], logger: logger());
+$toolbox = new Toolbox([new Clock(), new EuropeanCapitalsTool()], logger: logger());
 $processor = new AgentProcessor($toolbox);
 $agent = new Agent($platform, 'gemini-2.5-flash', [$processor], [$processor]);
 
@@ -35,13 +36,14 @@ $result = $agent->call($messages);
 echo 'Turn 1: '.$result->getContent().\PHP_EOL;
 $messages->add(Message::ofAssistant($result->getContent()));
 
-// tool call
-$messages->add(Message::ofUser('What time is it right now?'));
+// parallel tool calls – Clock returns a scalar string, EuropeanCapitalsTool returns a list
+// (the latter must be wrapped as a Protobuf Struct on the function_response leg)
+$messages->add(Message::ofUser('What time is it right now, and which European capitals do you know about via your tools?'));
 $result = $agent->call($messages);
 echo 'Turn 2: '.$result->getContent().\PHP_EOL;
 $messages->add(Message::ofAssistant($result->getContent()));
 
-// another chat with tool result in MessageBag
+// another chat with tool results in MessageBag
 $messages->add(Message::ofUser('What was the first question I asked you?'));
 $result = $agent->call($messages);
 echo 'Turn 3: '.$result->getContent().\PHP_EOL;

--- a/fixtures/EuropeanCapitalsTool.php
+++ b/fixtures/EuropeanCapitalsTool.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Fixtures;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+
+/**
+ * @author Benoit VIGNAL <git@benoit-vignal.fr>
+ */
+#[AsTool('list_european_capitals', 'Returns the capitals of a few European countries.')]
+final class EuropeanCapitalsTool
+{
+    /**
+     * @return list<string>
+     */
+    public function __invoke(): array
+    {
+        return ['Paris', 'Berlin', 'Madrid', 'Rome'];
+    }
+}

--- a/src/platform/src/Bridge/Gemini/Tests/AssistantReplayTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/AssistantReplayTest.php
@@ -104,7 +104,7 @@ final class AssistantReplayTest extends TestCase
                         ['functionResponse' => [
                             'id' => 'call_1',
                             'name' => 'clock',
-                            'response' => ['rawResponse' => '12:00'],
+                            'response' => ['result' => '12:00'],
                         ]],
                     ]],
                 ],
@@ -160,7 +160,7 @@ final class AssistantReplayTest extends TestCase
                         ['functionResponse' => [
                             'id' => 'call_2',
                             'name' => 'search',
-                            'response' => ['rawResponse' => 'PHP framework.'],
+                            'response' => ['result' => 'PHP framework.'],
                         ]],
                     ]],
                 ],
@@ -194,7 +194,7 @@ final class AssistantReplayTest extends TestCase
                         ['functionResponse' => [
                             'id' => 'call_3',
                             'name' => 'lookup',
-                            'response' => ['rawResponse' => 'ok'],
+                            'response' => ['result' => 'ok'],
                         ]],
                     ]],
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Follow-up to #1980, #1997 and #2040.

#1997 added `examples/gemini/toolcall-roundtrip.php` as the canonical regression test for #1980 (assistant message → function call shape). However, that example only exercises a `string`-returning tool (`Clock`), so it does not catch regressions on the *response* leg of the roundtrip — specifically the case fixed in #2040, where a tool returning a list (e.g. `list<string>`) produced a `function_response` whose `response` field was a JSON array instead of a Protobuf Struct, leading to:

```
Invalid JSON payload received. Unknown name "response" at 'contents[N].parts[0].function_response': Proto field is not repeating, cannot start list.
```

This PR extends the existing roundtrip example with an inline `EuropeanCapitalsTool` (returns `list<string>`) and a 4th turn that triggers it, so a single example now covers both legs of the Gemini tool roundtrip without growing the examples directory. If merged, the standalone `examples/gemini/toolcall-list-result.php` proposed in #2040 can be dropped from that PR in favor of this consolidation.

Per the [`google.protobuf.Struct` reference](https://protobuf.dev/reference/protobuf/google.protobuf/#struct), `FunctionResponse.response` must be a JSON object, never a list — which is what this example verifies end-to-end against the live Gemini API.