### PR TITLE
[Platform] Throw clear error on incomplete OpenResponses non-stream response

### DIFF
--- a/examples/scaleway/responses.php
+++ b/examples/scaleway/responses.php
@@ -25,7 +25,7 @@ $messages = new MessageBag(
 // gpt-oss-120b uses the Open Responses bridge to talk to Scaleway's Responses API.
 $result = $platform->invoke('gpt-oss-120b', $messages, [
     'reasoning' => ['effort' => 'medium'],
-    'max_output_tokens' => 200,
+    'max_output_tokens' => 2000,
 ]);
 
 echo $result->asText().\PHP_EOL;

--- a/src/platform/src/Bridge/Azure/CHANGELOG.md
+++ b/src/platform/src/Bridge/Azure/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10
+----
+
+ * Throw a clear exception when a non-streaming Responses response is incomplete or yields no content, instead of building an empty `MultiPartResult`
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Throw `ExceedContextSizeException` instead of `BadRequestException` when a 400 response reports a context overflow
  * Throw `IncompleteStreamException` when a stream ends before `response.completed`
+ * Throw a clear exception when a non-streaming response is incomplete or yields no content, instead of building an empty `MultiPartResult`
  * Replace malformed UTF-8 sequences in request bodies instead of aborting the request
 
 0.8

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -102,6 +102,19 @@ final class ResultConverter implements ResultConverterInterface
 
         $results = $this->convertOutputArray($data[self::KEY_OUTPUT]);
 
+        if ([] === $results) {
+            if ('incomplete' === ($data['status'] ?? null)) {
+                $reason = $data['incomplete_details']['reason'] ?? 'unknown';
+                if (!\is_string($reason) || '' === $reason) {
+                    $reason = 'unknown';
+                }
+
+                throw new RuntimeException(\sprintf('Responses API response is incomplete (%s) and contains no content.', $reason));
+            }
+
+            throw new RuntimeException('Response does not contain any content.');
+        }
+
         return 1 === \count($results) ? array_pop($results) : new MultiPartResult(array_values($results));
     }
 

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -252,6 +252,48 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('final', $result->getContent());
     }
 
+    public function testThrowsRuntimeExceptionWhenIncompleteResponseHasNoContent()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'status' => 'incomplete',
+            'incomplete_details' => ['reason' => 'max_output_tokens'],
+            'output' => [
+                [
+                    'type' => 'reasoning',
+                    'id' => 'rs_1',
+                    'summary' => [],
+                ],
+            ],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Responses API response is incomplete (max_output_tokens) and contains no content.');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsRuntimeExceptionWhenOutputYieldsNoContent()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'reasoning',
+                    'id' => 'rs_1',
+                    'summary' => [],
+                ],
+            ],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Response does not contain any content.');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
     public function testContentFilterException()
     {
         $converter = new ResultConverter();

--- a/src/platform/src/Bridge/Scaleway/CHANGELOG.md
+++ b/src/platform/src/Bridge/Scaleway/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Throw `ExceedContextSizeException` when a 400 response reports a context overflow
  * Throw `IncompleteStreamException` when a stream ends before a finish reason
+ * Throw a clear exception when a non-streaming response is incomplete or yields no content, instead of building an empty `MultiPartResult`
 
 0.9
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

When a non-streaming Responses API response is `incomplete` (e.g. `max_output_tokens` consumed entirely by reasoning) it yields no output items. Previously `convert()` built an empty `MultiPartResult`, violating its `non-empty-list` contract and surfacing as a cryptic `expected "TextResult", got "MultiPartResult"`. It now throws a clear `RuntimeException`, mirroring the streaming `response.incomplete` handling. The `scaleway/responses.php` example's `max_output_tokens` is bumped so reasoning leaves room for an answer.
