### PR TITLE
[Platform] Add Mock test provider for routing-aware, any-result-type mocks

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -1186,6 +1186,85 @@ This allows fast and isolated testing of AI-powered features without relying on 
 
     This requires `cURL` and the `ext-curl` extension to be installed.
 
+Routing-Aware Mock Provider
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``InMemoryPlatform`` replaces the *whole* platform, so it ignores routing and returns text only.
+When a test needs to go through real model routing, coexist with real providers, return non-text
+results, or assert on exactly what was sent, use the provider-level mock from
+:class:`Symfony\\AI\\Platform\\Test\\MockPlatformFactory` instead. It registers as a regular provider and
+threads a scripted :class:`Symfony\\AI\\Platform\\Result\\ResultInterface` through unchanged, so
+every result type is supported.
+
+The scripted response can be a fixed string, a map keyed by model name, or a closure::
+
+    use Symfony\AI\Platform\Test\MockPlatformFactory;
+
+    // 1. Fixed string - every call returns a TextResult
+    $platform = MockPlatformFactory::createPlatform('Mock result');
+    echo $platform->invoke('gpt-4o-mini', 'What is the capital of France?')->asText(); // "Mock result"
+
+    // 2. Map keyed by model name - per-model response
+    $platform = MockPlatformFactory::createPlatform([
+        'gpt-4o-mini' => 'cheap answer',
+        'gpt-4o' => 'expensive answer',
+    ]);
+
+    // 3. Closure - full control, branch on the payload or options
+    $platform = MockPlatformFactory::createPlatform(
+        fn ($model, $payload, $options) => "Echo: {$payload}"
+    );
+
+Because the result is passed through verbatim, structured output, embeddings, streams and tool
+calls work the same way::
+
+    use Symfony\AI\Platform\Result\ObjectResult;
+    use Symfony\AI\Platform\Result\VectorResult;
+    use Symfony\AI\Platform\Test\MockPlatformFactory;
+    use Symfony\AI\Platform\Vector\Vector;
+
+    $platform = MockPlatformFactory::createPlatform(fn () => new ObjectResult((object) ['city' => 'Paris']));
+    echo $platform->invoke('gpt-4o-mini', 'extract the city')->asObject()->city; // "Paris"
+
+    $platform = MockPlatformFactory::createPlatform(fn () => new VectorResult([new Vector([0.1, 0.2, 0.3])]));
+    $vectors = $platform->invoke('text-embedding-3-small', 'vectorize')->asVectors();
+
+The mock records every call, so a test can assert on the exact payload and options the platform
+built (tool option translation, merged model options, and so on). Build the provider yourself to
+keep a reference to its :class:`Symfony\\AI\\Platform\\Test\\MockModelClient`::
+
+    use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
+    use Symfony\AI\Platform\Platform;
+    use Symfony\AI\Platform\Provider;
+    use Symfony\AI\Platform\Test\MockModelClient;
+    use Symfony\AI\Platform\Test\MockResultConverter;
+
+    $client = new MockModelClient('ok');
+    $provider = new Provider('mock', [$client], [new MockResultConverter()], new FallbackModelCatalog());
+    $platform = new Platform([$provider]);
+
+    $platform->invoke('gpt-4o-mini', 'Hello', ['temperature' => 0.5]);
+
+    $calls = $client->getCalls();
+    // $calls[0]['model']->getName() === 'gpt-4o-mini'
+    // $calls[0]['options'] === ['temperature' => 0.5]
+
+By default the factory uses a :class:`Symfony\\AI\\Platform\\ModelCatalog\\FallbackModelCatalog`,
+so any model name resolves to the mock. To gate which model names route to the mock - for example
+in a multi-provider routing test - pass a :class:`Symfony\\AI\\Platform\\Test\\MockModelCatalog` with
+explicit models instead::
+
+    use Symfony\AI\Platform\Capability;
+    use Symfony\AI\Platform\Model;
+    use Symfony\AI\Platform\Test\MockModelCatalog;
+    use Symfony\AI\Platform\Test\MockPlatformFactory;
+
+    $provider = MockPlatformFactory::createProvider('mock answer', new MockModelCatalog([
+        'mock-model' => ['class' => Model::class, 'capabilities' => [Capability::INPUT_MESSAGES]],
+    ]));
+    // $provider->supports('mock-model') === true
+    // $provider->supports('gpt-4o') === false
+
 Code Examples
 ~~~~~~~~~~~~~
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Add `PartialJsonParser` for recovering partial JSON from streaming output
+ * Add routing-aware mock test provider (`Test\MockPlatformFactory`, `Test\MockModelClient`, `Test\MockResultConverter`, `Test\MockModelCatalog`) for any-result-type mocks in tests, complementing `Test\InMemoryPlatform`
 
 0.10
 ----

