### PR TITLE
[Mate] Add Knowledge bridge to crawl official documentation

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -361,6 +361,10 @@ deptrac:
       collectors:
         - type: classLike
           value: ^Symfony\\AI\\Mate\\(?!Bridge\\).*
+    - name: MateKnowledgeBridge
+      collectors:
+        - type: classLike
+          value: Symfony\\AI\\Mate\\Bridge\\Knowledge\\.*
     - name: MateMonologBridge
       collectors:
         - type: classLike
@@ -610,7 +614,11 @@ deptrac:
       - StoreComponent
       - PlatformComponent
     MateComponent: ~
+    MateKnowledgeBridge:
+      - MateComponent
+      - StoreComponent
     MateMonologBridge:
       - MateComponent
     MateSymfonyBridge:
       - MateComponent
+      - MateKnowledgeBridge

--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -406,6 +406,62 @@ log files are stored.
 2. Check file permissions on log files
 3. Ensure log files are not empty or corrupted
 
+Knowledge Bridge
+~~~~~~~~~~~~~~~~
+
+The Knowledge bridge (``symfony/ai-knowledge-mate-extension``) lets agents crawl
+official documentation through MCP tools. Documentation sources are pluggable:
+any service tagged ``ai_mate.knowledge_provider`` is exposed automatically. The
+Symfony bridge ships a built-in ``SymfonyDocsProvider`` that becomes available
+when both bridges are installed.
+
+**MCP Tools:**
+
+* ``knowledge-toc`` - Without arguments, lists registered providers. With a ``provider``, returns its table of contents at the given ``path`` (or the root if no path is given)
+* ``knowledge-read`` - Read a documentation page split into RST sections (chunks)
+* ``knowledge-search`` - Case-insensitive substring search across a provider's chunks
+
+**Behavior:**
+
+The first call for a provider clones its source repository into the local cache.
+Subsequent calls are served from disk. The cache is automatically refreshed
+(re-pulled and re-indexed) once it is older than ``ai_mate_knowledge.cache_ttl_seconds``
+(default: 24 hours).
+
+**Configuration:**
+
+Override the cache directory or refresh interval::
+
+    $container->parameters()
+        ->set('ai_mate_knowledge.cache_dir', '%mate.root_dir%/var/cache/knowledge')
+        ->set('ai_mate_knowledge.cache_ttl_seconds', 86400);
+
+**Adding a custom provider:**
+
+Implement ``Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface`` and tag
+the service with ``ai_mate.knowledge_provider``::
+
+    use Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface;
+    use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
+
+    final class MyDocsProvider implements DocsProviderInterface
+    {
+        public function __construct(private GitFetcher $fetcher) {}
+
+        public function getName(): string { return 'my-docs'; }
+        public function getTitle(): string { return 'My Docs'; }
+        public function getDescription(): string { return 'My project documentation'; }
+        public function getFormat(): string { return 'rst'; }
+
+        public function sync(string $cacheDir): string
+        {
+            $repo = $cacheDir.'/docs';
+            $this->fetcher->fetch('https://github.com/me/docs.git', 'main', $repo);
+
+            return $repo.'/index.rst';
+        }
+    }
+
 Built-in Tools
 --------------
 

--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -412,6 +412,62 @@ log files are stored.
 2. Check file permissions on log files
 3. Ensure log files are not empty or corrupted
 
+Knowledge Bridge
+~~~~~~~~~~~~~~~~
+
+The Knowledge bridge (``symfony/ai-knowledge-mate-extension``) lets agents crawl
+official documentation through MCP tools. Documentation sources are pluggable:
+any service tagged ``ai_mate.knowledge_provider`` is exposed automatically. The
+Symfony bridge ships a built-in ``SymfonyDocsProvider`` that becomes available
+when both bridges are installed.
+
+**MCP Tools:**
+
+* ``knowledge-toc`` - Without arguments, lists registered providers. With a ``provider``, returns its table of contents at the given ``path`` (or the root if no path is given)
+* ``knowledge-read`` - Read a documentation page split into RST sections (chunks)
+* ``knowledge-search`` - Case-insensitive substring search across a provider's chunks
+
+**Behavior:**
+
+The first call for a provider clones its source repository into the local cache.
+Subsequent calls are served from disk. The cache is automatically refreshed
+(re-pulled and re-indexed) once it is older than ``ai_mate_knowledge.cache_ttl_seconds``
+(default: 24 hours).
+
+**Configuration:**
+
+Override the cache directory or refresh interval::
+
+    $container->parameters()
+        ->set('ai_mate_knowledge.cache_dir', '%mate.root_dir%/var/cache/knowledge')
+        ->set('ai_mate_knowledge.cache_ttl_seconds', 86400);
+
+**Adding a custom provider:**
+
+Implement ``Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface`` and tag
+the service with ``ai_mate.knowledge_provider``::
+
+    use Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface;
+    use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
+
+    final class MyDocsProvider implements DocsProviderInterface
+    {
+        public function __construct(private GitFetcher $fetcher) {}
+
+        public function getName(): string { return 'my-docs'; }
+        public function getTitle(): string { return 'My Docs'; }
+        public function getDescription(): string { return 'My project documentation'; }
+        public function getFormat(): string { return 'rst'; }
+
+        public function sync(string $cacheDir): string
+        {
+            $repo = $cacheDir.'/docs';
+            $this->fetcher->fetch('https://github.com/me/docs.git', 'main', $repo);
+
+            return $repo.'/index.rst';
+        }
+    }
+
 Built-in Tools
 --------------
 

--- a/splitsh.json
+++ b/splitsh.json
@@ -34,6 +34,7 @@
             "prefixes": [{ "from": "src/mate", "to": "", "excludes": ["src/Bridge", "composer-plugin"] }]
         },
         "ai-mate-composer-plugin": "src/mate/composer-plugin",
+        "ai-knowledge-mate-extension": "src/mate/src/Bridge/Knowledge",
         "ai-monolog-mate-extension": "src/mate/src/Bridge/Monolog",
         "ai-symfony-mate-extension": "src/mate/src/Bridge/Symfony",
         "mcp-bundle": "src/mcp-bundle",

--- a/src/mate/src/Bridge/Knowledge/.gitattributes
+++ b/src/mate/src/Bridge/Knowledge/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/mate/src/Bridge/Knowledge/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/mate/src/Bridge/Knowledge/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/ai
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/mate/src/Bridge/Knowledge/.github/workflows/close-pull-request.yml
+++ b/src/mate/src/Bridge/Knowledge/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/ai
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/mate/src/Bridge/Knowledge/.gitignore
+++ b/src/mate/src/Bridge/Knowledge/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+phpunit.xml
+.phpunit.result.cache

--- a/src/mate/src/Bridge/Knowledge/CHANGELOG.md
+++ b/src/mate/src/Bridge/Knowledge/CHANGELOG.md
@@ -4,7 +4,4 @@ CHANGELOG
 0.9
 ---
 
- * Add bridge with `knowledge-toc`, `knowledge-read`, and `knowledge-search` MCP tools
- * Add `DocsProviderInterface` extension point — services tagged `ai_mate.knowledge_provider` are exposed as crawlable documentation sources
- * Reuse `Symfony\AI\Store\Document\Loader\RstLoader` for RST section-based chunking
- * Auto-refresh the cached source repository and rebuilt index after `ai_mate_knowledge.cache_ttl_seconds` (default 24h)
+ * Add bridge

--- a/src/mate/src/Bridge/Knowledge/CHANGELOG.md
+++ b/src/mate/src/Bridge/Knowledge/CHANGELOG.md
@@ -1,0 +1,10 @@
+CHANGELOG
+=========
+
+0.9
+---
+
+ * Add bridge with `knowledge-toc`, `knowledge-read`, and `knowledge-search` MCP tools
+ * Add `DocsProviderInterface` extension point — services tagged `ai_mate.knowledge_provider` are exposed as crawlable documentation sources
+ * Reuse `Symfony\AI\Store\Document\Loader\RstLoader` for RST section-based chunking
+ * Auto-refresh the cached source repository and rebuilt index after `ai_mate_knowledge.cache_ttl_seconds` (default 24h)

--- a/src/mate/src/Bridge/Knowledge/Capability/ReadTool.php
+++ b/src/mate/src/Bridge/Knowledge/Capability/ReadTool.php
@@ -22,6 +22,15 @@ use Symfony\AI\Mate\Encoding\ResponseEncoder;
  */
 final class ReadTool
 {
+    /**
+     * Caps to keep MCP responses bounded. The total budget is the soft ceiling
+     * for the whole page; per-section caps protect against single huge
+     * sections eating the entire budget.
+     */
+    private const MAX_SECTIONS = 50;
+    private const MAX_SECTION_CONTENT = 8000;
+    private const MAX_TOTAL_CONTENT = 60000;
+
     public function __construct(
         private ProviderRegistry $registry,
         private KnowledgeCache $cache,
@@ -40,15 +49,64 @@ final class ReadTool
 
         $pageTitle = $chunks[0]->getPageTitle();
 
-        return ResponseEncoder::encode([
+        $totalSections = \count($chunks);
+        $emittedSections = [];
+        $totalContent = 0;
+        $sectionTruncated = false;
+        $pageTruncated = false;
+
+        foreach ($chunks as $index => $chunk) {
+            if ($index >= self::MAX_SECTIONS) {
+                $pageTruncated = true;
+                break;
+            }
+
+            $content = $chunk->getContent();
+            if (\strlen($content) > self::MAX_SECTION_CONTENT) {
+                $content = substr($content, 0, self::MAX_SECTION_CONTENT);
+                $sectionTruncated = true;
+            }
+
+            $totalContent += \strlen($content);
+            if ($totalContent > self::MAX_TOTAL_CONTENT) {
+                $overflow = $totalContent - self::MAX_TOTAL_CONTENT;
+                $content = substr($content, 0, max(0, \strlen($content) - $overflow));
+                $emittedSections[] = $this->toArray($chunk, $content);
+                $pageTruncated = true;
+                break;
+            }
+
+            $emittedSections[] = $this->toArray($chunk, $content);
+        }
+
+        $payload = [
             'provider' => $provider,
             'path' => $path,
             'title' => $pageTitle,
-            'sections' => array_map(static fn (PageChunk $chunk) => [
-                'title' => $chunk->getSectionTitle(),
-                'depth' => $chunk->getDepth(),
-                'content' => $chunk->getContent(),
-            ], $chunks),
-        ]);
+            'sections' => $emittedSections,
+        ];
+
+        if ($pageTruncated || $sectionTruncated) {
+            $payload['truncated'] = [
+                'page' => $pageTruncated,
+                'sections' => $sectionTruncated,
+                'total_sections' => $totalSections,
+                'returned_sections' => \count($emittedSections),
+            ];
+        }
+
+        return ResponseEncoder::encode($payload);
+    }
+
+    /**
+     * @return array{title: string, depth: int, content: string}
+     */
+    private function toArray(PageChunk $chunk, string $content): array
+    {
+        return [
+            'title' => $chunk->getSectionTitle(),
+            'depth' => $chunk->getDepth(),
+            'content' => $content,
+        ];
     }
 }

