### PR TITLE
[AI Bundle][Platform] Add result text normalizer chain

### DIFF
--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 0.9
 ---
 
- * Wire result text normalizers: register `JsonFenceStripNormalizer` and `UnicodeNormalizer` services and auto-tag `TextNormalizerInterface` implementations with `ai.platform.result_normalizer`
+ * Wire result text normalizers and auto-tag custom implementations
  * Validate structured output using `symfony/validator` when available
  * Make `ai:platform:invoke` arguments optional and prompt for them interactively when missing
  * Visualize failed calls with `result_type: 'error'` in profiler

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.9
 ---
 
+ * Wire result text normalizers: register `JsonFenceStripNormalizer` and `UnicodeNormalizer` services and auto-tag `TextNormalizerInterface` implementations with `ai.platform.result_normalizer`
  * Validate structured output using `symfony/validator` when available
  * Make `ai:platform:invoke` arguments optional and prompt for them interactively when missing
  * Visualize failed calls with `result_type: 'error'` in profiler

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -72,6 +72,9 @@ use Symfony\AI\Platform\EventListener\TemplateRendererListener;
 use Symfony\AI\Platform\Message\TemplateRenderer\ExpressionLanguageTemplateRenderer;
 use Symfony\AI\Platform\Message\TemplateRenderer\StringTemplateRenderer;
 use Symfony\AI\Platform\Message\TemplateRenderer\TemplateRendererRegistry;
+use Symfony\AI\Platform\Result\Normalizer\JsonFenceStripNormalizer;
+use Symfony\AI\Platform\Result\Normalizer\PlatformSubscriber as NormalizerPlatformSubscriber;
+use Symfony\AI\Platform\Result\Normalizer\UnicodeNormalizer;
 use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
 use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactory;
 use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactoryInterface;
