### PR TITLE
[Store][S3Vectors] Avoid auto-pagination when iterating query results

### DIFF
--- a/src/store/src/Bridge/S3Vectors/Store.php
+++ b/src/store/src/Bridge/S3Vectors/Store.php
@@ -199,7 +199,8 @@ final class Store implements ManagedStoreInterface, StoreInterface
             'returnDistance' => $options['returnDistance'] ?? true,
         ]);
 
-        foreach ($result->getVectors() as $outputVector) {
+        // the result set is already bounded by topK, so only the current page is iterated to avoid auto-pagination
+        foreach ($result->getVectors(true) as $outputVector) {
             $metadata = $outputVector->getMetadata();
 
             /** @var array<string, mixed> $metadataArray */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

A recent `async-aws/s3-vectors` release changed `QueryVectorsOutput::getVectors()` to **auto-paginate by default** (`getVectors(bool $currentPageOnly = false)`). Auto-pagination requires the AWS client and the originating request to be injected into the result object.

This broke the `S3Vectors` `StoreTest` cases, which build the result via `ResultMockFactory::create()` and therefore have no client/request injected:

```
AsyncAws\Core\Exception\InvalidArgument: missing last request injected in paginated result
  vendor/async-aws/s3-vectors/src/Result/QueryVectorsOutput.php:86
  Store.php:202
```

Failing checks: `Unit / Store / S3Vectors / PHP 8.2` and `PHP 8.5`. The failure reproduces on a fresh `main` checkout (it surfaces whenever the bridge resolves the newer `async-aws/s3-vectors`), so it is not specific to any feature branch.

### Fix

The query is already bounded by `topK` and returned in a single page, so there is no reason to follow pagination. Iterate the current page only via `getVectors(true)`. This restores the previous behavior and fixes the mocked tests without needing a live client.

```diff
-        foreach ($result->getVectors() as $outputVector) {
+        // the result set is already bounded by topK, so only the current page is iterated to avoid auto-pagination
+        foreach ($result->getVectors(true) as $outputVector) {
```

All 14 `S3Vectors` unit tests pass with the change.
