### PR TITLE
[Store][Elasticsearch] Introduce a `StoreFactory`

### DIFF
--- a/examples/rag/elasticsearch.php
+++ b/examples/rag/elasticsearch.php
@@ -17,7 +17,7 @@ use Symfony\AI\Fixtures\Movies;
 use Symfony\AI\Platform\Bridge\OpenAi\Factory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\AI\Store\Bridge\Elasticsearch\Store;
+use Symfony\AI\Store\Bridge\Elasticsearch\StoreFactory;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\Vectorizer;
@@ -29,10 +29,10 @@ use Symfony\Component\Uid\Uuid;
 require_once dirname(__DIR__).'/bootstrap.php';
 
 // initialize the store
-$store = new Store(
-    httpClient: http_client(),
-    endpoint: env('ELASTICSEARCH_ENDPOINT'),
+$store = StoreFactory::create(
     indexName: 'movies',
+    endpoint: env('ELASTICSEARCH_ENDPOINT'),
+    httpClient: http_client(),
 );
 
 // create embeddings and documents

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Wire `Elasticsearch\StoreFactory` from `AiBundle`
+
 0.11
 ----
 

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -108,6 +108,7 @@ use Symfony\AI\Store\Bridge\ClickHouse\Store as ClickHouseStore;
 use Symfony\AI\Store\Bridge\Cloudflare\Store as CloudflareStore;
 use Symfony\AI\Store\Bridge\Cloudflare\StoreFactory as CloudflareStoreFactory;
 use Symfony\AI\Store\Bridge\Elasticsearch\Store as ElasticsearchStore;
+use Symfony\AI\Store\Bridge\Elasticsearch\StoreFactory as ElasticsearchStoreFactory;
 use Symfony\AI\Store\Bridge\ManticoreSearch\Store as ManticoreSearchStore;
 use Symfony\AI\Store\Bridge\MariaDb\Distance as MariaDbDistance;
 use Symfony\AI\Store\Bridge\MariaDb\Store as MariaDbStore;
@@ -1564,13 +1565,13 @@ final class AiBundle extends AbstractBundle
             }
 
             foreach ($stores as $name => $store) {
-                $definition = new Definition(ElasticsearchStore::class);
-                $definition
+                $definition = (new Definition(ElasticsearchStore::class))
+                    ->setFactory(ElasticsearchStoreFactory::class.'::create')
                     ->setLazy(true)
                     ->setArguments([
-                        new Reference($store['http_client']),
-                        $store['endpoint'],
                         $store['index_name'] ?? $name,
+                        $store['endpoint'] ?? null,
+                        new Reference($store['http_client']),
                         $store['vectors_field'],
                         $store['dimensions'],
                         $store['similarity'],

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -60,6 +60,8 @@ use Symfony\AI\Store\Bridge\ChromaDb\StoreFactory as ChromaDbStoreFactory;
 use Symfony\AI\Store\Bridge\ClickHouse\Store as ClickhouseStore;
 use Symfony\AI\Store\Bridge\Cloudflare\Store as CloudflareStore;
 use Symfony\AI\Store\Bridge\Cloudflare\StoreFactory as CloudflareStoreFactory;
+use Symfony\AI\Store\Bridge\Elasticsearch\Store as ElasticsearchStore;
+use Symfony\AI\Store\Bridge\Elasticsearch\StoreFactory as ElasticsearchStoreFactory;
 use Symfony\AI\Store\Bridge\ManticoreSearch\Store as ManticoreSearchStore;
 use Symfony\AI\Store\Bridge\MariaDb\Distance as MariaDbDistance;
 use Symfony\AI\Store\Bridge\MariaDb\Store as MariaDbStore;
@@ -1216,6 +1218,104 @@ class AiBundleTest extends TestCase
         $this->assertTrue($container->hasAlias(StoreInterface::class.' $myCloudflareStore'));
         $this->assertTrue($container->hasAlias(StoreInterface::class.' $cloudflareMyCloudflareStore'));
         $this->assertTrue($container->hasAlias(StoreInterface::class));
+    }
+
+    public function testElasticsearchStoreCanBeConfigured()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'store' => [
+                    'elasticsearch' => [
+                        'my_elasticsearch_store' => [
+                            'endpoint' => 'http://127.0.0.1:9200',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($container->hasDefinition('ai.store.elasticsearch.my_elasticsearch_store'));
+
+        $definition = $container->getDefinition('ai.store.elasticsearch.my_elasticsearch_store');
+        $this->assertSame([ElasticsearchStoreFactory::class, 'create'], $definition->getFactory());
+        $this->assertSame(ElasticsearchStore::class, $definition->getClass());
+
+        $this->assertTrue($definition->isLazy());
+        $this->assertCount(6, $definition->getArguments());
+        $this->assertSame('my_elasticsearch_store', $definition->getArgument(0));
+        $this->assertSame('http://127.0.0.1:9200', $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('http_client', (string) $definition->getArgument(2));
+        $this->assertSame('_vectors', $definition->getArgument(3));
+        $this->assertSame(1536, $definition->getArgument(4));
+        $this->assertSame('cosine', $definition->getArgument(5));
+
+        $this->assertTrue($definition->hasTag('proxy'));
+        $this->assertSame([
+            ['interface' => StoreInterface::class],
+            ['interface' => ManagedStoreInterface::class],
+        ], $definition->getTag('proxy'));
+        $this->assertTrue($definition->hasTag('ai.store'));
+
+        $this->assertTrue($container->hasAlias('.'.StoreInterface::class.' $my_elasticsearch_store'));
+        $this->assertTrue($container->hasAlias(StoreInterface::class.' $myElasticsearchStore'));
+        $this->assertTrue($container->hasAlias('.'.StoreInterface::class.' $elasticsearch_my_elasticsearch_store'));
+        $this->assertTrue($container->hasAlias(StoreInterface::class.' $elasticsearchMyElasticsearchStore'));
+        $this->assertTrue($container->hasAlias(StoreInterface::class));
+    }
+
+    public function testElasticsearchStoreWithCustomIndexCanBeConfigured()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'store' => [
+                    'elasticsearch' => [
+                        'my_elasticsearch_store' => [
+                            'endpoint' => 'http://127.0.0.1:9200',
+                            'index_name' => 'foo',
+                            'vectors_field' => 'embedding',
+                            'dimensions' => 768,
+                            'similarity' => 'dot_product',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $definition = $container->getDefinition('ai.store.elasticsearch.my_elasticsearch_store');
+        $this->assertSame([ElasticsearchStoreFactory::class, 'create'], $definition->getFactory());
+        $this->assertSame(ElasticsearchStore::class, $definition->getClass());
+
+        $this->assertSame('foo', $definition->getArgument(0));
+        $this->assertSame('http://127.0.0.1:9200', $definition->getArgument(1));
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('http_client', (string) $definition->getArgument(2));
+        $this->assertSame('embedding', $definition->getArgument(3));
+        $this->assertSame(768, $definition->getArgument(4));
+        $this->assertSame('dot_product', $definition->getArgument(5));
+    }
+
+    public function testElasticsearchStoreWithCustomHttpClientCanBeConfigured()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'store' => [
+                    'elasticsearch' => [
+                        'my_elasticsearch_store' => [
+                            'endpoint' => 'http://127.0.0.1:9200',
+                            'http_client' => 'my.scoped_http_client',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $definition = $container->getDefinition('ai.store.elasticsearch.my_elasticsearch_store');
+        $this->assertSame([ElasticsearchStoreFactory::class, 'create'], $definition->getFactory());
+        $this->assertSame(ElasticsearchStore::class, $definition->getClass());
+
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(2));
+        $this->assertSame('my.scoped_http_client', (string) $definition->getArgument(2));
     }
 
     public function testManticoreSearchStoreCanBeConfigured()

--- a/src/store/src/Bridge/Elasticsearch/CHANGELOG.md
+++ b/src/store/src/Bridge/Elasticsearch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Introduce `StoreFactory` and remove the `endpoint` constructor argument from `Store` in favor of a scoped HTTP client
+
 0.11
 ----
 

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -27,25 +27,18 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class Store implements ManagedStoreInterface, StoreInterface
 {
-    private readonly string $endpoint;
-
-    /**
-     * @param string $endpoint URL of the Elasticsearch instance, with or without a trailing slash
-     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        string $endpoint,
         private readonly string $indexName,
         private readonly string $vectorsField = '_vectors',
         private readonly int $dimensions = 1536,
         private readonly string $similarity = 'cosine',
     ) {
-        $this->endpoint = rtrim($endpoint, '/');
     }
 
     public function setup(array $options = []): void
     {
-        $indexExistResponse = $this->httpClient->request('HEAD', \sprintf('%s/%s', $this->endpoint, $this->indexName));
+        $indexExistResponse = $this->httpClient->request('HEAD', $this->indexName);
 
         if (200 === $indexExistResponse->getStatusCode()) {
             return;
@@ -66,7 +59,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function drop(array $options = []): void
     {
-        $indexExistResponse = $this->httpClient->request('HEAD', \sprintf('%s/%s', $this->endpoint, $this->indexName));
+        $indexExistResponse = $this->httpClient->request('HEAD', $this->indexName);
 
         if (404 === $indexExistResponse->getStatusCode()) {
             throw new InvalidArgumentException(\sprintf('The index "%s" does not exist.', $this->indexName));
@@ -152,8 +145,16 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
 
         $vector = $query->getVector();
+
         $k = $options['k'] ?? 100;
+        if (!\is_int($k)) {
+            throw new InvalidArgumentException('The "k" option must be an integer.');
+        }
+
         $numCandidates = $options['num_candidates'] ?? max($k * 2, 100);
+        if (!\is_int($numCandidates)) {
+            throw new InvalidArgumentException('The "num_candidates" option must be an integer.');
+        }
 
         $documents = $this->request('POST', \sprintf('%s/_search', $this->indexName), [
             'knn' => [
@@ -164,7 +165,21 @@ final class Store implements ManagedStoreInterface, StoreInterface
             ],
         ]);
 
-        foreach ($documents['hits']['hits'] as $document) {
+        $hits = $documents['hits'] ?? null;
+        if (!\is_array($hits)) {
+            throw new RuntimeException('The Elasticsearch search response is malformed.');
+        }
+
+        $innerHits = $hits['hits'] ?? null;
+        if (!\is_array($innerHits)) {
+            throw new RuntimeException('The Elasticsearch search response does not contain a result set.');
+        }
+
+        foreach ($innerHits as $document) {
+            if (!\is_array($document)) {
+                throw new RuntimeException('The Elasticsearch search response contains an invalid hit.');
+            }
+
             yield $this->convertToVectorDocument($document);
         }
     }
@@ -172,7 +187,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param \Closure|array<string, mixed> $payload
      *
-     * @return array<string, mixed>
+     * @return array<mixed>
      */
     private function request(string $method, string $path, \Closure|array $payload = []): array
     {
@@ -191,26 +206,75 @@ final class Store implements ManagedStoreInterface, StoreInterface
             ];
         }
 
-        $response = $this->httpClient->request($method, \sprintf('%s/%s', $this->endpoint, $path), $finalOptions);
+        $response = $this->httpClient->request($method, $path, $finalOptions);
 
         return $response->toArray();
     }
 
     /**
-     * @param array{
-     *     '_id'?: string,
-     *     '_source': array<string, mixed>,
-     *     '_score': float,
-     * } $document
+     * @param array<mixed> $document
      */
     private function convertToVectorDocument(array $document): VectorDocument
     {
         $id = $document['_id'] ?? throw new InvalidArgumentException('Missing "_id" field in the document data.');
+        if (!\is_string($id)) {
+            throw new InvalidArgumentException('The document "_id" field must be a string.');
+        }
 
-        $vector = !\array_key_exists($this->vectorsField, $document['_source']) || null === $document['_source'][$this->vectorsField]
-            ? new NullVector()
-            : new Vector($document['_source'][$this->vectorsField]);
+        $source = $document['_source'] ?? null;
+        if (!\is_array($source)) {
+            throw new InvalidArgumentException('Missing "_source" field in the document data.');
+        }
 
-        return new VectorDocument(Uuid::fromString($id), $vector, new Metadata(json_decode($document['_source']['metadata'], true)), $document['_score'] ?? null);
+        $rawVector = $source[$this->vectorsField] ?? null;
+        if (null === $rawVector) {
+            $vector = new NullVector();
+        } else {
+            if (!\is_array($rawVector)) {
+                throw new InvalidArgumentException('The document vector must be an array of numbers.');
+            }
+
+            $components = [];
+            foreach ($rawVector as $component) {
+                if (!\is_int($component) && !\is_float($component)) {
+                    throw new InvalidArgumentException('The document vector must contain only numbers.');
+                }
+
+                $components[] = (float) $component;
+            }
+
+            $vector = new Vector($components);
+        }
+
+        $rawMetadata = $source['metadata'] ?? null;
+        if (!\is_string($rawMetadata)) {
+            throw new InvalidArgumentException('The document metadata must be a JSON encoded string.');
+        }
+
+        $metadata = json_decode($rawMetadata, true);
+        if (!\is_array($metadata)) {
+            throw new InvalidArgumentException('The document metadata is not a valid JSON object.');
+        }
+
+        $normalizedMetadata = [];
+        foreach ($metadata as $key => $value) {
+            if (!\is_string($key)) {
+                throw new InvalidArgumentException('The document metadata must be keyed by strings.');
+            }
+
+            $normalizedMetadata[$key] = $value;
+        }
+
+        $score = $document['_score'] ?? null;
+        if (null !== $score && !\is_int($score) && !\is_float($score)) {
+            throw new InvalidArgumentException('The document "_score" field must be a number.');
+        }
+
+        return new VectorDocument(
+            Uuid::fromString($id),
+            $vector,
+            new Metadata($normalizedMetadata),
+            null === $score ? null : (float) $score,
+        );
     }
 }

--- a/src/store/src/Bridge/Elasticsearch/StoreFactory.php
+++ b/src/store/src/Bridge/Elasticsearch/StoreFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Elasticsearch;
+
+use Symfony\AI\Store\ManagedStoreInterface;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\ScopingHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ */
+final class StoreFactory
+{
+    public static function create(
+        string $indexName,
+        ?string $endpoint = null,
+        ?HttpClientInterface $httpClient = null,
+        string $vectorsField = '_vectors',
+        int $dimensions = 1536,
+        string $similarity = 'cosine',
+    ): StoreInterface&ManagedStoreInterface {
+        $httpClient ??= HttpClient::create();
+
+        if (null !== $endpoint) {
+            $httpClient = ScopingHttpClient::forBaseUri($httpClient, rtrim($endpoint, '/').'/');
+        }
+
+        return new Store($httpClient, $indexName, $vectorsField, $dimensions, $similarity);
+    }
+}

--- a/src/store/src/Bridge/Elasticsearch/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Elasticsearch/Tests/IntegrationTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Store\Bridge\Elasticsearch\Tests;
 
 use PHPUnit\Framework\Attributes\Group;
-use Symfony\AI\Store\Bridge\Elasticsearch\Store;
+use Symfony\AI\Store\Bridge\Elasticsearch\StoreFactory;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
 use Symfony\Component\HttpClient\HttpClient;
@@ -25,12 +25,7 @@ final class IntegrationTest extends AbstractStoreIntegrationTestCase
 {
     protected static function createStore(): StoreInterface
     {
-        return new Store(
-            HttpClient::create(),
-            'http://127.0.0.1:9200',
-            'test_index',
-            dimensions: 3,
-        );
+        return StoreFactory::create('test_index', 'http://127.0.0.1:9200', HttpClient::create(), dimensions: 3);
     }
 
     protected function waitForIndexing(): void

--- a/src/store/src/Bridge/Elasticsearch/Tests/StoreFactoryTest.php
+++ b/src/store/src/Bridge/Elasticsearch/Tests/StoreFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Elasticsearch\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Store\Bridge\Elasticsearch\Store;
+use Symfony\AI\Store\Bridge\Elasticsearch\StoreFactory;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\ScopingHttpClient;
+
+final class StoreFactoryTest extends TestCase
+{
+    public function testStoreCanBeCreatedWithHttpClientAndRequiredInfos()
+    {
+        $store = StoreFactory::create('my-index', 'http://127.0.0.1:9200');
+
+        $this->assertInstanceOf(Store::class, $store);
+    }
+
+    public function testStoreCanBeCreatedWithScopingHttpClient()
+    {
+        $store = StoreFactory::create('my-index', httpClient: ScopingHttpClient::forBaseUri(HttpClient::create(), 'http://127.0.0.1:9200/'));
+
+        $this->assertInstanceOf(Store::class, $store);
+    }
+
+    public function testStoreNormalizesTrailingSlashOnEndpoint()
+    {
+        $requestedUrl = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedUrl): JsonMockResponse {
+            $requestedUrl = $url;
+
+            return new JsonMockResponse('', [
+                'http_code' => 200,
+            ]);
+        });
+
+        $store = StoreFactory::create('foo', 'http://127.0.0.1:9200/', $httpClient);
+        $store->setup();
+
+        $this->assertSame('http://127.0.0.1:9200/foo', $requestedUrl);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+}

--- a/src/store/src/Bridge/Elasticsearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Elasticsearch/Tests/StoreTest.php
@@ -21,6 +21,7 @@ use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\Uid\Uuid;
 
 final class StoreTest extends TestCase
@@ -33,7 +34,7 @@ final class StoreTest extends TestCase
             ]),
         ]);
 
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
+        $store = new Store($httpClient, 'foo');
         $store->setup();
 
         $this->assertSame(1, $httpClient->getRequestsCount());
@@ -54,7 +55,7 @@ final class StoreTest extends TestCase
             ]),
         ]);
 
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
+        $store = new Store($httpClient, 'foo');
         $store->setup();
 
         $this->assertSame(2, $httpClient->getRequestsCount());