@@ -206,6 +209,17 @@ return static function (ContainerConfigurator $container): void {
         ->set('ai.platform.structured_output.validator_subscriber', ValidatorSubscriber::class)
             ->args([
                 service('validator')->nullOnInvalid(),
+            ])
+            ->tag('kernel.event_subscriber')
+
+        // result normalizers
+        ->set('ai.platform.result_normalizer.json_fence_strip', JsonFenceStripNormalizer::class)
+            ->tag('ai.platform.result_normalizer')
+        ->set('ai.platform.result_normalizer.unicode', UnicodeNormalizer::class)
+            ->tag('ai.platform.result_normalizer')
+        ->set('ai.platform.result_normalizer_subscriber', NormalizerPlatformSubscriber::class)
+            ->args([
+                tagged_iterator('ai.platform.result_normalizer'),
             ])
             ->tag('kernel.event_subscriber')
 

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -93,6 +93,7 @@ use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Platform;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\Normalizer\TextNormalizerInterface;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\AI\Store\Bridge\AzureSearch\SearchStore as AzureSearchStore;
 use Symfony\AI\Store\Bridge\AzureSearch\StoreFactory as AzureSearchStoreFactory;
@@ -353,6 +354,8 @@ final class AiBundle extends AbstractBundle
             ->addTag('ai.platform.model_client');
         $builder->registerForAutoconfiguration(ResultConverterInterface::class)
             ->addTag('ai.platform.result_converter');
+        $builder->registerForAutoconfiguration(TextNormalizerInterface::class)
+            ->addTag('ai.platform.result_normalizer');
 
         if (!ContainerBuilder::willBeAvailable('symfony/security-core', AuthorizationCheckerInterface::class, ['symfony/ai-bundle'])) {
             $builder->removeDefinition('ai.security.is_granted_attribute_listener');

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 0.9
 ---
 
+ * Add `Result\Normalizer\TextNormalizerInterface` and a `PlatformSubscriber` that applies tagged normalizers to text-bearing results after invocation
+ * Add `Result\Normalizer\JsonFenceStripNormalizer` to strip Markdown code fences around JSON output and `Result\Normalizer\UnicodeNormalizer` to remove Unicode format characters and convert non-breaking spaces
+ * Add `TextResult::withContent()` returning a new instance with replaced content while preserving signature and metadata
  * Add `ValidatorSubscriber` to validate structured output using Symfony Validator
  * Add support for multiple system messages in `MessageBag`
  * [BC BREAK] Rework `AssistantMessage` to hold `ContentInterface` parts (variadic constructor) instead of a single string content plus separate tool-call/thinking fields. Adds `Message\Content\Thinking`, `Message\Content\ExecutableCode`, and `Message\Content\CodeExecution` content classes, and makes `Result\ToolCall` implement `ContentInterface`. `Message::ofAssistant()` accepts strings, `ContentInterface`, and `ResultInterface` values, mapping `TextResult`/`ThinkingResult`/`ToolCallResult`/`ExecutableCodeResult`/`CodeExecutionResult`/`MultiPartResult` to their content equivalents; result types without a known mapping throw `InvalidArgumentException` so unhandled cases surface instead of being silently dropped.

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 0.9
 ---
 
- * Add `Result\Normalizer\TextNormalizerInterface` with `JsonFenceStripNormalizer` and `UnicodeNormalizer` implementations applied to text-bearing results via `Result\Normalizer\PlatformSubscriber`
+ * Add result text normalizer chain to clean up model output (JSON code fences, Unicode format characters)
  * Add `ValidatorSubscriber` to validate structured output using Symfony Validator
  * Add support for multiple system messages in `MessageBag`
  * [BC BREAK] Rework `AssistantMessage` to hold `ContentInterface` parts (variadic constructor) instead of a single string content plus separate tool-call/thinking fields. Adds `Message\Content\Thinking`, `Message\Content\ExecutableCode`, and `Message\Content\CodeExecution` content classes, and makes `Result\ToolCall` implement `ContentInterface`. `Message::ofAssistant()` accepts strings, `ContentInterface`, and `ResultInterface` values, mapping `TextResult`/`ThinkingResult`/`ToolCallResult`/`ExecutableCodeResult`/`CodeExecutionResult`/`MultiPartResult` to their content equivalents; result types without a known mapping throw `InvalidArgumentException` so unhandled cases surface instead of being silently dropped.

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,9 +4,7 @@ CHANGELOG
 0.9
 ---
 
- * Add `Result\Normalizer\TextNormalizerInterface` and a `PlatformSubscriber` that applies tagged normalizers to text-bearing results after invocation
- * Add `Result\Normalizer\JsonFenceStripNormalizer` to strip Markdown code fences around JSON output and `Result\Normalizer\UnicodeNormalizer` to remove Unicode format characters and convert non-breaking spaces
- * Add `TextResult::withContent()` returning a new instance with replaced content while preserving signature and metadata
+ * Add `Result\Normalizer\TextNormalizerInterface` with `JsonFenceStripNormalizer` and `UnicodeNormalizer` implementations applied to text-bearing results via `Result\Normalizer\PlatformSubscriber`
  * Add `ValidatorSubscriber` to validate structured output using Symfony Validator
  * Add support for multiple system messages in `MessageBag`
  * [BC BREAK] Rework `AssistantMessage` to hold `ContentInterface` parts (variadic constructor) instead of a single string content plus separate tool-call/thinking fields. Adds `Message\Content\Thinking`, `Message\Content\ExecutableCode`, and `Message\Content\CodeExecution` content classes, and makes `Result\ToolCall` implement `ContentInterface`. `Message::ofAssistant()` accepts strings, `ContentInterface`, and `ResultInterface` values, mapping `TextResult`/`ThinkingResult`/`ToolCallResult`/`ExecutableCodeResult`/`CodeExecutionResult`/`MultiPartResult` to their content equivalents; result types without a known mapping throw `InvalidArgumentException` so unhandled cases surface instead of being silently dropped.

--- a/src/platform/src/Result/Normalizer/JsonFenceStripNormalizer.php
+++ b/src/platform/src/Result/Normalizer/JsonFenceStripNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Normalizer;
+
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+
+/**
+ * Strips Markdown code fences (```json … ```) that some models wrap around
+ * JSON output despite being asked for structured output.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class JsonFenceStripNormalizer implements TextNormalizerInterface
+{
+    public function supports(Model $model, ResultInterface $result, array $options): bool
+    {
+        if ($result instanceof ObjectResult) {
+            return true;
+        }
+
+        $responseFormat = $options['response_format'] ?? null;
+
+        if ('json' === $responseFormat) {
+            return true;
+        }
+
+        if (\is_array($responseFormat) && 'json_schema' === ($responseFormat['type'] ?? null)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function normalize(string $text): string
+    {
+        if ('' === $text) {
+            return '';
+        }
+
+        if (1 !== preg_match('/^\s*```(?:json)?\s*(.*?)\s*```\s*$/is', $text, $matches)) {
+            return $text;
+        }
+
+        $candidate = $matches[1];
+
+        if (!json_validate($candidate)) {
+            return $text;
+        }
+
+        return $candidate;
+    }
+}

--- a/src/platform/src/Result/Normalizer/PlatformSubscriber.php
+++ b/src/platform/src/Result/Normalizer/PlatformSubscriber.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Normalizer;
+
+use Symfony\AI\Platform\Event\ResultEvent;
+use Symfony\AI\Platform\PlainConverter;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Applies registered text normalizers to text-bearing results after invocation.
+ *
+ * Runs before structured-output processing so normalizers can clean up the
+ * raw text (e.g. strip Markdown code fences) before it is decoded.
+ *
+ * Streaming results are intentionally left untouched.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PlatformSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param iterable<TextNormalizerInterface> $normalizers
+     */
+    public function __construct(
+        private readonly iterable $normalizers,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ResultEvent::class => ['onResult', 10],
+        ];
+    }
+
+    public function onResult(ResultEvent $event): void
+    {
+        $deferred = $event->getDeferredResult();
+        $result = $deferred->getResult();
+
+        $normalized = $this->normalizeResult($result, $event);
+
+        if ($normalized === $result) {
+            return;
+        }
+
+        $newDeferred = new DeferredResult(new PlainConverter($normalized), $deferred->getRawResult(), $event->getOptions());
+        $newDeferred->getMetadata()->set($deferred->getMetadata()->all());
+
+        $event->setDeferredResult($newDeferred);
+    }
+
+    private function normalizeResult(ResultInterface $result, ResultEvent $event): ResultInterface
+    {
+        if ($result instanceof TextResult) {
+            return $this->normalizeText($result, $event);
+        }
+
+        if ($result instanceof MultiPartResult) {
+            return $this->normalizeMultiPart($result, $event);
+        }
+
+        return $result;
+    }
+
+    private function normalizeText(TextResult $result, ResultEvent $event): TextResult
+    {
+        $original = $result->getContent();
+        $text = $original;
+
+        foreach ($this->normalizers as $normalizer) {
+            if (!$normalizer->supports($event->getModel(), $result, $event->getOptions())) {
+                continue;
+            }
+
+            $text = $normalizer->normalize($text);
+        }
+
+        if ($text === $original) {
+            return $result;
+        }
+
+        return $result->withContent($text);
+    }
+
+    private function normalizeMultiPart(MultiPartResult $result, ResultEvent $event): MultiPartResult
+    {
+        $parts = $result->getContent();
+        $newParts = [];
+        $changed = false;
+
+        foreach ($parts as $part) {
+            if ($part instanceof TextResult) {
+                $normalized = $this->normalizeText($part, $event);
+                if ($normalized !== $part) {
+                    $changed = true;
+                }
+                $newParts[] = $normalized;
+
+                continue;
+            }
+
+            $newParts[] = $part;
+        }
+
+        if (!$changed) {
+            return $result;
+        }
+
+        $rebuilt = new MultiPartResult($newParts);
+        $rebuilt->getMetadata()->set($result->getMetadata()->all());
+
+        if (null !== $rawResult = $result->getRawResult()) {
+            $rebuilt->setRawResult($rawResult);
+        }
+
+        return $rebuilt;
+    }
+}

