### PR TITLE
[Platform][Generic] Encode request body with `JSON_UNESCAPED_SLASHES`

### DIFF
--- a/src/platform/src/Bridge/Generic/Completions/ModelClient.php
+++ b/src/platform/src/Bridge/Generic/Completions/ModelClient.php
@@ -54,10 +54,17 @@ class ModelClient implements ModelClientInterface
         // endpoints, which reject unknown request body fields with a 400 error.
         unset($options['cacheRetention']);
 
+        // Encode the body explicitly with JSON_UNESCAPED_SLASHES instead of relying on the
+        // HttpClient "json" option: its encoder escapes forward slashes, so a namespaced
+        // model name like "qwen/qwen3.5-4b" goes on the wire as "qwen\/qwen3.5-4b", which
+        // some OpenAI-compatible backends fail to match. The remaining flags mirror
+        // Symfony's HttpClientTrait::jsonEncode() defaults.
+        $body = json_encode(array_merge($options, $payload), \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_PRESERVE_ZERO_FRACTION);
+
         return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.$this->path, [
             'auth_bearer' => $this->apiKey,
             'headers' => ['Content-Type' => 'application/json'],
-            'json' => array_merge($options, $payload),
+            'body' => $body,
         ]));
     }
 }

--- a/src/platform/src/Bridge/Generic/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Generic/Embeddings/ModelClient.php
@@ -40,13 +40,20 @@ class ModelClient implements ModelClientInterface
 
     public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
     {
+        // Encode the body explicitly with JSON_UNESCAPED_SLASHES instead of relying on the
+        // HttpClient "json" option: its encoder escapes forward slashes, so a namespaced
+        // model name like "qwen/qwen3-embedding" goes on the wire as "qwen\/qwen3-embedding",
+        // which some OpenAI-compatible backends fail to match. The remaining flags mirror
+        // Symfony's HttpClientTrait::jsonEncode() defaults.
+        $body = json_encode(array_merge($options, [
+            'model' => $model->getName(),
+            'input' => $payload,
+        ]), \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_PRESERVE_ZERO_FRACTION);
+
         return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.$this->path, [
             'auth_bearer' => $this->apiKey,
             'headers' => ['Content-Type' => 'application/json'],
-            'json' => array_merge($options, [
-                'model' => $model->getName(),
-                'input' => $payload,
-            ]),
+            'body' => $body,
         ]));
     }
 }

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
@@ -72,6 +72,19 @@ final class ModelClientTest extends TestCase
         $modelClient->request(new CompletionsModel('gpt-4o'), ['model' => 'gpt-4o', 'messages' => [['role' => 'user', 'content' => 'Hello']]], ['temperature' => 0.7]);
     }
 
+    public function testItDoesNotEscapeForwardSlashesInModelName()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
+            self::assertStringContainsString('"model":"qwen/qwen3.5-4b"', $options['body']);
+            self::assertStringNotContainsString('qwen\/qwen3.5-4b', $options['body']);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'http://localhost:8000', 'sk-valid-api-key');
+        $modelClient->request(new CompletionsModel('qwen/qwen3.5-4b'), ['model' => 'qwen/qwen3.5-4b', 'messages' => [['role' => 'user', 'content' => 'Hello']]]);
+    }
+
     #[TestWith(['https://api.inference.eu', 'https://api.inference.eu/v1/chat/completions'])]
     #[TestWith(['https://api.inference.com', 'https://api.inference.com/v1/chat/completions'])]
     public function testItUsesCorrectBaseUrl(string $baseUrl, string $expectedUrl)

--- a/src/platform/src/Bridge/Generic/Tests/Embeddings/ModelClientTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Embeddings/ModelClientTest.php
@@ -84,6 +84,19 @@ final class ModelClientTest extends TestCase
         $modelClient->request(new EmbeddingsModel('text-embedding-3-small'), ['text1', 'text2', 'text3']);
     }
 
+    public function testItDoesNotEscapeForwardSlashesInModelName()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
+            self::assertStringContainsString('"model":"qwen/qwen3-embedding"', $options['body']);
+            self::assertStringNotContainsString('qwen\/qwen3-embedding', $options['body']);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'http://localhost:8000', 'sk-api-key');
+        $modelClient->request(new EmbeddingsModel('qwen/qwen3-embedding'), 'test text');
+    }
+
     #[TestWith(['https://api.inference.eu', 'https://api.inference.eu/v1/embeddings'])]
     #[TestWith(['https://api.inference.com', 'https://api.inference.com/v1/embeddings'])]
     public function testItUsesCorrectBaseUrl(string $baseUrl, string $expectedUrl)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1973
| License       | MIT

The Generic completions and embeddings `ModelClient` classes passed the request payload via the HttpClient `json` option. Symfony's `HttpClientTrait::jsonEncode()` encodes without `JSON_UNESCAPED_SLASHES`, so a namespaced model name like `qwen/qwen3.5-4b` was sent on the wire as `"model":"qwen\/qwen3.5-4b"`.

That is valid JSON, but several OpenAI-compatible backends (observed with vLLM and LM Studio) do a raw string comparison of the model key during routing and fail to match the escaped form, returning a "model not found" error for any namespaced model name containing `/`.

Both clients now encode the body explicitly with `JSON_UNESCAPED_SLASHES` and pass it as `body`. The remaining flags mirror `HttpClientTrait::jsonEncode()` so the only intentional deviation is the unescaped slashes.

Tests added to both `ModelClientTest` classes asserting forward slashes in model names are not escaped.