### PR TITLE
[Platform] HTTP-boundary record/replay cassettes for bridge tests

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -1498,6 +1498,25 @@ This platform can also be configured when using the bundle::
 Testing Tools
 -------------
 
+The component ships more than one test double, and which one fits depends on *how much of the
+platform the test should keep running*. They cut the pipeline at different depths, from replacing
+everything down to replacing nothing but the network:
+
+* :class:`Symfony\\AI\\Platform\\Test\\InMemoryPlatform` replaces the whole platform. Routing, model
+  catalog, contract, ``ModelClient`` and ``ResultConverter`` are all skipped, and the answer is a
+  string or closure you write. Use it to test *your* code against a given answer.
+* :class:`Symfony\\AI\\Platform\\Test\\MockPlatformFactory` keeps the real ``Platform``, ``Provider``,
+  routing and contract, and fakes only the ``ModelClient`` and ``ResultConverter``. Use it when the
+  test is about the platform itself: model routing and resolution, non-text result types, or
+  asserting on the payload the platform built.
+* :class:`Symfony\\AI\\Platform\\Test\\Replay\\CassetteHttpClient` replaces nothing but the network.
+  Contract, ``ModelClient`` and ``ResultConverter`` all run for real, against bytes recorded from the
+  provider once. Use it when the test is about a bridge's internals.
+
+The lower a tool cuts, the more of the library a test actually covers, and the more setup it needs.
+A second axis runs across that: the first two return an answer you wrote by hand, while a cassette
+returns what a provider really sent, which is what makes it drift-checkable.
+
 For unit or integration testing, you can use the :class:`Symfony\\AI\\Platform\\Test\\InMemoryPlatform`,
 which implements :class:`Symfony\\AI\\Platform\\PlatformInterface` without calling external APIs.
 
@@ -1654,6 +1673,48 @@ explicit models instead::
     ]));
     // $provider->supports('mock-model') === true
     // $provider->supports('gpt-4o') === false
+
+Recording Real Responses
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To exercise a bridge's *internals* (its Contract normalizers, ``ModelClient`` payload building and
+``ResultConverter``) against realistic data without a network, record a real HTTP response once and
+replay it offline. :class:`Symfony\\AI\\Platform\\Test\\Replay\\CassetteHttpClient` is an
+``HttpClientInterface`` you pass to any real bridge ``Factory``; because replay serves a real
+``MockResponse``, the **real** converter runs on replay (unlike the mocks above, which bypass it).
+
+By default the mode follows the cassette file: record when it is missing, replay when it exists
+(override with an explicit ``record:`` argument). Record once with a real API key, commit the
+generated cassette, and replay it in CI::
+
+    use Symfony\AI\Platform\Bridge\Mistral\Factory;
+    use Symfony\AI\Platform\Message\Message;
+    use Symfony\AI\Platform\Message\MessageBag;
+    use Symfony\AI\Platform\Test\Replay\CassetteHttpClient;
+    use Symfony\AI\Platform\Test\Replay\HttpCassette;
+    use Symfony\Component\HttpClient\HttpClient;
+
+    $cassette = new HttpCassette(__DIR__.'/fixtures/mistral_chat.json');
+
+    // cassette missing (+ real key) -> hits the live API and writes the cassette (secrets redacted)
+    // cassette exists -> serves the recorded response; the real Mistral ResultConverter runs
+    $http = new CassetteHttpClient($cassette, HttpClient::create());
+
+    $platform = Factory::createPlatform($apiKey, $http);
+    $result = $platform->invoke('mistral-large-latest', new MessageBag(Message::ofUser('Hello')));
+
+    echo $result->asText(); // produced by the real converter from the recorded bytes
+
+Recorded interactions replay first-in-first-out (like ``MockHttpClient`` with an array of responses).
+A streamed response is stored with its raw Server-Sent Event body, so the bridge's stream parser frames
+it on replay exactly as it would on the wire, while headers describing the live transfer
+(``content-length``, ``content-encoding``, ...) are dropped because they would contradict the replayed
+body. Credentials (``Authorization``, ``x-api-key``, ``x-goog-api-key``, the ``auth_bearer`` shorthand,
+cookies and provider account identifiers) are replaced with ``[redacted]`` in both request and response
+headers before the cassette is written, so a cassette is safe to commit. Per-request trace headers
+(``date``, ``cf-ray``, correlation and request ids, proxy latencies) are dropped on write, so that
+re-recording a cassette produces a diff of what the provider actually changed instead of noise;
+rate limiting headers are kept, because the converters read them.
 
 Code Examples
 ~~~~~~~~~~~~~

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * [BC BREAK] Add `ListenerInterface::onError()` and `Result\Stream\ErrorEvent`, dispatched when draining a `StreamResult` throws, so a listener can finalize on a failed stream where `onComplete()` never fires; `AbstractStreamListener` provides a no-op default
+ * Add `Test\Replay\CassetteHttpClient` and `Test\Replay\HttpCassette` to record real HTTP responses (when the cassette file is missing) and replay them offline through the real bridge pipeline (Contract, `ModelClient`, `ResultConverter`) in tests, including raw Server-Sent Event streams
 
 0.12
 ----

--- a/src/platform/src/Bridge/Mistral/Tests/Fixtures/cassettes/bad_request_response.json
+++ b/src/platform/src/Bridge/Mistral/Tests/Fixtures/cassettes/bad_request_response.json
@@ -1,0 +1,51 @@
+{
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.mistral.ai/v1/chat/completions",
+                "signature": "3644a5561fd39da85ffa0127dc4eda52",
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "[redacted]"
+                    ]
+                },
+                "body": "{\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}],\"model\":\"mistral-does-not-exist\"}"
+            },
+            "response": {
+                "status": 400,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "content-length": [
+                        "140"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "access-control-allow-origin": [
+                        "*"
+                    ],
+                    "set-cookie": [
+                        "[redacted]"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15552000; includeSubDomains; preload"
+                    ],
+                    "x-content-type-options": [
+                        "nosniff"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\"object\":\"error\",\"message\":\"Invalid model: mistral-does-not-exist\",\"type\":\"invalid_model\",\"param\":null,\"code\":\"1500\",\"raw_status_code\":400}"
+            }
+        }
+    ]
+}

