### PR TITLE
[Platform] Accept Model instance in Platform::invoke()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -46,6 +46,18 @@ Platform
    picks the first provider in array order whose catalog owns the model; order the providers to
    disambiguate model ids exposed by more than one of them.
 
+ * `PlatformInterface::invoke()` now accepts `string|Model` for its first argument, and
+   `ProviderInterface::invoke()` and `ProviderInterface::supports()` were widened the same way. Custom
+   implementations and decorators must widen their signatures accordingly:
+
+   ```diff
+   -public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult
+   +public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
+
+   -public function supports(string $model): bool
+   +public function supports(string|Model $model): bool
+   ```
+
 Store
 -----
 

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -94,6 +94,35 @@ the default catalog. The ``ModelCatalog`` automatically queries the model inform
         Message::ofUser(...)
     ));
 
+Passing a Model Instance
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of a model name string, you can hand a fully defined model instance to ``Platform::invoke()``. This
+skips the catalog lookup entirely and is useful when a provider ships a model that is not (yet) part of the
+shipped catalog, without registering it or replacing the catalog::
+
+    use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
+    use Symfony\AI\Platform\Capability;
+    use Symfony\AI\Platform\Message\Message;
+    use Symfony\AI\Platform\Message\MessageBag;
+
+    $model = new Gpt('gpt-newest', [
+        Capability::INPUT_MESSAGES,
+        Capability::OUTPUT_TEXT,
+        Capability::TOOL_CALLING,
+    ], ['temperature' => 0.5]);
+
+    $result = $platform->invoke($model, new MessageBag(Message::ofUser(...)));
+
+.. note::
+
+    You must pass a **bridge-specific** model subclass (e.g. ``Gpt``, ``Claude``, ``Gemini``), not the base
+    :class:`Symfony\\AI\\Platform\\Model`. Model clients, result converters, and contract normalizers select
+    the right implementation via the concrete class, so a bare ``Model`` instance has no client to handle it.
+    The platform routes the instance to the first provider whose model clients accept it; in multi-provider
+    setups where the same class is shared (e.g. OpenAI and Azure both use ``Gpt``), the first matching provider
+    wins.
+
 Supported Models & Platforms
 ----------------------------
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Add support for passing a fully defined `Model` instance to `Platform::invoke()` (and `Provider::invoke()`) instead of a model name string, bypassing the model catalog; widen `ProviderInterface::supports()` to `string|Model` to route a model instance to the first provider whose model clients accept it
+
 0.9
 ---
 

--- a/src/platform/src/Bridge/Cache/CachePlatform.php
+++ b/src/platform/src/Bridge/Cache/CachePlatform.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Cache;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\PlatformInterface;
@@ -58,11 +59,13 @@ final class CachePlatform implements PlatformInterface
     ) {
     }
 