--- a/src/platform/src/Test/InMemoryPlatform.php
+++ b/src/platform/src/Test/InMemoryPlatform.php
@@ -19,7 +19,6 @@ use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\ResultInterface;
-use Symfony\AI\Platform\Result\TextResult;
 
 /**
  * A fake implementation of PlatformInterface that returns fixed or callable responses.
@@ -31,14 +30,16 @@ use Symfony\AI\Platform\Result\TextResult;
 class InMemoryPlatform implements PlatformInterface
 {
     private readonly ModelCatalogInterface $modelCatalog;
+    private readonly ScriptedResponse $response;
 
     /**
      * The mock result can be a string or a callable that returns a string.
      * If it's a closure, it receives the model, input, and optionally options as parameters like a real platform call.
      */
-    public function __construct(private readonly \Closure|string $mockResult)
+    public function __construct(\Closure|string $mockResult)
     {
         $this->modelCatalog = new FallbackModelCatalog();
+        $this->response = new ScriptedResponse($mockResult);
     }
 
     public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
@@ -51,13 +52,8 @@ class InMemoryPlatform implements PlatformInterface
                 }
             };
         }
-        $result = \is_string($this->mockResult) ? $this->mockResult : ($this->mockResult)($model, $input, $options);
 
-        if ($result instanceof ResultInterface) {
-            return $this->createDeferredResult($result, $options);
-        }
-
-        return $this->createDeferredResult(new TextResult($result), $options);
+        return $this->createDeferredResult($this->response->resolve($model, $input, $options), $options);
     }
 
     public function getModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Test/MockModelCatalog.php
+++ b/src/platform/src/Test/MockModelCatalog.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test;
+
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\ModelCatalog\AbstractModelCatalog;
+
+/**
+ * Optional catalog for the mock provider. Register models explicitly to gate which model names
+ * route to the mock provider; otherwise pass a FallbackModelCatalog so any name resolves.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class MockModelCatalog extends AbstractModelCatalog
+{
+    /**
+     * @param array<string, array{class: class-string, capabilities: list<Capability>}> $models
+     */
+    public function __construct(
+        protected array $models = [],
+    ) {
+    }
+}

--- a/src/platform/src/Test/MockModelClient.php
+++ b/src/platform/src/Test/MockModelClient.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test;
+
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+
+/**
+ * Test model client that returns scripted responses and records every call.
+ *
+ * The scripted response is resolved by {@see ScriptedResponse} and threaded through unchanged via
+ * the `object` slot of an {@see InMemoryRawResult}, so every result type is supported without
+ * per-type conversion code.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class MockModelClient implements ModelClientInterface
+{
+    /**
+     * @var list<array{model: Model, payload: array<string|int, mixed>|string, options: array<string, mixed>}>
+     */
+    private array $calls = [];
+
+    private readonly ScriptedResponse $response;
+
+    /**
+     * @param \Closure|string|array<string, ResultInterface|string> $responses
+     */
+    public function __construct(\Closure|string|array $responses)
+    {
+        $this->response = new ScriptedResponse($responses);
+    }
+
+    public function supports(Model $model): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array<string|int, mixed> $payload
+     * @param array<string, mixed>     $options
+     */
+    public function request(Model $model, array|string $payload, array $options = []): InMemoryRawResult
+    {
+        $this->calls[] = ['model' => $model, 'payload' => $payload, 'options' => $options];
+
+        return new InMemoryRawResult(object: $this->response->resolve($model, $payload, $options));
+    }
+
+    /**
+     * @return list<array{model: Model, payload: array<string|int, mixed>|string, options: array<string, mixed>}>
+     */
+    public function getCalls(): array
+    {
+        return $this->calls;
+    }
+}

