### PR TITLE
[Store] Harden remove() against query injection in SurrealDb, Typesense and Milvus bridges

### DIFF
--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -118,7 +118,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $this->request('POST', 'v2/vectordb/entities/delete', [
             'collectionName' => $this->collection,
-            'filter' => \sprintf('id in [%s]', implode(',', array_map(static fn ($id) => '"'.str_replace('"', '\"', $id).'"', $ids))),
+            'filter' => \sprintf('id in [%s]', implode(',', array_map(static fn ($id) => '"'.str_replace(['\\', '"'], ['\\\\', '\\"'], (string) $id).'"', $ids))),
         ]);
     }
 

--- a/src/store/src/Bridge/Milvus/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Milvus/Tests/StoreTest.php
@@ -240,6 +240,38 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testStoreCanRemove()
+    {
+        $body = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$body): JsonMockResponse {
+            $body = json_decode($options['body'] ?? '{}', true);
+
+            return new JsonMockResponse(['code' => 0], ['http_code' => 200]);
+        }, 'http://127.0.0.1:19530');
+
+        $store = new Store($httpClient, 'http://127.0.0.1:19530', 'test', 'test', 'test_collection');
+        $store->remove('abc');
+
+        $this->assertSame('id in ["abc"]', $body['filter']);
+    }
+
+    public function testStoreRemoveNeutralizesInjectedId()
+    {
+        $body = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$body): JsonMockResponse {
+            $body = json_decode($options['body'] ?? '{}', true);
+
+            return new JsonMockResponse(['code' => 0], ['http_code' => 200]);
+        }, 'http://127.0.0.1:19530');
+
+        $store = new Store($httpClient, 'http://127.0.0.1:19530', 'test', 'test', 'test_collection');
+
+        // A trailing backslash must not escape the closing quote of the string literal.
+        $store->remove(['a\\', ' or id != "x']);
+
+        $this->assertSame('id in ["a\\\\"," or id != \"x"]', $body['filter']);
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = new Store(new MockHttpClient(), 'http://localhost:19530', 'test-api-key', 'default', 'test_collection');

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -77,7 +77,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             return;
         }
 
-        $recordIds = array_map(fn (string $id) => \sprintf('%s:`%s`', $this->table, $id), $ids);
+        $recordIds = array_map(fn (string $id) => \sprintf('type::thing(%s, %s)', $this->escapeString($this->table), $this->escapeString($id)), $ids);
         $this->request('POST', 'sql', \sprintf('DELETE %s;', implode(', ', $recordIds)));
     }
 
@@ -110,6 +110,15 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->authenticate();
 
         $this->request('DELETE', \sprintf('key/%s', $this->table), []);
+    }
+
+    /**
+     * Escapes a value as a single-quoted SurrealQL string literal so it cannot
+     * break out of its context, even when sourced from untrusted input.
+     */
+    private function escapeString(string $value): string
+    {
+        return "'".str_replace(['\\', "'"], ['\\\\', "\\'"], $value)."'";
     }
 
     /**

--- a/src/store/src/Bridge/SurrealDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/SurrealDb/Tests/StoreTest.php
@@ -408,6 +408,38 @@ final class StoreTest extends TestCase
         $this->assertCount(2, $results);
     }
 
+    public function testStoreCanRemove()
+    {
+        $body = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$body): JsonMockResponse {
+            $body = $options['body'] ?? null;
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        }, 'http://127.0.0.1:8000');
+
+        $store = new Store($httpClient, 'http://127.0.0.1:8000', 'test', 'test', 'test', 'test', 'vectors');
+        $store->remove('123e4567-e89b-12d3-a456-426614174000');
+
+        $this->assertSame("DELETE type::thing('vectors', '123e4567-e89b-12d3-a456-426614174000');", $body);
+    }
+
+    public function testStoreRemoveNeutralizesInjectedId()
+    {
+        $body = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$body): JsonMockResponse {
+            $body = $options['body'] ?? null;
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        }, 'http://127.0.0.1:8000');
+
+        $store = new Store($httpClient, 'http://127.0.0.1:8000', 'test', 'test', 'test', 'test', 'vectors');
+        $store->remove("a'); DELETE vectors; --");
+
+        // The crafted id stays inside a single-quoted string literal (the quote is escaped),
+        // so the appended statements cannot break out and execute.
+        $this->assertSame("DELETE type::thing('vectors', 'a\\'); DELETE vectors; --');", $body);
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = new Store(new MockHttpClient(), 'http://localhost:8000', 'test', 'test', 'test_namespace', 'test_database', 'test_table');

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -89,6 +89,12 @@ final class Store implements ManagedStoreInterface, StoreInterface
             return;
         }
 
+        foreach ($ids as $id) {
+            if (1 !== preg_match('/^[\w.-]+$/', (string) $id)) {
+                throw new InvalidArgumentException(\sprintf('The document id "%s" contains unsupported characters; only letters, digits, "-", "_" and "." are allowed.', $id));
+            }
+        }
+
         $this->request('DELETE', \sprintf(
             'collections/%s/documents?filter_by=id:[%s]',
             $this->collection,

--- a/src/store/src/Bridge/Typesense/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Typesense/Tests/StoreTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Typesense\Store;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
@@ -216,6 +217,31 @@ final class StoreTest extends TestCase
 
         $this->assertCount(2, $results);
         $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testStoreCanRemove()
+    {
+        $url = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $u, array $options) use (&$url): JsonMockResponse {
+            $url = $u;
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        }, 'http://127.0.0.1:8108');
+
+        $store = new Store($httpClient, 'http://127.0.0.1:8108', 'test', 'test_collection');
+        $id = Uuid::v4()->toRfc4122();
+        $store->remove($id);
+
+        $this->assertStringContainsString(\sprintf('filter_by=id:[%s]', $id), urldecode((string) $url));
+    }
+
+    public function testStoreRemoveRejectsInjectedId()
+    {
+        $store = new Store(new MockHttpClient(), 'http://127.0.0.1:8108', 'test', 'test_collection');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $store->remove('1] || num_docs:>=0 || id:[2');
     }
 
     public function testStoreSupportsVectorQuery()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Hardens `Store::remove()` so untrusted document ids can no longer break out of the delete query:

- **SurrealDb**: build record ids via `type::thing()` with single-quote escaping instead of string interpolation.
- **Typesense**: reject ids containing characters outside `[\w.-]`.
- **Milvus**: escape backslashes as well as double quotes in the filter literal.

Tests added for each bridge.

/cc @alexandre-daubois