@@ -75,7 +76,7 @@ final class StoreTest extends TestCase
             ]),
         ]);
 
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
+        $store = new Store($httpClient, 'foo');
 
         $store->setup([
             'dimensions' => 768,
@@ -93,7 +94,7 @@ final class StoreTest extends TestCase
             ]),
         ]);
 
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
+        $store = new Store($httpClient, 'foo');
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The index "foo" does not exist.');
@@ -114,7 +115,7 @@ final class StoreTest extends TestCase
             ]),
         ]);
 
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
+        $store = new Store($httpClient, 'foo');
         $store->drop();
 
         $this->assertSame(2, $httpClient->getRequestsCount());
@@ -143,7 +144,7 @@ final class StoreTest extends TestCase
             ]),
         ]);
 
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
+        $store = new Store($httpClient, 'foo');
         $store->add([new VectorDocument(Uuid::v7(), new Vector([0.1, 0.2, 0.3]))]);
 
         $this->assertSame(1, $httpClient->getRequestsCount());
@@ -190,7 +191,7 @@ final class StoreTest extends TestCase
             ]),
         ]);
 
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
+        $store = new Store($httpClient, 'foo');
         $results = $store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])));
 
         $this->assertCount(2, iterator_to_array($results));
@@ -216,7 +217,7 @@ final class StoreTest extends TestCase
             ]);
         });
 
