### PR TITLE
[Platform][Mistral] Add OCR support via the /v1/ocr endpoint

### DIFF
--- a/demo/assets/app.js
+++ b/demo/assets/app.js
@@ -3,6 +3,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import './styles/app.css';
 import './styles/blog.css';
 import './styles/crop.css';
+import './styles/document.css';
 import './styles/recipe.css';
 import './styles/speech.css';
 import './styles/stream.css';

--- a/demo/assets/controllers/document_controller.js
+++ b/demo/assets/controllers/document_controller.js
@@ -1,0 +1,81 @@
+import { Controller } from "@hotwired/stimulus";
+import { getComponent } from "@symfony/ux-live-component";
+
+export default class extends Controller {
+    async initialize() {
+        this.component = await getComponent(this.element);
+        this.scrollToBottom();
+
+        this.component.on("loading.state:started", (event, request) => {
+            if (request.actions.includes("reset")) {
+                return;
+            }
+
+            if (request.actions.includes("start")) {
+                this.showLoading(
+                    this.selectedDocumentLabel(),
+                    "The Document OCR Bot is reading the document ...",
+                );
+                document.getElementById("welcome")?.remove();
+                return;
+            }
+
+            if (request.actions.includes("submit")) {
+                const input = document.getElementById("chat-message");
+                this.showLoading(
+                    input?.value || this.component.getData("message"),
+                    "The Document OCR Bot is preparing a response ...",
+                );
+                if (input) {
+                    input.value = "";
+                }
+            }
+        });
+
+        this.component.on("loading.state:finished", () => {
+            document.getElementById("loading-message")?.setAttribute("class", "d-none");
+        });
+
+        this.component.on("render:finished", () => {
+            this.scrollToBottom();
+        });
+    }
+
+    showLoading(userText, botText) {
+        const loadingMessage = document.getElementById("loading-message");
+        if (!loadingMessage) {
+            return;
+        }
+
+        const userMessage = loadingMessage.getElementsByClassName("user-message")[0];
+        if (userMessage) {
+            userMessage.textContent = userText || "Document";
+        }
+
+        const botMessage = loadingMessage.getElementsByClassName("bot-message")[0];
+        const botTextElement = botMessage?.querySelector("i");
+        if (botTextElement) {
+            botTextElement.textContent = botText;
+        }
+
+        loadingMessage.removeAttribute("class");
+        this.scrollToBottom();
+    }
+
+    selectedDocumentLabel() {
+        if (this.component.getData("sample") === "__own__") {
+            return document.getElementById("document-url")?.value || this.component.getData("url") || "Document URL";
+        }
+
+        const select = document.getElementById("document-sample");
+
+        return select?.selectedOptions[0]?.textContent || "Selected document";
+    }
+
+    scrollToBottom() {
+        const chatBody = document.getElementById("chat-body");
+        if (chatBody) {
+            chatBody.scrollTop = chatBody.scrollHeight;
+        }
+    }
+}

--- a/demo/assets/icons/mdi/file-document.svg
+++ b/demo/assets/icons/mdi/file-document.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M13 9h5.5L13 3.5zM6 2h8l6 6v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4c0-1.11.89-2 2-2m9 16v-2H6v2zm3-4v-2H6v2z"/></svg>

