### PR TITLE
[Platform] Add CachedModelCatalog and smoother model catalog DX

### DIFF
--- a/docs/components/platform/model-catalogs.rst
+++ b/docs/components/platform/model-catalogs.rst
@@ -188,6 +188,86 @@ directly::
 A model id resolves to the first provider (in array order) whose catalog knows it. When several
 providers expose the *same* id, order the array so the preferred one comes first.
 
+Combining Catalogs Explicitly
+-----------------------------
+
+A provider holds one catalog, but that catalog can be a composition.
+:class:`Symfony\\AI\\Platform\\ModelCatalog\\CompositeModelCatalog` merges several catalogs and
+resolves against them in order — first match wins. It is the plain-PHP way to keep a bridge's
+bundled catalog *and* add your own models on top::
+
+    use Symfony\AI\Platform\Bridge\OpenAi\Factory as OpenAiFactory;
+    use Symfony\AI\Platform\Bridge\OpenAi\ModelCatalog as OpenAiCatalog;
+    use Symfony\AI\Platform\ModelCatalog\CompositeModelCatalog;
+
+    $platform = OpenAiFactory::createPlatform(
+        apiKey: $_ENV['OPENAI_API_KEY'],
+        modelCatalog: new CompositeModelCatalog([
+            new MyCustomCatalog(), // checked first, so it overrides/extends...
+            new OpenAiCatalog(),   // ...the bridge's curated catalog
+        ]),
+    );
+
+For a single extra model on one bridge, pass an ``additionalModels`` array to that bridge's
+``ModelCatalog`` constructor instead; reach for ``CompositeModelCatalog`` to combine whole catalogs.
+
+Writing a Custom Catalog
+------------------------
+
+A catalog implements :class:`Symfony\\AI\\Platform\\ModelCatalog\\ModelCatalogInterface`:
+``getModel(string $name): Model`` and ``getModels(): array``. Extend
+:class:`Symfony\\AI\\Platform\\ModelCatalog\\AbstractModelCatalog` and fill its ``$models`` map for a
+static list (it parses ``model?temperature=0.5`` options and ``model:size`` variants for you), or
+implement the interface directly to source models from a database, feature flags, or a registry::
+
+    final class DatabaseModelCatalog implements ModelCatalogInterface
+    {
+        public function __construct(private readonly ModelRepository $repository)
+        {
+        }
+
+        public function getModel(string $modelName): Model
+        {
+            $row = $this->repository->find($modelName)
+                ?? throw new ModelNotFoundException(\sprintf('Model "%s" is not registered.', $modelName));
+
+            return new Gpt($row->name, $row->capabilities);
+        }
+
+        public function getModels(): array
+        {
+            // [name => ['class' => Gpt::class, 'capabilities' => [...]], ...]
+        }
+    }
+
+Throw :class:`Symfony\\AI\\Platform\\Exception\\ModelNotFoundException` for unknown names — that is
+the signal ``CompositeModelCatalog`` uses to fall through to the next catalog. For a provider that
+serves arbitrary models, return them with the full capability set instead; see
+:class:`Symfony\\AI\\Platform\\ModelCatalog\\FallbackModelCatalog`.
+
+Caching an API-Based Catalog
+----------------------------
+
+Some catalogs resolve a model by calling the provider's API (e.g. the Ollama bridge queries
+``api/show`` per model). Wrap any catalog in
+:class:`Symfony\\AI\\Platform\\ModelCatalog\\CachedModelCatalog` to resolve each model once and
+serve the rest from a PSR-6 pool, persisting across requests::
+
+    use Symfony\AI\Platform\Bridge\Ollama\ModelCatalog as OllamaCatalog;
+    use Symfony\AI\Platform\ModelCatalog\CachedModelCatalog;
+    use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+    $catalog = new CachedModelCatalog(new OllamaCatalog($httpClient), new FilesystemAdapter(), ttl: 3600);
+
+Failed lookups (``ModelNotFoundException``) are not cached. Note that
+``$platform->getModelCatalog()->getModels()`` queries *every* provider's catalog, triggering a live
+request per API-based provider — cache those if you call it on a hot path.
+
+The capabilities you list (Approach 1 and 2) come from the
+:class:`Symfony\\AI\\Platform\\Capability` enum: input/output modalities, ``TOOL_CALLING``,
+``EMBEDDINGS``, ``RERANKING``, ``THINKING``, and the voice/image/video variants. List the ones the
+model actually has, since they drive routing and ``$model->supports(...)`` checks.
+
 Choosing an Approach
 --------------------
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `IncompleteStreamException`, thrown by bridge converters when a stream ends before its terminal event
  * Add `JsonBodyEncodingTrait` so model clients can encode JSON request bodies without aborting on malformed UTF-8
  * Add support for passing a fully defined `Model` instance to `Platform::invoke()` (and `Provider::invoke()`) instead of a model name string, bypassing the model catalog; widen `ProviderInterface::supports()` to `string|Model` to route a model instance to the first provider whose model clients accept it
