### PR TITLE
[Platform] Add provider-level record/replay cassettes for test mocks

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -1505,6 +1505,9 @@ everything down to replacing nothing but the network:
 * :class:`Symfony\\AI\\Platform\\Test\\InMemoryPlatform` replaces the whole platform. Routing, model
   catalog, contract, ``ModelClient`` and ``ResultConverter`` are all skipped, and the answer is a
   string or closure you write. Use it to test *your* code against a given answer.
+* :class:`Symfony\\AI\\Platform\\Test\\Recording\\RecordingProvider` replaces one provider, keeping the
+  real ``Platform``, routing and model catalog. The answer is a real result captured once. Use it when
+  a test needs a realistic answer but does not care how the bridge produced it.
 * :class:`Symfony\\AI\\Platform\\Test\\MockPlatformFactory` keeps the real ``Platform``, ``Provider``,
   routing and contract, and fakes only the ``ModelClient`` and ``ResultConverter``. Use it when the
   test is about the platform itself: model routing and resolution, non-text result types, or
@@ -1514,8 +1517,9 @@ everything down to replacing nothing but the network:
   provider once. Use it when the test is about a bridge's internals.
 
 The lower a tool cuts, the more of the library a test actually covers, and the more setup it needs.
-A second axis runs across that: the first two return an answer you wrote by hand, while a cassette
-returns what a provider really sent, which is what makes it drift-checkable.
+A second axis runs across that: ``InMemoryPlatform`` and ``MockPlatformFactory`` return an answer you
+wrote by hand, while the two recorders return what a provider really sent, which is what makes them
+drift-checkable.
 
 For unit or integration testing, you can use the :class:`Symfony\\AI\\Platform\\Test\\InMemoryPlatform`,
 which implements :class:`Symfony\\AI\\Platform\\PlatformInterface` without calling external APIs.
@@ -1673,6 +1677,56 @@ explicit models instead::
     ]));
     // $provider->supports('mock-model') === true
     // $provider->supports('gpt-4o') === false
+
+Recording Real Provider Results
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a test only needs a realistic, deterministic answer from a provider, wrap a real provider in
+:class:`Symfony\\AI\\Platform\\Test\\Recording\\RecordingProvider`. The first run, when the cassette
+file does not exist yet, calls the real provider and captures its result into the cassette; commit
+the cassette and later runs replay it offline, so the real provider is never called and needs no API
+key. Delete the cassette to re-record::
+
+    use Symfony\AI\Platform\Bridge\Anthropic\Factory;
+    use Symfony\AI\Platform\Test\Recording\Cassette;
+    use Symfony\AI\Platform\Test\Recording\RecordingProvider;
+
+    $provider = new RecordingProvider(
+        Factory::createProvider($_SERVER['ANTHROPIC_API_KEY'] ?? 'no-key-needed-on-replay'),
+        new Cassette(__DIR__.'/fixtures/weather.json'),
+    );
+
+    $result = $provider->invoke('claude-sonnet-4-5', $messages);
+
+By default the mode follows the cassette file: record when it is missing, replay when it exists. Pass
+the third constructor argument to force a mode - for example ``record: false`` in CI to fail loudly
+instead of issuing a real request when a cassette is missing::
+
+    // force replay (never call the real provider)
+    $provider = new RecordingProvider($realProvider, $cassette, record: false);
+
+The recorded interaction is matched by a signature derived from the model, input and options, so a
+replayed call must use the same arguments. An input that legitimately differs between runs, such as
+a timestamp or retrieved context, would otherwise miss its own recording; pass a ``signature``
+closure to normalize those parts before hashing::
+
+    $provider = new RecordingProvider($realProvider, $cassette, signature: fn ($model, $input, $options) => hash(
+        'xxh128',
+        preg_replace('/\d{4}-\d{2}-\d{2}/', '<date>', json_encode([$model, $input, $options])),
+    ));
+
+Supported result types are text, structured output (``ObjectResult``), embeddings (``VectorResult``),
+tool calls (``ToolCallResult``) and text streams; result metadata and token usage are not preserved.
+
+A cassette stores the model name, the signature and the result. The input itself is never written,
+only its hash, but a recorded answer can still repeat back what the prompt contained, so treat a
+cassette like any other committed fixture.
+
+.. note::
+
+    On replay the recorded result is returned verbatim, so the bridge ``ResultConverter`` runs only
+    at record time. To exercise bridge internals offline, record at the HTTP boundary with
+    :class:`Symfony\\AI\\Platform\\Test\\Replay\\CassetteHttpClient` instead, described next.
 
 Recording Real Responses
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * [BC BREAK] Add `ListenerInterface::onError()` and `Result\Stream\ErrorEvent`, dispatched when draining a `StreamResult` throws, so a listener can finalize on a failed stream where `onComplete()` never fires; `AbstractStreamListener` provides a no-op default
  * Add `Test\Replay\CassetteHttpClient` and `Test\Replay\HttpCassette` to record real HTTP responses (when the cassette file is missing) and replay them offline through the real bridge pipeline (Contract, `ModelClient`, `ResultConverter`) in tests, including raw Server-Sent Event streams