--- a/demo/assets/styles/app.css
+++ b/demo/assets/styles/app.css
@@ -7,13 +7,33 @@ body {
 }
 
 .index {
+    .card {
+        height: 100%;
+    }
+
     .card-img-top {
         text-align: center;
 
         svg {
-            width: 150px;
-            height: 150px;
+            width: 120px;
+            height: 120px;
         }
+    }
+
+    .card-title {
+        font-size: 1.1rem;
+    }
+
+    .card-body {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .card-body .btn {
+        margin-top: auto;
+        font-size: 0.875rem;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
     }
 }
 

--- a/demo/assets/styles/document.css
+++ b/demo/assets/styles/document.css
@@ -1,0 +1,61 @@
+.document {
+    body&, .card-img-top {
+        background: #1a73e8;
+        background: linear-gradient(0deg, #0b66c3 0%, #1cc8d6 100%);
+    }
+
+    .card-img-top {
+        color: #ffffff;
+    }
+
+    &.chat {
+        .user-message {
+            background: #0b3d63;
+            color: #ffffff;
+        }
+
+        .bot-message {
+            color: #ffffff;
+            background: #1a73e8;
+
+            &.loading {
+                color: rgba(255, 255, 255, 0.5);
+            }
+
+            a {
+                color: #c5ddfb;
+
+                &:hover {
+                    color: #ffffff;
+                }
+            }
+
+            code {
+                color: #aeeaf3;
+            }
+        }
+
+        .avatar {
+            &.bot {
+                outline: 1px solid #bcd7fb;
+                background: #bcd7fb;
+            }
+
+            &.user {
+                outline: 1px solid #9fc3d6;
+                background: #9fc3d6;
+            }
+        }
+
+        #welcome h4 {
+            color: #1a73e8;
+        }
+
+        button {
+            &:hover {
+                background: #1cc8d6;
+                border-color: #1cc8d6;
+            }
+        }
+    }
+}

--- a/demo/composer.json
+++ b/demo/composer.json
@@ -18,6 +18,7 @@
         "symfony/ai-chat": "^0.10",
         "symfony/ai-clock-tool": "^0.10",
         "symfony/ai-hugging-face-platform": "^0.10",
+        "symfony/ai-mistral-platform": "^0.10",
         "symfony/ai-open-ai-platform": "^0.10",
         "symfony/ai-postgres-store": "^0.10",
         "symfony/ai-similarity-search-tool": "^0.10",

--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -4,7 +4,15 @@ ai:
             api_key: '%env(OPENAI_API_KEY)%'
         huggingface:
             api_key: '%env(HUGGINGFACE_API_KEY)%'
+        mistral:
+            api_key: '%env(MISTRAL_API_KEY)%'
     agent:
+        document:
+            platform: 'ai.platform.mistral'
+            model: 'mistral-medium-latest'
+            # The system prompt is built dynamically in App\Document\Chat::start(), where the
+            # OCR-extracted text is injected, so no static prompt is configured here.
+            tools: false
         blog:
             platform: 'ai.platform.openai'
             model: 'gpt-4.1'

--- a/demo/config/packages/ux_icons.yaml
+++ b/demo/config/packages/ux_icons.yaml
@@ -15,6 +15,7 @@ ux_icons:
         microphone: iconoir:microphone-solid
         video: tabler:video-filled
         turbo: mdi:car-turbocharger
+        document: mdi:file-document
         github: mdi:github
 
         # UI icons

--- a/demo/config/routes.yaml
+++ b/demo/config/routes.yaml
@@ -11,6 +11,13 @@ blog:
         template:  'chat.html.twig'
         context: { chat: 'blog' }
 
+document:
+    path: '/document'
+    controller: 'Symfony\Bundle\FrameworkBundle\Controller\TemplateController'
+    defaults:
+        template:  'chat.html.twig'
+        context: { chat: 'document' }
+
 crop:
     path: '/crop'
     controller: 'Symfony\Bundle\FrameworkBundle\Controller\TemplateController'

--- a/demo/config/services.yaml
+++ b/demo/config/services.yaml
@@ -3,6 +3,17 @@
 
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
+parameters:
+    app.document.samples:
+        - { title: "Emancipation Proclamation, 1863 (handwritten, NARA)", url: "https://catalog.archives.gov/medialive/98/2999/299998/content/arcmedia/master/ARC299998.pdf" }
+        - { title: "Civil War widow's pension file — USCT (15-page PDF)", url: "https://omeka-iaamcfh.s3.amazonaws.com/original/466438fd3594c782fcbf172a1fd2cfc66034bbf0.pdf" }
+        - { title: "Family Bible record (genealogy, PDF)", url: "https://omeka-iaamcfh.s3.amazonaws.com/original/46394498cdb8cc609c466b578845c0ac83b804df.pdf" }
+        - { title: "Census — Schedule of Inhabitants (handwritten)", url: "https://fsn1.your-objectstorage.com/dev-scanstation/cheztac/scans/2026-03/browser-1772563875823-63e64d45-p014.jpg" }
+        - { title: "Small-town newspaper page (dense print)", url: "https://s3.amazonaws.com/pastperfectonline/images/museum_986/006/20100110001.jpg" }
+        - { title: "Handwritten letter, 1726 (NARA)", url: "https://upload.wikimedia.org/wikipedia/commons/0/04/William_Burnett_Letter_May_24%2C_1726_-_NARA_-_193049.jpg" }
+        - { title: "NARA rediscovery record (PDF)", url: "https://s3.amazonaws.com/NARAprodstorage/lz/rediscovery/11020.pdf" }
+    app.document.prompts.summary: "Summarise this document in a few sentences — what it is and its key points — then invite me to ask questions about it."
+
 
 services:
     # default configuration for services in *this* file

--- a/demo/src/Document/Chat.php
+++ b/demo/src/Document/Chat.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Document;
+
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class Chat
+{
+    private const SESSION_KEY = 'document-chat';
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        #[Autowire(service: 'ai.agent.document')]
+        private readonly AgentInterface $agent,
+        private readonly OcrExtractor $ocrExtractor,
+        #[Autowire(param: 'app.document.prompts.summary')]
+        private readonly string $summaryPrompt,
+    ) {
+    }
+
+    public function loadMessages(): MessageBag
+    {
+        return $this->requestStack->getSession()->get(self::SESSION_KEY, new MessageBag());
+    }
+
+    public function start(string $url): void
+    {
+        // Step 1 — transcribe the document with Mistral OCR (cached per URL).
+        $ocr = $this->ocrExtractor->extract($url);
+        $markdown = $ocr->getMarkdown();
+
+        $system = <<<PROMPT
+            You are a helpful assistant that answers questions about a document based on its OCR-extracted text.
+            Only use information from the document below. If you can't answer a question, say so.
+            Use markdown for formatting the answer.
+
+            Document URL: {$url}
+            Extracted text:
+            {$markdown}
+            PROMPT;
+
+        // Step 2 — have the chat agent read the extracted text and open with a
+        // meaningful summary. This is the orchestration on display: one capability
+        // (OCR transcription) feeds another (the reasoning agent).
+        $summary = $this->agent->call(new MessageBag(
+            Message::forSystem($system),
+            Message::ofUser($this->summaryPrompt),
+        ));
+        \assert($summary instanceof TextResult);
+
+        $messages = new MessageBag(
+            Message::forSystem($system),
+            Message::ofUser($url),
+            Message::ofAssistant($summary->getContent()),
+        );
+
+        $this->reset();
+        $this->saveMessages($messages);
+    }
+
+    public function submitMessage(string $message): void
+    {
+        $messages = $this->loadMessages();
+
+        $messages->add(Message::ofUser($message));
+        $result = $this->agent->call($messages);
+
+        \assert($result instanceof TextResult);
+
+        $messages->add(Message::ofAssistant($result->getContent()));
+
+        $this->saveMessages($messages);
+    }
+
+    public function reset(): void
+    {
+        $this->requestStack->getSession()->remove(self::SESSION_KEY);
+    }
+
+    private function saveMessages(MessageBag $messages): void
+    {
+        $this->requestStack->getSession()->set(self::SESSION_KEY, $messages);
+    }
+}

--- a/demo/src/Document/OcrExtractor.php
+++ b/demo/src/Document/OcrExtractor.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Document;
+
+use Symfony\AI\Platform\Bridge\Mistral\Ocr\Result\OcrResult;
+use Symfony\AI\Platform\Message\Content\DocumentUrl;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final class OcrExtractor
+{
+    public function __construct(
+        #[Autowire(service: 'ai.platform.mistral')]
+        private readonly PlatformInterface $platform,
+        private readonly CacheInterface $cache,
+    ) {
+    }
+
+    /**
+     * OCR is billed per page, so the result for a given document URL is cached and
+     * the Mistral OCR endpoint is only ever called once per document.
+     */
+    public function extract(string $url): OcrResult
+    {
+        return $this->cache->get('mistral_ocr_'.hash('xxh128', $url), function (ItemInterface $item) use ($url): OcrResult {
+            $result = $this->platform->invoke('mistral-ocr-latest', new DocumentUrl($url));
+
+            $ocr = $result->asObject();
+            \assert($ocr instanceof OcrResult);
+
+            return $ocr;
+        });
+    }
+}

