### PR TITLE
[Platform] Fix double-counting of Anthropic streaming prompt and cache tokens

### DIFF
--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -155,13 +155,24 @@ class ResultConverter implements ResultConverterInterface
                 $inMessage = true;
             }
 
-            // Handle usage from message_start and message_delta
+            // Anthropic reports usage in both message_start and message_delta:
+            // message_start carries the prompt and cache token counts plus a
+            // provisional output_tokens, and message_delta repeats the same
+            // cumulative prompt/cache counts with the final output_tokens. As
+            // the stream aggregation sums every yielded usage, emitting the full
+            // payload from both events would double-count input and cache tokens.
+            // Yield the prompt/cache counts once (message_start, without the
+            // provisional output) and the final output once (message_delta).
             if ('message_start' === $type && isset($data['message']['usage'])) {
-                yield $this->getTokenUsageExtractor()->extractFromArray($data['message']['usage']);
+                $usage = $data['message']['usage'];
+                unset($usage['output_tokens']);
+                yield $this->getTokenUsageExtractor()->extractFromArray($usage);
             }
 
             if ('message_delta' === $type && isset($data['usage'])) {
-                yield $this->getTokenUsageExtractor()->extractFromArray($data['usage']);
+                yield $this->getTokenUsageExtractor()->extractFromArray([
+                    'output_tokens' => $data['usage']['output_tokens'] ?? 0,
+                ]);
             }
 
             // Handle text content deltas

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -35,6 +35,8 @@ use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\TokenUsage\StreamListener as TokenUsageStreamListener;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -234,6 +236,54 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('toolu_01ABC123', $toolCalls[0]->getId());
         $this->assertSame('get_weather', $toolCalls[0]->getName());
         $this->assertSame(['location' => 'Berlin'], $toolCalls[0]->getArguments());
+    }
+
+    public function testStreamingUsageIsNotDoubleCounted()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        // Anthropic repeats the cumulative prompt and cache token counts in
+        // both message_start and message_delta. The stream aggregation sums
+        // every yielded usage, so they must be counted only once.
+        $raw = new InMemoryRawResult([], [
+            ['type' => 'message_start', 'message' => ['id' => 'msg_123', 'type' => 'message', 'role' => 'assistant', 'content' => [], 'usage' => [
+                'input_tokens' => 100,
+                'cache_creation_input_tokens' => 200,
+                'cache_read_input_tokens' => 300,
+                'output_tokens' => 1,
+            ]]],
+            ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'text', 'text' => '']],
+            ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'text_delta', 'text' => 'Hello']],
+            ['type' => 'content_block_stop', 'index' => 0],
+            ['type' => 'message_delta', 'delta' => ['stop_reason' => 'end_turn'], 'usage' => [
+                'input_tokens' => 100,
+                'cache_creation_input_tokens' => 200,
+                'cache_read_input_tokens' => 300,
+                'output_tokens' => 50,
+            ]],
+            ['type' => 'message_stop'],
+        ], $httpResponse);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $streamResult);
+
+        $streamResult->addListener(new TokenUsageStreamListener());
+
+        foreach ($streamResult->getContent() as $part) {
+            // Drain the stream so the listener aggregates the usage events.
+        }
+
+        $tokenUsage = $streamResult->getMetadata()->get('token_usage');
+
+        $this->assertInstanceOf(TokenUsageInterface::class, $tokenUsage);
+        $this->assertSame(100, $tokenUsage->getPromptTokens());
+        $this->assertSame(200, $tokenUsage->getCacheCreationTokens());
+        $this->assertSame(300, $tokenUsage->getCacheReadTokens());
+        $this->assertSame(50, $tokenUsage->getCompletionTokens());
     }
 
     public function testStreamingThrowsWhenMessageStopIsMissing()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

When streaming, Anthropic reports token usage in **two** events:

- `message_start.usage` carries the prompt and cache token counts plus a provisional `output_tokens`.
- `message_delta.usage` repeats the **same cumulative** `input_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens`, together with the final `output_tokens`.

The Anthropic `ResultConverter` yielded a full `TokenUsage` for both events, and the stream aggregation (`TokenUsageAggregation`) **sums every field across all yielded usage events**. As a result, prompt and cache tokens (which dominate a cached conversation) were **counted twice**, roughly doubling the reported context usage.

This was observed in a coding agent where the context-window gauge climbed past 120% on a 1M-token model while the real usage was about 63%. A live replay of a stored request confirmed both events repeat the cumulative counts:

```
message_start.usage  → input_tokens:2, cache_creation:47119, cache_read:0, output_tokens:4
message_delta.usage  → input_tokens:2, cache_creation:47119, cache_read:0, output_tokens:64
```

The fix keeps the summing aggregation correct by emitting each number once: prompt and cache counts from `message_start` (dropping its provisional `output_tokens`), and the final `output_tokens` from `message_delta`.

A regression test asserts that the aggregated usage is not double-counted.
