### PR TITLE
[Platform] Fix OpenRouter speech example and model catalog

### DIFF
--- a/examples/openrouter/speech.php
+++ b/examples/openrouter/speech.php
@@ -16,11 +16,10 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = Factory::createPlatform(env('OPENROUTER_KEY'), http_client(), modelCatalog: new SpeechModelCatalog());
 
-$result = $platform->invoke('openai/gpt-4o-mini-tts-2025-12-15', 'Hello world from Symfony AI!', [
-    'voice' => 'echo',
-    'response_format' => 'mp3',
-    'speed' => 1.0,
+$result = $platform->invoke('google/gemini-3.1-flash-tts-preview', 'Hello world from Symfony AI!', [
+    'voice' => 'Zephyr',
+    'response_format' => 'pcm',
 ]);
 
-$result->asFile('/tmp/openrouter-speech.mp3');
-output()->writeln('Audio content saved to <comment>/tmp/openrouter-speech.mp3</comment>');
+$result->asFile('/tmp/openrouter-speech.pcm');
+output()->writeln('Audio content saved to <comment>/tmp/openrouter-speech.pcm</comment>');

--- a/src/platform/src/Bridge/OpenRouter/Speech/SpeechModelCatalog.php
+++ b/src/platform/src/Bridge/OpenRouter/Speech/SpeechModelCatalog.php
@@ -48,7 +48,7 @@ final class SpeechModelCatalog extends AbstractModelCatalog
                 Capability::TEXT_TO_SPEECH,
             ],
         ],
-        'mistralai/voxtral-mini-tts-2603' => [
+        'microsoft/mai-voice-2' => [
             'class' => SpeechModel::class,
             'capabilities' => [
                 Capability::INPUT_TEXT,
@@ -56,7 +56,7 @@ final class SpeechModelCatalog extends AbstractModelCatalog
                 Capability::TEXT_TO_SPEECH,
             ],
         ],
-        'openai/gpt-4o-mini-tts-2025-12-15' => [
+        'mistralai/voxtral-mini-tts-2603' => [
             'class' => SpeechModel::class,
             'capabilities' => [
                 Capability::INPUT_TEXT,
@@ -81,6 +81,14 @@ final class SpeechModelCatalog extends AbstractModelCatalog
             ],
         ],
         'zyphra/zonos-v0.1-transformer' => [
+            'class' => SpeechModel::class,
+            'capabilities' => [
+                Capability::INPUT_TEXT,
+                Capability::OUTPUT_AUDIO,
+                Capability::TEXT_TO_SPEECH,
+            ],
+        ],
+        'x-ai/grok-voice-tts-1.0' => [
             'class' => SpeechModel::class,
             'capabilities' => [
                 Capability::INPUT_TEXT,

--- a/src/platform/src/Bridge/OpenRouter/Tests/Speech/SpeechModelCatalogTest.php
+++ b/src/platform/src/Bridge/OpenRouter/Tests/Speech/SpeechModelCatalogTest.php
@@ -48,14 +48,14 @@ final class SpeechModelCatalogTest extends ModelCatalogTestCase
             $capabilities,
         ];
 
-        yield 'mistralai/voxtral-mini-tts-2603' => [
-            'mistralai/voxtral-mini-tts-2603',
+        yield 'microsoft/mai-voice-2' => [
+            'microsoft/mai-voice-2',
             SpeechModel::class,
             $capabilities,
         ];
 
-        yield 'openai/gpt-4o-mini-tts-2025-12-15' => [
-            'openai/gpt-4o-mini-tts-2025-12-15',
+        yield 'mistralai/voxtral-mini-tts-2603' => [
+            'mistralai/voxtral-mini-tts-2603',
             SpeechModel::class,
             $capabilities,
         ];
@@ -74,6 +74,12 @@ final class SpeechModelCatalogTest extends ModelCatalogTestCase
 
         yield 'zyphra/zonos-v0.1-transformer' => [
             'zyphra/zonos-v0.1-transformer',
+            SpeechModel::class,
+            $capabilities,
+        ];
+
+        yield 'x-ai/grok-voice-tts-1.0' => [
+            'x-ai/grok-voice-tts-1.0',
             SpeechModel::class,
             $capabilities,
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The OpenRouter speech example used `openai/gpt-4o-mini-tts-2025-12-15`, which OpenRouter does not serve (HTTP 400). Removed that non-existent entry from `SpeechModelCatalog`, added the two real TTS models that were missing (`microsoft/mai-voice-2`, `x-ai/grok-voice-tts-1.0`), and switched the example to `google/gemini-3.1-flash-tts-preview` with a valid voice and `pcm` output.