### PR TITLE
[AI Bundle] Make agent tools opt-in instead of opt-out

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,25 @@ Agent
    +$agent->call(clone $messages);
    ```
 
+AI Bundle
+---------
+
+ * Agent tools are now opt-in. Previously, when an agent did not configure the `tools` option, all
+   services tagged with `ai.tool` (e.g. classes using the `#[AsTool]` attribute) were injected into
+   the agent's toolbox. Now an agent without the `tools` option (or with `tools` set to `null` or an
+   empty list) gets no toolbox at all. To keep the previous behavior, enable tools explicitly:
+
+   ```diff
+    ai:
+        agent:
+            my_agent:
+                model: 'gpt-4o-mini'
+   +            tools: true
+   ```
+
+   Configuring an explicit list of tools, or `tools: false`, keeps working unchanged. Additionally,
+   enabling `prompt.include_tools` for an agent without configured tools now throws an exception.
+
 Platform
 --------
 

--- a/ai.symfony.com/templates/cookbook/content/ai-bundle-fast-track.html
+++ b/ai.symfony.com/templates/cookbook/content/ai-bundle-fast-track.html
@@ -373,8 +373,8 @@ options.</p>
     
 </h2>
 <p>Tools let an agent call your PHP code. Any service carrying the
-<a href="https://github.com/symfony/ai/blob/main/src/agent/src/Toolbox/Attribute/AsTool.php" class="reference external" title="Symfony\AI\Agent\Toolbox\Attribute\AsTool" rel="external noopener noreferrer" target="_blank">AsTool</a> attribute is auto-registered, and by
-default every known tool is injected into every agent:</p>
+<a href="https://github.com/symfony/ai/blob/main/src/agent/src/Toolbox/Attribute/AsTool.php" class="reference external" title="Symfony\AI\Agent\Toolbox\Attribute\AsTool" rel="external noopener noreferrer" target="_blank">AsTool</a> attribute is auto-registered in the
+tool registry, but each agent has to opt in to the tools it should use:</p>
 <div translate="no" class="highlight-php notranslate">
     <table class="highlighttable">
         <tbody>
@@ -411,8 +411,8 @@ default every known tool is injected into every agent:</p>
         </tbody>
     </table>
 </div>
-<p>To control which tools an agent receives, list them explicitly — or set <code translate="no" class="notranslate">tools: false</code> to
-disable tools entirely:</p>
+<p>To define which tools an agent receives, list them explicitly — or set <code translate="no" class="notranslate">tools: true</code> to
+inject all registered tools. Without the <code translate="no" class="notranslate">tools</code> option, the agent gets no tools at all:</p>
 <div translate="no" class="highlight-yaml notranslate">
     <table class="highlighttable">
         <tbody>

--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -99,7 +99,7 @@ Advanced Example with Multiple Agents
             research:
                 platform: 'ai.platform.anthropic'
                 model: 'claude-3-7-sonnet-latest'
-                tools: # If undefined, all tools are injected into the agent, use "tools: false" to disable tools.
+                tools: # Tools are opt-in: if undefined, the agent gets no tools; use "tools: true" to inject all tools.
                     - 'Symfony\AI\Agent\Bridge\Wikipedia\Wikipedia'
                 fault_tolerant_toolbox: false # Disables fault tolerant toolbox, default is true
             search_agent:
