### PR TITLE
[Store] Add maxDepth to RstToctreeLoader for scoped indexing

### DIFF
--- a/examples/.env
+++ b/examples/.env
@@ -215,3 +215,7 @@ OVH_AI_SECRET_KEY=
 # amazee.ai
 AMAZEEAI_LLM_KEY=
 AMAZEEAI_LLM_API_URL=
+
+# Symfony Docs RAG example (rag/symfony-docs.php)
+SYMFONY_DOCS_ENTRY=quick_tour/index.rst
+SYMFONY_DOCS_MAX_DEPTH=2

--- a/examples/rag/symfony-docs.php
+++ b/examples/rag/symfony-docs.php
@@ -47,11 +47,11 @@ $platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-small', logger(), includeText: true);
 $processor = new DocumentProcessor($vectorizer, $store, logger: logger());
 
-$loader = new RstToctreeLoader();
+$loader = new RstToctreeLoader(maxDepth: (int) env('SYMFONY_DOCS_MAX_DEPTH'));
 $indexer = new SourceIndexer($loader, $processor);
 
 output()->writeln('Indexing Symfony docs — this will produce many chunks and use embedding API credits...');
-$indexer->index($docsDir.'/index.rst');
+$indexer->index($docsDir.'/'.env('SYMFONY_DOCS_ENTRY'));
 output()->writeln('<info>Indexing complete.</info>');
 
 // 3. Retrieve

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.9
+---
+
+ * Add `maxDepth` constructor parameter to `RstToctreeLoader` to limit toctree recursion depth
+
 0.8
 ---
 

--- a/src/store/src/Document/Loader/RstToctreeLoader.php
+++ b/src/store/src/Document/Loader/RstToctreeLoader.php
@@ -29,7 +29,11 @@ final class RstToctreeLoader implements LoaderInterface
         private RstLoader $rstLoader = new RstLoader(),
         private bool $throwOnMissingEntry = false,
         private LoggerInterface $logger = new NullLogger(),
+        private ?int $maxDepth = null,
     ) {
+        if (null !== $maxDepth && $maxDepth < 0) {
+            throw new InvalidArgumentException(\sprintf('The maximum depth must be a non-negative integer or null, %d given.', $maxDepth));
+        }
     }
 
     /**
@@ -62,6 +66,10 @@ final class RstToctreeLoader implements LoaderInterface
         }
 
         yield from $this->rstLoader->loadContent($content, $path, ['depth' => $depth]);
+
+        if (null !== $this->maxDepth && $depth >= $this->maxDepth) {
+            return;
+        }
 
         foreach ($this->parseToctreeEntries($content, \dirname($path), $rootDir) as $entryPath) {
             yield from $this->processFile($entryPath, $depth + 1, $rootDir);

--- a/src/store/tests/Document/Loader/RstToctreeLoaderTest.php
+++ b/src/store/tests/Document/Loader/RstToctreeLoaderTest.php
@@ -270,6 +270,58 @@ final class RstToctreeLoaderTest extends TestCase
         }
     }
 
+    public function testConstructorRejectsNegativeMaxDepth()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The maximum depth must be a non-negative integer or null, -1 given.');
+        new RstToctreeLoader(maxDepth: -1);
+    }
+
+    public function testMaxDepthZeroLoadsOnlySourceFile()
+    {
+        $loader = new RstToctreeLoader(maxDepth: 0);
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_absolute_toctree/index.rst'), false);
+
+        $titles = array_map(
+            static fn (EmbeddableDocumentInterface $doc): string => $doc->getMetadata()->getTitle() ?? '',
+            $documents,
+        );
+
+        $this->assertContains('Main Documentation', $titles);
+        $this->assertNotContains('Getting Started', $titles);
+        $this->assertNotContains('Setup', $titles);
+    }
+
+    public function testMaxDepthOneFollowsDirectEntriesOnly()
+    {
+        $loader = new RstToctreeLoader(maxDepth: 1);
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_absolute_toctree/index.rst'), false);
+
+        $titles = array_map(
+            static fn (EmbeddableDocumentInterface $doc): string => $doc->getMetadata()->getTitle() ?? '',
+            $documents,
+        );
+
+        $this->assertContains('Main Documentation', $titles);
+        $this->assertContains('Getting Started', $titles);
+        $this->assertNotContains('Setup', $titles);
+    }
+
+    public function testNullMaxDepthLoadsEntireTree()
+    {
+        $loader = new RstToctreeLoader(maxDepth: null);
+        $documents = iterator_to_array($loader->load($this->fixturesDir.'/with_absolute_toctree/index.rst'), false);
+
+        $titles = array_map(
+            static fn (EmbeddableDocumentInterface $doc): string => $doc->getMetadata()->getTitle() ?? '',
+            $documents,
+        );
+
+        $this->assertContains('Main Documentation', $titles);
+        $this->assertContains('Getting Started', $titles);
+        $this->assertContains('Setup', $titles);
+    }
+
     public function testLoadSectionOverflowCreatesMultipleChunks()
     {
         // Create a temporary file with a very long section


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Adds an optional `maxDepth` constructor parameter to `RstToctreeLoader` (default `null` = unlimited, preserving current behavior) to cap toctree recursion depth.

This makes the `rag/symfony-docs.php` example fast for regression runs: it now reads optional `SYMFONY_DOCS_ENTRY` / `SYMFONY_DOCS_MAX_DEPTH` env vars, defaulting to the full recursive docs indexation. The example runner auto-scopes that example to the small `quick_tour` subtree, so the full example sweep no longer takes ages while still exercising recursive toctree indexing.

cc @wachterjohannes - JFYI, trying to speed up the `./runner` across all examples here