### PR TITLE
[AI Bundle] Fix data_collector template for tool parameter union types

### DIFF
--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -257,7 +257,7 @@
                                             {%- if parameter.type is defined -%}
                                                 {{ parameter.type is iterable ? parameter.type|join(', ') : parameter.type }}
                                             {%- elseif parameter.anyOf is defined -%}
-                                                {{ parameter.anyOf|map(p => p.type is iterable ? p.type|join(', ') : p.type)|join(', ') }}
+                                                {{ parameter.anyOf|map(p => p.type)|join(', ') }}
                                             {%- endif -%}
                                         {% endset %}
                                         <li>

--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -253,8 +253,15 @@
                             {% if tool.parameters %}
                                 <ul>
                                     {% for name, parameter in tool.parameters.properties %}
+                                        {% set parameterType %}
+                                            {%- if parameter.type is defined -%}
+                                                {{ parameter.type is iterable ? parameter.type|join(', ') : parameter.type }}
+                                            {%- elseif parameter.anyOf is defined -%}
+                                                {{ parameter.anyOf|map(p => p.type is iterable ? p.type|join(', ') : p.type)|join(', ') }}
+                                            {%- endif -%}
+                                        {% endset %}
                                         <li>
-                                            <strong>{{ name }} ({{ parameter.type is iterable ? parameter.type|join(', ') : parameter.type }})</strong><br />
+                                            <strong>{{ name }} ({{ parameterType }})</strong><br />
                                             <i>{{ parameter.description|default() }}</i>
                                         </li>
                                     {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

Somewhat similar to #700. For union types, the structure is not `['type' => [A, B]]` but `['anyOf' => [['type' => A], ['type' => B]]]` instead. Currently, the profiler tab is broken in such cases:
> Key "type" for sequence/mapping with keys "anyOf, description" does not exist in @Ai/data_collector.html.twig at line 257.