### PR TITLE
[Platform][Cerebras] Throw ModelNotFoundException on 404 responses

### DIFF
--- a/examples/cerebras/chat.php
+++ b/examples/cerebras/chat.php
@@ -21,6 +21,6 @@ $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),
     Message::ofUser('What is the capital of Japan?'),
 );
-$result = $platform->invoke('llama3.1-8b', $messages);
+$result = $platform->invoke('gpt-oss-120b', $messages);
 
 echo $result->asText().\PHP_EOL;

--- a/examples/cerebras/stream.php
+++ b/examples/cerebras/stream.php
@@ -22,7 +22,7 @@ $messages = new MessageBag(
     Message::ofUser('What are the top three destinations in France?'),
 );
 
-$result = $platform->invoke('llama3.1-8b', $messages, [
+$result = $platform->invoke('gpt-oss-120b', $messages, [
     'stream' => true,
 ]);
 

--- a/examples/cerebras/structured-output-math.php
+++ b/examples/cerebras/structured-output-math.php
@@ -27,6 +27,6 @@ $messages = new MessageBag(
     Message::ofUser('how can I solve 8x + 7 = -23'),
 );
 
-$result = $platform->invoke('qwen-3-235b-a22b-instruct-2507', $messages, ['response_format' => MathReasoning::class]);
+$result = $platform->invoke('gpt-oss-120b', $messages, ['response_format' => MathReasoning::class]);
 
 dump($result->asObject());

--- a/examples/cerebras/toolcall.php
+++ b/examples/cerebras/toolcall.php
@@ -23,7 +23,7 @@ $platform = Factory::createPlatform(env('CEREBRAS_API_KEY'), http_client());
 
 $toolbox = new Toolbox([new Clock()], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'qwen-3-235b-a22b-instruct-2507', [$processor], [$processor]);
+$agent = new Agent($platform, 'gpt-oss-120b', [$processor], [$processor]);
 
 $messages = new MessageBag(Message::ofUser('How many days until next Christmas?'));
 $result = $agent->call($messages);

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Add `IncompleteStreamException`, thrown by bridge converters when a stream ends before its terminal event
+ * Throw `ModelNotFoundException` on HTTP 404 responses in the shared `HttpStatusErrorHandlingTrait`
  * Add `JsonBodyEncodingTrait` so model clients can encode JSON request bodies without aborting on malformed UTF-8
  * Add support for passing a fully defined `Model` instance to `Platform::invoke()` (and `Provider::invoke()`) instead of a model name string, bypassing the model catalog; widen `ProviderInterface::supports()` to `string|Model` to route a model instance to the first provider whose model clients accept it
  * Add in-place `MessageBag::prepend()` and `MessageBag::removeSystemMessage()`

--- a/src/platform/src/Bridge/Cerebras/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cerebras/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
  * Throw `IncompleteStreamException` when a stream ends before a finish reason
+ * Throw `ModelNotFoundException` when a 404 response reports a missing model
 
 0.8
 ---

--- a/src/platform/src/Bridge/Cohere/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cohere/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
  * Throw `IncompleteStreamException` when a stream ends before `message-end`
+ * Throw `ModelNotFoundException` when a 404 response reports a missing model
 
 0.8
 ---

--- a/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
+++ b/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
  * Throw `IncompleteStreamException` when a stream ends before a finish reason
+ * Throw `ModelNotFoundException` when a 404 response reports a missing model
 
 0.8
 ---

--- a/src/platform/src/Bridge/Gemini/CHANGELOG.md
+++ b/src/platform/src/Bridge/Gemini/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+ * Throw `ModelNotFoundException` when a 404 response reports a missing model
 
 0.9
 ---

--- a/src/platform/src/Bridge/Mistral/CHANGELOG.md
+++ b/src/platform/src/Bridge/Mistral/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
  * Throw `IncompleteStreamException` when a stream ends before a finish reason
+ * Throw `ModelNotFoundException` when a 404 response reports a missing model
 
 0.8
 ---

--- a/src/platform/src/Bridge/OpenAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenAi/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
  * Throw `IncompleteStreamException` when a Responses stream ends before `response.completed`
  * Replace malformed UTF-8 sequences in request bodies instead of aborting the request
+ * Throw `ModelNotFoundException` when a 404 response reports a missing model
 
 0.8
 ---

--- a/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `IncompleteStreamException` when a stream ends before a finish reason
+ * Throw `ModelNotFoundException` when a 404 response reports a missing model
 
 0.9
 ---

--- a/src/platform/src/Bridge/Perplexity/CHANGELOG.md
+++ b/src/platform/src/Bridge/Perplexity/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
+ * Throw `ModelNotFoundException` when a 404 response reports a missing model
 
 0.8
 ---

--- a/src/platform/src/Result/HttpStatusErrorHandlingTrait.php
+++ b/src/platform/src/Result/HttpStatusErrorHandlingTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Result;
 
 use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *
  * Translates the common 4xx/429 responses returned by AI providers into
  * dedicated platform exceptions so consumers can react to auth failures,
- * bad requests and rate limits without parsing error bodies themselves.
+ * bad requests, missing models and rate limits without parsing error bodies
+ * themselves.
  *
  * Error bodies are parsed leniently: both the nested `error.message` shape
  * (OpenAI, Gemini, Perplexity) and the flat top-level `message` shape
@@ -47,6 +49,10 @@ trait HttpStatusErrorHandlingTrait
 
         if (400 === $status) {
             throw new BadRequestException($this->extractErrorMessage($response) ?? 'Bad Request');
+        }
+
+        if (404 === $status) {
+            throw new ModelNotFoundException($this->extractErrorMessage($response) ?? 'Not Found');
         }
 
         if (429 === $status) {

--- a/src/platform/tests/Result/HttpStatusErrorHandlingTraitTest.php
+++ b/src/platform/tests/Result/HttpStatusErrorHandlingTraitTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -27,8 +28,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 final class HttpStatusErrorHandlingTraitTest extends TestCase
 {
     /**
-     * Any status outside the 400/401/429 trio - success, redirect, server-error -
-     * is passed through untouched for the calling converter to handle.
+     * Any status outside the handled 400/401/404/429 set - success, redirect,
+     * server-error - is passed through untouched for the calling converter to handle.
      */
     #[DataProvider('unhandledStatusCodes')]
     public function testDoesNotThrowForUnhandledStatusCodes(int $status)
@@ -136,6 +137,45 @@ final class HttpStatusErrorHandlingTraitTest extends TestCase
 
         $this->expectException(BadRequestException::class);
         $this->expectExceptionMessage('Bad Request');
+
+        $this->subject()->throwOnHttpError($response);
+    }
+
+    public function testThrowsModelNotFoundExceptionOn404WithNestedErrorMessage()
+    {
+        $response = $this->response(json_encode([
+            'error' => [
+                'message' => 'The model `foo` does not exist',
+            ],
+        ]), 404);
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('The model `foo` does not exist');
+
+        $this->subject()->throwOnHttpError($response);
+    }
+
+    /**
+     * Flat top-level `message` is emitted by Mistral, Cerebras and Cohere.
+     */
+    public function testThrowsModelNotFoundExceptionOn404WithFlatMessage()
+    {
+        $response = $this->response(json_encode([
+            'message' => 'Model llama3.1-8b does not exist or you do not have access to it.',
+        ]), 404);
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('Model llama3.1-8b does not exist or you do not have access to it.');
+
+        $this->subject()->throwOnHttpError($response);
+    }
+
+    public function testThrowsModelNotFoundExceptionOn404WithEmptyBody()
+    {
+        $response = $this->response('', 404);
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('Not Found');
 
         $this->subject()->throwOnHttpError($response);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

A 404 from a streaming request (e.g. a deprecated or dedicated-only Cerebras model) was masked as `IncompleteStreamException`: the shared `HttpStatusErrorHandlingTrait` translated 400/401/429 but not 404, so the error fell through and the stream converter reported a missing finish reason instead.

It now throws `ModelNotFoundException` with the provider's error message, surfacing the real cause. Also points the Cerebras examples at `gpt-oss-120b` (the previous `llama3.1-8b` was retired from the public endpoint).