### PR TITLE
[Platform] Add ModelCard with pricing, region and extra metadata to model catalog

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add optional `signature` field to `Message\Content\Text`, `Result\ToolCall`, and `Result\TextResult` for provider-scoped signatures (currently used by Gemini/Vertex AI for `thoughtSignature` round-trip).
  * Memoize conversion failures in `DeferredResult::getResult()` so subsequent calls re-throw the cached exception instead of re-running the converter
  * Surface tool calls executed by the `ClaudeCode` and `Codex` CLI bridges as `ToolCallResult` parts of a `MultiPartResult`, mirroring the inference-API behavior of the Anthropic and Gemini bridges
+ * Add `ModelCatalog\ModelCard` and `ModelCatalog\ModelPricing`, exposed via `Model::getCard()`, with an optional `metadata` key in `ModelCatalog` entries (pricing, region, and an open `extra` bag)
 
 0.8
 ---

--- a/src/platform/src/Bridge/Anthropic/Claude.php
+++ b/src/platform/src/Bridge/Anthropic/Claude.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Anthropic;
 
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\ModelCard;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -33,12 +34,12 @@ class Claude extends Model
     /**
      * @param array<string, mixed> $options The default options for the model usage
      */
-    public function __construct(string $name, array $capabilities = [], array $options = [])
+    public function __construct(string $name, array $capabilities = [], array $options = [], ?ModelCard $card = null)
     {
         if (!isset($options['max_tokens'])) {
             $options['max_tokens'] = 1000;
         }
 
-        parent::__construct($name, $capabilities, $options);
+        parent::__construct($name, $capabilities, $options, $card);
     }
 }

--- a/src/platform/src/Bridge/Gemini/Embeddings.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Gemini;
 
 use Symfony\AI\Platform\Bridge\Gemini\Embeddings\TaskType;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\ModelCard;
 
 /**
  * @author Valtteri R <valtzu@gmail.com>
@@ -22,8 +23,8 @@ class Embeddings extends Model
     /**
      * @param array{dimensions?: int, task_type?: TaskType|string} $options
      */
-    public function __construct(string $name, array $capabilities = [], array $options = [])
+    public function __construct(string $name, array $capabilities = [], array $options = [], ?ModelCard $card = null)
     {
-        parent::__construct($name, $capabilities, $options);
+        parent::__construct($name, $capabilities, $options, $card);
     }
 }

--- a/src/platform/src/Bridge/OpenAi/Embeddings.php
+++ b/src/platform/src/Bridge/OpenAi/Embeddings.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\OpenAi;
 
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\ModelCard;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -21,8 +22,8 @@ class Embeddings extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name, array $capabilities = [], array $options = [])
+    public function __construct(string $name, array $capabilities = [], array $options = [], ?ModelCard $card = null)
     {
-        parent::__construct($name, $capabilities, $options);
+        parent::__construct($name, $capabilities, $options, $card);
     }
 }

--- a/src/platform/src/Bridge/Scaleway/Embeddings.php
+++ b/src/platform/src/Bridge/Scaleway/Embeddings.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Scaleway;
 
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\ModelCard;
 
 /**
  * @author Marcus Stöhr <marcus@fischteich.net>
@@ -21,8 +22,8 @@ final class Embeddings extends Model
     /**
      * @param array<string, mixed> $options
      */
-    public function __construct(string $name, array $capabilities = [], array $options = [])
+    public function __construct(string $name, array $capabilities = [], array $options = [], ?ModelCard $card = null)
     {
-        parent::__construct($name, $capabilities, $options);
+        parent::__construct($name, $capabilities, $options, $card);
     }
 }

--- a/src/platform/src/Bridge/Scaleway/Scaleway.php
+++ b/src/platform/src/Bridge/Scaleway/Scaleway.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Scaleway;
 
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\ModelCard;
 
 /**
  * @author Marcus Stöhr <marcus@fischteich.net>
@@ -25,7 +26,8 @@ final class Scaleway extends Model
         string $name,
         array $capabilities = [],
         array $options = [],
+        ?ModelCard $card = null,
     ) {
-        parent::__construct($name, $capabilities, $options);
+        parent::__construct($name, $capabilities, $options, $card);
     }
 }

--- a/src/platform/src/Bridge/Voyage/Voyage.php
+++ b/src/platform/src/Bridge/Voyage/Voyage.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Voyage;
 
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\ModelCard;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -24,8 +25,8 @@ class Voyage extends Model
     /**
      * @param array{dimensions?: int, input_type?: self::INPUT_TYPE_*, truncation?: bool} $options
      */
