### PR TITLE
[Agent] Avoid empty streamed assistant message on tool calls

### DIFF
--- a/src/agent/src/Toolbox/StreamListener.php
+++ b/src/agent/src/Toolbox/StreamListener.php
@@ -63,7 +63,8 @@ final class StreamListener extends AbstractStreamListener
             return;
         }
 
-        $this->result = ($this->handleToolCallsCallback)(new ToolCallResult($delta->getToolCalls()), Message::ofAssistant($this->buffer));
+        $streamedMessage = '' === $this->buffer ? null : Message::ofAssistant($this->buffer);
+        $this->result = ($this->handleToolCallsCallback)(new ToolCallResult($delta->getToolCalls()), $streamedMessage);
 
         $content = $this->result->getContent();
         $event->setDelta(\is_string($content) ? new TextDelta($content) : $content);

--- a/src/agent/tests/Toolbox/AgentProcessorTest.php
+++ b/src/agent/tests/Toolbox/AgentProcessorTest.php
@@ -370,6 +370,88 @@ class AgentProcessorTest extends TestCase
         $this->assertSame('bar', $metadata->get('foo'));
     }
 
+    public function testStreamedToolCallWithoutPrecedingTextDoesNotAddEmptyAssistantMessage()
+    {
+        $toolCall = new ToolCall('call_empty', 'tool_empty', ['foo' => 'bar']);
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Tool responded'));
+
+        // Streamed response that issues a tool call without any preceding text delta.
+        $result = new StreamResult((static function () use ($toolCall) {
+            yield new ToolCallComplete([$toolCall]);
+        })());
+
+        $capturedMessages = null;
+        $agent = $this->createMock(AgentInterface::class);
+        $agent
+            ->expects($this->once())
+            ->method('call')
+            ->willReturnCallback(static function (MessageBag $messages) use (&$capturedMessages) {
+                $capturedMessages = $messages;
+
+                return new TextResult('Final response');
+            });
+
+        $processor = new AgentProcessor($toolbox);
+        $processor->setAgent($agent);
+
+        $output = new Output('gpt-4', $result, new MessageBag());
+        $processor->processOutput($output);
+        iterator_to_array($output->getResult()->getContent());
+
+        $this->assertNotNull($capturedMessages);
+        foreach ($capturedMessages->getMessages() as $message) {
+            if ($message instanceof AssistantMessage && !$message->hasToolCalls() && '' === (string) $message->asText()) {
+                $this->fail('An empty assistant message must not be added to the message bag when the streamed tool call has no preceding text.');
+            }
+        }
+    }
+
+    public function testStreamedToolCallWithPrecedingTextKeepsAssistantMessage()
+    {
+        $toolCall = new ToolCall('call_text', 'tool_text', ['foo' => 'bar']);
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Tool responded'));
+
+        $result = new StreamResult((static function () use ($toolCall) {
+            yield new TextDelta('Let me ');
+            yield new TextDelta('check that.');
+            yield new ToolCallComplete([$toolCall]);
+        })());
+
+        $capturedMessages = null;
+        $agent = $this->createMock(AgentInterface::class);
+        $agent
+            ->expects($this->once())
+            ->method('call')
+            ->willReturnCallback(static function (MessageBag $messages) use (&$capturedMessages) {
+                $capturedMessages = $messages;
+
+                return new TextResult('Final response');
+            });
+
+        $processor = new AgentProcessor($toolbox);
+        $processor->setAgent($agent);
+
+        $output = new Output('gpt-4', $result, new MessageBag());
+        $processor->processOutput($output);
+        iterator_to_array($output->getResult()->getContent());
+
+        $this->assertNotNull($capturedMessages);
+        $textMessages = array_filter(
+            $capturedMessages->getMessages(),
+            static fn ($message) => $message instanceof AssistantMessage && !$message->hasToolCalls(),
+        );
+        $this->assertCount(1, $textMessages);
+        $this->assertSame('Let me check that.', reset($textMessages)->asText());
+    }
+
     public function testUsageMetadataGetsPropagatedInStreaming()
     {
         $toolCall = new ToolCall('call_meta_1', 'tool_meta', ['foo' => 'bar']);

--- a/src/agent/tests/Toolbox/StreamListenerTest.php
+++ b/src/agent/tests/Toolbox/StreamListenerTest.php
@@ -90,8 +90,10 @@ final class StreamListenerTest extends TestCase
             yield new ToolCallComplete([new ToolCall('test-id', 'test_tool')]);
         })());
 
+        $callbackCalled = false;
         $capturedAssistantMessage = null;
-        $handleToolCallsCallback = static function (ToolCallResult $tcr, AssistantMessage $msg) use (&$capturedAssistantMessage) {
+        $handleToolCallsCallback = static function (ToolCallResult $tcr, ?AssistantMessage $msg) use (&$callbackCalled, &$capturedAssistantMessage) {
+            $callbackCalled = true;
             $capturedAssistantMessage = $msg;
 
             return new TextResult('Immediate tool response');
@@ -103,8 +105,8 @@ final class StreamListenerTest extends TestCase
         $this->assertCount(1, $result);
         $this->assertInstanceOf(TextDelta::class, $result[0]);
         $this->assertSame('Immediate tool response', $result[0]->getText());
-        $this->assertNotNull($capturedAssistantMessage);
-        $this->assertSame('', $capturedAssistantMessage->asText());
+        $this->assertTrue($callbackCalled);
+        $this->assertNull($capturedAssistantMessage);
     }
 
     public function testGetContentWithToolCallCompleteReturningGenerator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

When a streamed response issues a tool call without any preceding text, `StreamListener` called `Message::ofAssistant($this->buffer)` with an empty buffer. That does not produce an empty message — `Message::toContent()` wraps `''` into a `Text('')` part, yielding an `AssistantMessage` with non-empty content but no actual text.

That message ends up in the message bag and serializes to `content: null`, which providers like OpenAI (Responses API), Cohere and Scaleway reject (`Invalid type for 'input[N].content'`, `must have non-empty content or tool calls`, etc.).

`StreamListener` now passes `null` when nothing was buffered, instead of fabricating an empty assistant message — the tool-call callback already accepts `?AssistantMessage`.