--- a/demo/src/Document/TwigComponent.php
+++ b/demo/src/Document/TwigComponent.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Document;
+
+use Psr\Log\LoggerInterface;
+use Symfony\AI\Platform\Message\MessageInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('document')]
+final class TwigComponent
+{
+    use DefaultActionTrait;
+
+    /** Picker selection: a sample URL, the literal "__own__", or empty. */
+    #[LiveProp(writable: true)]
+    public string $sample = '';
+
+    /** The URL typed in when "I'll provide my own" is chosen. */
+    #[LiveProp(writable: true)]
+    public ?string $url = null;
+
+    #[LiveProp(writable: true)]
+    public ?string $message = null;
+
+    /** The document currently under discussion — drives the header and survives turns. */
+    #[LiveProp]
+    public ?string $activeUrl = null;
+
+    #[LiveProp]
+    public ?string $activeTitle = null;
+
+    /** A user-facing error from the last failed start() — e.g. the host blocked OCR fetching. */
+    #[LiveProp(writable: true)]
+    public ?string $error = null;
+
+    /**
+     * @param list<array{title: string, url: string}> $samples
+     */
+    public function __construct(
+        private readonly Chat $document,
+        private readonly LoggerInterface $logger,
+        #[Autowire(param: 'app.document.samples')]
+        private readonly array $samples,
+    ) {
+    }
+
+    /**
+     * @return list<array{title: string, url: string}>
+     */
+    public function getSamples(): array
+    {
+        return $this->samples;
+    }
+
+    #[LiveAction]
+    public function start(): void
+    {
+        $this->error = null;
+        $url = '__own__' === $this->sample ? $this->url : $this->sample;
+        if (null === $url || '' === trim($url)) {
+            return;
+        }
+
+        try {
+            $this->document->start($url);
+            $this->activeUrl = $url;
+            $this->activeTitle = $this->titleFor($url);
+        } catch (\Throwable $e) {
+            $this->logger->error('Unable to start document OCR chat.', ['exception' => $e, 'url' => $url]);
+            $this->document->reset();
+            $this->error = \sprintf('Could not read that document — %s. The host may block automated fetching; try another, or host the file somewhere publicly reachable.', $e->getMessage());
+        }
+    }
+
+    /**
+     * @return MessageInterface[]
+     */
+    public function getMessages(): array
+    {
+        return $this->document->loadMessages()->withoutSystemMessage()->getMessages();
+    }
+
+    #[LiveAction]
+    public function submit(): void
+    {
+        if (null === $this->message || '' === trim($this->message)) {
+            return;
+        }
+
+        $this->document->submitMessage($this->message);
+
+        $this->message = null;
+    }
+
+    #[LiveAction]
+    public function reset(): void
+    {
+        $this->document->reset();
+        $this->sample = '';
+        $this->url = null;
+        $this->activeUrl = null;
+        $this->activeTitle = null;
+        $this->error = null;
+    }
+
+    private function titleFor(string $url): string
+    {
+        foreach ($this->samples as $sample) {
+            if ($sample['url'] === $url) {
+                return $sample['title'];
+            }
+        }
+
+        return 'your document';
+    }
+}

--- a/demo/templates/base.html.twig
+++ b/demo/templates/base.html.twig
@@ -35,6 +35,9 @@
                             <a class="nav-link" href="{{ path('blog') }}">{{ ux_icon('symfony') }} Symfony Blog</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ path('document') }}">{{ ux_icon('document') }} Document OCR</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" href="{{ path('crop') }}">{{ ux_icon('crop') }} Smart Crop</a>
                         </li>
                         <li class="nav-item">

--- a/demo/templates/components/document.html.twig
+++ b/demo/templates/components/document.html.twig
@@ -1,0 +1,74 @@
+{% import "_message.html.twig" as message %}
+
+<div class="card mx-auto shadow-lg" {{ attributes.defaults(stimulus_controller('document')) }}>
+    <div class="card-header p-2">
+        {{ ux_icon('document') }}
+        <strong class="ms-1 pt-1 d-inline-block">Document OCR Bot</strong>
+        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('cancel') }} Reset Chat</button>
+    </div>
+    <div id="chat-body" class="card-body p-4 overflow-auto">
+        {% if this.activeTitle %}
+            <div class="alert alert-light border d-flex align-items-center mb-3">
+                <span>We're discussing: <strong>{{ this.activeTitle }}</strong></span>
+                <a href="{{ this.activeUrl }}" target="_blank" rel="noopener" class="ms-auto text-decoration-none" title="Open the document in a new window">Open the document ↗</a>
+            </div>
+        {% endif %}
+        {% set messages = this.messages %}
+        {% for message in messages %}
+            {% include '_message.html.twig' with { message, latest: loop.last } %}
+        {% else %}
+            <div id="welcome" class="text-center mt-5 py-5 bg-white rounded-5 shadow-sm w-75 mx-auto">
+                {{ ux_icon('document', { color: '#1A73E8', height: '200px', width: '200px' }) }}
+                <h4 class="mt-5">Chat about a Document</h4>
+                <div class="w-75 mx-auto text-start">
+                    {% if error %}
+                        <div class="alert alert-danger" role="alert">{{ error }}</div>
+                    {% endif %}
+                    <label for="document-sample" class="form-label">Pick a document (or provide your own) to extract its text with Mistral OCR and start the chat:</label>
+                    <select id="document-sample" data-model="sample" class="form-select mb-2">
+                        <option value="">— Choose a document —</option>
+                        {% for s in this.samples %}
+                            <option value="{{ s.url }}">{{ s.title }}</option>
+                        {% endfor %}
+                        <option value="__own__">I'll provide my own URL…</option>
+                    </select>
+
+                    {% if sample == '__own__' %}
+                        <input autofocus type="url" id="document-url"
+                               data-model="norender|url"
+                               class="form-control mb-2" placeholder="https://example.com/document.pdf">
+                    {% elseif sample %}
+                        <p class="small text-muted mb-2">
+                            <a href="{{ sample }}" target="_blank" rel="noopener">Open this document in a new window ↗</a>
+                            to see what it is — then start the chat and ask away.
+                        </p>
+                    {% endif %}
+
+                    <form {{ live_action('start:prevent') }}>
+                        <button class="btn btn-secondary" id="chat-start" {{ not sample ? 'disabled' }} data-loading="action(start)|addAttribute(disabled)">
+                            <span data-loading="action(start)|hide">Start</span>
+                            <span data-loading="action(start)|show"><span class="spinner-border spinner-border-sm me-1"></span>Reading</span>
+                        </button>
+                    </form>
+                </div>
+            </div>
+        {% endfor %}
+        <div id="loading-message" class="d-none">
+            {{ message.user([{text:''}]) }}
+            {{ message.bot('The Document OCR Bot is reading the document ...', true) }}
+        </div>
+    </div>
+    <div class="card-footer p-2">
+        <form class="input-group" {{ live_action('submit:prevent') }}>
+            <input id="chat-message" {{ messages|length == 0 ? 'disabled'}}
+                   data-model="norender|message"
+                   data-loading="action(submit)|addAttribute(disabled)"
+                   type="text" class="form-control border-0" placeholder="Write a message ...">
+            <button {{ messages|length == 0 ? 'disabled'}}
+                class="btn btn-outline-secondary border-0" data-loading="action(submit)|addAttribute(disabled)">
+                <span data-loading="action(submit)|hide">{{ ux_icon('send') }} Submit</span>
+                <span data-loading="action(submit)|show"><span class="spinner-border spinner-border-sm me-1"></span>Preparing</span>
+            </button>
+        </form>
+    </div>
+</div>

