### PR TITLE
[Store][Meilisearch] Add HybridQuery support and fix hybrid example

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -103,6 +103,12 @@ Store
  * The `endpointUrl` parameter for Meilisearch `Store` has been removed
  * The `apiKey` parameter for Meilisearch `Store` has been removed
  * A `StoreFactory` has been introduced for Meilisearch `Store`
+ * The Meilisearch `Store` no longer reads `$options['q']` in `query()`. Use `HybridQuery` to combine vector and full-text search:
+
+   ```diff
+   -$store->query(new VectorQuery($embedding), ['q' => 'keyword', 'semanticRatio' => 0.5]);
+   +$store->query(new HybridQuery($embedding, 'keyword', 0.5));
+   ```
 
 UPGRADE FROM 0.7 to 0.8
 =======================

--- a/examples/rag/meilisearch-hybrid.php
+++ b/examples/rag/meilisearch-hybrid.php
@@ -55,12 +55,20 @@ $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);
 
+// Meilisearch indexes documents asynchronously - wait for pending tasks before querying
+echo "Waiting for Meilisearch to index documents...\n";
+sleep(1);
+
 // Create a query embedding
 $queryText = 'futuristic technology and artificial intelligence';
 echo "Query: \"$queryText\"\n\n";
 $queryEmbedding = $vectorizer->vectorize($queryText);
 
