### PR TITLE
[Chat][Cache] Require generic PSR-6, instead of Symfony Cache

### DIFF
--- a/src/chat/src/Bridge/Cache/composer.json
+++ b/src/chat/src/Bridge/Cache/composer.json
@@ -26,8 +26,11 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/cache": "^7.3|^8.0",
+        "psr/cache": "^2.0|^3.0",
         "symfony/ai-chat": "^0.9"
+    },    
+    "suggest": {
+        "symfony/cache": "PSR cache implementation"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",


### PR DESCRIPTION
Added PSR cache requirement and suggestion.
The cache bridge is actually using generic `Psr\Cache\CacheItemPoolInterface`

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes
| Issues        | n/a
| License       | MIT

Update component requirement to indicate the actual dependency to PSR-6 `psr/cache`, not Symfony Cache `symfony/cache`.
I used the same version that is required by the `symfony/cache`
