### PR TITLE
[Platform] Throw IncompleteStreamException in more streaming bridges

### DIFF
--- a/src/platform/src/Bridge/Cerebras/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cerebras/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+ * Throw `IncompleteStreamException` when a stream ends before a finish reason
 
 0.8
 ---

--- a/src/platform/src/Bridge/Cohere/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cohere/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+ * Throw `IncompleteStreamException` when a stream ends before `message-end`
 
 0.8
 ---

--- a/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Cohere\Llm;
 
 use Symfony\AI\Platform\Bridge\Cohere\Cohere;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
+use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
@@ -90,7 +91,10 @@ final class ResultConverter implements ResultConverterInterface
     private function convertStream(RawResultInterface $result): \Generator
     {
         $toolCalls = [];
+        $sawChunk = false;
+        $sawMessageEnd = false;
         foreach ($result->getDataStream() as $data) {
+            $sawChunk = true;
             $type = $data['type'] ?? null;
 
             if ('content-delta' === $type) {
@@ -120,9 +124,25 @@ final class ResultConverter implements ResultConverterInterface
                 continue;
             }
 
-            if ('message-end' === $type && [] !== $toolCalls) {
-                yield new ToolCallComplete(array_map($this->convertToolCall(...), $toolCalls));
+            if ('message-end' === $type) {
+                $sawMessageEnd = true;
+
+                $error = $data['delta']['error'] ?? null;
+                $finishReason = $data['delta']['finish_reason'] ?? null;
+                if (null !== $error || 'ERROR' === $finishReason) {
+                    $message = \is_array($error) ? ($error['message'] ?? 'Unknown error') : ($error ?? 'Unknown error');
+
+                    throw new RuntimeException(\sprintf('Cohere stream error: "%s".', $message));
+                }
+
+                if ([] !== $toolCalls) {
+                    yield new ToolCallComplete(array_map($this->convertToolCall(...), $toolCalls));
+                }
             }
+        }
+
+        if ($sawChunk && !$sawMessageEnd) {
+            throw new IncompleteStreamException('Cohere stream ended before message-end.');
         }
     }
 

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Cohere\Cohere;
 use Symfony\AI\Platform\Bridge\Cohere\Llm\ResultConverter;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
+use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -231,6 +232,80 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('call_1', $toolCalls[0]->getId());
         $this->assertSame('get_time', $toolCalls[0]->getName());
         $this->assertSame([], $toolCalls[0]->getArguments());
+    }
+
+    public function testItThrowsIncompleteStreamWhenMessageEndIsMissing()
+    {
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(
+            new InMemoryRawResult([], [
+                ['type' => 'content-delta', 'delta' => ['message' => ['content' => ['text' => 'Hello']]]],
+                // stream cut off: no message-end event
+            ], $httpResponse),
+            ['stream' => true],
+        );
+
+        $this->expectException(IncompleteStreamException::class);
+        $this->expectExceptionMessage('Cohere stream ended before message-end.');
+
+        iterator_to_array($result->getContent());
+    }
+
+    public function testItThrowsOnMessageEndError()
+    {
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(
+            new InMemoryRawResult([], [
+                ['type' => 'content-delta', 'delta' => ['message' => ['content' => ['text' => 'Hello']]]],
+                ['type' => 'message-end', 'delta' => ['finish_reason' => 'ERROR', 'error' => 'Something went wrong']],
+            ], $httpResponse),
+            ['stream' => true],
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cohere stream error: "Something went wrong".');
+
+        iterator_to_array($result->getContent());
+    }
+
+    public function testItThrowsOnStructuredMessageEndError()
+    {
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(
+            new InMemoryRawResult([], [
+                ['type' => 'content-delta', 'delta' => ['message' => ['content' => ['text' => 'Hello']]]],
+                ['type' => 'message-end', 'delta' => ['finish_reason' => 'ERROR', 'error' => ['message' => 'Something went wrong']]],
+            ], $httpResponse),
+            ['stream' => true],
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cohere stream error: "Something went wrong".');
+
+        iterator_to_array($result->getContent());
+    }
+
+    public function testItDoesNotThrowOnEmptyStream()
+    {
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(
+            new InMemoryRawResult([], [], $httpResponse),
+            ['stream' => true],
+        );
+
+        $this->assertSame([], iterator_to_array($result->getContent()));
     }
 
     public function testGetTokenUsageExtractor()

--- a/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
+++ b/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+ * Throw `IncompleteStreamException` when a stream ends before a finish reason
 
 0.8
 ---

--- a/src/platform/src/Bridge/DockerModelRunner/CHANGELOG.md
+++ b/src/platform/src/Bridge/DockerModelRunner/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `IncompleteStreamException` when a stream ends before a finish reason
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
+++ b/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Generic\Completions;
 
+use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
@@ -38,8 +39,23 @@ trait CompletionsConversionTrait
     {
         $toolCalls = [];
         $reasoning = '';
+        $sawChunk = false;
+        $sawFinishReason = false;
 
         foreach ($result->getDataStream() as $data) {
+            if (isset($data['error'])) {
+                $message = \is_array($data['error']) ? ($data['error']['message'] ?? 'Unknown error') : (string) $data['error'];
+                throw new RuntimeException(\sprintf('Stream error: "%s".', $message));
+            }
+
+            $sawChunk = true;
+
+            // A non-null finish_reason on the leading choice marks the terminal content chunk.
+            // It is null on every non-final chunk, and a trailing usage-only chunk has choices: [].
+            if (null !== ($data['choices'][0]['finish_reason'] ?? null)) {
+                $sawFinishReason = true;
+            }
+
             if (isset($data['usage'])) {
                 yield $this->convertStreamUsage($data['usage']);
             }
@@ -74,6 +90,10 @@ trait CompletionsConversionTrait
 
         if ('' !== $reasoning) {
             yield new ThinkingComplete($reasoning);
+        }
+
+        if ($sawChunk && !$sawFinishReason) {
+            throw new IncompleteStreamException('Completions stream ended before a finish reason was received.');
         }
     }
 

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
+use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
@@ -386,14 +387,7 @@ class ResultConverterTest extends TestCase
             ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'tool_calls']]],
         ];
 