--- a/src/platform/src/Bridge/Mistral/Tests/Fixtures/cassettes/text_response.json
+++ b/src/platform/src/Bridge/Mistral/Tests/Fixtures/cassettes/text_response.json
@@ -1,0 +1,69 @@
+{
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.mistral.ai/v1/chat/completions",
+                "signature": "2f7aa779f103549fae4561269691286d",
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "[redacted]"
+                    ]
+                },
+                "body": "{\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}],\"model\":\"mistral-large-latest\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "x-max-retry-attempts-reached": [
+                        "false"
+                    ],
+                    "x-ratelimit-limit-tokens-minute": [
+                        "400000"
+                    ],
+                    "x-ratelimit-remaining-tokens-minute": [
+                        "399960"
+                    ],
+                    "x-ratelimit-tokens-query-cost": [
+                        "40"
+                    ],
+                    "x-ratelimit-limit-req-minute": [
+                        "15"
+                    ],
+                    "x-ratelimit-remaining-req-minute": [
+                        "14"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "access-control-allow-origin": [
+                        "*"
+                    ],
+                    "set-cookie": [
+                        "[redacted]"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15552000; includeSubDomains; preload"
+                    ],
+                    "x-content-type-options": [
+                        "nosniff"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\"id\":\"5248f14cf2974cc29282cb6585a03296\",\"created\":1786820845,\"model\":\"mistral-large-latest\",\"usage\":{\"prompt_tokens\":4,\"total_tokens\":40,\"completion_tokens\":36,\"prompt_tokens_details\":{\"cached_tokens\":0},\"service_tier\":\"standard\"},\"object\":\"chat.completion\",\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"tool_calls\":null,\"content\":\"Hello! 😊 How can I assist you today? Whether you have a question, need help with something, or just want to chat, I'm here for you!\"}}]}"
+            }
+        }
+    ]
+}

--- a/src/platform/src/Bridge/Mistral/Tests/Fixtures/cassettes/tool_call_response.json
+++ b/src/platform/src/Bridge/Mistral/Tests/Fixtures/cassettes/tool_call_response.json
@@ -1,0 +1,69 @@
+{
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.mistral.ai/v1/chat/completions",
+                "signature": "5878e9b78f9014f2ddfc026706eb3a53",
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "[redacted]"
+                    ]
+                },
+                "body": "{\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get the current weather for a location\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"The city, e.g. Paris\"}},\"required\":[\"location\"]}}}],\"tool_choice\":\"any\",\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"model\":\"mistral-large-latest\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "x-max-retry-attempts-reached": [
+                        "false"
+                    ],
+                    "x-ratelimit-limit-tokens-minute": [
+                        "400000"
+                    ],
+                    "x-ratelimit-remaining-tokens-minute": [
+                        "399845"
+                    ],
+                    "x-ratelimit-tokens-query-cost": [
+                        "96"
+                    ],
+                    "x-ratelimit-limit-req-minute": [
+                        "15"
+                    ],
+                    "x-ratelimit-remaining-req-minute": [
+                        "12"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "access-control-allow-origin": [
+                        "*"
+                    ],
+                    "set-cookie": [
+                        "[redacted]"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15552000; includeSubDomains; preload"
+                    ],
+                    "x-content-type-options": [
+                        "nosniff"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\"id\":\"43233ead680145268be8e914e4efb5e0\",\"created\":1786820847,\"model\":\"mistral-large-latest\",\"usage\":{\"prompt_tokens\":84,\"total_tokens\":96,\"completion_tokens\":12,\"prompt_tokens_details\":{\"cached_tokens\":0},\"service_tier\":\"standard\"},\"object\":\"chat.completion\",\"choices\":[{\"index\":0,\"finish_reason\":\"tool_calls\",\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"id\":\"aq1aPdShN\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"location\\\": \\\"Paris\\\"}\"},\"index\":0}],\"content\":\"\"}}]}"
+            }
+        }
+    ]
+}

--- a/src/platform/src/Bridge/Mistral/Tests/Fixtures/cassettes/truncated_response.json
+++ b/src/platform/src/Bridge/Mistral/Tests/Fixtures/cassettes/truncated_response.json
@@ -1,0 +1,69 @@
+{
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.mistral.ai/v1/chat/completions",
+                "signature": "d96787b26f2d131b5e457230e908aa9b",
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "[redacted]"
+                    ]
+                },
+                "body": "{\"max_tokens\":5,\"messages\":[{\"role\":\"user\",\"content\":\"Write a long essay about the Eiffel Tower.\"}],\"model\":\"mistral-large-latest\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "x-max-retry-attempts-reached": [
+                        "false"
+                    ],
+                    "x-ratelimit-limit-tokens-minute": [
+                        "400000"
+                    ],
+                    "x-ratelimit-remaining-tokens-minute": [
+                        "399941"
+                    ],
+                    "x-ratelimit-tokens-query-cost": [
+                        "19"
+                    ],
+                    "x-ratelimit-limit-req-minute": [
+                        "15"
+                    ],
+                    "x-ratelimit-remaining-req-minute": [
+                        "13"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "access-control-allow-origin": [
+                        "*"
+                    ],
+                    "set-cookie": [
+                        "[redacted]"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15552000; includeSubDomains; preload"
+                    ],
+                    "x-content-type-options": [
+                        "nosniff"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\"id\":\"ec8ab704e0a2491aafcd70a88a60d980\",\"created\":1786820846,\"model\":\"mistral-large-latest\",\"usage\":{\"prompt_tokens\":14,\"total_tokens\":19,\"completion_tokens\":5,\"prompt_tokens_details\":{\"cached_tokens\":0},\"service_tier\":\"standard\"},\"object\":\"chat.completion\",\"choices\":[{\"index\":0,\"finish_reason\":\"length\",\"message\":{\"role\":\"assistant\",\"tool_calls\":null,\"content\":\"# **The Eiff\"}}]}"
+            }
+        }
+    ]
+}

