### PR TITLE
[Platform] Surface API error message on RateLimitExceededException

### DIFF
--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -64,7 +64,8 @@ class ResultConverter implements ResultConverterInterface
         if (429 === $response->getStatusCode()) {
             $retryAfter = $response->getHeaders(false)['retry-after'][0] ?? null;
             $retryAfterValue = $retryAfter ? (int) $retryAfter : null;
-            throw new RateLimitExceededException($retryAfterValue);
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new RateLimitExceededException($retryAfterValue, $errorMessage);
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterRateLimitTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterRateLimitTest.php
@@ -35,7 +35,7 @@ final class ResultConverterRateLimitTest extends TestCase
         $handler = new ResultConverter();
 
         $this->expectException(RateLimitExceededException::class);
-        $this->expectExceptionMessage('Rate limit exceeded');
+        $this->expectExceptionMessage('Rate limit exceeded. This request would exceed the rate limit for your organization');
 
         try {
             $handler->convert(new RawHttpResult($httpResponse));
@@ -57,7 +57,7 @@ final class ResultConverterRateLimitTest extends TestCase
         $handler = new ResultConverter();
 
         $this->expectException(RateLimitExceededException::class);
-        $this->expectExceptionMessage('Rate limit exceeded');
+        $this->expectExceptionMessage('Rate limit exceeded. This request would exceed the rate limit for your organization');
 
         try {
             $handler->convert(new RawHttpResult($httpResponse));

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterRateLimitTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterRateLimitTest.php
@@ -32,7 +32,7 @@ final class ResultConverterRateLimitTest extends TestCase
         $handler = new ResultConverter();
 
         $this->expectException(RateLimitExceededException::class);
-        $this->expectExceptionMessage('Rate limit exceeded.');
+        $this->expectExceptionMessage('Rate limit exceeded. Resource has been exhausted (e.g. check quota).');
 
         try {
             $handler->convert(new RawHttpResult($httpResponse));

--- a/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
@@ -56,7 +56,8 @@ class ResultConverter implements ResultConverterInterface
         }
 
         if (429 === $response->getStatusCode()) {
-            throw new RateLimitExceededException();
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new RateLimitExceededException(null, $errorMessage);
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/Generic/Embeddings/ResultConverter.php
+++ b/src/platform/src/Bridge/Generic/Embeddings/ResultConverter.php
@@ -53,7 +53,8 @@ class ResultConverter implements ResultConverterInterface
 
         if (429 === $response->getStatusCode()) {
             $retryAfter = $response->getHeaders(false)['retry-after'][0] ?? null;
-            throw new RateLimitExceededException(null !== $retryAfter ? (int) $retryAfter : null);
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new RateLimitExceededException(null !== $retryAfter ? (int) $retryAfter : null, $errorMessage);
         }
 
         if (!isset($data['data'][0]['embedding'])) {

--- a/src/platform/src/Bridge/Generic/Tests/Embeddings/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Embeddings/ResultConverterTest.php
@@ -40,6 +40,7 @@ class ResultConverterTest extends TestCase
         $httpResponse = $this->createStub(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(429);
         $httpResponse->method('getHeaders')->willReturn(['retry-after' => ['60']]);
+        $httpResponse->method('getContent')->willReturn('{"error":{"message":"You exceeded your current quota, please check your plan and billing details."}}');
 
         $exception = null;
         try {
@@ -50,6 +51,7 @@ class ResultConverterTest extends TestCase
 
         $this->assertNotNull($exception);
         $this->assertSame(60, $exception->getRetryAfter());
+        $this->assertSame('Rate limit exceeded. You exceeded your current quota, please check your plan and billing details.', $exception->getMessage());
     }
 
     public function testThrowsRateLimitExceededExceptionWithoutRetryAfterHeader()
@@ -67,6 +69,7 @@ class ResultConverterTest extends TestCase
 
         $this->assertNotNull($exception);
         $this->assertNull($exception->getRetryAfter());
+        $this->assertSame('Rate limit exceeded.', $exception->getMessage());
     }
 
     private function getEmbeddingStub(): string

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -73,8 +73,9 @@ final class ResultConverter implements ResultConverterInterface
             $resetTime = $headers['x-ratelimit-reset-requests'][0]
                 ?? $headers['x-ratelimit-reset-tokens'][0]
                 ?? null;
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
 
-            throw new RateLimitExceededException($resetTime ? self::parseResetTime($resetTime) : null);
+            throw new RateLimitExceededException($resetTime ? self::parseResetTime($resetTime) : null, $errorMessage);
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterRateLimitTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterRateLimitTest.php
@@ -37,7 +37,7 @@ final class ResultConverterRateLimitTest extends TestCase
         $handler = new ResultConverter();
 
         $this->expectException(RateLimitExceededException::class);
-        $this->expectExceptionMessage('Rate limit exceeded.');
+        $this->expectExceptionMessage('Rate limit exceeded. Rate limit reached for requests');
 
         try {
             $handler->convert(new RawHttpResult($httpResponse));
@@ -64,7 +64,7 @@ final class ResultConverterRateLimitTest extends TestCase
         $handler = new ResultConverter();
 
         $this->expectException(RateLimitExceededException::class);
-        $this->expectExceptionMessage('Rate limit exceeded.');
+        $this->expectExceptionMessage('Rate limit exceeded. Rate limit reached for tokens');
 
         try {
             $handler->convert(new RawHttpResult($httpResponse));

--- a/src/platform/src/Bridge/OpenAi/Tests/Whisper/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Whisper/ResultConverterTest.php
@@ -245,8 +245,10 @@ final class ResultConverterTest extends TestCase
         $httpResponse = $this->createStub(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(429);
         $httpResponse->method('toArray')->willReturn([]);
+        $httpResponse->method('getContent')->willReturn('{"error":{"message":"You exceeded your current quota, please check your plan and billing details."}}');
 
         $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded. You exceeded your current quota, please check your plan and billing details.');
 
         $this->resultConverter->convert(new RawHttpResult($httpResponse));
     }

--- a/src/platform/src/Bridge/OpenAi/Whisper/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Whisper/ResultConverter.php
@@ -53,7 +53,8 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if (429 === $response->getStatusCode()) {
-            throw new RateLimitExceededException();
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new RateLimitExceededException(null, $errorMessage);
         }
 
         if (isset($data['error']['code']) && 'content_filter' === $data['error']['code']) {

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -66,7 +66,8 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if (429 === $response->getStatusCode()) {
-            throw new RateLimitExceededException();
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new RateLimitExceededException(null, $errorMessage);
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -317,8 +317,10 @@ final class ResultConverterTest extends TestCase
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(429);
+        $httpResponse->method('getContent')->willReturn('{"error":{"message":"You exceeded your current quota, please check your plan and billing details."}}');
 
         $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded. You exceeded your current quota, please check your plan and billing details.');
 
         $converter->convert(new RawHttpResult($httpResponse));
     }

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -64,7 +64,8 @@ final class ResultConverter implements ResultConverterInterface
         $response = $result->getObject();
 
         if (429 === $response->getStatusCode()) {
-            throw new RateLimitExceededException();
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new RateLimitExceededException(null, $errorMessage);
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Exception/RateLimitExceededException.php
+++ b/src/platform/src/Exception/RateLimitExceededException.php
@@ -18,8 +18,14 @@ final class RateLimitExceededException extends RuntimeException
 {
     public function __construct(
         private readonly ?int $retryAfter = null,
+        ?string $errorMessage = null,
     ) {
-        parent::__construct('Rate limit exceeded.');
+        $message = 'Rate limit exceeded.';
+        if (null !== $errorMessage && '' !== $errorMessage) {
+            $message .= ' '.$errorMessage;
+        }
+
+        parent::__construct($message);
     }
 
     public function getRetryAfter(): ?int

--- a/src/platform/src/Result/HttpStatusErrorHandlingTrait.php
+++ b/src/platform/src/Result/HttpStatusErrorHandlingTrait.php
@@ -50,7 +50,7 @@ trait HttpStatusErrorHandlingTrait
         }
 
         if (429 === $status) {
-            throw new RateLimitExceededException($this->extractRetryAfter($response));
+            throw new RateLimitExceededException($this->extractRetryAfter($response), $this->extractErrorMessage($response));
         }
     }
 

--- a/src/platform/tests/Result/HttpStatusErrorHandlingTraitTest.php
+++ b/src/platform/tests/Result/HttpStatusErrorHandlingTraitTest.php
@@ -149,6 +149,7 @@ final class HttpStatusErrorHandlingTraitTest extends TestCase
             $this->fail('Expected RateLimitExceededException.');
         } catch (RateLimitExceededException $e) {
             $this->assertSame(42, $e->getRetryAfter());
+            $this->assertSame('Rate limit exceeded. Too many requests', $e->getMessage());
         }
     }
 
@@ -161,6 +162,38 @@ final class HttpStatusErrorHandlingTraitTest extends TestCase
             $this->fail('Expected RateLimitExceededException.');
         } catch (RateLimitExceededException $e) {
             $this->assertNull($e->getRetryAfter());
+            $this->assertSame('Rate limit exceeded. Too many requests', $e->getMessage());
+        }
+    }
+
+    /**
+     * Nested `error.message` is emitted by OpenAI, Anthropic, Gemini and others.
+     */
+    public function testThrowsRateLimitExceededExceptionOn429WithNestedErrorMessage()
+    {
+        $response = $this->response(json_encode([
+            'error' => [
+                'message' => 'You exceeded your current quota, please check your plan and billing details.',
+            ],
+        ]), 429);
+
+        try {
+            $this->subject()->throwOnHttpError($response);
+            $this->fail('Expected RateLimitExceededException.');
+        } catch (RateLimitExceededException $e) {
+            $this->assertSame('Rate limit exceeded. You exceeded your current quota, please check your plan and billing details.', $e->getMessage());
+        }
+    }
+
+    public function testThrowsRateLimitExceededExceptionOn429WithEmptyBody()
+    {
+        $response = $this->response('', 429);
+
+        try {
+            $this->subject()->throwOnHttpError($response);
+            $this->fail('Expected RateLimitExceededException.');
+        } catch (RateLimitExceededException $e) {
+            $this->assertSame('Rate limit exceeded.', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2042
| License       | MIT

A 429 response is ambiguous on most providers: OpenAI for example uses it for both per-minute rate limiting *and* for accounts that are out of credits, and the only way to distinguish the two is the error description in the response body — which `RateLimitExceededException` was throwing away.

This forwards the provider's `error.message` (or the flat top-level `message` used by Mistral/Cerebras/Cohere) into the exception:

```php
// before
catch (RateLimitExceededException $e) {
    $e->getMessage();      // "Rate limit exceeded."
    $e->getRetryAfter();   // 60
}

// after
catch (RateLimitExceededException $e) {
    $e->getMessage();      // "Rate limit exceeded. You exceeded your current quota, please check your plan and billing details."
    $e->getRetryAfter();   // 60
}
```

The constructor gains an optional second `?string $errorMessage` argument; passing `null` (or omitting it) preserves the previous `"Rate limit exceeded."` message verbatim, so the change is backward compatible. All 429 paths in the bridges (`HttpStatusErrorHandlingTrait` users + the Anthropic / OpenAI Gpt / OpenResponses / Whisper / VertexAi Gemini / Generic Embeddings & Completions converters that handle 429 directly) now extract and forward the message. Tests updated to assert the new behaviour and to cover the empty-body fallback.