+ * Add `CachedModelCatalog` decorator that caches the lookups of any `ModelCatalogInterface`, so API-based catalogs (e.g. the Ollama bridge) can persist resolutions across requests
  * Add in-place `MessageBag::prepend()` and `MessageBag::removeSystemMessage()`
 
 0.9

--- a/src/platform/src/ModelCatalog/CachedModelCatalog.php
+++ b/src/platform/src/ModelCatalog/CachedModelCatalog.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\ModelCatalog;
+
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Model;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * Caches the lookups of a wrapped catalog.
+ *
+ * Useful for API-based catalogs (e.g. the Ollama bridge) that would otherwise
+ * hit a remote endpoint on every resolution: the wrapped catalog is queried
+ * once per model name and the result is served from the cache afterwards,
+ * persisting across requests when backed by a shared cache pool.
+ *
+ * Lookups that fail with a {@see \Symfony\AI\Platform\Exception\ModelNotFoundException}
+ * are not cached, so a model that appears later resolves on the next call.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class CachedModelCatalog implements ModelCatalogInterface
+{
+    public function __construct(
+        private readonly ModelCatalogInterface $catalog,
+        private readonly CacheInterface $cache,
+        private readonly ?int $ttl = null,
+    ) {
+    }
+
+    public function getModel(string $modelName): Model
+    {
+        return $this->cache->get(
+            'symfony_ai_model_catalog.model.'.rawurlencode($modelName),
+            function (ItemInterface $item) use ($modelName): Model {
+                if (null !== $this->ttl) {
+                    $item->expiresAfter($this->ttl);
+                }
+
+                return $this->catalog->getModel($modelName);
+            },
+        );
+    }
+
+    /**
+     * @return array<string, array{class: class-string, capabilities: list<Capability>}>
+     */
+    public function getModels(): array
+    {
+        return $this->cache->get(
+            'symfony_ai_model_catalog.models',
+            function (ItemInterface $item): array {
+                if (null !== $this->ttl) {
+                    $item->expiresAfter($this->ttl);
+                }
+
+                return $this->catalog->getModels();
+            },
+        );
+    }
+}

--- a/src/platform/src/ModelCatalog/CompositeModelCatalog.php
+++ b/src/platform/src/ModelCatalog/CompositeModelCatalog.php
@@ -16,11 +16,13 @@ use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Model;
 
 /**
- * Merges multiple model catalogs into a single catalog.
+ * Merges several model catalogs into one, returning the first match.
  *
- * Iterates through all registered catalogs and returns the first match.
- * This is used by Platform to provide a unified view of all models
- * available across multiple providers.
+ * Hand one to a provider to stack catalogs explicitly — e.g. a bridge's bundled
+ * catalog plus your own custom models, or a models.dev-backed catalog for the long
+ * tail. Catalogs are queried in order and the first one that knows a model wins, so
+ * place the catalog whose definitions should take precedence first. Platform also
+ * uses it internally to expose a unified view of all models across its providers.
  *
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */

--- a/src/platform/src/Platform.php
+++ b/src/platform/src/Platform.php
@@ -81,6 +81,10 @@ final class Platform implements PlatformInterface
             }
         }
 
+        if (Model::class === $model::class) {
+            throw new ModelNotFoundException(\sprintf('No provider found for model "%s": a base "%s" instance has no model client. Pass a bridge-specific model subclass instead (e.g. "%s\\Bridge\\OpenAi\\Gpt", "%s\\Bridge\\Anthropic\\Claude", "%s\\Bridge\\Gemini\\Gemini").', $model->getName(), Model::class, __NAMESPACE__, __NAMESPACE__, __NAMESPACE__));
+        }
+
         throw new ModelNotFoundException(\sprintf('No provider found for model "%s" (%s).', $model->getName(), $model::class));
     }
 }