-    public function __construct(string $name, array $capabilities = [], array $options = [])
+    public function __construct(string $name, array $capabilities = [], array $options = [], ?ModelCard $card = null)
     {
-        parent::__construct($name, $capabilities, $options);
+        parent::__construct($name, $capabilities, $options, $card);
     }
 }

--- a/src/platform/src/Model.php
+++ b/src/platform/src/Model.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\ModelCatalog\ModelCard;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -27,6 +28,7 @@ class Model
         private readonly string $name,
         private readonly array $capabilities = [],
         private readonly array $options = [],
+        private readonly ?ModelCard $card = null,
     ) {
         if ('' === trim($name)) {
             throw new InvalidArgumentException('Model name cannot be empty.');
@@ -60,5 +62,10 @@ class Model
     public function getOptions(): array
     {
         return $this->options;
+    }
+
+    public function getCard(): ?ModelCard
+    {
+        return $this->card;
     }
 }

--- a/src/platform/src/ModelCatalog/AbstractModelCatalog.php
+++ b/src/platform/src/ModelCatalog/AbstractModelCatalog.php
@@ -22,7 +22,15 @@ use Symfony\AI\Platform\Model;
 abstract class AbstractModelCatalog implements ModelCatalogInterface
 {
     /**
-     * @var array<string, array{class: class-string, capabilities: list<Capability>}>
+     * @var array<string, array{
+     *     class: class-string,
+     *     capabilities: list<Capability>,
+     *     metadata?: array{
+     *         pricing?: array<string, mixed>,
+     *         region?: string|null,
+     *         extra?: array<string, mixed>,
+     *     },
+     * }>
      */
     protected array $models;
 
@@ -48,7 +56,11 @@ abstract class AbstractModelCatalog implements ModelCatalogInterface
             throw new InvalidArgumentException(\sprintf('Model class "%s" does not exist.', $modelClass));
         }
 
-        $model = new $modelClass($actualModelName, $modelConfig['capabilities'], $options);
+        $card = isset($modelConfig['metadata'])
+            ? ModelCard::fromArray($modelConfig['metadata'])
+            : null;
+
+        $model = new $modelClass($actualModelName, $modelConfig['capabilities'], $options, $card);
         if (!$model instanceof Model) {
             throw new InvalidArgumentException(\sprintf('Model class "%s" must extend "%s".', $modelClass, Model::class));
         }
@@ -57,7 +69,15 @@ abstract class AbstractModelCatalog implements ModelCatalogInterface
     }
 
     /**
-     * @return array<string, array{class: class-string, capabilities: list<Capability>}>
+     * @return array<string, array{
+     *     class: class-string,
+     *     capabilities: list<Capability>,
+     *     metadata?: array{
+     *         pricing?: array<string, mixed>,
+     *         region?: string|null,
+     *         extra?: array<string, mixed>,
+     *     },
+     * }>
      */
     public function getModels(): array
     {

--- a/src/platform/src/ModelCatalog/ModelCard.php
+++ b/src/platform/src/ModelCatalog/ModelCard.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\ModelCatalog;
+
+/**
+ * Objective, declarative facts about a model catalog entry.
+ *
+ * Carries platform-blessed facts (pricing, region) as typed fields, plus an open
+ * `extra` bag for app-specific values. Platform code never branches on the contents
+ * of `extra`.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelCard
+{
+    /**
+     * @param array<string, mixed> $extra App-specific values (e.g. tier, scores).
+     *                                    Conventional keys: "tier", "modelTier", "scores" —
+     *                                    documented so apps converge, but NOT enforced.
+     */
+    public function __construct(
+        private readonly ?ModelPricing $pricing = null,
+        private readonly ?string $region = null,
+        private readonly array $extra = [],
+    ) {
+    }
+
+    public function getPricing(): ?ModelPricing
+    {
+        return $this->pricing;
+    }
+
+    public function getRegion(): ?string
+    {
+        return $this->region;
+    }
+
+    /**
+     * Reads a value from the open `extra` bag.
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->extra[$key] ?? $default;
+    }
+
+    /**
+     * @return array<string, mixed> The `extra` bag
+     */
+    public function all(): array
+    {
+        return $this->extra;
+    }
+
+    /**
+     * @param array{
+     *     pricing?: array<string, mixed>,
+     *     region?: string|null,
+     *     extra?: array<string, mixed>,
+     * } $card
+     */
+    public static function fromArray(array $card): self
+    {
+        return new self(
+            isset($card['pricing']) ? ModelPricing::fromArray($card['pricing']) : null,
+            $card['region'] ?? null,
+            $card['extra'] ?? [],
+        );
+    }
+}