-        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
+        $store = new Store(ScopingHttpClient::forBaseUri($httpClient, 'http://127.0.0.1:9200/'), 'foo');
         $store->clear();
 
         $this->assertSame('POST', $requestedMethod);
@@ -225,39 +226,21 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
-    public function testStoreNormalizesTrailingSlashOnEndpoint()
-    {
-        $requestedUrl = null;
-        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedUrl): JsonMockResponse {
-            $requestedUrl = $url;
-
-            return new JsonMockResponse('', [
-                'http_code' => 200,
-            ]);
-        });
-
-        $store = new Store($httpClient, 'http://127.0.0.1:9200/', 'foo');
-        $store->setup();
-
-        $this->assertSame('http://127.0.0.1:9200/foo', $requestedUrl);
-        $this->assertSame(1, $httpClient->getRequestsCount());
-    }
-
     public function testStoreSupportsVectorQuery()
     {
-        $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');
+        $store = new Store(new MockHttpClient(), 'test-index');
         $this->assertTrue($store->supports(VectorQuery::class));
     }
 
     public function testStoreDoesNotSupportTextQuery()
     {
-        $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');
+        $store = new Store(new MockHttpClient(), 'test-index');
         $this->assertFalse($store->supports(TextQuery::class));
     }
 
     public function testStoreDoesNotSupportHybridQuery()
     {
-        $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');
+        $store = new Store(new MockHttpClient(), 'test-index');
         $this->assertFalse($store->supports(HybridQuery::class));
     }
 }

--- a/src/store/src/Bridge/Elasticsearch/phpstan.dist.neon
+++ b/src/store/src/Bridge/Elasticsearch/phpstan.dist.neon
@@ -3,7 +3,7 @@ includes:
     - ../../../../../.phpstan/extension.neon
 
 parameters:
-    level: 6
+    level: 10
     paths:
         - .
         - Tests/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | --
| License       | MIT

The `Store` constructor now expects a pre-scoped `HttpClientInterface`; endpoint scoping is performed by `StoreFactory::create()` via `ScopingHttpClient::forBaseUri()`. The `AiBundle` wiring switches to the factory.