### PR TITLE
[Platform][Anthropic] Add support for claude-fable-5

### DIFF
--- a/src/platform/src/Bridge/Anthropic/ModelCatalog.php
+++ b/src/platform/src/Bridge/Anthropic/ModelCatalog.php
@@ -116,6 +116,18 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::INPUT_PDF,
                 ],
             ],
+            'claude-fable-5' => [
+                'class' => Claude::class,
+                'capabilities' => [
+                    Capability::INPUT_MESSAGES,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                    Capability::OUTPUT_STRUCTURED,
+                    Capability::THINKING,
+                    Capability::TOOL_CALLING,
+                ],
+            ],
             'claude-haiku-4-5' => [
                 'class' => Claude::class,
                 'capabilities' => [

--- a/src/platform/src/Bridge/Anthropic/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ModelCatalogTest.php
@@ -38,6 +38,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'claude-sonnet-4-6' => ['claude-sonnet-4-6', Claude::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::THINKING, Capability::TOOL_CALLING]];
         yield 'claude-opus-4-7' => ['claude-opus-4-7', Claude::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::THINKING, Capability::TOOL_CALLING]];
         yield 'claude-opus-4-8' => ['claude-opus-4-8', Claude::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::THINKING, Capability::TOOL_CALLING]];
+        yield 'claude-fable-5' => ['claude-fable-5', Claude::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::THINKING, Capability::TOOL_CALLING]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | Not concerned
| Issues        | -
| License       | MIT

Adds the `claude-fable-5` model to the Anthropic `ModelCatalog`.

`claude-fable-5` is registered with the same capability set as `claude-opus-4-8` (its direct predecessor as the most capable Claude model): `INPUT_MESSAGES`, `INPUT_IMAGE`, `OUTPUT_TEXT`, `OUTPUT_STREAMING`, `OUTPUT_STRUCTURED`, `THINKING`, `TOOL_CALLING`. A matching entry is added to `ModelCatalogTest`.