### PR TITLE
[Agent] Fix variable.undefined PHPStan error on Toolbox::execute()

### DIFF
--- a/src/agent/src/Toolbox/Toolbox.php
+++ b/src/agent/src/Toolbox/Toolbox.php
@@ -100,6 +100,7 @@ final class Toolbox implements ToolboxInterface
             $arguments = $this->argumentResolver->resolveArguments($metadata, $toolCall);
             $this->eventDispatcher?->dispatch(new ToolCallArgumentsResolved($tool, $metadata, $arguments));
 
+            $sourceCollection = null;
             if ($tool instanceof HasSourcesInterface) {
                 $tool->setSourceCollection($sourceCollection = new SourceCollection());
             }
@@ -107,7 +108,7 @@ final class Toolbox implements ToolboxInterface
             $result = new ToolResult(
                 $toolCall,
                 $tool->{$metadata->getReference()->getMethod()}(...$arguments),
-                $tool instanceof HasSourcesInterface ? $sourceCollection : null,
+                $sourceCollection,
             );
 
             $this->eventDispatcher?->dispatch(new ToolCallSucceeded($tool, $metadata, $arguments, $result));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## Summary

`Toolbox::execute()` trips PHPStan's flow analysis with:

```
Variable $sourceCollection might not be defined.
src/Toolbox/Toolbox.php:110
```

The variable is assigned inside an `if ($tool instanceof HasSourcesInterface)` branch on line 104, then read back via a ternary using the same instanceof check on line 110. The code is safe at runtime — PHP only evaluates the variable when the ternary condition is true — but PHPStan can't infer this control-flow correlation, so the analysis fails.

## Fix

Initialise `$sourceCollection = null` up front and drop the redundant `$tool instanceof HasSourcesInterface ? ... : null` ternary; just pass `$sourceCollection` to `ToolResult` directly. Behavior is identical.

```diff
+            $sourceCollection = null;
             if ($tool instanceof HasSourcesInterface) {
                 $tool->setSourceCollection($sourceCollection = new SourceCollection());
             }

             $result = new ToolResult(
                 $toolCall,
                 $tool->{$metadata->getReference()->getMethod()}(...$arguments),
-                $tool instanceof HasSourcesInterface ? $sourceCollection : null,
+                $sourceCollection,
             );
```

## Verification

- `phpstan analyse src/agent` → green
- `phpunit` on Agent component → 247 tests, 596 assertions, all green

Currently the failure is blocking PHPStan on any Agent-touching PR (and also surfaces on PRs that don't touch Agent, e.g. #2102, because the matrix runs Agent's PHPStan unconditionally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
