### PR TITLE
[Platform] Fix OpenResponses null tool-call id and refresh deprecated example models

### DIFF
--- a/examples/gemini/structured-output-clock.php
+++ b/examples/gemini/structured-output-clock.php
@@ -30,7 +30,7 @@ $platform = Factory::createPlatform(env('GEMINI_API_KEY'), http_client(), eventD
 $clock = new Clock(new SymfonyClock());
 $toolbox = new Toolbox([$clock], logger: logger());
 $toolProcessor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gemini-3-pro-preview', [$toolProcessor], [$toolProcessor]);
+$agent = new Agent($platform, 'gemini-3.1-pro-preview', [$toolProcessor], [$toolProcessor]);
 
 $messages = new MessageBag(Message::ofUser('What date and time is it?'));
 $result = $agent->call($messages, ['response_format' => [

--- a/examples/gemini/toolcall-roundtrip.php
+++ b/examples/gemini/toolcall-roundtrip.php
@@ -24,7 +24,7 @@ $platform = Factory::createPlatform(env('GEMINI_API_KEY'), http_client());
 
 $toolbox = new Toolbox([new Clock(), new EuropeanCapitalsTool()], logger: logger());
 $processor = new AgentProcessor($toolbox);
-$agent = new Agent($platform, 'gemini-3-pro-preview', [$processor], [$processor]);
+$agent = new Agent($platform, 'gemini-3.1-pro-preview', [$processor], [$processor]);
 
 $messages = new MessageBag(
     Message::forSystem('You are a helpful assistant.'),

--- a/examples/rag/mariadb-gemini.php
+++ b/examples/rag/mariadb-gemini.php
@@ -52,7 +52,7 @@ $store->setup(['dimensions' => 768]);
 
 // create embeddings for documents
 $platform = Factory::createPlatform(env('GEMINI_API_KEY'), http_client());
-$model = 'gemini-embedding-exp-03-07?dimensions=768&task_type=SEMANTIC_SIMILARITY';
+$model = 'gemini-embedding-001?dimensions=768&task_type=SEMANTIC_SIMILARITY';
 $vectorizer = new Vectorizer($platform, $model, logger());
 $indexer = new DocumentIndexer(new DocumentProcessor($vectorizer, $store, logger: logger()));
 $indexer->index($documents);

--- a/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
@@ -47,7 +47,7 @@ class ResultConverter implements ResultConverterInterface
         $response = $result->getObject();
 
         if (401 === $response->getStatusCode()) {
-            $errorMessage = json_decode($response->getContent(false), true)['error']['message'];
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? 'Authentication failed.';
             throw new AuthenticationException($errorMessage);
         }
 

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -41,7 +41,7 @@ use Symfony\AI\Platform\ResultConverterInterface;
  * @phpstan-type OutputMessage array{content: array<Refusal|OutputText>, id: string, role: string, type: 'message'}
  * @phpstan-type OutputText array{type: 'output_text', text: string}
  * @phpstan-type Refusal array{type: 'refusal', refusal: string}
- * @phpstan-type FunctionCall array{id: string, arguments: string, call_id: string, name: string, type: 'function_call'}
+ * @phpstan-type FunctionCall array{id?: string|null, arguments: string, call_id?: string|null, name: string, type: 'function_call'}
  * @phpstan-type Thinking array{summary: list<array{type: string, text?: string}>, id: string}
  * @phpstan-type Error array{code?: string|null, type?: string|null, param?: string|null, message?: string|null}
  */
@@ -203,7 +203,8 @@ final class ResultConverter implements ResultConverterInterface
             if ('response.output_item.done' === $type && \is_array($event['item'] ?? null) && 'function_call' === ($event['item']['type'] ?? null)) {
                 /** @var FunctionCall $item */
                 $item = $event['item'];
-                $toolCalls[$item['id']] = $this->convertFunctionCall($item);
+                $toolCall = $this->convertFunctionCall($item);
+                $toolCalls[$toolCall->getId()] = $toolCall;
             }
 
             if ('response.completed' !== $type) {
@@ -278,7 +279,14 @@ final class ResultConverter implements ResultConverterInterface
     {
         $arguments = json_decode($toolCall['arguments'], true, flags: \JSON_THROW_ON_ERROR);
 
-        return new ToolCall($toolCall['id'], $toolCall['name'], $arguments);
+        // The Responses API addresses tool results by "call_id"; some providers (e.g. Scaleway)
+        // only send "call_id" and leave "id" empty, so prefer it and fall back to "id".
+        $id = $toolCall['call_id'] ?? $toolCall['id'] ?? null;
+        if (null === $id) {
+            throw new RuntimeException('Function call is missing both "call_id" and "id".');
+        }
+
+        return new ToolCall($id, $toolCall['name'], $arguments);
     }
 
     /**

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -88,6 +88,32 @@ final class ResultConverterTest extends TestCase
         $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->getArguments());
     }
 
+    public function testConvertToolCallResultUsesCallIdWhenIdIsMissing()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'function_call',
+                    'id' => null,
+                    'call_id' => 'call_789',
+                    'name' => 'test_function',
+                    'arguments' => '{"arg1": "value1"}',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $toolCalls = $result->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call_789', $toolCalls[0]->getId());
+        $this->assertSame('test_function', $toolCalls[0]->getName());
+        $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->getArguments());
+    }
+
     public function testConvertMultipleMessagesIntoMultiPartResult()
     {
         $converter = new ResultConverter();
@@ -591,6 +617,46 @@ final class ResultConverterTest extends TestCase
         $toolCalls = $chunks[0]->getToolCalls();
         $this->assertCount(1, $toolCalls);
         $this->assertSame('call_456', $toolCalls[0]->getId());
+        $this->assertSame('get_weather', $toolCalls[0]->getName());
+        $this->assertSame(['city' => 'Berlin'], $toolCalls[0]->getArguments());
+    }
+
+    public function testStreamWithToolCallOutputItemDoneUsesCallIdWhenIdIsMissing()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $events = [
+            [
+                'type' => 'response.output_item.done',
+                'item' => [
+                    'type' => 'function_call',
+                    'id' => null,
+                    'call_id' => 'call_789',
+                    'name' => 'get_weather',
+                    'arguments' => '{"city": "Berlin"}',
+                ],
+            ],
+            [
+                'type' => 'response.completed',
+                'response' => [
+                    'output' => [],
+                ],
+            ],
+        ];
+
+        $raw = new InMemoryRawResult([], $events, $httpResponse);
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $chunks = iterator_to_array($streamResult->getContent());
+
+        $this->assertCount(1, $chunks);
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $toolCalls = $chunks[0]->getToolCalls();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call_789', $toolCalls[0]->getId());
         $this->assertSame('get_weather', $toolCalls[0]->getName());
         $this->assertSame(['city' => 'Berlin'], $toolCalls[0]->getArguments());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Fixes a `TypeError` in the OpenResponses `ResultConverter` when a provider (e.g. Scaleway) returns a function call with a null `id` — now prefers `call_id` (which the Responses API uses to address tool results) and falls back to `id`. Also hardens the Generic completions converter against a null array offset on 401 responses, and refreshes deprecated models in three examples (`gemini-3-pro-preview` → `gemini-3.1-pro-preview`, `gemini-embedding-exp-03-07` → `gemini-embedding-001`).