-    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult
+    public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
     {
         if (null === $this->cache || !\array_key_exists('prompt_cache_key', $options) || '' === $options['prompt_cache_key']) {
             return $this->platform->invoke($model, $input, $options);
         }
+
+        $modelName = $model instanceof Model ? $model->getName() : $model;
 
         $normalizedInput = match (true) {
             \is_string($input) => md5($input),
@@ -73,7 +76,7 @@ final class CachePlatform implements PlatformInterface
 
         $cacheKey = (new UnicodeString())->join([
             $options['prompt_cache_key'] ?? $this->cacheKey,
-            (new UnicodeString($model))->camel(),
+            (new UnicodeString($modelName))->camel(),
             $normalizedInput,
         ]);
 
@@ -81,8 +84,8 @@ final class CachePlatform implements PlatformInterface
 
         unset($options['prompt_cache_key'], $options['prompt_cache_ttl']);
 
-        $cached = $this->cache->get($cacheKey, function (ItemInterface $item) use ($model, $input, $options, $cacheKey, $ttl): array {
-            $item->tag((new UnicodeString($model))->camel());
+        $cached = $this->cache->get($cacheKey, function (ItemInterface $item) use ($model, $modelName, $input, $options, $cacheKey, $ttl): array {
+            $item->tag((new UnicodeString($modelName))->camel());
 
             if (null !== $ttl) {
                 $item->expiresAfter($ttl);

--- a/src/platform/src/Bridge/Failover/FailoverPlatform.php
+++ b/src/platform/src/Bridge/Failover/FailoverPlatform.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -48,7 +49,7 @@ final class FailoverPlatform implements PlatformInterface
         $this->failedPlatforms = new \WeakMap();
     }
 
-    public function invoke(string $model, object|array|string $input, array $options = []): DeferredResult
+    public function invoke(string|Model $model, object|array|string $input, array $options = []): DeferredResult
     {
         return $this->do(static fn (PlatformInterface $platform): DeferredResult => $platform->invoke($model, $input, $options));
     }

--- a/src/platform/src/Platform.php
+++ b/src/platform/src/Platform.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform;
 
 use Symfony\AI\Platform\Event\ModelRoutingEvent;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\ModelCatalog\CompositeModelCatalog;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\ModelRouter\CatalogBasedModelRouter;
@@ -44,8 +45,12 @@ final class Platform implements PlatformInterface
         }
     }
 
-    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult
+    public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
     {
+        if ($model instanceof Model) {
+            return $this->resolveProviderForModel($model)->invoke($model, $input, $options);
+        }
+
         $event = new ModelRoutingEvent($model, $input, $options);
         $this->eventDispatcher?->dispatch($event);
 
@@ -63,5 +68,19 @@ final class Platform implements PlatformInterface
                 $this->providers,
             ),
         );
+    }
+
+    /**
+     * Routes a fully defined model to the first provider whose model clients accept it.
+     */
+    private function resolveProviderForModel(Model $model): ProviderInterface
+    {
+        foreach ($this->providers as $provider) {
+            if ($provider->supports($model)) {
+                return $provider;
+            }
+        }
+
+        throw new ModelNotFoundException(\sprintf('No provider found for model "%s" (%s).', $model->getName(), $model::class));
     }
 }

--- a/src/platform/src/PlatformInterface.php
+++ b/src/platform/src/PlatformInterface.php
@@ -20,11 +20,11 @@ use Symfony\AI\Platform\Result\DeferredResult;
 interface PlatformInterface
 {
     /**
-     * @param non-empty-string           $model   The model name
+     * @param non-empty-string|Model     $model   The model name to resolve via the catalog, or a fully defined model
      * @param array<mixed>|string|object $input   The input data
      * @param array<string, mixed>       $options The options to customize the model invocation
      */
-    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult;
+    public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult;
 
     public function getModelCatalog(): ModelCatalogInterface;
 }

--- a/src/platform/src/Provider.php
+++ b/src/platform/src/Provider.php
@@ -54,10 +54,20 @@ final class Provider implements ProviderInterface
         return $this->name;
     }
 
