### PR TITLE
[Platform][Anthropic] Support server-side tools via server_tools option

### DIFF
--- a/docs/components/platform/anthropic-server-tools.rst
+++ b/docs/components/platform/anthropic-server-tools.rst
@@ -1,15 +1,65 @@
 Anthropic Server Tools
 ======================
 
-Anthropic provides built-in server-side tools that allow the model to perform specific actions like executing code or editing files in a sandboxed environment.
+Anthropic provides built-in server-side tools that allow the model to perform specific actions like searching the
+web or executing code in a sandboxed environment.
 
 Overview
 --------
 
-Anthropic's server tools can be enabled when calling the model. These tools are executed on Anthropic's infrastructure.
+Anthropic's server tools can be enabled when calling the model. These tools are executed on Anthropic's
+infrastructure. Enable them with the ``server_tools`` option, a map of tool name to parameters (``true`` enables a
+tool with no extra parameters)::
+
+    $result = $platform->invoke('claude-sonnet-4-5-20250929', $messages, [
+        'server_tools' => [
+            'web_search' => true,
+            'code_execution' => true,
+        ],
+    ]);
+
+The bridge maps each recognized name to Anthropic's versioned tool ``type``. Only ``web_search`` and
+``code_execution`` are mapped, because those are the only server tools whose result blocks
+:class:`Symfony\\AI\\Platform\\Bridge\\Anthropic\\ResultConverter` currently understands. An unrecognized name
+throws :class:`Symfony\\AI\\Platform\\Exception\\InvalidArgumentException`.
 
 Available Server Tools
 ----------------------
+
+Web Search
+~~~~~~~~~~
+
+The Web Search tool (``web_search``) lets the model search the web and ground its response in the results::
+
+    $result = $platform->invoke('claude-sonnet-4-5-20250929', $messages, [
+        'server_tools' => [
+            'web_search' => ['max_uses' => 3],
+        ],
+    ]);
+
+Any parameters given (e.g. ``max_uses``, ``allowed_domains``, ``blocked_domains``, ``user_location``) are merged
+into the tool definition Anthropic sends, and this also lets a caller override the versioned ``type`` the bridge
+defaults to::
+
+    $result = $platform->invoke('claude-sonnet-5', $messages, [
+        'server_tools' => [
+            'web_search' => ['type' => 'web_search_20260209', 'max_uses' => 3],
+        ],
+    ]);
+
+The bridge defaults to ``web_search_20250305``, the basic variant every Claude model supports. Anthropic also
+offers ``web_search_20260209`` (dynamic filtering, Claude 4.6 and later) and ``web_search_20260318`` (adds
+``response_inclusion``). A caller can opt into either per call, without falling back to the raw ``tools``
+escape hatch.
+
+.. caution::
+
+    From ``web_search_20260209`` on, Anthropic runs the search from inside code execution to filter the
+    results, and provisions that itself, so ``code_execution`` is not declared alongside it. Two consequences:
+    the response then also carries code execution blocks that
+    :class:`Symfony\\AI\\Platform\\Bridge\\Anthropic\\ResultConverter` does not convert, and ``allowed_callers``
+    defaults to code execution, so a model without programmatic tool calling needs
+    ``'allowed_callers' => ['direct']`` or the API answers 400.
 
 Code Execution
 ~~~~~~~~~~~~~~
@@ -19,29 +69,65 @@ Anthropic provides two main tools for code execution:
 - **Bash** (``bash_code_execution``) - Allows the model to run bash commands.
 - **Text Editor** (``text_editor_code_execution``) - Allows the model to create and edit files, often used in conjunction with Python execution.
 
-To enable these tools you need to explicitly enable the code execution using the ``tools`` option::
+Both are enabled together through the single ``code_execution`` server tool::
 
