### PR TITLE
[Platform] Raise an error on unhandled HTTP statuses before streaming

### DIFF
--- a/src/platform/src/Bridge/Anthropic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Anthropic/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -76,6 +76,10 @@ class ResultConverter implements ResultConverterInterface
         }
 
         if ($options['stream'] ?? false) {
+            if (($code = $response->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $response->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -599,6 +599,18 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('sig_xyz', $result->getSignature());
     }
 
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['error' => 'Service Unavailable'], ['http_code' => 500]));
+        $httpResponse = $httpClient->request('POST', 'https://example.com');
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
+
     /**
      * @param array<array<string, mixed>> $events
      */

--- a/src/platform/src/Bridge/Cerebras/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cerebras/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/Cerebras/ResultConverter.php
+++ b/src/platform/src/Bridge/Cerebras/ResultConverter.php
@@ -56,6 +56,10 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if ($options['stream'] ?? false) {
+            if ($result instanceof RawHttpResult && ($status = $result->getObject()->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $status, $result->getObject()->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/Cerebras/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cerebras/Tests/ResultConverterTest.php
@@ -243,4 +243,16 @@ final class ResultConverterTest extends TestCase
 
         $converter->convert(new RawHttpResult($httpResponse));
     }
+
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['error' => 'Service Unavailable'], ['http_code' => 500]));
+        $httpResponse = $httpClient->request('POST', 'https://example.com');
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
 }

--- a/src/platform/src/Bridge/Cohere/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cohere/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
@@ -58,12 +58,16 @@ final class ResultConverter implements ResultConverterInterface
 
         $this->throwOnHttpError($httpResponse);
 
-        if (200 !== $code = $httpResponse->getStatusCode()) {
-            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $httpResponse->getContent(false)));
+        if ($options['stream'] ?? false) {
+            if (($code = $httpResponse->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $httpResponse->getContent(false)));
+            }
+
+            return new StreamResult($this->convertStream($result));
         }
 
-        if ($options['stream'] ?? false) {
-            return new StreamResult($this->convertStream($result));
+        if (200 !== $code = $httpResponse->getStatusCode()) {
+            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $httpResponse->getContent(false)));
         }
 
         $data = $result->getData();

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
@@ -314,4 +314,17 @@ final class ResultConverterTest extends TestCase
 
         $this->assertNotNull($converter->getTokenUsageExtractor());
     }
+
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(500);
+        $httpResponse->method('getContent')->willReturn('Service Unavailable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
 }

--- a/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
+++ b/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/DeepSeek/ResultConverter.php
+++ b/src/platform/src/Bridge/DeepSeek/ResultConverter.php
@@ -60,6 +60,10 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if ($options['stream'] ?? false) {
+            if ($result instanceof RawHttpResult && ($status = $result->getObject()->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $status, $result->getObject()->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Bridge\DeepSeek\ResultConverter;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\InvalidRequestException;
+use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -255,5 +256,17 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('Hello, ', $chunks[0]->getText());
         $this->assertInstanceOf(TextDelta::class, $chunks[1]);
         $this->assertSame('world!', $chunks[1]->getText());
+    }
+
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['error' => 'Service Unavailable'], ['http_code' => 500]));
+        $httpResponse = $httpClient->request('POST', 'https://example.com');
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }
 }

--- a/src/platform/src/Bridge/DockerModelRunner/CHANGELOG.md
+++ b/src/platform/src/Bridge/DockerModelRunner/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
@@ -41,6 +41,10 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
         if ($options['stream'] ?? false) {
+            if (($code = $result->getObject()->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $result->getObject()->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/DockerModelRunner/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Tests/Completions/ResultConverterTest.php
@@ -67,4 +67,17 @@ class ResultConverterTest extends TestCase
 
         (new ResultConverter())->convert(new RawHttpResult($response));
     }
+
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(500);
+        $httpResponse->method('getContent')->willReturn('Service Unavailable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
 }

--- a/src/platform/src/Bridge/Gemini/CHANGELOG.md
+++ b/src/platform/src/Bridge/Gemini/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -77,6 +77,10 @@ final class ResultConverter implements ResultConverterInterface
         $this->throwOnHttpError($response);
 
         if ($options['stream'] ?? false) {
+            if (($code = $response->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $response->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -400,4 +400,17 @@ final class ResultConverterTest extends TestCase
             ],
         ], ChoiceDelta::class, []];
     }
+
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(500);
+        $httpResponse->method('getContent')->willReturn('Service Unavailable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
 }

--- a/src/platform/src/Bridge/Generic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Generic/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
@@ -68,6 +68,10 @@ class ResultConverter implements ResultConverterInterface
         }
 
         if ($options['stream'] ?? false) {
+            if (($code = $response->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $response->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
@@ -336,6 +336,32 @@ class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
+    public function testThrowsOnUnhandledErrorStatusBeforeStreaming()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(404);
+        $httpResponse->method('getContent')->willReturn('404 page not found');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 404: "404 page not found"');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
+
+    public function testThrowsOnServerErrorStatus()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(503);
+        $httpResponse->method('getContent')->willReturn('service unavailable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 503: "service unavailable"');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
+
     public function testThrowsDetailedErrorException()
     {
         $converter = new ResultConverter();

--- a/src/platform/src/Bridge/Mistral/CHANGELOG.md
+++ b/src/platform/src/Bridge/Mistral/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -59,12 +59,12 @@ final class ResultConverter implements ResultConverterInterface
 
         $this->throwOnHttpError($httpResponse);
 
-        if ($options['stream'] ?? false) {
-            return new StreamResult($this->convertStream($result));
+        if (($code = $httpResponse->getStatusCode()) >= 400) {
+            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $httpResponse->getContent(false)));
         }
 
-        if (200 !== $code = $httpResponse->getStatusCode()) {
-            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $httpResponse->getContent(false)));
+        if ($options['stream'] ?? false) {
+            return new StreamResult($this->convertStream($result));
         }
 
         $data = $result->getData();

--- a/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\Mistral\Llm\ResultConverter;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
+use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -82,5 +83,17 @@ final class ResultConverterTest extends TestCase
         $converter = new ResultConverter();
 
         $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['error' => 'Service Unavailable'], ['http_code' => 500]));