--- a/src/platform/src/Test/MockPlatformFactory.php
+++ b/src/platform/src/Test/MockPlatformFactory.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test;
+
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\ModelRouter\CatalogBasedModelRouter;
+use Symfony\AI\Platform\ModelRouterInterface;
+use Symfony\AI\Platform\Platform;
+use Symfony\AI\Platform\Provider;
+use Symfony\AI\Platform\ProviderInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Builds a routing-aware mock provider/platform that returns scripted responses of any result type.
+ *
+ * Complements {@see InMemoryPlatform}: use this when a test must go through real routing, coexist
+ * with real providers, return non-text results, or assert on the exact payload/options the platform
+ * built (via {@see MockModelClient::getCalls()}).
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class MockPlatformFactory
+{
+    /**
+     * @param \Closure|string|array<string, ResultInterface|string> $responses
+     * @param non-empty-string                                      $name
+     */
+    public static function createProvider(
+        \Closure|string|array $responses,
+        ModelCatalogInterface $modelCatalog = new FallbackModelCatalog(),
+        ?Contract $contract = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+        string $name = 'mock',
+    ): ProviderInterface {
+        return new Provider(
+            $name,
+            [new MockModelClient($responses)],
+            [new MockResultConverter()],
+            $modelCatalog,
+            $contract,
+            $eventDispatcher,
+        );
+    }
+
+    /**
+     * @param \Closure|string|array<string, ResultInterface|string> $responses
+     * @param non-empty-string                                      $name
+     */
+    public static function createPlatform(
+        \Closure|string|array $responses,
+        ModelCatalogInterface $modelCatalog = new FallbackModelCatalog(),
+        ?Contract $contract = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+        string $name = 'mock',
+        ?ModelRouterInterface $modelRouter = null,
+    ): Platform {
+        return new Platform(
+            [self::createProvider($responses, $modelCatalog, $contract, $eventDispatcher, $name)],
+            $modelRouter ?? new CatalogBasedModelRouter(),
+            $eventDispatcher,
+        );
+    }
+}