--- a/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterCassetteTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterCassetteTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\Llm;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Factory;
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Test\Replay\CassetteHttpClient;
+use Symfony\AI\Platform\Test\Replay\HttpCassette;
+
+/**
+ * Drives the real Mistral bridge pipeline (Contract, ModelClient, Llm\ResultConverter) against
+ * cassettes recorded from api.mistral.ai, proving record/replay exercises bridge internals offline.
+ *
+ * Assertions on the shape of a provider response belong here rather than in
+ * {@see ResultConverterTest}, which keeps the checks that do not depend on a payload.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResultConverterCassetteTest extends TestCase
+{
+    public function testReplaysTextResponseThroughRealConverter()
+    {
+        $result = $this->replay('text_response.json', 'Hello');
+
+        $this->assertSame(
+            "Hello! 😊 How can I assist you today? Whether you have a question, need help with something, or just want to chat, I'm here for you!",
+            $result->asText(),
+        );
+        $this->assertTrue($result->getResult()->getMetadata()->get('finish_reason')->is(FinishReasonCase::STOP));
+    }
+
+    public function testReplaysTruncatedTextResponseThroughRealConverter()
+    {
+        $result = $this->replay('truncated_response.json', 'Write a long essay about the Eiffel Tower.', ['max_tokens' => 5]);
+
+        $this->assertSame('# **The Eiff', $result->asText());
+        $this->assertTrue($result->getResult()->getMetadata()->get('finish_reason')->is(FinishReasonCase::LENGTH));
+    }
+
+    public function testReplaysToolCallResponseThroughRealConverter()
+    {
+        $result = $this->replay('tool_call_response.json', 'What is the weather in Paris?', [
+            'tools' => [[
+                'type' => 'function',
+                'function' => [
+                    'name' => 'get_weather',
+                    'description' => 'Get the current weather for a location',
+                    'parameters' => [
+                        'type' => 'object',
+                        'properties' => ['location' => ['type' => 'string', 'description' => 'The city, e.g. Paris']],
+                        'required' => ['location'],
+                    ],
+                ],
+            ]],
+            'tool_choice' => 'any',
+        ]);
+
+        $toolCalls = $result->asToolCalls();
+
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('get_weather', $toolCalls[0]->getName());
+        $this->assertSame(['location' => 'Paris'], $toolCalls[0]->getArguments());
+    }
+
+    public function testReplaysBadRequestThroughRealConverter()
+    {
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Invalid model: mistral-does-not-exist');
+
+        $this->replay('bad_request_response.json', 'Hello', model: new Mistral('mistral-does-not-exist'))->asText();
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function replay(string $cassette, string $prompt, array $options = [], string|Mistral $model = 'mistral-large-latest'): DeferredResult
+    {
+        $platform = Factory::createPlatform('test-key', new CassetteHttpClient(
+            new HttpCassette(__DIR__.'/../Fixtures/cassettes/'.$cassette),
+            record: false,
+        ));
+
+        return $platform->invoke($model, new MessageBag(Message::ofUser($prompt)), $options);
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
@@ -14,12 +14,9 @@ namespace Symfony\AI\Platform\Bridge\Mistral\Tests\Llm;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Mistral\Llm\ResultConverter;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
-use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\ServerException;
-use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\RawHttpResult;
-use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 
@@ -32,55 +29,10 @@ final class ResultConverterTest extends TestCase
         $this->assertTrue($converter->supports(new Mistral('mistral-large-latest')));
     }
 
-    public function testConvertTextResult()
-    {
-        $httpClient = new MockHttpClient(new JsonMockResponse([
-            'choices' => [
-                [
-                    'index' => 0,
-                    'message' => [
-                        'role' => 'assistant',
-                        'content' => 'Hello world',
-                    ],
-                    'finish_reason' => 'stop',
-                ],
-            ],
-        ]));
-
-        $httpResponse = $httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions');
-        $converter = new ResultConverter();
-
-        $result = $converter->convert(new RawHttpResult($httpResponse));
-
-        $this->assertInstanceOf(TextResult::class, $result);
-        $this->assertSame('Hello world', $result->getContent());
-    }
-
-    public function testConvertTruncatedTextResult()
-    {
-        $httpClient = new MockHttpClient(new JsonMockResponse([
-            'choices' => [
-                [
-                    'index' => 0,
-                    'message' => [
-                        'role' => 'assistant',
-                        'content' => 'Truncated answ',
-                    ],
-                    'finish_reason' => 'length',
-                ],
-            ],
-        ]));
-
-        $httpResponse = $httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions');
-        $converter = new ResultConverter();
-
-        $result = $converter->convert(new RawHttpResult($httpResponse));
-
-        $this->assertInstanceOf(TextResult::class, $result);
-        $this->assertSame('Truncated answ', $result->getContent());
-        $this->assertTrue($result->getMetadata()->get('finish_reason')->is(FinishReasonCase::LENGTH));
-    }
-
+    /**
+     * Not a cassette: provoking this for real means overflowing the smallest available Mistral
+     * context window, so the recorded request body would be a ~640 KB prompt of filler text.
+     */
     public function testConvertThrowsExceedContextSizeExceptionOnContextOverflow()
     {
         $this->expectException(ExceedContextSizeException::class);
@@ -96,21 +48,10 @@ final class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
-    public function testConvertThrowsBadRequestExceptionOnOtherBadRequestErrors()
-    {
-        $this->expectException(BadRequestException::class);
-        $this->expectExceptionMessage('Invalid model specified');
-
-        $httpClient = new MockHttpClient(new JsonMockResponse([
-            'message' => 'Invalid model specified',
-        ], ['http_code' => 400]));
-
-        $httpResponse = $httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions');
-        $converter = new ResultConverter();
-
-        $converter->convert(new RawHttpResult($httpResponse));
-    }
-
+    /**
+     * Not a cassette: a provider cannot be asked for a 500 on demand. The assertion is on our own
+     * status handling anyway - the body is irrelevant - so a mock is the honest tool here.
+     */
     public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse(['error' => 'Service Unavailable'], ['http_code' => 500]));