@@ -984,16 +984,16 @@ Custom tools can be registered by using the :class:`Symfony\\AI\\Agent\\Toolbox\
         }
     }
 
-The agent configuration by default will inject all known tools into the agent.
-
-To disable this behavior, set the ``tools`` option to ``false``:
+Tools are not registered with an agent automatically - they are opt-in. To inject all known
+tools, meaning every service tagged with ``ai.tool``, e.g. via the ``#[AsTool]`` attribute,
+opt in explicitly by setting the ``tools`` option to ``true``:
 
 .. code-block:: yaml
 
     ai:
         agent:
             my_agent:
-                tools: false
+                tools: true
 
 To inject only specific tools, list them in the configuration:
 
@@ -1004,6 +1004,9 @@ To inject only specific tools, list them in the configuration:
             my_agent:
                 tools:
                     - 'Symfony\AI\Agent\Bridge\SimilaritySearch\SimilaritySearch'
+
+Omitting the ``tools`` option, or setting it to ``false``, ``null`` or an empty list, leaves the
+agent without any tools.
 
 To restrict the access to a tool, you can use the :class:`Symfony\\AI\\AiBundle\\Security\\Attribute\\IsGrantedTool` attribute, which
 works similar to :class:`Symfony\\Component\\Security\\Http\\Attribute\\IsGranted` attribute in `symfony/security-http`. For this to work,

--- a/docs/cookbook/ai-bundle-fast-track.rst
+++ b/docs/cookbook/ai-bundle-fast-track.rst
@@ -169,8 +169,8 @@ Step 5: Give the Agent Tools
 ----------------------------
 
 Tools let an agent call your PHP code. Any service carrying the
-:class:`Symfony\\AI\\Agent\\Toolbox\\Attribute\\AsTool` attribute is auto-registered, and by
-default every known tool is injected into every agent::
+:class:`Symfony\\AI\\Agent\\Toolbox\\Attribute\\AsTool` attribute is auto-registered in the
+tool registry, but each agent has to opt in to the tools it should use::
 
     use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 
@@ -183,8 +183,8 @@ default every known tool is injected into every agent::
         }
     }
 
-To control which tools an agent receives, list them explicitly — or set ``tools: false`` to
-disable tools entirely:
+To define which tools an agent receives, list them explicitly — or set ``tools: true`` to
+inject all registered tools. Without the ``tools`` option, the agent gets no tools at all:
 
 .. code-block:: yaml
 

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * [BC BREAK] Agent tools are now opt-in: when the `tools` option is not configured (or set to `null` or
+   an empty list), no toolbox is registered for the agent. Set `tools: true` to restore the previous
+   behavior of injecting all services tagged with `ai.tool`
+ * Throw an exception when `prompt.include_tools` is enabled for an agent without configured tools
+
 0.9
 ---
 

--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -263,21 +263,25 @@ return static function (DefinitionConfigurator $configurator): void {
                             ->end()
                         ->end()
                         ->arrayNode('tools')
+                            ->info('Tools are opt-in: set to true to inject all services tagged with "ai.tool", or configure an explicit list of tools. When the option is omitted (or set to null or false), no tools are registered.')
                             ->addDefaultsIfNotSet()
                             ->treatFalseLike(['enabled' => false])
                             ->treatTrueLike(['enabled' => true])
-                            ->treatNullLike(['enabled' => true])
+                            ->treatNullLike(['enabled' => false])
                             ->beforeNormalization()
                                 ->ifArray()
                                 ->then(static function (array $v): array {
+                                    $services = $v['services'] ?? $v;
+                                    unset($services['enabled']);
+
                                     return [
-                                        'enabled' => $v['enabled'] ?? true,
-                                        'services' => $v['services'] ?? $v,
+                                        'enabled' => $v['enabled'] ?? [] !== $services,
+                                        'services' => $services,
                                     ];
                                 })
                             ->end()
                             ->children()
-                                ->booleanNode('enabled')->defaultTrue()->end()
+                                ->booleanNode('enabled')->defaultFalse()->end()
                                 ->arrayNode('services')
                                     ->arrayPrototype()
                                         ->children()

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -1247,6 +1247,10 @@ final class AiBundle extends AbstractBundle
         if (isset($config['prompt'])) {
             $includeTools = isset($config['prompt']['include_tools']) && $config['prompt']['include_tools'];
 
+            if ($includeTools && !$config['tools']['enabled']) {
+                throw new InvalidArgumentException(\sprintf('Agent "%s" has "prompt.include_tools" enabled, but no tools are configured. Enable tools with "tools: true" or configure an explicit list of tools.', $name));
+            }
+
             // Create prompt from file if configured, otherwise use text
             if (isset($config['prompt']['file'])) {
                 $filePath = $config['prompt']['file'];

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -99,6 +99,7 @@ use Symfony\AI\Store\StoreInterface;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Clock\MonotonicClock;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -4423,6 +4424,156 @@ class AiBundleTest extends TestCase
         $this->assertTrue($foundOutput, 'Default tool processor should have output tag with full agent ID');
     }
 
+    public function testAgentWithoutToolsConfigDoesNotRegisterToolbox()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => 'gpt-4',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($container->hasDefinition('ai.toolbox.my_agent'));
+        $this->assertFalse($container->hasDefinition('ai.tool.agent_processor.my_agent'));
+        $this->assertFalse($container->hasDefinition('ai.toolbox.my_agent.memory_factory'));
+        $this->assertFalse($container->hasDefinition('ai.toolbox.my_agent.chain_factory'));
+        $this->assertFalse($container->hasDefinition('ai.fault_tolerant_toolbox.my_agent'));
+    }
+
+    public function testToolsNullDoesNotRegisterToolbox()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => 'gpt-4',
+                        'tools' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($container->hasDefinition('ai.toolbox.my_agent'));
+        $this->assertFalse($container->hasDefinition('ai.tool.agent_processor.my_agent'));
+    }
+
+    public function testToolsFalseDoesNotRegisterToolbox()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => 'gpt-4',
+                        'tools' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($container->hasDefinition('ai.toolbox.my_agent'));
+        $this->assertFalse($container->hasDefinition('ai.tool.agent_processor.my_agent'));
+    }
+
+    public function testToolsEmptyListDoesNotRegisterToolbox()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => 'gpt-4',
+                        'tools' => [],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($container->hasDefinition('ai.toolbox.my_agent'));
+        $this->assertFalse($container->hasDefinition('ai.tool.agent_processor.my_agent'));
+    }
+
+    public function testToolsTrueRegistersToolboxWithAllTaggedTools()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => 'gpt-4',
+                        'tools' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.toolbox.my_agent'));
+        $this->assertTrue($container->hasDefinition('ai.tool.agent_processor.my_agent'));
+
+        $toolboxDefinition = $container->getDefinition('ai.toolbox.my_agent');
+        $this->assertInstanceOf(ChildDefinition::class, $toolboxDefinition);
+        $this->assertSame('ai.toolbox.abstract', $toolboxDefinition->getParent());
+        $this->assertArrayNotHasKey('index_0', $toolboxDefinition->getArguments(), 'Tools argument should not be replaced, so the tagged iterator of the abstract definition applies');
+    }
+
+    public function testToolsEnabledArrayFormRegistersToolbox()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => 'gpt-4',
+                        'tools' => ['enabled' => true],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.toolbox.my_agent'));
+
+        $toolboxDefinition = $container->getDefinition('ai.toolbox.my_agent');
+        $this->assertArrayNotHasKey('index_0', $toolboxDefinition->getArguments(), 'Tools argument should not be replaced, so the tagged iterator of the abstract definition applies');
+    }
+
+    public function testToolsExplicitListRegistersOnlyConfiguredTools()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => 'gpt-4',
+                        'tools' => ['some_service'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.toolbox.my_agent'));
+
+        $toolboxDefinition = $container->getDefinition('ai.toolbox.my_agent');
+        $this->assertEquals([new Reference('some_service')], $toolboxDefinition->getArgument(0));
+    }
+
+    public function testIncludeToolsWithoutToolsThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Agent "my_agent" has "prompt.include_tools" enabled, but no tools are configured.');
+
+        $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'my_agent' => [
+                        'model' => 'gpt-4',
+                        'prompt' => [
+                            'text' => 'You are a helpful assistant.',
+                            'include_tools' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public function testElevenLabsPlatformCanBeConfigured()
     {
         $container = $this->buildContainer([
@@ -7993,6 +8144,7 @@ class AiBundleTest extends TestCase
                 'agent' => [
                     'my_agent' => [
                         'model' => 'gpt-4',
+                        'tools' => true,
                         'fault_tolerant_toolbox' => true,
                     ],
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

[BC BREAK] Agents no longer receive all `ai.tool`-tagged services implicitly when the `tools` option is not configured.

- No `tools` option (or `null`, `false`, `[]`) → no toolbox registered
- `tools: true` → explicit opt-in to inject all tagged tools (previous default)
- Explicit tool lists keep working unchanged
- `prompt.include_tools` without configured tools now throws a clear exception
- Updated bundle reference docs, fast-track cookbook (+ regenerated website artifacts), CHANGELOG, and UPGRADE.md for 0.10