--- a/src/platform/src/Test/MockResultConverter.php
+++ b/src/platform/src/Test/MockResultConverter.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test;
+
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+
+/**
+ * Pass-through converter for {@see MockModelClient}: returns the scripted {@see ResultInterface}
+ * verbatim, so any result type is supported without per-type conversion code.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class MockResultConverter implements ResultConverterInterface
+{
+    public function supports(Model $model): bool
+    {
+        return true;
+    }
+
+    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    {
+        $payload = $result->getObject();
+
+        if ($payload instanceof ResultInterface) {
+            return $payload;
+        }
+
+        return new TextResult((string) ($result->getData()['text'] ?? ''));
+    }
+
+    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    {
+        return null;
+    }
+}

--- a/src/platform/src/Test/ScriptedResponse.php
+++ b/src/platform/src/Test/ScriptedResponse.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test;
+
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+
+/**
+ * Resolves a scripted response into a {@see ResultInterface}.
+ *
+ * The script can be:
+ *  - a string: every call resolves to a {@see TextResult} wrapping it;
+ *  - a map keyed by model name: per-model {@see ResultInterface} or string;
+ *  - a \Closure(Model $model, array|string|object $input, array $options): ResultInterface|string.
+ *
+ * Bare strings are wrapped in a {@see TextResult}; a {@see ResultInterface} is returned verbatim,
+ * so every result type is supported. Shared by the provider-level {@see MockModelClient} and the
+ * platform-level {@see InMemoryPlatform} so both speak the same scripting language.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ScriptedResponse
+{
+    /**
+     * @param \Closure|string|array<string, ResultInterface|string> $script
+     */
+    public function __construct(
+        private readonly \Closure|string|array $script,
+    ) {
+    }
+
+    /**
+     * @param array<string|int, mixed>|string|object $input
+     * @param array<string, mixed>                   $options
+     */
+    public function resolve(Model $model, array|string|object $input, array $options): ResultInterface
+    {
+        $resolved = $this->resolveRaw($model, $input, $options);
+
+        if (\is_string($resolved)) {
+            return new TextResult($resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param array<string|int, mixed>|string|object $input
+     * @param array<string, mixed>                   $options
+     */
+    private function resolveRaw(Model $model, array|string|object $input, array $options): ResultInterface|string
+    {
+        if ($this->script instanceof \Closure) {
+            return ($this->script)($model, $input, $options);
+        }
+
+        if (\is_string($this->script)) {
+            return $this->script;
+        }
+
+        $name = $model->getName();
+
+        if (!\array_key_exists($name, $this->script)) {
+            throw new InvalidArgumentException(\sprintf('No scripted response configured for model "%s".', $name));
+        }
+
+        return $this->script[$name];
+    }
+}

--- a/src/platform/tests/Test/MockModelClientTest.php
+++ b/src/platform/tests/Test/MockModelClientTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Test;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Test\MockModelClient;
+
+final class MockModelClientTest extends TestCase
+{
+    public function testSupportsReturnsTrueForAnyModel()
+    {
+        $client = new MockModelClient('answer');
+
+        $this->assertTrue($client->supports(new Model('any-model')));
+    }
+
+    public function testStringResponseWrapsInTextResult()
+    {
+        $client = new MockModelClient('Hello world');
+
+        $rawResult = $client->request(new Model('any-model'), 'question');
+        $result = $rawResult->getObject();
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello world', $result->getContent());
+    }
+
+    public function testMapResponseSelectsByModelName()
+    {
+        $client = new MockModelClient([
+            'model-a' => 'answer a',
+            'model-b' => new ObjectResult(['foo' => 'bar']),
+        ]);
+
+        $resultA = $client->request(new Model('model-a'), 'q')->getObject();
+        $resultB = $client->request(new Model('model-b'), 'q')->getObject();
+
+        $this->assertInstanceOf(TextResult::class, $resultA);
+        $this->assertSame('answer a', $resultA->getContent());
+        $this->assertInstanceOf(ObjectResult::class, $resultB);
+        $this->assertSame(['foo' => 'bar'], $resultB->getContent());
+    }
+
+    public function testMapResponseThrowsForUnknownModel()
+    {
+        $client = new MockModelClient(['known' => 'answer']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No scripted response configured for model "unknown".');
+
+        $client->request(new Model('unknown'), 'q');
+    }
+
+    public function testClosureReceivesModelPayloadAndOptions()
+    {
+        $client = new MockModelClient(static function (Model $model, array|string $payload, array $options): string {
+            return \sprintf('%s|%s|%s', $model->getName(), $payload, $options['stream'] ? 'stream' : 'sync');
+        });
+
+        $result = $client->request(new Model('gpt'), 'hi', ['stream' => true])->getObject();
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('gpt|hi|stream', $result->getContent());
+    }
+
+    public function testGetCallsRecordsEveryInvocation()
+    {
+        $client = new MockModelClient('answer');
+
+        $client->request(new Model('model-a'), 'first', ['temperature' => 0.5]);
+        $client->request(new Model('model-b'), ['messages' => []]);
+
+        $calls = $client->getCalls();
+
+        $this->assertCount(2, $calls);
+        $this->assertSame('model-a', $calls[0]['model']->getName());
+        $this->assertSame('first', $calls[0]['payload']);
+        $this->assertSame(['temperature' => 0.5], $calls[0]['options']);
+        $this->assertSame('model-b', $calls[1]['model']->getName());
+        $this->assertSame(['messages' => []], $calls[1]['payload']);
+        $this->assertSame([], $calls[1]['options']);
+    }
+}

--- a/src/platform/tests/Test/MockPlatformFactoryTest.php
+++ b/src/platform/tests/Test/MockPlatformFactoryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Test;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Platform;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Test\MockModelCatalog;
+use Symfony\AI\Platform\Test\MockPlatformFactory;
+use Symfony\AI\Platform\Vector\Vector;
+
+final class MockPlatformFactoryTest extends TestCase
+{
+    public function testCreatePlatformWithStringRespondsToAnyModel()
+    {
+        $platform = MockPlatformFactory::createPlatform('hi');
+
+        $this->assertSame('hi', $platform->invoke('any-model', 'q')->asText());
+    }
+
+    public function testCreateProviderWithCatalogGatesRouting()
+    {
+        $provider = MockPlatformFactory::createProvider('answer', new MockModelCatalog([
+            'fake-model' => ['class' => Model::class, 'capabilities' => []],
+        ]));
+
+        $this->assertTrue($provider->supports('fake-model'));
+        $this->assertFalse($provider->supports('unknown-model'));
+    }
+
+    public function testInvokeUnknownModelThrowsWithSpecificCatalog()
+    {
+        $platform = MockPlatformFactory::createPlatform('answer', new MockModelCatalog([
+            'fake-model' => ['class' => Model::class, 'capabilities' => []],
+        ]));
+
+        $this->expectException(ModelNotFoundException::class);
+
+        $platform->invoke('unknown-model', 'q')->asText();
+    }
+
+    public function testStructuredResultRoundTrips()
+    {
+        $platform = MockPlatformFactory::createPlatform(static function (Model $model, array|string $payload, array $options): ResultInterface|string {
+            if (isset($options['response_format'])) {
+                return new ObjectResult((object) ['answer' => 42]);
+            }
+
+            return 'plain';
+        });
+
+        $result = $platform->invoke('any-model', 'q', ['response_format' => ['type' => 'json']]);
+
+        $this->assertEquals((object) ['answer' => 42], $result->asObject());
+    }
+
+    public function testStreamResultRoundTrips()
+    {
+        $platform = MockPlatformFactory::createPlatform(static fn (): ResultInterface => new StreamResult(
+            (static function (): \Generator {
+                yield new TextDelta('Hel');
+                yield new TextDelta('lo');
+            })(),
+        ));
+
+        $deltas = [];
+        foreach ($platform->invoke('any-model', 'q', ['stream' => true])->asStream() as $delta) {
+            $deltas[] = (string) $delta;
+        }
+
+        $this->assertSame(['Hel', 'lo'], $deltas);
+    }
+
+    public function testVectorResultRoundTrips()
+    {
+        $platform = MockPlatformFactory::createPlatform(static fn (): ResultInterface => new VectorResult([new Vector([0.1, 0.2, 0.3])]));
+
+        $vectors = $platform->invoke('any-model', 'q')->asVectors();
+
+        $this->assertCount(1, $vectors);
+        $this->assertSame([0.1, 0.2, 0.3], $vectors[0]->getData());
+    }
+
+    public function testMultiProviderRoutingPicksMockByModelName()
+    {
+        $providerA = MockPlatformFactory::createProvider('from A', new MockModelCatalog([
+            'model-a' => ['class' => Model::class, 'capabilities' => []],
+        ]), name: 'fake-a');
+
+        $providerB = MockPlatformFactory::createProvider('from B', new MockModelCatalog([
+            'model-b' => ['class' => Model::class, 'capabilities' => []],
+        ]), name: 'fake-b');
+
+        $platform = new Platform([$providerA, $providerB]);
+
+        $this->assertSame('from A', $platform->invoke('model-a', 'q')->asText());
+        $this->assertSame('from B', $platform->invoke('model-b', 'q')->asText());
+    }
+}

--- a/src/platform/tests/Test/MockResultConverterTest.php
+++ b/src/platform/tests/Test/MockResultConverterTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Test;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Test\MockResultConverter;
+use Symfony\AI\Platform\Vector\Vector;
+
+final class MockResultConverterTest extends TestCase
+{
+    public function testSupportsReturnsTrueForAnyModel()
+    {
+        $converter = new MockResultConverter();
+
+        $this->assertTrue($converter->supports(new Model('any-model')));
+    }
+
+    public function testGetTokenUsageExtractorReturnsNull()
+    {
+        $converter = new MockResultConverter();
+
+        $this->assertNull($converter->getTokenUsageExtractor());
+    }
+
+    /**
+     * @return iterable<string, array{ResultInterface}>
+     */
+    public static function provideResultTypes(): iterable
+    {
+        yield 'object' => [new ObjectResult(['foo' => 'bar'])];
+        yield 'stream' => [new StreamResult((static function (): \Generator { yield new TextDelta('delta'); })())];
+        yield 'tool-call' => [new ToolCallResult([new ToolCall('id-1', 'my_tool')])];
+        yield 'vector' => [new VectorResult([new Vector([0.1, 0.2, 0.3])])];
+    }
+
+    #[DataProvider('provideResultTypes')]
+    public function testConvertPassesResultThroughUnchanged(ResultInterface $result)
+    {
+        $converter = new MockResultConverter();
+
+        $converted = $converter->convert(new InMemoryRawResult(object: $result));
+
+        $this->assertSame($result, $converted);
+    }
+
+    public function testConvertFallsBackToTextResultFromData()
+    {
+        $converter = new MockResultConverter();
+
+        $converted = $converter->convert(new InMemoryRawResult(['text' => 'plain']));
+
+        $this->assertInstanceOf(TextResult::class, $converted);
+        $this->assertSame('plain', $converted->getContent());
+    }
+
+    public function testConvertFallsBackToEmptyStringWhenNoTextData()
+    {
+        $converter = new MockResultConverter();
+
+        $converted = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(TextResult::class, $converted);
+        $this->assertSame('', $converted->getContent());
+    }
+}

--- a/src/platform/tests/Test/ScriptedResponseTest.php
+++ b/src/platform/tests/Test/ScriptedResponseTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Test;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Test\ScriptedResponse;
+
+final class ScriptedResponseTest extends TestCase
+{
+    public function testStringScriptWrapsInTextResult()
+    {
+        $response = new ScriptedResponse('Hello world');
+
+        $result = $response->resolve(new Model('any-model'), 'q', []);
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello world', $result->getContent());
+    }
+
+    public function testMapScriptSelectsByModelName()
+    {
+        $object = new ObjectResult(['foo' => 'bar']);
+        $response = new ScriptedResponse([
+            'model-a' => 'answer a',
+            'model-b' => $object,
+        ]);
+
+        $resultA = $response->resolve(new Model('model-a'), 'q', []);
+        $resultB = $response->resolve(new Model('model-b'), 'q', []);
+
+        $this->assertInstanceOf(TextResult::class, $resultA);
+        $this->assertSame('answer a', $resultA->getContent());
+        $this->assertSame($object, $resultB);
+    }
+
+    public function testMapScriptThrowsForUnknownModel()
+    {
+        $response = new ScriptedResponse(['known' => 'answer']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No scripted response configured for model "unknown".');
+
+        $response->resolve(new Model('unknown'), 'q', []);
+    }
+
+    public function testClosureScriptReceivesModelInputAndOptions()
+    {
+        $response = new ScriptedResponse(static function (Model $model, array|string|object $input, array $options): string {
+            return \sprintf('%s|%s|%s', $model->getName(), $input, $options['stream'] ? 'stream' : 'sync');
+        });
+
+        $result = $response->resolve(new Model('gpt'), 'hi', ['stream' => true]);
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('gpt|hi|stream', $result->getContent());
+    }
+
+    public function testClosureScriptReturningResultInterfaceIsPassedThrough()
+    {
+        $object = new ObjectResult(['answer' => 42]);
+        $response = new ScriptedResponse(static fn (): ObjectResult => $object);
+
+        $this->assertSame($object, $response->resolve(new Model('any-model'), 'q', []));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Adds a provider-level test mock under `Symfony\AI\Platform\Mock` that registers like a real bridge, participates in model routing, returns scripted responses of **any** result type, and records call history for assertions.

### Why not just `Test\InMemoryPlatform`?

`Test\InMemoryPlatform` is a *platform-level* fake: it replaces the whole `Platform`, ignores routing, has no model catalog, and returns text only — perfect for unit tests injecting a `PlatformInterface` directly. The new `Mock` provider is *provider-level* and complementary. Reach for it when a test must:

- go through real DI / routing (functional tests),
- coexist with real providers and prove routing picks the mock (multi-provider tests),
- return non-text results (`ObjectResult`, `StreamResult`, `ToolCallResult`, `VectorResult`),
- assert on exactly what the platform sent (recorded call history via `getCalls()`).

### Design

`MockModelClient::request()` resolves a scripted `ResultInterface` (or wraps a string in `TextResult`), records the call, and threads the result through the `object` slot of the existing `InMemoryRawResult`. `MockResultConverter::convert()` pulls it back out and returns it verbatim — so every result type is supported with no per-type conversion code. The embedding-mock case falls out for free by scripting a `VectorResult`.

### Usage

```php
use Symfony\AI\Platform\Mock\Factory;
use Symfony\AI\Platform\Result\ObjectResult;

// string — every call returns a TextResult
$platform = Factory::createPlatform("Hello world");
$platform->invoke("any-model", "question")->asText(); // "Hello world"

// map keyed by model name
$platform = Factory::createPlatform(["gpt-4o" => "answer"]);

// closure — branch on payload/options
$platform = Factory::createPlatform(
    static fn ($model, $payload, $options) => isset($options["response_format"])
        ? new ObjectResult((object) ["ok" => true])
        : "plain text",
);
```

It lives in platform core (not under `src/Bridge/`, which `splitsh.json` excludes from the `symfony/ai-platform` package), so it ships with the platform exactly like `Test\InMemoryPlatform`.

### Scope / follow-ups

- **Out:** `ai-bundle` config node (`framework.ai.platform.mock`) — closures cannot be expressed in YAML; most consumers register the mock in a test kernel / compiler pass. The PHP API is what unblocks them.
- **Out:** a mock `Contract`/normalizer (the mock records payloads raw) and fault injection (scripted exceptions) — easy to add later.

### Verification

- `vendor/bin/phpunit tests/Mock` — 21 tests, 38 assertions, green.
- `vendor/bin/phpstan analyse` — clean.
- `php-cs-fixer` — clean.