-    $result = $platform->invoke('claude-3-5-sonnet-latest', $messages, [
+    $result = $platform->invoke('claude-sonnet-4-5-20250929', $messages, [
+        'server_tools' => [
+            'code_execution' => true,
+        ],
+    ]);
+
+Other Server Tools
+~~~~~~~~~~~~~~~~~~
+
+Anthropic offers further server tools (e.g. ``web_fetch``) that the bridge does not map to ``server_tools`` yet,
+because their result blocks are not converted into typed results. These remain reachable by passing the raw
+Anthropic tool spec through the ``tools`` option, which is forwarded to the request body as-is::
+
+    $result = $platform->invoke('claude-sonnet-4-5-20250929', $messages, [
         'tools' => [[
-            'type' => 'code_execution_20250825',
-            'name' => 'code_execution',
+            'type' => 'web_fetch_20250910',
+            'name' => 'web_fetch',
         ]],
     ]);
 
 Handling Results
 ----------------
 
-When server tools are used, the model may return multiple content blocks. Symfony AI abstracts these into a :class:`Symfony\\AI\\Platform\\Result\\MultiPartResult`.
+When server tools are used, the model may return multiple content blocks. Symfony AI abstracts these into a
+:class:`Symfony\\AI\\Platform\\Result\\MultiPartResult`.
 
 The individual parts can be any `ResultInterface` instances, but in practice they consist of the following result types:
 
 - :class:`Symfony\\AI\\Platform\\Result\\TextResult` - Normal text response.
 - :class:`Symfony\\AI\\Platform\\Result\\ExecutableCodeResult` - The code the model intended to run.
 - :class:`Symfony\\AI\\Platform\\Result\\CodeExecutionResult` - The output of the executed code (stdout/stderr).
+- :class:`Symfony\\AI\\Platform\\Result\\WebSearchResult` - One search the model performed. The converter merges
+  the ``server_tool_use`` call and its matching ``web_search_tool_result`` into a single part carrying the query,
+  id, and status together.
+
+.. note::
+
+    Server tool results are only converted for non-streaming requests. With ``stream: true`` the Anthropic
+    ``ResultConverter`` handles text, thinking and regular tool calls only, so server tool blocks are silently
+    dropped from the stream.
+
+.. caution::
+
+    :class:`Symfony\\AI\\Platform\\Result\\WebSearchResult` has no field for individual search hits (URL, title,
+    page age). Anthropic reports those on the ``web_search_tool_result`` block, but carrying them would require
+    changing a Platform-wide class the OpenResponses bridge also populates, so today the query, id and status
+    round-trip but the individual hits do not. Carrying search hits, handling ``citations`` on text blocks,
+    ``encrypted_content`` round-tripping, and adding a :class:`Symfony\\AI\\Platform\\Message\\Content\\WebSearch`
+    branch to ``Contract\AssistantMessageNormalizer`` (without it, a web search is dropped when re-serializing an
+    assistant turn, so multi-turn continuation after a search does not carry the search blocks) are open
+    follow-ups.
 
 Example
 -------
 
-See `examples/anthropic/server-tools-code-execution.php`_ for a complete working example.
+See `examples/anthropic/server-tools-code-execution.php`_ and `examples/anthropic/server-tools-web-search.php`_ for
+complete working examples.
 
 .. _`examples/anthropic/server-tools-code-execution.php`: https://github.com/symfony/ai/blob/main/examples/anthropic/server-tools-code-execution.php
+.. _`examples/anthropic/server-tools-web-search.php`: https://github.com/symfony/ai/blob/main/examples/anthropic/server-tools-web-search.php

--- a/examples/anthropic/server-tools-code-execution-roundtrip.php
+++ b/examples/anthropic/server-tools-code-execution-roundtrip.php
@@ -23,15 +23,13 @@ $platform = Factory::createPlatform(env('ANTHROPIC_API_KEY'), httpClient: http_c
 
 $agent = new Agent($platform, 'claude-sonnet-4-5-20250929');
 
-$tools = [
-    ['type' => 'code_execution_20250825', 'name' => 'code_execution'],
-];
+$serverTools = ['code_execution' => true];
 
 $messages = new MessageBag(
     Message::ofUser('Compute the 10th Fibonacci number using a short Python snippet.'),
 );
 
-$execution = $agent->call($messages, ['tools' => $tools]);
+$execution = $agent->call($messages, ['server_tools' => $serverTools]);
 $messages->add($assistant = Message::ofAssistant($execution->getResult()));
 
 output()->writeln('<info>====== Turn 1 ======</info>');
@@ -49,5 +47,5 @@ echo \PHP_EOL;
 
 output()->writeln('<info>====== Turn 2 ======</info>');
 $messages->add(Message::ofUser('What number did your snippet print? Answer with the number only.'));
-$execution = $agent->call($messages, ['tools' => $tools]);
+$execution = $agent->call($messages, ['server_tools' => $serverTools]);
 output()->writeln('<comment>Assistant:</comment> '.$execution->asText());

--- a/examples/anthropic/server-tools-web-search.php
+++ b/examples/anthropic/server-tools-web-search.php
@@ -13,7 +13,7 @@ use Symfony\AI\Agent\Agent;
 use Symfony\AI\Platform\Bridge\Anthropic\Factory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
 
 require_once dirname(__DIR__).'/bootstrap.php';
 
@@ -22,16 +22,18 @@ $platform = Factory::createPlatform(env('ANTHROPIC_API_KEY'), httpClient: http_c
 $agent = new Agent($platform, 'claude-sonnet-4-5-20250929');
 
 $messages = new MessageBag(
-    Message::ofUser('Calculate total cost of a mortgage with 1% interest on 100k€ principal with 25 year maturity'),
+    Message::ofUser('What is the current 12 month Euribor rate?'),
 );
 
 $result = $agent->call($messages, [
-    'server_tools' => ['code_execution' => true],
+    'server_tools' => [
+        'web_search' => ['max_uses' => 3],
+    ],
 ]);
 
 foreach ($result->asMultiPart() as $part) {
     echo match (true) {
-        $part instanceof ExecutableCodeResult => "<code>\n".$part->getContent()."\n</code>\n\n",
+        $part instanceof WebSearchResult => "<search query=\"{$part->getQuery()}\" status=\"{$part->getStatus()}\">\n",
         default => $part->getContent()."\n",
     };
 }

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.10
 ----
 
+ * Add support for server-side Anthropic tools (e.g. `web_search`) via the `server_tools` option, appended verbatim to the request tools
  * Add `RawSseStream` to parse Server-Sent Events from backends that omit the `text/event-stream` content type (used by the OpenResponses bridge for the ChatGPT Codex backend); `SseStream` now decodes only content-type-advertised SSE
  * Add `IncompleteStreamException`, thrown by bridge converters when a stream ends before its terminal event
  * Throw `ModelNotFoundException` on HTTP 404 responses in the shared `HttpStatusErrorHandlingTrait`

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.14
+----
+
+ * Add a `server_tools` option to the Anthropic `ModelClient`, mapping `web_search` and `code_execution` to their versioned Anthropic tool spec, mirroring the Gemini and Vertex AI bridges' name-to-params map shape; unmapped tool names throw instead of being silently forwarded, and the raw `tools` option remains the escape hatch for anything not mapped. The Anthropic `ResultConverter` now merges the `server_tool_use`/`web_search_tool_result` pair of a web search into a single `Result\WebSearchResult` carrying query, id and status, instead of dropping the blocks (or throwing when a response carries only web-search blocks)
+
 0.13
 ----
 

--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -66,6 +66,11 @@ final class ModelClient implements ModelClientInterface
         $payload = $this->injectCacheControl($payload);
         $payload = $this->injectSystemCacheControl($payload);
 
+        if (isset($options['server_tools'])) {
+            $options['tools'] = [...$options['tools'] ?? [], ...$options['server_tools']];
+            unset($options['server_tools']);
+        }
+
         if (isset($options['tools'])) {
             $options['tool_choice'] ??= ['type' => 'auto'];
             $options['tools'] = $this->injectToolsCacheControl($options['tools']);

--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -28,6 +28,18 @@ final class ModelClient implements ModelClientInterface
     use JsonSchemaSanitizerTrait;
     use PromptCachingTrait;
 
+    /**
+     * Anthropic requires a versioned `type` per server tool, so only tools whose
+     * result blocks the converter can round-trip are mapped here. Anything else
+     * stays reachable through the raw `tools` option.
+     *
+     * @var array<string, array{type: string, name: string}>
+     */
+    private const SERVER_TOOLS = [
+        'web_search' => ['type' => 'web_search_20250305', 'name' => 'web_search'],
+        'code_execution' => ['type' => 'code_execution_20250825', 'name' => 'code_execution'],
+    ];
+
     private readonly EventSourceHttpClient $httpClient;
     private readonly string $baseUrl;
 
@@ -78,6 +90,16 @@ final class ModelClient implements ModelClientInterface
             $options['tools'] = $this->injectToolsCacheControl($options['tools'], $cacheControl);
         }
 
+        if (isset($options['server_tools'])) {
+            $serverTools = $this->mapServerTools($options['server_tools']);
+            unset($options['server_tools']);
+
+            if ([] !== $serverTools) {
+                $options['tools'] = array_merge($options['tools'] ?? [], $serverTools);
+                $options['tool_choice'] ??= ['type' => 'auto'];
+            }
+        }
+
         // Adaptive thinking enables interleaved thinking on its own; the beta
         // header is only needed for the legacy enabled/budget_tokens format.
         if ('enabled' === ($options['thinking']['type'] ?? null)) {
@@ -102,5 +124,29 @@ final class ModelClient implements ModelClientInterface
             'headers' => $headers,
             'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));
+    }
+
+    /**
+     * @param array<string, array<string, mixed>|bool|null> $serverTools Name => params, `true` for "enabled, no params", falsy to skip
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function mapServerTools(array $serverTools): array
+    {
+        $tools = [];
+
+        foreach ($serverTools as $tool => $params) {
+            if (!$params) {
+                continue;
+            }
+
+            if (!isset(self::SERVER_TOOLS[$tool])) {
+                throw new InvalidArgumentException(\sprintf('Unsupported Anthropic server tool "%s". Supported server tools are "%s". Use the "tools" option to pass an unmapped tool through verbatim.', $tool, implode('", "', array_keys(self::SERVER_TOOLS))));
+            }
+
+            $tools[] = \is_array($params) ? array_merge(self::SERVER_TOOLS[$tool], $params) : self::SERVER_TOOLS[$tool];
+        }
+
+        return $tools;
     }
 }

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -42,6 +42,7 @@ use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 
 /**
@@ -117,6 +118,7 @@ class ResultConverter implements ResultConverterInterface
         }
 
         $results = [];
+        $webSearchIndexes = [];
         foreach ($data['content'] as $content) {
             if ('tool_use' === $content['type']) {
                 $results[] = new ToolCallResult([new ToolCall($content['id'], $content['name'], $content['input'])]);
@@ -130,6 +132,9 @@ class ResultConverter implements ResultConverterInterface
                     $results[] = new ExecutableCodeResult($content['input']['command'], 'bash', $content['id']);
                 } elseif ('text_editor_code_execution' === $content['name']) {
                     $results[] = new ExecutableCodeResult($content['input']['file_text'] ?? $content['input']['command'], null, $content['id']);
+                } elseif ('web_search' === $content['name']) {
+                    $webSearchIndexes[$content['id']] = \count($results);
+                    $results[] = new WebSearchResult($content['input']['query'] ?? null, $content['id']);
                 }
             } elseif ('bash_code_execution_tool_result' === $content['type']) {
                 $results[] = new CodeExecutionResult(
@@ -139,6 +144,21 @@ class ResultConverter implements ResultConverterInterface
                 );
             } elseif ('text_editor_code_execution_tool_result' === $content['type']) {
                 $results[] = new CodeExecutionResult(true, null, $content['tool_use_id']);
+            } elseif ('web_search_tool_result' === $content['type']) {
+                // Success carries a list of `web_search_result` blocks; an error is a single
+                // `web_search_tool_result_error` object instead. Neither result type reports the
+                // individual hits, so only the status survives the conversion.
+                $status = 'web_search_tool_result_error' === ($content['content']['type'] ?? null)
+                    ? $content['content']['error_code'] ?? null
+                    : 'completed';
+
+                $index = $webSearchIndexes[$content['tool_use_id']] ?? null;
+                if (null !== $index) {
+                    $call = $results[$index];
+                    $results[$index] = new WebSearchResult($call->getQuery(), $call->getId(), $status);
+                } else {
+                    $results[] = new WebSearchResult(id: $content['tool_use_id'], status: $status);
+                }
             } elseif ('thinking' === $content['type']) {
                 $results[] = new ThinkingResult($content['thinking'], $content['signature'] ?? null);
             }

--- a/src/platform/src/Bridge/Anthropic/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ModelClientTest.php
@@ -258,6 +258,125 @@ class ModelClientTest extends TestCase
         $this->modelClient->request($this->model, ['message' => 'test'], $options);
     }
 
+    public function testToolChoiceDefaultsToAutoWithOnlyServerTools()
+    {
+        $this->httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $body = json_decode($options['body'], true);
+            $this->assertSame(['type' => 'auto'], $body['tool_choice']);
+
+            return new JsonMockResponse('{"success": true}');
+        });
+
+        $this->modelClient = new ModelClient($this->httpClient, 'test-api-key');
+
+        $options = ['server_tools' => ['code_execution' => true]];
+        $this->modelClient->request($this->model, ['message' => 'test'], $options);
+    }
+
+    public function testServerToolWebSearchMapsToVersionedTypeAndMergesParams()
+    {
+        $this->httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $body = json_decode($options['body'], true);
+            $this->assertSame([
+                'type' => 'web_search_20250305',
+                'name' => 'web_search',
+                'max_uses' => 3,
+            ], $body['tools'][0]);
+
+            return new JsonMockResponse('{"success": true}');
+        });
+
+        $this->modelClient = new ModelClient($this->httpClient, 'test-api-key');
+
+        $options = ['server_tools' => ['web_search' => ['max_uses' => 3]]];
+        $this->modelClient->request($this->model, ['message' => 'test'], $options);
+    }
+
+    public function testServerToolCodeExecutionMapsWithoutParams()
+    {
+        $this->httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $body = json_decode($options['body'], true);
+            $this->assertSame([
+                'type' => 'code_execution_20250825',
+                'name' => 'code_execution',
+            ], $body['tools'][0]);
+
+            return new JsonMockResponse('{"success": true}');
+        });
+
+        $this->modelClient = new ModelClient($this->httpClient, 'test-api-key');
+
+        $options = ['server_tools' => ['code_execution' => true]];
+        $this->modelClient->request($this->model, ['message' => 'test'], $options);
+    }
+
+    public function testServerToolsSkipFalsyParams()
+    {
+        $this->httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $body = json_decode($options['body'], true);
+            $this->assertArrayNotHasKey('tools', $body);
+
+            return new JsonMockResponse('{"success": true}');
+        });
+
+        $this->modelClient = new ModelClient($this->httpClient, 'test-api-key');
+
+        $options = ['server_tools' => ['web_search' => false, 'code_execution' => null]];
+        $this->modelClient->request($this->model, ['message' => 'test'], $options);
+    }
+
+    public function testServerToolsUnknownNameThrows()
+    {
+        $this->modelClient = new ModelClient(new MockHttpClient(), 'test-api-key');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported Anthropic server tool "web_fetch". Supported server tools are "web_search", "code_execution". Use the "tools" option to pass an unmapped tool through verbatim.');
+
+        $this->modelClient->request($this->model, ['message' => 'test'], [
+            'server_tools' => ['web_fetch' => true],
+        ]);
+    }
+
+    public function testServerToolsAreAppendedAfterFunctionToolsCacheControl()
+    {
+        $this->httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $body = json_decode($options['body'], true);
+
+            $this->assertCount(2, $body['tools']);
+            $this->assertSame('tool_a', $body['tools'][0]['name']);
+            $this->assertSame('web_search', $body['tools'][1]['name']);
+
+            // Regression guard: cache_control must stay on the last function tool, never migrate to a server tool
+            $this->assertArrayHasKey('cache_control', $body['tools'][0]);
+            $this->assertArrayNotHasKey('cache_control', $body['tools'][1]);
+
+            return new JsonMockResponse('{"success": true}');
+        });
+
+        $this->modelClient = new ModelClient($this->httpClient, 'test-api-key', 'short');
+
+        $options = [
+            'tools' => [['name' => 'tool_a', 'description' => 'First tool', 'input_schema' => ['type' => 'object']]],
+            'server_tools' => ['web_search' => true],
+        ];
+        $this->modelClient->request($this->model, ['message' => 'test'], $options);
+    }
+
+    public function testServerToolsKeyNeverReachesRequestBody()
+    {
+        $this->httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $body = json_decode($options['body'], true);
+            $this->assertArrayNotHasKey('server_tools', $body);
+
+            return new JsonMockResponse('{"success": true}');
+        });
+
+        $this->modelClient = new ModelClient($this->httpClient, 'test-api-key');
+
+        $options = ['server_tools' => ['code_execution' => true]];
+        $this->modelClient->request($this->model, ['message' => 'test'], $options);
+    }
+
     public function testStringPayloadThrowsException()
     {
         $this->modelClient = new ModelClient(new MockHttpClient(), 'test-api-key');

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -42,6 +42,7 @@ use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
 use Symfony\AI\Platform\TokenUsage\StreamListener as TokenUsageStreamListener;
 use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -815,6 +816,253 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('finish_reason', $metadataDelta->getKey());
         $this->assertTrue($metadataDelta->getValue()->is(FinishReasonCase::STOP));
         $this->assertSame('end_turn', $metadataDelta->getValue()->getRaw());
+    }
+
+    public function testConvertServerToolUseWebSearchAloneIntoWebSearchResult()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_01WYG3ziw53XMcoyKL4XcZmE',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'claude shannon birth date'],
+                ],
+            ],
+        ]));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(WebSearchResult::class, $result);
+        $this->assertSame('claude shannon birth date', $result->getQuery());
+        $this->assertSame('srvtoolu_01WYG3ziw53XMcoyKL4XcZmE', $result->getId());
+        $this->assertNull($result->getStatus());
+    }
+
+    public function testConvertWebSearchCallAndSuccessResultMergeIntoOneWebSearchResult()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_01WYG3ziw53XMcoyKL4XcZmE',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'claude shannon birth date'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_01WYG3ziw53XMcoyKL4XcZmE',
+                    'content' => [
+                        [
+                            'type' => 'web_search_result',
+                            'url' => 'https://en.wikipedia.org/wiki/Claude_Shannon',
+                            'title' => 'Claude Shannon - Wikipedia',
+                            'encrypted_content' => 'EqgfCioIARgBIiQ3YTAwMjY1Mi1mZjM5LTQ1NGUtODgxNC1kNjNjNTk1ZWI3Y...',
+                            'page_age' => 'April 30, 2025',
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(WebSearchResult::class, $result);
+        $this->assertSame('claude shannon birth date', $result->getQuery());
+        $this->assertSame('srvtoolu_01WYG3ziw53XMcoyKL4XcZmE', $result->getId());
+        $this->assertSame('completed', $result->getStatus());
+    }
+
+    public function testConvertWebSearchCallAndErrorResultMergeIntoOneWebSearchResult()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_a93jad',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'claude shannon birth date'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_a93jad',
+                    'content' => [
+                        'type' => 'web_search_tool_result_error',
+                        'error_code' => 'max_uses_exceeded',
+                    ],
+                ],
+            ],
+        ]));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(WebSearchResult::class, $result);
+        $this->assertSame('claude shannon birth date', $result->getQuery());
+        $this->assertSame('srvtoolu_a93jad', $result->getId());
+        $this->assertSame('max_uses_exceeded', $result->getStatus());
+    }
+
+    public function testConvertOrphanWebSearchToolResultIntoWebSearchResultWithoutQuery()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_a93jad',
+                    'content' => [
+                        'type' => 'web_search_tool_result_error',
+                        'error_code' => 'max_uses_exceeded',
+                    ],
+                ],
+            ],
+        ]));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(WebSearchResult::class, $result);
+        $this->assertNull($result->getQuery());
+        $this->assertSame('srvtoolu_a93jad', $result->getId());
+        $this->assertSame('max_uses_exceeded', $result->getStatus());
+    }
+
+    public function testConvertResponseWithOnlyWebSearchBlocksDoesNotThrow()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_01WYG3ziw53XMcoyKL4XcZmE',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'claude shannon birth date'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_01WYG3ziw53XMcoyKL4XcZmE',
+                    'content' => [
+                        [
+                            'type' => 'web_search_result',
+                            'url' => 'https://en.wikipedia.org/wiki/Claude_Shannon',
+                            'title' => 'Claude Shannon - Wikipedia',
+                            'encrypted_content' => 'EqgfCioIARgBIiQ3YTAwMjY1Mi1mZjM5LTQ1NGUtODgxNC1kNjNjNTk1ZWI3Y...',
+                            'page_age' => 'April 30, 2025',
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(WebSearchResult::class, $result);
+        $this->assertSame('completed', $result->getStatus());
+    }
+
+    public function testConvertTwoDistinctWebSearchesYieldTwoWebSearchResults()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_first',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'claude shannon birth date'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_first',
+                    'content' => [
+                        [
+                            'type' => 'web_search_result',
+                            'url' => 'https://en.wikipedia.org/wiki/Claude_Shannon',
+                            'title' => 'Claude Shannon - Wikipedia',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_second',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'alan turing birth date'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_second',
+                    'content' => [
+                        [
+                            'type' => 'web_search_result',
+                            'url' => 'https://en.wikipedia.org/wiki/Alan_Turing',
+                            'title' => 'Alan Turing - Wikipedia',
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+
+        $this->assertInstanceOf(WebSearchResult::class, $parts[0]);
+        $this->assertSame('claude shannon birth date', $parts[0]->getQuery());
+        $this->assertSame('srvtoolu_first', $parts[0]->getId());
+        $this->assertSame('completed', $parts[0]->getStatus());
+
+        $this->assertInstanceOf(WebSearchResult::class, $parts[1]);
+        $this->assertSame('alan turing birth date', $parts[1]->getQuery());
+        $this->assertSame('srvtoolu_second', $parts[1]->getId());
+        $this->assertSame('completed', $parts[1]->getStatus());
+    }
+
+    public function testConvertWebSearchMergedWithTextBlockKeepsWireOrder()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_01WYG3ziw53XMcoyKL4XcZmE',
+                    'name' => 'web_search',
+                    'input' => ['query' => 'claude shannon birth date'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_01WYG3ziw53XMcoyKL4XcZmE',
+                    'content' => [
+                        [
+                            'type' => 'web_search_result',
+                            'url' => 'https://en.wikipedia.org/wiki/Claude_Shannon',
+                            'title' => 'Claude Shannon - Wikipedia',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'text',
+                    'text' => 'Claude Shannon was born on April 30, 1916.',
+                ],
+            ],
+        ]));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+
+        $this->assertInstanceOf(WebSearchResult::class, $parts[0]);
+        $this->assertSame('claude shannon birth date', $parts[0]->getQuery());
+        $this->assertSame('srvtoolu_01WYG3ziw53XMcoyKL4XcZmE', $parts[0]->getId());
+        $this->assertSame('completed', $parts[0]->getStatus());
+
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('Claude Shannon was born on April 30, 1916.', $parts[1]->getContent());
     }
 
     /**

--- a/src/platform/tests/Bridge/Anthropic/ModelClientTest.php
+++ b/src/platform/tests/Bridge/Anthropic/ModelClientTest.php
@@ -122,6 +122,87 @@ final class ModelClientTest extends TestCase
         $this->assertArrayNotHasKey('cache_control', $capturedBody['tools'][0]);
     }
 
+    public function testServerToolsAreAppendedToTools()
+    {
+        $capturedBody = null;
+
+        $httpClient = new MockHttpClient(static function ($method, $url, $options) use (&$capturedBody) {
+            $capturedBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'type' => 'message',
+                'content' => [['type' => 'text', 'text' => 'Hello']],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]));
+        });
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'none');
+
+        $payload = [
+            'model' => Claude::SONNET_4,
+            'messages' => [['role' => 'user', 'content' => 'Hello']],
+        ];
+
+        $serverTool = ['type' => 'web_search_20250305', 'name' => 'web_search', 'max_uses' => 3];
+
+        $client->request(new Claude(Claude::SONNET_4), $payload, ['server_tools' => [$serverTool]]);
+
+        $this->assertNotNull($capturedBody);
+
+        // Server tool appended verbatim
+        $this->assertSame([$serverTool], $capturedBody['tools']);
+
+        // tool_choice defaults to auto once any tool is present
+        $this->assertSame(['type' => 'auto'], $capturedBody['tool_choice']);
+
+        // server_tools key should not leak into the API body
+        $this->assertArrayNotHasKey('server_tools', $capturedBody);
+    }
+
+    public function testServerToolsAreAppendedAfterFunctionTools()
+    {
+        $capturedBody = null;
+
+        $httpClient = new MockHttpClient(static function ($method, $url, $options) use (&$capturedBody) {
+            $capturedBody = json_decode($options['body'], true);
+
+            return new MockResponse(json_encode([
+                'type' => 'message',
+                'content' => [['type' => 'text', 'text' => 'Hello']],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]));
+        });
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'short');
+
+        $functionTool = ['name' => 'tool_a', 'description' => 'First tool', 'input_schema' => ['type' => 'object']];
+        $serverTool = ['type' => 'web_search_20250305', 'name' => 'web_search', 'max_uses' => 3];
+
+        $payload = [
+            'model' => Claude::SONNET_4,
+            'messages' => [['role' => 'user', 'content' => 'Hello']],
+        ];
+
+        $client->request(new Claude(Claude::SONNET_4), $payload, [
+            'tools' => [$functionTool],
+            'server_tools' => [$serverTool],
+        ]);
+
+        $this->assertNotNull($capturedBody);
+
+        // Function tool first, server tool appended after
+        $this->assertSame('tool_a', $capturedBody['tools'][0]['name']);
+        $this->assertSame('web_search', $capturedBody['tools'][1]['name']);
+        $this->assertSame('web_search_20250305', $capturedBody['tools'][1]['type']);
+
+        // Last tool should have cache_control
+        $this->assertArrayHasKey('cache_control', $capturedBody['tools'][1]);
+        // First tool should NOT have cache_control
+        $this->assertArrayNotHasKey('cache_control', $capturedBody['tools'][0]);
+
+        $this->assertArrayNotHasKey('server_tools', $capturedBody);
+    }
+
     public function testSystemCacheControlIsInjectedWithShortRetention()
     {
         $capturedBody = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Reworked from the original raw-list version of this PR.

Adds a `server_tools` option to the Anthropic `ModelClient`, using the `name => params` map shape the Gemini and Vertex AI bridges already use:

```php
$platform->invoke('claude-sonnet-5', $messages, [
    'server_tools' => ['web_search' => ['max_uses' => 3]],
]);
```

**Why the shape changed.** Raw pass-through already works today: `request()` merges `$options` into the body, and the docs already showed that for code execution. So the first version of this option added a name, not a capability - and it used Gemini's name with a different shape, which reads portable without being portable.

Only `web_search` and `code_execution` are mapped, to their versioned Anthropic `type`. An unrecognized name throws `InvalidArgumentException` rather than being silently forwarded, since Anthropic needs a versioned `type` the bridge cannot guess; unmapped tools stay reachable through the raw `tools` option, now documented as exactly that. Params are merged over the default spec, so a caller on Opus 4.6+/Sonnet 4.6+ can opt into `web_search_20260209` per call.

Server tools are appended *after* `injectToolsCacheControl()` runs, so `cache_control` lands on the last function tool and never on a server tool - the previous version put it on a server tool and asserted that, without it having been verified against the live API.

`ResultConverter` now merges the `server_tool_use` call and its matching `web_search_tool_result` into a single `Result\WebSearchResult` carrying query, id and status - matching `OpenResponses`, which emits one per search. Previously both blocks were dropped, and a response carrying only web search blocks threw `Response content does not contain any supported content.`

Known limitations, documented in the RST rather than papered over: `WebSearchResult` has no field for individual search hits, and server tool blocks are not converted on streaming requests. Follow-ups: search hits, `citations` on text blocks, `encrypted_content` round-tripping, a `Content\WebSearch` branch in `AssistantMessageNormalizer` (without it a search is dropped when re-serializing an assistant turn), and streaming.
