### PR TITLE
[Platform][Anthropic] Move unsupported schema features to `description`

### DIFF
--- a/examples/anthropic/structured-output-constrained.php
+++ b/examples/anthropic/structured-output-constrained.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Demonstrates that JSON Schema constraints unsupported by Anthropic's API
+// (minimum, maximum, minLength, maxItems, etc.) are moved to the `description`
+// field by JsonSchemaSanitizerTrait so the model still reads and respects them.
+
+use Symfony\AI\Platform\Bridge\Anthropic\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$dispatcher = new EventDispatcher();
+$dispatcher->addSubscriber(new PlatformSubscriber());
+
+$platform = Factory::createPlatform(env('ANTHROPIC_API_KEY'), http_client(), eventDispatcher: $dispatcher);
+
+$messages = new MessageBag(
+    Message::forSystem('You are a product catalog assistant. Generate realistic product data that strictly respects all constraints in the schema descriptions.'),
+    Message::ofUser('Create a product entry for a mid-range wireless headphone.'),
+);
+
+$result = $platform->invoke('claude-sonnet-4-5-20250929', $messages, ['response_format' => [
+    'type' => 'json_schema',
+    'json_schema' => [
+        'name' => 'product',
+        'strict' => true,
+        'schema' => [
+            'type' => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                    'description' => 'The product name',
+                    'minLength' => 5,
+                    'maxLength' => 60,
+                ],
+                'price' => [
+                    'type' => 'number',
+                    'description' => 'Price in USD',
+                    'minimum' => 1,
+                    'maximum' => 500,
+                    'multipleOf' => 0.01,
+                ],
+                'rating' => [
+                    'type' => 'number',
+                    'description' => 'Average customer rating',
+                    'minimum' => 1.0,
+                    'maximum' => 5.0,
+                ],
+                'tags' => [
+                    'type' => 'array',
+                    'description' => 'Descriptive tags for the product',
+                    'items' => ['type' => 'string'],
+                    'minItems' => 2,
+                    'maxItems' => 6,
+                ],
+            ],
+            'required' => ['name', 'price', 'rating', 'tags'],
+            'additionalProperties' => false,
+        ],
+    ],
+]]);
+
+dump($result->getResult()->getContent());

