### PR TITLE
[Platform][Anthropic] Support cache_control on system prompt block

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -569,8 +569,10 @@ Prompt Caching (Anthropic)
 
 Anthropic supports `prompt caching`_, which can significantly reduce costs and
 latency for repeated prompts. Symfony AI automatically enables prompt caching
-when using the Anthropic bridge by annotating the last user message with a
-``cache_control`` marker.
+when using the Anthropic bridge by annotating the most cacheable regions of the
+request with ``cache_control`` markers: the system prompt, the last tool
+definition, and the last user message. The system prompt is typically the
+largest and most stable region, making it the most effective caching target.
 
 The caching behavior is configured via the ``cacheRetention`` parameter on the
 :class:`Symfony\\AI\\Platform\\Bridge\\Anthropic\\ModelClient`::

--- a/src/platform/src/Bridge/Anthropic/Contract/MessageBagNormalizer.php
+++ b/src/platform/src/Bridge/Anthropic/Contract/MessageBagNormalizer.php
@@ -32,7 +32,7 @@ final class MessageBagNormalizer extends ModelContractNormalizer implements Norm
      * @return array{
      *     messages: list<array<string, mixed>>,
      *     model?: string,
-     *     system?: string,
+     *     system?: list<array{type: 'text', text: string}>,
      * }
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
@@ -42,7 +42,9 @@ final class MessageBagNormalizer extends ModelContractNormalizer implements Norm
         ];
 
         if (null !== $system = $data->getSystemMessage()) {
-            $array['system'] = $system->getContent();
+            $array['system'] = [
+                ['type' => 'text', 'text' => (string) $system->getContent()],
+            ];
         }
 
         if (isset($context[Contract::CONTEXT_MODEL]) && $context[Contract::CONTEXT_MODEL] instanceof Model) {

--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -60,6 +60,7 @@ final class ModelClient implements ModelClientInterface
         ];
 
         $payload = $this->injectCacheControl($payload);
+        $payload = $this->injectSystemCacheControl($payload);
 
         if (isset($options['tools'])) {
             $options['tool_choice'] = ['type' => 'auto'];
@@ -119,6 +120,29 @@ final class ModelClient implements ModelClientInterface
     }
 
     /**
+     * Injects a prompt-caching marker on the last system content block.
+     *
+     * The system prompt is typically the largest and most stable region of a
+     * request, making it the single most effective caching target. This creates
+     * a cache breakpoint after the system block so it can be cached independently
+     * of the tools and messages that follow.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function injectSystemCacheControl(array $payload): array
+    {
+        if ('none' === $this->cacheRetention || !isset($payload['system']) || !\is_array($payload['system']) || [] === $payload['system']) {
+            return $payload;
+        }
+
+        $payload['system'][\count($payload['system']) - 1]['cache_control'] = $this->getCacheControl();
+
+        return $payload;
+    }
+
+    /**
      * Injects prompt-caching markers into the normalised message payload.
      *
      * Anthropic prompt caching requires a {"cache_control": {"type": "ephemeral"}}
@@ -140,9 +164,7 @@ final class ModelClient implements ModelClientInterface
             return $payload;
         }
 
-        $cacheControl = 'long' === $this->cacheRetention
-            ? ['type' => 'ephemeral', 'ttl' => '1h']
-            : ['type' => 'ephemeral'];
+        $cacheControl = $this->getCacheControl();
 
         for ($i = \count($messages) - 1; $i >= 0; --$i) {
             if ('user' !== ($messages[$i]['role'] ?? '')) {
@@ -171,5 +193,19 @@ final class ModelClient implements ModelClientInterface
         $payload['messages'] = $messages;
 
         return $payload;
+    }
+
+    /**
+     * Builds the prompt-caching marker matching the configured retention.
+     *
+     * @return array{type: 'ephemeral', ttl?: '1h'}
+     */
+    private function getCacheControl(): array
+    {
+        if ('long' === $this->cacheRetention) {
+            return ['type' => 'ephemeral', 'ttl' => '1h'];
+        }
+
+        return ['type' => 'ephemeral'];
     }
 }

--- a/src/platform/src/Bridge/Anthropic/Tests/AssistantReplayTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/AssistantReplayTest.php
@@ -281,7 +281,7 @@ final class AssistantReplayTest extends TestCase
                     ['role' => 'assistant', 'content' => 'Aye!'],
                     ['role' => 'user', 'content' => 'Again!'],
                 ],
-                'system' => 'You are a pirate.',
+                'system' => [['type' => 'text', 'text' => 'You are a pirate.']],
                 'model' => 'claude-sonnet-4-0',
             ],
         ];

