### PR TITLE
[Agent][MultiAgent] Make Decision::$reasoning required for strict structured outputs

### DIFF
--- a/src/agent/src/MultiAgent/Handoff/Decision.php
+++ b/src/agent/src/MultiAgent/Handoff/Decision.php
@@ -15,6 +15,8 @@ namespace Symfony\AI\Agent\MultiAgent\Handoff;
  * Represents the orchestrator's decision on which agent should handle a request.
  *
  * @author Oskar Stark <oskarstark@googlemail.com>
+ *
+ * @internal
  */
 final class Decision
 {
@@ -24,7 +26,7 @@ final class Decision
      */
     public function __construct(
         private readonly string $agentName,
-        private readonly string $reasoning = 'No reasoning provided',
+        private readonly string $reasoning,
     ) {
     }
 

--- a/src/agent/tests/MultiAgent/Handoff/DecisionTest.php
+++ b/src/agent/tests/MultiAgent/Handoff/DecisionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Agent\Tests\MultiAgent\Handoff;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\MultiAgent\Handoff\Decision;
+use Symfony\AI\Platform\Contract\JsonSchema\Factory;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
@@ -37,35 +38,25 @@ class DecisionTest extends TestCase
         $this->assertFalse($decision->hasAgent());
     }
 
-    public function testConstructorWithDefaultReasoning()
-    {
-        $decision = new Decision('general');
-
-        $this->assertSame('general', $decision->getAgentName());
-        $this->assertSame('No reasoning provided', $decision->getReasoning());
-        $this->assertTrue($decision->hasAgent());
-    }
-
-    public function testConstructorWithEmptyAgentAndDefaultReasoning()
-    {
-        $decision = new Decision('');
-
-        $this->assertSame('', $decision->getAgentName());
-        $this->assertSame('No reasoning provided', $decision->getReasoning());
-        $this->assertFalse($decision->hasAgent());
-    }
-
     public function testHasAgentReturnsTrueForNonEmptyAgent()
     {
-        $decision = new Decision('support');
+        $decision = new Decision('support', 'matched on keyword');
 
         $this->assertTrue($decision->hasAgent());
     }
 
     public function testHasAgentReturnsFalseForEmptyAgent()
     {
-        $decision = new Decision('');
+        $decision = new Decision('', 'no matching agent');
 
         $this->assertFalse($decision->hasAgent());
+    }
+
+    public function testJsonSchemaListsEveryPropertyAsRequired()
+    {
+        $schema = (new Factory())->buildProperties(Decision::class);
+
+        $this->assertSame(['agentName', 'reasoning'], array_keys($schema['properties']));
+        $this->assertSame(['agentName', 'reasoning'], $schema['required']);
     }
 }

--- a/src/agent/tests/MultiAgent/MultiAgentTest.php
+++ b/src/agent/tests/MultiAgent/MultiAgentTest.php
@@ -341,7 +341,7 @@ class MultiAgentTest extends TestCase
 
     public function testBuildAgentSelectionPromptIncludesFallback()
     {
-        $decision = new Decision('');
+        $decision = new Decision('', 'no agent matched');
 
         // Create a mock result that returns the Decision object
         $orchestratorResult = $this->createMock(ResultInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1985
| License       | MIT

Drops the default value on `Decision::$reasoning` so the parameter is reflected as required and ends up in the generated schema's `required` array — which OpenAI strict structured outputs (always enabled by `ResponseFormatFactory`) demands. Also marks the class `@internal`, since it's an LLM-produced DTO consumed only by `MultiAgent`'s orchestrator loop.

Reproducible via `examples/multi-agent/orchestrator.php` against OpenAI; passes again with this change.

---

Side notes:
alternatively we could just declare this as required in the schema or switch to `strict: false` in case there is a default - but both doesn't feel ideal as well.