+ * Add `Test\Recording\RecordingProvider` (with `Cassette`/`ResultSerializer`) to record a real provider's result once (when the cassette file is missing) and replay it offline in tests
 
 0.12
 ----

--- a/src/platform/src/Test/Recording/Cassette.php
+++ b/src/platform/src/Test/Recording/Cassette.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test\Recording;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+
+/**
+ * A JSON file of recorded provider interactions used by {@see RecordingProvider}.
+ *
+ * Each interaction stores the model, a request signature, and the serialized result (see
+ * {@see ResultSerializer}). Interactions sharing a signature are replayed first-in-first-out,
+ * mirroring the drop-in semantics of Symfony's MockHttpClient when given an array of responses.
+ *
+ * @phpstan-type Interaction array{model: string, signature: string, result: array<string, mixed>}
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class Cassette
+{
+    /**
+     * @var list<Interaction>
+     */
+    private array $interactions = [];
+
+    /**
+     * @var list<int>
+     */
+    private array $consumed = [];
+
+    private bool $loaded = false;
+
+    public function __construct(
+        private readonly string $path,
+    ) {
+    }
+
+    public function exists(): bool
+    {
+        return is_file($this->path);
+    }
+
+    /**
+     * @param array<string, mixed> $result the serialized result produced by {@see ResultSerializer::toArray()}
+     */
+    public function record(string $model, string $signature, array $result): void
+    {
+        $this->load();
+
+        $this->interactions[] = [
+            'model' => $model,
+            'signature' => $signature,
+            'result' => $result,
+        ];
+
+        $this->save();
+    }
+
+    /**
+     * Returns the next unused recorded result matching the given signature (FIFO).
+     *
+     * @return array<string, mixed> the serialized result for {@see ResultSerializer::fromArray()}
+     */
+    public function match(string $signature): array
+    {
+        $this->load();
+
+        foreach ($this->interactions as $index => $interaction) {
+            if ($interaction['signature'] !== $signature) {
+                continue;
+            }
+
+            if (\in_array($index, $this->consumed, true)) {
+                continue;
+            }
+
+            $this->consumed[] = $index;
+
+            return $interaction['result'];
+        }
+
+        throw new RuntimeException(\sprintf('Cassette "%s" has no recorded interaction for signature "%s"; delete the file to re-record it.', $this->path, $signature));
+    }
+
+    private function load(): void
+    {
+        if ($this->loaded) {
+            return;
+        }
+
+        $this->loaded = true;
+
+        if (!is_file($this->path)) {
+            return;
+        }
+
+        $raw = file_get_contents($this->path);
+        if (false === $raw || '' === trim($raw)) {
+            return;
+        }
+
+        $data = json_decode($raw, true, flags: \JSON_THROW_ON_ERROR);
+        $this->interactions = $data['interactions'] ?? [];
+    }
+
+    private function save(): void
+    {
+        $directory = \dirname($this->path);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($this->path, json_encode(['interactions' => $this->interactions], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)."\n");
+    }
+}

