### PR TITLE
[Platform][Anthropic] Allow overriding `tool_choice` from caller options

### DIFF
--- a/src/platform/src/Bridge/Anthropic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Anthropic/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Allow overriding `tool_choice` via caller options instead of always forcing `['type' => 'auto']`
+
 0.9
 ---
 

--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -62,7 +62,7 @@ final class ModelClient implements ModelClientInterface
         $payload = $this->injectCacheControl($payload);
 
         if (isset($options['tools'])) {
-            $options['tool_choice'] = ['type' => 'auto'];
+            $options['tool_choice'] ??= ['type' => 'auto'];
             $options['tools'] = $this->injectToolsCacheControl($options['tools']);
         }
 

--- a/src/platform/src/Bridge/Anthropic/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ModelClientTest.php
@@ -177,6 +177,39 @@ class ModelClientTest extends TestCase
         $this->modelClient->request($this->model, ['message' => 'test'], $options);
     }
 
+    public function testToolChoiceDefaultsToAutoWhenToolsArePresent()
+    {
+        $this->httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $body = json_decode($options['body'], true);
+            $this->assertSame(['type' => 'auto'], $body['tool_choice']);
+
+            return new JsonMockResponse('{"success": true}');
+        });
+
+        $this->modelClient = new ModelClient($this->httpClient, 'test-api-key');
+
+        $options = ['tools' => [['name' => 'noop', 'description' => '', 'input_schema' => []]]];
+        $this->modelClient->request($this->model, ['message' => 'test'], $options);
+    }
+
+    public function testToolChoiceFromCallerIsPreserved()
+    {
+        $this->httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $body = json_decode($options['body'], true);
+            $this->assertSame(['type' => 'tool', 'name' => 'noop'], $body['tool_choice']);
+
+            return new JsonMockResponse('{"success": true}');
+        });
+
+        $this->modelClient = new ModelClient($this->httpClient, 'test-api-key');
+
+        $options = [
+            'tools' => [['name' => 'noop', 'description' => '', 'input_schema' => []]],
+            'tool_choice' => ['type' => 'tool', 'name' => 'noop'],
+        ];
+        $this->modelClient->request($this->model, ['message' => 'test'], $options);
+    }
+
     public function testStringPayloadThrowsException()
     {
         $this->modelClient = new ModelClient(new MockHttpClient(), 'test-api-key');

--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
@@ -76,7 +76,7 @@ final class ClaudeModelClient implements ModelClientInterface
         unset($payload['model']);
 
         if (isset($options['tools'])) {
-            $options['tool_choice'] = ['type' => 'auto'];
+            $options['tool_choice'] ??= ['type' => 'auto'];
         }
 
         if (isset($options['response_format'])) {

--- a/src/platform/src/Bridge/Bedrock/CHANGELOG.md
+++ b/src/platform/src/Bridge/Bedrock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Allow overriding `tool_choice` via caller options instead of always forcing `['type' => 'auto']` for Anthropic Claude models
+
 0.9
 ---
 

--- a/src/platform/src/Bridge/Bedrock/Tests/Anthropic/ClaudeModelClientTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/Anthropic/ClaudeModelClientTest.php
@@ -206,6 +206,30 @@ final class ClaudeModelClientTest extends TestCase
         $this->assertInstanceOf(RawBedrockResult::class, $response);
     }
 
+    public function testToolChoiceFromCallerIsPreserved()
+    {
+        $this->bedrockClient->expects($this->once())
+            ->method('invokeModel')
+            ->with($this->callback(function ($arg) {
+                $this->assertInstanceOf(InvokeModelRequest::class, $arg);
+                $body = json_decode($arg->getBody(), true);
+                $this->assertSame(['type' => 'tool', 'name' => 'noop'], $body['tool_choice']);
+
+                return true;
+            }))
+            ->willReturn($this->createMock(InvokeModelResponse::class));
+
+        $this->modelClient = new ClaudeModelClient($this->bedrockClient, self::VERSION);
+
+        $options = [
+            'tools' => ['Tool'],
+            'tool_choice' => ['type' => 'tool', 'name' => 'noop'],
+        ];
+
+        $response = $this->modelClient->request($this->model, ['message' => 'test'], $options);
+        $this->assertInstanceOf(RawBedrockResult::class, $response);
+    }
+
     public function testTransformsResponseFormatToOutputConfig()
     {
         $this->bedrockClient->expects($this->once())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #2098
| License       | MIT

The Anthropic `ModelClient` and Bedrock `ClaudeModelClient` overwrote any caller-supplied `tool_choice` with `{type: 'auto'}` as soon as `tools` was present, so `{type: 'any'}` and `{type: 'tool', name: '...'}` were unreachable from `Platform::invoke()`.