--- a/src/platform/src/ModelCatalog/ModelCatalogInterface.php
+++ b/src/platform/src/ModelCatalog/ModelCatalogInterface.php
@@ -25,7 +25,15 @@ interface ModelCatalogInterface
     public function getModel(string $modelName): Model;
 
     /**
-     * @return array<string, array{class: string, capabilities: list<Capability>}>
+     * @return array<string, array{
+     *     class: string,
+     *     capabilities: list<Capability>,
+     *     metadata?: array{
+     *         pricing?: array<string, mixed>,
+     *         region?: string|null,
+     *         extra?: array<string, mixed>,
+     *     },
+     * }>
      */
     public function getModels(): array;
 }

--- a/src/platform/src/ModelCatalog/ModelPricing.php
+++ b/src/platform/src/ModelCatalog/ModelPricing.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\ModelCatalog;
+
+/**
+ * Objective, declarative pricing for a model catalog entry.
+ *
+ * All rates are expressed per 1,000,000 tokens, in the given currency.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelPricing
+{
+    /**
+     * @param float      $inputPerMillion       Rate for (uncached) input tokens
+     * @param float      $outputPerMillion      Rate for output tokens
+     * @param float|null $cachedInputPerMillion Rate for cache-read (cached prompt) input tokens
+     * @param float|null $cacheWritePerMillion  Rate for cache-write (cache creation) tokens
+     * @param string     $currency              ISO 4217 currency code
+     */
+    public function __construct(
+        private readonly float $inputPerMillion,
+        private readonly float $outputPerMillion,
+        private readonly ?float $cachedInputPerMillion = null,
+        private readonly ?float $cacheWritePerMillion = null,
+        private readonly string $currency = 'USD',
+    ) {
+    }
+
+    public function getInputPerMillion(): float
+    {
+        return $this->inputPerMillion;
+    }
+
+    public function getOutputPerMillion(): float
+    {
+        return $this->outputPerMillion;
+    }
+
+    public function getCachedInputPerMillion(): ?float
+    {
+        return $this->cachedInputPerMillion;
+    }
+
+    public function getCacheWritePerMillion(): ?float
+    {
+        return $this->cacheWritePerMillion;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    /**
+     * @param array{
+     *     input: float|int,
+     *     output: float|int,
+     *     cachedInput?: float|int,
+     *     cacheWrite?: float|int,
+     *     currency?: string,
+     * } $pricing
+     */
+    public static function fromArray(array $pricing): self
+    {
+        return new self(
+            (float) $pricing['input'],
+            (float) $pricing['output'],
+            isset($pricing['cachedInput']) ? (float) $pricing['cachedInput'] : null,
+            isset($pricing['cacheWrite']) ? (float) $pricing['cacheWrite'] : null,
+            $pricing['currency'] ?? 'USD',
+        );
+    }
+}

--- a/src/platform/tests/ModelCatalog/AbstractModelCatalogTest.php
+++ b/src/platform/tests/ModelCatalog/AbstractModelCatalogTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Tests\ModelCatalog;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Anthropic\Claude;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -171,17 +172,95 @@ final class AbstractModelCatalogTest extends TestCase
         $this->assertSame(2.5E3, $options['presence_penalty']);
     }
 
