### PR TITLE
[Platform] Throw ExceedContextSizeException across remaining LLM bridges

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -89,9 +89,11 @@ Platform
    +public function supports(string|Model $model): bool
    ```
 
- * The Anthropic, Generic, OpenAI, and OpenResponses bridges now throw `ExceedContextSizeException`
-   instead of `BadRequestException` when a 400 response reports a context overflow. As
-   `ExceedContextSizeException` does not extend `BadRequestException`, catch it explicitly:
+ * The Anthropic, Generic, OpenAI, OpenResponses, Cerebras, DeepSeek, Mistral, Cohere, Gemini,
+   Perplexity, Scaleway, and VertexAI bridges now throw `ExceedContextSizeException` when a 400
+   response reports a context overflow (previously `BadRequestException`, or a generic
+   `RuntimeException` for the Scaleway and VertexAI bridges). As `ExceedContextSizeException` does
+   not extend `BadRequestException`, catch it explicitly:
 
    ```diff
    +use Symfony\AI\Platform\Exception\ExceedContextSizeException;

--- a/src/platform/src/Bridge/Cerebras/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cerebras/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Cerebras/ResultConverter.php
+++ b/src/platform/src/Bridge/Cerebras/ResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Cerebras;
 
 use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -39,7 +40,19 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
         if ($result instanceof RawHttpResult) {
-            $this->throwOnHttpError($result->getObject());
+            $response = $result->getObject();
+
+            if (400 === $response->getStatusCode()) {
+                $body = json_decode($response->getContent(false), true) ?? [];
+                $code = $body['error']['code'] ?? $body['code'] ?? null;
+                $message = $body['error']['message'] ?? $body['message'] ?? '';
+
+                if ('context_length_exceeded' === $code || str_contains($message, 'context length')) {
+                    throw new ExceedContextSizeException('' !== $message ? $message : 'Context size exceeded');
+                }
+            }
+
+            $this->throwOnHttpError($response);
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/Cerebras/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cerebras/Tests/ResultConverterTest.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Platform\Bridge\Cerebras\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Cerebras\Model;
 use Symfony\AI\Platform\Bridge\Cerebras\ResultConverter;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -148,6 +150,43 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('call_def456', $result->getContent()[1]->getId());
         $this->assertSame('get_weather', $result->getContent()[1]->getName());
         $this->assertSame(['location' => 'London'], $result->getContent()[1]->getArguments());
+    }
+
+    public function testConvertThrowsExceedContextSizeExceptionOnContextOverflow()
+    {
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('Please reduce the length of the messages');
+
+        // Cerebras returns a flat error body whose message carries no "context length" hint,
+        // so detection has to rely on the "context_length_exceeded" code.
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'message' => 'Please reduce the length of the messages or completion. Current length is 300088 while limit is 131000',
+            'type' => 'invalid_request_error',
+            'param' => 'messages',
+            'code' => 'context_length_exceeded',
+        ], ['http_code' => 400]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.cerebras.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testConvertThrowsBadRequestExceptionOnOtherBadRequestErrors()
+    {
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Invalid model specified');
+
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'error' => [
+                'message' => 'Invalid model specified',
+            ],
+        ], ['http_code' => 400]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.cerebras.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $converter->convert(new RawHttpResult($httpResponse));
     }
 
     public function testConvertThrowsOnApiError()

--- a/src/platform/src/Bridge/Cohere/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cohere/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Cohere\Llm;
 
 use Symfony\AI\Platform\Bridge\Cohere\Cohere;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
@@ -44,6 +45,15 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
         $httpResponse = $result->getObject();
+
+        if (400 === $httpResponse->getStatusCode()) {
+            $body = json_decode($httpResponse->getContent(false), true) ?? [];
+            $message = $body['error']['message'] ?? $body['message'] ?? '';
+
+            if (str_contains(strtolower($message), 'too many tokens')) {
+                throw new ExceedContextSizeException('' !== $message ? $message : 'Context size exceeded');
+            }
+        }
 
         $this->throwOnHttpError($httpResponse);
 

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Cohere\Tests\Llm;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Cohere\Cohere;
 use Symfony\AI\Platform\Bridge\Cohere\Llm\ResultConverter;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -43,6 +44,22 @@ final class ResultConverterTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testItThrowsExceedContextSizeExceptionOnContextOverflow()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(400);