--- a/src/platform/src/Test/Recording/RecordingProvider.php
+++ b/src/platform/src/Test/Recording/RecordingProvider.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test\Recording;
+
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\PlainConverter;
+use Symfony\AI\Platform\ProviderInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+
+/**
+ * Decorates a real provider to record its result once and replay it offline in later test runs.
+ *
+ * By default recording happens automatically when the {@see Cassette} file does not exist yet:
+ * the inner provider is invoked against the live API, its finished {@see ResultInterface} is
+ * serialized to the cassette, and the same result is returned. Once the cassette exists, later
+ * runs replay it offline and the inner provider is never called. The mode can be forced with the
+ * explicit `$record` constructor argument.
+ *
+ * On replay the result is rebuilt from the cassette, so a bridge's `ResultConverter` runs live only
+ * at record time. A test that must exercise bridge internals offline needs to record at the HTTP
+ * boundary instead.
+ *
+ * @phpstan-type SignatureCallback \Closure(string|Model, array<mixed>|string|object, array<string, mixed>): string
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RecordingProvider implements ProviderInterface
+{
+    private readonly bool $record;
+
+    /**
+     * @var SignatureCallback
+     */
+    private readonly \Closure $signature;
+
+    /**
+     * A custom `$signature` derives the key an interaction is recorded and matched under. Pass one to
+     * normalize values that legitimately differ between runs (timestamps, ids, retrieved context) and
+     * would otherwise miss their own recording.
+     *
+     * @param bool|null              $record    whether to record (`true`) or replay (`false`); defaults to
+     *                                          recording when the cassette file does not exist yet
+     * @param SignatureCallback|null $signature
+     */
+    public function __construct(
+        private readonly ProviderInterface $provider,
+        private readonly Cassette $cassette,
+        ?bool $record = null,
+        ?\Closure $signature = null,
+    ) {
+        $this->record = $record ?? !$cassette->exists();
+        $this->signature = $signature ?? self::defaultSignature(...);
+    }
+
+    public function getName(): string
+    {
+        return $this->provider->getName();
+    }
+
+    public function supports(string|Model $model): bool
+    {
+        return $this->provider->supports($model);
+    }
+
+    public function getModelCatalog(): ModelCatalogInterface
+    {
+        return $this->provider->getModelCatalog();
+    }
+
+    public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
+    {
+        $signature = ($this->signature)($model, $input, $options);
+
+        if ($this->record) {
+            $result = $this->provider->invoke($model, $input, $options)->getResult();
+            $this->cassette->record($model instanceof Model ? $model->getName() : $model, $signature, ResultSerializer::toArray($result));
+        } else {
+            $result = ResultSerializer::fromArray($this->cassette->match($signature));
+        }
+
+        return self::createDeferredResult($result, $options);
+    }
+
+    /**
+     * Reconstructs a {@see DeferredResult} from a finished result, mirroring
+     * {@see \Symfony\AI\Platform\Test\InMemoryPlatform}.
+     *
+     * @param array<string, mixed> $options
+     */
+    private static function createDeferredResult(ResultInterface $result, array $options): DeferredResult
+    {
+        $rawResult = $result->getRawResult() ?? new InMemoryRawResult(
+            ['text' => $result->getContent()],
+            [],
+            (object) ['text' => $result->getContent()],
+        );
+
+        return new DeferredResult(new PlainConverter($result), $rawResult, $options);
+    }
+
+    /**
+     * A fully defined model is reduced to its name and options, so an equivalent model instance
+     * built by a later run matches the recorded interaction. Everything else is hashed verbatim,
+     * so an input that varies between runs needs a custom signature (see the constructor).
+     *
+     * @param array<mixed>|string|object $input
+     * @param array<string, mixed>       $options
+     */
+    private static function defaultSignature(string|Model $model, array|string|object $input, array $options): string
+    {
+        $normalizedModel = $model instanceof Model ? [$model->getName(), $model->getOptions()] : $model;
+
+        try {
+            $payload = json_encode([$normalizedModel, $input, $options], \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $payload = serialize([$normalizedModel, $input, $options]);
+        }
+
+        return hash('xxh128', $payload);
+    }
+}

--- a/src/platform/src/Test/Recording/ResultSerializer.php
+++ b/src/platform/src/Test/Recording/ResultSerializer.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Test\Recording;
+
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Vector\Vector;
+
+/**
+ * Converts a {@see ResultInterface} to and from a JSON-serializable array for {@see Cassette}.
+ *
+ * Supported result types (v1): text, object, vector, tool call, and text-delta streams. Result
+ * metadata and token usage are not preserved. Unsupported result or delta types throw.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResultSerializer
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(ResultInterface $result): array
+    {
+        if ($result instanceof TextResult) {
+            return [
+                'type' => 'text',
+                'content' => $result->getContent(),
+                'signature' => $result->getSignature(),
+            ];
+        }
+
+        if ($result instanceof ObjectResult) {
+            $content = $result->getContent();
+
+            return [
+                'type' => 'object',
+                'is_object' => \is_object($content),
+                'content' => json_encode($content, \JSON_THROW_ON_ERROR),
+            ];
+        }
+
+        if ($result instanceof VectorResult) {
+            return [
+                'type' => 'vector',
+                'vectors' => array_map(static fn (Vector $vector): array => $vector->getData(), $result->getContent()),
+            ];
+        }
+
+        if ($result instanceof ToolCallResult) {
+            return [
+                'type' => 'toolcall',
+                'tool_calls' => array_map(static fn (ToolCall $toolCall): array => [
+                    'id' => $toolCall->getId(),
+                    'name' => $toolCall->getName(),
+                    'arguments' => $toolCall->getArguments(),
+                    'signature' => $toolCall->getSignature(),
+                ], $result->getContent()),
+            ];
+        }
+
+        if ($result instanceof StreamResult) {
+            $deltas = [];
+            foreach ($result->getContent() as $delta) {
+                if (!$delta instanceof \Stringable) {
+                    throw new InvalidArgumentException(\sprintf('Cannot record stream delta of type "%s"; only text deltas are supported.', get_debug_type($delta)));
+                }
+
+                $deltas[] = (string) $delta;
+            }
+
+            return [
+                'type' => 'stream',
+                'deltas' => $deltas,
+            ];
+        }
+
+        throw new InvalidArgumentException(\sprintf('Cannot record result of type "%s".', $result::class));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): ResultInterface
+    {
+        $type = $data['type'] ?? null;
+
+        if ('text' === $type) {
+            return new TextResult((string) $data['content'], $data['signature'] ?? null);
+        }
+
+        if ('object' === $type) {
+            $content = json_decode((string) $data['content'], !($data['is_object'] ?? false), flags: \JSON_THROW_ON_ERROR);
+
+            return new ObjectResult($content);
+        }
+
+        if ('vector' === $type) {
+            return new VectorResult(array_map(
+                static fn (array $vector): Vector => new Vector(array_map(static fn ($value): float => (float) $value, $vector)),
+                $data['vectors'] ?? [],
+            ));
+        }
+
+        if ('toolcall' === $type) {
+            return new ToolCallResult(array_map(
+                static fn (array $toolCall): ToolCall => new ToolCall(
+                    (string) $toolCall['id'],
+                    (string) $toolCall['name'],
+                    $toolCall['arguments'] ?? [],
+                    $toolCall['signature'] ?? null,
+                ),
+                $data['tool_calls'] ?? [],
+            ));
+        }
+
+        if ('stream' === $type) {
+            $deltas = $data['deltas'] ?? [];
+
+            return new StreamResult((static function () use ($deltas): \Generator {
+                foreach ($deltas as $text) {
+                    yield new TextDelta((string) $text);
+                }
+            })());
+        }
+
+        throw new InvalidArgumentException(\sprintf('Cannot rebuild result of unknown type "%s".', \is_string($type) ? $type : get_debug_type($type)));
+    }
+}

--- a/src/platform/tests/Test/Recording/CassetteTest.php
+++ b/src/platform/tests/Test/Recording/CassetteTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Test\Recording;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Test\Recording\Cassette;
+
+final class CassetteTest extends TestCase
+{
+    private string $path;
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir().'/ai-recording-cassette-'.bin2hex(random_bytes(6)).'.json';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->path)) {
+            unlink($this->path);
+        }
+    }
+
+    public function testExistsReflectsFilePresence()
+    {
+        $cassette = new Cassette($this->path);
+        $this->assertFalse($cassette->exists());
+
+        $cassette->record('gpt-4o', 'sig', ['type' => 'text', 'content' => 'hi']);
+        $this->assertTrue($cassette->exists());
+    }
+
+    public function testRecordPersistsInteraction()
+    {
+        $cassette = new Cassette($this->path);
+        $cassette->record('gpt-4o', 'sig', ['type' => 'text', 'content' => 'hi']);
+
+        $data = json_decode((string) file_get_contents($this->path), true, flags: \JSON_THROW_ON_ERROR);
+
+        $this->assertSame('gpt-4o', $data['interactions'][0]['model']);
+        $this->assertSame('sig', $data['interactions'][0]['signature']);
+        $this->assertSame(['type' => 'text', 'content' => 'hi'], $data['interactions'][0]['result']);
+    }
+
+    public function testMatchReturnsRecordedResult()
+    {
+        $recorder = new Cassette($this->path);
+        $recorder->record('gpt-4o', 'sig', ['type' => 'text', 'content' => 'hi']);
+
+        $cassette = new Cassette($this->path);
+
+        $this->assertSame(['type' => 'text', 'content' => 'hi'], $cassette->match('sig'));
+    }
+
+    public function testMatchConsumesEqualSignaturesInOrder()
+    {
+        $recorder = new Cassette($this->path);
+        $recorder->record('gpt-4o', 'sig', ['type' => 'text', 'content' => 'first']);
+        $recorder->record('gpt-4o', 'sig', ['type' => 'text', 'content' => 'second']);
+
+        $cassette = new Cassette($this->path);
+
+        $this->assertSame('first', $cassette->match('sig')['content']);
+        $this->assertSame('second', $cassette->match('sig')['content']);
+    }
+
+    public function testMatchThrowsWhenSignatureMissing()
+    {
+        $recorder = new Cassette($this->path);
+        $recorder->record('gpt-4o', 'sig', ['type' => 'text', 'content' => 'hi']);
+
+        $cassette = new Cassette($this->path);
+
+        $this->expectException(RuntimeException::class);
+        $cassette->match('unknown');
+    }
+
+    public function testMatchThrowsWhenEqualSignatureExhausted()
+    {
+        $recorder = new Cassette($this->path);
+        $recorder->record('gpt-4o', 'sig', ['type' => 'text', 'content' => 'only']);
+
+        $cassette = new Cassette($this->path);
+        $cassette->match('sig');
+
+        $this->expectException(RuntimeException::class);
+        $cassette->match('sig');
+    }
+}

--- a/src/platform/tests/Test/Recording/RecordingProviderTest.php
+++ b/src/platform/tests/Test/Recording/RecordingProviderTest.php
@@ -1,0 +1,228 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Test\Recording;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Anthropic\Factory as AnthropicFactory;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\ProviderInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Test\MockPlatformFactory as MockFactory;
+use Symfony\AI\Platform\Test\Recording\Cassette;
+use Symfony\AI\Platform\Test\Recording\RecordingProvider;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+final class RecordingProviderTest extends TestCase
+{
+    private string $path;
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir().'/ai-recording-provider-'.bin2hex(random_bytes(6)).'.json';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->path)) {
+            unlink($this->path);
+        }
+    }
+
+    public function testRecordsResultToCassette()
+    {
+        $provider = new RecordingProvider(
+            MockFactory::createProvider('hello'),
+            new Cassette($this->path),
+            record: true,
+        );
+
+        $result = $provider->invoke('any-model', 'q');
+
+        $this->assertSame('hello', $result->asText());
+        $this->assertFileExists($this->path);
+    }
+
+    public function testReplaysWithoutInvokingInnerProvider()
+    {
+        $recorder = new RecordingProvider(MockFactory::createProvider('hello'), new Cassette($this->path), record: true);
+        $recorder->invoke('any-model', 'q');
+
+        $replay = new RecordingProvider($this->throwingProvider(), new Cassette($this->path), record: false);
+
+        $this->assertSame('hello', $replay->invoke('any-model', 'q')->asText());
+    }
+
+    public function testRecordsAutomaticallyWhenCassetteMissing()
+    {
+        $provider = new RecordingProvider(MockFactory::createProvider('hello'), new Cassette($this->path));
+
+        $this->assertSame('hello', $provider->invoke('any-model', 'q')->asText());
+        $this->assertFileExists($this->path);
+    }
+
+    public function testReplaysAutomaticallyWhenCassetteExists()
+    {
+        $recorder = new RecordingProvider(MockFactory::createProvider('hello'), new Cassette($this->path));
+        $recorder->invoke('any-model', 'q');
+
+        $replay = new RecordingProvider($this->throwingProvider(), new Cassette($this->path));
+
+        $this->assertSame('hello', $replay->invoke('any-model', 'q')->asText());
+    }
+
+    public function testReplaysObjectResult()
+    {
+        $this->record(MockFactory::createProvider(static fn (): ObjectResult => new ObjectResult((object) ['answer' => 42])));
+
+        $object = $this->replay()->invoke('any-model', 'q')->asObject();
+
+        $this->assertSame(42, $object->answer);
+    }
+
+    public function testReplaysVectorResult()
+    {
+        $this->record(MockFactory::createProvider(static fn (): VectorResult => new VectorResult([new Vector([0.1, 0.2, 0.3])])));
+
+        $vectors = $this->replay()->invoke('any-model', 'q')->asVectors();
+
+        $this->assertSame([0.1, 0.2, 0.3], $vectors[0]->getData());
+    }
+
+    public function testReplaysToolCallResult()
+    {
+        $this->record(MockFactory::createProvider(static fn (): ToolCallResult => new ToolCallResult([
+            new ToolCall('id-1', 'get_weather', ['location' => 'Paris']),
+        ])));
+
+        $toolCalls = $this->replay()->invoke('any-model', 'q')->asToolCalls();
+
+        $this->assertSame('get_weather', $toolCalls[0]->getName());
+        $this->assertSame(['location' => 'Paris'], $toolCalls[0]->getArguments());
+    }
+
+    public function testReplaysTextStreamResult()
+    {
+        $this->record(MockFactory::createProvider(static fn (): StreamResult => new StreamResult((static function (): \Generator {
+            yield new TextDelta('Hel');
+            yield new TextDelta('lo');
+        })())));
+
+        $text = '';
+        foreach ($this->replay()->invoke('any-model', 'q')->asTextStream() as $delta) {
+            $text .= (string) $delta;
+        }
+
+        $this->assertSame('Hello', $text);
+    }
+
+    public function testRecordRunsRealBridgeConverterThenReplayServesItOffline()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [['type' => 'text', 'text' => 'Recorded by Anthropic']],
+        ]));
+
+        $recorder = new RecordingProvider(
+            AnthropicFactory::createProvider('test-key', $httpClient),
+            new Cassette($this->path),
+            record: true,
+        );
+
+        $messages = new MessageBag(Message::ofUser('Hello'));
+
+        $this->assertSame('Recorded by Anthropic', $recorder->invoke('claude-3-7-sonnet-20250219', $messages)->asText());
+
+        $replay = new RecordingProvider($this->throwingProvider(), new Cassette($this->path), record: false);
+
+        $this->assertSame('Recorded by Anthropic', $replay->invoke('claude-3-7-sonnet-20250219', new MessageBag(Message::ofUser('Hello')))->asText());
+    }
+
+    public function testReplayThrowsOnSignatureMiss()
+    {
+        $recorder = new RecordingProvider(MockFactory::createProvider('hello'), new Cassette($this->path), record: true);
+        $recorder->invoke('any-model', 'q');
+
+        $replay = new RecordingProvider($this->throwingProvider(), new Cassette($this->path), record: false);
+
+        $this->expectException(RuntimeException::class);
+        $replay->invoke('any-model', 'different-input');
+    }
+
+    public function testCustomSignatureMatchesDespiteVaryingInput()
+    {
+        $signature = static fn (string|Model $model, array|string|object $input, array $options): string => 'fixed';
+
+        $recorder = new RecordingProvider(MockFactory::createProvider('hello'), new Cassette($this->path), record: true, signature: $signature);
+        $recorder->invoke('any-model', 'question asked at 2026-01-01');
+
+        $replay = new RecordingProvider($this->throwingProvider(), new Cassette($this->path), record: false, signature: $signature);
+
+        $this->assertSame('hello', $replay->invoke('any-model', 'question asked at 2026-08-16')->asText());
+    }
+
+    public function testDelegatesMetadataMethods()
+    {
+        $inner = MockFactory::createProvider('hello', name: 'inner');
+        $provider = new RecordingProvider($inner, new Cassette($this->path), record: false);
+
+        $this->assertSame('inner', $provider->getName());
+        $this->assertTrue($provider->supports('any-model'));
+        $this->assertSame($inner->getModelCatalog(), $provider->getModelCatalog());
+    }
+
+    private function record(ProviderInterface $inner): void
+    {
+        $provider = new RecordingProvider($inner, new Cassette($this->path), record: true);
+        $provider->invoke('any-model', 'q');
+    }
+
+    private function replay(): RecordingProvider
+    {
+        return new RecordingProvider($this->throwingProvider(), new Cassette($this->path), record: false);
+    }
+
+    private function throwingProvider(): ProviderInterface
+    {
+        return new class implements ProviderInterface {
+            public function getName(): string
+            {
+                return 'throwing';
+            }
+
+            public function supports(string|Model $model): bool
+            {
+                return true;
+            }
+
+            public function getModelCatalog(): ModelCatalogInterface
+            {
+                throw new RuntimeException('Inner provider must not be touched on replay.');
+            }
+
+            public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
+            {
+                throw new RuntimeException('Inner provider must not be invoked on replay.');
+            }
+        };
+    }
+}

--- a/src/platform/tests/Test/Recording/ResultSerializerTest.php
+++ b/src/platform/tests/Test/Recording/ResultSerializerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Test\Recording;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\Test\Recording\ResultSerializer;
+use Symfony\AI\Platform\Vector\Vector;
+
+final class ResultSerializerTest extends TestCase
+{
+    public function testTextRoundTrip()
+    {
+        $result = ResultSerializer::fromArray(ResultSerializer::toArray(new TextResult('Hello', 'sig-1')));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello', $result->getContent());
+        $this->assertSame('sig-1', $result->getSignature());
+    }
+
+    public function testObjectRoundTripWithObject()
+    {
+        $result = ResultSerializer::fromArray(ResultSerializer::toArray(new ObjectResult((object) ['answer' => 42])));
+
+        $this->assertInstanceOf(ObjectResult::class, $result);
+        $content = $result->getContent();
+        $this->assertIsObject($content);
+        $this->assertSame(42, $content->answer);
+    }
+
+    public function testObjectRoundTripWithArray()
+    {
+        $result = ResultSerializer::fromArray(ResultSerializer::toArray(new ObjectResult(['answer' => 42])));
+
+        $this->assertInstanceOf(ObjectResult::class, $result);
+        $this->assertSame(['answer' => 42], $result->getContent());
+    }
+
+    public function testVectorRoundTrip()
+    {
+        $result = ResultSerializer::fromArray(ResultSerializer::toArray(new VectorResult([new Vector([0.1, 0.2, 0.3])])));
+
+        $this->assertInstanceOf(VectorResult::class, $result);
+        $this->assertSame([0.1, 0.2, 0.3], $result->getContent()[0]->getData());
+    }
+
+    public function testToolCallRoundTrip()
+    {
+        $result = ResultSerializer::fromArray(ResultSerializer::toArray(new ToolCallResult([
+            new ToolCall('id-1', 'get_weather', ['location' => 'Paris'], 'sig-2'),
+        ])));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCall = $result->getContent()[0];
+        $this->assertSame('id-1', $toolCall->getId());
+        $this->assertSame('get_weather', $toolCall->getName());
+        $this->assertSame(['location' => 'Paris'], $toolCall->getArguments());
+        $this->assertSame('sig-2', $toolCall->getSignature());
+    }
+
+    public function testTextStreamRoundTrip()
+    {
+        $stream = new StreamResult((static function (): \Generator {
+            yield new TextDelta('Hel');
+            yield new TextDelta('lo');
+        })());
+
+        $result = ResultSerializer::fromArray(ResultSerializer::toArray($stream));
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $text = '';
+        foreach ($result->getContent() as $delta) {
+            $this->assertInstanceOf(TextDelta::class, $delta);
+            $text .= $delta->getText();
+        }
+
+        $this->assertSame('Hello', $text);
+    }
+
+    public function testUnsupportedResultTypeThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ResultSerializer::toArray(new BinaryResult('binary-data'));
+    }
+
+    public function testUnsupportedStreamDeltaThrows()
+    {
+        $stream = new StreamResult((static function (): \Generator {
+            yield new ThinkingDelta('reasoning');
+        })());
+
+        $this->expectException(InvalidArgumentException::class);
+        ResultSerializer::toArray($stream);
+    }
+
+    public function testUnknownTypeOnFromArrayThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ResultSerializer::fromArray(['type' => 'unknown']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Sibling of #2128, which records at the HTTP boundary. This one records a layer higher, at the provider, for tests that just need a realistic answer and do not care how the bridge produced it.

`Test\Recording\RecordingProvider` decorates a real `ProviderInterface`. Record when the cassette file is missing (invokes the provider, serializes its finished `ResultInterface`), replay when it exists (rebuilds the result, never calls the provider, needs no API key). Delete the cassette to re-record, or force the mode with `record:`.

```php
$provider = new RecordingProvider(
    Factory::createProvider($_SERVER['ANTHROPIC_API_KEY'] ?? 'no-key-needed-on-replay'),
    new Cassette(__DIR__.'/fixtures/weather.json'),
);
```

Covers text, `ObjectResult`, `VectorResult`, `ToolCallResult` and text streams. Interactions are matched by a signature over `(model, input, options)` and consumed FIFO; the signature function is injectable, so an input that varies between runs (timestamps, ids, retrieved context) can be normalized instead of forcing a re-record (thanks @MikiBuilder).

Two scope notes: on replay the recorded result is returned verbatim, so the bridge `ResultConverter` only runs at record time, and result metadata plus token usage are not preserved yet.

Rebased on main now that #2128 is merged, so this adds its own row to the "which test double do I pick" list that came with it, between `InMemoryPlatform` and `MockPlatformFactory`, which is where it cuts.

