### PR TITLE
[Platform][Inworld] Add bridge for TTS and STT

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -189,6 +189,10 @@ deptrac:
       collectors:
         - type: classLike
           value: Symfony\\AI\\Platform\\Bridge\\HuggingFace\\.*
+    - name: InworldPlatform
+      collectors:
+        - type: classLike
+          value: Symfony\\AI\\Platform\\Bridge\\Inworld\\.*
     - name: LmStudioPlatform
       collectors:
         - type: classLike
@@ -478,6 +482,8 @@ deptrac:
     GenericPlatform:
       - PlatformComponent
     HuggingFacePlatform:
+      - PlatformComponent
+    InworldPlatform:
       - PlatformComponent
     LmStudioPlatform:
       - PlatformComponent

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -193,6 +193,10 @@ deptrac:
       collectors:
         - type: classLike
           value: Symfony\\AI\\Platform\\Bridge\\HuggingFace\\.*
+    - name: InworldPlatform
+      collectors:
+        - type: classLike
+          value: Symfony\\AI\\Platform\\Bridge\\Inworld\\.*
     - name: LmStudioPlatform
       collectors:
         - type: classLike
@@ -488,6 +492,8 @@ deptrac:
     GenericPlatform:
       - PlatformComponent
     HuggingFacePlatform:
+      - PlatformComponent
+    InworldPlatform:
       - PlatformComponent
     LmStudioPlatform:
       - PlatformComponent

--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -58,6 +58,8 @@ Advanced Example with Multiple Agents
                     bedrock_runtime_client: 'async_aws.client.bedrock_runtime_eu'
             elevenlabs:
                 api_key: '%env(ELEVEN_LABS_API_KEY)%'
+            inworld:
+                api_key: '%env(INWORLD_API_KEY)%'
             gemini:
                 api_key: '%env(GEMINI_API_KEY)%'
             perplexity:
@@ -1271,6 +1273,9 @@ must be configured. Both can be enabled independently:
 - **TTS only**: configure ``text_to_speech_platform`` along with ``tts_model`` (and optionally ``tts_options``) to convert the agent's text response to audio
 - **STT only**: configure ``speech_to_text_platform`` along with ``stt_model`` (and optionally ``stt_options``) to transcribe audio input before sending it to the agent
 - **STS**: configure both for a full speech-to-speech pipeline
+
+Any platform tagged with ``ai.platform.speech`` can be used as ``text_to_speech_platform`` or ``speech_to_text_platform``. The
+``cartesia``, ``elevenlabs`` and ``inworld`` platforms expose this tag out of the box.
 
 Speech is disabled by default and can be disabled when needed with ``speech: false``:
 

--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -60,6 +60,8 @@ Advanced Example with Multiple Agents
                 api_key: '%env(DEEPGRAM_API_KEY)%'
             elevenlabs:
                 api_key: '%env(ELEVEN_LABS_API_KEY)%'
+            inworld:
+                api_key: '%env(INWORLD_API_KEY)%'
             gemini:
                 api_key: '%env(GEMINI_API_KEY)%'
             perplexity:
@@ -1399,6 +1401,9 @@ must be configured. Both can be enabled independently:
 - **TTS only**: configure ``text_to_speech_platform`` along with ``tts_model`` (and optionally ``tts_options``) to convert the agent's text response to audio
 - **STT only**: configure ``speech_to_text_platform`` along with ``stt_model`` (and optionally ``stt_options``) to transcribe audio input before sending it to the agent
 - **STS**: configure both for a full speech-to-speech pipeline
+
+Any platform tagged with ``ai.platform.speech`` can be used as ``text_to_speech_platform`` or ``speech_to_text_platform``. The
+``cartesia``, ``elevenlabs`` and ``inworld`` platforms expose this tag out of the box.
 
 Speech is disabled by default and can be disabled when needed with ``speech: false``:
 

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -126,6 +126,8 @@ Supported Models & Platforms
   * `ElevenLabs STT`_ with `ElevenLabs`_ as Platform
   * `Cartesia TTS`_ with `Cartesia`_ as Platform
   * `Cartesia STT`_ with `Cartesia`_ as Platform
+  * `Inworld TTS`_ with `Inworld`_ as Platform
+  * `Inworld STT`_ with `Inworld`_ as Platform
 * **Image/Video Models**
   * `Decart T2I`_ with `Decart`_  as Platform
   * `Decart T2V`_ with `Decart`_  as Platform
@@ -1008,6 +1010,9 @@ Code Examples
 .. _`ElevenLabs`: https://elevenlabs.io/
 .. _`ElevenLabs STT`: https://elevenlabs.io/speech-to-text
 .. _`ElevenLabs TTS`: https://elevenlabs.io/text-to-speech
+.. _`Inworld`: https://inworld.ai/
+.. _`Inworld STT`: https://docs.inworld.ai/api-reference/sttAPI/speechtotext/transcribe
+.. _`Inworld TTS`: https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech
 .. _`LiteLLM example`: https://github.com/symfony/ai/blob/main/examples/litellm/chat.php
 .. _`Meta's Llama`: https://www.llama.com/
 .. _`Ollama`: https://ollama.com/

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -156,6 +156,8 @@ Supported Models & Platforms
   * `ElevenLabs STT`_ with `ElevenLabs`_ as Platform
   * `Cartesia TTS`_ with `Cartesia`_ as Platform
   * `Cartesia STT`_ with `Cartesia`_ as Platform
+  * `Inworld TTS`_ with `Inworld`_ as Platform
+  * `Inworld STT`_ with `Inworld`_ as Platform
   * `Deepgram TTS`_ with `Deepgram`_ as Platform
   * `Deepgram STT`_ with `Deepgram`_ as Platform
 
@@ -1606,6 +1608,9 @@ Code Examples
 .. _`ElevenLabs`: https://elevenlabs.io/
 .. _`ElevenLabs STT`: https://elevenlabs.io/speech-to-text
 .. _`ElevenLabs TTS`: https://elevenlabs.io/text-to-speech
+.. _`Inworld`: https://inworld.ai/
+.. _`Inworld STT`: https://docs.inworld.ai/api-reference/sttAPI/speechtotext/transcribe
+.. _`Inworld TTS`: https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech
 .. _`LiteLLM example`: https://github.com/symfony/ai/blob/main/examples/litellm/chat.php
 .. _`Meta's Llama`: https://www.llama.com/
 .. _`Ollama`: https://ollama.com/

--- a/docs/components/platform/inworld.rst
+++ b/docs/components/platform/inworld.rst
@@ -1,0 +1,176 @@
+Inworld
+=======
+
+Inworld provides text-to-speech (TTS) and speech-to-text (STT) models accessible through a REST API. The
+Symfony AI Platform component ships a bridge for synchronous synthesis, streaming synthesis (line-delimited
+JSON) and transcription.
+
+For comprehensive information about Inworld, see the `Inworld API reference`_.
+
+Setup
+-----
+
+Authentication
+~~~~~~~~~~~~~~
+
+Inworld authenticates REST API requests with the Base64 API key issued from the `Inworld Portal`_. The
+bridge attaches it as an ``Authorization: Basic <api-key>`` header.
+
+.. code-block:: bash
+
+    INWORLD_API_KEY=...
+
+Custom HTTP Client
+~~~~~~~~~~~~~~~~~~
+
+The factory accepts any ``Symfony\Contracts\HttpClient\HttpClientInterface`` instance, which lets you wire
+custom timeouts, retries, proxies, or instrumentation::
+
+    use Symfony\AI\Platform\Bridge\Inworld\Factory;
+    use Symfony\Component\HttpClient\HttpClient;
+    use Symfony\Component\HttpClient\RetryableHttpClient;
+
+    $httpClient = new RetryableHttpClient(
+        HttpClient::create(['timeout' => 30, 'max_duration' => 60]),
+    );
+
+    $platform = Factory::createPlatform(
+        apiKey: $_ENV['INWORLD_API_KEY'],
+        httpClient: $httpClient,
+    );
+
+You can also provide a preconfigured ``ScopingHttpClient`` that already carries the ``Authorization`` header
+and the base URI — in that case omit the ``apiKey`` argument and the bridge skips its own header attachment::
+
+    use Symfony\AI\Platform\Bridge\Inworld\Factory;
+    use Symfony\Component\HttpClient\HttpClient;
+    use Symfony\Component\HttpClient\ScopingHttpClient;
+
+    $httpClient = ScopingHttpClient::forBaseUri(
+        HttpClient::create(),
+        'https://api.inworld.ai/',
+        ['headers' => ['Authorization' => 'Basic '.$_ENV['INWORLD_API_KEY']]],
+    );
+
+    $platform = Factory::createPlatform(httpClient: $httpClient);
+
+In the bundle, point the ``http_client`` option at any service that implements
+``HttpClientInterface``:
+
+.. code-block:: yaml
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            inworld:
+                http_client: 'ai.inworld'
+
+Usage
+-----
+
+Text-to-Speech (synchronous)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Synchronous TTS returns a ``BinaryResult`` containing decoded MP3 bytes::
+
+    use Symfony\AI\Platform\Bridge\Inworld\Factory;
+    use Symfony\AI\Platform\Message\Content\Text;
+
+    $platform = Factory::createPlatform(apiKey: $_ENV['INWORLD_API_KEY']);
+
+    $result = $platform->invoke('inworld-tts-2', new Text('The first move is what sets everything in motion.'), [
+        'voice' => 'Dennis',
+    ]);
+
+    file_put_contents('/tmp/speech.mp3', $result->asBinary());
+
+Available models: ``inworld-tts-1``, ``inworld-tts-1-max``, ``inworld-tts-1.5-mini``, ``inworld-tts-1.5-max``,
+``inworld-tts-2`` (the catalog is also fetched dynamically from the Inworld API and may include more entries).
+
+Common options:
+
+* ``voice`` (required) — voice identifier (e.g. ``Dennis``).
+* ``audioConfig`` — audio encoding settings; defaults to ``{ audioEncoding: 'MP3', sampleRateHertz: 48000 }``.
+* ``language`` — BCP-47 tag (``en-US``, ``fr-FR``, ``ja-JP``, …); auto-detected when omitted.
+* ``temperature`` — float in ``]0, 2]``; default ``1.0``.
+* ``deliveryMode`` — ``STABLE``, ``BALANCED``, or ``CREATIVE`` (TTS-2 only).
+
+Text-to-Speech (streaming)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set ``stream: true`` to receive a ``StreamResult`` yielding ``BinaryDelta`` chunks as the audio is generated::
+
+    use Symfony\AI\Platform\Bridge\Inworld\Factory;
+    use Symfony\AI\Platform\Message\Content\Text;
+    use Symfony\AI\Platform\Result\Stream\Delta\BinaryDelta;
+
+    $platform = Factory::createPlatform(apiKey: $_ENV['INWORLD_API_KEY']);
+
+    $result = $platform->invoke('inworld-tts-2', new Text('The first move is what sets everything in motion.'), [
+        'voice' => 'Dennis',
+        'stream' => true,
+    ]);
+
+    foreach ($result->asStream() as $chunk) {
+        if ($chunk instanceof BinaryDelta) {
+            echo $chunk->getData();
+        }
+    }
+
+The bridge consumes the Inworld NDJSON stream, decodes each chunk's base64 ``audioContent``, and yields the
+raw bytes through ``BinaryDelta``. Pipe the output directly to a player or aggregate it into a file.
+
+Speech-to-Text
+~~~~~~~~~~~~~~
+
+Pass an ``Audio`` content object to a transcription model to obtain a ``TextResult``::
+
+    use Symfony\AI\Platform\Bridge\Inworld\Factory;
+    use Symfony\AI\Platform\Message\Content\Audio;
+
+    $platform = Factory::createPlatform(apiKey: $_ENV['INWORLD_API_KEY']);
+
+    $result = $platform->invoke(
+        'inworld/inworld-stt-1',
+        Audio::fromFile('/path/to/audio.mp3'),
+    );
+
+    echo $result->asText();
+
+Available STT models: ``inworld/inworld-stt-1``, ``groq/whisper-large-v3``.
+
+Common options (placed under ``transcribeConfig`` by the bridge):
+
+* ``audioEncoding`` — ``AUTO_DETECT`` (default), ``LINEAR16``, ``MP3``, ``OGG_OPUS``, ``FLAC``.
+* ``language`` — BCP-47 tag; auto-detected when omitted.
+* ``sampleRateHertz`` — defaults to ``16000``.
+* ``includeWordTimestamps`` — boolean; default ``false``.
+
+Bundle Configuration
+--------------------
+
+When the bridge is exposed through ``symfony/ai-bundle``, configure it in your application:
+
+.. code-block:: yaml
+
+    # config/packages/ai.yaml
+    ai:
+        platform:
+            inworld:
+                api_key: '%env(INWORLD_API_KEY)%'
+
+The resulting service ``ai.platform.inworld`` is autowireable as ``PlatformInterface $inworld`` and is tagged
+``ai.platform.speech``, so it can be used as ``text_to_speech_platform`` or ``speech_to_text_platform`` in the
+agent ``speech:`` configuration.
+
+Examples
+--------
+
+See the ``examples/inworld/`` directory for complete working examples:
+
+* ``text-to-speech.php`` — Synchronous synthesis to MP3 bytes
+* ``text-to-speech-as-stream.php`` — Streaming synthesis with ``BinaryDelta`` iteration
+* ``speech-to-text.php`` — Transcription from a local audio file
+
+.. _Inworld API reference: https://docs.inworld.ai/api-reference/introduction
+.. _Inworld Portal: https://platform.inworld.ai/

