### PR TITLE
[Platform][Cache] Cache content-object inputs via CacheKeyGenerator strategy

### DIFF
--- a/src/platform/src/Bridge/Cache/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cache/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Add `CacheKeyGenerator` strategy and a default set (`MessageBag`, `DocumentUrl`, `ImageUrl`, `File`/`Audio`), so `CachePlatform` can cache document, OCR and audio-transcription tasks, not just `string`/`array`/`MessageBag` inputs; custom input types can be supported by registering an additional generator
+
 0.3
 ---
 

--- a/src/platform/src/Bridge/Cache/CacheKeyGenerator.php
+++ b/src/platform/src/Bridge/Cache/CacheKeyGenerator.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache;
+
+/**
+ * Builds a stable, cache-key-safe identifier for a non-scalar platform input.
+ *
+ * Implementations are registered with {@see CachePlatform} and tried in order;
+ * the first one whose {@see self::supports()} returns true keys the input. This
+ * keeps the knowledge of how to cache a given input type inside the Cache bridge
+ * instead of leaking it into the Platform component or its content classes.
+ *
+ * @author Tac Tacelosky <tacman@gmail.com>
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+interface CacheKeyGenerator
+{
+    public function supports(object $input): bool;
+
+    /**
+     * Returns a stable, cache-key-safe identifier for the given input.
+     *
+     * The value is used verbatim as part of a cache key, so it must not contain
+     * the PSR-6 reserved characters ("{}()/\@:"). Hash any value that might
+     * (e.g. a URL or raw bytes).
+     */
+    public function generate(object $input): string;
+}

--- a/src/platform/src/Bridge/Cache/CachePlatform.php
+++ b/src/platform/src/Bridge/Cache/CachePlatform.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Platform\Bridge\Cache;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
-use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\PlainConverter;
@@ -44,6 +43,9 @@ use Symfony\Contracts\Cache\ItemInterface;
  */
 final class CachePlatform implements PlatformInterface
 {
+    /**
+     * @param iterable<CacheKeyGenerator> $cacheKeyGenerators Tried in order to key non-scalar inputs (objects)
+     */
     public function __construct(
         private readonly PlatformInterface $platform,
         private readonly ClockInterface $clock = new MonotonicClock(),
@@ -56,6 +58,12 @@ final class CachePlatform implements PlatformInterface
         ], [new JsonEncoder()]),
         private readonly ?string $cacheKey = null,
         private readonly ?int $cacheTtl = null,
+        private iterable $cacheKeyGenerators = [
+            new MessageBagCacheKeyGenerator(),
+            new DocumentUrlCacheKeyGenerator(),
+            new ImageUrlCacheKeyGenerator(),
+            new FileCacheKeyGenerator(),
+        ],
     ) {
     }
 