--- a/demo/templates/index.html.twig
+++ b/demo/templates/index.html.twig
@@ -12,8 +12,8 @@
             configuration can be found in <code>config/packages/ai.yaml</code>.
         </p>
         <h3 class="text-dark">{{ 'home.examples'|trans }}</h3>
-        <div class="row">
-            <div class="col-md-3">
+        <div class="row row-cols-1 row-cols-md-5 g-3">
+            <div class="col">
                 <div class="card youtube bg-body shadow-sm">
                     <div class="card-img-top py-2">
                         {{ ux_icon('youtube') }}
@@ -32,7 +32,7 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="col-md-3">
+            <div class="col">
                 <div class="card recipe bg-body shadow-sm">
                     <div class="card-img-top py-2">
                         {{ ux_icon('recipe') }}
@@ -51,7 +51,7 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="col-md-3">
+            <div class="col">
                 <div class="card wikipedia bg-body shadow-sm">
                     <div class="card-img-top py-2">
                         {{ ux_icon('wikipedia') }}
@@ -70,7 +70,7 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="col-md-3">
+            <div class="col">
                 <div class="card blog bg-body shadow-sm">
                     <div class="card-img-top py-2">
                         {{ ux_icon('symfony') }}
@@ -89,9 +89,7 @@
                     {% endif %}
                 </div>
             </div>
-        </div>
-        <div class="row mt-4">
-            <div class="col-md-3">
+            <div class="col">
                 <div class="card speech bg-body shadow-sm">
                     <div class="card-img-top py-2">
                         {{ ux_icon('microphone') }}
@@ -110,7 +108,9 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="col-md-3">
+        </div>
+        <div class="row mt-2 row-cols-1 row-cols-md-5 g-3 justify-content-center">
+            <div class="col">
                 <div class="card video bg-body shadow-sm">
                     <div class="card-img-top py-2">
                         {{ ux_icon('video') }}
@@ -129,7 +129,7 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="col-md-3">
+            <div class="col">
                 <div class="card crop bg-body shadow-sm">
                     <div class="card-img-top py-2">
                         {{ ux_icon('crop') }}
@@ -148,7 +148,7 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="col-md-3">
+            <div class="col">
                 <div class="card stream bg-body shadow-sm">
                     <div class="card-img-top py-2">
                         {{ ux_icon('turbo') }}
@@ -163,6 +163,25 @@
                         <div class="card-footer">
                             {{ ux_icon('code') }}
                             <a href="{{ path('_profiler_open_file', { file: 'src/Stream/TwigComponent.php', line: 41 }) }}">See Implementation</a>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="col">
+                <div class="card document bg-body shadow-sm">
+                    <div class="card-img-top py-2">
+                        {{ ux_icon('document') }}
+                    </div>
+                    <div class="card-body">
+                        <h5 class="card-title">Document OCR Bot</h5>
+                        <p class="card-text">Question answering started with a document URL whose text is extracted via Mistral OCR.</p>
+                        <a href="{{ path('document') }}" class="btn btn-outline-dark d-block">Try Document OCR Bot</a>
+                    </div>
+                    {# Profiler route only available in dev #}
+                    {% if 'dev' == app.environment %}
+                        <div class="card-footer">
+                            {{ ux_icon('code') }}
+                            <a href="{{ path('_profiler_open_file', { file: 'src/Document/Chat.php', line: 21 }) }}">See Implementation</a>
                         </div>
                     {% endif %}
                 </div>

--- a/demo/tests/SmokeTest.php
+++ b/demo/tests/SmokeTest.php
@@ -28,7 +28,7 @@ final class SmokeTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
         $this->assertSelectorTextContains('h1', 'Welcome to the Symfony AI Demo');
-        $this->assertSelectorCount(8, '.card');
+        $this->assertSelectorCount(9, '.card');
     }
 
     #[DataProvider('provideChats')]
@@ -51,6 +51,7 @@ final class SmokeTest extends WebTestCase
         yield 'Recipe' => ['/recipe', 'Cooking Recipes'];
         yield 'Wikipedia' => ['/wikipedia', 'Wikipedia Research'];
         yield 'YouTube' => ['/youtube', 'Chat about a YouTube Video'];
