### PR TITLE
[Platform] Add RawSseStream and slim down SseStream

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.10
 ----
 
+ * Add `RawSseStream` to parse Server-Sent Events from backends that omit the `text/event-stream` content type; `SseStream` now decodes only content-type-advertised SSE
  * Add `IncompleteStreamException`, thrown by bridge converters when a stream ends before its terminal event
  * Throw `ModelNotFoundException` on HTTP 404 responses in the shared `HttpStatusErrorHandlingTrait`
  * Add `JsonBodyEncodingTrait` so model clients can encode JSON request bodies without aborting on malformed UTF-8

--- a/src/platform/src/Result/Stream/RawSseStream.php
+++ b/src/platform/src/Result/Stream/RawSseStream.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Stream;
+
+use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Handles Server-Sent Events streaming responses that omit the
+ * "text/event-stream" content type (e.g. the ChatGPT Codex inference
+ * endpoint). Without that header the HTTP client never assembles the
+ * "event:"/"data:" framing into {@see ServerSentEvent} chunks, so the raw body
+ * is buffered here and split on blank-line event separators.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class RawSseStream implements HttpStreamInterface
+{
+    public function stream(ResponseInterface $response): iterable
+    {
+        $buffer = '';
+
+        foreach ((new EventSourceHttpClient())->stream($response) as $chunk) {
+            if ($chunk->isFirst() || $chunk->isLast()) {
+                continue;
+            }
+
+            // Defensive: the content type may have been present after all, in
+            // which case the client already framed the event for us.
+            if ($chunk instanceof ServerSentEvent) {
+                if (null !== ($decoded = $this->decode($chunk->getData()))) {
+                    yield $decoded;
+                }
+
+                continue;
+            }
+
+            $buffer .= $chunk->getContent();
+
+            while (1 === preg_match('/(?:\r\n){2,}|\r{2,}|\n{2,}/', $buffer, $match, \PREG_OFFSET_CAPTURE)) {
+                $event = substr($buffer, 0, $match[0][1]);
+                $buffer = substr($buffer, $match[0][1] + \strlen($match[0][0]));
+
+                if (null !== ($decoded = $this->decode($this->extractEventData($event)))) {
+                    yield $decoded;
+                }
+            }
+        }
+
+        // Flush a trailing event that ended without a final blank-line separator.
+        if ('' !== trim($buffer) && null !== ($decoded = $this->decode($this->extractEventData($buffer)))) {
+            yield $decoded;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decode(?string $data): ?array
+    {
+        if (null === $data) {
+            return null;
+        }
+
+        $data = trim($data);
+        if ('' === $data || '[DONE]' === $data) {
+            return null;
+        }
+
+        return json_decode($data, true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Extracts the concatenated "data:" payload from a raw SSE event block.
+     */
+    private function extractEventData(string $event): ?string
+    {
+        if (str_starts_with($event, "\xEF\xBB\xBF")) {
+            $event = substr($event, 3);
+        }
+
+        $data = null;
+        foreach (explode("\n", str_replace(["\r\n", "\r"], "\n", $event)) as $line) {
+            // lines starting with a colon identify as comment
+            if (str_starts_with($line, ':')) {
+                continue;
+            }
+
+            if (str_starts_with($line, 'data:')) {
+                $payload = ltrim(substr($line, 5), ' ');
+                $data = null === $data ? $payload : $data."\n".$payload;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/src/platform/src/Result/Stream/SseStream.php
+++ b/src/platform/src/Result/Stream/SseStream.php
@@ -16,7 +16,9 @@ use Symfony\Component\HttpClient\EventSourceHttpClient;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
- * Handles SSE (Server-Sent Events) streaming responses.
+ * Handles Server-Sent Events streaming responses that advertise the
+ * "text/event-stream" content type, so the HTTP client assembles each event
+ * into a {@see ServerSentEvent} chunk before it reaches this decoder.
  *
  * @author Johannes Wachter <johannes@sulu.io>
  */
@@ -25,31 +27,16 @@ final class SseStream implements HttpStreamInterface
     public function stream(ResponseInterface $response): iterable
     {
         foreach ((new EventSourceHttpClient())->stream($response) as $chunk) {
-            if ($chunk->isFirst() || $chunk->isLast() || ($chunk instanceof ServerSentEvent && '[DONE]' === $chunk->getData())) {
+            if (!$chunk instanceof ServerSentEvent) {
                 continue;
             }
 
-            $jsonDelta = $chunk instanceof ServerSentEvent ? $chunk->getData() : $chunk->getContent();
-
-            // Remove leading/trailing brackets
-            if (str_starts_with($jsonDelta, '[') || str_starts_with($jsonDelta, ',')) {
-                $jsonDelta = substr($jsonDelta, 1);
-            }
-            if (str_ends_with($jsonDelta, ']')) {
-                $jsonDelta = substr($jsonDelta, 0, -1);
+            $data = $chunk->getData();
+            if ('' === $data || '[DONE]' === $data) {
+                continue;
             }
 
-            // Split in case of multiple JSON objects
-            $deltas = explode(",\r\n", $jsonDelta);
-
-            foreach ($deltas as $delta) {
-                // lines starting with a colon identify as comment
-                if ('' === trim($delta) || str_starts_with($delta, ':')) {
-                    continue;
-                }
-
-                yield json_decode($delta, true, flags: \JSON_THROW_ON_ERROR);
-            }
+            yield json_decode($data, true, flags: \JSON_THROW_ON_ERROR);
         }
     }
 }

--- a/src/platform/tests/Result/Stream/RawSseStreamTest.php
+++ b/src/platform/tests/Result/Stream/RawSseStreamTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result\Stream;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\Stream\RawSseStream;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class RawSseStreamTest extends TestCase
+{
+    public function testParsesHeaderlessSseFraming()
+    {
+        // Some backends (e.g. the ChatGPT Codex backend) stream SSE without
+        // advertising "text/event-stream", so the chunks arrive raw and still
+        // carry the "event:"/"data:" framing.
+        $body = "event: response.output_text.delta\ndata: {\"foo\": \"bar\"}\n\n"
+            ."event: response.completed\ndata: {\"baz\": \"qux\"}\n\ndata: [DONE]\n\n";
+
+        $results = iterator_to_array((new RawSseStream())->stream($this->createResponse($body)));
+
+        $this->assertSame([['foo' => 'bar'], ['baz' => 'qux']], $results);
+    }
+
+    public function testIgnoresCommentLines()
+    {
+        $body = ": OPENROUTER PROCESSING\n\ndata: {\"foo\": \"bar\"}\n\n";
+
+        $results = iterator_to_array((new RawSseStream())->stream($this->createResponse($body)));
+
+        $this->assertSame([['foo' => 'bar']], $results);
+    }
+
+    public function testParsesFramingSplitAcrossChunks()
+    {
+        $response = $this->createResponse(['data: {"foo": ', "\"bar\"}\n\ndata: {\"baz\": \"qux\"}\n\n"]);
+
+        $results = iterator_to_array((new RawSseStream())->stream($response));
+
+        $this->assertSame([['foo' => 'bar'], ['baz' => 'qux']], $results);
+    }
+
+    public function testParsesCrlfLineEndings()
+    {
+        $body = "event: x\r\ndata: {\"foo\": \"bar\"}\r\n\r\ndata: {\"baz\": \"qux\"}\r\n\r\n";
+
+        $results = iterator_to_array((new RawSseStream())->stream($this->createResponse($body)));
+
+        $this->assertSame([['foo' => 'bar'], ['baz' => 'qux']], $results);
+    }
+
+    public function testParsesCarriageReturnLineEndings()
+    {
+        $body = "event: x\rdata: {\"foo\": \"bar\"}\r\rdata: {\"baz\": \"qux\"}\r\r";
+
+        $results = iterator_to_array((new RawSseStream())->stream($this->createResponse($body)));
+
+        $this->assertSame([['foo' => 'bar'], ['baz' => 'qux']], $results);
+    }
+
+    public function testParsesLeadingBom()
+    {
+        $results = iterator_to_array((new RawSseStream())->stream($this->createResponse("\xEF\xBB\xBFdata: {\"foo\": \"bar\"}\n\n")));
+
+        $this->assertSame([['foo' => 'bar']], $results);
+    }
+
+    public function testFlushesTrailingEventWithoutBlankLineSeparator()
+    {
+        $results = iterator_to_array((new RawSseStream())->stream($this->createResponse('data: {"foo": "bar"}')));
+
+        $this->assertSame([['foo' => 'bar']], $results);
+    }
+
+    /**
+     * @param string|list<string> $body
+     */
+    private function createResponse(string|array $body): ResponseInterface
+    {
+        $mockHttpClient = new MockHttpClient([new MockResponse($body, ['response_headers' => ['content-type' => 'application/json']])]);
+        $eventSourceClient = new EventSourceHttpClient($mockHttpClient);
+
+        return $eventSourceClient->request('GET', 'https://example.com');
+    }
+}

--- a/src/platform/tests/Result/Stream/SseStreamTest.php
+++ b/src/platform/tests/Result/Stream/SseStreamTest.php
@@ -59,19 +59,6 @@ final class SseStreamTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $results[0]);
     }
 
-    public function testStreamHandlesBracketsAndCommas()
-    {
-        $sse = "data: [{\"foo\": \"bar\"}]\n\ndata: ,{\"baz\": \"qux\"}\n\n";
-        $response = $this->createResponse($sse);
-
-        $stream = new SseStream();
-        $results = iterator_to_array($stream->stream($response));
-
-        $this->assertCount(2, $results);
-        $this->assertSame(['foo' => 'bar'], $results[0]);
-        $this->assertSame(['baz' => 'qux'], $results[1]);
-    }
-
     private function createResponse(string $body): ResponseInterface
     {
         $mockHttpClient = new MockHttpClient([new MockResponse($body, ['response_headers' => ['content-type' => 'text/event-stream']])]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | n/a
| License       | MIT

Adds a dedicated `RawSseStream` for backends that stream Server-Sent Events without a `text/event-stream` content type (e.g. the ChatGPT Codex inference endpoint), selected explicitly by a bridge the same way Ollama selects `NdjsonStream`. With that case extracted, `SseStream` decodes only content-type-advertised `ServerSentEvent` chunks — the JSON-array passthru it carried for Gemini's pre-`alt=sse` streaming is gone, since Gemini moved to SSE in 47e7ac162 and the other OpenAI-compatible providers stream SSE with the header.

Alternative to #2170: same outcome (headerless SSE parses) but via an implementation selected at the bridge instead of runtime content-sniffing in a single class. `RawSseStream` also flushes a trailing event that ends without a final blank-line separator.