--- a/src/platform/src/Result/Normalizer/TextNormalizerInterface.php
+++ b/src/platform/src/Result/Normalizer/TextNormalizerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Normalizer;
+
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ResultInterface;
+
+/**
+ * Normalizes the textual content of model results after invocation.
+ *
+ * Implementations clean up provider-agnostic quirks in model output
+ * (e.g. Markdown code fences around JSON, Unicode format characters).
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+interface TextNormalizerInterface
+{
+    /**
+     * @param array<string, mixed> $options The options passed to Platform::invoke()
+     */
+    public function supports(Model $model, ResultInterface $result, array $options): bool;
+
+    public function normalize(string $text): string;
+}

--- a/src/platform/src/Result/Normalizer/UnicodeNormalizer.php
+++ b/src/platform/src/Result/Normalizer/UnicodeNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Normalizer;
+
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ResultInterface;
+
+/**
+ * Strips Unicode "Cf" (format control) characters — zero-width spaces, BOM,
+ * etc. — and converts non-breaking space (U+00A0) to a regular space.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class UnicodeNormalizer implements TextNormalizerInterface
+{
+    public function supports(Model $model, ResultInterface $result, array $options): bool
+    {
+        return true;
+    }
+
+    public function normalize(string $text): string
+    {
+        if ('' === $text) {
+            return '';
+        }
+
+        $text = preg_replace('/[\p{Cf}]/u', '', $text);
+
+        if (null === $text) {
+            return '';
+        }
+
+        return str_replace("\u{00A0}", ' ', $text);
+    }
+}

--- a/src/platform/src/Result/TextResult.php
+++ b/src/platform/src/Result/TextResult.php
@@ -35,4 +35,23 @@ final class TextResult extends BaseResult
     {
         return $this->signature;
     }
+
+    /**
+     * Returns a new instance with the given content and preserved signature/metadata.
+     */
+    public function withContent(string $content): self
+    {
+        if ($content === $this->content) {
+            return $this;
+        }
+
+        $clone = new self($content, $this->signature);
+        $clone->getMetadata()->set($this->getMetadata()->all());
+
+        if (null !== $rawResult = $this->getRawResult()) {
+            $clone->setRawResult($rawResult);
+        }
+
+        return $clone;
+    }
 }