-// Test different semantic ratios to compare results
+// Test different semantic ratios to compare results.
+// Note: Meilisearch's semanticRatio is a retrieval weight, not a smooth score blend.
+// At intermediate ratios, both retrievals run and results are merged, but each
+// document keeps its own scorer's score - so top-K can look identical at 0.0 and
+// 0.5 when keyword scores outrank vector scores.
 $ratios = [
     ['ratio' => 0.0, 'description' => '100% Full-text search (keyword matching)'],
     ['ratio' => 0.5, 'description' => 'Balanced hybrid (50% semantic + 50% full-text)'],
@@ -71,16 +79,16 @@ foreach ($ratios as $config) {
     echo "--- {$config['description']} ---\n";
 
     // Override the semantic ratio for this specific query
-    $results = $store->query(new HybridQuery($queryEmbedding, 'technology', $config['ratio']));
+    $results = iterator_to_array($store->query(new HybridQuery($queryEmbedding, 'space', $config['ratio'])));
 
-    echo "Top 3 results:\n";
-    foreach (array_slice($results, 0, 3) as $i => $result) {
-        $metadata = $result->metadata->getArrayCopy();
+    echo "Top 5 results:\n";
+    foreach (array_slice($results, 0, 5) as $i => $result) {
+        $metadata = $result->getMetadata()->getArrayCopy();
         echo sprintf(
             "  %d. %s (Score: %.4f)\n",
             $i + 1,
             $metadata['title'] ?? 'Unknown',
-            $result->score ?? 0.0
+            $result->getScore() ?? 0.0
         );
     }
     echo "\n";
@@ -89,16 +97,16 @@ foreach ($ratios as $config) {
 echo "--- Custom query with pure semantic search ---\n";
 echo "Query: Movies about space exploration\n";
 $spaceEmbedding = $vectorizer->vectorize('space exploration and cosmic adventures');
-$results = $store->query(new VectorQuery($spaceEmbedding));
+$results = iterator_to_array($store->query(new VectorQuery($spaceEmbedding)));
 
-echo "Top 3 results:\n";
-foreach (array_slice($results, 0, 3) as $i => $result) {
-    $metadata = $result->metadata->getArrayCopy();
+echo "Top 5 results:\n";
+foreach (array_slice($results, 0, 5) as $i => $result) {
+    $metadata = $result->getMetadata()->getArrayCopy();
     echo sprintf(
         "  %d. %s (Score: %.4f)\n",
         $i + 1,
         $metadata['title'] ?? 'Unknown',
-        $result->score ?? 0.0
+        $result->getScore() ?? 0.0
     );
 }
 echo "\n";

--- a/src/store/src/Bridge/Meilisearch/CHANGELOG.md
+++ b/src/store/src/Bridge/Meilisearch/CHANGELOG.md
@@ -4,10 +4,12 @@ CHANGELOG
 0.9
 ---
 
+ * Add `HybridQuery` support to `Store`
  * Introduce a `StoreFactory`
  * [BC BREAK] Add support for `ScopingHttpClient` in `Store`
  * [BC BREAK] The `endpointUrl` parameter for `Store` has been removed
  * [BC BREAK] The `apiKey` parameter for `Store` has been removed
+ * [BC BREAK] `Store::query()` no longer reads `$options['q']`; use `HybridQuery` to combine vector and full-text search
 
 0.1
 ---

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -18,6 +18,7 @@ use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\QueryInterface;
 use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
@@ -96,24 +97,32 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function supports(string $queryClass): bool
     {
-        return VectorQuery::class === $queryClass;
+        return \in_array($queryClass, [
+            VectorQuery::class,
+            HybridQuery::class,
+        ], true);
     }
 
     public function query(QueryInterface $query, array $options = []): iterable
     {
-        if (!$query instanceof VectorQuery) {
+        if ($query instanceof HybridQuery) {
+            $vector = $query->getVector();
+            $text = $query->getText();
+            $semanticRatio = $options['semanticRatio'] ?? $query->getSemanticRatio();
+        } elseif ($query instanceof VectorQuery) {
+            $vector = $query->getVector();
+            $text = '';
+            $semanticRatio = $options['semanticRatio'] ?? $this->semanticRatio;
+        } else {
             throw new UnsupportedQueryTypeException($query::class, $this);
         }
-
-        $vector = $query->getVector();
-        $semanticRatio = $options['semanticRatio'] ?? $this->semanticRatio;
 
         if ($semanticRatio < 0.0 || $semanticRatio > 1.0) {
             throw new InvalidArgumentException(\sprintf('The semantic ratio must be between 0.0 and 1.0, "%s" given.', $semanticRatio));
         }
 
         $result = $this->request('POST', \sprintf('indexes/%s/search', $this->indexName), [
-            'q' => $options['q'] ?? '',
+            'q' => $text,
             'vector' => $vector->getData(),
             'showRankingScore' => true,
             'retrieveVectors' => true,

--- a/src/store/src/Bridge/Meilisearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Meilisearch/Tests/StoreTest.php
@@ -468,9 +468,65 @@ final class StoreTest extends TestCase
         $this->assertFalse($store->supports(TextQuery::class));
     }
 
-    public function testStoreDoesNotSupportHybridQuery()
+    public function testStoreSupportsHybridQuery()
     {
         $store = new Store(new MockHttpClient(), 'test-index');
-        $this->assertFalse($store->supports(HybridQuery::class));
+        $this->assertTrue($store->supports(HybridQuery::class));
+    }
+
+    public function testQueryWithHybridQuery()
+    {
+        $responses = [
+            new MockResponse(json_encode([
+                'hits' => [
+                    [
+                        'id' => '550e8400-e29b-41d4-a716-446655440000',
+                        '_vectors' => [
+                            'default' => [
+                                'embeddings' => [0.1, 0.2, 0.3],
+                            ],
+                        ],
+                        '_rankingScore' => 0.9,
+                        'title' => 'Symfony AI',
+                    ],
+                ],
+            ])),
+        ];
+
+        $httpClient = new MockHttpClient($responses);
+        $store = new Store($httpClient, 'index', semanticRatio: 1.0);
+
+        $vector = new Vector([0.1, 0.2, 0.3]);
+        $results = iterator_to_array($store->query(new HybridQuery($vector, 'symfony', 0.3)));
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(VectorDocument::class, $results[0]);
+
+        $request = $responses[0]->getRequestOptions();
+        $body = json_decode($request['body'], true);
+
+        $this->assertSame('symfony', $body['q']);
+        $this->assertSame([0.1, 0.2, 0.3], $body['vector']);
+        $this->assertSame(0.3, $body['hybrid']['semanticRatio']);
+    }
+
+    public function testQueryCanOverrideSemanticRatioOnHybridQuery()
+    {
+        $responses = [
+            new MockResponse(json_encode([
+                'hits' => [],
+            ])),
+        ];
+
+        $httpClient = new MockHttpClient($responses);
+        $store = new Store($httpClient, 'index');
+
+        $vector = new Vector([0.1, 0.2, 0.3]);
+        iterator_to_array($store->query(new HybridQuery($vector, 'symfony', 0.3), ['semanticRatio' => 0.8]));
+
+        $request = $responses[0]->getRequestOptions();
+        $body = json_decode($request['body'], true);
+
+        $this->assertSame(0.8, $body['hybrid']['semanticRatio']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes (see UPGRADE.md)
| Docs?         | no
| Issues        | Fix #2080
| License       | MIT

The `rag/meilisearch-hybrid.php` example was broken in multiple ways:

- `array_slice()` was called on the `Generator` returned by `Store::query()` — the originally reported crash.
- The example used `HybridQuery`, but the Meilisearch `Store` only accepted `VectorQuery` and threw `UnsupportedQueryTypeException` for anything else. The generator semantics hid this behind the `array_slice` failure.
- It accessed private `VectorDocument` properties (`->metadata`, `->score`) directly.
- Queries were issued before Meilisearch finished its async indexing, so prior "working" runs were actually reading stale data left behind by earlier failed runs.

Changes:

- Make the Meilisearch `Store` accept `HybridQuery` natively. The vector, text and `semanticRatio` come from the query object, with an optional `options['semanticRatio']` override.
- **[BC BREAK]** Drop `$options['q']` from `VectorQuery` handling — `VectorQuery` is now pure vector search, `HybridQuery` is the only way to combine vector + full-text. Documented in `UPGRADE.md`:

  ```diff
  -$store->query(new VectorQuery($embedding), ['q' => 'keyword', 'semanticRatio' => 0.5]);
  +$store->query(new HybridQuery($embedding, 'keyword', 0.5));
  ```
- Update the example to materialize results with `iterator_to_array()`, use `getMetadata()` / `getScore()` accessors, wait for indexing, and use the keyword `"space"` (which actually exists in the movie fixtures) so the demo produces meaningful output.
- Bump the displayed list from top 3 to top 5, so the hybrid retrieval at `ratio=0.5` is visible (both keyword and vector matches show up in the same list).
- Add a comment noting that Meilisearch's `semanticRatio` is a retrieval weight, not a smooth score blend — top-K can look identical between `0.0` and `0.5` when keyword scores dominate, which surprised us during testing.
- Add tests covering `HybridQuery` and the `semanticRatio` override; flip the existing `testStoreDoesNotSupportHybridQuery` accordingly.

Example output after the fix:

```
--- 100% Full-text search (keyword matching) ---
Top 5 results:
  1. WALL-E (Score: 0.7879)
  2. Interstellar (Score: 0.7879)
  3. Project Hail Mary (Score: 0.7803)

--- Balanced hybrid (50% semantic + 50% full-text) ---
Top 5 results:
  1. WALL-E (Score: 0.7879)
  2. Interstellar (Score: 0.7879)
  3. Project Hail Mary (Score: 0.7803)
  4. The Matrix (Score: 0.6473)
  5. Inception (Score: 0.6137)

--- 100% Semantic search (vector similarity) ---
Top 5 results:
  1. The Matrix (Score: 0.6473)
  2. WALL-E (Score: 0.6457)
  3. Interstellar (Score: 0.6288)
  4. Inception (Score: 0.6137)
  5. Project Hail Mary (Score: 0.6016)
```

A separate `[Chat][Meilisearch]` polling-loop hang was found while testing other examples for similar issues — see #2082.