--- a/src/platform/src/Bridge/Anthropic/JsonSchemaSanitizerTrait.php
+++ b/src/platform/src/Bridge/Anthropic/JsonSchemaSanitizerTrait.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Anthropic;
+
+/**
+ * Strips JSON Schema features that Anthropic's structured-output API does not support.
+ *
+ * @see https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations
+ *
+ * @internal
+ */
+trait JsonSchemaSanitizerTrait
+{
+    /**
+     * @param array<string, mixed> $schema
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizeStructuredOutputSchema(array $schema): array
+    {
+        $unsupported = [];
+
+        foreach (['minimum', 'maximum', 'multipleOf', 'exclusiveMinimum', 'exclusiveMaximum', 'minLength', 'maxLength', 'maxItems', 'uniqueItems', 'minContains', 'maxContains'] as $key) {
+            if (isset($schema[$key])) {
+                $unsupported[$key] = $schema[$key];
+                unset($schema[$key]);
+            }
+        }
+
+        if (isset($schema['minItems']) && $schema['minItems'] > 1) {
+            $unsupported['minItems'] = $schema['minItems'];
+            unset($schema['minItems']);
+        }
+
+        if (isset($schema['additionalProperties']) && false !== $schema['additionalProperties']) {
+            $unsupported['additionalProperties'] = $schema['additionalProperties'];
+            unset($schema['additionalProperties']);
+        }
+
+        if (isset($schema['$ref']) && !str_starts_with((string) $schema['$ref'], '#')) {
+            $unsupported['$ref'] = $schema['$ref'];
+            unset($schema['$ref']);
+        }
+
+        if ([] !== $unsupported) {
+            $schema['description'] = (($schema['description'] ?? null) ? $schema['description']."\n\n" : '').json_encode($unsupported, \JSON_UNESCAPED_SLASHES);
+        }
+
+        if (isset($schema['properties']) && \is_array($schema['properties'])) {
+            foreach ($schema['properties'] as $key => $property) {
+                if (\is_array($property)) {
+                    $schema['properties'][$key] = $this->normalizeStructuredOutputSchema($property);
+                }
+            }
+        }
+
+        foreach (['anyOf', 'allOf', 'oneOf', 'not'] as $combiner) {
+            if (!isset($schema[$combiner]) || !\is_array($schema[$combiner])) {
+                continue;
+            }
+
+            foreach ($schema[$combiner] as $i => $subSchema) {
+                if (\is_array($subSchema)) {
+                    $schema[$combiner][$i] = $this->normalizeStructuredOutputSchema($subSchema);
+                }
+            }
+        }
+
+        if (isset($schema['items']) && \is_array($schema['items'])) {
+            $schema['items'] = $this->normalizeStructuredOutputSchema($schema['items']);
+        }
+
+        return $schema;
+    }
+}

--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -25,6 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class ModelClient implements ModelClientInterface
 {
     use JsonBodyEncodingTrait;
+    use JsonSchemaSanitizerTrait;
 
     private readonly EventSourceHttpClient $httpClient;
 
@@ -76,10 +77,11 @@ final class ModelClient implements ModelClientInterface
         }
 
         if (isset($options['response_format'])) {
+            $schema = $options['response_format']['json_schema']['schema'] ?? [];
             $options['output_config'] = [
                 'format' => [
                     'type' => 'json_schema',
-                    'schema' => $options['response_format']['json_schema']['schema'] ?? [],
+                    'schema' => \is_array($schema) ? $this->normalizeStructuredOutputSchema($schema) : $schema,
                 ],
             ];
             unset($options['response_format']);

--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeModelClient.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Bedrock\Anthropic;
 use AsyncAws\BedrockRuntime\BedrockRuntimeClient;
 use AsyncAws\BedrockRuntime\Input\InvokeModelRequest;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
+use Symfony\AI\Platform\Bridge\Anthropic\JsonSchemaSanitizerTrait;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Bridge\Bedrock\RegionMapper;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
@@ -25,6 +26,8 @@ use Symfony\AI\Platform\ModelClientInterface;
  */
 final class ClaudeModelClient implements ModelClientInterface
 {
+    use JsonSchemaSanitizerTrait;
+
     /**
      * Bedrock model identifiers differ from Anthropic API names — some require version suffixes,
      * others don't. See https://platform.claude.com/docs/en/about-claude/models/overview for details.
@@ -81,10 +84,11 @@ final class ClaudeModelClient implements ModelClientInterface
         }
 
         if (isset($options['response_format'])) {
+            $schema = $options['response_format']['json_schema']['schema'] ?? [];
             $options['output_config'] = [
                 'format' => [
                     'type' => 'json_schema',
-                    'schema' => $options['response_format']['json_schema']['schema'] ?? [],
+                    'schema' => \is_array($schema) ? $this->normalizeStructuredOutputSchema($schema) : $schema,
                 ],
             ];
             unset($options['response_format']);

--- a/src/platform/tests/Bridge/Anthropic/JsonSchemaSanitizerTraitTest.php
+++ b/src/platform/tests/Bridge/Anthropic/JsonSchemaSanitizerTraitTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\Anthropic;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Anthropic\JsonSchemaSanitizerTrait;
+
+/**
+ * @author Valtteri R <valtzu@gmail.com>
+ */
+final class JsonSchemaSanitizerTraitTest extends TestCase
+{
+    private object $sanitizer;
+
+    protected function setUp(): void
+    {
+        $this->sanitizer = new class {
+            use JsonSchemaSanitizerTrait { normalizeStructuredOutputSchema as public; }
+        };
+    }
+
+    public function testUnsupportedConstraintsAreMovedToDescription()
+    {
+        $schema = [
+            'type' => 'integer',
+            'minimum' => 1,
+            'maximum' => 100,
+            'multipleOf' => 5,
+        ];
+
+        $result = $this->sanitizer->normalizeStructuredOutputSchema($schema);
+
+        $this->assertArrayNotHasKey('minimum', $result);
+        $this->assertArrayNotHasKey('maximum', $result);
+        $this->assertArrayNotHasKey('multipleOf', $result);
+        $this->assertSame('{"minimum":1,"maximum":100,"multipleOf":5}', $result['description']);
+    }
+
+    public function testUnsupportedConstraintsAreAppendedToExistingDescription()
+    {
+        $schema = [
+            'type' => 'string',
+            'description' => 'A short label',
+            'minLength' => 2,
+            'maxLength' => 50,
+        ];
+
+        $result = $this->sanitizer->normalizeStructuredOutputSchema($schema);
+
+        $this->assertArrayNotHasKey('minLength', $result);
+        $this->assertArrayNotHasKey('maxLength', $result);
+        $this->assertSame("A short label\n\n{\"minLength\":2,\"maxLength\":50}", $result['description']);
+    }
+
+    public function testMinItemsGreaterThanOneIsMovedToDescription()
+    {
+        $schema = ['type' => 'array', 'minItems' => 3];
+
+        $result = $this->sanitizer->normalizeStructuredOutputSchema($schema);
+
+        $this->assertArrayNotHasKey('minItems', $result);
+        $this->assertSame('{"minItems":3}', $result['description']);
+    }
+
+    public function testMinItemsOneIsKept()
+    {
+        $schema = ['type' => 'array', 'minItems' => 1];
+
+        $result = $this->sanitizer->normalizeStructuredOutputSchema($schema);
+
+        $this->assertSame(1, $result['minItems']);
+        $this->assertArrayNotHasKey('description', $result);
+    }
+
+    public function testAdditionalPropertiesTrueIsMovedToDescription()
+    {
+        $schema = ['type' => 'object', 'additionalProperties' => true];
+
+        $result = $this->sanitizer->normalizeStructuredOutputSchema($schema);
+
+        $this->assertArrayNotHasKey('additionalProperties', $result);
+        $this->assertSame('{"additionalProperties":true}', $result['description']);
+    }
+
+    public function testAdditionalPropertiesFalseIsKept()
+    {
+        $schema = ['type' => 'object', 'additionalProperties' => false];
+
+        $result = $this->sanitizer->normalizeStructuredOutputSchema($schema);
+
+        $this->assertFalse($result['additionalProperties']);
+        $this->assertArrayNotHasKey('description', $result);
+    }
+
+    public function testExternalRefIsMovedToDescription()
+    {
+        $schema = ['$ref' => 'https://example.com/schema.json'];
+
+        $result = $this->sanitizer->normalizeStructuredOutputSchema($schema);
+
+        $this->assertArrayNotHasKey('$ref', $result);
+        $this->assertSame('{"$ref":"https://example.com/schema.json"}', $result['description']);
+    }
+
+    public function testLocalRefIsKept()
+    {
+        $schema = ['$ref' => '#/definitions/Foo'];
+
+        $result = $this->sanitizer->normalizeStructuredOutputSchema($schema);
+
+        $this->assertSame('#/definitions/Foo', $result['$ref']);
+        $this->assertArrayNotHasKey('description', $result);
+    }
+
+    public function testNestedPropertiesAreSanitizedRecursively()
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'age' => ['type' => 'integer', 'minimum' => 0, 'maximum' => 150],
+            ],
+        ];
+
+        $result = $this->sanitizer->normalizeStructuredOutputSchema($schema);
+
+        $age = $result['properties']['age'];
+        $this->assertArrayNotHasKey('minimum', $age);
+        $this->assertArrayNotHasKey('maximum', $age);
+        $this->assertSame('{"minimum":0,"maximum":150}', $age['description']);
+    }
+
+    public function testSupportedPropertiesAreNotTouched()
+    {
+        $schema = [
+            'type' => 'object',
+            'description' => 'A person',
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+            'required' => ['name'],
+            'additionalProperties' => false,
+            'minItems' => 0,
+        ];
+
+        $result = $this->sanitizer->normalizeStructuredOutputSchema($schema);
+
+        $this->assertSame('A person', $result['description']);
+        $this->assertFalse($result['additionalProperties']);
+        $this->assertSame(0, $result['minItems']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2119
| License       | MIT

Move unsupported schema properties in Anthropic structured output to `description`, like done in official Anthropic PHP SDK.

Related docs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations