### PR TITLE
[Agent] Fix AgentProcessor dropping tool calls beyond the first ToolCallResult

### DIFF
--- a/src/agent/src/Toolbox/AgentProcessor.php
+++ b/src/agent/src/Toolbox/AgentProcessor.php
@@ -88,7 +88,20 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
         }
 
         if ($result instanceof MultiPartResult) {
-            $result = array_find($result->getContent(), static fn (ResultInterface $part) => $part instanceof ToolCallResult);
+            $toolCalls = [];
+            foreach ($result->getContent() as $part) {
+                if ($part instanceof ToolCallResult) {
+                    foreach ($part->getContent() as $toolCall) {
+                        $toolCalls[] = $toolCall;
+                    }
+                }
+            }
+
+            if ([] === $toolCalls) {
+                return;
+            }
+
+            $result = new ToolCallResult($toolCalls);
         }
 
         if (!$result instanceof ToolCallResult) {

--- a/src/agent/tests/Toolbox/AgentProcessorTest.php
+++ b/src/agent/tests/Toolbox/AgentProcessorTest.php
@@ -190,6 +190,47 @@ class AgentProcessorTest extends TestCase
         $this->assertSame($result, $output->getResult());
     }
 
+    public function testProcessOutputWithMultiPartResultContainingMultipleToolCallResultsExecutesAllToolCalls()
+    {
+        // Models like Anthropic Claude emit one tool_use block per parallel tool call,
+        // which the Anthropic ResultConverter (since v0.8.1) maps to one ToolCallResult per call.
+        // AgentProcessor must execute every ToolCall, not just the first ToolCallResult.
+        $toolCall1 = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolCall2 = new ToolCall('id2', 'tool2', ['arg2' => 'value2']);
+
+        $executedToolCalls = [];
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->expects($this->exactly(2))
+            ->method('execute')
+            ->willReturnCallback(static function (ToolCall $tc) use (&$executedToolCalls): ToolResult {
+                $executedToolCalls[] = $tc->getName();
+
+                return new ToolResult($tc, 'Result of '.$tc->getName());
+            });
+
+        $messageBag = new MessageBag();
+        $result = new MultiPartResult([
+            new TextResult('Let me look that up for you.'),
+            new ToolCallResult([$toolCall1]),
+            new ToolCallResult([$toolCall2]),
+        ]);
+
+        $agent = $this->createStub(AgentInterface::class);
+        $agent->method('call')->willReturn(new TextResult('Final response'));
+
+        $processor = new AgentProcessor($toolbox);
+        $processor->setAgent($agent);
+
+        $output = new Output('gpt-4', $result, $messageBag);
+
+        $processor->processOutput($output);
+
+        $this->assertSame(['tool1', 'tool2'], $executedToolCalls);
+        $this->assertInstanceOf(TextResult::class, $output->getResult());
+        $this->assertSame('Final response', $output->getResult()->getContent());
+    }
+
     public function testSourcesEndUpInResultMetadataWithSettingOn()
     {
         $toolCall = new ToolCall('call_1234', 'tool_sources', ['arg1' => 'value1']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

## Problem

When a model returns several `tool_use` blocks in a single response (parallel tool use), `Bridge/Anthropic/ResultConverter` (since v0.8.1 / #1981) maps each block to its **own** `ToolCallResult` inside a `MultiPartResult`.

`AgentProcessor::processOutput` then picks **only the first** `ToolCallResult` via `array_find`:

```php
if ($result instanceof MultiPartResult) {
    $result = array_find($result->getContent(),
        static fn (ResultInterface $part) => $part instanceof ToolCallResult);
}
```

Subsequent `ToolCallResult` parts are silently discarded → only the first tool of a parallel call would execute; the others are lost.

I hit this in production with Anthropic Claude returning `[text_preamble, tool_use, tool_use]` after #1981 (where each `tool_use` becomes its own `ToolCallResult`). Only 1 of 2 parallel `get_*` calls actually ran, leaving the agent's reasoning starved of half the data it had asked for.

## Fix

Aggregate every `ToolCall` from every `ToolCallResult` inside the `MultiPartResult` into a single `ToolCallResult`, then feed it to `handleToolCallsCallback()` which already iterates over all the `ToolCall`s it contains:

```php
if ($result instanceof MultiPartResult) {
    $toolCalls = [];
    foreach ($result->getContent() as $part) {
        if ($part instanceof ToolCallResult) {
            foreach ($part->getContent() as $toolCall) {
                $toolCalls[] = $toolCall;
            }
        }
    }

    if ([] === $toolCalls) {
        return;
    }

    $result = new ToolCallResult($toolCalls);
}
```

## Test plan

- New regression test `testProcessOutputWithMultiPartResultContainingMultipleToolCallResultsExecutesAllToolCalls` builds a `MultiPartResult` with one `TextResult` preamble and **two** distinct `ToolCallResult` parts, asserts that `Toolbox::execute()` is invoked twice (once per `ToolCall`) and that both tool names are recorded in invocation order.
- Existing tests (`...ContainingToolCall`, `...NotContainingToolCall`) still pass — the new code is a strict generalisation of the previous `array_find` behaviour.

```
$ vendor/bin/phpunit tests/Toolbox/AgentProcessorTest.php
OK (17 tests, 56 assertions)
```