### PR TITLE
 Declare batched input support for OpenAI embeddings

### DIFF
--- a/src/platform/src/Bridge/OpenAi/ModelCatalog.php
+++ b/src/platform/src/Bridge/OpenAi/ModelCatalog.php
@@ -312,15 +312,15 @@ final class ModelCatalog extends AbstractModelCatalog
             ],
             'text-embedding-ada-002' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'text-embedding-3-large' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'text-embedding-3-small' => [
                 'class' => Embeddings::class,
-                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
             ],
             'tts-1' => [
                 'class' => TextToSpeech::class,

--- a/src/platform/src/Bridge/OpenAi/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/ModelCatalogTest.php
@@ -51,9 +51,9 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'gpt-5.5-pro' => ['gpt-5.5-pro', Gpt::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::TOOL_CALLING, Capability::INPUT_IMAGE, Capability::INPUT_PDF, Capability::OUTPUT_STRUCTURED]];
 
         // Embedding models
-        yield 'text-embedding-ada-002' => ['text-embedding-ada-002', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
-        yield 'text-embedding-3-large' => ['text-embedding-3-large', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
-        yield 'text-embedding-3-small' => ['text-embedding-3-small', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'text-embedding-ada-002' => ['text-embedding-ada-002', Embeddings::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'text-embedding-3-large' => ['text-embedding-3-large', Embeddings::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'text-embedding-3-small' => ['text-embedding-3-small', Embeddings::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
 
         // Text-to-speech models
         yield 'tts-1' => ['tts-1', TextToSpeech::class, [Capability::INPUT_TEXT, Capability::OUTPUT_AUDIO]];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2127
| License       | MIT

OpenAI embedding models accept an array input and the existing model client forwards array payloads correctly. This adds `Capability::INPUT_MULTIPLE` to the OpenAI embedding catalog entries so vectorization can use a single batched request for multiple strings.

Tests:

```
./vendor/bin/phpunit Tests/ModelCatalogTest.php
./vendor/bin/phpunit Tests/Embeddings/ModelClientTest.php
./vendor/bin/phpunit
./vendor/bin/phpstan analyse --no-progress --memory-limit=1G
```