### PR TITLE
[Docs] Mention installing symfony/ai-agent in the Quick Start

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,11 +22,12 @@ AI capabilities to your application:
 Quick Start
 -----------
 
-Install the AI Bundle to get started with Symfony AI:
+Install the AI Bundle to get started with Symfony AI, together with the Agent
+component used in the example below:
 
 .. code-block:: terminal
 
-    $ composer require symfony/ai-bundle
+    $ composer require symfony/ai-bundle symfony/ai-agent
 
 Configure your AI platform:
 


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Bug fix?     | no
| New feature? | no
| Docs?        | yes
| Issues       | Fix #1728
| License      | MIT

The Quick Start uses `AgentInterface` from `symfony/ai-agent`, but only
`symfony/ai-bundle` was installed, so the example couldn't be followed as-is.
This adds `symfony/ai-agent` to the install command (as agreed in #1728).