+        yield 'Document' => ['/document', 'Chat about a Document'];
     }
 
     public function testCrop()

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -147,6 +147,7 @@ Supported Models & Platforms
 * **Other Models**
   * `OpenAI's Dall·E`_ with `OpenAI`_ as Platform
   * `OpenAI's Whisper`_ with `OpenAI`_ and `Azure`_ as Platform
+  * `Mistral OCR`_ with `Mistral`_ as Platform
   * `LM Studio Catalog`_ and `HuggingFace`_ Models  with `LM Studio`_ as Platform.
   * All models provided by `HuggingFace`_ can be listed with a command in the examples folder,
     and also filtered, e.g. ``php examples/huggingface/_model.php --provider=hf-inference --task=object-detection``
@@ -774,6 +775,39 @@ Code Examples
 
 * `Audio Output with GPT`_
 
+Document OCR
+------------
+
+Mistral's ``mistral-ocr-latest`` model uses a dedicated ``/v1/ocr`` endpoint that extracts text
+(as markdown), layout images and per-page annotations from a document or image. Unlike chat
+completions, it is invoked with a single document content object - a
+:class:`Symfony\\AI\\Platform\\Message\\Content\\DocumentUrl`,
+:class:`Symfony\\AI\\Platform\\Message\\Content\\Document` (binary PDF) or
+:class:`Symfony\\AI\\Platform\\Message\\Content\\ImageUrl` - and returns a typed
+:class:`Symfony\\AI\\Platform\\Bridge\\Mistral\\Ocr\\Result\\OcrResult`::
+
+    use Symfony\AI\Platform\Bridge\Mistral\Factory;
+    use Symfony\AI\Platform\Bridge\Mistral\Ocr\Result\OcrResult;
+    use Symfony\AI\Platform\Message\Content\DocumentUrl;
+
+    $platform = Factory::createPlatform($apiKey);
+
+    $result = $platform->invoke('mistral-ocr-latest', new DocumentUrl('https://example.com/document.pdf'));
+
+    $ocr = $result->asObject();
+    \assert($ocr instanceof OcrResult);
+
+    echo $ocr->getMarkdown();
+
+The result exposes every ``Page`` with its markdown, dimensions, extracted layout images
+(with bounding boxes) and optional annotations.
+
+Code Examples
+~~~~~~~~~~~~~
+
+* `OCR with Mistral (URL)`_
+* `OCR with Mistral (binary)`_
+
 Embeddings
 ----------
 
@@ -1317,6 +1351,7 @@ Code Examples
 .. _`Mistral Embed`: https://www.mistral.ai/
 .. _`OpenAI's Dall·E`: https://platform.openai.com/docs/guides/image-generation
 .. _`OpenAI's Whisper`: https://platform.openai.com/docs/guides/speech-to-text
+.. _`Mistral OCR`: https://docs.mistral.ai/api/endpoint/ocr
 .. _`HuggingFace`: https://huggingface.co/
 .. _`Mercure`: https://mercure.rocks/
 .. _`Streaming Claude`: https://github.com/symfony/ai/blob/main/examples/anthropic/stream.php
@@ -1328,6 +1363,8 @@ Code Examples
 .. _`Audio Output with GPT`: https://github.com/symfony/ai/blob/main/examples/openai/audio-output.php
 .. _`PDF Input with GPT`: https://github.com/symfony/ai/blob/main/examples/openai/pdf-input-binary.php
 .. _`PDF Input with Claude`: https://github.com/symfony/ai/blob/main/examples/anthropic/pdf-input-binary.php
+.. _`OCR with Mistral (URL)`: https://github.com/symfony/ai/blob/main/examples/mistral/ocr-url.php
+.. _`OCR with Mistral (binary)`: https://github.com/symfony/ai/blob/main/examples/mistral/ocr-binary.php
 .. _`Embeddings with OpenAI`: https://github.com/symfony/ai/blob/main/examples/openai/embeddings.php
 .. _`Embeddings with Voyage`: https://github.com/symfony/ai/blob/main/examples/voyage/text-embeddings.php
 .. _`Multimodal embeddings with Voyage`: https://github.com/symfony/ai/blob/main/examples/voyage/multimodal-embeddings.php

--- a/examples/mistral/ocr-binary.php
+++ b/examples/mistral/ocr-binary.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Mistral\Factory;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr\Result\OcrResult;
+use Symfony\AI\Platform\Message\Content\Document;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('MISTRAL_API_KEY'), httpClient: http_client());
+
+$result = $platform->invoke('mistral-ocr-latest', Document::fromFile(dirname(__DIR__, 2).'/fixtures/document.pdf'));
+
+$ocr = $result->asObject();
+assert($ocr instanceof OcrResult);
+
+echo $ocr->getMarkdown().\PHP_EOL.\PHP_EOL;
+echo 'Pages processed: '.count($ocr->getPages()).\PHP_EOL;

--- a/examples/mistral/ocr-url.php
+++ b/examples/mistral/ocr-url.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Mistral\Factory;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr\Result\OcrResult;
+use Symfony\AI\Platform\Message\Content\DocumentUrl;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('MISTRAL_API_KEY'), httpClient: http_client());
+
+$result = $platform->invoke('mistral-ocr-latest', new DocumentUrl('https://arxiv.org/pdf/2201.04234'));
+
+$ocr = $result->asObject();
+assert($ocr instanceof OcrResult);
+
+echo $ocr->getMarkdown().\PHP_EOL.\PHP_EOL;
+echo 'Pages processed: '.count($ocr->getPages()).\PHP_EOL;

--- a/src/platform/dev/update-model-catalogs.php
+++ b/src/platform/dev/update-model-catalogs.php
@@ -90,6 +90,7 @@ $modelsDevBridges = [
         'default' => BRIDGE_NS.'Mistral\\Mistral',
         'single' => false,
         'rules' => [
+            [static fn (array $m): bool => str_contains($m['id'] ?? '', 'ocr'), BRIDGE_NS.'Mistral\\Ocr'],
             [static fn (array $m): bool => CapabilityMapper::isEmbeddingModel($m), BRIDGE_NS.'Mistral\\Embeddings'],
         ],
     ],

