### PR TITLE
[Agent] Add SystemPromptInputProcessor::getSystemPrompt()

### DIFF
--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Add `SystemPromptInputProcessor::getSystemPrompt()` to read the configured system prompt without reflection
+
 0.8
 ---
 

--- a/src/agent/src/InputProcessor/SystemPromptInputProcessor.php
+++ b/src/agent/src/InputProcessor/SystemPromptInputProcessor.php
@@ -43,6 +43,11 @@ final class SystemPromptInputProcessor implements InputProcessorInterface
         }
     }
 
+    public function getSystemPrompt(): \Stringable|TranslatableInterface|string|File
+    {
+        return $this->systemPrompt;
+    }
+
     public function processInput(Input $input): void
     {
         $messages = $input->getMessageBag();

--- a/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
+++ b/src/agent/tests/InputProcessor/SystemPromptInputProcessorTest.php
@@ -31,6 +31,21 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class SystemPromptInputProcessorTest extends TestCase
 {
+    public function testGetSystemPromptReturnsTheConfiguredPrompt()
+    {
+        $processor = new SystemPromptInputProcessor('You are a helpful assistant.');
+        $this->assertSame('You are a helpful assistant.', $processor->getSystemPrompt());
+
+        $stringable = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'stringable prompt';
+            }
+        };
+        $processor = new SystemPromptInputProcessor($stringable);
+        $this->assertSame($stringable, $processor->getSystemPrompt());
+    }
+
     public function testProcessInputAddsSystemMessageWhenNoneExists()
     {
         $processor = new SystemPromptInputProcessor('This is a system prompt');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fixes #2154
| License       | MIT

The configured system prompt lives in a `private readonly` property on `SystemPromptInputProcessor` with no accessor, so inspecting or displaying an agent's prompt — e.g. in a CLI agent picker, or to enrich the bundle's own `ai:chat` listing — currently requires reflection.

This adds a public getter that returns the prompt exactly as configured:

```php
public function getSystemPrompt(): \Stringable|TranslatableInterface|string|File
{
    return $this->systemPrompt;
}
```

Pure addition, no BC break.

Per the discussion in #2154, this is intentionally scoped to the system prompt only. The original issue also floated `getModel()` on `AgentInterface`, but that's the wrong layer: `MultiAgent`, `SpeechAgent` and `MockAgent` have no single model, so a model belongs on the concrete `Agent` (which already exposes `getModel()`), not on the agent abstraction.