### PR TITLE
[Agent] Fix PHPStan undefined variable in Toolbox::execute

### DIFF
--- a/src/agent/src/Toolbox/Toolbox.php
+++ b/src/agent/src/Toolbox/Toolbox.php
@@ -100,6 +100,7 @@ final class Toolbox implements ToolboxInterface
             $arguments = $this->argumentResolver->resolveArguments($metadata, $toolCall);
             $this->eventDispatcher?->dispatch(new ToolCallArgumentsResolved($tool, $metadata, $arguments));
 
+            $sourceCollection = null;
             if ($tool instanceof HasSourcesInterface) {
                 $tool->setSourceCollection($sourceCollection = new SourceCollection());
             }
@@ -107,7 +108,7 @@ final class Toolbox implements ToolboxInterface
             $result = new ToolResult(
                 $toolCall,
                 $tool->{$metadata->getReference()->getMethod()}(...$arguments),
-                $tool instanceof HasSourcesInterface ? $sourceCollection : null,
+                $sourceCollection,
             );
 
             $this->eventDispatcher?->dispatch(new ToolCallSucceeded($tool, $metadata, $arguments, $result));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Resolves CI error:

```
Run cd src/agent && vendor/bin/phpstan
Note: Using configuration file /home/runner/work/ai/ai/src/agent/phpstan.dist.neon.
   0/123 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
 123/123 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

Error: Variable $sourceCollection might not be defined.
 ------ -------------------------------------------------- 
  Line   src/Toolbox/Toolbox.php                           
 ------ -------------------------------------------------- 
  110    Variable $sourceCollection might not be defined.  
         🪪  variable.undefined                            
 ------ -------------------------------------------------- 
 ```