### PR TITLE
[Chat] Whitelist content type in UserMessage denormalization

### DIFF
--- a/src/chat/src/MessageNormalizer.php
+++ b/src/chat/src/MessageNormalizer.php
@@ -57,9 +57,16 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
             SystemMessage::class => new SystemMessage($content),
             AssistantMessage::class => new AssistantMessage(...self::denormalizeAssistantParts($data)),
             UserMessage::class => new UserMessage(...array_map(
-                static fn (array $contentAsBase64): ContentInterface => \in_array($contentAsBase64['type'], [File::class, Image::class, Audio::class], true)
-                    ? $contentAsBase64['type']::fromDataUrl($contentAsBase64['content'])
-                    : new $contentAsBase64['type']($contentAsBase64['content']),
+                static fn (array $part): ContentInterface => match ($part['type']) {
+                    File::class,
+                    Document::class,
+                    Image::class,
+                    Audio::class => $part['type']::fromDataUrl($part['content']),
+                    Text::class => new Text($part['content']),
+                    ImageUrl::class => new ImageUrl($part['content']),
+                    DocumentUrl::class => new DocumentUrl($part['content']),
+                    default => throw new LogicException(\sprintf('Unknown content type "%s".', $part['type'])),
+                },
                 $contentAsBase64,
             )),
             ToolCallMessage::class => new ToolCallMessage(

--- a/src/chat/tests/MessageNormalizerTest.php
+++ b/src/chat/tests/MessageNormalizerTest.php
@@ -12,9 +12,12 @@
 namespace Symfony\AI\Chat\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Chat\Exception\LogicException;
 use Symfony\AI\Chat\MessageNormalizer;
 use Symfony\AI\Platform\Contract\Normalizer\Result\ToolCallNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\DocumentUrl;
+use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Message\Message;
@@ -83,6 +86,49 @@ final class MessageNormalizerTest extends TestCase
         $this->assertSame($uuid, $message->getId()->toRfc4122());
         $this->assertSame(Role::User, $message->getRole());
         $this->assertArrayHasKey('addedAt', $message->getMetadata()->all());
+    }
+
+    public function testItCanDenormalizeUserMessageWithUrlContents()
+    {
+        $normalizer = new MessageNormalizer();
+        $message = Message::ofUser(
+            new ImageUrl('https://example.com/cat.png'),
+            new DocumentUrl('https://example.com/doc.pdf'),
+        );
+
+        $payload = $normalizer->normalize($message);
+        /** @var UserMessage $denormalized */
+        $denormalized = $normalizer->denormalize($payload, MessageInterface::class);
+
+        $contents = $denormalized->getContent();
+        $this->assertCount(2, $contents);
+        $this->assertInstanceOf(ImageUrl::class, $contents[0]);
+        $this->assertSame('https://example.com/cat.png', $contents[0]->getUrl());
+        $this->assertInstanceOf(DocumentUrl::class, $contents[1]);
+        $this->assertSame('https://example.com/doc.pdf', $contents[1]->getUrl());
+    }
+
+    public function testItRejectsUnknownUserMessageContentType()
+    {
+        $normalizer = new MessageNormalizer();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Unknown content type "%s".', \stdClass::class));
+
+        $normalizer->denormalize([
+            'id' => Uuid::v7()->toRfc4122(),
+            'type' => UserMessage::class,
+            'content' => '',
+            'contentAsBase64' => [
+                [
+                    'type' => \stdClass::class,
+                    'content' => 'arbitrary-constructor-argument',
+                ],
+            ],
+            'toolsCalls' => [],
+            'metadata' => [],
+            'addedAt' => (new \DateTimeImmutable())->getTimestamp(),
+        ], MessageInterface::class);
     }
 
     public function testItCanDenormalizeWithCustomIdentifier()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

`MessageNormalizer` instantiated `UserMessage` content parts from an arbitrary `type` value in the payload, allowing any class to be constructed during denormalization. The denormalizer now whitelists the known content types (`Text`, `Image`, `Audio`, `File`, `Document`, `ImageUrl`, `DocumentUrl`) and throws a `LogicException` otherwise. This also fixes denormalization of URL-based content (`ImageUrl`/`DocumentUrl`), which previously took the wrong constructor path.

Tests added.

/cc @alexandre-daubois
