### PR TITLE
[Platform] Remove unmatched PHPStan ignore in JsonSchema Schema attribute

### DIFF
--- a/src/platform/src/Contract/JsonSchema/Attribute/Schema.php
+++ b/src/platform/src/Contract/JsonSchema/Attribute/Schema.php
@@ -71,7 +71,6 @@ final class Schema
         }
 
         if (\is_array($enum)) {
-            /* @phpstan-ignore-next-line function.alreadyNarrowedType */
             if (array_filter($enum, static fn (mixed $item) => null === $item || \is_int($item) || \is_float($item) || \is_string($item)) !== $enum) {
                 throw new InvalidArgumentException('All enum values must be float, integer, strings, or null.');
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

PHPStan no longer reports `function.alreadyNarrowedType` on the `array_filter($enum, ...) !== $enum` check in `Schema::__construct`, so the `@phpstan-ignore-next-line` annotation above it has itself become an error (`ignore.unmatchedLine`, non-ignorable). This currently fails the `PHPStan / Component / Platform` CI job on `main` and on every open PR.

This PR drops the now-unneeded annotation. Verified locally:

```
$ vendor/bin/phpstan analyse --no-progress
 [OK] No errors
```

JsonSchema-related PHPUnit tests still pass (116 tests, 130 assertions).