@@ -70,8 +78,7 @@ final class CachePlatform implements PlatformInterface
         $normalizedInput = match (true) {
             \is_string($input) => md5($input),
             \is_array($input) => json_encode($input),
-            $input instanceof MessageBag => $input->getId()->toString(),
-            default => throw new InvalidArgumentException(\sprintf('Unsupported input type: %s', get_debug_type($input))),
+            default => $this->generateInputCacheKey($input),
         };
 
         $cacheKey = (new UnicodeString())->join([
@@ -127,5 +134,16 @@ final class CachePlatform implements PlatformInterface
     public function getModelCatalog(): ModelCatalogInterface
     {
         return $this->platform->getModelCatalog();
+    }
+
+    private function generateInputCacheKey(object $input): string
+    {
+        foreach ($this->cacheKeyGenerators as $generator) {
+            if ($generator->supports($input)) {
+                return $generator->generate($input);
+            }
+        }
+
+        throw new InvalidArgumentException(\sprintf('Unsupported input type: "%s".', get_debug_type($input)));
     }
 }

--- a/src/platform/src/Bridge/Cache/DocumentUrlCacheKeyGenerator.php
+++ b/src/platform/src/Bridge/Cache/DocumentUrlCacheKeyGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache;
+
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\DocumentUrl;
+
+/**
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class DocumentUrlCacheKeyGenerator implements CacheKeyGenerator
+{
+    public function supports(object $input): bool
+    {
+        return $input instanceof DocumentUrl;
+    }
+
+    public function generate(object $input): string
+    {
+        if (!$input instanceof DocumentUrl) {
+            throw new InvalidArgumentException(\sprintf('"%s" only supports "%s" inputs, "%s" given.', self::class, DocumentUrl::class, get_debug_type($input)));
+        }
+
+        return hash('xxh128', $input->getUrl());
+    }
+}

--- a/src/platform/src/Bridge/Cache/FileCacheKeyGenerator.php
+++ b/src/platform/src/Bridge/Cache/FileCacheKeyGenerator.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache;
+
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\File;
+
+/**
+ * Keys any {@see File} input (and its {@see \Symfony\AI\Platform\Message\Content\Audio},
+ * {@see \Symfony\AI\Platform\Message\Content\Image}, {@see \Symfony\AI\Platform\Message\Content\Video}
+ * and {@see \Symfony\AI\Platform\Message\Content\Document} subclasses) on a hash of its bytes.
+ *
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class FileCacheKeyGenerator implements CacheKeyGenerator
+{
+    public function supports(object $input): bool
+    {
+        return $input instanceof File;
+    }
+
+    public function generate(object $input): string
+    {
+        if (!$input instanceof File) {
+            throw new InvalidArgumentException(\sprintf('"%s" only supports "%s" inputs, "%s" given.', self::class, File::class, get_debug_type($input)));
+        }
+
+        return hash('xxh128', $input->getFormat().':'.$input->asBinary());
+    }
+}

--- a/src/platform/src/Bridge/Cache/ImageUrlCacheKeyGenerator.php
+++ b/src/platform/src/Bridge/Cache/ImageUrlCacheKeyGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache;
+
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\ImageUrl;
+
+/**
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class ImageUrlCacheKeyGenerator implements CacheKeyGenerator
+{
+    public function supports(object $input): bool
+    {
+        return $input instanceof ImageUrl;
+    }
+
+    public function generate(object $input): string
+    {
+        if (!$input instanceof ImageUrl) {
+            throw new InvalidArgumentException(\sprintf('"%s" only supports "%s" inputs, "%s" given.', self::class, ImageUrl::class, get_debug_type($input)));
+        }
+
+        return hash('xxh128', $input->getUrl());
+    }
+}

--- a/src/platform/src/Bridge/Cache/MessageBagCacheKeyGenerator.php
+++ b/src/platform/src/Bridge/Cache/MessageBagCacheKeyGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache;
+
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\MessageBag;
+
+/**
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class MessageBagCacheKeyGenerator implements CacheKeyGenerator
+{
+    public function supports(object $input): bool
+    {
+        return $input instanceof MessageBag;
+    }
+
+    public function generate(object $input): string
+    {
+        if (!$input instanceof MessageBag) {
+            throw new InvalidArgumentException(\sprintf('"%s" only supports "%s" inputs, "%s" given.', self::class, MessageBag::class, get_debug_type($input)));
+        }
+
+        return $input->getId()->toString();
+    }
+}

--- a/src/platform/src/Bridge/Cache/Tests/CachePlatformTest.php
+++ b/src/platform/src/Bridge/Cache/Tests/CachePlatformTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\AI\Platform\Bridge\Cache\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cache\CacheKeyGenerator;
 use Symfony\AI\Platform\Bridge\Cache\CachePlatform;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\DocumentUrl;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\PlainConverter;
@@ -151,6 +154,82 @@ final class CachePlatformTest extends TestCase
         $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $secondMessageBag->getId()->toRfc4122()), $adapter->getValues());
         $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
         $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
+        $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+    }
+
+    public function testPlatformCachesContentObjectInput()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $document = new DocumentUrl('https://example.com/document.pdf');
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+
+        $deferredResult = $cachedPlatform->invoke('foo', $document, ['prompt_cache_key' => 'symfony']);
+        $this->assertSame('test content', $deferredResult->getResult()->getContent());
+        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', $document, ['prompt_cache_key' => 'symfony']);
+        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
+        $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+    }
+
+    public function testPlatformDoesNotShareCacheBetweenDifferentContentObjectInputs()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+
+        $cachedPlatform->invoke('foo', new DocumentUrl('https://example.com/first.pdf'), ['prompt_cache_key' => 'symfony']);
+        $cachedPlatform->invoke('foo', new DocumentUrl('https://example.com/second.pdf'), ['prompt_cache_key' => 'symfony']);
+    }
+
+    public function testPlatformThrowsOnUnsupportedObjectInput()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->never())->method('invoke');
+
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported input type: "stdClass".');
+
+        $cachedPlatform->invoke('foo', new \stdClass(), ['prompt_cache_key' => 'symfony']);
+    }
+
+    public function testPlatformUsesCustomCacheKeyGenerator()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $generator = new class implements CacheKeyGenerator {
+            public function supports(object $input): bool
+            {
+                return $input instanceof \stdClass;
+            }
+
+            public function generate(object $input): string
+            {
+                return $input->id;
+            }
+        };
+
+        $input = new \stdClass();
+        $input->id = 'custom-key';
+
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()), cacheKeyGenerators: [$generator]);
+
+        $deferredResult = $cachedPlatform->invoke('foo', $input, ['prompt_cache_key' => 'symfony']);
+        $this->assertSame('test content', $deferredResult->getResult()->getContent());
+
+        $secondDeferredResult = $cachedPlatform->invoke('foo', $input, ['prompt_cache_key' => 'symfony']);
         $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no <!-- CHANGELOG entry added; the strategy is documented via its docblock -->
| Issues        | Fix #2159
| License       | MIT

`CachePlatform` (the `ai.platform.cache.*` decorator) could only build a cache
key for `string`, `array` and `MessageBag` inputs — it threw
`Unsupported input type` on anything else. That means it could not decorate any
platform task whose top-level input is a content object, which is the normal
shape for the slow/expensive calls most worth caching:

- audio transcription — `$platform->invoke('whisper-1', Audio::fromFile(...))`
- OCR — `$platform->invoke('mistral-ocr-latest', new DocumentUrl(...))`
- single-image vision — `$platform->invoke($model, new ImageUrl(...))`

### Approach

Per @chr-hertel's review (keying inputs is the bridge's job — it shouldn't leak
into the Platform component or its content classes), this keeps the knowledge of
*how* to key an input **inside the Cache bridge** via a small strategy
interface:

```php
namespace Symfony\AI\Platform\Bridge\Cache;

interface CacheKeyGenerator
{
    public function supports(object $input): bool;
    public function generate(object $input): string;
}
```

`CachePlatform` holds an ordered list of generators and the first one that
`supports()` an input keys it:

```php
$normalizedInput = match (true) {
    \is_string($input) => md5($input),
    \is_array($input) => json_encode($input),
    default => $this->generateInputCacheKey($input), // tries each CacheKeyGenerator
};
```

The default set covers `MessageBag`, `DocumentUrl`, `ImageUrl` and
`File` (and its `Audio`/`Image`/`Video`/`Document` subclasses). `DocumentUrl`
and `ImageUrl` key on the URL; `File` on a hash of its bytes. `getCacheKey()`
values are used verbatim in a cache key, so the URL/byte arms hash their value
(`xxh128`) the same way the existing `string` arm uses `md5()`.

`MessageBag` now routes through the same mechanism
(`MessageBagCacheKeyGenerator`), so **all** object inputs go through one
consistent path instead of a special-cased inline arm.

```php
$cached = new CachePlatform($platform, cache: $pool);
$cached->invoke('mistral-ocr-latest', new DocumentUrl('https://…/doc.pdf'), [
    'prompt_cache_key' => 'ocr',
]); // now cached instead of throwing
```

A userland content type opts in by registering its own generator — no change to
`CachePlatform` or to core content classes:

```php
new CachePlatform($platform, cache: $pool, cacheKeyGenerators: [
    new MyContentCacheKeyGenerator(),
    new MessageBagCacheKeyGenerator(),
    // …
]);
```

### Scope

Fully isolated in the bridge: **no changes to the Platform component or its
content classes**, so the dependency points bridge → component only. This is
also additive — behavior for `string`/`array`/`MessageBag` inputs is unchanged.

Tests added to `CachePlatformTest` (content-object cached once; different inputs
not shared; unsupported object still throws; custom generator honored). Surfaced
while adding a Mistral OCR bridge (#2072), but independent of it — the gap
already affects Whisper today.

> Supersedes the earlier `CacheableInputInterface`-in-Platform approach from
> this PR's first revision, which leaked the bridge's caching concern into the
> core content classes.
