### PR TITLE
[Platform][Ollama] Capability insert ollama platform fix

### DIFF
--- a/src/platform/src/Bridge/Ollama/ModelCatalog.php
+++ b/src/platform/src/Bridge/Ollama/ModelCatalog.php
@@ -69,6 +69,7 @@ final class ModelCatalog implements ModelCatalogInterface
                 'thinking' => Capability::THINKING,
                 'vision' => Capability::INPUT_IMAGE,
                 'audio' => Capability::INPUT_AUDIO,
+                'insert' => Capability::FILL_IN_THE_MIDDLE,
                 default => throw new InvalidArgumentException(\sprintf('The "%s" capability is not supported', $capability)),
             },
             $payload['capabilities'],

--- a/src/platform/src/Bridge/Ollama/Tests/OllamaApiCatalogTest.php
+++ b/src/platform/src/Bridge/Ollama/Tests/OllamaApiCatalogTest.php
@@ -130,6 +130,39 @@ final class OllamaApiCatalogTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testModelCatalogCanReturnInsertModelsFromApi()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'models' => [
+                    [
+                        'name' => 'qwen2.5-coder',
+                        'details' => [],
+                    ],
+                ],
+            ]),
+            new JsonMockResponse([
+                'capabilities' => ['insert'],
+            ]),
+        ], 'http://127.0.0.1:11434');
+
+        $modelCatalog = new ModelCatalog($httpClient);
+
+        $models = $modelCatalog->getModels();
+
+        $this->assertCount(1, $models);
+        $this->assertArrayHasKey('qwen2.5-coder', $models);
+
+        $model = $models['qwen2.5-coder'];
+        $this->assertSame(Ollama::class, $model['class']);
+        $this->assertCount(2, $model['capabilities']);
+        $this->assertSame([
+            Capability::FILL_IN_THE_MIDDLE,
+            Capability::OUTPUT_STRUCTURED,
+        ], $model['capabilities']);
+        $this->assertSame(2, $httpClient->getRequestsCount());
+    }
+
     #[TestDox('Returns empty array when Ollama has no models')]
     public function testGetModelsReturnsEmptyArrayWhenNoModels()
     {

--- a/src/platform/src/Capability.php
+++ b/src/platform/src/Capability.php
@@ -61,4 +61,7 @@ enum Capability: string
 
     // Thinking
     case THINKING = 'thinking';
+
+    // Fill-in-the-middle (insert)
+    case FILL_IN_THE_MIDDLE = 'fill-in-the-middle';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #2019 
| License       | MIT

Fixes an issue with some models (e.g., qwen2.5-coder) reporting 'insert' capability if you attempt to list the available models. Adds 'insert' as a valid capability.