--- a/examples/.env
+++ b/examples/.env
@@ -69,6 +69,9 @@ ELEVEN_LABS_API_KEY=
 CARTESIA_API_KEY=
 CARTESIA_API_VERSION=2025-04-16
 
+# For using Inworld (provide the Base64 API key from the Inworld Portal)
+INWORLD_API_KEY=
+
 # For using Decart
 DECART_ENDPOINT=https://api.decart.ai/v1
 DECART_API_KEY=

--- a/examples/.env
+++ b/examples/.env
@@ -72,6 +72,9 @@ CARTESIA_API_VERSION=2025-04-16
 # For using Deepgram
 DEEPGRAM_API_KEY=
 
+# For using Inworld (provide the Base64 API key from the Inworld Portal)
+INWORLD_API_KEY=
+
 # For using Decart
 DECART_ENDPOINT=https://api.decart.ai/v1
 DECART_API_KEY=

--- a/examples/inworld/README.md
+++ b/examples/inworld/README.md
@@ -1,0 +1,12 @@
+# Inworld Examples
+
+Inworld provides text-to-speech and speech-to-text models. The bridge supports synchronous and streaming TTS.
+
+To run the examples, you can use additional tools like [mpg123](https://www.mpg123.de/):
+
+```bash
+php inworld/text-to-speech.php | mpg123 -
+php inworld/text-to-speech-as-stream.php | mpg123 -
+```
+
+Authentication uses the Base64 API key from the [Inworld Portal](https://platform.inworld.ai/). See the [Inworld API introduction](https://docs.inworld.ai/api-reference/introduction) for details.

--- a/examples/inworld/speech-to-text.php
+++ b/examples/inworld/speech-to-text.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Inworld\Factory;
+use Symfony\AI\Platform\Message\Content\Audio;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(
+    apiKey: env('INWORLD_API_KEY'),
+    httpClient: http_client(),
+);
+
+$result = $platform->invoke('inworld/inworld-stt-1', Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3'));
+
+echo $result->asText().\PHP_EOL;

--- a/examples/inworld/text-to-speech-as-stream.php
+++ b/examples/inworld/text-to-speech-as-stream.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Inworld\Factory;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Result\Stream\Delta\BinaryDelta;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(
+    apiKey: env('INWORLD_API_KEY'),
+    httpClient: http_client(),
+);
+
+$result = $platform->invoke('inworld-tts-2', new Text('The first move is what sets everything in motion.'), [
+    'voice' => 'Dennis',
+    'stream' => true,
+]);
+
+foreach ($result->asStream() as $chunk) {
+    if ($chunk instanceof BinaryDelta) {
+        echo $chunk->getData();
+    }
+}
+
+echo \PHP_EOL;

--- a/examples/inworld/text-to-speech.php
+++ b/examples/inworld/text-to-speech.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Inworld\Factory;
+use Symfony\AI\Platform\Message\Content\Text;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(
+    apiKey: env('INWORLD_API_KEY'),
+    httpClient: http_client(),
+);
+
+$result = $platform->invoke('inworld-tts-2', new Text('The first move is what sets everything in motion.'), [
+    'voice' => 'Dennis',
+]);
+
+echo $result->asBinary().\PHP_EOL;

--- a/splitsh.json
+++ b/splitsh.json
@@ -60,6 +60,7 @@
         "ai-gemini-platform": "src/platform/src/Bridge/Gemini",
         "ai-generic-platform": "src/platform/src/Bridge/Generic",
         "ai-hugging-face-platform": "src/platform/src/Bridge/HuggingFace",
+        "ai-inworld-platform": "src/platform/src/Bridge/Inworld",
         "ai-lm-studio-platform": "src/platform/src/Bridge/LmStudio",
         "ai-meta-platform": "src/platform/src/Bridge/Meta",
         "ai-mistral-platform": "src/platform/src/Bridge/Mistral",

--- a/splitsh.json
+++ b/splitsh.json
@@ -61,6 +61,7 @@
         "ai-gemini-platform": "src/platform/src/Bridge/Gemini",
         "ai-generic-platform": "src/platform/src/Bridge/Generic",
         "ai-hugging-face-platform": "src/platform/src/Bridge/HuggingFace",
+        "ai-inworld-platform": "src/platform/src/Bridge/Inworld",
         "ai-lm-studio-platform": "src/platform/src/Bridge/LmStudio",
         "ai-meta-platform": "src/platform/src/Bridge/Meta",
         "ai-mini-max-platform": "src/platform/src/Bridge/MiniMax",

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * The `endpoint` option for `Meilisearch` is now `null` by default to allow the usage of a `ScopingHttpClient`
  * Wire `Meilisearch\StoreFactory` from `AiBundle`
  * Add `lang` option for `Postgres`
+ * Add `inworld` platform configuration for TTS and STT
 
 0.8
 ---

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Add `inworld` platform configuration for TTS and STT
+
 0.11
 ----
 

--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -63,6 +63,7 @@
         "symfony/ai-gemini-platform": "^0.9",
         "symfony/ai-generic-platform": "^0.9",
         "symfony/ai-hugging-face-platform": "^0.9",
+        "symfony/ai-inworld-platform": "^0.9",
         "symfony/ai-lm-studio-platform": "^0.9",
         "symfony/ai-manticore-search-store": "^0.9",
         "symfony/ai-maria-db-store": "^0.9",

--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -64,6 +64,7 @@
         "symfony/ai-gemini-platform": "^0.11",
         "symfony/ai-generic-platform": "^0.11",
         "symfony/ai-hugging-face-platform": "^0.11",
+        "symfony/ai-inworld-platform": "^0.11",
         "symfony/ai-lm-studio-platform": "^0.11",
         "symfony/ai-manticore-search-store": "^0.11",
         "symfony/ai-maria-db-store": "^0.11",

--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -44,6 +44,7 @@ return static function (DefinitionConfigurator $configurator): void {
                     ->append($import('platform/gemini'))
                     ->append($import('platform/generic'))
                     ->append($import('platform/huggingface'))
+                    ->append($import('platform/inworld'))
                     ->append($import('platform/lmstudio'))
                     ->append($import('platform/mistral'))
                     ->append($import('platform/ollama'))

--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -46,6 +46,7 @@ return static function (DefinitionConfigurator $configurator): void {
                     ->append($import('platform/gemini'))
                     ->append($import('platform/generic'))
                     ->append($import('platform/huggingface'))
+                    ->append($import('platform/inworld'))
                     ->append($import('platform/lmstudio'))
                     ->append($import('platform/minimax'))
                     ->append($import('platform/mistral'))

--- a/src/ai-bundle/config/platform/inworld.php
+++ b/src/ai-bundle/config/platform/inworld.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition\Configurator;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+return (new ArrayNodeDefinition('inworld'))
+    ->children()
+        ->stringNode('api_key')->end()
+        ->stringNode('endpoint')
+            ->defaultValue('https://api.inworld.ai/')
+        ->end()
+        ->stringNode('http_client')
+            ->defaultValue('http_client')
+            ->info('Service ID of the HTTP client to use')
+        ->end()
+    ->end();

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -43,6 +43,7 @@ use Symfony\AI\Platform\Bridge\Gemini\Contract\GeminiContract;
 use Symfony\AI\Platform\Bridge\Gemini\ModelCatalog as GeminiModelCatalog;
 use Symfony\AI\Platform\Bridge\HuggingFace\Contract\HuggingFaceContract;
 use Symfony\AI\Platform\Bridge\HuggingFace\ModelCatalog as HuggingFaceModelCatalog;
+use Symfony\AI\Platform\Bridge\Inworld\Contract\InworldContract;
 use Symfony\AI\Platform\Bridge\LmStudio\ModelCatalog as LmStudioModelCatalog;
 use Symfony\AI\Platform\Bridge\Meta\ModelCatalog as MetaModelCatalog;
 use Symfony\AI\Platform\Bridge\Mistral\ModelCatalog as MistralModelCatalog;
@@ -96,6 +97,8 @@ return static function (ContainerConfigurator $container): void {
             ->factory([GeminiContract::class, 'create'])
         ->set('ai.platform.contract.huggingface', Contract::class)
             ->factory([HuggingFaceContract::class, 'create'])
+        ->set('ai.platform.contract.inworld', Contract::class)
+            ->factory([InworldContract::class, 'create'])
         ->set('ai.platform.contract.vertexai.gemini', Contract::class)
             ->factory([VertexAiGeminiContract::class, 'create'])
         ->set('ai.platform.contract.ollama', Contract::class)

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -44,6 +44,7 @@ use Symfony\AI\Platform\Bridge\Gemini\Contract\GeminiContract;
 use Symfony\AI\Platform\Bridge\Gemini\ModelCatalog as GeminiModelCatalog;
 use Symfony\AI\Platform\Bridge\HuggingFace\Contract\HuggingFaceContract;
 use Symfony\AI\Platform\Bridge\HuggingFace\ModelCatalog as HuggingFaceModelCatalog;
+use Symfony\AI\Platform\Bridge\Inworld\Contract\InworldContract;
 use Symfony\AI\Platform\Bridge\LmStudio\ModelCatalog as LmStudioModelCatalog;
 use Symfony\AI\Platform\Bridge\Meta\ModelCatalog as MetaModelCatalog;
 use Symfony\AI\Platform\Bridge\MiniMax\Contract\MiniMaxContract;
@@ -104,6 +105,8 @@ return static function (ContainerConfigurator $container): void {
             ->factory([GeminiContract::class, 'create'])
         ->set('ai.platform.contract.huggingface', Contract::class)
             ->factory([HuggingFaceContract::class, 'create'])
+        ->set('ai.platform.contract.inworld', Contract::class)
+            ->factory([InworldContract::class, 'create'])
         ->set('ai.platform.contract.minimax', Contract::class)
             ->factory([MiniMaxContract::class, 'create'])
         ->set('ai.platform.contract.vertexai.gemini', Contract::class)

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -72,6 +72,7 @@ use Symfony\AI\Platform\Bridge\Gemini\Factory as GeminiFactory;
 use Symfony\AI\Platform\Bridge\Generic\Factory as GenericFactory;
 use Symfony\AI\Platform\Bridge\Generic\FallbackModelCatalog as GenericFallbackModelCatalog;
 use Symfony\AI\Platform\Bridge\HuggingFace\Factory as HuggingFaceFactory;
+use Symfony\AI\Platform\Bridge\Inworld\Factory as InworldFactory;
 use Symfony\AI\Platform\Bridge\LmStudio\Factory as LmStudioFactory;
 use Symfony\AI\Platform\Bridge\Mistral\Factory as MistralFactory;
 use Symfony\AI\Platform\Bridge\Ollama\Factory as OllamaFactory;
@@ -632,6 +633,31 @@ final class AiBundle extends AbstractBundle
 
             $definition = (new Definition(Platform::class))
                 ->setFactory(ElevenLabsFactory::class.'::createPlatform')
+                ->setLazy(true)
+                ->setArguments([
+                    $platform['endpoint'],
+                    $platform['api_key'] ?? null,
+                    new Reference($platform['http_client']),
+                    new Reference('ai.platform.contract.'.$type),
+                    new Reference('event_dispatcher'),
+                ])
+                ->addTag('proxy', ['interface' => PlatformInterface::class])
+                ->addTag('ai.platform.speech', ['name' => $type])
+                ->addTag('ai.platform', ['name' => $type]);
+
+            $container->setDefinition('ai.platform.'.$type, $definition);
+            $container->registerAliasForArgument('ai.platform.'.$type, PlatformInterface::class, $type);
+
+            return;
+        }
+
+        if ('inworld' === $type) {
+            if (!ContainerBuilder::willBeAvailable('symfony/ai-inworld-platform', InworldFactory::class, ['symfony/ai-bundle'])) {
+                throw new RuntimeException('Inworld platform configuration requires "symfony/ai-inworld-platform" package. Try running "composer require symfony/ai-inworld-platform".');
+            }
+
+            $definition = (new Definition(Platform::class))
+                ->setFactory(InworldFactory::class.'::createPlatform')
                 ->setLazy(true)
                 ->setArguments([
                     $platform['endpoint'],

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -74,6 +74,7 @@ use Symfony\AI\Platform\Bridge\Gemini\Factory as GeminiFactory;
 use Symfony\AI\Platform\Bridge\Generic\Factory as GenericFactory;
 use Symfony\AI\Platform\Bridge\Generic\FallbackModelCatalog as GenericFallbackModelCatalog;
 use Symfony\AI\Platform\Bridge\HuggingFace\Factory as HuggingFaceFactory;
+use Symfony\AI\Platform\Bridge\Inworld\Factory as InworldFactory;
 use Symfony\AI\Platform\Bridge\LmStudio\Factory as LmStudioFactory;
 use Symfony\AI\Platform\Bridge\MiniMax\Factory as MiniMaxFactory;
 use Symfony\AI\Platform\Bridge\Mistral\Factory as MistralFactory;
@@ -642,6 +643,31 @@ final class AiBundle extends AbstractBundle
 
             $definition = (new Definition(Platform::class))
                 ->setFactory(ElevenLabsFactory::class.'::createPlatform')
+                ->setLazy(true)
+                ->setArguments([
+                    $platform['endpoint'],
+                    $platform['api_key'] ?? null,
+                    new Reference($platform['http_client']),
+                    new Reference('ai.platform.contract.'.$type),
+                    new Reference('event_dispatcher'),
+                ])
+                ->addTag('proxy', ['interface' => PlatformInterface::class])
+                ->addTag('ai.platform.speech', ['name' => $type])
+                ->addTag('ai.platform', ['name' => $type]);
+
+            $container->setDefinition('ai.platform.'.$type, $definition);
+            $container->registerAliasForArgument('ai.platform.'.$type, PlatformInterface::class, $type);
+
+            return;
+        }
+
+        if ('inworld' === $type) {
+            if (!ContainerBuilder::willBeAvailable('symfony/ai-inworld-platform', InworldFactory::class, ['symfony/ai-bundle'])) {
+                throw new RuntimeException('Inworld platform configuration requires "symfony/ai-inworld-platform" package. Try running "composer require symfony/ai-inworld-platform".');
+            }
+
+            $definition = (new Definition(Platform::class))
+                ->setFactory(InworldFactory::class.'::createPlatform')
                 ->setLazy(true)
                 ->setArguments([
                     $platform['endpoint'],

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -38,6 +38,7 @@ use Symfony\AI\Platform\Bridge\Decart\Factory as DecartFactory;
 use Symfony\AI\Platform\Bridge\ElevenLabs\Factory as ElevenLabsFactory;
 use Symfony\AI\Platform\Bridge\Failover\FailoverPlatform;
 use Symfony\AI\Platform\Bridge\Failover\FailoverPlatformFactory;
+use Symfony\AI\Platform\Bridge\Inworld\Factory as InworldFactory;
 use Symfony\AI\Platform\Bridge\Ollama\Factory as OllamaFactory;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\EventListener\TemplateRendererListener;
@@ -4564,6 +4565,156 @@ class AiBundleTest extends TestCase
         $this->assertSame([['name' => 'elevenlabs']], $definition->getTag('ai.platform'));
 
         $this->assertTrue($container->hasAlias(PlatformInterface::class.' $elevenlabs'));
+        $this->assertTrue($container->hasAlias(PlatformInterface::class));
+    }
+
+    public function testInworldPlatformCanBeConfigured()
+    {
+        // Default endpoint + API key
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'inworld' => [
+                        'api_key' => 'api-key',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.inworld'));
+
+        $definition = $container->getDefinition('ai.platform.inworld');
+        $this->assertSame([InworldFactory::class, 'createPlatform'], $definition->getFactory());
+        $this->assertTrue($definition->isLazy());
+
+        $this->assertCount(5, $definition->getArguments());
+        $this->assertSame('https://api.inworld.ai/', $definition->getArgument(0));
+        $this->assertSame('api-key', $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('http_client', (string) $definition->getArgument(2));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
+        $this->assertSame('ai.platform.contract.inworld', (string) $definition->getArgument(3));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(4));
+        $this->assertSame('event_dispatcher', (string) $definition->getArgument(4));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.platform'));
+        $this->assertSame([['name' => 'inworld']], $definition->getTag('ai.platform'));
+        $this->assertTrue($definition->hasTag('ai.platform.speech'));
+        $this->assertSame([['name' => 'inworld']], $definition->getTag('ai.platform.speech'));
+
+        $this->assertTrue($container->hasAlias(PlatformInterface::class.' $inworld'));
+        $this->assertTrue($container->hasAlias(PlatformInterface::class));
+
+        // Custom endpoint + API key
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'inworld' => [
+                        'endpoint' => 'https://staging.api.inworld.ai/',
+                        'api_key' => 'api-key',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.inworld'));
+
+        $definition = $container->getDefinition('ai.platform.inworld');
+        $this->assertSame([InworldFactory::class, 'createPlatform'], $definition->getFactory());
+        $this->assertTrue($definition->isLazy());
+
+        $this->assertCount(5, $definition->getArguments());
+        $this->assertSame('https://staging.api.inworld.ai/', $definition->getArgument(0));
+        $this->assertSame('api-key', $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('http_client', (string) $definition->getArgument(2));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
+        $this->assertSame('ai.platform.contract.inworld', (string) $definition->getArgument(3));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(4));
+        $this->assertSame('event_dispatcher', (string) $definition->getArgument(4));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.platform'));
+        $this->assertSame([['name' => 'inworld']], $definition->getTag('ai.platform'));
+        $this->assertTrue($definition->hasTag('ai.platform.speech'));
+
+        $this->assertTrue($container->hasAlias(PlatformInterface::class.' $inworld'));
+        $this->assertTrue($container->hasAlias(PlatformInterface::class));
+
+        // Custom http client + API key
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'inworld' => [
+                        'api_key' => 'api-key',
+                        'http_client' => 'custom_http_client',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.inworld'));
+
+        $definition = $container->getDefinition('ai.platform.inworld');
+        $this->assertSame([InworldFactory::class, 'createPlatform'], $definition->getFactory());
+        $this->assertTrue($definition->isLazy());
+
+        $this->assertCount(5, $definition->getArguments());
+        $this->assertSame('https://api.inworld.ai/', $definition->getArgument(0));
+        $this->assertSame('api-key', $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('custom_http_client', (string) $definition->getArgument(2));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
+        $this->assertSame('ai.platform.contract.inworld', (string) $definition->getArgument(3));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(4));
+        $this->assertSame('event_dispatcher', (string) $definition->getArgument(4));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.platform'));
+        $this->assertSame([['name' => 'inworld']], $definition->getTag('ai.platform'));
+        $this->assertTrue($definition->hasTag('ai.platform.speech'));
+
+        $this->assertTrue($container->hasAlias(PlatformInterface::class.' $inworld'));
+        $this->assertTrue($container->hasAlias(PlatformInterface::class));
+
+        // Scoped http client (preconfigured with the API key externally)
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'inworld' => [
+                        'http_client' => 'custom_scoped',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.inworld'));
+
+        $definition = $container->getDefinition('ai.platform.inworld');
+        $this->assertSame([InworldFactory::class, 'createPlatform'], $definition->getFactory());
+        $this->assertTrue($definition->isLazy());
+
+        $this->assertCount(5, $definition->getArguments());
+        $this->assertSame('https://api.inworld.ai/', $definition->getArgument(0));
+        $this->assertNull($definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('custom_scoped', (string) $definition->getArgument(2));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
+        $this->assertSame('ai.platform.contract.inworld', (string) $definition->getArgument(3));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(4));
+        $this->assertSame('event_dispatcher', (string) $definition->getArgument(4));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.platform'));
+        $this->assertSame([['name' => 'inworld']], $definition->getTag('ai.platform'));
+        $this->assertTrue($definition->hasTag('ai.platform.speech'));
+
+        $this->assertTrue($container->hasAlias(PlatformInterface::class.' $inworld'));
         $this->assertTrue($container->hasAlias(PlatformInterface::class));
     }
 

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -40,6 +40,7 @@ use Symfony\AI\Platform\Bridge\Deepgram\Factory as DeepgramFactory;
 use Symfony\AI\Platform\Bridge\ElevenLabs\Factory as ElevenLabsFactory;
 use Symfony\AI\Platform\Bridge\Failover\FailoverPlatform;
 use Symfony\AI\Platform\Bridge\Failover\FailoverPlatformFactory;
+use Symfony\AI\Platform\Bridge\Inworld\Factory as InworldFactory;
 use Symfony\AI\Platform\Bridge\MiniMax\Factory as MiniMaxFactory;
 use Symfony\AI\Platform\Bridge\Ollama\Factory as OllamaFactory;
 use Symfony\AI\Platform\Capability;
@@ -5056,6 +5057,156 @@ class AiBundleTest extends TestCase
         $this->assertSame([['name' => 'deepgram']], $definition->getTag('ai.platform.speech'));
         $this->assertTrue($definition->hasTag('ai.platform'));
         $this->assertSame([['name' => 'deepgram']], $definition->getTag('ai.platform'));
+    }
+
+    public function testInworldPlatformCanBeConfigured()
+    {
+        // Default endpoint + API key
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'inworld' => [
+                        'api_key' => 'api-key',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.inworld'));
+
+        $definition = $container->getDefinition('ai.platform.inworld');
+        $this->assertSame([InworldFactory::class, 'createPlatform'], $definition->getFactory());
+        $this->assertTrue($definition->isLazy());
+
+        $this->assertCount(5, $definition->getArguments());
+        $this->assertSame('https://api.inworld.ai/', $definition->getArgument(0));
+        $this->assertSame('api-key', $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('http_client', (string) $definition->getArgument(2));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
+        $this->assertSame('ai.platform.contract.inworld', (string) $definition->getArgument(3));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(4));
+        $this->assertSame('event_dispatcher', (string) $definition->getArgument(4));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.platform'));
+        $this->assertSame([['name' => 'inworld']], $definition->getTag('ai.platform'));
+        $this->assertTrue($definition->hasTag('ai.platform.speech'));
+        $this->assertSame([['name' => 'inworld']], $definition->getTag('ai.platform.speech'));
+
+        $this->assertTrue($container->hasAlias(PlatformInterface::class.' $inworld'));
+        $this->assertTrue($container->hasAlias(PlatformInterface::class));
+
+        // Custom endpoint + API key
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'inworld' => [
+                        'endpoint' => 'https://staging.api.inworld.ai/',
+                        'api_key' => 'api-key',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.inworld'));
+
+        $definition = $container->getDefinition('ai.platform.inworld');
+        $this->assertSame([InworldFactory::class, 'createPlatform'], $definition->getFactory());
+        $this->assertTrue($definition->isLazy());
+
+        $this->assertCount(5, $definition->getArguments());
+        $this->assertSame('https://staging.api.inworld.ai/', $definition->getArgument(0));
+        $this->assertSame('api-key', $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('http_client', (string) $definition->getArgument(2));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
+        $this->assertSame('ai.platform.contract.inworld', (string) $definition->getArgument(3));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(4));
+        $this->assertSame('event_dispatcher', (string) $definition->getArgument(4));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.platform'));
+        $this->assertSame([['name' => 'inworld']], $definition->getTag('ai.platform'));
+        $this->assertTrue($definition->hasTag('ai.platform.speech'));
+
+        $this->assertTrue($container->hasAlias(PlatformInterface::class.' $inworld'));
+        $this->assertTrue($container->hasAlias(PlatformInterface::class));
+
+        // Custom http client + API key
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'inworld' => [
+                        'api_key' => 'api-key',
+                        'http_client' => 'custom_http_client',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.inworld'));
+
+        $definition = $container->getDefinition('ai.platform.inworld');
+        $this->assertSame([InworldFactory::class, 'createPlatform'], $definition->getFactory());
+        $this->assertTrue($definition->isLazy());
+
+        $this->assertCount(5, $definition->getArguments());
+        $this->assertSame('https://api.inworld.ai/', $definition->getArgument(0));
+        $this->assertSame('api-key', $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('custom_http_client', (string) $definition->getArgument(2));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
+        $this->assertSame('ai.platform.contract.inworld', (string) $definition->getArgument(3));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(4));
+        $this->assertSame('event_dispatcher', (string) $definition->getArgument(4));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.platform'));
+        $this->assertSame([['name' => 'inworld']], $definition->getTag('ai.platform'));
+        $this->assertTrue($definition->hasTag('ai.platform.speech'));
+
+        $this->assertTrue($container->hasAlias(PlatformInterface::class.' $inworld'));
+        $this->assertTrue($container->hasAlias(PlatformInterface::class));
+
+        // Scoped http client (preconfigured with the API key externally)
+        $container = $this->buildContainer([
+            'ai' => [
+                'platform' => [
+                    'inworld' => [
+                        'http_client' => 'custom_scoped',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.platform.inworld'));
+
+        $definition = $container->getDefinition('ai.platform.inworld');
+        $this->assertSame([InworldFactory::class, 'createPlatform'], $definition->getFactory());
+        $this->assertTrue($definition->isLazy());
+
+        $this->assertCount(5, $definition->getArguments());
+        $this->assertSame('https://api.inworld.ai/', $definition->getArgument(0));
+        $this->assertNull($definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('custom_scoped', (string) $definition->getArgument(2));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(3));
+        $this->assertSame('ai.platform.contract.inworld', (string) $definition->getArgument(3));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(4));
+        $this->assertSame('event_dispatcher', (string) $definition->getArgument(4));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.platform'));
+        $this->assertSame([['name' => 'inworld']], $definition->getTag('ai.platform'));
+        $this->assertTrue($definition->hasTag('ai.platform.speech'));
+
+        $this->assertTrue($container->hasAlias(PlatformInterface::class.' $inworld'));
+        $this->assertTrue($container->hasAlias(PlatformInterface::class));
     }
 
     public function testFailoverPlatformCanBeCreated()

--- a/src/ai-bundle/tests/DependencyInjection/BridgeConfigCompilationTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/BridgeConfigCompilationTest.php
@@ -311,6 +311,7 @@ class BridgeConfigCompilationTest extends TestCase
         yield 'gemini' => ['gemini', ['api_key' => 'k'], 'ai.platform.gemini'];
         yield 'generic' => ['generic', ['inst' => ['base_url' => 'http://localhost:8080']], 'ai.platform.generic.inst'];
         yield 'huggingface' => ['huggingface', ['api_key' => 'k'], 'ai.platform.huggingface'];
+        yield 'inworld' => ['inworld', ['api_key' => 'k'], 'ai.platform.inworld'];
         yield 'lmstudio' => ['lmstudio', ['host_url' => 'http://localhost:1234'], 'ai.platform.lmstudio'];
         yield 'mistral' => ['mistral', ['api_key' => 'k'], 'ai.platform.mistral'];
         yield 'ollama' => ['ollama', [], 'ai.platform.ollama'];

--- a/src/ai-bundle/tests/DependencyInjection/BridgeConfigCompilationTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/BridgeConfigCompilationTest.php
@@ -312,6 +312,7 @@ class BridgeConfigCompilationTest extends TestCase
         yield 'gemini' => ['gemini', ['api_key' => 'k'], 'ai.platform.gemini'];
         yield 'generic' => ['generic', ['inst' => ['base_url' => 'http://localhost:8080']], 'ai.platform.generic.inst'];
         yield 'huggingface' => ['huggingface', ['api_key' => 'k'], 'ai.platform.huggingface'];
+        yield 'inworld' => ['inworld', ['api_key' => 'k'], 'ai.platform.inworld'];
         yield 'lmstudio' => ['lmstudio', ['host_url' => 'http://localhost:1234'], 'ai.platform.lmstudio'];
         yield 'minimax' => ['minimax', ['api_key' => 'k'], 'ai.platform.minimax'];
         yield 'mistral' => ['mistral', ['api_key' => 'k'], 'ai.platform.mistral'];

--- a/src/platform/src/Bridge/Inworld/.gitattributes
+++ b/src/platform/src/Bridge/Inworld/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/platform/src/Bridge/Inworld/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/platform/src/Bridge/Inworld/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/ai
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/platform/src/Bridge/Inworld/.github/workflows/close-pull-request.yml
+++ b/src/platform/src/Bridge/Inworld/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/ai
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/platform/src/Bridge/Inworld/.gitignore
+++ b/src/platform/src/Bridge/Inworld/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+phpunit.xml
+.phpunit.result.cache

--- a/src/platform/src/Bridge/Inworld/CHANGELOG.md
+++ b/src/platform/src/Bridge/Inworld/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+0.9
+---
+
+ * Add the bridge

--- a/src/platform/src/Bridge/Inworld/CHANGELOG.md
+++ b/src/platform/src/Bridge/Inworld/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+0.12
+----
+
+ * Add the bridge

--- a/src/platform/src/Bridge/Inworld/Contract/AudioNormalizer.php
+++ b/src/platform/src/Bridge/Inworld/Contract/AudioNormalizer.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld\Contract;
+
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class AudioNormalizer implements NormalizerInterface
+{
+    /**
+     * @param Audio $data
+     *
+     * @return array{type: 'input_audio', input_audio: array{
+     *     data: string,
+     *     path: string|null,
+     *     format: 'mp3'|'wav'|string,
+     * }}
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        return [
+            'type' => 'input_audio',
+            'input_audio' => [
+                'data' => $data->asBase64(),
+                'path' => $data->asPath(),
+                'format' => match ($data->getFormat()) {
+                    'audio/mpeg' => 'mp3',
+                    'audio/wav' => 'wav',
+                    default => $data->getFormat(),
+                },
+            ],
+        ];
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Audio;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            Audio::class => true,
+        ];
+    }
+}

--- a/src/platform/src/Bridge/Inworld/Contract/InworldContract.php
+++ b/src/platform/src/Bridge/Inworld/Contract/InworldContract.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld\Contract;
+
+use Symfony\AI\Platform\Contract;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class InworldContract extends Contract
+{
+    /**
+     * @param NormalizerInterface[] $normalizers
+     */
+    public static function create(array $normalizers = []): Contract
+    {
+        return parent::create([
+            new AudioNormalizer(),
+            ...$normalizers,
+        ]);
+    }
+}

--- a/src/platform/src/Bridge/Inworld/Factory.php
+++ b/src/platform/src/Bridge/Inworld/Factory.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld;
+
+use Symfony\AI\Platform\Bridge\Inworld\Contract\InworldContract;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\ModelRouter\CatalogBasedModelRouter;
+use Symfony\AI\Platform\ModelRouterInterface;
+use Symfony\AI\Platform\Platform;
+use Symfony\AI\Platform\Provider;
+use Symfony\AI\Platform\ProviderInterface;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\HttpClient\ScopingHttpClient;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class Factory
+{
+    /**
+     * @param non-empty-string $name
+     */
+    public static function createProvider(
+        string $endpoint = 'https://api.inworld.ai/',
+        #[\SensitiveParameter] ?string $apiKey = null,
+        ?HttpClientInterface $httpClient = null,
+        ?Contract $contract = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+        string $name = 'inworld',
+    ): ProviderInterface {
+        $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+
+        if (null !== $apiKey) {
+            $httpClient = ScopingHttpClient::forBaseUri($httpClient, $endpoint, [
+                'headers' => [
+                    'Authorization' => 'Basic '.$apiKey,
+                ],
+            ]);
+        }
+
+        return new Provider(
+            $name,
+            [new InworldClient($httpClient)],
+            [new InworldResultConverter()],
+            new ModelCatalog($httpClient),
+            $contract ?? InworldContract::create(),
+            $eventDispatcher,
+        );
+    }
+
+    /**
+     * @param non-empty-string $name
+     */
+    public static function createPlatform(
+        string $endpoint = 'https://api.inworld.ai/',
+        #[\SensitiveParameter] ?string $apiKey = null,
+        ?HttpClientInterface $httpClient = null,
+        ?Contract $contract = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+        string $name = 'inworld',
+        ?ModelRouterInterface $modelRouter = null,
+    ): Platform {
+        return new Platform(
+            [self::createProvider($endpoint, $apiKey, $httpClient, $contract, $eventDispatcher, $name)],
+            $modelRouter ?? new CatalogBasedModelRouter(),
+            $eventDispatcher,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Inworld/Inworld.php
+++ b/src/platform/src/Bridge/Inworld/Inworld.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld;
+
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class Inworld extends Model
+{
+}

--- a/src/platform/src/Bridge/Inworld/InworldClient.php
+++ b/src/platform/src/Bridge/Inworld/InworldClient.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld;
+
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\Stream\NdjsonStream;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class InworldClient implements ModelClientInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+    ) {
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Inworld;
+    }
+
+    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface
+    {
+        return match (true) {
+            $model->supports(Capability::SPEECH_TO_TEXT) => $this->doSpeechToText($model, $payload, [
+                ...$options,
+                ...$model->getOptions(),
+            ]),
+            $model->supports(Capability::TEXT_TO_SPEECH) => $this->doTextToSpeech($model, $payload, [
+                ...$options,
+                ...$model->getOptions(),
+            ]),
+            default => throw new InvalidArgumentException(\sprintf('The model "%s" does not support text-to-speech or speech-to-text, please check the model information.', $model->getName())),
+        };
+    }
+
+    /**
+     * @param array<string|int, mixed> $payload
+     * @param array<string, mixed>     $options
+     */
+    private function doTextToSpeech(Model $model, array|string $payload, array $options): RawHttpResult
+    {
+        $voice = $options['voice'] ?? throw new InvalidArgumentException('The voice option is required.');
+
+        if (!\is_string($voice)) {
+            throw new InvalidArgumentException('The voice option must be a string.');
+        }
+
+        if (\is_string($payload)) {
+            $text = $payload;
+        } else {
+            $rawText = $payload['text'] ?? throw new InvalidArgumentException('The payload must contain a "text" key.');
+
+            if (!\is_string($rawText)) {
+                throw new InvalidArgumentException('The "text" key of the payload must be a string.');
+            }
+
+            $text = $rawText;
+        }
+
+        $stream = ($options['stream'] ?? false) === true;
+        $audioConfig = $options['audioConfig'] ?? [
+            'audioEncoding' => 'MP3',
+            'sampleRateHertz' => 48000,
+        ];
+
+        unset($options['voice'], $options['stream'], $options['audioConfig']);
+
+        $body = [
+            'text' => $text,
+            'voiceId' => $voice,
+            'modelId' => $model->getName(),
+            'audioConfig' => $audioConfig,
+            ...$options,
+        ];
+
+        $url = $stream ? 'tts/v1/voice:stream' : 'tts/v1/voice';
+
+        $response = $this->httpClient->request('POST', $url, [
+            'json' => $body,
+        ]);
+
+        if ($stream) {
+            return new RawHttpResult($response, new NdjsonStream());
+        }
+
+        return new RawHttpResult($response);
+    }
+
+    /**
+     * @param array<string|int, mixed> $payload
+     * @param array<string, mixed>     $options
+     */
+    private function doSpeechToText(Model $model, array|string $payload, array $options): RawHttpResult
+    {
+        if (!\is_array($payload)) {
+            throw new InvalidArgumentException(\sprintf('Payload must be an array for speech-to-text request, got "%s".', \gettype($payload)));
+        }
+
+        if (!isset($payload['input_audio']) || !\is_array($payload['input_audio'])) {
+            throw new InvalidArgumentException('Input audio is required for speech-to-text request.');
+        }
+
+        $data = $payload['input_audio']['data'] ?? null;
+
+        if (!\is_string($data) || '' === $data) {
+            throw new InvalidArgumentException('The "input_audio" entry must contain a non-empty base64 "data" key.');
+        }
+
+        $audioEncoding = $options['audioEncoding'] ?? 'AUTO_DETECT';
+
+        unset($options['audioEncoding']);
+
+        $body = [
+            'transcribeConfig' => [
+                'modelId' => $model->getName(),
+                'audioEncoding' => $audioEncoding,
+                ...$options,
+            ],
+            'audioData' => [
+                'content' => $data,
+            ],
+        ];
+
+        return new RawHttpResult($this->httpClient->request('POST', 'stt/v1/transcribe', [
+            'json' => $body,
+        ]));
+    }
+}

--- a/src/platform/src/Bridge/Inworld/InworldResultConverter.php
+++ b/src/platform/src/Bridge/Inworld/InworldResultConverter.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\BinaryDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+use Symfony\Component\HttpClient\Exception\JsonException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class InworldResultConverter implements ResultConverterInterface
+{
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Inworld;
+    }
+
+    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    {
+        $response = $result->getObject();
+
+        if (!$response instanceof ResponseInterface) {
+            throw new RuntimeException('Unexpected response object from Inworld API.');
+        }
+
+        if (200 !== $response->getStatusCode()) {
+            $errorMessage = $this->extractErrorMessage($response)
+                ?? \sprintf('The Inworld API returned a non-successful status code "%d".', $response->getStatusCode());
+
+            throw new RuntimeException($errorMessage);
+        }
+
+        $url = $this->getUrl($response);
+
+        if (str_contains($url, 'tts/v1/voice:stream')) {
+            return new StreamResult($this->convertToGenerator($result));
+        }
+
+        if (str_contains($url, 'tts/v1/voice')) {
+            $data = $result->getData();
+            $audio = $data['audioContent'] ?? null;
+
+            if (!\is_string($audio) || '' === $audio) {
+                throw new RuntimeException('The Inworld API returned an empty audio content.');
+            }
+
+            return BinaryResult::fromBase64($audio, 'audio/mpeg');
+        }
+
+        if (str_contains($url, 'stt/v1/transcribe')) {
+            $data = $result->getData();
+            $transcription = $data['transcription'] ?? null;
+
+            if (!\is_array($transcription)) {
+                throw new RuntimeException('The Inworld API returned an invalid transcription payload.');
+            }
+
+            $transcript = $transcription['transcript'] ?? null;
+
+            if (!\is_string($transcript)) {
+                throw new RuntimeException('The Inworld API returned an invalid transcription payload.');
+            }
+
+            return new TextResult($transcript);
+        }
+
+        throw new RuntimeException('Unsupported Inworld response.');
+    }
+
+    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    {
+        return null;
+    }
+
+    private function convertToGenerator(RawResultInterface $result): \Generator
+    {
+        foreach ($result->getDataStream() as $chunk) {
+            if (!\is_array($chunk)) {
+                continue;
+            }
+
+            $innerResult = $chunk['result'] ?? null;
+
+            if (!\is_array($innerResult)) {
+                continue;
+            }
+
+            $audio = $innerResult['audioContent'] ?? null;
+
+            if (!\is_string($audio) || '' === $audio) {
+                continue;
+            }
+
+            $decoded = base64_decode($audio, true);
+
+            if (false === $decoded) {
+                continue;
+            }
+
+            yield new BinaryDelta($decoded, 'audio/mpeg');
+        }
+    }
+
+    private function extractErrorMessage(ResponseInterface $response): ?string
+    {
+        try {
+            $data = $response->toArray(false);
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (isset($data['message']) && \is_string($data['message'])) {
+            return $data['message'];
+        }
+
+        if (isset($data['error']) && \is_array($data['error']) && isset($data['error']['message']) && \is_string($data['error']['message'])) {
+            return $data['error']['message'];
+        }
+
+        return null;
+    }
+
+    private function getUrl(ResponseInterface $response): string
+    {
+        $url = $response->getInfo('url');
+
+        if (!\is_string($url)) {
+            throw new RuntimeException('Unable to read the response URL from the Inworld API.');
+        }
+
+        return $url;
+    }
+}

--- a/src/platform/src/Bridge/Inworld/LICENSE
+++ b/src/platform/src/Bridge/Inworld/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/platform/src/Bridge/Inworld/ModelCatalog.php
+++ b/src/platform/src/Bridge/Inworld/ModelCatalog.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld;
+
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class ModelCatalog implements ModelCatalogInterface
+{
+    private const TTS_CAPABILITIES = [
+        Capability::TEXT_TO_SPEECH,
+        Capability::INPUT_TEXT,
+        Capability::OUTPUT_AUDIO,
+    ];
+
+    private const STT_CAPABILITIES = [
+        Capability::SPEECH_TO_TEXT,
+        Capability::INPUT_AUDIO,
+        Capability::OUTPUT_TEXT,
+    ];
+
+    /**
+     * @var array<string, array{class: class-string, capabilities: list<Capability>}>|null
+     */
+    private ?array $models = null;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+    ) {
+    }
+
+    public function getModel(string $modelName): Inworld
+    {
+        $models = $this->getModels();
+
+        if (!\array_key_exists($modelName, $models)) {
+            throw new InvalidArgumentException(\sprintf('The model "%s" cannot be retrieved from the API.', $modelName));
+        }
+
+        if ([] === $models[$modelName]['capabilities']) {
+            throw new InvalidArgumentException(\sprintf('The model "%s" is not supported, please check the Inworld API.', $modelName));
+        }
+
+        return new Inworld($modelName, $models[$modelName]['capabilities']);
+    }
+
+    public function getModels(): array
+    {
+        if (null !== $this->models) {
+            return $this->models;
+        }
+
+        $response = $this->httpClient->request('GET', 'llm/v1alpha/models');
+
+        $payload = $response->toArray(false);
+        $models = $payload['models'] ?? null;
+
+        if (!\is_array($models)) {
+            return $this->models = [];
+        }
+
+        $result = [];
+
+        foreach ($models as $model) {
+            if (!\is_array($model)) {
+                continue;
+            }
+
+            $name = $model['model'] ?? null;
+
+            if (!\is_string($name) || '' === $name) {
+                continue;
+            }
+
+            $result[$name] = [
+                'class' => Inworld::class,
+                'capabilities' => self::resolveCapabilities($model),
+            ];
+        }
+
+        return $this->models = $result;
+    }
+
+    /**
+     * @param array<string|int, mixed> $model
+     *
+     * @return list<Capability>
+     */
+    private static function resolveCapabilities(array $model): array
+    {
+        $spec = $model['spec'] ?? null;
+
+        if (!\is_array($spec)) {
+            return [];
+        }
+
+        $inputs = $spec['inputModalities'] ?? null;
+        $outputs = $spec['outputModalities'] ?? null;
+
+        if (!\is_array($inputs) || !\is_array($outputs)) {
+            return [];
+        }
+
+        $hasText = \in_array('text', $inputs, true);
+        $hasAudioIn = \in_array('audio', $inputs, true);
+        $hasAudioOut = \in_array('audio', $outputs, true);
+        $hasTextOut = \in_array('text', $outputs, true);
+
+        if ($hasText && $hasAudioOut) {
+            return self::TTS_CAPABILITIES;
+        }
+
+        if ($hasAudioIn && $hasTextOut) {
+            return self::STT_CAPABILITIES;
+        }
+
+        return [];
+    }
+}

--- a/src/platform/src/Bridge/Inworld/README.md
+++ b/src/platform/src/Bridge/Inworld/README.md
@@ -1,0 +1,21 @@
+Inworld Platform
+================
+
+Inworld platform bridge for Symfony AI.
+
+Inworld Documentation
+---------------------
+
+ * [Authentication](https://docs.inworld.ai/api-reference/introduction)
+ * [Text-to-speech (synthesize)](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech)
+ * [Text-to-speech (streaming)](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech-stream)
+ * [Speech-to-text (transcribe)](https://docs.inworld.ai/api-reference/sttAPI/speechtotext/transcribe)
+ * [List models](https://docs.inworld.ai/api-reference/modelsAPI/modelservice/list-models)
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/ai/issues) and
+   [send Pull Requests](https://github.com/symfony/ai/pulls)
+   in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/platform/src/Bridge/Inworld/Tests/FactoryTest.php
+++ b/src/platform/src/Bridge/Inworld/Tests/FactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Inworld\Factory;
+use Symfony\AI\Platform\Bridge\Inworld\ModelCatalog;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\ScopingHttpClient;
+
+final class FactoryTest extends TestCase
+{
+    public function testProviderCanBeCreatedWithApiKeyAndHttpClient()
+    {
+        $provider = Factory::createProvider(apiKey: 'api-key', httpClient: HttpClient::create());
+
+        $this->assertInstanceOf(ModelCatalog::class, $provider->getModelCatalog());
+    }
+
+    public function testProviderCanBeCreatedWithPreconfiguredScopingHttpClient()
+    {
+        $provider = Factory::createProvider(httpClient: ScopingHttpClient::forBaseUri(HttpClient::create(), 'https://api.inworld.ai/', [
+            'headers' => [
+                'Authorization' => 'Basic api-key',
+            ],
+        ]));
+
+        $this->assertInstanceOf(ModelCatalog::class, $provider->getModelCatalog());
+    }
+
+    public function testProviderAttachesBasicAuthorizationHeader()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): JsonMockResponse {
+            $this->assertSame('GET', $method);
+            $this->assertSame('https://api.inworld.ai/llm/v1alpha/models', $url);
+            $this->assertIsIterable($options['headers']);
+            $this->assertContains('Authorization: Basic api-key', $options['headers']);
+
+            return new JsonMockResponse(['models' => []]);
+        });
+
+        $provider = Factory::createProvider(apiKey: 'api-key', httpClient: $httpClient);
+        $provider->getModelCatalog()->getModels();
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+}

--- a/src/platform/src/Bridge/Inworld/Tests/InworldClientTest.php
+++ b/src/platform/src/Bridge/Inworld/Tests/InworldClientTest.php
@@ -1,0 +1,311 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Inworld\Contract\AudioNormalizer;
+use Symfony\AI\Platform\Bridge\Inworld\Inworld;
+use Symfony\AI\Platform\Bridge\Inworld\InworldClient;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class InworldClientTest extends TestCase
+{
+    public function testSupportsModel()
+    {
+        $client = new InworldClient(new MockHttpClient());
+
+        $this->assertTrue($client->supports(new Inworld('inworld-tts-2')));
+        $this->assertFalse($client->supports(new Model('any-model')));
+    }
+
+    public function testClientCannotPerformWithUnsupportedModel()
+    {
+        $client = new InworldClient(new MockHttpClient());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The model "foo" does not support text-to-speech or speech-to-text, please check the model information.');
+        $this->expectExceptionCode(0);
+        $client->request(new Inworld('foo', []), [
+            'text' => 'bar',
+        ]);
+    }
+
+    public function testClientCannotPerformTextToSpeechWithoutVoice()
+    {
+        $client = new InworldClient(new MockHttpClient());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The voice option is required.');
+        $this->expectExceptionCode(0);
+        $client->request(new Inworld('inworld-tts-2', [Capability::TEXT_TO_SPEECH]), [
+            'text' => 'foo',
+        ]);
+    }
+
+    public function testClientCannotPerformTextToSpeechWithoutTextPayload()
+    {
+        $client = new InworldClient(new MockHttpClient());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The payload must contain a "text" key.');
+        $this->expectExceptionCode(0);
+        $client->request(new Inworld('inworld-tts-2', [Capability::TEXT_TO_SPEECH]), [], [
+            'voice' => 'Dennis',
+        ]);
+    }
+
+    public function testClientCanPerformTextToSpeech()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): JsonMockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.inworld.ai/tts/v1/voice', $url);
+            $this->assertIsString($options['body']);
+            $body = json_decode($options['body'], true, flags: \JSON_THROW_ON_ERROR);
+            $this->assertIsArray($body);
+            $this->assertSame('Hello world', $body['text']);
+            $this->assertSame('Dennis', $body['voiceId']);
+            $this->assertSame('inworld-tts-2', $body['modelId']);
+            $this->assertSame([
+                'audioEncoding' => 'MP3',
+                'sampleRateHertz' => 48000,
+            ], $body['audioConfig']);
+            $this->assertArrayNotHasKey('voice', $body);
+            $this->assertArrayNotHasKey('stream', $body);
+
+            return new JsonMockResponse([
+                'audioContent' => base64_encode('binary-audio'),
+            ]);
+        }, 'https://api.inworld.ai/');
+
+        $client = new InworldClient($httpClient);
+
+        $result = $client->request(new Inworld('inworld-tts-2', [Capability::TEXT_TO_SPEECH]), [
+            'text' => 'Hello world',
+        ], [
+            'voice' => 'Dennis',
+        ]);
+
+        $this->assertInstanceOf(RawHttpResult::class, $result);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testClientCanPerformTextToSpeechWithStringPayload()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): JsonMockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.inworld.ai/tts/v1/voice', $url);
+            $this->assertIsString($options['body']);
+            $body = json_decode($options['body'], true, flags: \JSON_THROW_ON_ERROR);
+            $this->assertIsArray($body);
+            $this->assertSame('foo', $body['text']);
+
+            return new JsonMockResponse([
+                'audioContent' => base64_encode('audio'),
+            ]);
+        }, 'https://api.inworld.ai/');
+
+        $client = new InworldClient($httpClient);
+
+        $client->request(new Inworld('inworld-tts-2', [Capability::TEXT_TO_SPEECH]), 'foo', [
+            'voice' => 'Dennis',
+        ]);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testClientCanPerformTextToSpeechWithCustomAudioConfig()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): JsonMockResponse {
+            $this->assertIsString($options['body']);
+            $body = json_decode($options['body'], true, flags: \JSON_THROW_ON_ERROR);
+            $this->assertIsArray($body);
+            $this->assertSame([
+                'audioEncoding' => 'LINEAR16',
+                'sampleRateHertz' => 24000,
+                'speakingRate' => 1.2,
+            ], $body['audioConfig']);
+            $this->assertSame('en-US', $body['language']);
+
+            return new JsonMockResponse([
+                'audioContent' => base64_encode('audio'),
+            ]);
+        }, 'https://api.inworld.ai/');
+
+        $client = new InworldClient($httpClient);
+
+        $client->request(new Inworld('inworld-tts-2', [Capability::TEXT_TO_SPEECH]), 'foo', [
+            'voice' => 'Dennis',
+            'audioConfig' => [
+                'audioEncoding' => 'LINEAR16',
+                'sampleRateHertz' => 24000,
+                'speakingRate' => 1.2,
+            ],
+            'language' => 'en-US',
+        ]);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testClientCanPerformTextToSpeechAsStream()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.inworld.ai/tts/v1/voice:stream', $url);
+            $this->assertIsString($options['body']);
+            $body = json_decode($options['body'], true, flags: \JSON_THROW_ON_ERROR);
+            $this->assertIsArray($body);
+            $this->assertArrayNotHasKey('stream', $body);
+
+            return new MockResponse(json_encode(['result' => ['audioContent' => base64_encode('chunk')]])."\n");
+        }, 'https://api.inworld.ai/');
+
+        $client = new InworldClient($httpClient);
+
+        $result = $client->request(new Inworld('inworld-tts-2', [Capability::TEXT_TO_SPEECH]), 'foo', [
+            'voice' => 'Dennis',
+            'stream' => true,
+        ]);
+
+        $this->assertInstanceOf(RawHttpResult::class, $result);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testClientCanPerformTextToSpeechWithVoiceFromModelOptions()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): JsonMockResponse {
+            $this->assertIsString($options['body']);
+            $body = json_decode($options['body'], true, flags: \JSON_THROW_ON_ERROR);
+            $this->assertIsArray($body);
+            $this->assertSame('Dennis', $body['voiceId']);
+
+            return new JsonMockResponse([
+                'audioContent' => base64_encode('audio'),
+            ]);
+        }, 'https://api.inworld.ai/');
+
+        $client = new InworldClient($httpClient);
+
+        $client->request(new Inworld('inworld-tts-2', [Capability::TEXT_TO_SPEECH], [
+            'voice' => 'Dennis',
+        ]), 'foo');
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testClientCannotPerformSpeechToTextWithInvalidPayload()
+    {
+        $client = new InworldClient(new MockHttpClient());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Payload must be an array for speech-to-text request, got "string".');
+        $this->expectExceptionCode(0);
+        $client->request(new Inworld('inworld/inworld-stt-1', [Capability::SPEECH_TO_TEXT]), 'foo');
+    }
+
+    public function testClientCannotPerformSpeechToTextWithoutInputAudio()
+    {
+        $client = new InworldClient(new MockHttpClient());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Input audio is required for speech-to-text request.');
+        $this->expectExceptionCode(0);
+        $client->request(new Inworld('inworld/inworld-stt-1', [Capability::SPEECH_TO_TEXT]), [
+            'foo' => 'bar',
+        ]);
+    }
+
+    public function testClientCannotPerformSpeechToTextWithEmptyAudioData()
+    {
+        $client = new InworldClient(new MockHttpClient());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "input_audio" entry must contain a non-empty base64 "data" key.');
+        $this->expectExceptionCode(0);
+        $client->request(new Inworld('inworld/inworld-stt-1', [Capability::SPEECH_TO_TEXT]), [
+            'input_audio' => [
+                'data' => '',
+            ],
+        ]);
+    }
+
+    public function testClientCanPerformSpeechToText()
+    {
+        $payload = (new AudioNormalizer())->normalize(Audio::fromFile(\dirname(__DIR__, 6).'/fixtures/audio.mp3'));
+
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): JsonMockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.inworld.ai/stt/v1/transcribe', $url);
+            $this->assertIsString($options['body']);
+            $body = json_decode($options['body'], true, flags: \JSON_THROW_ON_ERROR);
+            $this->assertIsArray($body);
+            $this->assertIsArray($body['transcribeConfig']);
+            $this->assertIsArray($body['audioData']);
+            $this->assertSame('inworld/inworld-stt-1', $body['transcribeConfig']['modelId']);
+            $this->assertSame('AUTO_DETECT', $body['transcribeConfig']['audioEncoding']);
+            $this->assertIsString($body['audioData']['content']);
+            $this->assertNotSame('', $body['audioData']['content']);
+            $this->assertNotFalse(base64_decode($body['audioData']['content'], true));
+
+            return new JsonMockResponse([
+                'transcription' => ['transcript' => 'Hello world'],
+            ]);
+        }, 'https://api.inworld.ai/');
+
+        $client = new InworldClient($httpClient);
+
+        $client->request(new Inworld('inworld/inworld-stt-1', [Capability::SPEECH_TO_TEXT]), $payload);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testSpeechToTextOptionsAreNestedUnderTranscribeConfig()
+    {
+        $payload = (new AudioNormalizer())->normalize(Audio::fromFile(\dirname(__DIR__, 6).'/fixtures/audio.mp3'));
+
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): JsonMockResponse {
+            $this->assertIsString($options['body']);
+            $body = json_decode($options['body'], true, flags: \JSON_THROW_ON_ERROR);
+            $this->assertIsArray($body);
+            $this->assertIsArray($body['transcribeConfig']);
+            $this->assertSame('en-US', $body['transcribeConfig']['language']);
+            $this->assertSame(16000, $body['transcribeConfig']['sampleRateHertz']);
+            $this->assertTrue($body['transcribeConfig']['includeWordTimestamps']);
+            $this->assertSame('LINEAR16', $body['transcribeConfig']['audioEncoding']);
+            $this->assertArrayNotHasKey('language', $body);
+            $this->assertArrayNotHasKey('sampleRateHertz', $body);
+            $this->assertArrayNotHasKey('includeWordTimestamps', $body);
+            $this->assertArrayNotHasKey('audioEncoding', $body);
+
+            return new JsonMockResponse([
+                'transcription' => ['transcript' => 'Hello'],
+            ]);
+        }, 'https://api.inworld.ai/');
+
+        $client = new InworldClient($httpClient);
+
+        $client->request(new Inworld('inworld/inworld-stt-1', [Capability::SPEECH_TO_TEXT]), $payload, [
+            'language' => 'en-US',
+            'sampleRateHertz' => 16000,
+            'includeWordTimestamps' => true,
+            'audioEncoding' => 'LINEAR16',
+        ]);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+}

--- a/src/platform/src/Bridge/Inworld/Tests/InworldConverterTest.php
+++ b/src/platform/src/Bridge/Inworld/Tests/InworldConverterTest.php
@@ -1,0 +1,251 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Inworld\Inworld;
+use Symfony\AI\Platform\Bridge\Inworld\InworldResultConverter;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\Delta\BinaryDelta;
+use Symfony\AI\Platform\Result\Stream\NdjsonStream;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class InworldConverterTest extends TestCase
+{
+    public function testSupportsModel()
+    {
+        $converter = new InworldResultConverter();
+
+        $this->assertTrue($converter->supports(new Inworld('inworld-tts-2')));
+        $this->assertFalse($converter->supports(new Model('any-model')));
+    }
+
+    public function testConvertTextToSpeechResponse()
+    {
+        $audio = 'binary-audio-content';
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'audioContent' => base64_encode($audio),
+                'usage' => [
+                    'processedCharactersCount' => 11,
+                    'modelId' => 'inworld-tts-2',
+                ],
+            ]),
+        ]);
+        $rawResult = new RawHttpResult($httpClient->request('POST', 'https://api.inworld.ai/tts/v1/voice'));
+
+        $converter = new InworldResultConverter();
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(BinaryResult::class, $result);
+        $this->assertSame($audio, $result->getContent());
+        $this->assertSame('audio/mpeg', $result->getMimeType());
+    }
+
+    public function testConvertTextToSpeechResponseThrowsWhenAudioMissing()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'audioContent' => '',
+            ]),
+        ]);
+        $rawResult = new RawHttpResult($httpClient->request('POST', 'https://api.inworld.ai/tts/v1/voice'));
+
+        $converter = new InworldResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The Inworld API returned an empty audio content.');
+        $this->expectExceptionCode(0);
+        $converter->convert($rawResult);
+    }
+
+    public function testConvertTextToSpeechAsStreamResponse()
+    {
+        $chunk1 = 'first-chunk-bytes';
+        $chunk2 = 'second-chunk-bytes';
+
+        $body = json_encode([
+            'result' => [
+                'audioContent' => base64_encode($chunk1),
+                'usage' => ['processedCharactersCount' => 5, 'modelId' => 'inworld-tts-2'],
+            ],
+        ])."\n".json_encode([
+            'result' => [
+                'audioContent' => base64_encode($chunk2),
+                'usage' => ['processedCharactersCount' => 6, 'modelId' => 'inworld-tts-2'],
+            ],
+        ])."\n";
+
+        $httpClient = new EventSourceHttpClient(new MockHttpClient([new MockResponse($body)]));
+        $response = $httpClient->request('POST', 'https://api.inworld.ai/tts/v1/voice:stream');
+        $rawResult = new RawHttpResult($response, new NdjsonStream());
+
+        $converter = new InworldResultConverter();
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $deltas = [];
+
+        foreach ($result->getContent() as $delta) {
+            $this->assertInstanceOf(BinaryDelta::class, $delta);
+            $deltas[] = $delta;
+        }
+
+        $this->assertCount(2, $deltas);
+        $this->assertSame($chunk1, $deltas[0]->getData());
+        $this->assertSame('audio/mpeg', $deltas[0]->getMimeType());
+        $this->assertSame($chunk2, $deltas[1]->getData());
+    }
+
+    public function testConvertTextToSpeechStreamSkipsEmptyAudioContent()
+    {
+        $body = json_encode([
+            'result' => [
+                'audioContent' => '',
+                'usage' => ['processedCharactersCount' => 0, 'modelId' => 'inworld-tts-2'],
+            ],
+        ])."\n".json_encode([
+            'result' => [
+                'audioContent' => base64_encode('useful-chunk'),
+            ],
+        ])."\n";
+
+        $httpClient = new EventSourceHttpClient(new MockHttpClient([new MockResponse($body)]));
+        $response = $httpClient->request('POST', 'https://api.inworld.ai/tts/v1/voice:stream');
+        $rawResult = new RawHttpResult($response, new NdjsonStream());
+
+        $converter = new InworldResultConverter();
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $deltas = iterator_to_array($result->getContent(), false);
+
+        $this->assertCount(1, $deltas);
+        $this->assertInstanceOf(BinaryDelta::class, $deltas[0]);
+        $this->assertSame('useful-chunk', $deltas[0]->getData());
+    }
+
+    public function testConvertSpeechToTextResponse()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'transcription' => [
+                    'transcript' => 'Hello there',
+                    'isFinal' => true,
+                ],
+            ]),
+        ]);
+        $rawResult = new RawHttpResult($httpClient->request('POST', 'https://api.inworld.ai/stt/v1/transcribe'));
+
+        $converter = new InworldResultConverter();
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello there', $result->getContent());
+    }
+
+    public function testConvertSpeechToTextResponseThrowsWhenTranscriptMissing()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'transcription' => [],
+            ]),
+        ]);
+        $rawResult = new RawHttpResult($httpClient->request('POST', 'https://api.inworld.ai/stt/v1/transcribe'));
+
+        $converter = new InworldResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The Inworld API returned an invalid transcription payload.');
+        $this->expectExceptionCode(0);
+        $converter->convert($rawResult);
+    }
+
+    public function testConvertThrowsExceptionWithDetailedErrorMessage()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'code' => 5,
+                'message' => 'Unknown voice: John not found!',
+                'details' => [],
+            ], ['http_code' => 400]),
+        ]);
+        $rawResult = new RawHttpResult($httpClient->request('POST', 'https://api.inworld.ai/tts/v1/voice'));
+
+        $converter = new InworldResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unknown voice: John not found!');
+        $this->expectExceptionCode(0);
+        $converter->convert($rawResult);
+    }
+
+    public function testConvertThrowsExceptionFromNestedErrorPayload()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'error' => [
+                    'code' => 3,
+                    'message' => 'Invalid argument',
+                ],
+            ], ['http_code' => 400]),
+        ]);
+        $rawResult = new RawHttpResult($httpClient->request('POST', 'https://api.inworld.ai/tts/v1/voice'));
+
+        $converter = new InworldResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid argument');
+        $this->expectExceptionCode(0);
+        $converter->convert($rawResult);
+    }
+
+    public function testConvertThrowsExceptionWithoutErrorMessage()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('', ['http_code' => 500]),
+        ]);
+        $rawResult = new RawHttpResult($httpClient->request('POST', 'https://api.inworld.ai/tts/v1/voice'));
+
+        $converter = new InworldResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The Inworld API returned a non-successful status code "500".');
+        $this->expectExceptionCode(0);
+        $converter->convert($rawResult);
+    }
+
+    public function testConvertThrowsForUnknownUrl()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([]),
+        ]);
+        $rawResult = new RawHttpResult($httpClient->request('POST', 'https://api.inworld.ai/unknown/endpoint'));
+
+        $converter = new InworldResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported Inworld response.');
+        $this->expectExceptionCode(0);
+        $converter->convert($rawResult);
+    }
+}