-        $httpLike = new class {
-            public function getStatusCode(): int
-            {
-                return 200;
-            }
-        };
-
-        $raw = new InMemoryRawResult([], $events, $httpLike);
+        $raw = new InMemoryRawResult([], $events, $this->httpResponseStub());
         $streamResult = $converter->convert($raw, ['stream' => true]);
 
         $this->assertInstanceOf(StreamResult::class, $streamResult);
@@ -434,5 +428,94 @@ class ResultConverterTest extends TestCase
         $this->assertSame('call_1', $completed[0]->getId());
         $this->assertSame('get_weather', $completed[0]->getName());
         $this->assertSame(['city' => 'Beijing'], $completed[0]->getArguments());
+    }
+
+    public function testStreamingThrowsWhenFinishReasonIsMissing()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'Hello, ']]]],
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'world!']]]],
+            // stream cut off: no terminal chunk carrying a non-null finish_reason
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+
+        $this->expectException(IncompleteStreamException::class);
+        $this->expectExceptionMessage('Completions stream ended before a finish reason was received.');
+
+        iterator_to_array($streamResult->getContent());
+    }
+
+    public function testStreamingDoesNotThrowWhenFinishReasonIsPresent()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'Hello, ']]]],
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'world!']]]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+
+        $chunks = iterator_to_array($streamResult->getContent());
+
+        $this->assertCount(2, $chunks);
+        $this->assertContainsOnlyInstancesOf(TextDelta::class, $chunks);
+    }
+
+    public function testStreamingDoesNotThrowWithUsageOnlyFinalChunk()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'Hi']]]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
+            ['choices' => [], 'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2]],
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+
+        $textDeltas = array_values(array_filter(iterator_to_array($streamResult->getContent()), static fn ($c) => $c instanceof TextDelta));
+        $this->assertCount(1, $textDeltas);
+        $this->assertSame('Hi', $textDeltas[0]->getText());
+    }
+
+    public function testStreamingDoesNotThrowOnEmptyStream()
+    {
+        $converter = new ResultConverter();
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], [], $this->httpResponseStub()), ['stream' => true]);
+
+        $this->assertSame([], iterator_to_array($streamResult->getContent()));
+    }
+
+    public function testStreamingThrowsOnTopLevelErrorEvent()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'partial']]]],
+            ['error' => ['message' => 'Provider exploded mid-stream', 'code' => 'server_error']],
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Stream error: "Provider exploded mid-stream".');
+
+        iterator_to_array($streamResult->getContent());
+    }
+
+    private function httpResponseStub(): object
+    {
+        return new class {
+            public function getStatusCode(): int
+            {
+                return 200;
+            }
+        };
     }
 }

--- a/src/platform/src/Bridge/Mistral/CHANGELOG.md
+++ b/src/platform/src/Bridge/Mistral/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+ * Throw `IncompleteStreamException` when a stream ends before a finish reason
 
 0.8
 ---

