### PR TITLE
[Chat][Meilisearch] Stop polling loop on failed/canceled tasks

### DIFF
--- a/src/chat/src/Bridge/Meilisearch/MessageStore.php
+++ b/src/chat/src/Bridge/Meilisearch/MessageStore.php
@@ -126,7 +126,7 @@ final class MessageStore implements ManagedStoreInterface, MessageStoreInterface
             ],
         ]);
 
-        while ('succeeded' !== $currentTaskStatusCallback()->toArray()['status']) {
+        while (\in_array($currentTaskStatusCallback()->toArray()['status'], ['enqueued', 'processing'], true)) {
             $this->clock->sleep(1);
         }
 

--- a/src/chat/src/Bridge/Meilisearch/Tests/MessageStoreTest.php
+++ b/src/chat/src/Bridge/Meilisearch/Tests/MessageStoreTest.php
@@ -95,6 +95,50 @@ final class MessageStoreTest extends TestCase
         $this->assertSame(4, $httpClient->getRequestsCount());
     }
 
+    public function testSetupDoesNotHangWhenTaskFails()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'taskUid' => 1,
+                'indexUid' => 'test',
+                'status' => 'enqueued',
+                'type' => 'indexCreation',
+                'enqueuedAt' => '2025-01-01T00:00:00Z',
+            ], [
+                'http_code' => 202,
+            ]),
+            new JsonMockResponse([
+                'taskUid' => 1,
+                'indexUid' => 'test',
+                'status' => 'failed',
+                'type' => 'indexCreation',
+                'error' => [
+                    'message' => 'Index `test` already exists.',
+                    'code' => 'index_already_exists',
+                    'type' => 'invalid_request',
+                ],
+                'enqueuedAt' => '2025-01-01T00:00:00Z',
+            ], [
+                'http_code' => 200,
+            ]),
+            new JsonMockResponse([
+                'taskUid' => 2,
+                'indexUid' => 'test',
+                'status' => 'succeeded',
+                'type' => 'settingsUpdate',
+                'enqueuedAt' => '2025-01-01T00:00:00Z',
+            ], [
+                'http_code' => 202,
+            ]),
+        ], 'http://127.0.0.1:7700');
+
+        $store = new MessageStore($httpClient, 'http://127.0.0.1:7700', 'test', new MonotonicClock(), 'test');
+
+        $store->setup();
+
+        $this->assertSame(3, $httpClient->getRequestsCount());
+    }
+
     public function testStoreCannotDropOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        |
| License       | MIT

`MessageStore::request()` polled task status with the predicate `'succeeded' !== status`, so any **non-succeeded** terminal state (`failed`, `canceled`) caused an infinite loop.

Repro with `examples/chat/persistent-chat-meilisearch.php`:

1. First run: works (`Your name is Christopher.`)
2. Second run without dropping the index: `setup()` enqueues an `indexCreation` that fails with `index_already_exists`, the polling loop never exits, the example hangs silently and produces no output.

Changed the predicate to exit on any non-pending status:

```diff
-while ('succeeded' !== $currentTaskStatusCallback()->toArray()['status']) {
+while (\in_array($currentTaskStatusCallback()->toArray()['status'], ['enqueued', 'processing'], true)) {
     $this->clock->sleep(1);
 }
```

Added a regression test that mocks a `failed` task and asserts `setup()` returns.

Split off from #2081 to keep that PR focused on the Store/Meilisearch example fix.