### PR TITLE
[Platform] Add PartialJsonParser for streaming structured output

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -945,12 +945,42 @@ To enable validation, register the ``ValidatorSubscriber`` with your platform's 
 The ``ValidatorSubscriber`` will automatically validate any :class:`Symfony\\AI\\Platform\\Result\\ObjectResult` produced
 by the ``PlatformSubscriber``. To use this feature, make sure `symfony/validator` is installed in your project.
 
+Parsing Partial JSON from Streams
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When consuming structured output as a stream, every delta only contains a fragment of the final JSON payload. To
+render incremental UI updates (e.g. progressively filling a form, showing a partial list of items, etc.) you need a
+parser that can recover the largest valid structure from an incomplete payload. The
+``Symfony\AI\Platform\StructuredOutput\Streaming\PartialJsonParser`` provides exactly that.
+
+The parser first attempts a strict ``json_decode`` and, if that fails, applies best-effort fixes in order:
+trailing commas, unclosed strings, dangling colons, partial ``true``/``false``/``null`` literals, and unclosed
+``{`` / ``[`` structures::
+
+    use Symfony\AI\Platform\StructuredOutput\Streaming\PartialJsonParser;
+
+    $buffer = '';
+
+    foreach ($chunks as $chunk) {
+        $buffer .= $chunk;
+
+        $partial = PartialJsonParser::parse($buffer, $errorMessage);
+
+        if (null !== $partial) {
+            // render the partial structure (array/object/scalar)
+        }
+    }
+
+The method is ``static``, stateless, and dependency-free. It returns ``null`` and sets ``$errorMessage`` to the
+``json_last_error_msg()`` text only when the input is unrecoverable. On success ``$errorMessage`` is reset to ``null``.
+
 Code Examples
 ~~~~~~~~~~~~~
 
 * `Structured Output with PHP class`_
 * `Structured Output with array`_
 * `Populating existing objects`_
+* `Partial JSON parsing for streaming output`_
 
 Server Tools
 ------------
@@ -1226,6 +1256,7 @@ Code Examples
 .. _`Structured Output with PHP class`: https://github.com/symfony/ai/blob/main/examples/openai/structured-output-math.php
 .. _`Structured Output with array`: https://github.com/symfony/ai/blob/main/examples/openai/structured-output-clock.php
 .. _`Populating existing objects`: https://github.com/symfony/ai/blob/main/examples/platform/structured-output-populate-object.php
+.. _`Partial JSON parsing for streaming output`: https://github.com/symfony/ai/blob/main/examples/platform/partial-json-parser.php
 .. _`Parallel GPT Calls`: https://github.com/symfony/ai/blob/main/examples/misc/parallel-chat-gpt.php
 .. _`Parallel Embeddings Calls`: https://github.com/symfony/ai/blob/main/examples/misc/parallel-embeddings.php
 .. _`LM Studio`: https://lmstudio.ai/

--- a/examples/platform/partial-json-parser.php
+++ b/examples/platform/partial-json-parser.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\StructuredOutput\Streaming\PartialJsonParser;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+// Simulates the progressive deltas a chat completion would emit when producing
+// structured JSON output. Each chunk is appended to a running buffer and we try
+// to render the largest valid structure we can recover so far.
+$chunks = [
+    '{"title": "Symfony AI", ',
+    '"tags": ["php", "llm",',
+    ' "agents"], "author": {"name": "Fa',
+    'bien", "twitter": "@fabpot"',
+    '}, "released": tru',
+    'e}',
+];
+
+$buffer = '';
+
+foreach ($chunks as $index => $chunk) {
+    $buffer .= $chunk;
+
+    $partial = PartialJsonParser::parse($buffer, $error);
+
+    echo sprintf("Chunk %d: %s\n", $index + 1, $chunk);
+    echo 'Buffer: '.$buffer."\n";
+
+    if (null !== $partial) {
+        echo 'Parsed: '.json_encode($partial, \JSON_PRETTY_PRINT)."\n\n";
+    } else {
+        echo 'Unrecoverable: '.$error."\n\n";
+    }
+}

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Add `PartialJsonParser` for recovering partial JSON from streaming output
+
 0.10
 ----
 

--- a/src/platform/src/StructuredOutput/Streaming/PartialJsonParser.php
+++ b/src/platform/src/StructuredOutput/Streaming/PartialJsonParser.php
@@ -1,0 +1,359 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\StructuredOutput\Streaming;
+
+/**
+ * Best-effort parser for incomplete JSON strings produced by streaming structured output.
+ *
+ * Attempts a strict `json_decode` first and falls back to a sequence of recovery passes
+ * (trailing commas, unclosed strings, partial literals, unclosed structures) so callers
+ * can render partial objects before a model finishes emitting them.
+ *
+ * Byte-indexed scanning is intentional: `"` and `\` are always single-byte in UTF-8,
+ * so the string/escape tracking remains correct even for multi-byte payloads.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PartialJsonParser
+{
+    /**
+     * @param-out string|null $errorMessage null on success, json_last_error_msg() text on failure
+     */
+    public static function parse(string $json, ?string &$errorMessage = null): mixed
+    {
+        $data = @json_decode($json, true);
+
+        if (\JSON_ERROR_NONE === json_last_error()) {
+            $errorMessage = null;
+
+            return $data;
+        }
+
+        $errorMessage = json_last_error_msg();
+
+        return self::fixAndParse($json, $errorMessage);
+    }
+
+    private static function fixAndParse(string $json, ?string &$errorMessage): mixed
+    {
+        $fixed = self::fixSyntax($json);
+
+        $data = @json_decode($fixed, true);
+
+        if (\JSON_ERROR_NONE === json_last_error()) {
+            $errorMessage = null;
+
+            return $data;
+        }
+
+        $errorMessage = json_last_error_msg();
+
+        return null;
+    }
+
+    private static function fixSyntax(string $json): string
+    {
+        $json = self::removeTrailingCommas($json);
+        $json = self::closeUnclosedStrings($json);
+        $json = self::fixIncompleteValues($json);
+        $json = self::removeDanglingObjectKey($json);
+
+        return self::closeUnclosedStructures($json);
+    }
+
+    /**
+     * Removes commas that immediately precede `]`/`}` or the end of the buffer.
+     *
+     * The scan is string-aware: a comma inside a string value is content and must be preserved,
+     * otherwise payloads like `{"k":"a,]` would be silently corrupted to `a]`.
+     */
+    private static function removeTrailingCommas(string $json): string
+    {
+        $inString = false;
+        $escaped = false;
+        $length = \strlen($json);
+        $result = '';
+
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $json[$i];
+
+            if ('"' === $char && !$escaped) {
+                $inString = !$inString;
+            }
+
+            $escaped = '\\' === $char && !$escaped;
+
+            if (!$inString && ',' === $char) {
+                $next = $i + 1;
+                while ($next < $length && ctype_space($json[$next])) {
+                    ++$next;
+                }
+
+                if ($next >= $length || ']' === $json[$next] || '}' === $json[$next]) {
+                    continue;
+                }
+            }
+
+            $result .= $char;
+        }
+
+        return $result;
+    }
+
+    private static function closeUnclosedStrings(string $json): string
+    {
+        $inString = false;
+        $escaped = false;
+        $length = \strlen($json);
+
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $json[$i];
+
+            if ('"' === $char && !$escaped) {
+                $inString = !$inString;
+            }
+
+            $escaped = '\\' === $char && !$escaped;
+        }
+
+        if ($inString) {
+            $json = self::trimIncompleteTrailingEscape($json);
+            $json .= '"';
+        }
+
+        return $json;
+    }
+
+    /**
+     * Drops a trailing incomplete escape sequence inside an unterminated string so the closing
+     * quote appended by {@see closeUnclosedStrings()} is not swallowed (`{"a":"hello\`) and no
+     * invalid unicode escape is left behind (`{"a":"\u00`).
+     */
+    private static function trimIncompleteTrailingEscape(string $json): string
+    {
+        if (preg_match('/\\\\u[0-9a-fA-F]{0,3}$/', $json, $matches, \PREG_OFFSET_CAPTURE)) {
+            $offset = $matches[0][1];
+
+            if (self::isEscapeIntroducer($json, $offset)) {
+                return substr($json, 0, $offset);
+            }
+        }
+
+        $last = \strlen($json) - 1;
+        if ($last >= 0 && '\\' === $json[$last] && self::isEscapeIntroducer($json, $last)) {
+            return substr($json, 0, -1);
+        }
+
+        return $json;
+    }
+
+    /**
+     * Determines whether the backslash at the given position starts an escape sequence, i.e. it is
+     * not itself escaped by an even number of preceding backslashes.
+     */
+    private static function isEscapeIntroducer(string $json, int $position): bool
+    {
+        $backslashes = 0;
+        for ($i = $position - 1; $i >= 0 && '\\' === $json[$i]; --$i) {
+            ++$backslashes;
+        }
+
+        return 0 === $backslashes % 2;
+    }
+
+    private static function fixIncompleteValues(string $json): string
+    {
+        $json = self::completePartialLiterals($json);
+        $json = self::truncateIncompleteNumber($json);
+
+        $trimmed = rtrim($json);
+        if (preg_match('/:\s*$/', $trimmed)) {
+            return $trimmed.'null';
+        }
+
+        return $json;
+    }
+
+    private static function completePartialLiterals(string $json): string
+    {
+        $trimmed = rtrim($json);
+
+        if (preg_match('/([\s:,\[\{])tru$/i', $trimmed)) {
+            return substr($trimmed, 0, -3).'true';
+        }
+        if (preg_match('/([\s:,\[\{])tr$/i', $trimmed)) {
+            return substr($trimmed, 0, -2).'true';
+        }
+        if (preg_match('/([\s:,\[\{])fals$/i', $trimmed)) {
+            return substr($trimmed, 0, -4).'false';
+        }
+        if (preg_match('/([\s:,\[\{])fal$/i', $trimmed)) {
+            return substr($trimmed, 0, -3).'false';
+        }
+        if (preg_match('/([\s:,\[\{])fa$/i', $trimmed)) {
+            return substr($trimmed, 0, -2).'false';
+        }
+        if (preg_match('/([\s:,\[\{])nul$/i', $trimmed)) {
+            return substr($trimmed, 0, -3).'null';
+        }
+        if (preg_match('/([\s:,\[\{])nu$/i', $trimmed)) {
+            return substr($trimmed, 0, -2).'null';
+        }
+
+        return $json;
+    }
+
+    /**
+     * Truncates a trailing, not-yet-complete number to its longest valid prefix so streamed deltas
+     * such as `{"a": 1.`, `{"a": 1e` or `{"a": -` no longer abort the whole recovery.
+     */
+    private static function truncateIncompleteNumber(string $json): string
+    {
+        $trimmed = rtrim($json);
+
+        if (!preg_match('/[:,\[]\s*([-+0-9.eE]+)$/', $trimmed, $matches, \PREG_OFFSET_CAPTURE)) {
+            return $json;
+        }
+
+        $token = $matches[1][0];
+        $valid = self::longestValidNumberPrefix($token);
+
+        if ($valid === $token) {
+            return $json;
+        }
+
+        return substr($trimmed, 0, $matches[1][1]).$valid;
+    }
+
+    private static function longestValidNumberPrefix(string $token): string
+    {
+        for ($length = \strlen($token); $length > 0; --$length) {
+            $candidate = substr($token, 0, $length);
+
+            if (preg_match('/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/', $candidate)) {
+                return $candidate;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Drops a trailing object key that has no value yet (`{"a":1,"bb`). The scan tracks the
+     * enclosing container so that a trailing string in array context (`["foo", "bar`) is preserved
+     * as a value rather than mistaken for a key.
+     */
+    private static function removeDanglingObjectKey(string $json): string
+    {
+        $stack = [];
+        $inString = false;
+        $escaped = false;
+        $length = \strlen($json);
+
+        $stringStart = -1;
+        $lastStringStart = -1;
+        $lastStringEnd = -1;
+        $containerAtLastString = '';
+
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $json[$i];
+
+            if ($inString) {
+                if ('"' === $char && !$escaped) {
+                    $inString = false;
+                    $lastStringStart = $stringStart;
+                    $lastStringEnd = $i + 1;
+                    $containerAtLastString = [] !== $stack ? $stack[\count($stack) - 1] : '';
+                }
+
+                $escaped = '\\' === $char && !$escaped;
+
+                continue;
+            }
+
+            if ('"' === $char) {
+                $inString = true;
+                $stringStart = $i;
+                $escaped = false;
+
+                continue;
+            }
+
+            if ('[' === $char || '{' === $char) {
+                $stack[] = $char;
+            } elseif (']' === $char || '}' === $char) {
+                array_pop($stack);
+            }
+        }
+
+        if ($inString || -1 === $lastStringStart || '{' !== $containerAtLastString) {
+            return $json;
+        }
+
+        if ('' !== trim(substr($json, $lastStringEnd))) {
+            return $json;
+        }
+
+        $head = rtrim(substr($json, 0, $lastStringStart));
+
+        if (str_ends_with($head, ',')) {
+            return substr($head, 0, -1);
+        }
+
+        if (str_ends_with($head, '{')) {
+            return $head;
+        }
+
+        return $json;
+    }
+
+    private static function closeUnclosedStructures(string $json): string
+    {
+        $stack = [];
+        $inString = false;
+        $escaped = false;
+        $length = \strlen($json);
+
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $json[$i];
+
+            if ('"' === $char && !$escaped) {
+                $inString = !$inString;
+            }
+
+            $escaped = '\\' === $char && !$escaped;
+
+            if ($inString) {
+                continue;
+            }
+
+            if ('[' === $char || '{' === $char) {
+                $stack[] = $char;
+            } elseif (']' === $char) {
+                if ([] !== $stack && '[' === $stack[\count($stack) - 1]) {
+                    array_pop($stack);
+                }
+            } elseif ('}' === $char) {
+                if ([] !== $stack && '{' === $stack[\count($stack) - 1]) {
+                    array_pop($stack);
+                }
+            }
+        }
+
+        while ([] !== $stack) {
+            $open = array_pop($stack);
+            $json .= '[' === $open ? ']' : '}';
+        }
+
+        return $json;
+    }
+}