--- a/src/platform/src/Bridge/Inworld/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Inworld/Tests/ModelCatalogTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Inworld\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Inworld\Inworld;
+use Symfony\AI\Platform\Bridge\Inworld\ModelCatalog;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+final class ModelCatalogTest extends TestCase
+{
+    public function testReturnsEmptyWhenApiReturnsNoModels()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url): JsonMockResponse {
+            $this->assertSame('GET', $method);
+            $this->assertSame('https://api.inworld.ai/llm/v1alpha/models', $url);
+
+            return new JsonMockResponse(['models' => []]);
+        }, 'https://api.inworld.ai/');
+
+        $models = (new ModelCatalog($httpClient))->getModels();
+
+        $this->assertSame([], $models);
+    }
+
+    public function testReturnsEmptyWhenApiPayloadHasNoModelsKey()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([]),
+        ], 'https://api.inworld.ai/');
+
+        $models = (new ModelCatalog($httpClient))->getModels();
+
+        $this->assertSame([], $models);
+    }
+
+    public function testGetModelsIsMemoized()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['models' => []]),
+        ], 'https://api.inworld.ai/');
+
+        $catalog = new ModelCatalog($httpClient);
+        $catalog->getModels();
+        $catalog->getModels();
+        $catalog->getModels();
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testReturnsTtsModelFromApiWithCorrectCapabilities()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'models' => [
+                    [
+                        'model' => 'inworld-tts-2',
+                        'spec' => [
+                            'inputModalities' => ['text'],
+                            'outputModalities' => ['audio'],
+                        ],
+                    ],
+                ],
+            ]),
+        ], 'https://api.inworld.ai/');
+
+        $model = (new ModelCatalog($httpClient))->getModel('inworld-tts-2');
+
+        $this->assertInstanceOf(Inworld::class, $model);
+        $this->assertSame('inworld-tts-2', $model->getName());
+        $this->assertSame([
+            Capability::TEXT_TO_SPEECH,
+            Capability::INPUT_TEXT,
+            Capability::OUTPUT_AUDIO,
+        ], $model->getCapabilities());
+    }
+
+    public function testReturnsSttModelFromApiWithCorrectCapabilities()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'models' => [
+                    [
+                        'model' => 'inworld/inworld-stt-1',
+                        'spec' => [
+                            'inputModalities' => ['audio'],
+                            'outputModalities' => ['text'],
+                        ],
+                    ],
+                ],
+            ]),
+        ], 'https://api.inworld.ai/');
+
+        $model = (new ModelCatalog($httpClient))->getModel('inworld/inworld-stt-1');
+
+        $this->assertInstanceOf(Inworld::class, $model);
+        $this->assertSame('inworld/inworld-stt-1', $model->getName());
+        $this->assertSame([
+            Capability::SPEECH_TO_TEXT,
+            Capability::INPUT_AUDIO,
+            Capability::OUTPUT_TEXT,
+        ], $model->getCapabilities());
+    }
+
+    public function testThrowsForModelNotReturnedByApi()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['models' => []]),
+        ], 'https://api.inworld.ai/');
+
+        $catalog = new ModelCatalog($httpClient);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The model "foo" cannot be retrieved from the API.');
+        $this->expectExceptionCode(0);
+        $catalog->getModel('foo');
+    }
+
+    public function testThrowsForApiModelWithoutSupportedCapabilities()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'models' => [
+                    [
+                        'model' => 'gemini-2.5-flash',
+                        'spec' => [
+                            'inputModalities' => ['text'],
+                            'outputModalities' => ['text'],
+                        ],
+                    ],
+                ],
+            ]),
+        ], 'https://api.inworld.ai/');
+
+        $catalog = new ModelCatalog($httpClient);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The model "gemini-2.5-flash" is not supported, please check the Inworld API.');
+        $this->expectExceptionCode(0);
+        $catalog->getModel('gemini-2.5-flash');
+    }
+
+    public function testIgnoresApiEntriesWithMissingFields()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'models' => [
+                    ['no-model-key' => true],
+                    ['model' => 'no-spec'],
+                    ['model' => 'invalid-spec', 'spec' => 'not-an-array'],
+                    [
+                        'model' => 'missing-modalities',
+                        'spec' => [],
+                    ],
+                ],
+            ]),
+        ], 'https://api.inworld.ai/');
+
+        $models = (new ModelCatalog($httpClient))->getModels();
+
+        $this->assertArrayNotHasKey('no-model-key', $models);
+        $this->assertArrayHasKey('no-spec', $models);
+        $this->assertSame([], $models['no-spec']['capabilities']);
+        $this->assertArrayHasKey('invalid-spec', $models);
+        $this->assertSame([], $models['invalid-spec']['capabilities']);
+        $this->assertArrayHasKey('missing-modalities', $models);
+        $this->assertSame([], $models['missing-modalities']['capabilities']);
+    }
+
+    public function testIgnoresApiModelsListWhenNotArray()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['models' => 'not-an-array']),
+        ], 'https://api.inworld.ai/');
+
+        $models = (new ModelCatalog($httpClient))->getModels();
+
+        $this->assertSame([], $models);
+    }
+}

