### PR TITLE
[Agent][Store] Bring outlier classes in line with project final/readonly conventions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,12 @@
+UPGRADE FROM 0.9 to 0.10
+========================
+
+Store
+-----
+
+ * The `ClickHouse`, `Redis`, `SurrealDb`, and `InMemory` store implementations are now `final`.
+   Extending them is no longer possible; compose or decorate `StoreInterface` instead.
+
 UPGRADE FROM 0.8 to 0.9
 =======================
 

--- a/src/agent/src/Bridge/Wikipedia/Wikipedia.php
+++ b/src/agent/src/Bridge/Wikipedia/Wikipedia.php
@@ -27,8 +27,8 @@ final class Wikipedia implements HasSourcesInterface
     use HasSourcesTrait;
 
     public function __construct(
-        private HttpClientInterface $httpClient,
-        private string $locale = 'en',
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $locale = 'en',
     ) {
     }
 

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-class Store implements ManagedStoreInterface, StoreInterface
+final class Store implements ManagedStoreInterface, StoreInterface
 {
     public function __construct(
         private readonly HttpClientInterface $httpClient,

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -25,7 +25,7 @@ use Symfony\AI\Store\StoreInterface;
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-class Store implements ManagedStoreInterface, StoreInterface
+final class Store implements ManagedStoreInterface, StoreInterface
 {
     public function __construct(
         private readonly \Redis $redis,

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-class Store implements ManagedStoreInterface, StoreInterface
+final class Store implements ManagedStoreInterface, StoreInterface
 {
     private string $authenticationToken = '';
 

--- a/src/store/src/InMemory/Store.php
+++ b/src/store/src/InMemory/Store.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\Service\ResetInterface;
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  */
-class Store implements ManagedStoreInterface, StoreInterface, ResetInterface
+final class Store implements ManagedStoreInterface, StoreInterface, ResetInterface
 {
     /**
      * @var VectorDocument[]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Two small consistency cleanups across Agent and Store bridges:

**`readonly` on Wikipedia bridge constructor (`src/agent/src/Bridge/Wikipedia/Wikipedia.php`)**

Every other Agent HTTP-client bridge — Brave, Firecrawl, Mapbox, Ollama, OpenMeteo, Scraper, SerpApi, Tavily, Youtube — already declares its promoted constructor parameters as `readonly`. Wikipedia was the only outlier.

**`final` on four Store implementations**

- `src/store/src/Bridge/ClickHouse/Store.php`
- `src/store/src/Bridge/Redis/Store.php`
- `src/store/src/Bridge/SurrealDb/Store.php`
- `src/store/src/InMemory/Store.php`

Every other `Store` bridge in the project is already `final`. These four were missed. I checked the monorepo for `extends ...\Store` against each of these classes — no subclasses exist.

Note that `SurrealDb\Store` retains its non-readonly `$authenticationToken` field, which is set lazily by the `authenticate()` method; `final` does not affect that.