+    public function testGetModelWithoutMetadataYieldsNullCard()
+    {
+        $catalog = $this->createTestCatalog();
+        $model = $catalog->getModel('test-model');
+
+        $this->assertNull($model->getCard());
+    }
+
+    public function testGetModelWithMetadataYieldsPopulatedCard()
+    {
+        $catalog = $this->createCatalog([
+            'gpt-4' => [
+                'class' => Model::class,
+                'capabilities' => [Capability::INPUT_TEXT],
+                'metadata' => [
+                    'pricing' => ['input' => 5.0, 'output' => 30.0, 'cachedInput' => 0.5],
+                    'region' => 'us',
+                    'extra' => ['tier' => 'flagship'],
+                ],
+            ],
+        ]);
+
+        $card = $catalog->getModel('gpt-4')->getCard();
+
+        $this->assertNotNull($card);
+        $this->assertSame(5.0, $card->getPricing()->getInputPerMillion());
+        $this->assertSame(0.5, $card->getPricing()->getCachedInputPerMillion());
+        $this->assertSame('us', $card->getRegion());
+        $this->assertSame('flagship', $card->get('tier'));
+    }
+
+    public function testMetadataIsParsedAlongsideQueryStringOptions()
+    {
+        $catalog = $this->createCatalog([
+            'gpt-4' => [
+                'class' => Model::class,
+                'capabilities' => [Capability::INPUT_TEXT],
+                'metadata' => ['region' => 'eu'],
+            ],
+        ]);
+
+        $model = $catalog->getModel('gpt-4?temperature=0.7');
+
+        $this->assertSame(['temperature' => 0.7], $model->getOptions());
+        $this->assertSame('eu', $model->getCard()->getRegion());
+    }
+
+    public function testMetadataSurvivesThroughSubclassConstructor()
+    {
+        // Claude overrides __construct; guards the positional-arg trap where a subclass
+        // that does not forward the 4th argument would silently drop the card.
+        $catalog = $this->createCatalog([
+            'claude-3-7-sonnet' => [
+                'class' => Claude::class,
+                'capabilities' => [Capability::INPUT_MESSAGES],
+                'metadata' => ['region' => 'us', 'extra' => ['tier' => 'flagship']],
+            ],
+        ]);
+
+        $model = $catalog->getModel('claude-3-7-sonnet');
+
+        $this->assertInstanceOf(Claude::class, $model);
+        $this->assertNotNull($model->getCard());
+        $this->assertSame('us', $model->getCard()->getRegion());
+        $this->assertSame('flagship', $model->getCard()->get('tier'));
+    }
+
     private function createTestCatalog(): AbstractModelCatalog
     {
-        return new class extends AbstractModelCatalog {
-            public function __construct()
+        return $this->createCatalog([
+            'test-model' => [
+                'class' => Model::class,
+                'capabilities' => [Capability::INPUT_TEXT],
+            ],
+        ]);
+    }
+
+    /**
+     * @param array<string, array{class: class-string, capabilities: list<Capability>, metadata?: array<string, mixed>}> $models
+     */
+    private function createCatalog(array $models): AbstractModelCatalog
+    {
+        return new class($models) extends AbstractModelCatalog {
+            /**
+             * @param array<string, array{class: class-string, capabilities: list<Capability>, metadata?: array<string, mixed>}> $models
+             */
+            public function __construct(array $models)
             {
-                $this->models = [
-                    'test-model' => [
-                        'class' => Model::class,
-                        'capabilities' => [Capability::INPUT_TEXT],
-                    ],
-                ];
+                $this->models = $models;
             }
         };
     }

--- a/src/platform/tests/ModelCatalog/ModelCardTest.php
+++ b/src/platform/tests/ModelCatalog/ModelCardTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\ModelCatalog;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\ModelCatalog\ModelCard;
+use Symfony\AI\Platform\ModelCatalog\ModelPricing;
+
+final class ModelCardTest extends TestCase
+{
+    public function testTypedGetters()
+    {
+        $pricing = new ModelPricing(5.0, 30.0);
+        $card = new ModelCard($pricing, 'eu');
+
+        $this->assertSame($pricing, $card->getPricing());
+        $this->assertSame('eu', $card->getRegion());
+    }
+
+    public function testDefaultsAreEmpty()
+    {
+        $card = new ModelCard();
+
+        $this->assertNull($card->getPricing());
+        $this->assertNull($card->getRegion());
+        $this->assertSame([], $card->all());
+    }
+
+    public function testGetReadsExtraWithDefaultFallback()
+    {
+        $card = new ModelCard(null, null, ['tier' => 'flagship']);
+
+        $this->assertSame('flagship', $card->get('tier'));
+        $this->assertNull($card->get('missing'));
+        $this->assertSame('fallback', $card->get('missing', 'fallback'));
+    }
+
+    public function testAllReturnsExtraBag()
+    {
+        $extra = ['tier' => 'flagship', 'scores' => ['speed' => 5]];
+        $card = new ModelCard(null, null, $extra);
+
+        $this->assertSame($extra, $card->all());
+    }
+
+    public function testFromArrayBuildsNestedPricing()
+    {
+        $card = ModelCard::fromArray([
+            'pricing' => ['input' => 5.0, 'output' => 30.0, 'cachedInput' => 0.5],
+            'region' => 'us',
+            'extra' => ['tier' => 'flagship'],
+        ]);
+
+        $this->assertInstanceOf(ModelPricing::class, $card->getPricing());
+        $this->assertSame(5.0, $card->getPricing()->getInputPerMillion());
+        $this->assertSame(0.5, $card->getPricing()->getCachedInputPerMillion());
+        $this->assertSame('us', $card->getRegion());
+        $this->assertSame('flagship', $card->get('tier'));
+    }
+
+    public function testFromArrayWithAbsentKeys()
+    {
+        $card = ModelCard::fromArray([]);
+
+        $this->assertNull($card->getPricing());
+        $this->assertNull($card->getRegion());
+        $this->assertSame([], $card->all());
+    }
+}

--- a/src/platform/tests/ModelCatalog/ModelPricingTest.php
+++ b/src/platform/tests/ModelCatalog/ModelPricingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\ModelCatalog;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\ModelCatalog\ModelPricing;
+
+final class ModelPricingTest extends TestCase
+{
+    public function testGettersRoundTrip()
+    {
+        $pricing = new ModelPricing(5.0, 30.0, 0.5, 6.25, 'EUR');
+
+        $this->assertSame(5.0, $pricing->getInputPerMillion());
+        $this->assertSame(30.0, $pricing->getOutputPerMillion());
+        $this->assertSame(0.5, $pricing->getCachedInputPerMillion());
+        $this->assertSame(6.25, $pricing->getCacheWritePerMillion());
+        $this->assertSame('EUR', $pricing->getCurrency());
+    }
+
+    public function testCacheFieldsDefaultToNullAndCurrencyToUsd()
+    {
+        $pricing = new ModelPricing(5.0, 30.0);
+
+        $this->assertNull($pricing->getCachedInputPerMillion());
+        $this->assertNull($pricing->getCacheWritePerMillion());
+        $this->assertSame('USD', $pricing->getCurrency());
+    }
+
+    public function testFromArrayWithFullInput()
+    {
+        $pricing = ModelPricing::fromArray([
+            'input' => 5.0,
+            'output' => 30.0,
+            'cachedInput' => 0.5,
+            'cacheWrite' => 6.25,
+            'currency' => 'EUR',
+        ]);
+
+        $this->assertSame(5.0, $pricing->getInputPerMillion());
+        $this->assertSame(30.0, $pricing->getOutputPerMillion());
+        $this->assertSame(0.5, $pricing->getCachedInputPerMillion());
+        $this->assertSame(6.25, $pricing->getCacheWritePerMillion());
+        $this->assertSame('EUR', $pricing->getCurrency());
+    }
+
+    public function testFromArrayWithMinimalInput()
+    {
+        $pricing = ModelPricing::fromArray(['input' => 5.0, 'output' => 30.0]);
+
+        $this->assertSame(5.0, $pricing->getInputPerMillion());
+        $this->assertSame(30.0, $pricing->getOutputPerMillion());
+        $this->assertNull($pricing->getCachedInputPerMillion());
+        $this->assertNull($pricing->getCacheWritePerMillion());
+        $this->assertSame('USD', $pricing->getCurrency());
+    }
+
+    public function testFromArrayCoercesIntegerRatesToFloat()
+    {
+        $pricing = ModelPricing::fromArray(['input' => 5, 'output' => 30]);
+
+        $this->assertSame(5.0, $pricing->getInputPerMillion());
+        $this->assertSame(30.0, $pricing->getOutputPerMillion());
+    }
+}

--- a/src/platform/tests/ModelTest.php
+++ b/src/platform/tests/ModelTest.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Platform\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\ModelCard;
+use Symfony\AI\Platform\ModelCatalog\ModelPricing;
 
 final class ModelTest extends TestCase
 {
@@ -63,5 +65,22 @@ final class ModelTest extends TestCase
         $model = new Model('gpt-4');
 
         $this->assertSame([], $model->getOptions());
+    }
+
+    public function testCardIsNullByDefault()
+    {
+        $model = new Model('gpt-4');
+
+        $this->assertNull($model->getCard());
+    }
+
+    public function testExposesProvidedCard()
+    {
+        $card = new ModelCard(new ModelPricing(5.0, 30.0), 'us', ['tier' => 'flagship']);
+        $model = new Model('gpt-4', [], [], $card);
+
+        $this->assertSame($card, $model->getCard());
+        $this->assertSame('us', $model->getCard()->getRegion());
+        $this->assertSame('flagship', $model->getCard()->get('tier'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no <!-- follow-up: documented usage once consumers (cost tracker / criteria router) land -->
| Issues        | -
| License       | MIT

Adds an optional, **objective** metadata layer to model catalog entries so a `Model`
can answer "what do you cost?" and "where do you run?". This is the data layer that a
cost tracker (token usage → money) and a criteria router (filter by region/tier) build
on; both are out of scope here.

### What's added

- `ModelCatalog\ModelPricing` — immutable VO with per-1M-token rates, cache-aware
  (`cachedInputPerMillion` / `cacheWritePerMillion`, matching `TokenUsage`'s cache
  counters), `currency` defaulting to `USD`.
- `ModelCatalog\ModelCard` — immutable VO holding platform-blessed facts (`pricing`,
  `region`) plus an open, app-owned `extra` bag (`get()` / `all()`). Platform code never
  branches on `extra` contents.
- `Model::getCard(): ?ModelCard` — new optional 4th constructor slot, defaulting to
  `null`.
- `AbstractModelCatalog` parses an optional `metadata` key per entry and attaches the
  card.

### Usage

```php
// In a ModelCatalog's $models array:
'gpt-x' => [
    'class'        => Gpt::class,
    'capabilities' => [Capability::INPUT_TEXT, Capability::TOOL_CALLING],
    'metadata'     => [
        'pricing' => ['input' => 5.0, 'output' => 30.0, 'cachedInput' => 0.5],
        'region'  => 'us',
        'extra'   => ['tier' => 'flagship'],
    ],
],

// Consuming it:
$card = $catalog->getModel('gpt-x')->getCard();
$card?->getPricing()?->getInputPerMillion(); // 5.0
$card?->getRegion();                          // 'us'
$card?->get('tier');                          // 'flagship'
```

### Notes

- **Fully backward compatible** — `metadata` is optional and `getCard()` returns `null`
  when absent; no existing catalog entry needs editing.
- The getter is named `getCard()` (not `getMetadata()`) on purpose: the platform already
  has a generic mutable `Metadata\Metadata` bag exposed via `getMetadata(): Metadata` on
  every Result/Message (runtime side-channel data). A `ModelCard` is a static catalog
  descriptor, so it gets its own name to avoid overloading that convention.
- **Mechanism only** — no real bridge pricing data is shipped; apps populate their own
  catalogs. Model subclasses that override `__construct` (Claude, OpenAi/Gemini/Scaleway
  Embeddings, Scaleway, Voyage) forward the new argument so the card isn't silently
  dropped; a regression test guards this through a subclass.

Possible follow-ups (separate PRs): wiring a pricing source such as `ModelsDev`,
populating real bridge data, the cost tracker, and the criteria router.