--- a/src/platform/src/Test/Replay/CassetteHttpClient.php
+++ b/src/platform/src/Test/Replay/CassetteHttpClient.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test\Replay;
+
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+/**
+ * An {@see HttpClientInterface} that records real HTTP responses to an {@see HttpCassette} and
+ * replays them offline. Pass it to any bridge `Factory` (which accepts a `?HttpClientInterface`)
+ * so the real Contract, ModelClient and ResultConverter run end-to-end against recorded bytes.
+ *
+ * By default the mode follows the cassette file (override with the explicit `$record` argument):
+ *  - record (cassette missing, + a real client): performs the live request, persists status/headers/body
+ *    (secrets redacted), and returns a buffered response identical to what replay will serve;
+ *  - replay (cassette exists): serves the next recorded interaction (FIFO).
+ *
+ * Delete the cassette to re-record. Requires `symfony/http-client` (the `MockHttpClient`/`MockResponse` classes).
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class CassetteHttpClient implements HttpClientInterface
+{
+    /**
+     * Response headers describing the live transfer: they do not survive re-framing through the mock
+     * transport - a recorded `content-length` or `gzip` encoding would contradict the replayed body.
+     */
+    private const STRIPPED_RESPONSE_HEADERS = ['content-length', 'content-encoding', 'transfer-encoding', 'connection'];
+
+    private readonly bool $record;
+
+    private readonly MockHttpClient $replayClient;
+
+    /**
+     * @param bool|null $record whether to record (`true`) or replay (`false`); defaults to recording
+     *                          when the cassette file does not exist yet and replaying otherwise
+     */
+    public function __construct(
+        private readonly HttpCassette $cassette,
+        private readonly ?HttpClientInterface $realClient = null,
+        ?bool $record = null,
+    ) {
+        $this->record = $record ?? !$cassette->exists();
+
+        if ($this->record && null === $realClient) {
+            throw new InvalidArgumentException('Recording requires a real HttpClientInterface to delegate to; pass one as the second argument.');
+        }
+
+        $this->replayClient = new MockHttpClient(function (): MockResponse {
+            return self::toMockResponse($this->cassette->next());
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        if (!$this->record) {
+            return $this->replayClient->request($method, $url, $options);
+        }
+
+        $response = $this->realClient->request($method, $url, $options);
+
+        $status = $response->getStatusCode();
+        $headers = $response->getHeaders(false);
+        $body = $response->getContent(false);
+        $bodyFormat = self::detectBodyFormat($headers, $body);
+
+        $this->cassette->record($method, $url, $options, $status, $headers, $body, $bodyFormat);
+
+        // Re-issue the recorded bytes through a MockHttpClient so the caller reads exactly what
+        // replay will serve (a bare MockResponse cannot be consumed on its own).
+        return (new MockHttpClient(self::toMockResponse(['status' => $status, 'headers' => $headers, 'body' => $body, 'body_format' => $bodyFormat])))
+            ->request($method, $url, $options);
+    }
+
+    public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        return $this->replayClient->stream($responses, $timeout);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function withOptions(array $options): static
+    {
+        return new self($this->cassette, $this->realClient?->withOptions($options), $this->record);
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     *
+     * @return 'json'|'sse'
+     */
+    private static function detectBodyFormat(array $headers, string $body): string
+    {
+        if (str_contains($headers['content-type'][0] ?? '', 'text/event-stream')) {
+            return 'sse';
+        }
+
+        if (str_starts_with($body, 'data:') || str_starts_with($body, 'event:')) {
+            return 'sse';
+        }
+
+        return 'json';
+    }
+
+    /**
+     * @param array{status: int, headers: array<string, list<string>|string>, body: mixed, body_format?: 'json'|'sse'} $recorded
+     */
+    private static function toMockResponse(array $recorded): MockResponse
+    {
+        $body = $recorded['body'];
+        if (!\is_string($body)) {
+            $body = json_encode($body, \JSON_THROW_ON_ERROR);
+        }
+
+        $headers = $recorded['headers'];
+        foreach ($headers as $name => $values) {
+            if (\in_array(strtolower($name), self::STRIPPED_RESPONSE_HEADERS, true)) {
+                unset($headers[$name]);
+            }
+        }
+
+        // A cassette recorded before this key existed replays as JSON, which is what it was.
+        if ('sse' === ($recorded['body_format'] ?? 'json') && !isset($headers['content-type'])) {
+            $headers['content-type'] = ['text/event-stream'];
+        }
+
+        return new MockResponse($body, [
+            'http_code' => $recorded['status'],
+            'response_headers' => self::flattenHeaders($headers),
+        ]);
+    }
+
+    /**
+     * @param array<string, list<string>|string> $headers
+     *
+     * @return list<string>
+     */
+    private static function flattenHeaders(array $headers): array
+    {
+        $flat = [];
+        foreach ($headers as $name => $values) {
+            foreach ((array) $values as $value) {
+                $flat[] = $name.': '.$value;
+            }
+        }
+
+        return $flat;
+    }
+}

--- a/src/platform/src/Test/Replay/HttpCassette.php
+++ b/src/platform/src/Test/Replay/HttpCassette.php
@@ -1,0 +1,275 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test\Replay;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+
+/**
+ * A JSON file of recorded HTTP interactions used by {@see CassetteHttpClient}.
+ *
+ * Interactions are replayed first-in-first-out, mirroring the drop-in semantics of
+ * Symfony's MockHttpClient when given an array of responses. On write, secrets are redacted and
+ * per-request trace headers are dropped, so a cassette is safe to commit and a re-record diff shows
+ * provider changes rather than noise.
+ *
+ * Streamed responses are stored with their raw Server-Sent Event body and a `sse` body format,
+ * so the bridge's stream parser frames them on replay exactly as it would on the wire.
+ *
+ * @phpstan-type RecordedResponse array{status: int, headers: array<string, list<string>>, body: mixed, body_format?: 'json'|'sse'}
+ * @phpstan-type Interaction array{request: array<string, mixed>, response: RecordedResponse}
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class HttpCassette
+{
+    /**
+     * Request and response headers that must never end up in a committed cassette.
+     */
+    private const SENSITIVE_HEADERS = [
+        'authorization',
+        'api-key',
+        'x-api-key',
+        'x-goog-api-key',
+        'openai-organization',
+        'openai-project',
+        'cookie',
+        'set-cookie',
+    ];
+
+    /**
+     * Headers dropped on write: per-request trace identifiers, proxy latencies and timestamps.
+     * Nothing asserts on them, they differ on every recording - which would drown a re-record diff
+     * in noise, the very signal a cassette exists for - and some tie a recording to an account.
+     *
+     * Rate limiting headers are deliberately *not* listed: `retry-after` and `x-ratelimit-reset-*`
+     * are read by the converters (see `Result\HttpStatusErrorHandlingTrait`), so a cassette must be
+     * able to replay them.
+     */
+    private const TRACE_HEADERS = [
+        'date',
+        'alt-svc',
+        'cf-cache-status',
+        'cf-ray',
+        'mistral-correlation-id',
+        'nel',
+        'openai-processing-ms',
+        'report-to',
+        'request-id',
+        'server-timing',
+        'x-amzn-requestid',
+        'x-amzn-trace-id',
+        'x-envoy-upstream-service-time',
+        'x-kong-proxy-latency',
+        'x-kong-request-id',
+        'x-kong-upstream-latency',
+        'x-request-id',
+    ];
+
+    private const REDACTED = '[redacted]';
+
+    /**
+     * @var list<Interaction>
+     */
+    private array $interactions = [];
+
+    private bool $loaded = false;
+
+    private int $cursor = 0;
+
+    public function __construct(
+        private readonly string $path,
+    ) {
+    }
+
+    public function exists(): bool
+    {
+        return is_file($this->path);
+    }
+
+    /**
+     * @param array<string, mixed>        $options    the Symfony HttpClient request options
+     * @param array<string, list<string>> $headers    the recorded response headers
+     * @param 'json'|'sse'                $bodyFormat how the body is framed on the wire
+     */
+    public function record(string $method, string $url, array $options, int $status, array $headers, string $body, string $bodyFormat = 'json'): void
+    {
+        $this->load();
+
+        $this->interactions[] = [
+            'request' => self::redactRequest($method, $url, $options),
+            'response' => [
+                'status' => $status,
+                'headers' => self::sanitizeHeaders($headers),
+                'body_format' => $bodyFormat,
+                'body' => $body,
+            ],
+        ];
+
+        $this->save();
+    }
+
+    /**
+     * Returns the next unused recorded response (FIFO).
+     *
+     * @return RecordedResponse
+     */
+    public function next(): array
+    {
+        $this->load();
+
+        if (!isset($this->interactions[$this->cursor])) {
+            throw new RuntimeException(\sprintf('Cassette "%s" is exhausted after %d interaction(s); delete it to re-record.', $this->path, \count($this->interactions)));
+        }
+
+        return $this->interactions[$this->cursor++]['response'];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private static function redactRequest(string $method, string $url, array $options): array
+    {
+        $headers = self::sanitizeHeaders(self::normalizeRequestHeaders($options));
+
+        $request = ['method' => $method, 'url' => $url];
+
+        $body = $options['json'] ?? $options['body'] ?? null;
+        $request['signature'] = self::signature($method, $url, $body);
+
+        if ([] !== $headers) {
+            $request['headers'] = $headers;
+        }
+
+        if (null !== $body) {
+            $request['body'] = $body;
+        }
+
+        return $request;
+    }
+
+    /**
+     * Normalizes the `headers` option - which may be a map or a list of `Name: value` lines - into a
+     * lowercased map, and materializes the `auth_bearer` shorthand so its secret cannot slip through.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, list<string>>
+     */
+    private static function normalizeRequestHeaders(array $options): array
+    {
+        $headers = [];
+
+        $rawHeaders = $options['headers'] ?? [];
+        if (\is_array($rawHeaders)) {
+            foreach ($rawHeaders as $name => $value) {
+                if (\is_int($name) && \is_string($value) && str_contains($value, ':')) {
+                    [$name, $value] = explode(':', $value, 2);
+                    $value = ltrim($value, ' ');
+                }
+
+                if (!\is_string($name)) {
+                    continue;
+                }
+
+                $headers[strtolower($name)] = array_values(array_map(strval(...), (array) $value));
+            }
+        }
+
+        if (isset($options['auth_bearer'])) {
+            $headers['authorization'] = ['Bearer '.self::REDACTED];
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Replaces credentials with a placeholder and drops per-request trace headers.
+     *
+     * @param array<string, list<string>> $headers
+     *
+     * @return array<string, list<string>>
+     */
+    private static function sanitizeHeaders(array $headers): array
+    {
+        foreach ($headers as $name => $values) {
+            $lowercased = strtolower((string) $name);
+
+            if (\in_array($lowercased, self::TRACE_HEADERS, true)) {
+                unset($headers[$name]);
+
+                continue;
+            }
+
+            if (\in_array($lowercased, self::SENSITIVE_HEADERS, true)) {
+                $headers[$name] = [self::REDACTED];
+            }
+        }
+
+        return $headers;
+    }
+
+    private static function signature(string $method, string $url, mixed $body): string
+    {
+        $normalized = $body;
+        if (\is_array($normalized)) {
+            self::ksortRecursive($normalized);
+        }
+
+        return hash('xxh128', $method.'|'.$url.'|'.json_encode($normalized));
+    }
+
+    /**
+     * @param array<string|int, mixed> $array
+     */
+    private static function ksortRecursive(array &$array): void
+    {
+        ksort($array);
+        foreach ($array as &$value) {
+            if (\is_array($value)) {
+                self::ksortRecursive($value);
+            }
+        }
+    }
+
+    private function load(): void
+    {
+        if ($this->loaded) {
+            return;
+        }
+
+        $this->loaded = true;
+
+        if (!is_file($this->path)) {
+            return;
+        }
+
+        $raw = file_get_contents($this->path);
+        if (false === $raw || '' === trim($raw)) {
+            return;
+        }
+
+        $data = json_decode($raw, true, flags: \JSON_THROW_ON_ERROR);
+        $this->interactions = $data['interactions'] ?? [];
+    }
+
+    private function save(): void
+    {
+        $directory = \dirname($this->path);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($this->path, json_encode(['interactions' => $this->interactions], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)."\n");
+    }
+}

--- a/src/platform/tests/Test/Replay/CassetteHttpClientTest.php
+++ b/src/platform/tests/Test/Replay/CassetteHttpClientTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Test\Replay;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\SseStream;
+use Symfony\AI\Platform\Test\Replay\CassetteHttpClient;
+use Symfony\AI\Platform\Test\Replay\HttpCassette;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class CassetteHttpClientTest extends TestCase
+{
+    private string $path;
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir().'/ai-cassette-'.bin2hex(random_bytes(6)).'.json';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->path)) {
+            unlink($this->path);
+        }
+    }
+
+    public function testRecordsRealResponseAndReturnsBufferedCopy()
+    {
+        $realClient = new MockHttpClient(new JsonMockResponse(['foo' => 'bar']));
+        $client = new CassetteHttpClient(new HttpCassette($this->path), $realClient, record: true);
+
+        $response = $client->request('POST', 'https://api.mistral.ai/v1/chat/completions', [
+            'auth_bearer' => 'sk-secret',
+            'json' => ['model' => 'mistral-large-latest'],
+        ]);
+
+        $this->assertSame(['foo' => 'bar'], $response->toArray());
+
+        $data = json_decode((string) file_get_contents($this->path), true, flags: \JSON_THROW_ON_ERROR);
+        $this->assertSame('{"foo":"bar"}', $data['interactions'][0]['response']['body']);
+        $this->assertStringNotContainsString('sk-secret', (string) file_get_contents($this->path));
+    }
+
+    public function testRecordsAutomaticallyWhenCassetteMissing()
+    {
+        $realClient = new MockHttpClient(new JsonMockResponse(['foo' => 'bar']));
+        $client = new CassetteHttpClient(new HttpCassette($this->path), $realClient);
+
+        $this->assertSame(['foo' => 'bar'], $client->request('GET', 'https://example.com')->toArray());
+        $this->assertFileExists($this->path);
+    }
+
+    public function testReplaysAutomaticallyWhenCassetteExists()
+    {
+        $recorder = new HttpCassette($this->path);
+        $recorder->record('GET', 'https://example.com', [], 200, ['content-type' => ['application/json']], '{"n":1}');
+
+        // no real client given: replay is auto-detected because the cassette exists
+        $client = new CassetteHttpClient(new HttpCassette($this->path));
+
+        $this->assertSame(['n' => 1], $client->request('GET', 'https://example.com')->toArray());
+    }
+
+    public function testReplaysRecordedResponsesInOrder()
+    {
+        $recorder = new HttpCassette($this->path);
+        $recorder->record('POST', 'https://example.com', [], 200, ['content-type' => ['application/json']], '{"n":1}');
+        $recorder->record('POST', 'https://example.com', [], 200, ['content-type' => ['application/json']], '{"n":2}');
+
+        $client = new CassetteHttpClient(new HttpCassette($this->path), record: false);
+
+        $this->assertSame(['n' => 1], $client->request('POST', 'https://example.com')->toArray());
+        $this->assertSame(['n' => 2], $client->request('POST', 'https://example.com')->toArray());
+    }
+
+    public function testReplayThrowsWhenCassetteExhausted()
+    {
+        $recorder = new HttpCassette($this->path);
+        $recorder->record('GET', 'https://example.com', [], 200, [], 'only');
+
+        $client = new CassetteHttpClient(new HttpCassette($this->path), record: false);
+        $client->request('GET', 'https://example.com')->getContent();
+
+        $this->expectException(RuntimeException::class);
+        $client->request('GET', 'https://example.com')->getContent();
+    }
+
+    public function testRecordRequiresRealClient()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new CassetteHttpClient(new HttpCassette($this->path), null, record: true);
+    }
+
+    public function testReplaysServerSentEventStream()
+    {
+        $sse = "data: {\"delta\": \"Hel\"}\n\ndata: {\"delta\": \"lo\"}\n\n";
+        $recorder = new HttpCassette($this->path);
+        $recorder->record('POST', 'https://example.com', [], 200, ['content-type' => ['text/event-stream']], $sse);
+
+        $client = new CassetteHttpClient(new HttpCassette($this->path), record: false);
+        $response = (new EventSourceHttpClient($client))->request('POST', 'https://example.com');
+
+        $deltas = iterator_to_array((new RawHttpResult($response, new SseStream()))->getDataStream());
+
+        $this->assertSame([['delta' => 'Hel'], ['delta' => 'lo']], $deltas);
+    }
+
+    public function testRecordsStreamAsServerSentEventsAndReplaysItWithoutContentType()
+    {
+        $sse = "data: {\"delta\": \"Hel\"}\n\ndata: {\"delta\": \"lo\"}\n\n";
+
+        // A provider may omit the content type; the body shape still identifies the framing.
+        $realClient = new MockHttpClient(new MockResponse($sse));
+        $recording = new CassetteHttpClient(new HttpCassette($this->path), $realClient, record: true);
+        $recording->request('POST', 'https://example.com')->getContent();
+
+        $data = json_decode((string) file_get_contents($this->path), true, flags: \JSON_THROW_ON_ERROR);
+        $this->assertSame('sse', $data['interactions'][0]['response']['body_format']);
+
+        $client = new CassetteHttpClient(new HttpCassette($this->path), record: false);
+        $response = (new EventSourceHttpClient($client))->request('POST', 'https://example.com');
+
+        $deltas = iterator_to_array((new RawHttpResult($response, new SseStream()))->getDataStream());
+
+        $this->assertSame([['delta' => 'Hel'], ['delta' => 'lo']], $deltas);
+    }
+
+    public function testReplayDropsRecordedTransferHeaders()
+    {
+        $recorder = new HttpCassette($this->path);
+        $recorder->record('GET', 'https://example.com', [], 200, [
+            'content-type' => ['application/json'],
+            'content-length' => ['999'],
+            'content-encoding' => ['gzip'],
+        ], '{"ok":true}');
+
+        $client = new CassetteHttpClient(new HttpCassette($this->path), record: false);
+        $response = $client->request('GET', 'https://example.com');
+
+        $this->assertSame(['ok' => true], $response->toArray());
+        $this->assertArrayNotHasKey('content-length', $response->getHeaders());
+        $this->assertArrayNotHasKey('content-encoding', $response->getHeaders());
+    }
+
+    public function testWithOptionsReturnsWorkingClient()
+    {
+        $recorder = new HttpCassette($this->path);
+        $recorder->record('GET', 'https://example.com', [], 200, ['content-type' => ['application/json']], '{"ok":true}');
+
+        $client = (new CassetteHttpClient(new HttpCassette($this->path), record: false))->withOptions(['base_uri' => 'https://example.com']);
+
+        $this->assertInstanceOf(CassetteHttpClient::class, $client);
+        $this->assertSame(['ok' => true], $client->request('GET', 'https://example.com')->toArray());
+    }
+}