-    public function supports(string $modelName): bool
+    public function supports(string|Model $model): bool
     {
+        if ($model instanceof Model) {
+            foreach ($this->modelClients as $modelClient) {
+                if ($modelClient->supports($model)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         try {
-            $this->resolvedModel = $this->modelCatalog->getModel($modelName);
+            $this->resolvedModel = $this->modelCatalog->getModel($model);
 
             return true;
         } catch (ModelNotFoundException) {
@@ -67,9 +77,11 @@ final class Provider implements ProviderInterface
         }
     }
 
-    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult
+    public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
     {
-        if (null !== $this->resolvedModel && $this->resolvedModel->getName() === $model) {
+        if ($model instanceof Model) {
+            $this->resolvedModel = null;
+        } elseif (null !== $this->resolvedModel && $this->resolvedModel->getName() === $model) {
             $model = $this->resolvedModel;
             $this->resolvedModel = null;
         } else {

--- a/src/platform/src/ProviderInterface.php
+++ b/src/platform/src/ProviderInterface.php
@@ -30,18 +30,18 @@ interface ProviderInterface
     public function getName(): string;
 
     /**
-     * Whether this provider can handle the given model name.
+     * Whether this provider can handle the given model name, or fully defined model.
      *
-     * @param non-empty-string $modelName
+     * @param non-empty-string|Model $model
      */
-    public function supports(string $modelName): bool;
+    public function supports(string|Model $model): bool;
 
     /**
-     * @param non-empty-string           $model   The model name
+     * @param non-empty-string|Model     $model   The model name to resolve via the catalog, or a fully defined model
      * @param array<mixed>|string|object $input   The input data
      * @param array<string, mixed>       $options The options to customize the model invocation
      */
-    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult;
+    public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult;
 
     public function getModelCatalog(): ModelCatalogInterface;
 }

--- a/src/platform/src/Test/InMemoryPlatform.php
+++ b/src/platform/src/Test/InMemoryPlatform.php
@@ -41,14 +41,16 @@ class InMemoryPlatform implements PlatformInterface
         $this->modelCatalog = new FallbackModelCatalog();
     }
 
-    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult
+    public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
     {
-        $model = new class($model) extends Model {
-            public function __construct(string $name)
-            {
-                parent::__construct($name);
-            }
-        };
+        if (!$model instanceof Model) {
+            $model = new class($model) extends Model {
+                public function __construct(string $name)
+                {
+                    parent::__construct($name);
+                }
+            };
+        }
         $result = \is_string($this->mockResult) ? $this->mockResult : ($this->mockResult)($model, $input, $options);
 
         if ($result instanceof ResultInterface) {

--- a/src/platform/src/TraceablePlatform.php
+++ b/src/platform/src/TraceablePlatform.php
@@ -46,7 +46,7 @@ final class TraceablePlatform implements PlatformInterface, ResetInterface
         $this->resultCache = new \WeakMap();
     }
 
-    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult
+    public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
     {
         $deferredResult = $this->platform->invoke($model, $input, $options);
 

--- a/src/platform/tests/PlatformTest.php
+++ b/src/platform/tests/PlatformTest.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Platform\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Event\ModelRoutingEvent;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
+use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\CompositeModelCatalog;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\ModelRouterInterface;
@@ -140,6 +142,87 @@ final class PlatformTest extends TestCase
         $result = $platform->invoke('gpt-4o', 'Hello');
 
         $this->assertSame($deferredResult, $result);
+    }
+
+    public function testInvokeWithModelObjectRoutesViaSupports()
+    {
+        $model = new Model('custom-model', []);
+        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
+
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('supports')
+            ->with($model)
+            ->willReturn(true);
+        $provider->expects($this->once())
+            ->method('invoke')
+            ->with($model, 'Hello', [])
+            ->willReturn($deferredResult);
+
+        $router = $this->createMock(ModelRouterInterface::class);
+        $router->expects($this->never())->method('resolve');
+
+        $platform = new Platform([$provider], $router);
+
+        $result = $platform->invoke($model, 'Hello');
+
+        $this->assertSame($deferredResult, $result);
+    }
+
+    public function testInvokeWithModelObjectPicksFirstSupportingProvider()
+    {
+        $model = new Model('custom-model', []);
+        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
+
+        $firstProvider = $this->createMock(ProviderInterface::class);
+        $firstProvider->method('supports')->with($model)->willReturn(false);
+        $firstProvider->expects($this->never())->method('invoke');
+
+        $secondProvider = $this->createMock(ProviderInterface::class);
+        $secondProvider->method('supports')->with($model)->willReturn(true);
+        $secondProvider->expects($this->once())
+            ->method('invoke')
+            ->with($model, 'Hello', [])
+            ->willReturn($deferredResult);
+
+        $platform = new Platform([$firstProvider, $secondProvider]);
+
+        $result = $platform->invoke($model, 'Hello');
+
+        $this->assertSame($deferredResult, $result);
+    }
+
+    public function testInvokeWithModelObjectThrowsWhenNoProviderSupports()
+    {
+        $model = new Model('custom-model', []);
+
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider->method('supports')->with($model)->willReturn(false);
+        $provider->expects($this->never())->method('invoke');
+
+        $platform = new Platform([$provider]);
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No provider found for model "custom-model"');
+
+        $platform->invoke($model, 'Hello');
+    }
+
+    public function testInvokeWithModelObjectDoesNotDispatchModelRoutingEvent()
+    {
+        $model = new Model('custom-model', []);
+        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
+
+        $provider = $this->createStub(ProviderInterface::class);
+        $provider->method('supports')->willReturn(true);
+        $provider->method('invoke')->willReturn($deferredResult);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
+
+        $platform = new Platform([$provider], eventDispatcher: $eventDispatcher);
+
+        $platform->invoke($model, 'Hello');
     }
 
     public function testGetModelCatalogBuildsComposite()

--- a/src/platform/tests/ProviderTest.php
+++ b/src/platform/tests/ProviderTest.php
@@ -62,6 +62,56 @@ final class ProviderTest extends TestCase
         $this->assertFalse($provider->supports('unknown-model'));
     }
 
+    public function testSupportsWithModelObjectReturnsTrueWhenAModelClientSupportsIt()
+    {
+        $model = new Model('custom-model', [Capability::INPUT_MESSAGES]);
+
+        $modelClient = $this->createStub(ModelClientInterface::class);
+        $modelClient->method('supports')->willReturn(true);
+
+        $provider = new Provider('openai', [$modelClient], [], $this->createStub(ModelCatalogInterface::class));
+
+        $this->assertTrue($provider->supports($model));
+    }
+
+    public function testSupportsWithModelObjectReturnsFalseWhenNoModelClientSupportsIt()
+    {
+        $model = new Model('custom-model', [Capability::INPUT_MESSAGES]);
+
+        $modelClient = $this->createStub(ModelClientInterface::class);
+        $modelClient->method('supports')->willReturn(false);
+
+        $provider = new Provider('openai', [$modelClient], [], $this->createStub(ModelCatalogInterface::class));
+
+        $this->assertFalse($provider->supports($model));
+    }
+
+    public function testInvokeWithModelObjectSkipsCatalogResolution()
+    {
+        $model = new Model('custom-model', [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]);
+        $rawResult = $this->createStub(RawResultInterface::class);
+
+        $catalog = $this->createMock(ModelCatalogInterface::class);
+        $catalog->expects($this->never())->method('getModel');
+
+        $modelClient = $this->createMock(ModelClientInterface::class);
+        $modelClient->method('supports')->with($model)->willReturn(true);
+        $modelClient->expects($this->once())
+            ->method('request')
+            ->with($model)
+            ->willReturn($rawResult);
+
+        $resultConverter = $this->createStub(ResultConverterInterface::class);
+        $resultConverter->method('supports')->willReturn(true);
+        $resultConverter->method('convert')->willReturn(new TextResult('Hello'));
+
+        $provider = new Provider('openai', [$modelClient], [$resultConverter], $catalog);
+
+        $result = $provider->invoke($model, 'Hello');
+
+        $this->assertInstanceOf(DeferredResult::class, $result);
+    }
+
     public function testInvokeResolvesModelAndDelegates()
     {
         $model = new Model('gpt-4o', [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Platform bridges ship static model catalogs that go stale as providers release new models. Today, using a model that's not in the shipped catalog means registering `additionalModels`, swapping in a `FallbackModelCatalog`, or patching the lib.

This widens `Platform::invoke()` (and `Provider::invoke()` / `Provider::supports()`) to accept `string|Model`, so a fully defined model can be handed over per call, bypassing the catalog entirely:

```php
use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
use Symfony\AI\Platform\Capability;

$model = new Gpt('gpt-newest', [
    Capability::INPUT_MESSAGES,
    Capability::OUTPUT_TEXT,
    Capability::TOOL_CALLING,
], ['temperature' => 0.5]);

$result = $platform->invoke($model, $messages);
```

A `string` keeps the existing catalog-based routing untouched. A `Model` instance is routed to the first provider whose model clients accept it.

Note: you must pass a bridge-specific subclass (`Gpt`, `Claude`, …), not the base `Model`, since model clients, result converters and normalizers dispatch on the concrete class. All bridge model classes are directly instantiable (the `final` ones included — `final` only blocks subclassing, not `new`).