--- a/src/platform/src/Result/TextResult.php
+++ b/src/platform/src/Result/TextResult.php
@@ -36,9 +36,6 @@ final class TextResult extends BaseResult
         return $this->signature;
     }
 
-    /**
-     * Returns a new instance with the given content and preserved signature/metadata.
-     */
     public function withContent(string $content): self
     {
         if ($content === $this->content) {

--- a/src/platform/tests/Result/Normalizer/JsonFenceStripNormalizerTest.php
+++ b/src/platform/tests/Result/Normalizer/JsonFenceStripNormalizerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\Normalizer\JsonFenceStripNormalizer;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Vector\Vector;
+
+final class JsonFenceStripNormalizerTest extends TestCase
+{
+    public function testStripsJsonFencedBlock()
+    {
+        $normalizer = new JsonFenceStripNormalizer();
+
+        $input = "```json\n{\"foo\": \"bar\"}\n```";
+
+        $this->assertSame('{"foo": "bar"}', $normalizer->normalize($input));
+    }
+
+    public function testStripsFencedBlockWithoutLanguageTag()
+    {
+        $normalizer = new JsonFenceStripNormalizer();
+
+        $input = "```\n{\"foo\": \"bar\"}\n```";
+
+        $this->assertSame('{"foo": "bar"}', $normalizer->normalize($input));
+    }
+
+    public function testLeavesTextUnchangedWhenFenceContentsAreInvalidJson()
+    {
+        $normalizer = new JsonFenceStripNormalizer();
+
+        $input = "```json\nnot valid json\n```";
+
+        $this->assertSame($input, $normalizer->normalize($input));
+    }
+
+    public function testLeavesTextUnchangedWhenNoFencePresent()
+    {
+        $normalizer = new JsonFenceStripNormalizer();
+
+        $input = '{"foo": "bar"}';
+
+        $this->assertSame($input, $normalizer->normalize($input));
+    }
+
+    public function testReturnsEmptyStringOnEmptyInput()
+    {
+        $normalizer = new JsonFenceStripNormalizer();
+
+        $this->assertSame('', $normalizer->normalize(''));
+    }
+
+    public function testSupportsReturnsTrueForJsonResponseFormat()
+    {
+        $normalizer = new JsonFenceStripNormalizer();
+
+        $this->assertTrue($normalizer->supports(
+            new Model('gpt-4'),
+            new TextResult('foo'),
+            ['response_format' => 'json'],
+        ));
+    }
+
+    public function testSupportsReturnsTrueForJsonSchemaResponseFormat()
+    {
+        $normalizer = new JsonFenceStripNormalizer();
+
+        $this->assertTrue($normalizer->supports(
+            new Model('gpt-4'),
+            new TextResult('foo'),
+            ['response_format' => ['type' => 'json_schema', 'json_schema' => []]],
+        ));
+    }
+
+    public function testSupportsReturnsTrueForObjectResultRegardlessOfOptions()
+    {
+        $normalizer = new JsonFenceStripNormalizer();
+
+        $this->assertTrue($normalizer->supports(
+            new Model('gpt-4'),
+            new ObjectResult(['foo' => 'bar']),
+            [],
+        ));
+    }
+
+    public function testSupportsReturnsFalseWithoutResponseFormatAndTextResult()
+    {
+        $normalizer = new JsonFenceStripNormalizer();
+
+        $this->assertFalse($normalizer->supports(
+            new Model('gpt-4'),
+            new TextResult('foo'),
+            [],
+        ));
+    }
+
+    public function testSupportsReturnsFalseForVectorResult()
+    {
+        $normalizer = new JsonFenceStripNormalizer();
+
+        $this->assertFalse($normalizer->supports(
+            new Model('text-embedding-3-small'),
+            new VectorResult([new Vector([0.1, 0.2])]),
+            [],
+        ));
+    }
+}

--- a/src/platform/tests/Result/Normalizer/PlatformSubscriberTest.php
+++ b/src/platform/tests/Result/Normalizer/PlatformSubscriberTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Event\ResultEvent;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\PlainConverter;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\Normalizer\PlatformSubscriber;
+use Symfony\AI\Platform\Result\Normalizer\TextNormalizerInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Vector\Vector;
+
+final class PlatformSubscriberTest extends TestCase
+{
+    public function testAppliesAllMatchingNormalizersInRegistrationOrder()
+    {
+        $subscriber = new PlatformSubscriber([
+            $this->createNormalizer(static fn (string $text) => $text.'-first'),
+            $this->createNormalizer(static fn (string $text) => $text.'-second'),
+        ]);
+
+        $event = $this->createResultEvent(new TextResult('value'));
+        $subscriber->onResult($event);
+
+        $this->assertInstanceOf(TextResult::class, $result = $event->getDeferredResult()->getResult());
+        $this->assertSame('value-first-second', $result->getContent());
+    }
+
+    public function testSkipsNonMatchingNormalizers()
+    {
+        $subscriber = new PlatformSubscriber([
+            $this->createNormalizer(static fn (string $text) => $text.'-applied', supports: false),
+            $this->createNormalizer(static fn (string $text) => $text.'-also-applied'),
+        ]);
+
+        $event = $this->createResultEvent(new TextResult('value'));
+        $subscriber->onResult($event);
+
+        $this->assertInstanceOf(TextResult::class, $result = $event->getDeferredResult()->getResult());
+        $this->assertSame('value-also-applied', $result->getContent());
+    }
+
+    public function testLeavesResultUntouchedWhenNoNormalizerMatches()
+    {
+        $original = new TextResult('value');
+        $subscriber = new PlatformSubscriber([
+            $this->createNormalizer(static fn (string $text) => $text.'-never', supports: false),
+        ]);
+
+        $event = $this->createResultEvent($original);
+        $originalDeferred = $event->getDeferredResult();
+        $subscriber->onResult($event);
+
+        $this->assertSame($originalDeferred, $event->getDeferredResult());
+        $this->assertSame($original, $event->getDeferredResult()->getResult());
+    }
+
+    public function testLeavesResultUntouchedWhenNormalizersProduceSameText()
+    {
+        $original = new TextResult('value');
+        $subscriber = new PlatformSubscriber([
+            $this->createNormalizer(static fn (string $text) => $text),
+        ]);
+
+        $event = $this->createResultEvent($original);
+        $originalDeferred = $event->getDeferredResult();
+        $subscriber->onResult($event);
+
+        $this->assertSame($originalDeferred, $event->getDeferredResult());
+        $this->assertSame($original, $event->getDeferredResult()->getResult());
+    }
+
+    public function testLeavesNonTextResultsUntouched()
+    {
+        $vectorResult = new VectorResult([new Vector([0.1, 0.2])]);
+
+        $subscriber = new PlatformSubscriber([
+            $this->createNormalizer(static fn (string $text) => $text.'-modified'),
+        ]);
+
+        $event = $this->createResultEvent($vectorResult);
+        $originalDeferred = $event->getDeferredResult();
+        $subscriber->onResult($event);
+
+        $this->assertSame($originalDeferred, $event->getDeferredResult());
+        $this->assertSame($vectorResult, $event->getDeferredResult()->getResult());
+    }
+
+    public function testNormalizesTextPartsInsideMultiPartResult()
+    {
+        $multiPart = new MultiPartResult([
+            new TextResult('foo'),
+            new VectorResult([new Vector([0.1, 0.2])]),
+            new TextResult('bar'),
+        ]);
+
+        $subscriber = new PlatformSubscriber([
+            $this->createNormalizer(static fn (string $text) => $text.'!'),
+        ]);
+
+        $event = $this->createResultEvent($multiPart);
+        $subscriber->onResult($event);
+
+        $this->assertInstanceOf(MultiPartResult::class, $result = $event->getDeferredResult()->getResult());
+        $parts = $result->getContent();
+        $this->assertCount(3, $parts);
+        $this->assertInstanceOf(TextResult::class, $parts[0]);
+        $this->assertSame('foo!', $parts[0]->getContent());
+        $this->assertInstanceOf(VectorResult::class, $parts[1]);
+        $this->assertInstanceOf(TextResult::class, $parts[2]);
+        $this->assertSame('bar!', $parts[2]->getContent());
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function createResultEvent(ResultInterface $result, array $options = []): ResultEvent
+    {
+        $deferred = new DeferredResult(new PlainConverter($result), new InMemoryRawResult(), $options);
+
+        return new ResultEvent(new Model('gpt-4'), $deferred, $options);
+    }
+
+    private function createNormalizer(\Closure $normalize, bool $supports = true): TextNormalizerInterface
+    {
+        return new class($normalize, $supports) implements TextNormalizerInterface {
+            public function __construct(
+                private readonly \Closure $normalize,
+                private readonly bool $supports,
+            ) {
+            }
+
+            public function supports(Model $model, ResultInterface $result, array $options): bool
+            {
+                return $this->supports;
+            }
+
+            public function normalize(string $text): string
+            {
+                return ($this->normalize)($text);
+            }
+        };
+    }
+}

--- a/src/platform/tests/Result/Normalizer/UnicodeNormalizerTest.php
+++ b/src/platform/tests/Result/Normalizer/UnicodeNormalizerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\Normalizer\UnicodeNormalizer;
+use Symfony\AI\Platform\Result\TextResult;
+
+final class UnicodeNormalizerTest extends TestCase
+{
+    public function testRemovesZeroWidthSpace()
+    {
+        $normalizer = new UnicodeNormalizer();
+
+        $input = "foo\u{200B}bar";
+
+        $this->assertSame('foobar', $normalizer->normalize($input));
+    }
+
+    public function testRemovesByteOrderMark()
+    {
+        $normalizer = new UnicodeNormalizer();
+
+        $input = "\u{FEFF}hello";
+
+        $this->assertSame('hello', $normalizer->normalize($input));
+    }
+
+    public function testConvertsNonBreakingSpaceToRegularSpace()
+    {
+        $normalizer = new UnicodeNormalizer();
+
+        $input = "foo\u{00A0}bar";
+
+        $this->assertSame('foo bar', $normalizer->normalize($input));
+    }
+
+    public function testReturnsEmptyStringOnEmptyInput()
+    {
+        $normalizer = new UnicodeNormalizer();
+
+        $this->assertSame('', $normalizer->normalize(''));
+    }
+
+    public function testLeavesPlainTextUnchanged()
+    {
+        $normalizer = new UnicodeNormalizer();
+
+        $input = 'Hello, World!';
+
+        $this->assertSame($input, $normalizer->normalize($input));
+    }
+
+    public function testSupportsReturnsTrueRegardlessOfContext()
+    {
+        $normalizer = new UnicodeNormalizer();
+
+        $this->assertTrue($normalizer->supports(
+            new Model('gpt-4'),
+            new TextResult('foo'),
+            [],
+        ));
+    }
+}

--- a/src/platform/tests/Result/TextResultTest.php
+++ b/src/platform/tests/Result/TextResultTest.php
@@ -21,4 +21,25 @@ final class TextResultTest extends TestCase
         $result = new TextResult($expected = 'foo');
         $this->assertSame($expected, $result->getContent());
     }
+
+    public function testWithContentReturnsNewInstanceWithUpdatedContent()
+    {
+        $original = new TextResult('foo', 'signature');
+        $original->getMetadata()->add('key', 'value');
+
+        $modified = $original->withContent('bar');
+
+        $this->assertNotSame($original, $modified);
+        $this->assertSame('bar', $modified->getContent());
+        $this->assertSame('signature', $modified->getSignature());
+        $this->assertSame(['key' => 'value'], $modified->getMetadata()->all());
+        $this->assertSame('foo', $original->getContent());
+    }
+
+    public function testWithContentReturnsSameInstanceWhenContentUnchanged()
+    {
+        $original = new TextResult('foo');
+
+        $this->assertSame($original, $original->withContent('foo'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

This PR adds a normalizer pipeline that cleans the textual content of `TextResult` (and its parts inside `MultiPartResult`) after a model call. The fence/Unicode quirks are model-output problems, not provider problems, so the wiring lives in `platform` and applies across every bridge.

## What ships

`Symfony\AI\Platform\Result\Normalizer\TextNormalizerInterface`:

```php
public function supports(Model $model, ResultInterface $result, array $options): bool;
public function normalize(string $text): string;
```

`supports()` receives the original `$options` so a normalizer can react to e.g. `response_format`.

Two implementations:

- `JsonFenceStripNormalizer` — strips ```` ```json … ``` ```` (and bare ```` ``` … ``` ````) wrappers when the fenced body is valid JSON. Active when the request asks for `response_format: json` / `json_schema`, or when the converted result is already an `ObjectResult`.
- `UnicodeNormalizer` — removes Unicode `Cf` (format control) characters such as zero-width spaces and BOM, and converts non-breaking space (`U+00A0`) to a regular space. Always active.

`PlatformSubscriber` listens to `ResultEvent` at priority `10` (before structured-output processing) and walks the registered normalizers in order. Non-text results pass through untouched; `MultiPartResult` parts are normalized individually.

`TextResult` gets a `withContent()` helper that returns a new instance with replaced content, preserving signature and metadata. Streaming results are intentionally out of scope for this PR.

## AI Bundle wiring

The bundle ships both normalizers and the subscriber as services and auto-tags any `TextNormalizerInterface` implementation with `ai.platform.result_normalizer`. No user-facing config — normalizers are enabled by default.