+        $response->method('getContent')->willReturn(json_encode([
+            'message' => 'too many tokens: size limit exceeded by 213302 tokens. Try using shorter or fewer inputs. The limit for this model is 288000 tokens.',
+        ]));
+
+        $converter = new ResultConverter();
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('too many tokens');
 
         $converter->convert(new RawHttpResult($response));
     }

--- a/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
+++ b/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/DeepSeek/ResultConverter.php
+++ b/src/platform/src/Bridge/DeepSeek/ResultConverter.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\DeepSeek;
 
 use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
 use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\InvalidRequestException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -41,7 +42,21 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
         if ($result instanceof RawHttpResult) {
-            $this->throwOnHttpError($result->getObject());
+            $response = $result->getObject();
+
+            if (400 === $response->getStatusCode()) {
+                $body = json_decode($response->getContent(false), true) ?? [];
+                $code = $body['error']['code'] ?? $body['code'] ?? null;
+                $message = $body['error']['message'] ?? $body['message'] ?? '';
+
+                // DeepSeek tags context overflows as a generic "invalid_request_error" code, so detection
+                // relies on the message; the "context_length_exceeded" code is kept as an OpenAI-compatible fallback.
+                if ('context_length_exceeded' === $code || str_contains($message, 'context length')) {
+                    throw new ExceedContextSizeException('' !== $message ? $message : 'Context size exceeded');
+                }
+            }
+
+            $this->throwOnHttpError($response);
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\DeepSeek\DeepSeek;
 use Symfony\AI\Platform\Bridge\DeepSeek\ResultConverter;
 use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\InvalidRequestException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
@@ -121,6 +122,27 @@ final class ResultConverterTest extends TestCase
                 'message' => 'Content filtered',
             ],
         ]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.deepseek.com/chat/completions');
+        $converter = new ResultConverter();
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testConvertThrowsExceedContextSizeExceptionOnContextOverflow()
+    {
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('maximum context length');
+
+        // DeepSeek reports context overflows with the generic "invalid_request_error" code,
+        // so detection has to key off the message rather than a dedicated code.
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'error' => [
+                'message' => "This model's maximum context length is 65536 tokens. However, you requested 600018 tokens.",
+                'type' => 'invalid_request_error',
+                'code' => 'invalid_request_error',
+            ],
+        ], ['http_code' => 400]));
 
         $httpResponse = $httpClient->request('POST', 'https://api.deepseek.com/chat/completions');
         $converter = new ResultConverter();

--- a/src/platform/src/Bridge/Gemini/CHANGELOG.md
+++ b/src/platform/src/Bridge/Gemini/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+
 0.9
 ---
 

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Gemini\Gemini;
 
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
@@ -64,6 +65,14 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
         $response = $result->getObject();
+
+        if (400 === $response->getStatusCode()) {
+            $message = json_decode($response->getContent(false), true)['error']['message'] ?? '';
+
+            if (str_contains($message, 'maximum number of tokens') || str_contains($message, 'input token count')) {
+                throw new ExceedContextSizeException($message);
+            }
+        }
 
         $this->throwOnHttpError($response);
 

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Gemini\Tests\Gemini;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Result\BinaryResult;
@@ -51,6 +52,25 @@ final class ResultConverterTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Error "500" - "INTERNAL": "Internal error encountered.".');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testConvertThrowsExceedContextSizeExceptionOnContextOverflow()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->willReturn(json_encode([
+            'error' => [
+                'code' => 400,
+                'status' => 'INVALID_ARGUMENT',
+                'message' => 'The input token count (1294145) exceeds the maximum number of tokens allowed (1048576).',
+            ],
+        ]));
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('exceeds the maximum number of tokens allowed');
 
         $converter->convert(new RawHttpResult($httpResponse));
     }

--- a/src/platform/src/Bridge/Mistral/CHANGELOG.md
+++ b/src/platform/src/Bridge/Mistral/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Mistral\Llm;
 
 use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -45,6 +46,16 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
         $httpResponse = $result->getObject();
