### PR TITLE
[Platform] Replace malformed UTF-8 in request bodies of the remaining LLM model clients

### DIFF
--- a/src/platform/src/Bridge/Azure/Meta/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Azure/Meta/LlamaModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Azure\Meta;
 
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -23,6 +24,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class LlamaModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly string $baseUrl,
@@ -48,7 +51,7 @@ final class LlamaModelClient implements ModelClientInterface
                 'Content-Type' => 'application/json',
                 'Authorization' => $this->apiKey,
             ],
-            'json' => array_merge($options, $payload),
+            'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Azure/Responses/ModelClient.php
+++ b/src/platform/src/Bridge/Azure/Responses/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Azure\Responses;
 
 use Symfony\AI\Platform\Bridge\OpenResponses\ResponsesModel;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -25,6 +26,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
     private readonly string $endpoint;
 
@@ -67,8 +70,9 @@ final class ModelClient implements ModelClientInterface
         return new RawHttpResult($this->httpClient->request('POST', $this->endpoint, [
             'headers' => [
                 'api-key' => $this->apiKey,
+                'Content-Type' => 'application/json',
             ],
-            'json' => array_merge($options, ['model' => $this->deployment ?? $model->getName()], $payload),
+            'body' => $this->encodeJsonBody(array_merge($options, ['model' => $this->deployment ?? $model->getName()], $payload)),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Azure/Tests/Meta/LlamaModelClientTest.php
+++ b/src/platform/src/Bridge/Azure/Tests/Meta/LlamaModelClientTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Azure\Tests\Meta;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Azure\Meta\LlamaModelClient;
+use Symfony\AI\Platform\Bridge\Meta\Llama;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class LlamaModelClientTest extends TestCase
+{
+    public function testItIsExecutingTheCorrectRequest()
+    {
+        $httpClient = new MockHttpClient([function (string $method, string $url, array $options): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://test.azure.com/chat/completions', $url);
+            $this->assertSame('Authorization: test-api-key', $options['normalized_headers']['authorization'][0]);
+            $this->assertSame('{"messages":[{"role":"user","content":"Hello"}]}', $options['body']);
+
+            return new MockResponse();
+        }]);
+
+        $client = new LlamaModelClient($httpClient, 'test.azure.com', 'test-api-key');
+        $client->request(new Llama('llama-3.3-70b-instruct'), ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
+    }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $httpClient = new MockHttpClient([function (string $method, string $url, array $options): MockResponse {
+            $this->assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            $this->assertJson($options['body']);
+            $this->assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new MockResponse();
+        }]);
+
+        $client = new LlamaModelClient($httpClient, 'test.azure.com', 'test-api-key');
+        $client->request(new Llama('llama-3.3-70b-instruct'), ['messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
+}

--- a/src/platform/src/Bridge/Azure/Tests/Responses/ModelClientTest.php
+++ b/src/platform/src/Bridge/Azure/Tests/Responses/ModelClientTest.php
@@ -130,4 +130,19 @@ final class ModelClientTest extends TestCase
         $client = new ModelClient($httpClient, 'test.openai.azure.com', 'test-api-key', 'gpt-4o');
         $client->request(new ResponsesModel('gpt-4o'), ['input' => [['role' => 'user', 'content' => 'Hello']]], $options);
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): MockResponse {
+            self::assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            self::assertJson($options['body']);
+            self::assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new MockResponse();
+        };
+
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $client = new ModelClient($httpClient, 'test.openai.azure.com', 'test-api-key');
+        $client->request(new ResponsesModel('gpt-4o'), ['input' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
 }

--- a/src/platform/src/Bridge/Cerebras/ModelClient.php
+++ b/src/platform/src/Bridge/Cerebras/ModelClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Cerebras;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -23,6 +24,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
 
     public function __construct(
@@ -59,7 +62,7 @@ final class ModelClient implements ModelClientInterface
                         'Content-Type' => 'application/json',
                         'Authorization' => \sprintf('Bearer %s', $this->apiKey),
                     ],
-                    'json' => array_merge($payload, $options),
+                    'body' => $this->encodeJsonBody(array_merge($payload, $options)),
                 ]
             )
         );

--- a/src/platform/src/Bridge/Cerebras/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Cerebras/Tests/ModelClientTest.php
@@ -86,4 +86,18 @@ class ModelClientTest extends TestCase
         $this->assertSame('https://api.cerebras.ai/v1/chat/completions', $info['url']);
         $this->assertSame($expectedResponse, $data);
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            $this->assertJson($options['body']);
+            $this->assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new JsonMockResponse(['choices' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'csk-1234567890abcdef');
+        $client->request(new Model('llama-3.3-70b'), ['messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
 }

--- a/src/platform/src/Bridge/Cohere/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Cohere\Llm;
 
 use Symfony\AI\Platform\Bridge\Cohere\Cohere;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -24,6 +25,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
@@ -46,7 +49,7 @@ final class ModelClient implements ModelClientInterface
             'headers' => [
                 'Content-Type' => 'application/json',
             ],
-            'json' => array_merge($options, $payload),
+            'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/ModelClientTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/ModelClientTest.php
@@ -63,4 +63,23 @@ final class ModelClientTest extends TestCase
 
         $client->request(new Cohere('command-a-03-2025'), 'string payload');
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $httpClient = new MockHttpClient([function (
+            string $method,
+            string $url,
+            array $options,
+        ): MockResponse {
+            $this->assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            $this->assertJson($options['body']);
+            $this->assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key');
+
+        $client->request(new Cohere('command-a-03-2025'), ['model' => 'command-a-03-2025', 'messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
 }

--- a/src/platform/src/Bridge/DeepSeek/ModelClient.php
+++ b/src/platform/src/Bridge/DeepSeek/ModelClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\DeepSeek;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -23,6 +24,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
 
     public function __construct(
@@ -45,7 +48,8 @@ final class ModelClient implements ModelClientInterface
 
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.deepseek.com/chat/completions', [
             'auth_bearer' => $this->apiKey,
-            'json' => array_merge($options, $payload),
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));
     }
 }

--- a/src/platform/src/Bridge/DeepSeek/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/DeepSeek/Tests/ModelClientTest.php
@@ -85,4 +85,18 @@ final class ModelClientTest extends TestCase
         );
         $this->assertTrue($requestMade);
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $httpClient = new MockHttpClient(static function ($method, $url, $options) {
+            self::assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            self::assertJson($options['body']);
+            self::assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new JsonMockResponse(['choices' => [['message' => ['content' => 'Hello'], 'finish_reason' => 'stop']]]);
+        });
+
+        $modelClient = new ModelClient($httpClient, 'test-api-key');
+        $modelClient->request(new DeepSeek('deepseek-chat'), ['messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
 }

--- a/src/platform/src/Bridge/DockerModelRunner/Completions/ModelClient.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Completions/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\DockerModelRunner\Completions;
 
 use Symfony\AI\Platform\Bridge\DockerModelRunner\Completions;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -24,6 +25,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
 
     public function __construct(
@@ -45,7 +48,8 @@ final class ModelClient implements ModelClientInterface
         }
 
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/engines/v1/chat/completions', $this->hostUrl), [
-            'json' => array_merge($options, $payload),
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));
     }
 }

--- a/src/platform/src/Bridge/DockerModelRunner/Tests/Completions/ModelClientTest.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Tests/Completions/ModelClientTest.php
@@ -92,4 +92,19 @@ class ModelClientTest extends TestCase
 
         $this->assertSame($eventSourceHttpClient, $reflection->getValue($client));
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): MockResponse {
+            self::assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            self::assertJson($options['body']);
+            self::assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new MockResponse();
+        };
+
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $client = new ModelClient($httpClient, 'http://localhost:1234');
+        $client->request(new Completions('test-model'), ['model' => 'test-model', 'messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
 }

--- a/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Gemini\Gemini;
 
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -26,6 +27,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
 
     public function __construct(
@@ -92,8 +95,9 @@ final class ModelClient implements ModelClientInterface
         return new RawHttpResult($this->httpClient->request('POST', $url, [
             'headers' => [
                 'x-goog-api-key' => $this->apiKey,
+                'Content-Type' => 'application/json',
             ],
-            'json' => array_merge($config, $payload),
+            'body' => $this->encodeJsonBody(array_merge($config, $payload)),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ModelClientTest.php
@@ -81,4 +81,18 @@ final class ModelClientTest extends TestCase
         $client = new ModelClient($httpClient, 'test-api-key');
         $client->request(new Gemini('gemini-1.5-flash'), ['contents' => []], ['stream' => true]);
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            $this->assertJson($options['body']);
+            $this->assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new JsonMockResponse(['candidates' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'test-api-key');
+        $client->request(new Gemini('gemini-1.5-flash'), ['contents' => [['parts' => [['text' => "tool output \xB1 here"]]]]]);
+    }
 }

--- a/src/platform/src/Bridge/Generic/Completions/ModelClient.php
+++ b/src/platform/src/Bridge/Generic/Completions/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Generic\Completions;
 
 use Symfony\AI\Platform\Bridge\Generic\CompletionsModel;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -27,6 +28,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
 
     public function __construct(
@@ -65,7 +68,7 @@ class ModelClient implements ModelClientInterface
         return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.$this->path, [
             'auth_bearer' => $this->apiKey,
             'headers' => ['Content-Type' => 'application/json'],
-            'json' => array_merge($options, $payload),
+            'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
@@ -143,4 +143,18 @@ final class ModelClientTest extends TestCase
         $modelClient = new ModelClient($httpClient, 'https://api.inference.com', 'sk-valid-api-key', $path);
         $modelClient->request(new CompletionsModel('gpt-4o'), ['messages' => []]);
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
+            self::assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            self::assertJson($options['body']);
+            self::assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'http://localhost:8000', 'sk-valid-api-key');
+        $modelClient->request(new CompletionsModel('gpt-4o'), ['messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
 }

--- a/src/platform/src/Bridge/HuggingFace/ModelClient.php
+++ b/src/platform/src/Bridge/HuggingFace/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\HuggingFace;
 
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -22,6 +23,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
 
     public function __construct(
@@ -82,7 +85,7 @@ final class ModelClient implements ModelClientInterface
             }
 
             return [
-                'json' => ['inputs' => $inputs],
+                'body' => $this->encodeJsonBody(['inputs' => $inputs]),
                 'headers' => ['Content-Type' => 'application/json'],
             ];
         }
@@ -104,6 +107,12 @@ final class ModelClient implements ModelClientInterface
         // Third-party providers need the model name in the JSON body
         if (Task::CHAT_COMPLETION === $task && Provider::HF_INFERENCE !== $provider && isset($payload['json'])) {
             $payload['json']['model'] = $model->getName();
+        }
+
+        // Encode the JSON payload ourselves to tolerate malformed UTF-8 (e.g. raw tool output)
+        if (isset($payload['json'])) {
+            $payload['body'] = $this->encodeJsonBody($payload['json']);
+            unset($payload['json']);
         }
 
         $payload['headers'] ??= ['Content-Type' => 'application/json'];

--- a/src/platform/src/Bridge/HuggingFace/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/HuggingFace/Tests/ModelClientTest.php
@@ -295,6 +295,35 @@ final class ModelClientTest extends TestCase
         $this->assertContains('Content-Type: image/jpeg', $requestOptions['headers']);
     }
 
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $response = new MockResponse('{"result": "test"}');
+        $httpClient = new MockHttpClient($response);
+
+        $model = new Model('test-model');
+        $modelClient = new ModelClient($httpClient, Provider::HF_INFERENCE, 'test-api-key');
+
+        $contract = Contract::create([
+            new FileNormalizer(),
+            new MessageBagNormalizer(),
+        ]);
+
+        $messageBag = new MessageBag();
+        $messageBag->add(new UserMessage(new Text("tool output \xB1 here")));
+
+        $payload = $contract->createRequestPayload($model, $messageBag);
+
+        $modelClient->request($model, $payload, [
+            'task' => Task::CHAT_COMPLETION,
+        ]);
+
+        $requestOptions = $response->getRequestOptions();
+
+        $this->assertContains('Content-Type: application/json', $requestOptions['headers']);
+        $this->assertJson($requestOptions['body']);
+        $this->assertStringContainsString('tool output \ufffd here', $requestOptions['body']);
+    }
+
     public static function payloadTestCases(): \Iterator
     {
         yield 'string input' => [

--- a/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Mistral\Llm;
 
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -24,6 +25,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
 
     public function __construct(
@@ -50,7 +53,7 @@ final class ModelClient implements ModelClientInterface
                 'Content-Type' => 'application/json',
                 'Accept' => 'application/json',
             ],
-            'json' => array_merge($options, $payload),
+            'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Mistral/Tests/Llm/ModelClientTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Llm/ModelClientTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\Llm;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Llm\ModelClient;
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ModelClientTest extends TestCase
+{
+    public function testItIsExecutingTheCorrectRequest()
+    {
+        $httpClient = new MockHttpClient([function (string $method, string $url, array $options): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.mistral.ai/v1/chat/completions', $url);
+            $this->assertSame('Authorization: Bearer test-api-key', $options['normalized_headers']['authorization'][0]);
+            $this->assertSame('{"messages":[{"role":"user","content":"Hello"}]}', $options['body']);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-api-key');
+        $client->request(new Mistral('mistral-large-latest'), ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
+    }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $httpClient = new MockHttpClient([function (string $method, string $url, array $options): MockResponse {
+            $this->assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            $this->assertJson($options['body']);
+            $this->assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-api-key');
+        $client->request(new Mistral('mistral-large-latest'), ['messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
+}

--- a/src/platform/src/Bridge/Ollama/OllamaClient.php
+++ b/src/platform/src/Bridge/Ollama/OllamaClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Ollama;
 
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -25,6 +26,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class OllamaClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private const CHAT_TOP_LEVEL_KEYS = [
         'stream',
         'format',
@@ -82,7 +85,7 @@ final class OllamaClient implements ModelClientInterface
 
         $response = $this->httpClient->request('POST', '/api/chat', [
             'headers' => ['Content-Type' => 'application/json'],
-            'json' => array_merge($options, $payload),
+            'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]);
 
         return new RawHttpResult($response, new NdjsonStream());

--- a/src/platform/src/Bridge/Ollama/Tests/OllamaClientTest.php
+++ b/src/platform/src/Bridge/Ollama/Tests/OllamaClientTest.php
@@ -336,6 +336,24 @@ final class OllamaClientTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            $this->assertJson($options['body']);
+            $this->assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new JsonMockResponse([
+                'model' => 'llama3.2',
+                'message' => ['role' => 'assistant', 'content' => 'ok'],
+                'done' => true,
+            ]);
+        }, 'http://127.0.0.1:1234');
+
+        $client = new OllamaClient($httpClient);
+        $client->request(new Ollama('llama3.2', [Capability::INPUT_MESSAGES]), ['model' => 'llama3.2', 'messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
+
     /**
      * @param array<string, mixed> $options
      *

--- a/src/platform/src/Bridge/Perplexity/ModelClient.php
+++ b/src/platform/src/Bridge/Perplexity/ModelClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Perplexity;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -24,6 +25,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
 
     public function __construct(
@@ -54,7 +57,8 @@ final class ModelClient implements ModelClientInterface
 
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.perplexity.ai/chat/completions', [
             'auth_bearer' => $this->apiKey,
-            'json' => array_merge($options, $payload),
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Perplexity/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Perplexity/Tests/ModelClientTest.php
@@ -107,4 +107,18 @@ final class ModelClientTest extends TestCase
         $modelClient = new ModelClient($httpClient, 'pplx-api-key');
         $modelClient->request(new Perplexity('sonar'), ['model' => 'sonar', 'messages' => [['role' => 'user', 'content' => 'Hello']]]);
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
+            self::assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            self::assertJson($options['body']);
+            self::assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'pplx-api-key');
+        $modelClient->request(new Perplexity('sonar'), ['model' => 'sonar', 'messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
 }

--- a/src/platform/src/Bridge/Replicate/Client.php
+++ b/src/platform/src/Bridge/Replicate/Client.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Replicate;
 
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -21,6 +22,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class Client
 {
+    use JsonBodyEncodingTrait;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly ClockInterface $clock,
@@ -39,7 +42,7 @@ final class Client
         $response = $this->httpClient->request('POST', $url, [
             'headers' => ['Content-Type' => 'application/json'],
             'auth_bearer' => $this->apiKey,
-            'json' => ['input' => $body],
+            'body' => $this->encodeJsonBody(['input' => $body]),
         ]);
         $data = $response->toArray(false);
 

--- a/src/platform/src/Bridge/Replicate/Tests/ClientTest.php
+++ b/src/platform/src/Bridge/Replicate/Tests/ClientTest.php
@@ -120,4 +120,18 @@ final class ClientTest extends TestCase
 
         $client->request('meta/llama-3.1-405b-instruct', 'predictions', ['prompt' => 'Hello']);
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): MockResponse {
+            self::assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            self::assertJson($options['body']);
+            self::assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new MockResponse('{"status": "succeeded", "output": ["ok"]}');
+        });
+
+        $client = new Client($httpClient, new MockClock(), 'test-api-key');
+        $client->request('meta/llama-3.1-405b-instruct', 'predictions', ['prompt' => "tool output \xB1 here"]);
+    }
 }

--- a/src/platform/src/Bridge/Scaleway/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Scaleway/Llm/ModelClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Scaleway\Llm;
 
 use Symfony\AI\Platform\Bridge\Scaleway\Scaleway;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -24,6 +25,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
 
     public function __construct(
@@ -46,7 +49,8 @@ final class ModelClient implements ModelClientInterface
 
         return new RawHttpResult($this->httpClient->request('POST', 'https://api.scaleway.ai/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,
-            'json' => array_merge($options, $payload),
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Scaleway/Tests/Llm/ModelClientTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Llm/ModelClientTest.php
@@ -105,4 +105,18 @@ final class ModelClientTest extends TestCase
         $modelClient = new ModelClient($httpClient, 'scaleway-api-key');
         $modelClient->request(new Scaleway('deepseek-r1-distill-llama-70b'), ['messages' => []], []);
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
+            self::assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            self::assertJson($options['body']);
+            self::assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'scaleway-api-key');
+        $modelClient->request(new Scaleway('deepseek-r1-distill-llama-70b'), ['messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
+    }
 }

--- a/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\VertexAi\Gemini;
 
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -24,6 +25,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly EventSourceHttpClient $httpClient;
 
     public function __construct(
@@ -126,7 +129,8 @@ final class ModelClient implements ModelClientInterface
                 'POST',
                 $url,
                 [
-                    'json' => array_merge($options, $payload),
+                    'headers' => ['Content-Type' => 'application/json'],
+                    'body' => $this->encodeJsonBody(array_merge($options, $payload)),
                     'query' => $query,
                 ]
             )

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
@@ -92,4 +92,18 @@ final class ModelClientTest extends TestCase
         $client = new ModelClient($httpClient, 'global', 'test');
         $client->request(new Model('gemini-2.0-flash'), $payload, ['server_tools' => ['google_search' => true]]);
     }
+
+    public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+            $this->assertJson($options['body']);
+            $this->assertStringContainsString('tool output \ufffd here', $options['body']);
+
+            return new JsonMockResponse(['candidates' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => [['parts' => [['text' => "tool output \xB1 here"]]]]]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

Follow-up to #2163, which introduced `JsonBodyEncodingTrait` for the Anthropic, GPT, and OpenResponses bridges. This rolls the same malformed-UTF-8-tolerant encoding out to the remaining HTTP-based LLM chat clients: Azure (Llama, Responses), Cerebras, Cohere, DeepSeek, DockerModelRunner, Gemini, Generic, HuggingFace, Mistral, Ollama (chat endpoint), Perplexity, Replicate, Scaleway, and Vertex AI.

Each client now sends an explicit `Content-Type: application/json` header where it wasn't already set, and a `testMalformedUtf8InPayloadDoesNotAbortTheRequest` test was added per bridge.

HuggingFace and Replicate build their request bodies differently (HuggingFace assembles the payload across several task-dependent branches and also supports raw binary bodies; Replicate wraps the payload in `{"input": ...}` via a shared helper), so the encoding is applied at the single point where the JSON body is finalized rather than via a one-line option swap.