--- a/src/platform/tests/Test/Replay/HttpCassetteTest.php
+++ b/src/platform/tests/Test/Replay/HttpCassetteTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Test\Replay;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Test\Replay\HttpCassette;
+
+final class HttpCassetteTest extends TestCase
+{
+    private string $path;
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir().'/ai-cassette-'.bin2hex(random_bytes(6)).'.json';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->path)) {
+            unlink($this->path);
+        }
+    }
+
+    public function testExistsReflectsTheFile()
+    {
+        $cassette = new HttpCassette($this->path);
+        $this->assertFalse($cassette->exists());
+
+        $cassette->record('POST', 'https://example.com', [], 200, [], '{}');
+        $this->assertTrue($cassette->exists());
+    }
+
+    public function testRecordRedactsSensitiveHeadersAndKeepsBody()
+    {
+        $cassette = new HttpCassette($this->path);
+        $cassette->record(
+            'POST',
+            'https://api.mistral.ai/v1/chat/completions',
+            [
+                'auth_bearer' => 'sk-secret',
+                'headers' => ['Authorization' => 'Bearer sk-secret', 'Content-Type' => 'application/json'],
+                'json' => ['model' => 'mistral-large-latest'],
+            ],
+            200,
+            ['content-type' => ['application/json']],
+            '{"ok":true}',
+        );
+
+        $data = json_decode((string) file_get_contents($this->path), true, flags: \JSON_THROW_ON_ERROR);
+        $request = $data['interactions'][0]['request'];
+
+        $this->assertSame('POST', $request['method']);
+        $this->assertSame(['[redacted]'], $request['headers']['authorization']);
+        $this->assertSame(['application/json'], $request['headers']['content-type']);
+        $this->assertSame(['model' => 'mistral-large-latest'], $request['body']);
+        $this->assertArrayHasKey('signature', $request);
+
+        $serialized = (string) file_get_contents($this->path);
+        $this->assertStringNotContainsString('sk-secret', $serialized);
+    }
+
+    public function testRecordRedactsSecretsPassedAsHeaderLinesAndResponseHeaders()
+    {
+        $cassette = new HttpCassette($this->path);
+        $cassette->record(
+            'POST',
+            'https://generativelanguage.googleapis.com/v1beta/models/gemini:generateContent',
+            ['headers' => ['x-goog-api-key: super-secret', 'Content-Type: application/json']],
+            200,
+            ['content-type' => ['application/json'], 'set-cookie' => ['session=leaky']],
+            '{"ok":true}',
+        );
+
+        $data = json_decode((string) file_get_contents($this->path), true, flags: \JSON_THROW_ON_ERROR);
+        $interaction = $data['interactions'][0];
+
+        $this->assertSame(['[redacted]'], $interaction['request']['headers']['x-goog-api-key']);
+        $this->assertSame(['[redacted]'], $interaction['response']['headers']['set-cookie']);
+
+        $serialized = (string) file_get_contents($this->path);
+        $this->assertStringNotContainsString('super-secret', $serialized);
+        $this->assertStringNotContainsString('session=leaky', $serialized);
+    }
+
+    public function testRecordDropsTraceHeadersButKeepsRateLimitHeaders()
+    {
+        $cassette = new HttpCassette($this->path);
+        $cassette->record(
+            'POST',
+            'https://api.mistral.ai/v1/chat/completions',
+            [],
+            429,
+            [
+                'content-type' => ['application/json'],
+                'date' => ['Sat, 15 Aug 2026 19:03:05 GMT'],
+                'cf-ray' => ['a2ba750efb21d8e2-VIE'],
+                'mistral-correlation-id' => ['01a006ce-6575-7811-a112-202834b45bfc'],
+                'x-envoy-upstream-service-time' => ['963'],
+                'retry-after' => ['12'],
+                'x-ratelimit-remaining-req-minute' => ['0'],
+            ],
+            '{"message":"rate limited"}',
+        );
+
+        $data = json_decode((string) file_get_contents($this->path), true, flags: \JSON_THROW_ON_ERROR);
+        $headers = $data['interactions'][0]['response']['headers'];
+
+        $this->assertArrayNotHasKey('date', $headers);
+        $this->assertArrayNotHasKey('cf-ray', $headers);
+        $this->assertArrayNotHasKey('mistral-correlation-id', $headers);
+        $this->assertArrayNotHasKey('x-envoy-upstream-service-time', $headers);
+
+        // read by the converters, so they have to survive
+        $this->assertSame(['12'], $headers['retry-after']);
+        $this->assertSame(['0'], $headers['x-ratelimit-remaining-req-minute']);
+        $this->assertSame(['application/json'], $headers['content-type']);
+    }
+
+    public function testRecordStoresBodyFormat()
+    {
+        $cassette = new HttpCassette($this->path);
+        $cassette->record('POST', 'https://example.com', [], 200, [], "data: {}\n\n", 'sse');
+
+        $data = json_decode((string) file_get_contents($this->path), true, flags: \JSON_THROW_ON_ERROR);
+
+        $this->assertSame('sse', $data['interactions'][0]['response']['body_format']);
+    }
+
+    public function testNextReturnsInteractionsInOrder()
+    {
+        $cassette = new HttpCassette($this->path);
+        $cassette->record('GET', 'https://example.com/1', [], 200, [], 'first');
+        $cassette->record('GET', 'https://example.com/2', [], 201, [], 'second');
+
+        $replay = new HttpCassette($this->path);
+        $this->assertSame('first', $replay->next()['body']);
+        $this->assertSame('second', $replay->next()['body']);
+    }
+
+    public function testNextThrowsWhenExhausted()
+    {
+        $cassette = new HttpCassette($this->path);
+        $cassette->record('GET', 'https://example.com', [], 200, [], 'only');
+
+        $replay = new HttpCassette($this->path);
+        $replay->next();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('is exhausted after 1 interaction(s); delete it to re-record.');
+        $replay->next();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

`Test\Replay\CassetteHttpClient` is an `HttpClientInterface` you pass to any bridge `Factory`. Cassette missing: it performs the live request and writes a JSON cassette, credentials redacted. Cassette present: it replays the recorded bytes as a real `MockResponse`, so the real Contract, `ModelClient` and `ResultConverter` run with no network. Delete the cassette to re-record.

**Why.** Bridge tests assert against hand-written `MockResponse` fixtures, which cannot drift-check themselves: when a provider changes its response shape, the fixture keeps passing and the converter breaks in production. A cassette surfaces that change as a diff on the next re-record.

**Pilot.** `Bridge/Mistral/Tests/Llm/ResultConverterCassetteTest` drives the real Mistral `ResultConverter` from cassettes recorded against api.mistral.ai, covering `stop` and `length` finishes, a tool call and a real `400`. Recording them already corrected the hand-written fixture from the previous revision: Mistral sends `"content": ""` and an explicit `"tool_calls": null`, not `"content": null`. Two mocks stay in `ResultConverterTest` for cases a provider cannot be asked to produce, each with the reason in its docblock.

This is the tool plus a worked example, not the migration. The remaining bridges are follow-up work, ideally by whoever holds that provider's API key.

**Details.** FIFO replay, like `MockHttpClient` with an array of responses. Streams keep their raw SSE body, so the bridge stream parser re-frames them on replay exactly as on the wire. Credentials and per-request trace headers are stripped on write, rate limiting headers are kept because the converters read them. It ships in `src/Test/` rather than `tests/` because bridges are standalone packages and can only use what `symfony/ai-platform` ships, same as `InMemoryPlatform`.

**Not `@internal`.** symfony/symfony#63781 (`RecorderHttpClient`) is the same idea upstream, but it targets 8.2 while this component requires `symfony/* ^7.3|^8.0`, which is too far out to wait for. So it ships as normal API now and gets swapped for the upstream one later through a deprecation.

Related: chr-hertel/ai#36 builds the same HTTP-boundary recorder plus an `examples/`-driven golden-stdout layer. Its SSE handling and header redaction are folded in here; the examples layer is the distinct half and can land on top.