--- a/src/platform/tests/StructuredOutput/Streaming/PartialJsonParserTest.php
+++ b/src/platform/tests/StructuredOutput/Streaming/PartialJsonParserTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\StructuredOutput\Streaming;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\StructuredOutput\Streaming\PartialJsonParser;
+
+final class PartialJsonParserTest extends TestCase
+{
+    /**
+     * @param array<mixed>|scalar|null $expected
+     */
+    #[DataProvider('provideAlreadyValid')]
+    #[DataProvider('provideTrailingCommas')]
+    #[DataProvider('provideUnclosedStrings')]
+    #[DataProvider('provideIncompleteValues')]
+    #[DataProvider('provideIncompleteNumbers')]
+    #[DataProvider('provideUnclosedStructures')]
+    #[DataProvider('provideStringsContainingBrackets')]
+    public function testParseRecovers(string $input, array|bool|float|int|string|null $expected)
+    {
+        $errorMessage = 'pre-existing';
+
+        $this->assertSame($expected, PartialJsonParser::parse($input, $errorMessage));
+        $this->assertNull($errorMessage);
+    }
+
+    public function testParseReturnsNullForUnrecoverableInput()
+    {
+        $errorMessage = null;
+
+        $this->assertNull(PartialJsonParser::parse('not json at all !!!', $errorMessage));
+        $this->assertIsString($errorMessage);
+        $this->assertNotSame('', $errorMessage);
+    }
+
+    public function testParseWorksWithoutErrorMessageArgument()
+    {
+        $this->assertSame(['a' => 1], PartialJsonParser::parse('{"a":1}'));
+        $this->assertSame(['a' => 'hel'], PartialJsonParser::parse('{"a":"hel'));
+    }
+
+    public function testErrorMessageIsResetOnSuccessfulRecovery()
+    {
+        $errorMessage = 'leftover';
+
+        PartialJsonParser::parse('{"a":1', $errorMessage);
+
+        $this->assertNull($errorMessage);
+    }
+
+    /**
+     * @return iterable<string, array{string, array<mixed>|scalar|null}>
+     */
+    public static function provideAlreadyValid(): iterable
+    {
+        yield 'simple object' => ['{"a":1}', ['a' => 1]];
+        yield 'empty object' => ['{}', []];
+        yield 'empty array' => ['[]', []];
+        yield 'nested' => ['{"a":{"b":[1,2,3]}}', ['a' => ['b' => [1, 2, 3]]]];
+        yield 'string scalar' => ['"hello"', 'hello'];
+        yield 'numeric scalar' => ['42', 42];
+        yield 'boolean true' => ['true', true];
+        yield 'null' => ['null', null];
+    }
+
+    /**
+     * @return iterable<string, array{string, array<mixed>|scalar|null}>
+     */
+    public static function provideTrailingCommas(): iterable
+    {
+        yield 'object trailing comma' => ['{"a":1,}', ['a' => 1]];
+        yield 'array trailing comma' => ['[1, 2, 3,]', [1, 2, 3]];
+        yield 'nested trailing comma' => ['{"a":[1, 2,], "b":3,}', ['a' => [1, 2], 'b' => 3]];
+    }
+
+    /**
+     * @return iterable<string, array{string, array<mixed>|scalar|null}>
+     */
+    public static function provideUnclosedStrings(): iterable
+    {
+        yield 'unclosed value string' => ['{"a":"hel', ['a' => 'hel']];
+        yield 'escaped quote inside unclosed string' => ['{"a":"he\"l', ['a' => 'he"l']];
+        yield 'unclosed string in array' => ['["foo", "bar', ['foo', 'bar']];
+        yield 'dangling string escape' => ['{"a":"hello\\', ['a' => 'hello']];
+        yield 'incomplete unicode escape' => ['{"a":"\u00', ['a' => '']];
+    }
+
+    /**
+     * @return iterable<string, array{string, array<mixed>|scalar|null}>
+     */
+    public static function provideIncompleteValues(): iterable
+    {
+        yield 'dangling colon' => ['{"a":', ['a' => null]];
+        yield 'partial true (tru)' => ['{"a":tru', ['a' => true]];
+        yield 'partial true (tr)' => ['{"a":tr', ['a' => true]];
+        yield 'partial false (fals)' => ['{"a":fals', ['a' => false]];
+        yield 'partial false (fal)' => ['{"a":fal', ['a' => false]];
+        yield 'partial false (fa)' => ['{"a":fa', ['a' => false]];
+        yield 'partial null (nul)' => ['{"a":nul', ['a' => null]];
+        yield 'partial null (nu)' => ['{"a":nu', ['a' => null]];
+        yield 'partial literal inside array' => ['[1, tru', [1, true]];
+        yield 'partial object key' => ['{"a":1,"bb', ['a' => 1]];
+    }
+
+    /**
+     * @return iterable<string, array{string, array<mixed>|scalar|null}>
+     */
+    public static function provideIncompleteNumbers(): iterable
+    {
+        yield 'incomplete float' => ['{"a": 1.', ['a' => 1]];
+        yield 'incomplete negative number' => ['{"a": -', ['a' => null]];
+        yield 'incomplete exponent' => ['{"a": 1e', ['a' => 1]];
+        yield 'incomplete signed exponent' => ['{"a": 1e-', ['a' => 1]];
+        yield 'incomplete fraction with exponent' => ['{"a": -0.5e', ['a' => -0.5]];
+    }
+
+    /**
+     * @return iterable<string, array{string, array<mixed>|scalar|null}>
+     */
+    public static function provideUnclosedStructures(): iterable
+    {
+        yield 'unclosed nested object' => ['{"a":{"b":1', ['a' => ['b' => 1]]];
+        yield 'unclosed nested array' => ['[1, [2, 3', [1, [2, 3]]];
+        yield 'mixed object with array of objects' => ['{"items":[{"n":1', ['items' => [['n' => 1]]]];
+        yield 'just opened object' => ['{', []];
+        yield 'just opened array' => ['[', []];
+    }
+
+    /**
+     * @return iterable<string, array{string, array<mixed>|scalar|null}>
+     */
+    public static function provideStringsContainingBrackets(): iterable
+    {
+        yield 'braces inside string value' => ['{"x":"}{"', ['x' => '}{']];
+        yield 'brackets inside string value' => ['{"x":"][", "y":1', ['x' => '][', 'y' => 1]];
+        yield 'brackets inside unclosed string' => ['{"x":"hello {world', ['x' => 'hello {world']];
+        yield 'comma before bracket in string' => ['{"k":"a,]', ['k' => 'a,]']];
+        yield 'comma before brace in string' => ['{"path":"a,}', ['path' => 'a,}']];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

This PR adds `Symfony\AI\Platform\StructuredOutput\Streaming\PartialJsonParser`, a static, dependency-free utility that recovers the largest valid structure from an incomplete JSON string. This unblocks rendering partial objects from streamed structured output before the model finishes emitting them.

### Algorithm

`PartialJsonParser::parse()` attempts a strict `json_decode` first; on failure it applies best-effort fixes in order and tries again:

1. Strip trailing commas before `]` / `}`.
2. Close unclosed strings by tracking `"` and `\` byte-wise (UTF-8 safe because both are single-byte).
3. Fix incomplete values at the tail:
   - dangling colon → append `null`
   - partial literals (`tru`, `fals`, `nul`, ...) → complete them
   - trailing comma at EOF → strip it
4. Close unclosed `{` / `[` by walking the string with a stack that ignores chars inside strings.

If still invalid, returns `null` and populates the `&$errorMessage` reference with `json_last_error_msg()`.

### Usage

```php
use Symfony\AI\Platform\StructuredOutput\Streaming\PartialJsonParser;

$buffer = '';
foreach ($chunks as $chunk) {
    $buffer .= $chunk;
    $partial = PartialJsonParser::parse($buffer);

    if (null !== $partial) {
        // render the partial structure
    }
}
```

### Notes

- Ported from `ModelflowAi\Chat\Util\Json\OptimisticJsonParser`
- No platform wiring changes — follow-up PRs can wire it into `StreamResult` / structured-output streaming.
- `composer test`, `vendor/bin/phpstan analyse`, and `php-cs-fixer` pass cleanly on the new files.