### PR TITLE
[Mate] Bound PCRE backtracking in monolog-search regex matching

### DIFF
--- a/src/mate/src/Bridge/Monolog/Model/LogEntry.php
+++ b/src/mate/src/Bridge/Monolog/Model/LogEntry.php
@@ -29,6 +29,8 @@ namespace Symfony\AI\Mate\Bridge\Monolog\Model;
  */
 final class LogEntry
 {
+    private const REGEX_BACKTRACK_LIMIT = 10000;
+
     /**
      * @param array<string, mixed> $context
      * @param array<string, mixed> $extra
@@ -119,7 +121,16 @@ final class LogEntry
     {
         $searchable = $this->message.' '.json_encode($this->context).' '.json_encode($this->extra);
 
-        return (bool) preg_match($pattern, $searchable);
+        // Lower the PCRE backtrack limit temporarily so a model-supplied
+        // catastrophic pattern cannot stall the worker (regex injection / ReDoS).
+        $previousLimit = ini_set('pcre.backtrack_limit', self::REGEX_BACKTRACK_LIMIT);
+        try {
+            return (bool) @preg_match($pattern, $searchable);
+        } finally {
+            if (false !== $previousLimit) {
+                ini_set('pcre.backtrack_limit', $previousLimit);
+            }
+        }
     }
 
     public function hasContextValue(string $key, string $value): bool

--- a/src/mate/src/Bridge/Monolog/Tests/Model/LogEntryTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Model/LogEntryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Monolog\Tests\Model;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Monolog\Model\LogEntry;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class LogEntryTest extends TestCase
+{
+    public function testMatchesRegexMatches()
+    {
+        $entry = new LogEntry(new \DateTimeImmutable('2024-01-01T00:00:00+00:00'), 'app', 'ERROR', 'Database connection failed');
+
+        $this->assertTrue($entry->matchesRegex('/connection/i'));
+        $this->assertFalse($entry->matchesRegex('/timeout/i'));
+    }
+
+    public function testMatchesRegexDoesNotHangOnPathologicalPattern()
+    {
+        $entry = new LogEntry(new \DateTimeImmutable('2024-01-01T00:00:00+00:00'), 'app', 'ERROR', str_repeat('a', 41));
+
+        $start = microtime(true);
+        $result = $entry->matchesRegex('/^(a+)+$/');
+        $elapsed = microtime(true) - $start;
+
+        $this->assertFalse($result);
+        $this->assertLessThan(1.0, $elapsed, 'ReDoS pattern must not stall preg_match');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

A model-supplied search pattern reaching `LogEntry::matchesRegex()` could trigger catastrophic backtracking (ReDoS) and stall the worker. The PCRE backtrack limit is now temporarily lowered around the `preg_match()` call and restored afterwards.

Tests added.

/cc @alexandre-daubois @wachterjohannes 