+        $httpResponse = $httpClient->request('POST', 'https://example.com');
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }
 }

--- a/src/platform/src/Bridge/OpenAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenAi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -87,6 +87,10 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if ($options['stream'] ?? false) {
+            if (($code = $response->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $response->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -645,4 +645,17 @@ class ResultConverterTest extends TestCase
         $this->assertInstanceOf(TextDelta::class, $chunks[4]);
         $this->assertSame('The answer is 42.', $chunks[4]->getText());
     }
+
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(500);
+        $httpResponse->method('getContent')->willReturn('Service Unavailable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
 }

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -83,6 +83,10 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if ($options['stream'] ?? false) {
+            if (($code = $response->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $response->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -865,4 +865,17 @@ final class ResultConverterTest extends TestCase
         $this->assertInstanceOf(TextDelta::class, $chunks[4]);
         $this->assertSame('The answer is 42.', $chunks[4]->getText());
     }
+
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(500);
+        $httpResponse->method('getContent')->willReturn('Service Unavailable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
 }

--- a/src/platform/src/Bridge/Perplexity/CHANGELOG.md
+++ b/src/platform/src/Bridge/Perplexity/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/Perplexity/ResultConverter.php
+++ b/src/platform/src/Bridge/Perplexity/ResultConverter.php
@@ -55,6 +55,10 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if ($options['stream'] ?? false) {
+            if ($result instanceof RawHttpResult && ($code = $result->getObject()->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $result->getObject()->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/Perplexity/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Perplexity/Tests/ResultConverterTest.php
@@ -215,6 +215,19 @@ final class ResultConverterTest extends TestCase
         $this->assertSame(['https://example.com/1'], $deferredResult->getMetadata()->get('citations'));
     }
 
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(500);
+        $httpResponse->method('getContent')->willReturn('Service Unavailable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
+
     /**
      * @return iterable<array<string, mixed>>
      */

--- a/src/platform/src/Bridge/Scaleway/CHANGELOG.md
+++ b/src/platform/src/Bridge/Scaleway/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -38,6 +39,10 @@ final class ResultConverter implements ResultConverterInterface
     public function convert(RawResultInterface $result, array $options = []): ResultInterface
     {
         if ($options['stream'] ?? false) {
+            if ($result instanceof RawHttpResult && ($code = $result->getObject()->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $result->getObject()->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/Scaleway/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Llm/ResultConverterTest.php
@@ -304,4 +304,17 @@ final class ResultConverterTest extends TestCase
 
         $converter->convert(new RawHttpResult($httpResponse));
     }
+
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(500);
+        $httpResponse->method('getContent')->willReturn('Service Unavailable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
 }

--- a/src/platform/src/Bridge/VertexAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/VertexAi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -80,6 +80,10 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if ($options['stream'] ?? false) {
+            if (($code = $response->getStatusCode()) >= 400) {
+                throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $response->getContent(false)));
+            }
+
             return new StreamResult($this->convertStream($result));
         }
 

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ResultConverter;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
+use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
@@ -517,5 +518,18 @@ final class ResultConverterTest extends TestCase
         $this->assertSame(40, $items[2]->getTotalTokens());
         $this->assertInstanceOf(TextDelta::class, $items[3]);
         $this->assertSame('!', $items[3]->getText());
+    }
+
+    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(500);
+        $httpResponse->method('getContent')->willReturn('Service Unavailable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected response code 500');
+
+        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

I spent quite some time understanding why my coding agent was just ending a conversation with no messages and no errors. It was a stupid config error on my side which led to a 500 (local model) that was not showing up. Here is the fix.