--- a/src/platform/src/Bridge/Ollama/CHANGELOG.md
+++ b/src/platform/src/Bridge/Ollama/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `IncompleteStreamException` when a stream ends before a `done` message
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
+++ b/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Ollama;
 
+use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -102,7 +103,21 @@ final class OllamaResultConverter implements ResultConverterInterface
     private function convertStream(RawResultInterface $result): \Generator
     {
         $toolCalls = [];
+        $sawChunk = false;
+        $sawDone = false;
         foreach ($result->getDataStream() as $data) {
+            // Ollama emits {"error": "..."} on HTTP 200 in practice; not part of the
+            // documented schema, so this guard is defensive.
+            if (isset($data['error'])) {
+                throw new RuntimeException(\sprintf('Ollama stream error: "%s".', \is_string($data['error']) ? $data['error'] : 'Unknown error'));
+            }
+
+            $sawChunk = true;
+
+            if (isset($data['done']) && true === $data['done']) {
+                $sawDone = true;
+            }
+
             if ($this->streamIsToolCall($data)) {
                 $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);
             }
@@ -125,6 +140,10 @@ final class OllamaResultConverter implements ResultConverterInterface
                     completionTokens: $data['eval_count'],
                 );
             }
+        }
+
+        if ($sawChunk && !$sawDone) {
+            throw new IncompleteStreamException('Ollama stream ended before a "done" message.');
         }
     }
 

--- a/src/platform/src/Bridge/Ollama/Tests/OllamaResultConverterTest.php
+++ b/src/platform/src/Bridge/Ollama/Tests/OllamaResultConverterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Ollama\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Ollama\Ollama;
 use Symfony\AI\Platform\Bridge\Ollama\OllamaResultConverter;
+use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -249,6 +250,39 @@ final class OllamaResultConverterTest extends TestCase
         $this->assertInstanceOf(TokenUsageInterface::class, $chunks[1]);
         $this->assertSame(11, $chunks[1]->getPromptTokens());
         $this->assertSame(4, $chunks[1]->getCompletionTokens());
+    }
+
+    public function testConvertStreamingThrowsWhenDoneIsMissing()
+    {
+        $converter = new OllamaResultConverter();
+        $rawResult = new InMemoryRawResult(dataStream: (static function (): iterable {
+            yield ['model' => 'llama3.2', 'message' => ['role' => 'assistant', 'content' => 'Hello'], 'done' => false];
+            yield ['model' => 'llama3.2', 'message' => ['role' => 'assistant', 'content' => ' world'], 'done' => false];
+            // stream cut off: no object with done => true
+        })());
+
+        $result = $converter->convert($rawResult, options: ['stream' => true]);
+
+        $this->expectException(IncompleteStreamException::class);
+        $this->expectExceptionMessage('Ollama stream ended before a "done" message.');
+
+        iterator_to_array($result->getContent());
+    }
+
+    public function testConvertStreamingThrowsOnErrorObject()
+    {
+        $converter = new OllamaResultConverter();
+        $rawResult = new InMemoryRawResult(dataStream: (static function (): iterable {
+            yield ['model' => 'llama3.2', 'message' => ['role' => 'assistant', 'content' => 'Hello'], 'done' => false];
+            yield ['error' => 'model runner crashed'];
+        })());
+
+        $result = $converter->convert($rawResult, options: ['stream' => true]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Ollama stream error: "model runner crashed".');
+
+        iterator_to_array($result->getContent());
     }
 
     /**

--- a/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw `IncompleteStreamException` when a stream ends before a finish reason
+
 0.9
 ---
 

--- a/src/platform/src/Bridge/Scaleway/CHANGELOG.md
+++ b/src/platform/src/Bridge/Scaleway/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ExceedContextSizeException` when a 400 response reports a context overflow
+ * Throw `IncompleteStreamException` when a stream ends before a finish reason
 
 0.9
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

Follow-up to #2162, extending incomplete-stream detection to the remaining streaming bridges whose terminal/error semantics are clearly documented:

- `Generic\Completions\CompletionsConversionTrait` (covers Mistral, DeepSeek, Cerebras, OpenRouter, Scaleway, DockerModelRunner) — throws when a stream ends before a non-null `finish_reason`.
- Cohere — throws when a stream ends before `message-end`, and surfaces `message-end` errors (string or structured).
- Ollama — throws when a stream ends before a `done` message.

A genuinely empty stream (zero chunks) is treated as a no-op in all three, not an incomplete stream.

Gemini/VertexAi, Perplexity, Codex and ElevenLabs are intentionally skipped (undocumented or anomalous terminal/error semantics).