### PR TITLE
[Platform] Parse SSE streams that omit the text/event-stream content type

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.10
 ----
 
+ * Add `RawSseStream` to parse Server-Sent Events from backends that omit the `text/event-stream` content type (used by the OpenResponses bridge for the ChatGPT Codex backend); `SseStream` now decodes only content-type-advertised SSE
  * Add `IncompleteStreamException`, thrown by bridge converters when a stream ends before its terminal event
  * Throw `ModelNotFoundException` on HTTP 404 responses in the shared `HttpStatusErrorHandlingTrait`
  * Add `JsonBodyEncodingTrait` so model clients can encode JSON request bodies without aborting on malformed UTF-8

--- a/src/platform/src/Bridge/OpenResponses/ModelClient.php
+++ b/src/platform/src/Bridge/OpenResponses/ModelClient.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\RawSseStream;
 use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
 use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -67,6 +68,8 @@ class ModelClient implements ModelClientInterface
             $requestOptions['auth_bearer'] = $this->apiKey;
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.$this->path, $requestOptions));
+        // The ChatGPT Codex backend streams SSE without a text/event-stream
+        // content type, so use a stream parser that handles that framing too.
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.$this->path, $requestOptions), new RawSseStream());
     }
 }

--- a/src/platform/src/Bridge/OpenResponses/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ModelClientTest.php
@@ -122,6 +122,22 @@ final class ModelClientTest extends TestCase
         );
     }
 
