### PR TITLE
[Platform] Add MessageBag::withoutToolMessages() and use it in demo chats

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,15 @@ Agent
    +$agent->call(clone $messages);
    ```
 
+   Alternatively, if you do want to keep the appended messages in your bag (e.g. for conversation
+   history) but need to render or re-send only the conversational messages, strip the tool-call
+   messages and tool-call-only assistant messages with the new `MessageBag::withoutToolMessages()`:
+
+   ```diff
+   -$messages->withoutSystemMessage()->getMessages();
+   +$messages->withoutSystemMessage()->withoutToolMessages()->getMessages();
+   ```
+
 AI Bundle
 ---------
 

--- a/demo/src/Blog/TwigComponent.php
+++ b/demo/src/Blog/TwigComponent.php
@@ -35,7 +35,7 @@ final class TwigComponent
      */
     public function getMessages(): array
     {
-        return $this->chat->loadMessages()->withoutSystemMessage()->getMessages();
+        return $this->chat->loadMessages()->withoutSystemMessage()->withoutToolMessages()->getMessages();
     }
 
     #[LiveAction]

--- a/demo/src/Speech/TwigComponent.php
+++ b/demo/src/Speech/TwigComponent.php
@@ -35,7 +35,7 @@ final class TwigComponent
      */
     public function getMessages(): array
     {
-        return $this->chat->loadMessages()->withoutSystemMessage()->getMessages();
+        return $this->chat->loadMessages()->withoutSystemMessage()->withoutToolMessages()->getMessages();
     }
 
     #[LiveAction]

--- a/demo/src/Stream/TwigComponent.php
+++ b/demo/src/Stream/TwigComponent.php
@@ -42,7 +42,7 @@ final class TwigComponent extends AbstractController
      */
     public function getMessages(): array
     {
-        return $this->chat->loadMessages()->withoutSystemMessage()->getMessages();
+        return $this->chat->loadMessages()->withoutSystemMessage()->withoutToolMessages()->getMessages();
     }
 
     #[LiveAction]

--- a/demo/src/Wikipedia/TwigComponent.php
+++ b/demo/src/Wikipedia/TwigComponent.php
@@ -35,7 +35,7 @@ final class TwigComponent
      */
     public function getMessages(): array
     {
-        return $this->wikipedia->loadMessages()->withoutSystemMessage()->getMessages();
+        return $this->wikipedia->loadMessages()->withoutSystemMessage()->withoutToolMessages()->getMessages();
     }
 
     #[LiveAction]

--- a/demo/src/YouTube/TwigComponent.php
+++ b/demo/src/YouTube/TwigComponent.php
@@ -63,7 +63,7 @@ final class TwigComponent
      */
     public function getMessages(): array
     {
-        return $this->youTube->loadMessages()->withoutSystemMessage()->getMessages();
+        return $this->youTube->loadMessages()->withoutSystemMessage()->withoutToolMessages()->getMessages();
     }
 
     #[LiveAction]

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `JsonBodyEncodingTrait` so model clients can encode JSON request bodies without aborting on malformed UTF-8
  * Add support for passing a fully defined `Model` instance to `Platform::invoke()` (and `Provider::invoke()`) instead of a model name string, bypassing the model catalog; widen `ProviderInterface::supports()` to `string|Model` to route a model instance to the first provider whose model clients accept it
  * Add in-place `MessageBag::prepend()` and `MessageBag::removeSystemMessage()`
+ * Add `MessageBag::withoutToolMessages()` to strip tool-call messages and tool-call-only assistant messages
 
 0.9
 ---

--- a/src/platform/src/Message/MessageBag.php
+++ b/src/platform/src/Message/MessageBag.php
@@ -156,6 +156,31 @@ class MessageBag implements \Countable, \IteratorAggregate
     }
 
     /**
+     * Clones the MessageBag without tool-call messages and tool-call-only assistant messages,
+     * leaving only the conversational messages (user input and assistant messages carrying text).
+     */
+    public function withoutToolMessages(): self
+    {
+        $messages = clone $this;
+        $messages->messages = array_values(array_filter(
+            $messages->messages,
+            static function (MessageInterface $message): bool {
+                if ($message instanceof ToolCallMessage) {
+                    return false;
+                }
+
+                if ($message instanceof AssistantMessage && null === $message->asText()) {
+                    return false;
+                }
+
+                return true;
+            },
+        ));
+
+        return $messages;
+    }
+
+    /**
      * Clones the MessageBag without previous system message and prepends the given one.
      */
     public function withSystemMessage(SystemMessage $message): self

--- a/src/platform/tests/Message/MessageBagTest.php
+++ b/src/platform/tests/Message/MessageBagTest.php
@@ -131,6 +131,33 @@ final class MessageBagTest extends TestCase
         $this->assertSame('Hello, world!', $userMessage->getContent()[0]->getText());
     }
 
+    public function testWithoutToolMessages()
+    {
+        $messageBag = new MessageBag(
+            Message::ofUser('What is the weather?'),
+            Message::ofAssistant(new ToolCall('id1', 'get_weather', ['city' => 'Paris'])),
+            Message::ofToolCall(new ToolCall('id1', 'get_weather', ['city' => 'Paris']), 'It is sunny.'),
+            Message::ofAssistant('The weather in Paris is sunny.'),
+            Message::ofAssistant('Let me check again.', new ToolCall('id2', 'get_weather', ['city' => 'Paris'])),
+        );
+
+        $newMessageBag = $messageBag->withoutToolMessages();
+
+        $this->assertCount(5, $messageBag);
+        $this->assertCount(3, $newMessageBag);
+
+        $userMessage = $newMessageBag->getMessages()[0];
+        $this->assertInstanceOf(UserMessage::class, $userMessage);
+
+        $assistantMessage = $newMessageBag->getMessages()[1];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('The weather in Paris is sunny.', $assistantMessage->asText());
+
+        $assistantWithToolCall = $newMessageBag->getMessages()[2];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantWithToolCall);
+        $this->assertSame('Let me check again.', $assistantWithToolCall->asText());
+    }
+
     public function testWithSystemMessage()
     {
         $messageBag = new MessageBag(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Adds `MessageBag::withoutToolMessages()` to strip tool-call messages and tool-call-only assistant messages, leaving only conversational messages.

Since #2009, agent input processors mutate the message bag in place, so tool-call messages appended during the run leak into the caller's bag. The demo chats persist that bag and render it, producing empty user-message artifacts in the Wikipedia/Blog/etc. chats. The five demo `TwigComponent::getMessages()` now chain `withoutToolMessages()` to filter them at render time. `UPGRADE.md` documents this as an alternative to `clone $messages`.

```php
$messages->withoutSystemMessage()->withoutToolMessages()->getMessages();
```