### PR TITLE
[Platform][OpenAi] Add support for gpt-5.5 and gpt-5.5-pro

### DIFF
--- a/src/platform/src/Bridge/OpenAi/ModelCatalog.php
+++ b/src/platform/src/Bridge/OpenAi/ModelCatalog.php
@@ -287,6 +287,29 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::TOOL_CALLING,
                 ],
             ],
+            'gpt-5.5' => [
+                'class' => Gpt::class,
+                'capabilities' => [
+                    Capability::INPUT_IMAGE,
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_PDF,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::OUTPUT_TEXT,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
+            'gpt-5.5-pro' => [
+                'class' => Gpt::class,
+                'capabilities' => [
+                    Capability::INPUT_IMAGE,
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_PDF,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::OUTPUT_TEXT,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
             'text-embedding-ada-002' => [
                 'class' => Embeddings::class,
                 'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],

--- a/src/platform/src/Bridge/OpenAi/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/ModelCatalogTest.php
@@ -47,6 +47,8 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'gpt-5-chat-latest' => ['gpt-5-chat-latest', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::INPUT_IMAGE, Capability::INPUT_PDF]];
         yield 'gpt-5-mini' => ['gpt-5-mini', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF, Capability::OUTPUT_STRUCTURED]];
         yield 'gpt-5-nano' => ['gpt-5-nano', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF, Capability::OUTPUT_STRUCTURED]];
+        yield 'gpt-5.5' => ['gpt-5.5', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF, Capability::OUTPUT_STRUCTURED]];
+        yield 'gpt-5.5-pro' => ['gpt-5.5-pro', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF]];
 
         // Embedding models
         yield 'text-embedding-ada-002' => ['text-embedding-ada-002', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | Not concerned
| License       | MIT

Add support for the `gpt-5.5` and `gpt-5.5-pro` models to the OpenAi bridge.