--- a/src/platform/src/Bridge/Mistral/CHANGELOG.md
+++ b/src/platform/src/Bridge/Mistral/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+ * Add OCR support by `mistral-ocr-latest` model and `/v1/ocr` endpoint, returning a typed `OcrResult` with pages, layout images and annotations
 
 0.10
 ----

--- a/src/platform/src/Bridge/Mistral/Contract/DocumentNormalizer.php
+++ b/src/platform/src/Bridge/Mistral/Contract/DocumentNormalizer.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Mistral\Contract;
 
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\Content\Document;
 use Symfony\AI\Platform\Model;
@@ -39,6 +40,6 @@ class DocumentNormalizer extends ModelContractNormalizer
 
     protected function supportsModel(Model $model): bool
     {
-        return $model instanceof Mistral;
+        return $model instanceof Mistral || $model instanceof Ocr;
     }
 }

--- a/src/platform/src/Bridge/Mistral/Contract/DocumentUrlNormalizer.php
+++ b/src/platform/src/Bridge/Mistral/Contract/DocumentUrlNormalizer.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Mistral\Contract;
 
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\Content\DocumentUrl;
 use Symfony\AI\Platform\Model;
@@ -38,6 +39,6 @@ class DocumentUrlNormalizer extends ModelContractNormalizer
 
     protected function supportsModel(Model $model): bool
     {
-        return $model instanceof Mistral;
+        return $model instanceof Mistral || $model instanceof Ocr;
     }
 }

--- a/src/platform/src/Bridge/Mistral/Contract/ImageUrlNormalizer.php
+++ b/src/platform/src/Bridge/Mistral/Contract/ImageUrlNormalizer.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Mistral\Contract;
 
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Model;
@@ -41,6 +42,6 @@ class ImageUrlNormalizer extends ModelContractNormalizer
 
     protected function supportsModel(Model $model): bool
     {
-        return $model instanceof Mistral;
+        return $model instanceof Mistral || $model instanceof Ocr;
     }
 }

