### PR TITLE
[Platform] Throw ExceedContextSizeException when a request exceeds the model's context window

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -70,6 +70,22 @@ Platform
    +public function supports(string|Model $model): bool
    ```
 
+ * The Anthropic, Generic, OpenAI, and OpenResponses bridges now throw `ExceedContextSizeException`
+   instead of `BadRequestException` when a 400 response reports a context overflow. As
+   `ExceedContextSizeException` does not extend `BadRequestException`, catch it explicitly:
+
+   ```diff
+   +use Symfony\AI\Platform\Exception\ExceedContextSizeException;
+
+    try {
+        $result = $platform->invoke($model, $messages)->getResult();
+   +} catch (ExceedContextSizeException $e) {
+   +    // shrink the conversation and retry
+    } catch (BadRequestException $e) {
+        // ...
+    }
+   ```
+
 Store
 -----
 

--- a/src/platform/src/Bridge/Anthropic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Anthropic/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.10
 ----
 
+ * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
  * Allow overriding `tool_choice` via caller options instead of always forcing `['type' => 'auto']`
 
 0.9

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Anthropic;
 
 use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -58,6 +59,11 @@ class ResultConverter implements ResultConverterInterface
 
         if (400 === $response->getStatusCode()) {
             $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? 'Bad Request';
+
+            if (str_contains($errorMessage, 'prompt is too long')) {
+                throw new ExceedContextSizeException($errorMessage);
+            }
+
             throw new BadRequestException($errorMessage);
         }
 

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -13,6 +13,8 @@ namespace Symfony\AI\Platform\Bridge\Anthropic\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Anthropic\ResultConverter;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
@@ -126,6 +128,36 @@ final class ResultConverterTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('API Error [Unknown]: "An unknown error occurred."');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testThrowsExceedContextSizeExceptionWhenPromptIsTooLong()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 213021 tokens > 204698 maximum"}}', ['http_code' => 400]),
+        ]);
+
+        $response = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+        $converter = new ResultConverter();
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('prompt is too long: 213021 tokens > 204698 maximum');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testThrowsBadRequestExceptionOnOtherBadRequestErrors()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens is required"}}', ['http_code' => 400]),
+        ]);
+
+        $response = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+        $converter = new ResultConverter();
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('max_tokens is required');
 
         $converter->convert(new RawHttpResult($response));
     }

--- a/src/platform/src/Bridge/Generic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Generic/CHANGELOG.md
@@ -2,8 +2,9 @@ CHANGELOG
 =========
 
 0.10
----
+----
 
+ * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
  * Request usage stats for streamed responses by default when no `stream_options` provided
 
 0.8

--- a/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Bridge\Generic\CompletionsModel;
 use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -51,7 +52,13 @@ class ResultConverter implements ResultConverterInterface
         }
 
         if (400 === $response->getStatusCode()) {
-            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? 'Bad Request';
+            $error = json_decode($response->getContent(false), true)['error'] ?? [];
+            $errorMessage = $error['message'] ?? 'Bad Request';
+
+            if ('context_length_exceeded' === ($error['code'] ?? null) || preg_match('/context[_ ]length[_ ]exceeded/i', $errorMessage)) {
+                throw new ExceedContextSizeException($errorMessage);
+            }
+
             throw new BadRequestException($errorMessage);
         }
 

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\AI\Platform\Bridge\Generic\Tests\Completions;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Generic\Completions\ResultConverter;
 use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
@@ -275,6 +277,33 @@ class ResultConverterTest extends TestCase
         $this->expectExceptionMessage('Unsupported finish reason "unsupported_reason"');
 
         $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    /**
+     * @param array{message: string, code?: string|int} $error
+     */
+    #[DataProvider('provideContextOverflowErrors')]
+    public function testThrowsExceedContextSizeExceptionOnContextOverflow(array $error)
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->willReturn(json_encode(['error' => $error]));
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage($error['message']);
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    /**
+     * @return iterable<string, array{array{message: string, code?: string|int}}>
+     */
+    public static function provideContextOverflowErrors(): iterable
+    {
+        yield 'error code' => [['message' => "This model's maximum context length is 128000 tokens.", 'code' => 'context_length_exceeded']];
+        yield 'snake_case code in message' => [['message' => 'Error: context_length_exceeded', 'code' => 400]];
+        yield 'spaced code variant in message' => [['message' => 'Context length exceeded for this request.']];
     }
 
     public function testThrowsBadRequestExceptionOnBadRequestResponse()

--- a/src/platform/src/Bridge/OpenAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenAi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Bridge\OpenAi\Gpt;
 use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -64,7 +65,13 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if (400 === $response->getStatusCode()) {
-            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? 'Bad Request';
+            $error = json_decode($response->getContent(false), true)['error'] ?? [];
+            $errorMessage = $error['message'] ?? 'Bad Request';
+
+            if ('context_length_exceeded' === ($error['code'] ?? null)) {
+                throw new ExceedContextSizeException($errorMessage);
+            }
+
             throw new BadRequestException($errorMessage);
         }
 

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\OpenAi\Gpt\ResultConverter;
 use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
@@ -277,6 +278,26 @@ class ResultConverterTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Response does not contain output');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsExceedContextSizeExceptionOnContextLengthExceeded()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->willReturn(json_encode([
+            'error' => [
+                'message' => "This model's maximum context length is 128000 tokens. However, your messages resulted in 145575 tokens.",
+                'type' => 'invalid_request_error',
+                'param' => 'messages',
+                'code' => 'context_length_exceeded',
+            ],
+        ]));
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('maximum context length is 128000 tokens');
 
         $converter->convert(new RawHttpResult($httpResponse));
     }

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\OpenResponses;
 use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -61,7 +62,13 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if (400 === $response->getStatusCode()) {
-            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? 'Bad Request';
+            $error = json_decode($response->getContent(false), true)['error'] ?? [];
+            $errorMessage = $error['message'] ?? 'Bad Request';
+
+            if ('context_length_exceeded' === ($error['code'] ?? null) || str_contains($errorMessage, 'exceeds the context window')) {
+                throw new ExceedContextSizeException($errorMessage);
+            }
+
             throw new BadRequestException($errorMessage);
         }
 

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\OpenResponses\ResultConverter;
 use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
@@ -279,6 +280,43 @@ final class ResultConverterTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Response does not contain output');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsExceedContextSizeExceptionWhenInputExceedsContextWindow()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->willReturn(json_encode([
+            'error' => [
+                'message' => 'Your input exceeds the context window of this model. Please decrease the length of your messages.',
+                'type' => 'invalid_request_error',
+            ],
+        ]));
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('Your input exceeds the context window of this model.');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsExceedContextSizeExceptionOnContextLengthExceededCode()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->willReturn(json_encode([
+            'error' => [
+                'message' => 'Context length exceeded for this request.',
+                'type' => 'invalid_request_error',
+                'code' => 'context_length_exceeded',
+            ],
+        ]));
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('Context length exceeded for this request.');
 
         $converter->convert(new RawHttpResult($httpResponse));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

As ExceedContextSizeException already exists, let's use it when appropriate.