### PR TITLE
[Examples][Gemini] Pin toolcall-roundtrip to gemini-3-pro-preview

### DIFF
--- a/examples/gemini/toolcall-roundtrip.php
+++ b/examples/gemini/toolcall-roundtrip.php
@@ -24,7 +24,7 @@ $platform = Factory::createPlatform(env('GEMINI_API_KEY'), http_client());
 
 $toolbox = new Toolbox([new Clock(), new EuropeanCapitalsTool()], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gemini-2.5-flash', [$processor], [$processor]);
+$agent = new Agent($platform, 'gemini-3-pro-preview', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1539
| License       | MIT

Switches `examples/gemini/toolcall-roundtrip.php` from `gemini-2.5-flash` to `gemini-3-pro-preview` so the example actually exercises the `thoughtSignature` round-trip on tool calls (the original failure mode of #1539). With #1853 + follow-ups merged, the bridge correctly extracts and re-emits `thoughtSignature` on `Text` / `Thinking` / `ToolCall` parts, and Gemini accepts the replayed signatures (verified live).

Note: `gemini-3-pro-preview` is preview-tier and occasionally returns `MALFORMED_FUNCTION_CALL` / `MALFORMED_RESPONSE` with no parts — a server-side instability unrelated to the bridge.