--- a/src/platform/tests/Bridge/Anthropic/Contract/MessageBagNormalizerTest.php
+++ b/src/platform/tests/Bridge/Anthropic/Contract/MessageBagNormalizerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\Anthropic\Contract;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Anthropic\Claude;
+use Symfony\AI\Platform\Bridge\Anthropic\Contract\MessageBagNormalizer;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\SystemMessage;
+use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class MessageBagNormalizerTest extends TestCase
+{
+    private MessageBagNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new MessageBagNormalizer();
+
+        $innerNormalizer = $this->createMock(NormalizerInterface::class);
+        $innerNormalizer->method('normalize')->willReturn([
+            ['role' => 'user', 'content' => 'Hello'],
+        ]);
+
+        $this->normalizer->setNormalizer($innerNormalizer);
+    }
+
+    public function testSupportsNormalization()
+    {
+        $context = [Contract::CONTEXT_MODEL => new Claude(Claude::SONNET_4)];
+
+        $this->assertTrue($this->normalizer->supportsNormalization(new MessageBag(), null, $context));
+        $this->assertFalse($this->normalizer->supportsNormalization(new MessageBag(), null, []));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass(), null, $context));
+    }
+
+    public function testNormalizeEmitsSystemMessageAsContentBlockArray()
+    {
+        $messageBag = new MessageBag(
+            new SystemMessage('You are a helpful assistant.'),
+            new UserMessage(new Text('Hello')),
+        );
+
+        $result = $this->normalizer->normalize($messageBag, context: [
+            Contract::CONTEXT_MODEL => new Claude(Claude::SONNET_4),
+        ]);
+
+        $this->assertSame([
+            ['type' => 'text', 'text' => 'You are a helpful assistant.'],
+        ], $result['system']);
+    }
+
+    public function testNormalizeWithoutSystemMessageHasNoSystemKey()
+    {
+        $messageBag = new MessageBag(
+            new UserMessage(new Text('Hello')),
+        );
+
+        $result = $this->normalizer->normalize($messageBag, context: [
+            Contract::CONTEXT_MODEL => new Claude(Claude::SONNET_4),
+        ]);
+
+        $this->assertArrayNotHasKey('system', $result);
+    }
+}

--- a/src/platform/tests/Bridge/Anthropic/ModelClientTest.php
+++ b/src/platform/tests/Bridge/Anthropic/ModelClientTest.php
@@ -121,4 +121,96 @@ final class ModelClientTest extends TestCase
         $this->assertNotNull($capturedBody);
         $this->assertArrayNotHasKey('cache_control', $capturedBody['tools'][0]);
     }
+
+    public function testSystemCacheControlIsInjectedWithShortRetention()
+    {
+        $capturedBody = null;
+
+        $httpClient = new MockHttpClient(static function ($method, $url, $options) use (&$capturedBody) {
+            $capturedBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'type' => 'message',
+                'content' => [['type' => 'text', 'text' => 'Hello']],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]));
+        });
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'short');
+
+        $payload = [
+            'model' => Claude::SONNET_4,
+            'system' => [['type' => 'text', 'text' => 'You are a helpful assistant.']],
+            'messages' => [['role' => 'user', 'content' => 'Hello']],
+        ];
+
+        $client->request(new Claude(Claude::SONNET_4), $payload);
+
+        $this->assertNotNull($capturedBody);
+        $this->assertSame(['type' => 'ephemeral'], $capturedBody['system'][0]['cache_control']);
+    }
+
+    public function testSystemCacheControlIsInjectedOnLastBlockWithLongRetention()
+    {
+        $capturedBody = null;
+
+        $httpClient = new MockHttpClient(static function ($method, $url, $options) use (&$capturedBody) {
+            $capturedBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'type' => 'message',
+                'content' => [['type' => 'text', 'text' => 'Hello']],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]));
+        });
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'long');
+
+        $payload = [
+            'model' => Claude::SONNET_4,
+            'system' => [
+                ['type' => 'text', 'text' => 'First block.'],
+                ['type' => 'text', 'text' => 'Second block.'],
+            ],
+            'messages' => [['role' => 'user', 'content' => 'Hello']],
+        ];
+
+        $client->request(new Claude(Claude::SONNET_4), $payload);
+
+        $this->assertNotNull($capturedBody);
+
+        // Last system block should have the long-retention cache_control
+        $this->assertSame(['type' => 'ephemeral', 'ttl' => '1h'], $capturedBody['system'][1]['cache_control']);
+
+        // First system block should NOT have cache_control
+        $this->assertArrayNotHasKey('cache_control', $capturedBody['system'][0]);
+    }
+
+    public function testSystemCacheControlIsNotInjectedWithNoneRetention()
+    {
+        $capturedBody = null;
+
+        $httpClient = new MockHttpClient(static function ($method, $url, $options) use (&$capturedBody) {
+            $capturedBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'type' => 'message',
+                'content' => [['type' => 'text', 'text' => 'Hello']],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]));
+        });
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'none');
+
+        $payload = [
+            'model' => Claude::SONNET_4,
+            'system' => [['type' => 'text', 'text' => 'You are a helpful assistant.']],
+            'messages' => [['role' => 'user', 'content' => 'Hello']],
+        ];
+
+        $client->request(new Claude(Claude::SONNET_4), $payload);
+
+        $this->assertNotNull($capturedBody);
+        $this->assertArrayNotHasKey('cache_control', $capturedBody['system'][0]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #2111
| License       | MIT

- MessageBagNormalizer now emits the system prompt as a typed content-block array ([{type: text, text: ...}]) instead of a bare string, so a cache marker can be attached. Anthropic accepts both shapes, so callers see no difference.
- ModelClient attaches a cache_control marker to the system block when cacheRetention is short/long (skipped for none), mirroring the existing tool-definition caching.
