### PR TITLE
[Platform] Fix red CI: gpt-5.5-pro capabilities mismatch and class_exists() on Validator interface

### DIFF
--- a/src/platform/src/Bridge/OpenAi/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/ModelCatalogTest.php
@@ -48,7 +48,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'gpt-5-mini' => ['gpt-5-mini', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF, Capability::OUTPUT_STRUCTURED]];
         yield 'gpt-5-nano' => ['gpt-5-nano', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF, Capability::OUTPUT_STRUCTURED]];
         yield 'gpt-5.5' => ['gpt-5.5', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF, Capability::OUTPUT_STRUCTURED]];
-        yield 'gpt-5.5-pro' => ['gpt-5.5-pro', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF]];
+        yield 'gpt-5.5-pro' => ['gpt-5.5-pro', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF, Capability::OUTPUT_STRUCTURED]];
 
         // Embedding models
         yield 'text-embedding-ada-002' => ['text-embedding-ada-002', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];

--- a/src/platform/src/Contract/JsonSchema/Describer/Describer.php
+++ b/src/platform/src/Contract/JsonSchema/Describer/Describer.php
@@ -36,7 +36,7 @@ final class Describer implements ObjectDescriberInterface, PropertyDescriberInte
                 new PropertyInfoDescriber(),
             ];
 
-            if (class_exists(ValidatorInterface::class)) {
+            if (interface_exists(ValidatorInterface::class)) {
                 $describers[] = new ValidatorConstraintsDescriber();
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | N/A
| License       | MIT

Two fixes for currently-red `main` CI:

1. **`Unit / Platform / OpenAi`** — `gpt-5.5-pro` catalog and test disagreed on capabilities. Aligned the test with the catalog (`OUTPUT_STRUCTURED`, no `OUTPUT_STREAMING`).
2. **`PHPStan / Component / Platform`** — `Describer` gated the validator describer behind `class_exists(ValidatorInterface::class)`, but it's an interface, so that's always `false`. Switched to `interface_exists()` (also re-enables the describer at runtime).