+
+        if (400 === $httpResponse->getStatusCode()) {
+            $body = json_decode($httpResponse->getContent(false), true) ?? [];
+            $code = $body['error']['code'] ?? $body['code'] ?? null;
+            $message = $body['error']['message'] ?? $body['message'] ?? '';
+
+            if ('context_length_exceeded' === $code || str_contains($message, 'maximum context length')) {
+                throw new ExceedContextSizeException('' !== $message ? $message : 'Context size exceeded');
+            }
+        }
 
         $this->throwOnHttpError($httpResponse);
 

--- a/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\Llm;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Llm\ResultConverter;
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+final class ResultConverterTest extends TestCase
+{
+    public function testItSupportsMistralModel()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertTrue($converter->supports(new Mistral('mistral-large-latest')));
+    }
+
+    public function testConvertTextResult()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Hello world',
+                    ],
+                    'finish_reason' => 'stop',
+                ],
+            ],
+        ]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello world', $result->getContent());
+    }
+
+    public function testConvertThrowsExceedContextSizeExceptionOnContextOverflow()
+    {
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('maximum context length');
+
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'message' => 'Prompt contains 300019 tokens and 0 draft tokens, too large for model with 262144 maximum context length',
+        ], ['http_code' => 400]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testConvertThrowsBadRequestExceptionOnOtherBadRequestErrors()
+    {
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Invalid model specified');
+
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'message' => 'Invalid model specified',
+        ], ['http_code' => 400]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+}

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -65,7 +65,10 @@ final class ResultConverter implements ResultConverterInterface
             $error = json_decode($response->getContent(false), true)['error'] ?? [];
             $errorMessage = $error['message'] ?? 'Bad Request';
 
-            if ('context_length_exceeded' === ($error['code'] ?? null) || str_contains($errorMessage, 'exceeds the context window')) {
+            if ('context_length_exceeded' === ($error['code'] ?? null)
+                || str_contains($errorMessage, 'exceeds the context window')
+                || str_contains($errorMessage, 'max_model_len')
+            ) {
                 throw new ExceedContextSizeException($errorMessage);
             }
 

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -321,6 +321,24 @@ final class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
+    public function testThrowsExceedContextSizeExceptionOnVllmMaxModelLen()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->willReturn(json_encode([
+            'error' => [
+                'message' => 'The engine prompt length 300072 exceeds the max_model_len 131072. Please reduce prompt.',
+                'type' => 'invalid_request_error',
+            ],
+        ]));
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('exceeds the max_model_len');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
     public function testThrowsBadRequestExceptionOnBadRequestResponse()
     {
         $converter = new ResultConverter();

--- a/src/platform/src/Bridge/Perplexity/CHANGELOG.md
+++ b/src/platform/src/Bridge/Perplexity/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Perplexity/ResultConverter.php
+++ b/src/platform/src/Bridge/Perplexity/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Perplexity;
 
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -39,7 +40,18 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
         if ($result instanceof RawHttpResult) {
-            $this->throwOnHttpError($result->getObject());
+            $response = $result->getObject();
+
+            if (400 === $response->getStatusCode()) {
+                $error = json_decode($response->getContent(false), true)['error'] ?? [];
+                $message = $error['message'] ?? '';
+
+                if ('too_many_prompt_tokens' === ($error['type'] ?? null) || str_contains(strtolower($message), 'too long')) {
+                    throw new ExceedContextSizeException('' !== $message ? $message : 'Context size exceeded');
+                }
+            }
+
+            $this->throwOnHttpError($response);
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/Perplexity/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Perplexity/Tests/ResultConverterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Perplexity\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Perplexity\ResultConverter;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -44,6 +45,25 @@ final class ResultConverterTest extends TestCase
 
         $this->assertInstanceOf(TextResult::class, $result);
         $this->assertSame('Hello world', $result->getContent());
+    }
+
+    public function testConvertThrowsExceedContextSizeExceptionOnContextOverflow()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(400);
+        $httpResponse->method('getContent')->willReturn(json_encode([
+            'error' => [
+                'message' => 'The total length of all messages is too long.',
+                'type' => 'too_many_prompt_tokens',
+                'code' => 400,
+            ],
+        ]));
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('The total length of all messages is too long.');
+
+        $converter->convert(new RawHttpResult($httpResponse));
     }
 
     public function testConvertMultipleChoices()

--- a/src/platform/src/Bridge/Scaleway/CHANGELOG.md
+++ b/src/platform/src/Bridge/Scaleway/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `ExceedContextSizeException` when a 400 response reports a context overflow
+
 0.9
 ---
 

--- a/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Scaleway\Llm;
 use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
 use Symfony\AI\Platform\Bridge\Scaleway\Scaleway;
 use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -47,6 +48,15 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if (isset($data['error'])) {
+            $errorMessage = $data['error']['message'] ?? '';
+
+            if ('context_length_exceeded' === ($data['error']['code'] ?? null)
+                || str_contains($errorMessage, 'context length')
+                || str_contains($errorMessage, 'max_model_len')
+            ) {
+                throw new ExceedContextSizeException('' !== $errorMessage ? $errorMessage : 'Context size exceeded');
+            }
+
             throw new RuntimeException(\sprintf('Error "%s": "%s".', $data['error']['type'] ?? $data['error']['code'] ?? 'unknown', $data['error']['message'] ?? 'Unknown error'));
         }
 

--- a/src/platform/src/Bridge/Scaleway/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Llm/ResultConverterTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\Scaleway\Llm\ResultConverter;
 use Symfony\AI\Platform\Bridge\Scaleway\Scaleway;
 use Symfony\AI\Platform\Bridge\Scaleway\ScalewayResponses;
 use Symfony\AI\Platform\Exception\ContentFilterException;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -248,6 +249,24 @@ final class ResultConverterTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Error "invalid_request_error": "Invalid model specified"');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsExceedContextSizeExceptionOnContextOverflow()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = self::createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'code' => 'context_length_exceeded',
+                'message' => "This model's maximum context length is 128000 tokens.",
+            ],
+        ]);
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('maximum context length');
 
         $converter->convert(new RawHttpResult($httpResponse));
     }