--- a/src/platform/src/Bridge/Inworld/composer.json
+++ b/src/platform/src/Bridge/Inworld/composer.json
@@ -1,0 +1,56 @@
+{
+    "name": "symfony/ai-inworld-platform",
+    "description": "Inworld platform bridge for Symfony AI",
+    "license": "MIT",
+    "type": "symfony-ai-platform",
+    "keywords": [
+        "ai",
+        "bridge",
+        "inworld",
+        "platform",
+        "stt",
+        "tts"
+    ],
+    "authors": [
+        {
+            "name": "Guillaume Loulier",
+            "email": "personal@guillaumeloulier.fr"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/ai-platform": "^0.9",
+        "symfony/http-client": "^7.3|^8.0"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.5.53"
+    },
+    "minimum-stability": "dev",
+    "autoload": {
+        "psr-4": {
+            "Symfony\\AI\\Platform\\Bridge\\Inworld\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\AI\\PHPStan\\": "../../../../../.phpstan/",
+            "Symfony\\AI\\Platform\\Bridge\\Inworld\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ai",
+            "url": "https://github.com/symfony/ai"
+        }
+    }
+}

--- a/src/platform/src/Bridge/Inworld/composer.json
+++ b/src/platform/src/Bridge/Inworld/composer.json
@@ -1,0 +1,56 @@
+{
+    "name": "symfony/ai-inworld-platform",
+    "description": "Inworld platform bridge for Symfony AI",
+    "license": "MIT",
+    "type": "symfony-ai-platform",
+    "keywords": [
+        "ai",
+        "bridge",
+        "inworld",
+        "platform",
+        "stt",
+        "tts"
+    ],
+    "authors": [
+        {
+            "name": "Guillaume Loulier",
+            "email": "personal@guillaumeloulier.fr"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/ai-platform": "^0.11",
+        "symfony/http-client": "^7.3|^8.0"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.5.53"
+    },
+    "minimum-stability": "dev",
+    "autoload": {
+        "psr-4": {
+            "Symfony\\AI\\Platform\\Bridge\\Inworld\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\AI\\PHPStan\\": "../../../../../.phpstan/",
+            "Symfony\\AI\\Platform\\Bridge\\Inworld\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "thanks": {
+            "name": "symfony/ai",
+            "url": "https://github.com/symfony/ai"
+        }
+    }
+}

--- a/src/platform/src/Bridge/Inworld/phpstan.dist.neon
+++ b/src/platform/src/Bridge/Inworld/phpstan.dist.neon
@@ -1,0 +1,29 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../../../../../.phpstan/extension.neon
+
+parameters:
+    level: 10
+    paths:
+        - .
+        - Tests/
+    excludePaths:
+        - vendor/
+    treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+            reportUnmatched: false
+        -
+            message: '#^Call to( static)? method PHPUnit\\Framework\\Assert::.* will always evaluate to true\.$#'
+            reportUnmatched: false
+        -
+            identifier: 'symfonyAi.forbidNativeException'
+            path: Tests/*
+            reportUnmatched: false
+
+services:
+    - # Conditionally enabled by bleeding edge in phpstan/phpstan-phpunit 2.x
+        class: PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension
+        tags:
+            - phpstan.ignoreErrorExtension

--- a/src/platform/src/Bridge/Inworld/phpunit.xml.dist
+++ b/src/platform/src/Bridge/Inworld/phpunit.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         executionOrder="random"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony AI Inworld Platform Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | --
| License       | MIT

Introduces a dedicated bridge package (symfony/ai-inworld-platform) that exposes Inworld's synthesize-speech, synthesize-speech (streaming) and transcribe endpoints through Symfony AI's platform abstraction.

The catalog reads available models dynamically from the `/llm/v1alpha/models` endpoint, classifying entries as TTS or STT based on their input/output modalities. Authentication uses a JWT Bearer token attached via `ScopingHttpClient`. Streaming TTS is wired through `NdjsonStream`, decoding base64 chunks into `BinaryDelta` instances.

The ai-bundle exposes the bridge through a new `inworld:` platform configuration node, mirroring the ElevenLabs wiring with `jwt` replacing `api_key`. The resulting `ai.platform.inworld` service is tagged `ai.platform.speech` so it can be used as `text_to_speech_platform` or `speech_to_text_platform` in the SpeechAgent decoration.

Tests cover routing, payload shape, error extraction, streaming and catalog resolution at PHPStan level 10 on the bridge package, plus full DI compilation coverage and a detailed scenario test in AiBundleTest.
