### PR TITLE
[Platform][Anthropic] Merge structured output into a caller-supplied output_config

### DIFF
--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -84,11 +84,9 @@ final class ModelClient implements ModelClientInterface
 
         if (isset($options['response_format'])) {
             $schema = $options['response_format']['json_schema']['schema'] ?? [];
-            $options['output_config'] = [
-                'format' => [
-                    'type' => 'json_schema',
-                    'schema' => \is_array($schema) ? $this->normalizeStructuredOutputSchema($schema) : $schema,
-                ],
+            $options['output_config']['format'] = [
+                'type' => 'json_schema',
+                'schema' => \is_array($schema) ? $this->normalizeStructuredOutputSchema($schema) : $schema,
             ];
             unset($options['response_format']);
         }

--- a/src/platform/src/Bridge/Anthropic/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ModelClientTest.php
@@ -177,6 +177,33 @@ class ModelClientTest extends TestCase
         $this->modelClient->request($this->model, ['message' => 'test'], $options);
     }
 
+    public function testResponseFormatPreservesExistingOutputConfig()
+    {
+        $this->httpClient = new MockHttpClient(function ($method, $url, $options) {
+            $body = json_decode($options['body'], true);
+
+            $this->assertSame('medium', $body['output_config']['effort']);
+            $this->assertSame('json_schema', $body['output_config']['format']['type']);
+            $this->assertSame(['type' => 'object'], $body['output_config']['format']['schema']);
+            $this->assertArrayNotHasKey('response_format', $body);
+
+            return new JsonMockResponse('{"success": true}');
+        });
+
+        $this->modelClient = new ModelClient($this->httpClient, 'test-api-key');
+
+        $options = [
+            'output_config' => ['effort' => 'medium'],
+            'response_format' => [
+                'json_schema' => [
+                    'schema' => ['type' => 'object'],
+                ],
+            ],
+        ];
+
+        $this->modelClient->request($this->model, ['message' => 'test'], $options);
+    }
+
     public function testToolChoiceDefaultsToAutoWhenToolsArePresent()
     {
         $this->httpClient = new MockHttpClient(function ($method, $url, $options) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

Set the format sub-key instead of replacing output_config so a caller-supplied effort survives alongside structured output.
