### PR TITLE
[Platform][Generic] Request usage stats for streamed responses

### DIFF
--- a/src/platform/src/Bridge/Generic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Generic/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+---
+
+ * Request usage stats for streamed responses by default when no `stream_options` provided
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Generic/Completions/ModelClient.php
+++ b/src/platform/src/Bridge/Generic/Completions/ModelClient.php
@@ -49,6 +49,14 @@ class ModelClient implements ModelClientInterface
             throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
         }
 
+        // Request usage stats for streamed responses by default,
+        // but preserve explicit stream_options when provided.
+        if ($options['stream'] ?? false) {
+            if (!\array_key_exists('stream_options', $options)) {
+                $options['stream_options'] = ['include_usage' => true];
+            }
+        }
+
         // cacheRetention is an internal Symfony AI option consumed by PromptCacheNormalizer
         // (Anthropic-only).  Strip it here so it is never forwarded to OpenAI-compatible
         // endpoints, which reject unknown request body fields with a 400 error.

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
@@ -72,6 +72,46 @@ final class ModelClientTest extends TestCase
         $modelClient->request(new CompletionsModel('gpt-4o'), ['model' => 'gpt-4o', 'messages' => [['role' => 'user', 'content' => 'Hello']]], ['temperature' => 0.7]);
     }
 
+    public function testItRequestsUsageForStreamedResponses()
+    {
+        $resultCallback = function (string $method, string $url, array $options): HttpResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('http://localhost:8000/v1/chat/completions', $url);
+            $this->assertSame('Authorization: Bearer sk-valid-api-key', $options['normalized_headers']['authorization'][0]);
+
+            $this->assertSame('{"stream":true,"stream_options":{"include_usage":true},"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}', $options['body']);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'http://localhost:8000', 'sk-valid-api-key');
+        $modelClient->request(
+            new CompletionsModel('gpt-4o'),
+            ['model' => 'gpt-4o', 'messages' => [['role' => 'user', 'content' => 'Hello']]],
+            ['stream' => true],
+        );
+    }
+
+    public function testItPreservesExplicitStreamOptionsForStreamedResponses()
+    {
+        $resultCallback = function (string $method, string $url, array $options): HttpResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('http://localhost:8000/v1/chat/completions', $url);
+            $this->assertSame('Authorization: Bearer sk-valid-api-key', $options['normalized_headers']['authorization'][0]);
+
+            $this->assertSame('{"stream":true,"stream_options":{"foo":"bar"},"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}', $options['body']);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'http://localhost:8000', 'sk-valid-api-key');
+        $modelClient->request(
+            new CompletionsModel('gpt-4o'),
+            ['model' => 'gpt-4o', 'messages' => [['role' => 'user', 'content' => 'Hello']]],
+            ['stream' => true, 'stream_options' => ['foo' => 'bar']],
+        );
+    }
+
     #[TestWith(['https://api.inference.eu', 'https://api.inference.eu/v1/chat/completions'])]
     #[TestWith(['https://api.inference.com', 'https://api.inference.com/v1/chat/completions'])]
     public function testItUsesCorrectBaseUrl(string $baseUrl, string $expectedUrl)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1700
| License       | MIT

Generic chat-completions streams can expose token usage in the final event when the request includes `stream_options.include_usage`.

This updates the Generic completions model client to request streamed usage by default whenever `stream` is enabled and no explicit `stream_options` were provided by the caller. Existing `stream_options` are preserved unchanged.

Tests were added for both the default streamed request and the explicit `stream_options` case.
