### PR TITLE
[Platform][VertexAi] Use SSE format for streaming to avoid partial-JSON parsing

### DIFF
--- a/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
@@ -45,7 +45,8 @@ final class ModelClient implements ModelClientInterface
      */
     public function request(BaseModel $model, array|string $payload, array $options = []): RawHttpResult
     {
-        $method = $options['stream'] ?? false ? 'streamGenerateContent' : 'generateContent';
+        $isStream = $options['stream'] ?? false;
+        $method = $isStream ? 'streamGenerateContent' : 'generateContent';
 
         if (null !== $this->location && null !== $this->projectId) {
             $url = \sprintf(
@@ -66,6 +67,9 @@ final class ModelClient implements ModelClientInterface
         $query = [];
         if (null !== $this->apiKey) {
             $query['key'] = $this->apiKey;
+        }
+        if ($isStream) {
+            $query['alt'] = 'sse';
         }
 
         if (isset($options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema'])) {

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
@@ -49,6 +49,19 @@ final class ModelClientTest extends TestCase
         $this->assertSame($expectedResponse, $data);
     }
 
+    public function testRequestWithStreamAsksForSseFormat()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertStringContainsString(':streamGenerateContent', $url);
+            $this->assertStringContainsString('alt=sse', $url);
+
+            return new JsonMockResponse(['candidates' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => []], ['stream' => true]);
+    }
+
     public function testItPassesServerToolsFromOptions()
     {
         $payload = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2121, same root cause as #1184, mirrors #1988
| License       | MIT

#1988 fixed partial-JSON parsing errors on the Gemini bridge by asking Google's API for SSE via `?alt=sse`. The compatibility note in that PR explicitly mentioned VertexAi was unaffected because it builds its own URLs — but the same JSON-chunk-splitting issue applies (stack trace in #2121), so the fix needs to be ported.

### Change

Append `alt=sse` to the query string of `streamGenerateContent` requests in `Bridge/VertexAi/Gemini/ModelClient.php`. The VertexAi client already passes a `query` array to the HTTP client (for the optional `key`), so the change is a single entry added when streaming.

### Compatibility

- Non-streaming path (`stream: false`) unchanged
- API-key path (`?key=…`) still works — both query params are merged