--- a/src/platform/src/Bridge/Mistral/Factory.php
+++ b/src/platform/src/Bridge/Mistral/Factory.php
@@ -46,8 +46,8 @@ final class Factory
 
         return new Provider(
             $name,
-            [new Embeddings\ModelClient($httpClient, $apiKey), new Llm\ModelClient($httpClient, $apiKey)],
-            [new Embeddings\ResultConverter(), new Llm\ResultConverter()],
+            [new Embeddings\ModelClient($httpClient, $apiKey), new Llm\ModelClient($httpClient, $apiKey), new Ocr\ModelClient($httpClient, $apiKey)],
+            [new Embeddings\ResultConverter(), new Llm\ResultConverter(), new Ocr\ResultConverter()],
             $modelCatalog,
             $contract ?? Contract::create([
                 new ToolNormalizer(),

--- a/src/platform/src/Bridge/Mistral/ModelCatalog.php
+++ b/src/platform/src/Bridge/Mistral/ModelCatalog.php
@@ -250,6 +250,22 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::TOOL_CALLING,
                 ],
             ],
+            'mistral-ocr-2505' => [
+                'class' => Ocr::class,
+                'capabilities' => [
+                    Capability::INPUT_PDF,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                ],
+            ],
+            'mistral-ocr-latest' => [
+                'class' => Ocr::class,
+                'capabilities' => [
+                    Capability::INPUT_PDF,
+                    Capability::INPUT_IMAGE,
+                    Capability::OUTPUT_TEXT,
+                ],
+            ],
             'mistral-saba-latest' => [
                 'class' => Mistral::class,
                 'capabilities' => [

--- a/src/platform/src/Bridge/Mistral/Ocr.php
+++ b/src/platform/src/Bridge/Mistral/Ocr.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral;
+
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class Ocr extends Model
+{
+}

--- a/src/platform/src/Bridge/Mistral/Ocr/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Ocr/ModelClient.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Ocr;
+
+use Symfony\AI\Platform\Bridge\Mistral\Ocr;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class ModelClient implements ModelClientInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        #[\SensitiveParameter] private readonly string $apiKey,
+    ) {
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Ocr;
+    }
+
+    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    {
+        if (\is_string($payload)) {
+            throw new InvalidArgumentException(\sprintf('The payload must be an array of normalized document content, but a string was given to "%s".', self::class));
+        }
+
+        return new RawHttpResult($this->httpClient->request('POST', 'https://api.mistral.ai/v1/ocr', [
+            'auth_bearer' => $this->apiKey,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'json' => array_merge($options, [
+                'model' => $model->getName(),
+                'document' => $payload,
+            ]),
+        ]));
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Ocr/Result/Image.php
+++ b/src/platform/src/Bridge/Mistral/Ocr/Result/Image.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Ocr\Result;
+
+/**
+ * An image extracted from a page of a Mistral OCR result.
+ *
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class Image
+{
+    public function __construct(
+        private readonly string $id,
+        private readonly ?int $topLeftX = null,
+        private readonly ?int $topLeftY = null,
+        private readonly ?int $bottomRightX = null,
+        private readonly ?int $bottomRightY = null,
+        private readonly ?string $imageBase64 = null,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getTopLeftX(): ?int
+    {
+        return $this->topLeftX;
+    }
+
+    public function getTopLeftY(): ?int
+    {
+        return $this->topLeftY;
+    }
+
+    public function getBottomRightX(): ?int
+    {
+        return $this->bottomRightX;
+    }
+
+    public function getBottomRightY(): ?int
+    {
+        return $this->bottomRightY;
+    }
+
+    public function getImageBase64(): ?string
+    {
+        return $this->imageBase64;
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Ocr/Result/OcrResult.php
+++ b/src/platform/src/Bridge/Mistral/Ocr/Result/OcrResult.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Ocr\Result;
+
+/**
+ * Structured result of a Mistral OCR (/v1/ocr) request.
+ *
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class OcrResult
+{
+    /**
+     * @param Page[]                    $pages
+     * @param array<string, mixed>|null $usageInfo
+     */
+    public function __construct(
+        private readonly array $pages,
+        private readonly string $model,
+        private readonly ?array $usageInfo = null,
+        private readonly ?string $documentAnnotation = null,
+    ) {
+    }
+
+    /**
+     * @return Page[]
+     */
+    public function getPages(): array
+    {
+        return $this->pages;
+    }
+
+    public function getModel(): string
+    {
+        return $this->model;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getUsageInfo(): ?array
+    {
+        return $this->usageInfo;
+    }
+
+    /**
+     * The document-wide annotation, present when document annotation was requested.
+     */
+    public function getDocumentAnnotation(): ?string
+    {
+        return $this->documentAnnotation;
+    }
+
+    /**
+     * Returns the markdown of all pages concatenated, separated by a blank line.
+     */
+    public function getMarkdown(): string
+    {
+        return implode("\n\n", array_map(static fn (Page $page): string => $page->getMarkdown(), $this->pages));
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Ocr/Result/Page.php
+++ b/src/platform/src/Bridge/Mistral/Ocr/Result/Page.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Ocr\Result;
+
+/**
+ * A single page of a Mistral OCR result.
+ *
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class Page
+{
+    /**
+     * @param Image[]                   $images
+     * @param array<string, mixed>|null $dimensions
+     */
+    public function __construct(
+        private readonly int $index,
+        private readonly string $markdown,
+        private readonly array $images = [],
+        private readonly ?array $dimensions = null,
+    ) {
+    }
+
+    public function getIndex(): int
+    {
+        return $this->index;
+    }
+
+    public function getMarkdown(): string
+    {
+        return $this->markdown;
+    }
+
+    /**
+     * @return Image[]
+     */
+    public function getImages(): array
+    {
+        return $this->images;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getDimensions(): ?array
+    {
+        return $this->dimensions;
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Ocr/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Ocr/ResultConverter.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Ocr;
+
+use Symfony\AI\Platform\Bridge\Mistral\Ocr;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr\Result\Image;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr\Result\OcrResult;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr\Result\Page;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+
+/**
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class ResultConverter implements ResultConverterInterface
+{
+    use HttpStatusErrorHandlingTrait;
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Ocr;
+    }
+
+    public function convert(RawResultInterface $result, array $options = []): ObjectResult
+    {
+        $httpResponse = $result->getObject();
+
+        $this->throwOnHttpError($httpResponse);
+
+        if (200 !== $httpResponse->getStatusCode()) {
+            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $httpResponse->getStatusCode(), $httpResponse->getContent(false)));
+        }
+
+        $data = $result->getData();
+
+        if (!isset($data['pages']) || !\is_array($data['pages'])) {
+            throw new RuntimeException('Response does not contain pages.');
+        }
+
+        $pages = array_map(static function (array $page): Page {
+            $images = array_map(static fn (array $image): Image => new Image(
+                $image['id'] ?? '',
+                $image['top_left_x'] ?? null,
+                $image['top_left_y'] ?? null,
+                $image['bottom_right_x'] ?? null,
+                $image['bottom_right_y'] ?? null,
+                $image['image_base64'] ?? null,
+            ), $page['images'] ?? []);
+
+            return new Page(
+                $page['index'] ?? 0,
+                $page['markdown'] ?? '',
+                $images,
+                $page['dimensions'] ?? null,
+            );
+        }, $data['pages']);
+
+        return new ObjectResult(new OcrResult(
+            $pages,
+            $data['model'] ?? '',
+            $data['usage_info'] ?? null,
+            $data['document_annotation'] ?? null,
+        ));
+    }
+
+    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    {
+        return null;
+    }
+}

--- a/src/platform/src/Bridge/Mistral/README.md
+++ b/src/platform/src/Bridge/Mistral/README.md
@@ -8,6 +8,8 @@ Mistral Documentation
 
  * [API reference](https://docs.mistral.ai/api/)
  * [Chat completions](https://docs.mistral.ai/api/endpoint/chat)
+ * [OCR](https://docs.mistral.ai/api/endpoint/ocr)
+
 
 Test Fixtures
 -------------

--- a/src/platform/src/Bridge/Mistral/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/ModelCatalogTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Mistral\Tests;
 use Symfony\AI\Platform\Bridge\Mistral\Embeddings;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Bridge\Mistral\ModelCatalog;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Test\ModelCatalogTestCase;
@@ -40,6 +41,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'voxtral-small-latest' => ['voxtral-small-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::INPUT_AUDIO, Capability::TOOL_CALLING]];
         yield 'voxtral-mini-latest' => ['voxtral-mini-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::INPUT_AUDIO, Capability::TOOL_CALLING]];
         yield 'mistral-embed' => ['mistral-embed', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'mistral-ocr-latest' => ['mistral-ocr-latest', Ocr::class, [Capability::INPUT_PDF, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/Mistral/Tests/Ocr/ModelClientTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Ocr/ModelClientTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\Ocr;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Embeddings;
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr\ModelClient;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ModelClientTest extends TestCase
+{
+    public function testItSupportsOcrModelOnly()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'sk-test-key');
+
+        $this->assertTrue($client->supports(new Ocr('mistral-ocr-latest')));
+        $this->assertFalse($client->supports(new Mistral('mistral-large-latest')));
+        $this->assertFalse($client->supports(new Embeddings('mistral-embed')));
+    }
+
+    public function testItSendsDocumentToOcrEndpoint()
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): MockResponse {
+            self::assertSame('POST', $method);
+            self::assertSame('https://api.mistral.ai/v1/ocr', $url);
+
+            $body = json_decode($options['body'], true);
+            self::assertSame('mistral-ocr-latest', $body['model']);
+            self::assertSame([
+                'type' => 'document_url',
+                'document_url' => 'https://example.com/document.pdf',
+            ], $body['document']);
+
+            return new JsonMockResponse(['pages' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'sk-test-key');
+        $client->request(new Ocr('mistral-ocr-latest'), [
+            'type' => 'document_url',
+            'document_url' => 'https://example.com/document.pdf',
+        ]);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testItForwardsOptions()
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): MockResponse {
+            $body = json_decode($options['body'], true);
+            self::assertTrue($body['include_image_base64']);
+
+            return new JsonMockResponse(['pages' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'sk-test-key');
+        $client->request(new Ocr('mistral-ocr-latest'), [
+            'type' => 'image_url',
+            'image_url' => 'https://example.com/image.png',
+        ], ['include_image_base64' => true]);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testItThrowsExceptionForStringPayload()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'sk-test-key');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $client->request(new Ocr('mistral-ocr-latest'), 'not-an-array');
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Tests/Ocr/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Ocr/ResultConverterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\Ocr;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr\Result\OcrResult;
+use Symfony\AI\Platform\Bridge\Mistral\Ocr\ResultConverter;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+final class ResultConverterTest extends TestCase
+{
+    public function testItSupportsOcrModelOnly()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertTrue($converter->supports(new Ocr('mistral-ocr-latest')));
+        $this->assertFalse($converter->supports(new Mistral('mistral-large-latest')));
+    }
+
+    public function testItConvertsPagesIntoStructuredResult()
+    {
+        $response = new JsonMockResponse([
+            'model' => 'mistral-ocr-latest',
+            'pages' => [
+                [
+                    'index' => 0,
+                    'markdown' => "# Title\n\nFirst page.",
+                    'dimensions' => ['width' => 2480, 'height' => 3508, 'dpi' => 200],
+                    'images' => [
+                        [
+                            'id' => 'img-0',
+                            'top_left_x' => 10,
+                            'top_left_y' => 20,
+                            'bottom_right_x' => 110,
+                            'bottom_right_y' => 220,
+                            'image_base64' => 'data:image/png;base64,abc',
+                        ],
+                    ],
+                ],
+                [
+                    'index' => 1,
+                    'markdown' => 'Second page.',
+                ],
+            ],
+            'document_annotation' => '{"language":"en"}',
+            'usage_info' => ['pages_processed' => 2, 'doc_size_bytes' => 12345],
+        ]);
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($this->responseOf($response)));
+
+        $this->assertInstanceOf(ObjectResult::class, $result);
+
+        $ocr = $result->getContent();
+        \assert($ocr instanceof OcrResult);
+
+        $this->assertSame('mistral-ocr-latest', $ocr->getModel());
+        $this->assertCount(2, $ocr->getPages());
+        $this->assertSame("# Title\n\nFirst page.\n\nSecond page.", $ocr->getMarkdown());
+        $this->assertSame('{"language":"en"}', $ocr->getDocumentAnnotation());
+        $this->assertSame(['pages_processed' => 2, 'doc_size_bytes' => 12345], $ocr->getUsageInfo());
+
+        $firstPage = $ocr->getPages()[0];
+        $this->assertSame(0, $firstPage->getIndex());
+        $this->assertSame(['width' => 2480, 'height' => 3508, 'dpi' => 200], $firstPage->getDimensions());
+        $this->assertCount(1, $firstPage->getImages());
+
+        $image = $firstPage->getImages()[0];
+        $this->assertSame('img-0', $image->getId());
+        $this->assertSame(10, $image->getTopLeftX());
+        $this->assertSame(220, $image->getBottomRightY());
+        $this->assertSame('data:image/png;base64,abc', $image->getImageBase64());
+    }
+
+    public function testItThrowsWhenPagesAreMissing()
+    {
+        $result = new RawHttpResult($this->responseOf(new JsonMockResponse(['model' => 'mistral-ocr-latest'])));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Response does not contain pages.');
+
+        (new ResultConverter())->convert($result);
+    }
+
+    private function responseOf(JsonMockResponse $response): \Symfony\Contracts\HttpClient\ResponseInterface
+    {
+        $client = new MockHttpClient($response);
+
+        return $client->request('POST', 'https://api.mistral.ai/v1/ocr');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #2072
| License       | MIT

Adds OCR support to the Mistral bridge via the dedicated `/v1/ocr` endpoint, as
discussed in #2072.

Mistral's `mistral-ocr-latest` model is not a chat completion — it uses a
separate endpoint and returns structured per-page output, so it can't be routed
through `MessageBag`/chat. Following the existing Whisper bridge pattern, this
adds a dedicated `Ocr` model with its own `ModelClient` and `ResultConverter`:

```php
use Symfony\AI\Platform\Bridge\Mistral\Factory;
use Symfony\AI\Platform\Bridge\Mistral\Ocr\Result\OcrResult;
use Symfony\AI\Platform\Message\Content\DocumentUrl;

$platform = Factory::createPlatform($apiKey);

$result = $platform->invoke('mistral-ocr-latest', new DocumentUrl('https://example.com/document.pdf'));

$ocr = $result->asObject();
\assert($ocr instanceof OcrResult);

echo $ocr->getMarkdown();
```

The result is a typed `OcrResult` (pages with markdown, layout images + bounding
boxes, per-page annotations, usage info) via `ObjectResult`/`asObject()`, not a
text blob. Document URL, binary PDF and image inputs all work — the existing
`Document`, `DocumentUrl` and `ImageUrl` contract normalizers were widened to
also accept the `Ocr` model. Catalog entries (`mistral-ocr-latest`,
`mistral-ocr-2505`) plus a generator rule keep OCR models out of the chat class.

Verified end-to-end against the live API (a 29-page arXiv PDF by URL and a
binary PDF by base64), plus unit tests for the client, converter and catalog.

Also includes a `Document OCR` demo (`demo/`) showing the feature as a chat that
extracts a document's text and answers questions about it.

Docs: `docs/components/platform.rst`, the bridge `README.md`, examples under
`examples/mistral/`, and a `CHANGELOG.md` entry.

Companion PR #2160 (`CacheableInputInterface`) makes the `ai.platform.cache.*`
decorator able to cache content-object inputs like `DocumentUrl`, so OCR results
can be cached at the platform layer — independent of this PR.