+    public function testItParsesHeaderlessSseStreams()
+    {
+        $response = new MockResponse(
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}\n\n",
+            ['response_headers' => ['content-type' => 'application/json']],
+        );
+        $modelClient = new ModelClient(new MockHttpClient([$response]), 'https://api.example.com', 'test-api-key');
+
+        $result = $modelClient->request(new ResponsesModel('test-model'), ['input' => []], ['stream' => true]);
+
+        $this->assertSame(
+            [['type' => 'response.output_text.delta', 'delta' => 'Hello']],
+            iterator_to_array($result->getDataStream(), false),
+        );
+    }
+
     public function testItHandlesStructuredOutputOption()
     {
         $resultCallback = static function (string $method, string $url, array $options): HttpResponse {

--- a/src/platform/src/Result/Stream/RawSseStream.php
+++ b/src/platform/src/Result/Stream/RawSseStream.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Stream;
+
+use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Handles Server-Sent Events streaming responses that omit the
+ * "text/event-stream" content type (e.g. the ChatGPT Codex inference
+ * endpoint). Without that header the HTTP client never assembles the
+ * "event:"/"data:" framing into {@see ServerSentEvent} chunks, so the raw body
+ * is buffered here and split on blank-line event separators before each
+ * "data:" payload is decoded. Responses that do advertise the header are
+ * handled by {@see SseStream}.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class RawSseStream implements HttpStreamInterface
+{
+    public function stream(ResponseInterface $response): iterable
+    {
+        $buffer = '';
+
+        foreach ((new EventSourceHttpClient())->stream($response) as $chunk) {
+            if ($chunk->isFirst() || $chunk->isLast()) {
+                continue;
+            }
+
+            // Defensive: the content type may have been present after all, in
+            // which case the client already framed the event for us.
+            if ($chunk instanceof ServerSentEvent) {
+                if (null !== $event = $this->decode($chunk->getData())) {
+                    yield $event;
+                }
+
+                continue;
+            }
+
+            $buffer .= $chunk->getContent();
+
+            // Events are separated by a blank line, which the SSE spec allows to
+            // use any of LF, CR or CRLF as a line ending.
+            while (1 === preg_match('/(?:\r\n){2,}|\r{2,}|\n{2,}/', $buffer, $match, \PREG_OFFSET_CAPTURE)) {
+                $block = substr($buffer, 0, $match[0][1]);
+                $buffer = substr($buffer, $match[0][1] + \strlen($match[0][0]));
+
+                if (null !== $event = $this->decode($this->extractEventData($block))) {
+                    yield $event;
+                }
+            }
+        }
+
+        // Flush a trailing event that ended without a final blank-line separator.
+        if (null !== $event = $this->decode($this->extractEventData($buffer))) {
+            yield $event;
+        }
+    }
+
+    /**
+     * Extracts the concatenated "data:" payload from a raw SSE event block.
+     */
+    private function extractEventData(string $block): ?string
+    {
+        // A UTF-8 byte order mark may prefix the very first event of the stream.
+        if (str_starts_with($block, "\xEF\xBB\xBF")) {
+            $block = substr($block, 3);
+        }
+
+        $data = null;
+        foreach (explode("\n", str_replace(["\r\n", "\r"], "\n", $block)) as $line) {
+            // lines starting with a colon are comments
+            if (str_starts_with($line, ':')) {
+                continue;
+            }
+
+            if (str_starts_with($line, 'data:')) {
+                $payload = ltrim(substr($line, 5), ' ');
+                $data = null === $data ? $payload : $data."\n".$payload;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decode(?string $data): ?array
+    {
+        if (null === $data) {
+            return null;
+        }
+
+        $data = trim($data);
+        if ('' === $data || '[DONE]' === $data) {
+            return null;
+        }
+
+        return json_decode($data, true, flags: \JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/platform/src/Result/Stream/SseStream.php
+++ b/src/platform/src/Result/Stream/SseStream.php
@@ -16,7 +16,10 @@ use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
- * Handles SSE (Server-Sent Events) streaming responses.
+ * Handles Server-Sent Events streaming responses that advertise the
+ * "text/event-stream" content type, so the HTTP client assembles each event
+ * into a {@see ServerSentEvent} chunk before it reaches this decoder. Backends
+ * that omit that header are handled by {@see RawSseStream}.
  *
  * @author Johannes Wachter <johannes@sulu.io>
  */
@@ -25,31 +28,16 @@ final class SseStream implements HttpStreamInterface
     public function stream(ResponseInterface $response): iterable
     {
         foreach ((new EventSourceHttpClient())->stream($response) as $chunk) {
-            if ($chunk->isFirst() || $chunk->isLast() || ($chunk instanceof ServerSentEvent && '[DONE]' === $chunk->getData())) {
+            if (!$chunk instanceof ServerSentEvent) {
                 continue;
             }
 
-            $jsonDelta = $chunk instanceof ServerSentEvent ? $chunk->getData() : $chunk->getContent();
-
-            // Remove leading/trailing brackets
-            if (str_starts_with($jsonDelta, '[') || str_starts_with($jsonDelta, ',')) {
-                $jsonDelta = substr($jsonDelta, 1);
-            }
-            if (str_ends_with($jsonDelta, ']')) {
-                $jsonDelta = substr($jsonDelta, 0, -1);
+            $data = $chunk->getData();
+            if ('' === $data || '[DONE]' === $data) {
+                continue;
             }
 
-            // Split in case of multiple JSON objects
-            $deltas = explode(",\r\n", $jsonDelta);
-
-            foreach ($deltas as $delta) {
-                // lines starting with a colon identify as comment
-                if ('' === trim($delta) || str_starts_with($delta, ':')) {
-                    continue;
-                }
-
-                yield json_decode($delta, true, flags: \JSON_THROW_ON_ERROR);
-            }
+            yield json_decode($data, true, flags: \JSON_THROW_ON_ERROR);
         }
     }
 }

--- a/src/platform/tests/Result/Stream/RawSseStreamTest.php
+++ b/src/platform/tests/Result/Stream/RawSseStreamTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result\Stream;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\Stream\RawSseStream;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class RawSseStreamTest extends TestCase
+{
+    public function testParsesRegularSseWithEventStreamContentType()
+    {
+        $body = "data: {\"foo\": \"bar\"}\n\ndata: {\"baz\": \"qux\"}\n\ndata: [DONE]\n\n";
+        $response = $this->createResponse($body, 'text/event-stream');
+
+        $results = iterator_to_array((new RawSseStream())->stream($response), false);
+
+        $this->assertSame([['foo' => 'bar'], ['baz' => 'qux']], $results);
+    }
+
+    public function testParsesSseFramingWhenContentTypeIsNotEventStream()
+    {
+        // The ChatGPT Codex backend streams SSE without advertising
+        // "text/event-stream", so the chunks arrive raw and still carry the
+        // "event:"/"data:" framing.
+        $body = "event: response.output_text.delta\ndata: {\"foo\": \"bar\"}\n\n"
+            ."event: response.completed\ndata: {\"baz\": \"qux\"}\n\ndata: [DONE]\n\n";
+        $response = $this->createResponse($body, 'application/json');
+
+        $results = iterator_to_array((new RawSseStream())->stream($response), false);
+
+        $this->assertSame([['foo' => 'bar'], ['baz' => 'qux']], $results);
+    }
+
+    public function testParsesSseFramingSplitAcrossChunks()
+    {
+        $response = $this->createResponse(['data: {"foo": ', "\"bar\"}\n\ndata: {\"baz\": \"qux\"}\n\n"], 'application/json');
+
+        $results = iterator_to_array((new RawSseStream())->stream($response), false);
+
+        $this->assertSame([['foo' => 'bar'], ['baz' => 'qux']], $results);
+    }
+
+    public function testParsesSseFramingWithCrlfLineEndings()
+    {
+        $body = "event: x\r\ndata: {\"foo\": \"bar\"}\r\n\r\ndata: {\"baz\": \"qux\"}\r\n\r\n";
+        $response = $this->createResponse($body, 'application/json');
+
+        $results = iterator_to_array((new RawSseStream())->stream($response), false);
+
+        $this->assertSame([['foo' => 'bar'], ['baz' => 'qux']], $results);
+    }
+
+    public function testParsesSseFramingWithBareCrLineEndings()
+    {
+        $body = "event: x\rdata: {\"foo\": \"bar\"}\r\rdata: {\"baz\": \"qux\"}\r\r";
+        $response = $this->createResponse($body, 'application/json');
+
+        $results = iterator_to_array((new RawSseStream())->stream($response), false);
+
+        $this->assertSame([['foo' => 'bar'], ['baz' => 'qux']], $results);
+    }
+
+    public function testStripsLeadingByteOrderMark()
+    {
+        $response = $this->createResponse("\xEF\xBB\xBFdata: {\"foo\": \"bar\"}\n\n", 'application/json');
+
+        $results = iterator_to_array((new RawSseStream())->stream($response), false);
+
+        $this->assertSame([['foo' => 'bar']], $results);
+    }
+
+    public function testFlushesTrailingEventWithoutBlankLineSeparator()
+    {
+        $response = $this->createResponse('data: {"foo": "bar"}', 'application/json');
+
+        $results = iterator_to_array((new RawSseStream())->stream($response), false);
+
+        $this->assertSame([['foo' => 'bar']], $results);
+    }
+
+    public function testIgnoresEventsWithoutDataLines()
+    {
+        $body = ": keep-alive comment\n\nevent: ping\n\ndata: {\"foo\": \"bar\"}\n\n";
+        $response = $this->createResponse($body, 'application/json');
+
+        $results = iterator_to_array((new RawSseStream())->stream($response), false);
+
+        $this->assertSame([['foo' => 'bar']], $results);
+    }
+
+    /**
+     * @param string|list<string> $body
+     */
+    private function createResponse(string|array $body, string $contentType): ResponseInterface
+    {
+        $mockHttpClient = new MockHttpClient([new MockResponse($body, ['response_headers' => ['content-type' => $contentType]])]);
+        $eventSourceClient = new EventSourceHttpClient($mockHttpClient);
+
+        return $eventSourceClient->request('GET', 'https://example.com');
+    }
+}

--- a/src/platform/tests/Result/Stream/SseStreamTest.php
+++ b/src/platform/tests/Result/Stream/SseStreamTest.php
@@ -59,19 +59,6 @@ final class SseStreamTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $results[0]);
     }
 
-    public function testStreamHandlesBracketsAndCommas()
-    {
-        $sse = "data: [{\"foo\": \"bar\"}]\n\ndata: ,{\"baz\": \"qux\"}\n\n";
-        $response = $this->createResponse($sse);
-
-        $stream = new SseStream();
-        $results = iterator_to_array($stream->stream($response));
-
-        $this->assertCount(2, $results);
-        $this->assertSame(['foo' => 'bar'], $results[0]);
-        $this->assertSame(['baz' => 'qux'], $results[1]);
-    }
-
     private function createResponse(string $body): ResponseInterface
     {
         $mockHttpClient = new MockHttpClient([new MockResponse($body, ['response_headers' => ['content-type' => 'text/event-stream']])]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

SseStream only parsed `Server-Sent` Events when the response advertised `Content-Type: text/event-stream`. Some backends (e.g. the ChatGPT Codex backend) stream raw `event:/data:` framing without that header, so the framing reached `json_decode` verbatim and blew up with a syntax error.

The passthru branch now detects the payload format from the first bytes and parses accordingly:

* starts with `[/{` → streamed JSON array (Gemini/Vertex AI without alt=sse), unchanged behavior
* otherwise → SSE framing, buffered and split on blank lines

Properly-detected SSE keeps its existing code path untouched.
