### PR TITLE
[AI Bundle][Store] Rename StoreFactory::createStoreFromPDO to createStoreFromPdo

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -1826,7 +1826,7 @@ final class AiBundle extends AbstractBundle
                     ]);
 
                     $definition
-                        ->setFactory([PostgresStoreFactory::class, 'createStoreFromPDO'])
+                        ->setFactory([PostgresStoreFactory::class, 'createStoreFromPdo'])
                         ->setArguments([
                             $pdo,
                             $store['table_name'] ?? $name,

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -2609,7 +2609,7 @@ class AiBundleTest extends TestCase
 
         $definition = $container->getDefinition('ai.store.postgres.db');
         $this->assertSame(PostgresStore::class, $definition->getClass());
-        $this->assertSame([PostgresStoreFactory::class, 'createStoreFromPDO'], $definition->getFactory());
+        $this->assertSame([PostgresStoreFactory::class, 'createStoreFromPdo'], $definition->getFactory());
 
         $this->assertTrue($definition->isLazy());
         $this->assertCount(5, $definition->getArguments());
@@ -2651,7 +2651,7 @@ class AiBundleTest extends TestCase
 
         $definition = $container->getDefinition('ai.store.postgres.db');
         $this->assertSame(PostgresStore::class, $definition->getClass());
-        $this->assertSame([PostgresStoreFactory::class, 'createStoreFromPDO'], $definition->getFactory());
+        $this->assertSame([PostgresStoreFactory::class, 'createStoreFromPdo'], $definition->getFactory());
 
         $this->assertTrue($definition->isLazy());
         $this->assertCount(5, $definition->getArguments());

--- a/src/store/src/Bridge/Postgres/StoreFactory.php
+++ b/src/store/src/Bridge/Postgres/StoreFactory.php
@@ -21,7 +21,7 @@ use Symfony\AI\Store\StoreInterface;
  */
 final class StoreFactory
 {
-    public static function createStoreFromPDO(
+    public static function createStoreFromPdo(
         \PDO $connection,
         string $tableName,
         string $vectorFieldName = 'embedding',
@@ -44,6 +44,6 @@ final class StoreFactory
             throw new InvalidArgumentException('Only DBAL connections using PDO driver are supported.');
         }
 
-        return static::createStoreFromPDO($pdo, $tableName, $vectorFieldName, $distance, $lang);
+        return static::createStoreFromPdo($pdo, $tableName, $vectorFieldName, $distance, $lang);
     }
 }

--- a/src/store/src/Bridge/Postgres/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Postgres/Tests/IntegrationTest.php
@@ -26,7 +26,7 @@ final class IntegrationTest extends AbstractStoreIntegrationTestCase
     {
         $pdo = new \PDO('pgsql:host=127.0.0.1;port=5432;dbname=test_database', 'postgres', 'postgres');
 
-        return StoreFactory::createStoreFromPDO($pdo, 'test_vectors');
+        return StoreFactory::createStoreFromPdo($pdo, 'test_vectors');
     }
 
     protected static function getSetupOptions(): array

--- a/src/store/src/Bridge/Postgres/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Postgres/Tests/StoreTest.php
@@ -463,7 +463,7 @@ final class StoreTest extends TestCase
     {
         $pdo = $this->createMock(\PDO::class);
 
-        $store = StoreFactory::createStoreFromPDO($pdo, 'test_table', 'vector_field');
+        $store = StoreFactory::createStoreFromPdo($pdo, 'test_table', 'vector_field');
 
         $this->assertInstanceOf(Store::class, $store);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Renames the unreleased Postgres `StoreFactory::createStoreFromPDO` to `createStoreFromPdo` for casing consistency with `createStoreFromDbal`.