--- a/src/mate/src/Bridge/Knowledge/Capability/ReadTool.php
+++ b/src/mate/src/Bridge/Knowledge/Capability/ReadTool.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Capability;
+
+use Mcp\Capability\Attribute\McpTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Model\PageChunk;
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\ProviderRegistry;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KnowledgeCache;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ReadTool
+{
+    public function __construct(
+        private ProviderRegistry $registry,
+        private KnowledgeCache $cache,
+    ) {
+    }
+
+    /**
+     * @param string $provider Provider name as returned by knowledge-providers (e.g. "symfony")
+     * @param string $path     Page path as returned by knowledge-toc (e.g. "setup/web_server_configuration")
+     */
+    #[McpTool(name: 'knowledge-read', description: 'Read a documentation page. Returns the page split into RST sections so the agent can pick the relevant chunk.')]
+    public function read(string $provider, string $path): string
+    {
+        $providerService = $this->registry->get($provider);
+        $chunks = $this->cache->getChunksForPath($providerService, $path);
+
+        $pageTitle = $chunks[0]->getPageTitle();
+
+        return ResponseEncoder::encode([
+            'provider' => $provider,
+            'path' => $path,
+            'title' => $pageTitle,
+            'sections' => array_map(static fn (PageChunk $chunk) => [
+                'title' => $chunk->getSectionTitle(),
+                'depth' => $chunk->getDepth(),
+                'content' => $chunk->getContent(),
+            ], $chunks),
+        ]);
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Capability/SearchTool.php
+++ b/src/mate/src/Bridge/Knowledge/Capability/SearchTool.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Capability;
+
+use Mcp\Capability\Attribute\McpTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\ProviderRegistry;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KeywordSearcher;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KnowledgeCache;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SearchTool
+{
+    public function __construct(
+        private ProviderRegistry $registry,
+        private KnowledgeCache $cache,
+        private KeywordSearcher $searcher,
+    ) {
+    }
+
+    /**
+     * @param string $provider Provider name as returned by knowledge-providers (e.g. "symfony")
+     * @param string $query    Case-insensitive substring to search for
+     * @param int    $limit    Maximum results to return (default 20)
+     */
+    #[McpTool(name: 'knowledge-search', description: 'Substring search across a provider\'s documentation chunks. Use this to discover relevant pages when you don\'t know where to start, then refine with knowledge-read.')]
+    public function search(string $provider, string $query, int $limit = 20): string
+    {
+        $providerService = $this->registry->get($provider);
+        $chunks = $this->cache->getChunks($providerService);
+
+        return ResponseEncoder::encode([
+            'provider' => $provider,
+            'query' => $query,
+            'results' => $this->searcher->search($chunks, $query, $limit),
+        ]);
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Capability/SearchTool.php
+++ b/src/mate/src/Bridge/Knowledge/Capability/SearchTool.php
@@ -13,8 +13,8 @@ namespace Symfony\AI\Mate\Bridge\Knowledge\Capability;
 
 use Mcp\Capability\Attribute\McpTool;
 use Symfony\AI\Mate\Bridge\Knowledge\Provider\ProviderRegistry;
-use Symfony\AI\Mate\Bridge\Knowledge\Service\KeywordSearcher;
 use Symfony\AI\Mate\Bridge\Knowledge\Service\KnowledgeCache;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\SearcherInterface;
 use Symfony\AI\Mate\Encoding\ResponseEncoder;
 
 /**
@@ -22,28 +22,38 @@ use Symfony\AI\Mate\Encoding\ResponseEncoder;
  */
 final class SearchTool
 {
+    /**
+     * Hard ceiling on the number of results regardless of what the caller asks
+     * for. Keeps MCP responses small and predictable.
+     */
+    private const MAX_LIMIT = 50;
+    private const DEFAULT_LIMIT = 20;
+
     public function __construct(
         private ProviderRegistry $registry,
         private KnowledgeCache $cache,
-        private KeywordSearcher $searcher,
+        private SearcherInterface $searcher,
     ) {
     }
 
     /**
      * @param string $provider Provider name as returned by knowledge-providers (e.g. "symfony")
      * @param string $query    Case-insensitive substring to search for
-     * @param int    $limit    Maximum results to return (default 20)
+     * @param int    $limit    Maximum results to return (default 20, capped at 50)
      */
     #[McpTool(name: 'knowledge-search', description: 'Substring search across a provider\'s documentation chunks. Use this to discover relevant pages when you don\'t know where to start, then refine with knowledge-read.')]
-    public function search(string $provider, string $query, int $limit = 20): string
+    public function search(string $provider, string $query, int $limit = self::DEFAULT_LIMIT): string
     {
         $providerService = $this->registry->get($provider);
         $chunks = $this->cache->getChunks($providerService);
 
+        $effectiveLimit = max(1, min(self::MAX_LIMIT, $limit));
+
         return ResponseEncoder::encode([
             'provider' => $provider,
             'query' => $query,
-            'results' => $this->searcher->search($chunks, $query, $limit),
+            'limit' => $effectiveLimit,
+            'results' => $this->searcher->search($chunks, $query, $effectiveLimit),
         ]);
     }
 }

--- a/src/mate/src/Bridge/Knowledge/Capability/TocTool.php
+++ b/src/mate/src/Bridge/Knowledge/Capability/TocTool.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Capability;
+
+use Mcp\Capability\Attribute\McpTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\PageNotFoundException;
+use Symfony\AI\Mate\Bridge\Knowledge\Model\TocNode;
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\ProviderRegistry;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KnowledgeCache;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class TocTool
+{
+    public function __construct(
+        private ProviderRegistry $registry,
+        private KnowledgeCache $cache,
+    ) {
+    }
+
+    /**
+     * @param string|null $provider Provider name to browse (e.g. "symfony"). Omit to list all available providers.
+     * @param string|null $path     Optional path of the TOC node to expand (e.g. "setup"). Omit for the provider's root.
+     */
+    #[McpTool(name: 'knowledge-toc', description: 'Browse documentation. Without arguments, lists all registered providers. With a provider, returns its table of contents at the given path (or the root if no path is given). The first call for a provider triggers a one-time clone of its source repository; subsequent calls are served from the local cache and refreshed automatically when stale.')]
+    public function browse(?string $provider = null, ?string $path = null): string
+    {
+        if (null === $provider || '' === $provider) {
+            return $this->listProviders();
+        }
+
+        return $this->browseProvider($provider, $path);
+    }
+
+    private function listProviders(): string
+    {
+        $providers = [];
+        foreach ($this->registry->all() as $registered) {
+            $providers[] = [
+                'name' => $registered->getName(),
+                'title' => $registered->getTitle(),
+                'description' => $registered->getDescription(),
+                'format' => $registered->getFormat(),
+            ];
+        }
+
+        return ResponseEncoder::encode([
+            'providers' => $providers,
+            'usage' => 'Call knowledge-toc again with one of the provider names to browse its table of contents.',
+        ]);
+    }
+
+    private function browseProvider(string $provider, ?string $path): string
+    {
+        $providerService = $this->registry->get($provider);
+        $root = $this->cache->getToc($providerService);
+
+        $node = null === $path || '' === $path
+            ? $root
+            : $root->findByPath($path);
+
+        if (null === $node) {
+            throw new PageNotFoundException(\sprintf('TOC path "%s" not found in provider "%s".', $path ?? '', $provider));
+        }
+
+        return ResponseEncoder::encode([
+            'provider' => $provider,
+            'path' => $node->getPath(),
+            'title' => $node->getTitle(),
+            'has_content' => $node->hasContent(),
+            'children' => array_map(static fn (TocNode $child) => [
+                'path' => $child->getPath(),
+                'title' => $child->getTitle(),
+                'has_content' => $child->hasContent(),
+                'has_children' => [] !== $child->getChildren(),
+            ], $node->getChildren()),
+        ]);
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Exception/InvalidProviderNameException.php
+++ b/src/mate/src/Bridge/Knowledge/Exception/InvalidProviderNameException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Exception;
+
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ */
+class InvalidProviderNameException extends InvalidArgumentException
+{
+}

--- a/src/mate/src/Bridge/Knowledge/Exception/PageNotFoundException.php
+++ b/src/mate/src/Bridge/Knowledge/Exception/PageNotFoundException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Exception;
+
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ */
+class PageNotFoundException extends InvalidArgumentException
+{
+}

--- a/src/mate/src/Bridge/Knowledge/Exception/ProviderNotFoundException.php
+++ b/src/mate/src/Bridge/Knowledge/Exception/ProviderNotFoundException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Exception;
+
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ */
+class ProviderNotFoundException extends InvalidArgumentException
+{
+}

--- a/src/mate/src/Bridge/Knowledge/Exception/SyncFailedException.php
+++ b/src/mate/src/Bridge/Knowledge/Exception/SyncFailedException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Exception;
+
+use Symfony\AI\Mate\Exception\RuntimeException;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ *
+ * @internal
+ */
+class SyncFailedException extends RuntimeException
+{
+}

--- a/src/mate/src/Bridge/Knowledge/INSTRUCTIONS.md
+++ b/src/mate/src/Bridge/Knowledge/INSTRUCTIONS.md
@@ -1,0 +1,22 @@
+## Knowledge Bridge
+
+Crawl official documentation through MCP tools instead of guessing from training data.
+
+| Tool               | Purpose                                                                                       |
+|--------------------|-----------------------------------------------------------------------------------------------|
+| `knowledge-toc`    | Without arguments: list providers. With a provider: browse its table of contents at a path.   |
+| `knowledge-read`   | Read a documentation page split into RST sections (chunks).                                   |
+| `knowledge-search` | Case-insensitive substring search across a provider's chunks.                                 |
+
+### How to use
+
+1. Call `knowledge-toc` with no arguments to discover available providers (e.g. `symfony`).
+2. Call `knowledge-toc` with a `provider` to browse its table of contents. Pass a `path` to drill into a subsection.
+3. Use `knowledge-read` for a specific page once you have its `path`. The page comes back as ordered sections; pick the relevant one.
+4. Use `knowledge-search` when you don't know where to start — it returns matching pages with snippets.
+
+### Behavior
+
+- The first call for a provider clones the source repository into the local Mate cache. Expect a delay on cold start.
+- Subsequent calls are served from the cache.
+- The cache is automatically refreshed (re-pulled and re-indexed) once it is older than the configured TTL (default: 24 hours).

--- a/src/mate/src/Bridge/Knowledge/INSTRUCTIONS.md
+++ b/src/mate/src/Bridge/Knowledge/INSTRUCTIONS.md
@@ -1,6 +1,11 @@
 ## Knowledge Bridge
 
-Crawl official documentation through MCP tools instead of guessing from training data.
+Structured access to official documentation through MCP tools. Browse the
+table of contents, read specific pages, and run substring search across
+cached content — instead of guessing from training data.
+
+This is **not** semantic / RAG search. Matches are case-insensitive substring
+hits.
 
 | Tool               | Purpose                                                                                       |
 |--------------------|-----------------------------------------------------------------------------------------------|
@@ -20,3 +25,5 @@ Crawl official documentation through MCP tools instead of guessing from training
 - The first call for a provider clones the source repository into the local Mate cache. Expect a delay on cold start.
 - Subsequent calls are served from the cache.
 - The cache is automatically refreshed (re-pulled and re-indexed) once it is older than the configured TTL (default: 24 hours).
+- `knowledge-search` caps results at 50 regardless of the requested `limit`.
+- `knowledge-read` truncates very large pages and reports `truncated: true` in the response.

--- a/src/mate/src/Bridge/Knowledge/LICENSE
+++ b/src/mate/src/Bridge/Knowledge/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2025-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/mate/src/Bridge/Knowledge/LICENSE
+++ b/src/mate/src/Bridge/Knowledge/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2025-present Fabien Potencier
+Copyright (c) 2026-present Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/mate/src/Bridge/Knowledge/Model/PageChunk.php
+++ b/src/mate/src/Bridge/Knowledge/Model/PageChunk.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Model;
+
+/**
+ * A single section/chunk of a documentation page.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PageChunk
+{
+    public function __construct(
+        private string $path,
+        private string $pageTitle,
+        private string $sectionTitle,
+        private int $depth,
+        private string $content,
+    ) {
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getPageTitle(): string
+    {
+        return $this->pageTitle;
+    }
+
+    public function getSectionTitle(): string
+    {
+        return $this->sectionTitle;
+    }
+
+    public function getDepth(): int
+    {
+        return $this->depth;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @return array{path: string, page_title: string, section_title: string, depth: int, content: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'path' => $this->path,
+            'page_title' => $this->pageTitle,
+            'section_title' => $this->sectionTitle,
+            'depth' => $this->depth,
+            'content' => $this->content,
+        ];
+    }
+
+    /**
+     * @param array{path: string, page_title: string, section_title: string, depth: int, content: string} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['path'],
+            $data['page_title'],
+            $data['section_title'],
+            $data['depth'],
+            $data['content'],
+        );
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Model/TocNode.php
+++ b/src/mate/src/Bridge/Knowledge/Model/TocNode.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Model;
+
+/**
+ * Node of the table-of-contents tree built from RST toctree directives.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class TocNode
+{
+    /**
+     * @param list<TocNode> $children
+     */
+    public function __construct(
+        private string $path,
+        private string $title,
+        private bool $hasContent,
+        private array $children = [],
+    ) {
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function hasContent(): bool
+    {
+        return $this->hasContent;
+    }
+
+    /**
+     * @return list<TocNode>
+     */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    public function addChild(self $child): void
+    {
+        $this->children[] = $child;
+    }
+
+    public function findByPath(string $path): ?self
+    {
+        if ($this->path === $path) {
+            return $this;
+        }
+
+        foreach ($this->children as $child) {
+            $found = $child->findByPath($path);
+            if (null !== $found) {
+                return $found;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{path: string, title: string, has_content: bool, children: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'path' => $this->path,
+            'title' => $this->title,
+            'has_content' => $this->hasContent,
+            'children' => array_map(static fn (self $child) => $child->toArray(), $this->children),
+        ];
+    }
+
+    /**
+     * @param array{path: string, title: string, has_content: bool, children: list<array<string, mixed>>} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $children = [];
+        /** @var array{path: string, title: string, has_content: bool, children: list<array<string, mixed>>} $childData */
+        foreach ($data['children'] as $childData) {
+            $children[] = self::fromArray($childData);
+        }
+
+        return new self($data['path'], $data['title'], $data['has_content'], $children);
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Provider/DocsProviderInterface.php
+++ b/src/mate/src/Bridge/Knowledge/Provider/DocsProviderInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Provider;
+
+/**
+ * Describes a documentation source that can be cloned, indexed, and crawled.
+ *
+ * Implementations are registered as services tagged `ai_mate.knowledge_provider`.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+interface DocsProviderInterface
+{
+    /**
+     * Unique slug used in tool arguments (e.g. "symfony").
+     */
+    public function getName(): string;
+
+    /**
+     * Human-readable title (e.g. "Symfony Documentation").
+     */
+    public function getTitle(): string;
+
+    /**
+     * Short description shown by the `knowledge-providers` tool.
+     */
+    public function getDescription(): string;
+
+    /**
+     * Source format. Currently only "rst" is supported.
+     */
+    public function getFormat(): string;
+
+    /**
+     * Idempotently fetch (clone or pull) the documentation source under $cacheDir.
+     *
+     * @return string Absolute path to the entry-point file (the file containing
+     *                the top-level `.. toctree::`, typically index.rst)
+     */
+    public function sync(string $cacheDir): string;
+}

--- a/src/mate/src/Bridge/Knowledge/Provider/ProviderRegistry.php
+++ b/src/mate/src/Bridge/Knowledge/Provider/ProviderRegistry.php
@@ -49,7 +49,7 @@ final class ProviderRegistry
     public function get(string $name): DocsProviderInterface
     {
         if (!isset($this->providers[$name])) {
-            throw new ProviderNotFoundException(\sprintf('Knowledge provider "%s" is not registered. Available providers: %s', $name, '' === ($list = implode(', ', array_keys($this->providers))) ? '(none)' : $list));
+            throw new ProviderNotFoundException(\sprintf('Knowledge provider "%s" is not registered. Available providers: "%s".', $name, '' === ($list = implode(', ', array_keys($this->providers))) ? '(none)' : $list));
         }
 
         return $this->providers[$name];

--- a/src/mate/src/Bridge/Knowledge/Provider/ProviderRegistry.php
+++ b/src/mate/src/Bridge/Knowledge/Provider/ProviderRegistry.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Bridge\Knowledge\Provider;
 
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\InvalidProviderNameException;
 use Symfony\AI\Mate\Bridge\Knowledge\Exception\ProviderNotFoundException;
 
 /**
@@ -18,6 +19,12 @@ use Symfony\AI\Mate\Bridge\Knowledge\Exception\ProviderNotFoundException;
  */
 final class ProviderRegistry
 {
+    /**
+     * Provider names must be safe to use as a single path component (the cache
+     * dir lives at `{cacheDir}/{provider-name}/`) and as a tool argument.
+     */
+    private const PROVIDER_NAME_PATTERN = '/^[a-z0-9][a-z0-9_-]{0,63}$/';
+
     /**
      * @var array<string, DocsProviderInterface>
      */
@@ -29,7 +36,13 @@ final class ProviderRegistry
     public function __construct(iterable $providers = [])
     {
         foreach ($providers as $provider) {
-            $this->providers[$provider->getName()] = $provider;
+            $name = $provider->getName();
+
+            if (1 !== preg_match(self::PROVIDER_NAME_PATTERN, $name)) {
+                throw new InvalidProviderNameException(\sprintf('Knowledge provider "%s" (class "%s") has an invalid name. Allowed characters: lowercase letters, digits, "-" and "_"; must start with a letter or digit; max 64 characters.', $name, $provider::class));
+            }
+
+            $this->providers[$name] = $provider;
         }
     }
 

--- a/src/mate/src/Bridge/Knowledge/Provider/ProviderRegistry.php
+++ b/src/mate/src/Bridge/Knowledge/Provider/ProviderRegistry.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Provider;
+
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\ProviderNotFoundException;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ProviderRegistry
+{
+    /**
+     * @var array<string, DocsProviderInterface>
+     */
+    private array $providers = [];
+
+    /**
+     * @param iterable<DocsProviderInterface> $providers
+     */
+    public function __construct(iterable $providers = [])
+    {
+        foreach ($providers as $provider) {
+            $this->providers[$provider->getName()] = $provider;
+        }
+    }
+
+    public function get(string $name): DocsProviderInterface
+    {
+        if (!isset($this->providers[$name])) {
+            throw new ProviderNotFoundException(\sprintf('Knowledge provider "%s" is not registered. Available providers: %s', $name, '' === ($list = implode(', ', array_keys($this->providers))) ? '(none)' : $list));
+        }
+
+        return $this->providers[$name];
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->providers[$name]);
+    }
+
+    /**
+     * @return array<string, DocsProviderInterface>
+     */
+    public function all(): array
+    {
+        return $this->providers;
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/README.md
+++ b/src/mate/src/Bridge/Knowledge/README.md
@@ -1,0 +1,17 @@
+Knowledge Bridge
+================
+
+Exposes documentation sources (RST today, more formats later) as crawlable MCP tools
+for Symfony AI Mate. Other extensions can register additional providers by tagging
+a service with `ai_mate.knowledge_provider`.
+
+The Symfony bridge ships a `SymfonyDocsProvider` that becomes available when this
+package is installed alongside it.
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/ai/issues) and
+   [send Pull Requests](https://github.com/symfony/ai/pulls)
+   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/mate/src/Bridge/Knowledge/README.md
+++ b/src/mate/src/Bridge/Knowledge/README.md
@@ -1,12 +1,18 @@
 Knowledge Bridge
 ================
 
-Exposes documentation sources (RST today, more formats later) as crawlable MCP tools
-for Symfony AI Mate. Other extensions can register additional providers by tagging
-a service with `ai_mate.knowledge_provider`.
+Provides structured, offline access to official documentation as crawlable MCP
+tools for Symfony AI Mate. Agents browse the table of contents, read specific
+pages, and run substring search across cached content instead of guessing from
+training data.
 
-The Symfony bridge ships a `SymfonyDocsProvider` that becomes available when this
-package is installed alongside it.
+This bridge does **not** perform semantic / vector / RAG search. A
+`SearcherInterface` seam is provided so a future implementation can plug in
+embedding-based search without changing the tool surface.
+
+Other extensions can register additional providers by tagging a service with
+`ai_mate.knowledge_provider`. The Symfony bridge ships a `SymfonyDocsProvider`
+that becomes available when this package is installed alongside it.
 
 Resources
 ---------

--- a/src/mate/src/Bridge/Knowledge/Service/ChunkBuilder.php
+++ b/src/mate/src/Bridge/Knowledge/Service/ChunkBuilder.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Service;
+
+use Symfony\AI\Mate\Bridge\Knowledge\Model\PageChunk;
+use Symfony\AI\Mate\Bridge\Knowledge\Model\TocNode;
+use Symfony\AI\Store\Document\EmbeddableDocumentInterface;
+use Symfony\AI\Store\Document\Loader\RstLoader;
+
+/**
+ * Walks a TOC tree and produces a flat list of {@see PageChunk} objects by
+ * splitting each page at its RST heading boundaries.
+ *
+ * Reuses {@see RstLoader::loadContent()} so the chunking semantics (15K-char
+ * overflow, section depth) stay consistent with the Store component.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ChunkBuilder
+{
+    public function __construct(
+        private RstLoader $rstLoader = new RstLoader(),
+    ) {
+    }
+
+    /**
+     * @return list<PageChunk>
+     */
+    public function build(TocNode $toc, string $rootDir): array
+    {
+        $chunks = [];
+        $this->collect($toc, $rootDir, $chunks);
+
+        return $chunks;
+    }
+
+    /**
+     * @param list<PageChunk> $chunks
+     */
+    private function collect(TocNode $node, string $rootDir, array &$chunks): void
+    {
+        if ($node->hasContent()) {
+            foreach ($this->loadPage($node, $rootDir) as $chunk) {
+                $chunks[] = $chunk;
+            }
+        }
+
+        foreach ($node->getChildren() as $child) {
+            $this->collect($child, $rootDir, $chunks);
+        }
+    }
+
+    /**
+     * @return iterable<PageChunk>
+     */
+    private function loadPage(TocNode $node, string $rootDir): iterable
+    {
+        $absolutePath = $this->resolveAbsolutePath($node->getPath(), $rootDir);
+
+        if (null === $absolutePath || !file_exists($absolutePath)) {
+            return;
+        }
+
+        $content = file_get_contents($absolutePath);
+        if (false === $content) {
+            return;
+        }
+
+        foreach ($this->rstLoader->loadContent($content, $absolutePath) as $document) {
+            \assert($document instanceof EmbeddableDocumentInterface);
+            $metadata = $document->getMetadata();
+            $text = $metadata->getText() ?? '';
+
+            if ('' === $text) {
+                continue;
+            }
+
+            yield new PageChunk(
+                $node->getPath(),
+                $node->getTitle(),
+                $metadata->getTitle() ?? '',
+                $metadata->getDepth() ?? 0,
+                $text,
+            );
+        }
+    }
+
+    private function resolveAbsolutePath(string $relativePath, string $rootDir): ?string
+    {
+        $rootDir = rtrim($rootDir, '/');
+
+        $candidates = [
+            $rootDir.'/'.$relativePath.'.rst',
+            $rootDir.'/'.$relativePath.'/index.rst',
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (file_exists($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Service/GitFetcher.php
+++ b/src/mate/src/Bridge/Knowledge/Service/GitFetcher.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Service;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\SyncFailedException;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Clones (or pulls) a Git repository into a target directory.
+ *
+ * Uses a shallow clone by default to keep cache size and clone time small.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class GitFetcher
+{
+    public function __construct(
+        private LoggerInterface $logger = new NullLogger(),
+        private int $timeoutSeconds = 300,
+    ) {
+    }
+
+    /**
+     * Ensures $targetDir contains an up-to-date checkout of $repoUrl on $branch.
+     *
+     * - When the directory does not exist, performs a shallow `git clone`.
+     * - When it exists and is a git checkout, runs `git fetch` + hard reset to origin.
+     */
+    public function fetch(string $repoUrl, string $branch, string $targetDir): void
+    {
+        if (!is_dir($targetDir.'/.git')) {
+            $this->clone($repoUrl, $branch, $targetDir);
+
+            return;
+        }
+
+        $this->pull($branch, $targetDir);
+    }
+
+    private function clone(string $repoUrl, string $branch, string $targetDir): void
+    {
+        $parent = \dirname($targetDir);
+        if (!is_dir($parent) && !mkdir($parent, 0755, true) && !is_dir($parent)) {
+            throw new SyncFailedException(\sprintf('Could not create cache directory "%s".', $parent));
+        }
+
+        $this->logger->info('Cloning knowledge repository', [
+            'repo' => $repoUrl,
+            'branch' => $branch,
+            'target' => $targetDir,
+        ]);
+
+        $this->run([
+            'git', 'clone',
+            '--depth', '1',
+            '--branch', $branch,
+            '--single-branch',
+            $repoUrl,
+            $targetDir,
+        ], \dirname($targetDir));
+    }
+
+    private function pull(string $branch, string $targetDir): void
+    {
+        $this->logger->info('Updating knowledge repository', [
+            'branch' => $branch,
+            'target' => $targetDir,
+        ]);
+
+        $this->run(['git', 'fetch', '--depth', '1', 'origin', $branch], $targetDir);
+        $this->run(['git', 'reset', '--hard', 'origin/'.$branch], $targetDir);
+    }
+
+    /**
+     * @param list<string> $command
+     */
+    private function run(array $command, string $cwd): void
+    {
+        $process = new Process($command, $cwd, null, null, $this->timeoutSeconds);
+
+        try {
+            $process->mustRun();
+        } catch (ProcessFailedException $e) {
+            throw new SyncFailedException(\sprintf('Git command failed: %s', $e->getMessage()), 0, $e);
+        }
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Service/GitFetcher.php
+++ b/src/mate/src/Bridge/Knowledge/Service/GitFetcher.php
@@ -93,7 +93,7 @@ final class GitFetcher
         try {
             $process->mustRun();
         } catch (ProcessFailedException $e) {
-            throw new SyncFailedException(\sprintf('Git command failed: %s', $e->getMessage()), 0, $e);
+            throw new SyncFailedException(\sprintf('Git command failed: "%s".', $e->getMessage()), 0, $e);
         }
     }
 }

--- a/src/mate/src/Bridge/Knowledge/Service/KeywordSearcher.php
+++ b/src/mate/src/Bridge/Knowledge/Service/KeywordSearcher.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Service;
+
+use Symfony\AI\Mate\Bridge\Knowledge\Model\PageChunk;
+
+/**
+ * Case-insensitive substring search across a provider's chunks.
+ *
+ * Score = total number of occurrences of the query in the chunk content
+ * (with section title bonus). Snippet = ~200 chars around the first hit.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class KeywordSearcher
+{
+    private const SNIPPET_RADIUS = 100;
+
+    /**
+     * @param list<PageChunk> $chunks
+     *
+     * @return list<array{path: string, page_title: string, section_title: string, score: int, snippet: string}>
+     */
+    public function search(array $chunks, string $query, int $limit = 20): array
+    {
+        $needle = trim($query);
+        if ('' === $needle) {
+            return [];
+        }
+
+        $needleLower = mb_strtolower($needle);
+        $results = [];
+
+        foreach ($chunks as $chunk) {
+            $haystack = $chunk->getContent();
+            $haystackLower = mb_strtolower($haystack);
+            $occurrences = mb_substr_count($haystackLower, $needleLower);
+
+            $titleHit = str_contains(mb_strtolower($chunk->getSectionTitle()), $needleLower)
+                || str_contains(mb_strtolower($chunk->getPageTitle()), $needleLower);
+
+            if (0 === $occurrences && !$titleHit) {
+                continue;
+            }
+
+            $score = $occurrences + ($titleHit ? 5 : 0);
+
+            $results[] = [
+                'path' => $chunk->getPath(),
+                'page_title' => $chunk->getPageTitle(),
+                'section_title' => $chunk->getSectionTitle(),
+                'score' => $score,
+                'snippet' => $this->makeSnippet($haystack, $haystackLower, $needleLower),
+            ];
+        }
+
+        usort($results, static fn (array $a, array $b) => $b['score'] <=> $a['score']);
+
+        return \array_slice($results, 0, max(1, $limit));
+    }
+
+    private function makeSnippet(string $haystack, string $haystackLower, string $needleLower): string
+    {
+        $position = mb_strpos($haystackLower, $needleLower);
+        if (false === $position) {
+            return mb_substr(trim($haystack), 0, self::SNIPPET_RADIUS * 2);
+        }
+
+        $start = max(0, $position - self::SNIPPET_RADIUS);
+        $length = self::SNIPPET_RADIUS * 2 + mb_strlen($needleLower);
+        $snippet = mb_substr($haystack, $start, $length);
+        $snippet = trim(preg_replace('/\s+/', ' ', $snippet) ?? $snippet);
+
+        if ($start > 0) {
+            $snippet = '...'.$snippet;
+        }
+        if ($start + $length < mb_strlen($haystack)) {
+            $snippet .= '...';
+        }
+
+        return $snippet;
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Service/KeywordSearcher.php
+++ b/src/mate/src/Bridge/Knowledge/Service/KeywordSearcher.php
@@ -21,7 +21,7 @@ use Symfony\AI\Mate\Bridge\Knowledge\Model\PageChunk;
  *
  * @author Johannes Wachter <johannes@sulu.io>
  */
-final class KeywordSearcher
+final class KeywordSearcher implements SearcherInterface
 {
     private const SNIPPET_RADIUS = 100;
 

--- a/src/mate/src/Bridge/Knowledge/Service/KnowledgeCache.php
+++ b/src/mate/src/Bridge/Knowledge/Service/KnowledgeCache.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Service;
+
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\PageNotFoundException;
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\SyncFailedException;
+use Symfony\AI\Mate\Bridge\Knowledge\Model\PageChunk;
+use Symfony\AI\Mate\Bridge\Knowledge\Model\TocNode;
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface;
+
+/**
+ * Orchestrates fetch + index for a knowledge provider and caches the results
+ * (toc.json, chunks.json) on disk for fast tool calls.
+ *
+ * Layout:
+ *   {cacheDir}/{provider}/docs/      cloned source tree
+ *   {cacheDir}/{provider}/toc.json   serialized TocNode tree
+ *   {cacheDir}/{provider}/chunks.json flat list of PageChunk
+ *
+ * Cache freshness: when the on-disk artifacts are older than $ttlSeconds, the
+ * next call to {@see ensure()} transparently re-syncs (git pull) and rebuilds
+ * the index. Pass 0 to disable the TTL and only sync once.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class KnowledgeCache
+{
+    public function __construct(
+        private string $cacheDir,
+        private TocBuilder $tocBuilder,
+        private ChunkBuilder $chunkBuilder,
+        private int $ttlSeconds = 86400,
+    ) {
+    }
+
+    /**
+     * Ensures the provider is cloned and indexed. Idempotent.
+     *
+     * - If no cache exists, clones the source and builds the index.
+     * - If the cache exists but is older than the TTL, re-syncs and rebuilds.
+     */
+    public function ensure(DocsProviderInterface $provider): void
+    {
+        $tocFile = $this->tocFile($provider);
+
+        if (file_exists($tocFile) && !$this->isStale($tocFile)) {
+            return;
+        }
+
+        $providerDir = $this->providerDir($provider);
+        $entryPoint = $provider->sync($providerDir);
+
+        $this->buildIndex($provider, $entryPoint);
+    }
+
+    public function getToc(DocsProviderInterface $provider): TocNode
+    {
+        $this->ensure($provider);
+
+        $tocFile = $this->tocFile($provider);
+        $raw = file_get_contents($tocFile);
+        if (false === $raw) {
+            throw new SyncFailedException(\sprintf('Could not read TOC cache "%s".', $tocFile));
+        }
+
+        /** @var array{path: string, title: string, has_content: bool, children: list<array<string, mixed>>} $data */
+        $data = json_decode($raw, true, 512, \JSON_THROW_ON_ERROR);
+
+        return TocNode::fromArray($data);
+    }
+
+    /**
+     * @return list<PageChunk>
+     */
+    public function getChunks(DocsProviderInterface $provider): array
+    {
+        $this->ensure($provider);
+
+        $chunksFile = $this->chunksFile($provider);
+        $raw = file_get_contents($chunksFile);
+        if (false === $raw) {
+            throw new SyncFailedException(\sprintf('Could not read chunks cache "%s".', $chunksFile));
+        }
+
+        /** @var list<array{path: string, page_title: string, section_title: string, depth: int, content: string}> $data */
+        $data = json_decode($raw, true, 512, \JSON_THROW_ON_ERROR);
+
+        return array_map(static fn (array $row) => PageChunk::fromArray($row), $data);
+    }
+
+    /**
+     * @return list<PageChunk>
+     */
+    public function getChunksForPath(DocsProviderInterface $provider, string $path): array
+    {
+        $matches = array_values(array_filter(
+            $this->getChunks($provider),
+            static fn (PageChunk $chunk) => $chunk->getPath() === $path,
+        ));
+
+        if ([] === $matches) {
+            throw new PageNotFoundException(\sprintf('Page "%s" not found in provider "%s".', $path, $provider->getName()));
+        }
+
+        return $matches;
+    }
+
+    public function docsDir(DocsProviderInterface $provider): string
+    {
+        return $this->providerDir($provider).'/docs';
+    }
+
+    private function isStale(string $tocFile): bool
+    {
+        if ($this->ttlSeconds <= 0) {
+            return false;
+        }
+
+        $mtime = @filemtime($tocFile);
+        if (false === $mtime) {
+            return true;
+        }
+
+        return (time() - $mtime) >= $this->ttlSeconds;
+    }
+
+    private function providerDir(DocsProviderInterface $provider): string
+    {
+        return rtrim($this->cacheDir, '/').'/'.$provider->getName();
+    }
+
+    private function tocFile(DocsProviderInterface $provider): string
+    {
+        return $this->providerDir($provider).'/toc.json';
+    }
+
+    private function chunksFile(DocsProviderInterface $provider): string
+    {
+        return $this->providerDir($provider).'/chunks.json';
+    }
+
+    private function buildIndex(DocsProviderInterface $provider, string $entryPoint): void
+    {
+        $docsRoot = \dirname($entryPoint);
+
+        $toc = $this->tocBuilder->build($entryPoint, $docsRoot);
+        $chunks = $this->chunkBuilder->build($toc, $docsRoot);
+
+        $this->writeJson($this->tocFile($provider), $toc->toArray());
+        $this->writeJson(
+            $this->chunksFile($provider),
+            array_map(static fn (PageChunk $chunk) => $chunk->toArray(), $chunks),
+        );
+    }
+
+    /**
+     * @param mixed $data
+     */
+    private function writeJson(string $file, $data): void
+    {
+        $dir = \dirname($file);
+        if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
+            throw new SyncFailedException(\sprintf('Could not create cache directory "%s".', $dir));
+        }
+
+        $encoded = json_encode($data, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES);
+
+        if (false === file_put_contents($file, $encoded)) {
+            throw new SyncFailedException(\sprintf('Could not write cache file "%s".', $file));
+        }
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Service/KnowledgeCache.php
+++ b/src/mate/src/Bridge/Knowledge/Service/KnowledgeCache.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Bridge\Knowledge\Service;
 
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\InvalidProviderNameException;
 use Symfony\AI\Mate\Bridge\Knowledge\Exception\PageNotFoundException;
 use Symfony\AI\Mate\Bridge\Knowledge\Exception\SyncFailedException;
 use Symfony\AI\Mate\Bridge\Knowledge\Model\PageChunk;
@@ -19,21 +20,35 @@ use Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface;
 
 /**
  * Orchestrates fetch + index for a knowledge provider and caches the results
- * (toc.json, chunks.json) on disk for fast tool calls.
+ * (toc.json, chunks.json, metadata.json) on disk for fast tool calls.
  *
  * Layout:
- *   {cacheDir}/{provider}/docs/      cloned source tree
- *   {cacheDir}/{provider}/toc.json   serialized TocNode tree
- *   {cacheDir}/{provider}/chunks.json flat list of PageChunk
+ *   {cacheDir}/{provider}/docs/         cloned source tree
+ *   {cacheDir}/{provider}/toc.json      serialized TocNode tree
+ *   {cacheDir}/{provider}/chunks.json   flat list of PageChunk
+ *   {cacheDir}/{provider}/metadata.json provider, synced_at, chunk_count, revision
+ *   {cacheDir}/{provider}/.lock         flock file for concurrent ensure() calls
  *
  * Cache freshness: when the on-disk artifacts are older than $ttlSeconds, the
  * next call to {@see ensure()} transparently re-syncs (git pull) and rebuilds
  * the index. Pass 0 to disable the TTL and only sync once.
  *
+ * Concurrency: ensure() uses an exclusive flock on a per-provider lock file
+ * so concurrent processes do not clobber each other's cache build. JSON
+ * artifacts are written to a temp file and atomically renamed into place.
+ *
  * @author Johannes Wachter <johannes@sulu.io>
  */
 final class KnowledgeCache
 {
+    /**
+     * Provider names are used as directory components inside the cache dir, so
+     * they must not contain anything that could be interpreted as a path or
+     * shell metacharacter. We accept the same characters as a Composer-style
+     * package suffix: lowercase letters, digits, hyphen and underscore.
+     */
+    private const PROVIDER_NAME_PATTERN = '/^[a-z0-9][a-z0-9_-]{0,63}$/';
+
     public function __construct(
         private string $cacheDir,
         private TocBuilder $tocBuilder,
@@ -57,9 +72,24 @@ final class KnowledgeCache
         }
 
         $providerDir = $this->providerDir($provider);
-        $entryPoint = $provider->sync($providerDir);
+        $this->ensureDirectory($providerDir);
 
-        $this->buildIndex($provider, $entryPoint);
+        $lockHandle = $this->acquireLock($providerDir);
+
+        try {
+            // Double-checked: another process may have rebuilt while we waited
+            // for the lock.
+            clearstatcache(true, $tocFile);
+            if (file_exists($tocFile) && !$this->isStale($tocFile)) {
+                return;
+            }
+
+            $entryPoint = $provider->sync($providerDir);
+
+            $this->buildIndex($provider, $entryPoint);
+        } finally {
+            $this->releaseLock($lockHandle);
+        }
     }
 
     public function getToc(DocsProviderInterface $provider): TocNode
@@ -135,7 +165,16 @@ final class KnowledgeCache
 
     private function providerDir(DocsProviderInterface $provider): string
     {
-        return rtrim($this->cacheDir, '/').'/'.$provider->getName();
+        return rtrim($this->cacheDir, '/').'/'.$this->validateProviderName($provider->getName());
+    }
+
+    private function validateProviderName(string $name): string
+    {
+        if (1 !== preg_match(self::PROVIDER_NAME_PATTERN, $name)) {
+            throw new InvalidProviderNameException(\sprintf('Knowledge provider name "%s" is invalid. Allowed characters: lowercase letters, digits, "-" and "_"; must start with a letter or digit; max 64 characters.', $name));
+        }
+
+        return $name;
     }
 
     private function tocFile(DocsProviderInterface $provider): string
@@ -146,6 +185,55 @@ final class KnowledgeCache
     private function chunksFile(DocsProviderInterface $provider): string
     {
         return $this->providerDir($provider).'/chunks.json';
+    }
+
+    private function metadataFile(DocsProviderInterface $provider): string
+    {
+        return $this->providerDir($provider).'/metadata.json';
+    }
+
+    private function lockFile(string $providerDir): string
+    {
+        return $providerDir.'/.lock';
+    }
+
+    /**
+     * @return resource
+     */
+    private function acquireLock(string $providerDir)
+    {
+        $lockFile = $this->lockFile($providerDir);
+        $handle = @fopen($lockFile, 'c');
+        if (false === $handle) {
+            throw new SyncFailedException(\sprintf('Could not open lock file "%s".', $lockFile));
+        }
+
+        if (!flock($handle, \LOCK_EX)) {
+            fclose($handle);
+            throw new SyncFailedException(\sprintf('Could not acquire exclusive lock on "%s".', $lockFile));
+        }
+
+        return $handle;
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private function releaseLock($handle): void
+    {
+        flock($handle, \LOCK_UN);
+        fclose($handle);
+    }
+
+    private function ensureDirectory(string $dir): void
+    {
+        if (is_dir($dir)) {
+            return;
+        }
+
+        if (!mkdir($dir, 0755, true) && !is_dir($dir)) {
+            throw new SyncFailedException(\sprintf('Could not create cache directory "%s".', $dir));
+        }
     }
 
     private function buildIndex(DocsProviderInterface $provider, string $entryPoint): void
@@ -160,22 +248,77 @@ final class KnowledgeCache
             $this->chunksFile($provider),
             array_map(static fn (PageChunk $chunk) => $chunk->toArray(), $chunks),
         );
+        $this->writeJson(
+            $this->metadataFile($provider),
+            $this->buildMetadata($provider, $docsRoot, \count($chunks)),
+        );
     }
 
     /**
-     * @param mixed $data
+     * @return array{provider: string, synced_at: string, chunk_count: int, docs_dir: string, revision: ?string}
      */
-    private function writeJson(string $file, $data): void
+    private function buildMetadata(DocsProviderInterface $provider, string $docsRoot, int $chunkCount): array
     {
-        $dir = \dirname($file);
-        if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
-            throw new SyncFailedException(\sprintf('Could not create cache directory "%s".', $dir));
+        return [
+            'provider' => $provider->getName(),
+            'synced_at' => gmdate('Y-m-d\TH:i:s\Z'),
+            'chunk_count' => $chunkCount,
+            'docs_dir' => $docsRoot,
+            'revision' => $this->readRevision($docsRoot),
+        ];
+    }
+
+    private function readRevision(string $docsRoot): ?string
+    {
+        $candidates = [
+            $docsRoot.'/.git/HEAD',
+            \dirname($docsRoot).'/.git/HEAD',
+        ];
+
+        foreach ($candidates as $head) {
+            if (!is_file($head)) {
+                continue;
+            }
+
+            $content = @file_get_contents($head);
+            if (false === $content) {
+                continue;
+            }
+
+            $content = trim($content);
+            if (str_starts_with($content, 'ref: ')) {
+                $ref = substr($content, 5);
+                $refFile = \dirname($head).'/'.$ref;
+                if (is_file($refFile)) {
+                    $hash = @file_get_contents($refFile);
+                    if (false !== $hash) {
+                        return trim($hash);
+                    }
+                }
+
+                return $content;
+            }
+
+            return $content;
         }
+
+        return null;
+    }
+
+    private function writeJson(string $file, mixed $data): void
+    {
+        $this->ensureDirectory(\dirname($file));
 
         $encoded = json_encode($data, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES);
 
-        if (false === file_put_contents($file, $encoded)) {
-            throw new SyncFailedException(\sprintf('Could not write cache file "%s".', $file));
+        $tmp = $file.'.tmp.'.bin2hex(random_bytes(6));
+        if (false === @file_put_contents($tmp, $encoded)) {
+            throw new SyncFailedException(\sprintf('Could not write cache file "%s".', $tmp));
+        }
+
+        if (!@rename($tmp, $file)) {
+            @unlink($tmp);
+            throw new SyncFailedException(\sprintf('Could not move cache file "%s" to "%s".', $tmp, $file));
         }
     }
 }

--- a/src/mate/src/Bridge/Knowledge/Service/SearcherInterface.php
+++ b/src/mate/src/Bridge/Knowledge/Service/SearcherInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Service;
+
+use Symfony\AI\Mate\Bridge\Knowledge\Model\PageChunk;
+
+/**
+ * Extension seam for swapping the search strategy used by `knowledge-search`.
+ *
+ * The bridge ships a {@see KeywordSearcher} that performs case-insensitive
+ * substring matching. A future implementation could plug in semantic search
+ * powered by {@see \Symfony\AI\Store\Document\Vectorizer} without touching
+ * the `SearchTool` capability.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+interface SearcherInterface
+{
+    /**
+     * @param list<PageChunk> $chunks
+     *
+     * @return list<array{path: string, page_title: string, section_title: string, score: int|float, snippet: string}>
+     */
+    public function search(array $chunks, string $query, int $limit = 20): array;
+}

--- a/src/mate/src/Bridge/Knowledge/Service/TocBuilder.php
+++ b/src/mate/src/Bridge/Knowledge/Service/TocBuilder.php
@@ -1,0 +1,245 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Service;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\SyncFailedException;
+use Symfony\AI\Mate\Bridge\Knowledge\Model\TocNode;
+
+/**
+ * Walks RST `.. toctree::` directives starting from an entry-point file
+ * and produces a parent/child {@see TocNode} tree.
+ *
+ * Toctree parsing rules mirror Symfony\AI\Store\Document\Loader\RstToctreeLoader
+ * (handles "Title <entry>" syntax, absolute paths, glob patterns, .rst files
+ * vs. directories with index.rst).
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class TocBuilder
+{
+    private const RST_ADORNMENT_CHARS = '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~';
+
+    public function __construct(
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    /**
+     * Builds the TOC tree starting from the given entry point.
+     *
+     * @param string $entryPoint Absolute path to the root .rst file (typically index.rst)
+     * @param string $rootDir    Absolute path to the documentation root directory
+     */
+    public function build(string $entryPoint, string $rootDir): TocNode
+    {
+        if (!file_exists($entryPoint)) {
+            throw new SyncFailedException(\sprintf('Entry point "%s" does not exist.', $entryPoint));
+        }
+
+        $visited = [];
+
+        return $this->buildNode($entryPoint, $rootDir, $visited, true);
+    }
+
+    /**
+     * @param array<string, true> $visited
+     */
+    private function buildNode(string $absolutePath, string $rootDir, array &$visited, bool $isRoot = false): TocNode
+    {
+        $visited[$absolutePath] = true;
+
+        $content = file_get_contents($absolutePath);
+        if (false === $content) {
+            throw new SyncFailedException(\sprintf('Could not read "%s".', $absolutePath));
+        }
+
+        $title = $this->extractFirstTitle($content) ?? $this->fallbackTitle($absolutePath, $rootDir);
+        $relativePath = $isRoot ? '' : $this->toRelativePath($absolutePath, $rootDir);
+
+        $node = new TocNode($relativePath, $title, true);
+
+        foreach ($this->parseToctreeEntries($content, \dirname($absolutePath), $rootDir) as $childPath) {
+            if (isset($visited[$childPath])) {
+                continue;
+            }
+
+            $node->addChild($this->buildNode($childPath, $rootDir, $visited));
+        }
+
+        return $node;
+    }
+
+    private function toRelativePath(string $absolutePath, string $rootDir): string
+    {
+        $rootDir = rtrim($rootDir, '/');
+
+        if (!str_starts_with($absolutePath, $rootDir.'/')) {
+            return $absolutePath;
+        }
+
+        $relative = substr($absolutePath, \strlen($rootDir) + 1);
+
+        if (str_ends_with($relative, '/index.rst')) {
+            return substr($relative, 0, -\strlen('/index.rst'));
+        }
+
+        if (str_ends_with($relative, '.rst')) {
+            return substr($relative, 0, -\strlen('.rst'));
+        }
+
+        return $relative;
+    }
+
+    private function fallbackTitle(string $absolutePath, string $rootDir): string
+    {
+        $relative = $this->toRelativePath($absolutePath, $rootDir);
+        $base = basename($relative);
+
+        return ucwords(str_replace(['-', '_', '/'], ' ', $base));
+    }
+
+    private function extractFirstTitle(string $content): ?string
+    {
+        $lines = explode(\PHP_EOL, $content);
+        $count = \count($lines);
+
+        for ($i = 0; $i < $count - 1; ++$i) {
+            $line = trim($lines[$i]);
+            $next = trim($lines[$i + 1]);
+
+            if ('' === $line || '' === $next) {
+                continue;
+            }
+
+            if (!$this->isAdornmentLine($next)) {
+                continue;
+            }
+
+            if (mb_strlen($next) >= mb_strlen($line)) {
+                return $line;
+            }
+        }
+
+        return null;
+    }
+
+    private function isAdornmentLine(string $line): bool
+    {
+        if ('' === $line) {
+            return false;
+        }
+
+        $char = $line[0];
+
+        if (!str_contains(self::RST_ADORNMENT_CHARS, $char)) {
+            return false;
+        }
+
+        return str_repeat($char, \strlen($line)) === $line;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseToctreeEntries(string $content, string $baseDir, string $rootDir): array
+    {
+        $lines = explode(\PHP_EOL, $content);
+        $count = \count($lines);
+        $entries = [];
+        $i = 0;
+
+        while ($i < $count) {
+            if (1 !== preg_match('/^(\s*)\.\. toctree::/i', $lines[$i], $match)) {
+                ++$i;
+                continue;
+            }
+
+            $directiveIndent = \strlen($match[1]);
+            ++$i;
+
+            while ($i < $count) {
+                $line = $lines[$i];
+
+                if ('' === trim($line)) {
+                    ++$i;
+                    continue;
+                }
+
+                $lineIndent = \strlen($line) - \strlen(ltrim($line));
+
+                if ($lineIndent <= $directiveIndent) {
+                    break;
+                }
+
+                $trimmed = trim($line);
+
+                if (str_starts_with($trimmed, ':')) {
+                    ++$i;
+                    continue;
+                }
+
+                $entryPath = $trimmed;
+                if (1 === preg_match('/^.*<(.+?)>$/', $trimmed, $entryMatch)) {
+                    $entryPath = trim($entryMatch[1]);
+                }
+
+                if (str_starts_with($entryPath, '/')) {
+                    $dir = $rootDir;
+                    $entryPath = ltrim($entryPath, '/');
+                } else {
+                    $dir = $baseDir;
+                }
+
+                if (str_ends_with($entryPath, '.rst')) {
+                    $pattern = $dir.'/'.$entryPath;
+                } elseif (str_ends_with($entryPath, '/')) {
+                    $pattern = $dir.'/'.$entryPath.'index.rst';
+                } else {
+                    $pattern = $dir.'/'.$entryPath.'.rst';
+                }
+
+                if (str_contains($entryPath, '*') || str_contains($entryPath, '?')) {
+                    $globbed = glob($pattern);
+                    if (false !== $globbed) {
+                        sort($globbed);
+                        foreach ($globbed as $globPath) {
+                            if (!\in_array($globPath, $entries, true)) {
+                                $entries[] = $globPath;
+                            }
+                        }
+                    }
+                    ++$i;
+                    continue;
+                }
+
+                if (!file_exists($pattern)) {
+                    $this->logger->warning('Skipping toctree entry — file not found.', [
+                        'entry' => $entryPath,
+                        'path' => $pattern,
+                    ]);
+                    ++$i;
+                    continue;
+                }
+
+                if (!\in_array($pattern, $entries, true)) {
+                    $entries[] = $pattern;
+                }
+
+                ++$i;
+            }
+        }
+
+        return $entries;
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Tests/Capability/ToolsTest.php
+++ b/src/mate/src/Bridge/Knowledge/Tests/Capability/ToolsTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Tests\Capability;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Knowledge\Capability\ReadTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Capability\SearchTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Capability\TocTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\ProviderRegistry;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\ChunkBuilder;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KeywordSearcher;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KnowledgeCache;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\TocBuilder;
+use Symfony\AI\Mate\Bridge\Knowledge\Tests\Fixtures\FixtureProvider;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ToolsTest extends TestCase
+{
+    private string $cacheDir;
+    private ProviderRegistry $registry;
+    private KnowledgeCache $cache;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir().'/ai_mate_knowledge_tools_'.uniqid();
+        mkdir($this->cacheDir, 0755, true);
+
+        $provider = new FixtureProvider(\dirname(__DIR__).'/Fixtures/docs');
+        $this->registry = new ProviderRegistry([$provider]);
+        $this->cache = new KnowledgeCache($this->cacheDir, new TocBuilder(), new ChunkBuilder());
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->cacheDir);
+    }
+
+    public function testTocToolWithoutProviderListsRegisteredProviders()
+    {
+        $tool = new TocTool($this->registry, $this->cache);
+
+        $output = ResponseEncoder::decode($tool->browse());
+
+        $this->assertCount(1, $output['providers']);
+        $this->assertSame('fixture', $output['providers'][0]['name']);
+        $this->assertSame('rst', $output['providers'][0]['format']);
+        $this->assertArrayHasKey('usage', $output);
+    }
+
+    public function testTocToolReturnsRootChildrenWhenNoPathGiven()
+    {
+        $tool = new TocTool($this->registry, $this->cache);
+
+        $output = ResponseEncoder::decode($tool->browse('fixture'));
+
+        $this->assertSame('fixture', $output['provider']);
+        $this->assertSame('Sample Documentation', $output['title']);
+        $this->assertCount(2, $output['children']);
+    }
+
+    public function testTocToolDrillsIntoChildPath()
+    {
+        $tool = new TocTool($this->registry, $this->cache);
+
+        $output = ResponseEncoder::decode($tool->browse('fixture', 'advanced'));
+
+        $this->assertSame('advanced', $output['path']);
+        $this->assertCount(1, $output['children']);
+        $this->assertSame('advanced/caching', $output['children'][0]['path']);
+    }
+
+    public function testReadToolReturnsSectionsForPage()
+    {
+        $tool = new ReadTool($this->registry, $this->cache);
+
+        $output = ResponseEncoder::decode($tool->read('fixture', 'setup'));
+
+        $this->assertSame('setup', $output['path']);
+        $this->assertNotEmpty($output['sections']);
+
+        $titles = array_map(static fn (array $section) => $section['title'], $output['sections']);
+        $this->assertContains('Installing', $titles);
+        $this->assertContains('Configuration', $titles);
+    }
+
+    public function testSearchToolFindsMatchingChunks()
+    {
+        $tool = new SearchTool($this->registry, $this->cache, new KeywordSearcher());
+
+        $output = ResponseEncoder::decode($tool->search('fixture', 'FrameworkBundle'));
+
+        $this->assertSame('FrameworkBundle', $output['query']);
+        $this->assertNotEmpty($output['results']);
+        $this->assertSame('setup', $output['results'][0]['path']);
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $items = scandir($directory);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ('.' === $item || '..' === $item) {
+                continue;
+            }
+
+            $path = $directory.\DIRECTORY_SEPARATOR.$item;
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($directory);
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/FixtureProvider.php
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/FixtureProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Tests\Fixtures;
+
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface;
+
+/**
+ * Test provider that points at a pre-cloned fixture directory instead of a real git repo.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class FixtureProvider implements DocsProviderInterface
+{
+    public function __construct(
+        private string $fixtureDocsDir,
+        private string $name = 'fixture',
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getTitle(): string
+    {
+        return 'Fixture Documentation';
+    }
+
+    public function getDescription(): string
+    {
+        return 'In-tree RST fixtures for Knowledge bridge tests.';
+    }
+
+    public function getFormat(): string
+    {
+        return 'rst';
+    }
+
+    public function sync(string $cacheDir): string
+    {
+        return $this->fixtureDocsDir.'/index.rst';
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/absolute.rst
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/absolute.rst
@@ -1,0 +1,4 @@
+Absolute Entry
+==============
+
+Referenced via an absolute (``/absolute``) toctree entry.

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/aliased.rst
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/aliased.rst
@@ -1,0 +1,4 @@
+Real Aliased Title
+==================
+
+This file is referenced from the toctree with a ``Title <path>`` alias.

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/duplicate.rst
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/duplicate.rst
@@ -1,0 +1,4 @@
+Duplicate Entry
+===============
+
+Referenced twice from the same toctree. Should only appear once.

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/glob/alpha.rst
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/glob/alpha.rst
@@ -1,0 +1,4 @@
+Alpha Glob Page
+===============
+
+Picked up by the ``glob/*`` toctree entry.

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/glob/beta.rst
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/glob/beta.rst
@@ -1,0 +1,4 @@
+Beta Glob Page
+==============
+
+Picked up by the ``glob/*`` toctree entry.

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/index.rst
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs-edge/index.rst
@@ -1,0 +1,12 @@
+Edge Case Documentation
+=======================
+
+.. toctree::
+    :maxdepth: 2
+
+    Aliased Title <aliased>
+    /absolute
+    missing-page
+    duplicate
+    duplicate
+    glob/*

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs/advanced/caching.rst
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs/advanced/caching.rst
@@ -1,0 +1,9 @@
+Caching
+=======
+
+How to cache responses for performance.
+
+Strategies
+----------
+
+Use HTTP caching headers and the cache contracts component to speed things up.

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs/advanced/index.rst
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs/advanced/index.rst
@@ -1,0 +1,9 @@
+Advanced Topics
+===============
+
+Deeper guides for advanced users.
+
+.. toctree::
+    :maxdepth: 1
+
+    caching

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs/index.rst
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs/index.rst
@@ -1,0 +1,10 @@
+Sample Documentation
+====================
+
+Welcome to the sample docs used to exercise the Knowledge bridge.
+
+.. toctree::
+    :maxdepth: 2
+
+    setup
+    advanced/index

--- a/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs/setup.rst
+++ b/src/mate/src/Bridge/Knowledge/Tests/Fixtures/docs/setup.rst
@@ -1,0 +1,14 @@
+Setup Guide
+===========
+
+This page covers installing the FrameworkBundle and friends.
+
+Installing
+----------
+
+Run ``composer require sample/bundle`` to install the FrameworkBundle.
+
+Configuration
+-------------
+
+Edit ``config/packages/framework.yaml`` to configure the bundle.

--- a/src/mate/src/Bridge/Knowledge/Tests/Provider/ProviderRegistryTest.php
+++ b/src/mate/src/Bridge/Knowledge/Tests/Provider/ProviderRegistryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\ProviderNotFoundException;
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\ProviderRegistry;
+use Symfony\AI\Mate\Bridge\Knowledge\Tests\Fixtures\FixtureProvider;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ProviderRegistryTest extends TestCase
+{
+    public function testGetReturnsRegisteredProvider()
+    {
+        $provider = new FixtureProvider('/tmp', 'fixture');
+        $registry = new ProviderRegistry([$provider]);
+
+        $this->assertSame($provider, $registry->get('fixture'));
+        $this->assertTrue($registry->has('fixture'));
+    }
+
+    public function testGetThrowsForUnknownProvider()
+    {
+        $registry = new ProviderRegistry();
+
+        $this->expectException(ProviderNotFoundException::class);
+        $this->expectExceptionMessage('Knowledge provider "missing" is not registered');
+
+        $registry->get('missing');
+    }
+
+    public function testAllReturnsRegisteredProviders()
+    {
+        $a = new FixtureProvider('/tmp', 'a');
+        $b = new FixtureProvider('/tmp', 'b');
+
+        $registry = new ProviderRegistry([$a, $b]);
+
+        $this->assertSame(['a' => $a, 'b' => $b], $registry->all());
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Tests/Provider/ProviderRegistryTest.php
+++ b/src/mate/src/Bridge/Knowledge/Tests/Provider/ProviderRegistryTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\AI\Mate\Bridge\Knowledge\Tests\Provider;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\InvalidProviderNameException;
 use Symfony\AI\Mate\Bridge\Knowledge\Exception\ProviderNotFoundException;
 use Symfony\AI\Mate\Bridge\Knowledge\Provider\ProviderRegistry;
 use Symfony\AI\Mate\Bridge\Knowledge\Tests\Fixtures\FixtureProvider;
@@ -48,5 +50,29 @@ final class ProviderRegistryTest extends TestCase
         $registry = new ProviderRegistry([$a, $b]);
 
         $this->assertSame(['a' => $a, 'b' => $b], $registry->all());
+    }
+
+    #[DataProvider('invalidNameProvider')]
+    public function testRegistrationRejectsUnsafeProviderNames(string $name)
+    {
+        $this->expectException(InvalidProviderNameException::class);
+
+        new ProviderRegistry([new FixtureProvider('/tmp', $name)]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidNameProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'path traversal' => ['../escape'];
+        yield 'slash' => ['foo/bar'];
+        yield 'backslash' => ['foo\\bar'];
+        yield 'uppercase' => ['Symfony'];
+        yield 'shell metacharacter' => ['foo;rm'];
+        yield 'leading dash' => ['-foo'];
+        yield 'leading underscore' => ['_foo'];
+        yield 'null byte' => ["foo\0bar"];
     }
 }

--- a/src/mate/src/Bridge/Knowledge/Tests/Service/ChunkBuilderTest.php
+++ b/src/mate/src/Bridge/Knowledge/Tests/Service/ChunkBuilderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\ChunkBuilder;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\TocBuilder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ChunkBuilderTest extends TestCase
+{
+    private string $docsDir;
+
+    protected function setUp(): void
+    {
+        $this->docsDir = \dirname(__DIR__).'/Fixtures/docs';
+    }
+
+    public function testBuildProducesChunksForEveryPageInTheToc()
+    {
+        $toc = (new TocBuilder())->build($this->docsDir.'/index.rst', $this->docsDir);
+        $builder = new ChunkBuilder();
+
+        $chunks = $builder->build($toc, $this->docsDir);
+
+        $paths = array_unique(array_map(static fn ($chunk) => $chunk->getPath(), $chunks));
+        sort($paths);
+
+        $this->assertSame(['', 'advanced', 'advanced/caching', 'setup'], $paths);
+    }
+
+    public function testSetupPageIsSplitIntoSections()
+    {
+        $toc = (new TocBuilder())->build($this->docsDir.'/index.rst', $this->docsDir);
+        $chunks = (new ChunkBuilder())->build($toc, $this->docsDir);
+
+        $setupChunks = array_values(array_filter(
+            $chunks,
+            static fn ($chunk) => 'setup' === $chunk->getPath(),
+        ));
+
+        $sectionTitles = array_map(static fn ($chunk) => $chunk->getSectionTitle(), $setupChunks);
+
+        $this->assertContains('Setup Guide', $sectionTitles);
+        $this->assertContains('Installing', $sectionTitles);
+        $this->assertContains('Configuration', $sectionTitles);
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Tests/Service/KeywordSearcherTest.php
+++ b/src/mate/src/Bridge/Knowledge/Tests/Service/KeywordSearcherTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Knowledge\Model\PageChunk;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KeywordSearcher;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class KeywordSearcherTest extends TestCase
+{
+    public function testSearchFindsCaseInsensitiveContentMatches()
+    {
+        $chunks = [
+            new PageChunk('setup', 'Setup', 'Installing', 0, 'Run composer require to install the FrameworkBundle.'),
+            new PageChunk('intro', 'Intro', 'Overview', 0, 'Welcome to the docs.'),
+        ];
+
+        $searcher = new KeywordSearcher();
+        $results = $searcher->search($chunks, 'frameworkbundle');
+
+        $this->assertCount(1, $results);
+        $this->assertSame('setup', $results[0]['path']);
+        $this->assertStringContainsString('FrameworkBundle', $results[0]['snippet']);
+    }
+
+    public function testSearchScoresTitleMatchesHigher()
+    {
+        $chunks = [
+            new PageChunk('a', 'Random page', 'Random', 0, 'mentions caching once'),
+            new PageChunk('b', 'Caching guide', 'Strategies', 0, 'one mention'),
+        ];
+
+        $results = (new KeywordSearcher())->search($chunks, 'caching');
+
+        $this->assertSame('b', $results[0]['path']);
+    }
+
+    public function testSearchReturnsEmptyArrayForEmptyQuery()
+    {
+        $chunks = [new PageChunk('a', 'A', 'A', 0, 'whatever')];
+
+        $this->assertSame([], (new KeywordSearcher())->search($chunks, ''));
+    }
+
+    public function testSearchHonorsLimit()
+    {
+        $chunks = [];
+        for ($i = 0; $i < 5; ++$i) {
+            $chunks[] = new PageChunk('p'.$i, 'P', 'S', 0, 'symfony');
+        }
+
+        $results = (new KeywordSearcher())->search($chunks, 'symfony', 2);
+
+        $this->assertCount(2, $results);
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Tests/Service/KnowledgeCacheTest.php
+++ b/src/mate/src/Bridge/Knowledge/Tests/Service/KnowledgeCacheTest.php
@@ -114,6 +114,39 @@ final class KnowledgeCacheTest extends TestCase
         $this->assertSame($originalMtime, filemtime($tocFile));
     }
 
+    public function testEnsureWritesMetadataFile()
+    {
+        $cache = $this->createCache();
+        $provider = $this->createProvider();
+
+        $cache->ensure($provider);
+
+        $metadataFile = $this->cacheDir.'/fixture/metadata.json';
+        $this->assertFileExists($metadataFile);
+
+        $contents = file_get_contents($metadataFile);
+        $this->assertNotFalse($contents);
+        $metadata = json_decode($contents, true);
+
+        $this->assertSame('fixture', $metadata['provider']);
+        $this->assertIsInt($metadata['chunk_count']);
+        $this->assertGreaterThan(0, $metadata['chunk_count']);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/', $metadata['synced_at']);
+        $this->assertArrayHasKey('revision', $metadata);
+        $this->assertArrayHasKey('docs_dir', $metadata);
+    }
+
+    public function testJsonArtifactsAreWrittenAtomicallyWithoutLeftoverTempFiles()
+    {
+        $cache = $this->createCache();
+        $provider = $this->createProvider();
+
+        $cache->ensure($provider);
+
+        $files = glob($this->cacheDir.'/fixture/*.tmp.*');
+        $this->assertSame([], $files, 'No temp files should be left behind after atomic writes.');
+    }
+
     public function testTtlOfZeroDisablesAutoRebuild()
     {
         $cache = new KnowledgeCache($this->cacheDir, new TocBuilder(), new ChunkBuilder(), ttlSeconds: 0);

--- a/src/mate/src/Bridge/Knowledge/Tests/Service/KnowledgeCacheTest.php
+++ b/src/mate/src/Bridge/Knowledge/Tests/Service/KnowledgeCacheTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Knowledge\Exception\PageNotFoundException;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\ChunkBuilder;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KnowledgeCache;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\TocBuilder;
+use Symfony\AI\Mate\Bridge\Knowledge\Tests\Fixtures\FixtureProvider;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class KnowledgeCacheTest extends TestCase
+{
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir().'/ai_mate_knowledge_test_'.uniqid();
+        mkdir($this->cacheDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->cacheDir);
+    }
+
+    public function testEnsureBuildsTocAndChunkArtifacts()
+    {
+        $cache = $this->createCache();
+        $provider = $this->createProvider();
+
+        $cache->ensure($provider);
+
+        $this->assertFileExists($this->cacheDir.'/fixture/toc.json');
+        $this->assertFileExists($this->cacheDir.'/fixture/chunks.json');
+    }
+
+    public function testGetTocReturnsTreeWithExpectedShape()
+    {
+        $cache = $this->createCache();
+        $provider = $this->createProvider();
+
+        $toc = $cache->getToc($provider);
+
+        $this->assertSame('Sample Documentation', $toc->getTitle());
+        $this->assertCount(2, $toc->getChildren());
+    }
+
+    public function testGetChunksForPathReturnsOnlyPageChunks()
+    {
+        $cache = $this->createCache();
+        $provider = $this->createProvider();
+
+        $chunks = $cache->getChunksForPath($provider, 'setup');
+
+        foreach ($chunks as $chunk) {
+            $this->assertSame('setup', $chunk->getPath());
+        }
+        $this->assertNotEmpty($chunks);
+    }
+
+    public function testGetChunksForPathThrowsWhenPageMissing()
+    {
+        $cache = $this->createCache();
+        $provider = $this->createProvider();
+
+        $this->expectException(PageNotFoundException::class);
+
+        $cache->getChunksForPath($provider, 'does/not/exist');
+    }
+
+    public function testEnsureRebuildsCacheWhenOlderThanTtl()
+    {
+        $cache = new KnowledgeCache($this->cacheDir, new TocBuilder(), new ChunkBuilder(), ttlSeconds: 1);
+        $provider = $this->createProvider();
+
+        $cache->ensure($provider);
+        $tocFile = $this->cacheDir.'/fixture/toc.json';
+        // Backdate the cache file so it appears stale on the next ensure() call.
+        $past = time() - 3600;
+        touch($tocFile, $past);
+        clearstatcache(true, $tocFile);
+
+        $cache->ensure($provider);
+
+        clearstatcache(true, $tocFile);
+        $this->assertGreaterThan($past, filemtime($tocFile));
+    }
+
+    public function testEnsureKeepsCacheWhenWithinTtl()
+    {
+        $cache = new KnowledgeCache($this->cacheDir, new TocBuilder(), new ChunkBuilder(), ttlSeconds: 86400);
+        $provider = $this->createProvider();
+
+        $cache->ensure($provider);
+        $tocFile = $this->cacheDir.'/fixture/toc.json';
+        $originalMtime = filemtime($tocFile);
+
+        $cache->ensure($provider);
+
+        clearstatcache(true, $tocFile);
+        $this->assertSame($originalMtime, filemtime($tocFile));
+    }
+
+    public function testTtlOfZeroDisablesAutoRebuild()
+    {
+        $cache = new KnowledgeCache($this->cacheDir, new TocBuilder(), new ChunkBuilder(), ttlSeconds: 0);
+        $provider = $this->createProvider();
+
+        $cache->ensure($provider);
+        $tocFile = $this->cacheDir.'/fixture/toc.json';
+        touch($tocFile, time() - 86400 * 30);
+        clearstatcache(true, $tocFile);
+        $stableMtime = filemtime($tocFile);
+
+        $cache->ensure($provider);
+
+        clearstatcache(true, $tocFile);
+        $this->assertSame($stableMtime, filemtime($tocFile));
+    }
+
+    private function createCache(): KnowledgeCache
+    {
+        return new KnowledgeCache($this->cacheDir, new TocBuilder(), new ChunkBuilder());
+    }
+
+    private function createProvider(): FixtureProvider
+    {
+        return new FixtureProvider(\dirname(__DIR__).'/Fixtures/docs');
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $items = scandir($directory);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ('.' === $item || '..' === $item) {
+                continue;
+            }
+
+            $path = $directory.\DIRECTORY_SEPARATOR.$item;
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($directory);
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Tests/Service/TocBuilderEdgeCasesTest.php
+++ b/src/mate/src/Bridge/Knowledge/Tests/Service/TocBuilderEdgeCasesTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Knowledge\Model\TocNode;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\TocBuilder;
+
+/**
+ * Covers toctree edge cases: ``Title <path>`` aliases, absolute entries,
+ * missing files (silently skipped), duplicate entries, and glob patterns.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class TocBuilderEdgeCasesTest extends TestCase
+{
+    private string $docsDir;
+
+    protected function setUp(): void
+    {
+        $this->docsDir = \dirname(__DIR__).'/Fixtures/docs-edge';
+    }
+
+    public function testTitleAliasSyntaxResolvesToTargetFile()
+    {
+        $root = (new TocBuilder())->build($this->docsDir.'/index.rst', $this->docsDir);
+
+        $node = $this->findChildByPath($root, 'aliased');
+
+        $this->assertNotNull($node, 'Aliased entry "Aliased Title <aliased>" should resolve to aliased.rst');
+        $this->assertSame('Real Aliased Title', $node->getTitle());
+    }
+
+    public function testAbsoluteToctreeEntryIsResolvedFromDocsRoot()
+    {
+        $root = (new TocBuilder())->build($this->docsDir.'/index.rst', $this->docsDir);
+
+        $node = $this->findChildByPath($root, 'absolute');
+
+        $this->assertNotNull($node, 'Absolute toctree entry "/absolute" should be resolved relative to the docs root');
+        $this->assertSame('Absolute Entry', $node->getTitle());
+    }
+
+    public function testMissingFileEntryIsSilentlyDroppedFromToc()
+    {
+        $root = (new TocBuilder())->build($this->docsDir.'/index.rst', $this->docsDir);
+
+        $this->assertNull(
+            $this->findChildByPath($root, 'missing-page'),
+            'Missing toctree entry "missing-page" must not appear in the TOC',
+        );
+    }
+
+    public function testDuplicateEntryIsIncludedOnlyOnce()
+    {
+        $root = (new TocBuilder())->build($this->docsDir.'/index.rst', $this->docsDir);
+
+        $duplicates = array_filter(
+            $root->getChildren(),
+            static fn (TocNode $child) => 'duplicate' === $child->getPath(),
+        );
+
+        $this->assertCount(1, $duplicates, 'A repeated toctree entry must be deduplicated.');
+    }
+
+    public function testGlobEntryPullsInAllMatchingFiles()
+    {
+        $root = (new TocBuilder())->build($this->docsDir.'/index.rst', $this->docsDir);
+
+        $globPaths = array_values(array_filter(
+            array_map(static fn (TocNode $child) => $child->getPath(), $root->getChildren()),
+            static fn (string $path) => str_starts_with($path, 'glob/'),
+        ));
+
+        sort($globPaths);
+
+        $this->assertSame(['glob/alpha', 'glob/beta'], $globPaths);
+    }
+
+    private function findChildByPath(TocNode $root, string $path): ?TocNode
+    {
+        foreach ($root->getChildren() as $child) {
+            if ($child->getPath() === $path) {
+                return $child;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/Tests/Service/TocBuilderTest.php
+++ b/src/mate/src/Bridge/Knowledge/Tests/Service/TocBuilderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Knowledge\Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\TocBuilder;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class TocBuilderTest extends TestCase
+{
+    private string $docsDir;
+
+    protected function setUp(): void
+    {
+        $this->docsDir = \dirname(__DIR__).'/Fixtures/docs';
+    }
+
+    public function testBuildProducesNestedTreeFromToctrees()
+    {
+        $builder = new TocBuilder();
+
+        $root = $builder->build($this->docsDir.'/index.rst', $this->docsDir);
+
+        $this->assertSame('', $root->getPath());
+        $this->assertSame('Sample Documentation', $root->getTitle());
+        $this->assertCount(2, $root->getChildren());
+
+        $children = $root->getChildren();
+        $this->assertSame('setup', $children[0]->getPath());
+        $this->assertSame('Setup Guide', $children[0]->getTitle());
+        $this->assertSame([], $children[0]->getChildren());
+
+        $this->assertSame('advanced', $children[1]->getPath());
+        $this->assertSame('Advanced Topics', $children[1]->getTitle());
+        $this->assertCount(1, $children[1]->getChildren());
+
+        $caching = $children[1]->getChildren()[0];
+        $this->assertSame('advanced/caching', $caching->getPath());
+        $this->assertSame('Caching', $caching->getTitle());
+    }
+
+    public function testFindByPathLocatesNestedNodes()
+    {
+        $builder = new TocBuilder();
+        $root = $builder->build($this->docsDir.'/index.rst', $this->docsDir);
+
+        $node = $root->findByPath('advanced/caching');
+
+        $this->assertNotNull($node);
+        $this->assertSame('Caching', $node->getTitle());
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/composer.json
+++ b/src/mate/src/Bridge/Knowledge/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony/ai-knowledge-mate-extension",
-    "description": "Knowledge bridge for AI Mate - exposes documentation sources (RST, Markdown, ...) as crawlable MCP tools",
+    "description": "Knowledge bridge for AI Mate - structured access to official documentation as MCP tools (browse TOC, read pages, substring search; no semantic/RAG search)",
     "license": "MIT",
     "type": "symfony-ai-mate",
     "keywords": [

--- a/src/mate/src/Bridge/Knowledge/composer.json
+++ b/src/mate/src/Bridge/Knowledge/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-mate": "^0.8",
-        "symfony/ai-store": "^0.1|^0.8",
+        "symfony/ai-store": "^0.8",
         "symfony/dependency-injection": "^7.3|^8.0",
         "symfony/process": "^7.3|^8.0"
     },

--- a/src/mate/src/Bridge/Knowledge/composer.json
+++ b/src/mate/src/Bridge/Knowledge/composer.json
@@ -1,0 +1,69 @@
+{
+    "name": "symfony/ai-knowledge-mate-extension",
+    "description": "Knowledge bridge for AI Mate - exposes documentation sources (RST, Markdown, ...) as crawlable MCP tools",
+    "license": "MIT",
+    "type": "symfony-ai-mate",
+    "keywords": [
+        "ai",
+        "mcp",
+        "docs",
+        "documentation",
+        "knowledge",
+        "rst",
+        "bridge"
+    ],
+    "authors": [
+        {
+            "name": "Johannes Wachter",
+            "email": "johannes@sulu.io"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/ai-mate": "^0.8",
+        "symfony/ai-store": "^0.1|^0.8",
+        "symfony/dependency-injection": "^7.3|^8.0",
+        "symfony/process": "^7.3|^8.0"
+    },
+    "require-dev": {
+        "helgesverre/toon": "^3.1",
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.5.53"
+    },
+    "minimum-stability": "dev",
+    "autoload": {
+        "psr-4": {
+            "Symfony\\AI\\Mate\\Bridge\\Knowledge\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\AI\\PHPStan\\": "../../../../../.phpstan/",
+            "Symfony\\AI\\Mate\\Bridge\\Knowledge\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ai",
+            "url": "https://github.com/symfony/ai"
+        },
+        "ai-mate": {
+            "scan-dirs": [
+                "Capability"
+            ],
+            "includes": [
+                "config/config.php"
+            ],
+            "instructions": "INSTRUCTIONS.md"
+        }
+    }
+}

--- a/src/mate/src/Bridge/Knowledge/config/config.php
+++ b/src/mate/src/Bridge/Knowledge/config/config.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Mate\Bridge\Knowledge\Capability\ReadTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Capability\SearchTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Capability\TocTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\ProviderRegistry;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\ChunkBuilder;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KeywordSearcher;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KnowledgeCache;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\TocBuilder;
+use Symfony\AI\Store\Document\Loader\RstLoader;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+
+return static function (ContainerConfigurator $configurator) {
+    $configurator->parameters()
+        ->set('ai_mate_knowledge.cache_dir', '%mate.root_dir%/var/cache/knowledge')
+        ->set('ai_mate_knowledge.cache_ttl_seconds', 86400);
+
+    $services = $configurator->services();
+
+    $services->set(GitFetcher::class);
+    $services->set(RstLoader::class);
+
+    $services->set(TocBuilder::class);
+
+    $services->set(ChunkBuilder::class)
+        ->args([service(RstLoader::class)]);
+
+    $services->set(KnowledgeCache::class)
+        ->args([
+            '%ai_mate_knowledge.cache_dir%',
+            service(TocBuilder::class),
+            service(ChunkBuilder::class),
+            '%ai_mate_knowledge.cache_ttl_seconds%',
+        ]);
+
+    $services->set(KeywordSearcher::class);
+
+    $services->set(ProviderRegistry::class)
+        ->args([tagged_iterator('ai_mate.knowledge_provider')]);
+
+    $services->set(TocTool::class)
+        ->args([
+            service(ProviderRegistry::class),
+            service(KnowledgeCache::class),
+        ]);
+
+    $services->set(ReadTool::class)
+        ->args([
+            service(ProviderRegistry::class),
+            service(KnowledgeCache::class),
+        ]);
+
+    $services->set(SearchTool::class)
+        ->args([
+            service(ProviderRegistry::class),
+            service(KnowledgeCache::class),
+            service(KeywordSearcher::class),
+        ]);
+};

--- a/src/mate/src/Bridge/Knowledge/config/config.php
+++ b/src/mate/src/Bridge/Knowledge/config/config.php
@@ -17,6 +17,7 @@ use Symfony\AI\Mate\Bridge\Knowledge\Service\ChunkBuilder;
 use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
 use Symfony\AI\Mate\Bridge\Knowledge\Service\KeywordSearcher;
 use Symfony\AI\Mate\Bridge\Knowledge\Service\KnowledgeCache;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\SearcherInterface;
 use Symfony\AI\Mate\Bridge\Knowledge\Service\TocBuilder;
 use Symfony\AI\Store\Document\Loader\RstLoader;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -48,6 +49,7 @@ return static function (ContainerConfigurator $configurator) {
         ]);
 
     $services->set(KeywordSearcher::class);
+    $services->alias(SearcherInterface::class, KeywordSearcher::class);
 
     $services->set(ProviderRegistry::class)
         ->args([tagged_iterator('ai_mate.knowledge_provider')]);
@@ -68,6 +70,6 @@ return static function (ContainerConfigurator $configurator) {
         ->args([
             service(ProviderRegistry::class),
             service(KnowledgeCache::class),
-            service(KeywordSearcher::class),
+            service(SearcherInterface::class),
         ]);
 };

--- a/src/mate/src/Bridge/Knowledge/phpstan.dist.neon
+++ b/src/mate/src/Bridge/Knowledge/phpstan.dist.neon
@@ -1,0 +1,28 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../../../../../.phpstan/extension.neon
+
+parameters:
+    level: 6
+    paths:
+        - .
+        - Tests/
+    excludePaths:
+        - vendor/
+    treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+        -
+            message: '#^Call to( static)? method PHPUnit\\Framework\\Assert::.* will always evaluate to true\.$#'
+            reportUnmatched: false
+        -
+            identifier: 'symfonyAi.forbidNativeException'
+            path: Tests/*
+            reportUnmatched: false
+
+services:
+    - # Conditionally enabled by bleeding edge in phpstan/phpstan-phpunit 2.x
+        class: PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension
+        tags:
+            - phpstan.ignoreErrorExtension

--- a/src/mate/src/Bridge/Knowledge/phpunit.xml.dist
+++ b/src/mate/src/Bridge/Knowledge/phpunit.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         executionOrder="random"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony AI Mate Knowledge Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+</phpunit>

--- a/src/mate/src/Bridge/Symfony/CHANGELOG.md
+++ b/src/mate/src/Bridge/Symfony/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.9
+---
+
+ * Add `SymfonyDocsProvider` registering the official Symfony documentation as a knowledge provider when `symfony/ai-knowledge-mate-extension` is installed
+
 0.7
 ---
 

--- a/src/mate/src/Bridge/Symfony/CHANGELOG.md
+++ b/src/mate/src/Bridge/Symfony/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 0.9
 ---
 
- * Add `SymfonyDocsProvider` registering the official Symfony documentation as a knowledge provider when `symfony/ai-knowledge-mate-extension` is installed
+ * Add `SymfonyDocsProvider` registering the official Symfony documentation as a knowledge provider when `symfony/ai-knowledge-mate-extension` is installed; the cloned branch is auto-detected from the host application's installed Symfony version (`Composer\InstalledVersions`) and can be overridden via `ai_mate_symfony.docs_branch` / `ai_mate_symfony.docs_repository_url`
 
 0.7
 ---

--- a/src/mate/src/Bridge/Symfony/Knowledge/SymfonyDocsProvider.php
+++ b/src/mate/src/Bridge/Symfony/Knowledge/SymfonyDocsProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Knowledge;
+
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
+
+/**
+ * Exposes the official Symfony documentation (https://github.com/symfony/symfony-docs)
+ * as a knowledge provider.
+ *
+ * Only registered when the Knowledge bridge is installed (see config.php).
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SymfonyDocsProvider implements DocsProviderInterface
+{
+    public function __construct(
+        private GitFetcher $fetcher,
+        private string $repositoryUrl = 'https://github.com/symfony/symfony-docs.git',
+        private string $branch = '7.3',
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'symfony';
+    }
+
+    public function getTitle(): string
+    {
+        return 'Symfony Documentation';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Official Symfony framework documentation, branch '.$this->branch.'.';
+    }
+
+    public function getFormat(): string
+    {
+        return 'rst';
+    }
+
+    public function sync(string $cacheDir): string
+    {
+        $repoDir = rtrim($cacheDir, '/').'/docs';
+        $this->fetcher->fetch($this->repositoryUrl, $this->branch, $repoDir);
+
+        return $repoDir.'/index.rst';
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Knowledge/SymfonyDocsProvider.php
+++ b/src/mate/src/Bridge/Symfony/Knowledge/SymfonyDocsProvider.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Mate\Bridge\Symfony\Knowledge;
 
+use Composer\InstalledVersions;
 use Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface;
 use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
 
@@ -20,15 +21,43 @@ use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
  *
  * Only registered when the Knowledge bridge is installed (see config.php).
  *
+ * The cloned docs branch defaults to the major.minor version of the host
+ * application's installed Symfony (read from `vendor/composer/installed.json`
+ * via `Composer\InstalledVersions`). When the version cannot be resolved (e.g.
+ * the bridge runs outside a Composer-installed Symfony app), the
+ * {@see DEFAULT_BRANCH} constant is used as a last resort.
+ *
  * @author Johannes Wachter <johannes@sulu.io>
  */
 final class SymfonyDocsProvider implements DocsProviderInterface
 {
+    /**
+     * Fallback when nothing else can be detected. Updated alongside the
+     * symfony-docs release schedule.
+     */
+    public const DEFAULT_BRANCH = '7.3';
+
+    /**
+     * Packages probed (in order) for the host Symfony version. The first one
+     * Composer reports as installed wins — `framework-bundle` is the canonical
+     * "what Symfony version do we have" marker for an application, the others
+     * are progressively weaker fallbacks.
+     */
+    private const VERSION_PROBE_PACKAGES = [
+        'symfony/framework-bundle',
+        'symfony/runtime',
+        'symfony/http-kernel',
+        'symfony/dependency-injection',
+    ];
+
+    private string $branch;
+
     public function __construct(
         private GitFetcher $fetcher,
         private string $repositoryUrl = 'https://github.com/symfony/symfony-docs.git',
-        private string $branch = '7.3',
+        ?string $branch = null,
     ) {
+        $this->branch = $branch ?? self::detectBranch();
     }
 
     public function getName(): string
@@ -57,5 +86,34 @@ final class SymfonyDocsProvider implements DocsProviderInterface
         $this->fetcher->fetch($this->repositoryUrl, $this->branch, $repoDir);
 
         return $repoDir.'/index.rst';
+    }
+
+    /**
+     * Looks up the installed Symfony version via Composer's runtime API and
+     * extracts the `major.minor` component — that's the branch naming
+     * convention used by symfony-docs (e.g. `7.3`, `6.4`).
+     */
+    private static function detectBranch(): string
+    {
+        if (!class_exists(InstalledVersions::class)) {
+            return self::DEFAULT_BRANCH;
+        }
+
+        foreach (self::VERSION_PROBE_PACKAGES as $package) {
+            if (!InstalledVersions::isInstalled($package)) {
+                continue;
+            }
+
+            $version = InstalledVersions::getVersion($package);
+            if (null === $version) {
+                continue;
+            }
+
+            if (1 === preg_match('/^(\d+\.\d+)/', $version, $matches)) {
+                return $matches[1];
+            }
+        }
+
+        return self::DEFAULT_BRANCH;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Tests/Knowledge/SymfonyDocsProviderIntegrationTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Knowledge/SymfonyDocsProviderIntegrationTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Knowledge;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Knowledge\Capability\ReadTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Capability\SearchTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Capability\TocTool;
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\ProviderRegistry;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\ChunkBuilder;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KeywordSearcher;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\KnowledgeCache;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\TocBuilder;
+use Symfony\AI\Mate\Bridge\Symfony\Knowledge\SymfonyDocsProvider;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * End-to-end test that wires the Symfony bridge's {@see SymfonyDocsProvider}
+ * through the Knowledge bridge's registry, cache and MCP tools.
+ *
+ * The "remote" Symfony docs repo is replaced with a local bare git repo that
+ * contains a small RST fixture, so the test exercises the real `git clone`
+ * code path without hitting the network.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SymfonyDocsProviderIntegrationTest extends TestCase
+{
+    private string $sandbox;
+    private string $remoteRepo;
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        if (null === (new ExecutableFinder())->find('git')) {
+            $this->markTestSkipped('git binary is not available in PATH.');
+        }
+
+        $this->sandbox = sys_get_temp_dir().'/ai_mate_symfony_docs_e2e_'.uniqid();
+        $this->remoteRepo = $this->sandbox.'/remote.git';
+        $this->cacheDir = $this->sandbox.'/cache';
+
+        mkdir($this->cacheDir, 0755, true);
+
+        $this->setUpRemoteRepo();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->sandbox);
+    }
+
+    public function testKnowledgeToolsServeSymfonyProviderEndToEnd()
+    {
+        $provider = new SymfonyDocsProvider(new GitFetcher(), 'file://'.$this->remoteRepo, 'main');
+        $registry = new ProviderRegistry([$provider]);
+        $cache = new KnowledgeCache($this->cacheDir, new TocBuilder(), new ChunkBuilder());
+
+        // 1. Listing providers without arguments
+        $tocTool = new TocTool($registry, $cache);
+        $listed = ResponseEncoder::decode($tocTool->browse());
+        $this->assertSame('symfony', $listed['providers'][0]['name']);
+
+        // 2. Browsing the Symfony provider triggers the clone + index
+        $browsed = ResponseEncoder::decode($tocTool->browse('symfony'));
+        $this->assertSame('symfony', $browsed['provider']);
+        $this->assertSame('Symfony Docs (Fake)', $browsed['title']);
+        $childPaths = array_map(static fn (array $c): string => $c['path'], $browsed['children']);
+        $this->assertContains('setup', $childPaths);
+
+        // 3. Reading a page returns ordered sections
+        $read = ResponseEncoder::decode((new ReadTool($registry, $cache))->read('symfony', 'setup'));
+        $this->assertSame('Setup', $read['title']);
+        $sectionTitles = array_map(static fn (array $s): string => $s['title'], $read['sections']);
+        $this->assertContains('Installation', $sectionTitles);
+
+        // 4. Searching across chunks
+        $search = ResponseEncoder::decode((new SearchTool($registry, $cache, new KeywordSearcher()))->search('symfony', 'FrameworkBundle'));
+        $this->assertSame('FrameworkBundle', $search['query']);
+        $this->assertNotEmpty($search['results']);
+        $this->assertSame('setup', $search['results'][0]['path']);
+
+        // 5. Cache artifacts including metadata.json are present
+        $this->assertFileExists($this->cacheDir.'/symfony/toc.json');
+        $this->assertFileExists($this->cacheDir.'/symfony/chunks.json');
+        $this->assertFileExists($this->cacheDir.'/symfony/metadata.json');
+        $metadata = json_decode((string) file_get_contents($this->cacheDir.'/symfony/metadata.json'), true);
+        $this->assertSame('symfony', $metadata['provider']);
+        $this->assertGreaterThan(0, $metadata['chunk_count']);
+    }
+
+    private function setUpRemoteRepo(): void
+    {
+        $working = $this->sandbox.'/working';
+        mkdir($working, 0755, true);
+        mkdir($working.'/setup', 0755, true);
+
+        file_put_contents($working.'/index.rst', <<<RST
+            Symfony Docs (Fake)
+            ===================
+
+            .. toctree::
+                :maxdepth: 2
+
+                setup/index
+
+            RST);
+
+        file_put_contents($working.'/setup/index.rst', <<<RST
+            Setup
+            =====
+
+            Installation
+            ------------
+
+            Run ``composer require symfony/framework-bundle`` to install the FrameworkBundle.
+
+            Configuration
+            -------------
+
+            Edit ``config/packages/framework.yaml`` to configure the FrameworkBundle.
+
+            RST);
+
+        $this->git(['init', '--initial-branch=main', '--quiet'], $working);
+        $this->git(['config', 'user.email', 'test@example.com'], $working);
+        $this->git(['config', 'user.name', 'Test'], $working);
+        $this->git(['add', '.'], $working);
+        $this->git(['commit', '-m', 'init', '--quiet'], $working);
+
+        // Convert the working repo into a bare repo that SymfonyDocsProvider can clone.
+        mkdir($this->remoteRepo, 0755, true);
+        $this->git(['clone', '--bare', '--quiet', $working, $this->remoteRepo], $this->sandbox);
+    }
+
+    /**
+     * @param list<string> $command
+     */
+    private function git(array $command, string $cwd): void
+    {
+        $process = new Process(array_merge(['git'], $command), $cwd, null, null, 60);
+        $process->mustRun();
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $items = scandir($directory);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ('.' === $item || '..' === $item) {
+                continue;
+            }
+
+            $path = $directory.\DIRECTORY_SEPARATOR.$item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->removeDirectory($path);
+            } else {
+                @unlink($path);
+            }
+        }
+
+        rmdir($directory);
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Knowledge/SymfonyDocsProviderIntegrationTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Knowledge/SymfonyDocsProviderIntegrationTest.php
@@ -23,6 +23,7 @@ use Symfony\AI\Mate\Bridge\Knowledge\Service\KnowledgeCache;
 use Symfony\AI\Mate\Bridge\Knowledge\Service\TocBuilder;
 use Symfony\AI\Mate\Bridge\Symfony\Knowledge\SymfonyDocsProvider;
 use Symfony\AI\Mate\Encoding\ResponseEncoder;
+use Symfony\AI\Store\Document\Loader\RstLoader;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -38,12 +39,16 @@ use Symfony\Component\Process\Process;
  */
 final class SymfonyDocsProviderIntegrationTest extends TestCase
 {
-    private string $sandbox;
-    private string $remoteRepo;
-    private string $cacheDir;
+    private string $sandbox = '';
+    private string $remoteRepo = '';
+    private string $cacheDir = '';
 
     protected function setUp(): void
     {
+        if (!class_exists(RstLoader::class)) {
+            $this->markTestSkipped('symfony/ai-store version with RstLoader is required for this end-to-end test.');
+        }
+
         if (null === (new ExecutableFinder())->find('git')) {
             $this->markTestSkipped('git binary is not available in PATH.');
         }
@@ -59,7 +64,9 @@ final class SymfonyDocsProviderIntegrationTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->removeDirectory($this->sandbox);
+        if ('' !== $this->sandbox) {
+            $this->removeDirectory($this->sandbox);
+        }
     }
 
     public function testKnowledgeToolsServeSymfonyProviderEndToEnd()

--- a/src/mate/src/Bridge/Symfony/Tests/Knowledge/SymfonyDocsProviderTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Knowledge/SymfonyDocsProviderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Knowledge;
+
+use Composer\InstalledVersions;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
+use Symfony\AI\Mate\Bridge\Symfony\Knowledge\SymfonyDocsProvider;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SymfonyDocsProviderTest extends TestCase
+{
+    public function testExplicitBranchOverridesAutoDetection()
+    {
+        $provider = new SymfonyDocsProvider(new GitFetcher(), 'https://example.invalid/docs.git', '6.4');
+
+        $this->assertStringContainsString('branch 6.4', $provider->getDescription());
+    }
+
+    public function testNullBranchAutoDetectsFromInstalledSymfony()
+    {
+        $version = $this->resolveInstalledMajorMinor();
+        if (null === $version) {
+            $this->markTestSkipped('No Symfony package is reported as installed via Composer\\InstalledVersions; cannot verify auto-detection.');
+        }
+
+        $provider = new SymfonyDocsProvider(new GitFetcher());
+
+        $this->assertStringContainsString('branch '.$version, $provider->getDescription());
+    }
+
+    public function testNameAndFormatAreStable()
+    {
+        $provider = new SymfonyDocsProvider(new GitFetcher(), 'https://example.invalid/docs.git', '7.3');
+
+        $this->assertSame('symfony', $provider->getName());
+        $this->assertSame('Symfony Documentation', $provider->getTitle());
+        $this->assertSame('rst', $provider->getFormat());
+    }
+
+    private function resolveInstalledMajorMinor(): ?string
+    {
+        foreach (['symfony/framework-bundle', 'symfony/runtime', 'symfony/http-kernel', 'symfony/dependency-injection'] as $package) {
+            if (!InstalledVersions::isInstalled($package)) {
+                continue;
+            }
+
+            $version = InstalledVersions::getVersion($package);
+            if (null !== $version && 1 === preg_match('/^(\d+\.\d+)/', $version, $matches)) {
+                return $matches[1];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -38,14 +38,25 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5.53",
+        "symfony/ai-knowledge-mate-extension": "@dev",
         "symfony/http-kernel": "^7.3|^8.0",
         "symfony/mailer": "^7.3|^8.0",
         "symfony/translation": "^7.3|^8.0",
         "symfony/var-dumper": "^7.3|^8.0",
         "symfony/web-profiler-bundle": "^7.3|^8.0"
     },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../Knowledge",
+            "options": {
+                "symlink": false
+            }
+        }
+    ],
     "suggest": {
         "doctrine/doctrine-bundle": "Required for Doctrine database profiler formatter",
+        "symfony/ai-knowledge-mate-extension": "Required to expose the Symfony documentation as a knowledge provider",
         "symfony/http-kernel": "Required for profiler data access tools",
         "symfony/mailer": "Required for mailer profiler formatter",
         "symfony/translation": "Required for translation profiler collector formatter",

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -45,15 +45,6 @@
         "symfony/var-dumper": "^7.3|^8.0",
         "symfony/web-profiler-bundle": "^7.3|^8.0"
     },
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../Knowledge",
-            "options": {
-                "symlink": false
-            }
-        }
-    ],
     "suggest": {
         "doctrine/doctrine-bundle": "Required for Doctrine database profiler formatter",
         "symfony/ai-knowledge-mate-extension": "Required to expose the Symfony documentation as a knowledge provider",

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -38,6 +38,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5.53",
+        "symfony/ai-knowledge-mate-extension": "@dev",
         "symfony/http-kernel": "^7.3|^8.0",
         "symfony/mailer": "^7.3|^8.0",
         "symfony/stopwatch": "^7.3|^8.0",
@@ -45,8 +46,18 @@
         "symfony/var-dumper": "^7.3|^8.0",
         "symfony/web-profiler-bundle": "^7.3|^8.0"
     },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../Knowledge",
+            "options": {
+                "symlink": false
+            }
+        }
+    ],
     "suggest": {
         "doctrine/doctrine-bundle": "Required for Doctrine database profiler formatter",
+        "symfony/ai-knowledge-mate-extension": "Required to expose the Symfony documentation as a knowledge provider",
         "symfony/http-kernel": "Required for profiler data access tools",
         "symfony/mailer": "Required for mailer profiler formatter",
         "symfony/translation": "Required for translation profiler collector formatter",

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -46,15 +46,6 @@
         "symfony/var-dumper": "^7.3|^8.0",
         "symfony/web-profiler-bundle": "^7.3|^8.0"
     },
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../Knowledge",
-            "options": {
-                "symlink": false
-            }
-        }
-    ],
     "suggest": {
         "doctrine/doctrine-bundle": "Required for Doctrine database profiler formatter",
         "symfony/ai-knowledge-mate-extension": "Required to expose the Symfony documentation as a knowledge provider",

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -90,8 +90,19 @@ return static function (ContainerConfigurator $configurator) {
 
     // Knowledge provider (optional - only when the Knowledge bridge is installed)
     if (interface_exists(DocsProviderInterface::class)) {
+        // `docs_branch: null` lets SymfonyDocsProvider auto-detect the
+        // major.minor branch from the host application's installed Symfony
+        // (Composer\InstalledVersions). Set it explicitly to pin a branch.
+        $configurator->parameters()
+            ->set('ai_mate_symfony.docs_repository_url', 'https://github.com/symfony/symfony-docs.git')
+            ->set('ai_mate_symfony.docs_branch', null);
+
         $services->set(SymfonyDocsProvider::class)
-            ->args([service(GitFetcher::class)])
+            ->args([
+                service(GitFetcher::class),
+                '%ai_mate_symfony.docs_repository_url%',
+                '%ai_mate_symfony.docs_branch%',
+            ])
             ->tag('ai_mate.knowledge_provider');
     }
 };

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -9,9 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ProfilerResourceTemplate;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ProfilerTool;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ServiceTool;
+use Symfony\AI\Mate\Bridge\Symfony\Knowledge\SymfonyDocsProvider;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
@@ -83,5 +86,12 @@ return static function (ContainerConfigurator $configurator) {
 
         $services->set(ProfilerResourceTemplate::class)
             ->args([service(ProfilerDataProvider::class)]);
+    }
+
+    // Knowledge provider (optional - only when the Knowledge bridge is installed)
+    if (interface_exists(DocsProviderInterface::class)) {
+        $services->set(SymfonyDocsProvider::class)
+            ->args([service(GitFetcher::class)])
+            ->tag('ai_mate.knowledge_provider');
     }
 };

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -9,9 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface;
+use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ProfilerResourceTemplate;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ProfilerTool;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ServiceTool;
+use Symfony\AI\Mate\Bridge\Symfony\Knowledge\SymfonyDocsProvider;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\DoctrineCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
@@ -90,5 +93,12 @@ return static function (ContainerConfigurator $configurator) {
 
         $services->set(ProfilerResourceTemplate::class)
             ->args([service(ProfilerDataProvider::class)]);
+    }
+
+    // Knowledge provider (optional - only when the Knowledge bridge is installed)
+    if (interface_exists(DocsProviderInterface::class)) {
+        $services->set(SymfonyDocsProvider::class)
+            ->args([service(GitFetcher::class)])
+            ->tag('ai_mate.knowledge_provider');
     }
 };

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -97,8 +97,19 @@ return static function (ContainerConfigurator $configurator) {
 
     // Knowledge provider (optional - only when the Knowledge bridge is installed)
     if (interface_exists(DocsProviderInterface::class)) {
+        // `docs_branch: null` lets SymfonyDocsProvider auto-detect the
+        // major.minor branch from the host application's installed Symfony
+        // (Composer\InstalledVersions). Set it explicitly to pin a branch.
+        $configurator->parameters()
+            ->set('ai_mate_symfony.docs_repository_url', 'https://github.com/symfony/symfony-docs.git')
+            ->set('ai_mate_symfony.docs_branch', null);
+
         $services->set(SymfonyDocsProvider::class)
-            ->args([service(GitFetcher::class)])
+            ->args([
+                service(GitFetcher::class),
+                '%ai_mate_symfony.docs_repository_url%',
+                '%ai_mate_symfony.docs_branch%',
+            ])
             ->tag('ai_mate.knowledge_provider');
     }
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

## Summary

Introduces a new Mate bridge — `symfony/ai-knowledge-mate-extension` — that gives agents **structured access to official documentation** through MCP tools (browse TOC, read pages, substring search). The goal is to replace "guessing from training data" with crawling the actual docs.

This bridge does **not** ship semantic / vector / RAG search. A `SearcherInterface` extension seam is provided so a future implementation can plug in embedding-based search without changing the tool surface.

The Symfony bridge ships a built-in `SymfonyDocsProvider` for [symfony/symfony-docs](https://github.com/symfony/symfony-docs) that registers itself when the Knowledge bridge is also installed (`interface_exists()` guard). The cloned docs branch is **auto-detected from the host application's installed Symfony version** via `Composer\InstalledVersions` (probing `symfony/framework-bundle` → `symfony/runtime` → `symfony/http-kernel` → `symfony/dependency-injection`) and can be pinned explicitly with `ai_mate_symfony.docs_branch`.

## Tools

| Tool               | Purpose |
|--------------------|---------|
| `knowledge-toc`    | Without arguments: list providers. With a `provider`: browse its TOC at `path` (or root). |
| `knowledge-read`   | Read a documentation page split into RST sections (response is capped — see below). |
| `knowledge-search` | Case-insensitive substring search across a provider's chunks (limit capped at 50). |

## Behavior

- The first call for a provider clones the source repo (`git clone --depth 1`) into the local cache.
- Subsequent calls hit the cache.
- The cache auto-refreshes once it's older than `ai_mate_knowledge.cache_ttl_seconds` (default 24h).
- Section-based chunking reuses `Symfony\AI\Store\Document\Loader\RstLoader` so chunking semantics stay aligned with the Store component.
- Concurrent `ensure()` calls are safe: a per-provider `flock` serializes work, and the toc/chunks/metadata JSON files are written atomically (temp + rename).
- Provider names must match `^[a-z0-9][a-z0-9_-]{0,63}$` so they can't escape the cache dir or be used as shell metacharacters.
- A `metadata.json` is written next to the cache artifacts (`provider`, `synced_at`, `chunk_count`, git revision when available) for debugging.

## Adding a custom provider

```php
use Symfony\AI\Mate\Bridge\Knowledge\Provider\DocsProviderInterface;
use Symfony\AI\Mate\Bridge\Knowledge\Service\GitFetcher;

final class MyDocsProvider implements DocsProviderInterface
{
    public function __construct(private GitFetcher $fetcher) {}

    public function getName(): string { return 'my-docs'; }
    public function getTitle(): string { return 'My Docs'; }
    public function getDescription(): string { return 'My project documentation'; }
    public function getFormat(): string { return 'rst'; }

    public function sync(string $cacheDir): string
    {
        $repo = $cacheDir.'/docs';
        $this->fetcher->fetch('https://github.com/me/docs.git', 'main', $repo);

        return $repo.'/index.rst';
    }
}
```

Tag the service `ai_mate.knowledge_provider`.

## Future-proofing

The chunk model (`PageChunk`) already matches what `Symfony\AI\Store\Document\Vectorizer` consumes, and a `SearcherInterface` seam is exposed so an embedding-based searcher can replace `KeywordSearcher` without changing the tool surface. An indexer seam (over the JSON cache step) would be the other half — left out for now to keep scope tight (YAGNI).

## Test plan

- [x] Knowledge bridge: 39/39 PHPUnit tests pass (services, models, registry, tools, TTL behavior, atomic writes, metadata, provider-name validation, RST edge cases — title aliases, absolute entries, missing files, duplicate entries, glob entries)
- [x] Symfony bridge: 118/118 tests pass (114 pre-existing + 3 `SymfonyDocsProvider` unit tests covering auto-detection vs. explicit-branch override + 1 end-to-end integration test wiring `SymfonyDocsProvider` → `ProviderRegistry` → `KnowledgeCache` → all three MCP tools against a local bare git repo)
- [x] PHPStan clean on Knowledge bridge
- [x] doctor-rst clean on docs change
- [x] End-to-end: `SymfonyDocsProviderIntegrationTest` exercises a real `git clone` from a local bare repo through every tool (`knowledge-toc` → `knowledge-read` → `knowledge-search`) and asserts the cache artifacts (`toc.json`, `chunks.json`, `metadata.json`) land on disk with the expected shape.