--- a/src/platform/tests/ModelCatalog/CachedModelCatalogTest.php
+++ b/src/platform/tests/ModelCatalog/CachedModelCatalogTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\ModelCatalog;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\CachedModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class CachedModelCatalogTest extends TestCase
+{
+    public function testGetModelHitsInnerCatalogOnlyOnce()
+    {
+        $model = new Model('gpt-4o', [Capability::INPUT_MESSAGES]);
+
+        $inner = $this->createMock(ModelCatalogInterface::class);
+        $inner->expects($this->once())
+            ->method('getModel')
+            ->with('gpt-4o')
+            ->willReturn($model);
+
+        $catalog = new CachedModelCatalog($inner, new ArrayAdapter());
+
+        $this->assertEquals($model, $catalog->getModel('gpt-4o'));
+        $this->assertEquals($model, $catalog->getModel('gpt-4o'));
+    }
+
+    public function testGetModelsHitsInnerCatalogOnlyOnce()
+    {
+        $models = ['gpt-4o' => ['class' => Model::class, 'capabilities' => [Capability::INPUT_MESSAGES]]];
+
+        $inner = $this->createMock(ModelCatalogInterface::class);
+        $inner->expects($this->once())
+            ->method('getModels')
+            ->willReturn($models);
+
+        $catalog = new CachedModelCatalog($inner, new ArrayAdapter());
+
+        $this->assertSame($models, $catalog->getModels());
+        $this->assertSame($models, $catalog->getModels());
+    }
+
+    public function testModelNotFoundIsNotCached()
+    {
+        $model = new Model('gpt-4o', [Capability::INPUT_MESSAGES]);
+
+        $callCount = 0;
+        $inner = $this->createMock(ModelCatalogInterface::class);
+        $inner->expects($this->exactly(2))
+            ->method('getModel')
+            ->with('gpt-4o')
+            ->willReturnCallback(static function () use (&$callCount, $model): Model {
+                ++$callCount;
+                if (1 === $callCount) {
+                    throw new ModelNotFoundException('Model "gpt-4o" not found.');
+                }
+
+                return $model;
+            });
+
+        $catalog = new CachedModelCatalog($inner, new ArrayAdapter());
+
+        try {
+            $catalog->getModel('gpt-4o');
+            $this->fail('Expected ModelNotFoundException was not thrown.');
+        } catch (ModelNotFoundException) {
+            // expected: the failed lookup must not be cached
+        }
+
+        $this->assertEquals($model, $catalog->getModel('gpt-4o'));
+    }
+
+    public function testModelNamesWithReservedCharactersAreCachedSeparately()
+    {
+        $base = new Model('qwen3', [Capability::INPUT_MESSAGES]);
+        $variant = new Model('qwen3', [Capability::INPUT_MESSAGES, Capability::TOOL_CALLING]);
+
+        $inner = $this->createMock(ModelCatalogInterface::class);
+        $inner->expects($this->exactly(2))
+            ->method('getModel')
+            ->willReturnCallback(static fn (string $name): Model => str_contains($name, ':32b') ? $variant : $base);
+
+        $catalog = new CachedModelCatalog($inner, new ArrayAdapter());
+
+        $this->assertEquals($base, $catalog->getModel('qwen3'));
+        $this->assertEquals($variant, $catalog->getModel('qwen3:32b'));
+        // second round served from cache, inner not hit again
+        $this->assertEquals($base, $catalog->getModel('qwen3'));
+        $this->assertEquals($variant, $catalog->getModel('qwen3:32b'));
+    }
+}

--- a/src/platform/tests/PlatformTest.php
+++ b/src/platform/tests/PlatformTest.php
@@ -208,6 +208,22 @@ final class PlatformTest extends TestCase
         $platform->invoke($model, 'Hello');
     }
 
+    public function testInvokeWithBaseModelInstanceHintsAtBridgeSubclass()
+    {
+        $model = new Model('custom-model', []);
+
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider->method('supports')->with($model)->willReturn(false);
+        $provider->expects($this->never())->method('invoke');
+
+        $platform = new Platform([$provider]);
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('a base "Symfony\AI\Platform\Model" instance has no model client. Pass a bridge-specific model subclass instead');
+
+        $platform->invoke($model, 'Hello');
+    }
+
     public function testInvokeWithModelObjectDoesNotDispatchModelRoutingEvent()
     {
         $model = new Model('custom-model', []);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Three small DX improvements around model catalogs:

- **`CachedModelCatalog`** — a decorator that memoizes any `ModelCatalogInterface` behind a PSR-6 cache pool (without caching `ModelNotFoundException`), so API-based catalogs (Ollama, amazee.ai, ...) can persist resolutions across requests instead of hitting the API on every lookup.
- **`CompositeModelCatalog`** — softened the docblock so it reads as a public composition tool ("bundled catalog + my own models"), not an internal Platform detail.
- **Base `Model` pitfall** — passing a bare `new Model(...)` (instead of a bridge subclass like `Gpt`/`Claude`) now fails with a message that names the required subclasses, instead of an opaque "No provider found".

```php
$catalog = new CachedModelCatalog(new OllamaCatalog($http), new FilesystemAdapter(), ttl: 3600);
```

Docs: new sections in `model-catalogs.rst` (composition, custom catalogs, caching, capability reference).