--- a/src/platform/src/Bridge/VertexAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/VertexAi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `ExceedContextSizeException` when a 400 response reports a context overflow
+
 0.9
 ---
 

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\VertexAi\Gemini;
 
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model as BaseModel;
@@ -66,6 +67,16 @@ final class ResultConverter implements ResultConverterInterface
         if (429 === $response->getStatusCode()) {
             $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
             throw new RateLimitExceededException(null, $errorMessage);
+        }
+
+        if (400 === $response->getStatusCode()) {
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+
+            if (null !== $errorMessage
+                && (str_contains($errorMessage, 'maximum number of tokens') || str_contains($errorMessage, 'input token count'))
+            ) {
+                throw new ExceedContextSizeException($errorMessage);
+            }
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\VertexAi\Tests\Gemini;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ResultConverter;
+use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
@@ -53,6 +54,26 @@ final class ResultConverterTest extends TestCase
 
         $this->assertInstanceOf(TextResult::class, $result);
         $this->assertSame('Hello, world!', $result->getContent());
+    }
+
+    public function testItThrowsExceedContextSizeExceptionOnContextOverflow()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(400);
+        $response->method('getContent')->willReturn(json_encode([
+            'error' => [
+                'code' => 400,
+                'status' => 'INVALID_ARGUMENT',
+                'message' => 'The input token count (1294145) exceeds the maximum number of tokens allowed (1048576).',
+            ],
+        ]));
+
+        $resultConverter = new ResultConverter();
+
+        $this->expectException(ExceedContextSizeException::class);
+        $this->expectExceptionMessage('exceeds the maximum number of tokens allowed');
+
+        $resultConverter->convert(new RawHttpResult($response));
     }
 
     public function testItReturnsAggregatedTextOnSuccess()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Follow-up to #2165: extends `ExceedContextSizeException` to the remaining LLM bridges where the provider's context-overflow error is documented and detectable from the HTTP response.

Detection is centralized in a shared `ExceedContextSizeException::matches()` predicate, applied via `HttpStatusErrorHandlingTrait` (covers Cerebras, DeepSeek, Mistral, Cohere, Gemini, Perplexity) plus inline handling in Scaleway and VertexAI.

Skipped where no easy/documented signal exists: Bedrock, Ollama, Codex, ClaudeCode, Replicate, Azure/Meta, HuggingFace, TransformersPhp.