### PR TITLE
[Agent] Fix Filesystem sandbox escape via prefix check in PathValidator

### DIFF
--- a/src/agent/src/Bridge/Filesystem/PathValidator.php
+++ b/src/agent/src/Bridge/Filesystem/PathValidator.php
@@ -113,7 +113,21 @@ final class PathValidator
             throw new PathSecurityException(\sprintf('Base path "%s" does not exist.', $this->basePath));
         }
 
-        if (!str_starts_with($resolvedPath, $realBasePath)) {
+        $base = $realBasePath;
+        $candidate = $resolvedPath;
+
+        // On Windows, realpath() yields backslashes while non-existing paths are
+        // assembled with "/", and the filesystem is case-insensitive. Normalize both
+        // so the directory boundary is detected reliably. On Unix the backslash is a
+        // valid filename character, so it must be left untouched there.
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $base = strtolower(str_replace('\\', '/', $base));
+            $candidate = strtolower(str_replace('\\', '/', $candidate));
+        }
+
+        $base = rtrim($base, '/');
+
+        if ($candidate !== $base && !str_starts_with($candidate, $base.'/')) {
             throw new PathSecurityException(\sprintf('Path "%s" is outside the allowed base path.', $resolvedPath));
         }
     }

--- a/src/agent/src/Bridge/Filesystem/Tests/PathValidatorTest.php
+++ b/src/agent/src/Bridge/Filesystem/Tests/PathValidatorTest.php
@@ -137,4 +137,46 @@ class PathValidatorTest extends TestCase
 
         $this->assertSame($this->fixturesPath, $validator->getBasePath());
     }
+
+    public function testValidateThrowsOnSiblingDirectoryWithSharedPrefix()
+    {
+        $base = sys_get_temp_dir().'/'.uniqid('fsdemo_', true).'/data';
+        $sibling = \dirname($base).'/data-private';
+        mkdir($base, 0o777, true);
+        mkdir($sibling, 0o777, true);
+        file_put_contents($sibling.'/secrets.txt', 'SECRET: outside the sandbox');
+
+        try {
+            $validator = new PathValidator($base, [], [], []);
+
+            $this->expectException(PathSecurityException::class);
+            $this->expectExceptionMessage('outside the allowed base path');
+
+            $validator->validate($sibling.'/secrets.txt');
+        } finally {
+            @unlink($sibling.'/secrets.txt');
+            @rmdir($sibling);
+            @rmdir($base);
+            @rmdir(\dirname($base));
+        }
+    }
+
+    public function testValidateDirectoryThrowsOnNonExistentSiblingWithSharedPrefix()
+    {
+        $base = sys_get_temp_dir().'/'.uniqid('fsdemo_', true).'/data';
+        $sibling = \dirname($base).'/datax';
+        mkdir($base, 0o777, true);
+
+        try {
+            $validator = new PathValidator($base, [], [], []);
+
+            $this->expectException(PathSecurityException::class);
+            $this->expectExceptionMessage('outside the allowed base path');
+
+            $validator->validateDirectory($sibling, mustExist: false);
+        } finally {
+            @rmdir($base);
+            @rmdir(\dirname($base));
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Fixes a sandbox escape in the Filesystem tool's `PathValidator`: the boundary check used a bare `str_starts_with`, so a sibling directory sharing the base path's prefix (e.g. `/data` vs `/data-private`) passed validation. The check now requires an exact match or a `/` directory boundary, with Windows path normalization.

Tests added.

/cc @alexandre-daubois
