### PR TITLE
[Mate] Use actual binary path in command help and error notes

### DIFF
--- a/src/mate/src/Command/ResourcesReadCommand.php
+++ b/src/mate/src/Command/ResourcesReadCommand.php
@@ -67,11 +67,13 @@ class ResourcesReadCommand extends Command
 
     protected function configure(): void
     {
+        $script = $_SERVER['PHP_SELF'] ?? 'vendor/bin/mate';
+
         $this
             ->addArgument('uri', InputArgument::REQUIRED, 'URI of the resource to read')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (pretty, json, toon)', 'pretty')
             ->setHelp(
-                <<<'HELP'
+                <<<HELP
 The <info>%command.name%</info> command reads an MCP resource by its URI.
 
 Both static resource URIs and URIs matching a registered resource template are supported.
@@ -88,8 +90,8 @@ Both static resource URIs and URIs matching a registered resource template are s
   %command.full_name% symfony-profiler://profile/abc123 --format=json
 
   <comment># For a list of available resource templates, use:</comment>
-  bin/mate.php debug:capabilities --type=resource
-  bin/mate.php debug:capabilities --type=template
+  {$script} debug:capabilities --type=resource
+  {$script} debug:capabilities --type=template
 HELP
             );
     }
@@ -113,7 +115,7 @@ HELP
             $reference = $this->registry->getResource($uri);
         } catch (ResourceNotFoundException $e) {
             $io->error(\sprintf('Resource "%s" not found', $uri));
-            $io->note('Use "bin/mate.php debug:capabilities --type=resource" to see all available resources');
+            $io->note(\sprintf('Use "%s debug:capabilities --type=resource" to see all available resources', $_SERVER['PHP_SELF'] ?? 'vendor/bin/mate'));
 
             return Command::FAILURE;
         }

--- a/src/mate/src/Command/ToolsCallCommand.php
+++ b/src/mate/src/Command/ToolsCallCommand.php
@@ -64,12 +64,14 @@ class ToolsCallCommand extends Command
 
     protected function configure(): void
     {
+        $script = $_SERVER['PHP_SELF'] ?? 'vendor/bin/mate';
+
         $this
             ->addArgument('tool-name', InputArgument::REQUIRED, 'Name of the tool to execute')
             ->addArgument('json-input', InputArgument::OPTIONAL, 'JSON object with tool parameters', '{}')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (json, pretty, toon)', 'pretty')
             ->setHelp(
-                <<<'HELP'
+                <<<HELP
 The <info>%command.name%</info> command executes MCP tools with JSON input parameters.
 
 <info>Usage Examples:</info>
@@ -87,10 +89,10 @@ The <info>%command.name%</info> command executes MCP tools with JSON input param
   %command.full_name% server-info --format=json
 
   <comment># For a list of available tools, use:</comment>
-  bin/mate.php mcp:tools:list
+  {$script} mcp:tools:list
 
   <comment># For detailed tool information and schema, use:</comment>
-  bin/mate.php mcp:tools:inspect <tool-name>
+  {$script} mcp:tools:inspect <tool-name>
 HELP
             );
     }
@@ -130,7 +132,7 @@ HELP
             $tool = $this->registry->getTool($toolName);
         } catch (ToolNotFoundException $e) {
             $io->error(\sprintf('Tool "%s" not found', $toolName));
-            $io->note('Use "bin/mate.php mcp:tools:list" to see all available tools');
+            $io->note(\sprintf('Use "%s mcp:tools:list" to see all available tools', $_SERVER['PHP_SELF'] ?? 'vendor/bin/mate'));
 
             return Command::FAILURE;
         }

--- a/src/mate/src/Command/ToolsInspectCommand.php
+++ b/src/mate/src/Command/ToolsInspectCommand.php
@@ -70,11 +70,13 @@ class ToolsInspectCommand extends Command
 
     protected function configure(): void
     {
+        $script = $_SERVER['PHP_SELF'] ?? 'vendor/bin/mate';
+
         $this
             ->addArgument('tool-name', InputArgument::REQUIRED, 'Name of the tool to inspect')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (text, json, toon)', 'text')
             ->setHelp(
-                <<<'HELP'
+                <<<HELP
 The <info>%command.name%</info> command displays detailed information about a specific MCP tool including its full JSON schema.
 
 <info>Usage Examples:</info>
@@ -89,7 +91,7 @@ The <info>%command.name%</info> command displays detailed information about a sp
   %command.full_name% search-logs
 
   <comment># For a list of all available tools, use:</comment>
-  bin/mate.php mcp:tools:list
+  {$script} mcp:tools:list
 HELP
             );
     }
@@ -118,7 +120,7 @@ HELP
 
         if (!isset($allTools[$toolName])) {
             $io->error(\sprintf('Tool "%s" not found', $toolName));
-            $io->note('Use "bin/mate.php mcp:tools:list" to see all available tools');
+            $io->note(\sprintf('Use "%s mcp:tools:list" to see all available tools', $_SERVER['PHP_SELF'] ?? 'vendor/bin/mate'));
 
             return Command::FAILURE;
         }

--- a/src/mate/src/Command/ToolsListCommand.php
+++ b/src/mate/src/Command/ToolsListCommand.php
@@ -71,12 +71,14 @@ class ToolsListCommand extends Command
 
     protected function configure(): void
     {
+        $script = $_SERVER['PHP_SELF'] ?? 'vendor/bin/mate';
+
         $this
             ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter by tool name pattern (supports wildcards)')
             ->addOption('extension', null, InputOption::VALUE_REQUIRED, 'Filter by extension package name')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (table, json, toon)', 'table')
             ->setHelp(
-                <<<'HELP'
+                <<<HELP
 The <info>%command.name%</info> command displays all available MCP tools with their metadata.
 
 <info>Usage Examples:</info>
@@ -98,7 +100,7 @@ The <info>%command.name%</info> command displays all available MCP tools with th
   %command.full_name% --extension=symfony/ai-monolog-mate-extension --filter="search*"
 
   <comment># For detailed tool information with schema, use:</comment>
-  bin/mate.php mcp:tools:inspect <tool-name>
+  {$script} mcp:tools:inspect <tool-name>
 HELP
             );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

The Mate console commands (`mcp:tools:call`, `mcp:tools:inspect`, `mcp:tools:list`, `mcp:resources:read`) hardcoded `bin/mate.php` in their help text and error notes, even though end users invoke Mate via `vendor/bin/mate`. When a tool was not found, the suggestion was misleading:

```
 ! [NOTE] Use "bin/mate.php mcp:tools:list" to see all available tools
```

This PR replaces the hardcoded reference with `$_SERVER['PHP_SELF']` (the same source Symfony Console uses to expand `%command.full_name%`), so the suggestion mirrors the actual invocation:

```
 ! [NOTE] Use "vendor/bin/mate mcp:tools:list" to see all available tools
```

Falls back to `vendor/bin/mate` if `PHP_SELF` is unset.