### PR TITLE
[Platform] Add a retryable ServerException for transient 5xx and Anthropic overloaded errors

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `PartialJsonParser` for recovering partial JSON from streaming output
  * Add routing-aware mock test provider (`Test\MockPlatformFactory`, `Test\MockModelClient`, `Test\MockResultConverter`, `Test\MockModelCatalog`) for any-result-type mocks in tests, complementing `Test\InMemoryPlatform`
  * [BC BREAK] Rework `ToolCallMessage` to hold `Content\ContentInterface` parts (variadic constructor) instead of a single string content, mirroring `UserMessage`: `getContent()` now returns `Content\ContentInterface[]` and `asText()` returns the flattened text. `Message::ofToolCall()` accepts strings, `\Stringable`, and `Content\ContentInterface` values, upcasting strings to `Content\Text`. This enables multimodal tool results (e.g. text and images): the Anthropic and Amazon Bedrock (Nova/Converse) bridges render them as `tool_result` content blocks, the Gemini and Vertex AI bridges attach them as `inline_data` parts next to the `functionResponse`, and bridges without multimodal tool-result support degrade to text.
+ * Add `ServerException`, thrown on transient server errors (HTTP 5xx) by `HttpStatusErrorHandlingTrait` and the bridge converters so consumers can retry without parsing error messages
 
 0.10
 ----

--- a/src/platform/src/Bridge/Anthropic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Anthropic/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add a `baseUrl` argument to `ModelClient` and the factory to target Anthropic-compatible endpoints
  * Extract prompt-caching injection into a reusable `PromptCachingTrait` so alternative model clients can share it
+ * Throw `ServerException` on server errors (HTTP 5xx) and on `overloaded_error` / `api_error` events, including mid-stream, instead of a generic `RuntimeException`
+ * Throw `RateLimitExceededException` on rate limit error events
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
@@ -75,6 +76,11 @@ class ResultConverter implements ResultConverterInterface
             throw new RateLimitExceededException($retryAfterValue, $errorMessage);
         }
 
+        if (($code = $response->getStatusCode()) >= 500) {
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new ServerException($code, $errorMessage);
+        }
+
         if ($options['stream'] ?? false) {
             if (($code = $response->getStatusCode()) >= 400) {
                 throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $response->getContent(false)));
@@ -88,6 +94,15 @@ class ResultConverter implements ResultConverterInterface
         if (isset($data['type']) && 'error' === $data['type']) {
             $type = $data['error']['type'] ?? 'Unknown';
             $message = $data['error']['message'] ?? 'An unknown error occurred.';
+
+            if ('rate_limit_error' === $type) {
+                throw new RateLimitExceededException(null, \sprintf('API Error [%s]: "%s"', $type, $message));
+            }
+
+            if (\in_array($type, ['overloaded_error', 'api_error'], true)) {
+                throw new ServerException(null, \sprintf('API Error [%s]: "%s"', $type, $message));
+            }
+
             throw new RuntimeException(\sprintf('API Error [%s]: "%s"', $type, $message));
         }
 
@@ -152,7 +167,17 @@ class ResultConverter implements ResultConverterInterface
             $type = $data['type'] ?? '';
 
             if ('error' === $type) {
-                throw new RuntimeException($data['error']['message'] ?? 'Unknown Anthropic stream error.');
+                $message = $data['error']['message'] ?? 'Unknown Anthropic stream error.';
+
+                if ('rate_limit_error' === ($data['error']['type'] ?? null)) {
+                    throw new RateLimitExceededException(null, $message);
+                }
+
+                if (\in_array($data['error']['type'] ?? null, ['overloaded_error', 'api_error'], true)) {
+                    throw new ServerException(null, $message);
+                }
+
+                throw new RuntimeException($message);
             }
 
             if ('message_start' === $type) {

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterRateLimitTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterRateLimitTest.php
@@ -14,9 +14,11 @@ namespace Symfony\AI\Platform\Bridge\Anthropic\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Anthropic\ResultConverter;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class ResultConverterRateLimitTest extends TestCase
 {
@@ -65,5 +67,40 @@ final class ResultConverterRateLimitTest extends TestCase
             $this->assertNull($e->getRetryAfter());
             throw $e;
         }
+    }
+
+    public function testRateLimitErrorBodyThrowsException()
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('{"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed the rate limit for your organization"}}'),
+        ]);
+
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+        $handler = new ResultConverter();
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded. API Error [rate_limit_error]: "This request would exceed the rate limit for your organization"');
+
+        $handler->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testStreamRateLimitErrorEventThrowsException()
+    {
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $handler = new ResultConverter();
+
+        $streamResult = $handler->convert(new InMemoryRawResult([], [[
+            'type' => 'error',
+            'error' => [
+                'type' => 'rate_limit_error',
+                'message' => 'This request would exceed the rate limit for your organization',
+            ],
+        ]], $httpResponse), ['stream' => true]);
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded. This request would exceed the rate limit for your organization');
+
+        iterator_to_array($streamResult->getContent());
     }
 }

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
@@ -599,16 +600,64 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('sig_xyz', $result->getSignature());
     }
 
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['error' => ['message' => 'Service Unavailable']], ['http_code' => 503]));
+        $httpResponse = $httpClient->request('POST', 'https://example.com');
+        $converter = new ResultConverter();
+
+        try {
+            $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+            $this->fail('Expected a ServerException to be thrown.');
+        } catch (ServerException $e) {
+            $this->assertSame(503, $e->getStatusCode());
+            $this->assertStringContainsString('Service Unavailable', $e->getMessage());
+        }
+    }
+
     public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
     {
-        $httpClient = new MockHttpClient(new JsonMockResponse(['error' => 'Service Unavailable'], ['http_code' => 500]));
+        $httpClient = new MockHttpClient(new JsonMockResponse(['error' => 'Teapot'], ['http_code' => 418]));
         $httpResponse = $httpClient->request('POST', 'https://example.com');
         $converter = new ResultConverter();
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectExceptionMessage('Unexpected response code 418');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
+
+    public function testThrowsServerExceptionOnOverloadedErrorEventMidStream()
+    {
+        $converter = new ResultConverter();
+        $raw = $this->createRawResult([
+            ['type' => 'error', 'error' => ['type' => 'overloaded_error', 'message' => 'Overloaded']],
+        ]);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Overloaded');
+
+        iterator_to_array($streamResult->getContent());
+    }
+
+    public function testDoesNotThrowServerExceptionOnClientErrorEventMidStream()
+    {
+        $converter = new ResultConverter();
+        $raw = $this->createRawResult([
+            ['type' => 'error', 'error' => ['type' => 'invalid_request_error', 'message' => 'Bad input']],
+        ]);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        try {
+            iterator_to_array($streamResult->getContent());
+            $this->fail('Expected a RuntimeException to be thrown.');
+        } catch (RuntimeException $e) {
+            $this->assertNotInstanceOf(ServerException::class, $e);
+            $this->assertStringContainsString('Bad input', $e->getMessage());
+        }
     }
 
     /**

--- a/src/platform/src/Bridge/Cerebras/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cerebras/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Cerebras/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cerebras/Tests/ResultConverterTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Bridge\Cerebras\ResultConverter;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -244,14 +245,14 @@ final class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse(['error' => 'Service Unavailable'], ['http_code' => 500]));
         $httpResponse = $httpClient->request('POST', 'https://example.com');
         $converter = new ResultConverter();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }

--- a/src/platform/src/Bridge/Cohere/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cohere/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Cohere/Tests/Embeddings/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Embeddings/ResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Cohere\Embeddings;
 use Symfony\AI\Platform\Bridge\Cohere\Embeddings\ResultConverter;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -36,8 +37,8 @@ final class ResultConverterTest extends TestCase
 
         $converter = new ResultConverter();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($response));
     }

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Bridge\Cohere\Llm\ResultConverter;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
@@ -43,8 +44,8 @@ final class ResultConverterTest extends TestCase
 
         $converter = new ResultConverter();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($response));
     }
@@ -315,15 +316,15 @@ final class ResultConverterTest extends TestCase
         $this->assertNotNull($converter->getTokenUsageExtractor());
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(500);
         $httpResponse->method('getContent')->willReturn('Service Unavailable');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }

--- a/src/platform/src/Bridge/Cohere/Tests/Reranker/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Reranker/ResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Cohere\Reranker;
 use Symfony\AI\Platform\Bridge\Cohere\Reranker\ResultConverter;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RerankingResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -36,8 +37,8 @@ final class ResultConverterTest extends TestCase
 
         $converter = new ResultConverter();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($response));
     }

--- a/src/platform/src/Bridge/Cohere/Tests/SpeechToText/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/SpeechToText/ResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Cohere\SpeechToText;
 use Symfony\AI\Platform\Bridge\Cohere\SpeechToText\ResultConverter;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -36,8 +37,8 @@ final class ResultConverterTest extends TestCase
 
         $converter = new ResultConverter();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($response));
     }

--- a/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
+++ b/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterTest.php
@@ -17,7 +17,7 @@ use Symfony\AI\Platform\Bridge\DeepSeek\ResultConverter;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\InvalidRequestException;
-use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -258,14 +258,14 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('world!', $chunks[1]->getText());
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse(['error' => 'Service Unavailable'], ['http_code' => 500]));
         $httpResponse = $httpClient->request('POST', 'https://example.com');
         $converter = new ResultConverter();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }

--- a/src/platform/src/Bridge/DockerModelRunner/CHANGELOG.md
+++ b/src/platform/src/Bridge/DockerModelRunner/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Completions/ResultConverter.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -40,6 +41,11 @@ final class ResultConverter implements ResultConverterInterface
 
     public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        if (($code = $result->getObject()->getStatusCode()) >= 500) {
+            $errorMessage = json_decode($result->getObject()->getContent(false), true)['error']['message'] ?? null;
+            throw new ServerException($code, $errorMessage);
+        }
+
         if ($options['stream'] ?? false) {
             if (($code = $result->getObject()->getStatusCode()) >= 400) {
                 throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $result->getObject()->getContent(false)));

--- a/src/platform/src/Bridge/DockerModelRunner/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Tests/Completions/ResultConverterTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Bridge\DockerModelRunner\Completions;
 use Symfony\AI\Platform\Bridge\DockerModelRunner\Completions\ResultConverter;
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -68,15 +69,15 @@ class ResultConverterTest extends TestCase
         (new ResultConverter())->convert(new RawHttpResult($response));
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(500);
         $httpResponse->method('getContent')->willReturn('Service Unavailable');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }

--- a/src/platform/src/Bridge/Gemini/CHANGELOG.md
+++ b/src/platform/src/Bridge/Gemini/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
@@ -41,17 +42,17 @@ final class ResultConverterTest extends TestCase
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
-        $httpResponse->method('getStatusCode')->willReturn(500);
+        $httpResponse->method('getStatusCode')->willReturn(403);
         $httpResponse->method('toArray')->willReturn([
             'error' => [
-                'code' => 500,
-                'status' => 'INTERNAL',
-                'message' => 'Internal error encountered.',
+                'code' => 403,
+                'status' => 'PERMISSION_DENIED',
+                'message' => 'The caller does not have permission.',
             ],
         ]);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Error "500" - "INTERNAL": "Internal error encountered.".');
+        $this->expectExceptionMessage('Error "403" - "PERMISSION_DENIED": "The caller does not have permission.".');
 
         $converter->convert(new RawHttpResult($httpResponse));
     }
@@ -401,15 +402,15 @@ final class ResultConverterTest extends TestCase
         ], ChoiceDelta::class, []];
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(500);
         $httpResponse->method('getContent')->willReturn('Service Unavailable');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }

--- a/src/platform/src/Bridge/Generic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Generic/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Throw typed exceptions on rate limit and server error events mid-stream
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
+++ b/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
@@ -12,7 +12,9 @@
 namespace Symfony\AI\Platform\Bridge\Generic\Completions;
 
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
@@ -45,7 +47,19 @@ trait CompletionsConversionTrait
         foreach ($result->getDataStream() as $data) {
             if (isset($data['error'])) {
                 $message = \is_array($data['error']) ? ($data['error']['message'] ?? 'Unknown error') : (string) $data['error'];
-                throw new RuntimeException(\sprintf('Stream error: "%s".', $message));
+                $code = \is_array($data['error']) ? ($data['error']['code'] ?? null) : null;
+                $type = \is_array($data['error']) ? ($data['error']['type'] ?? null) : null;
+                $errorMessage = \sprintf('Stream error: "%s".', $message);
+
+                if ($this->isRateLimitError($code, $type)) {
+                    throw new RateLimitExceededException(null, $errorMessage);
+                }
+
+                if ($this->isServerError($code, $type)) {
+                    throw new ServerException(null, $errorMessage);
+                }
+
+                throw new RuntimeException($errorMessage);
             }
 
             $sawChunk = true;
@@ -225,5 +239,17 @@ trait CompletionsConversionTrait
         }
 
         return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
+    }
+
+    private function isRateLimitError(mixed $code, mixed $type): bool
+    {
+        return \in_array($code, ['rate_limit_exceeded', 'rate_limit_error', 'too_many_requests'], true)
+            || \in_array($type, ['rate_limit_exceeded', 'rate_limit_error', 'too_many_requests'], true);
+    }
+
+    private function isServerError(mixed $code, mixed $type): bool
+    {
+        return \in_array($code, ['server_error', 'internal_error'], true)
+            || \in_array($type, ['server_error', 'internal_error'], true);
     }
 }

--- a/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
+++ b/src/platform/src/Bridge/Generic/Completions/ResultConverter.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -65,6 +66,11 @@ class ResultConverter implements ResultConverterInterface
         if (429 === $response->getStatusCode()) {
             $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
             throw new RateLimitExceededException(null, $errorMessage);
+        }
+
+        if (($code = $response->getStatusCode()) >= 500) {
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new ServerException($code, $errorMessage);
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
@@ -19,7 +19,9 @@ use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -349,17 +351,20 @@ class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }
 
-    public function testThrowsOnServerErrorStatus()
+    public function testThrowsServerExceptionOnServerErrorStatus()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(503);
-        $httpResponse->method('getContent')->willReturn('service unavailable');
+        $httpResponse->method('getContent')->willReturn('{"error":{"message":"service unavailable"}}');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 503: "service unavailable"');
-
-        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+        try {
+            $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+            $this->fail('Expected a ServerException to be thrown.');
+        } catch (ServerException $e) {
+            $this->assertSame(503, $e->getStatusCode());
+            $this->assertStringContainsString('service unavailable', $e->getMessage());
+        }
     }
 
     public function testThrowsDetailedErrorException()
@@ -524,13 +529,41 @@ class ResultConverterTest extends TestCase
 
         $events = [
             ['choices' => [['index' => 0, 'delta' => ['content' => 'partial']]]],
-            ['error' => ['message' => 'Provider exploded mid-stream', 'code' => 'server_error']],
+            ['error' => ['message' => 'Invalid model', 'code' => 'invalid_request_error']],
         ];
 
         $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Stream error: "Provider exploded mid-stream".');
+        $this->expectExceptionMessage('Stream error: "Invalid model".');
+
+        iterator_to_array($streamResult->getContent());
+    }
+
+    public function testStreamingThrowsServerExceptionOnServerErrorEvent()
+    {
+        $converter = new ResultConverter();
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], [[
+            'error' => ['message' => 'Provider exploded mid-stream', 'code' => 'server_error'],
+        ]], $this->httpResponseStub()), ['stream' => true]);
+
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error. Stream error: "Provider exploded mid-stream".');
+
+        iterator_to_array($streamResult->getContent());
+    }
+
+    public function testStreamingThrowsRateLimitExceptionOnRateLimitEvent()
+    {
+        $converter = new ResultConverter();
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], [[
+            'error' => ['message' => 'Too many requests', 'code' => 'rate_limit_error'],
+        ]], $this->httpResponseStub()), ['stream' => true]);
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded. Stream error: "Too many requests".');
 
         iterator_to_array($streamResult->getContent());
     }

--- a/src/platform/src/Bridge/Mistral/CHANGELOG.md
+++ b/src/platform/src/Bridge/Mistral/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
  * Add OCR support by `mistral-ocr-latest` model and `/v1/ocr` endpoint, returning a typed `OcrResult` with pages, layout images and annotations
 

--- a/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Bridge\Mistral\Llm\ResultConverter;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
-use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -85,14 +85,14 @@ final class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse(['error' => 'Service Unavailable'], ['http_code' => 500]));
         $httpResponse = $httpClient->request('POST', 'https://example.com');
         $converter = new ResultConverter();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }

--- a/src/platform/src/Bridge/OpenAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenAi/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Throw typed exceptions on rate limit and server error events mid-stream
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -84,6 +85,11 @@ final class ResultConverter implements ResultConverterInterface
             $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
 
             throw new RateLimitExceededException($resetTime ? self::parseResetTime($resetTime) : null, $errorMessage);
+        }
+
+        if (($code = $response->getStatusCode()) >= 500) {
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new ServerException($code, $errorMessage);
         }
 
         if ($options['stream'] ?? false) {
@@ -169,12 +175,34 @@ final class ResultConverter implements ResultConverterInterface
             $sawResponseEvent = true;
 
             if ('error' === $type) {
-                throw new RuntimeException($this->generateErrorMessage($this->extractStreamError($event)));
+                $error = $this->extractStreamError($event);
+                $message = $this->generateErrorMessage($error);
+
+                if ($this->isRateLimitError($error)) {
+                    throw new RateLimitExceededException(null, $message);
+                }
+
+                if ($this->isServerError($error)) {
+                    throw new ServerException(null, $message);
+                }
+
+                throw new RuntimeException($message);
             }
 
             if ('response.failed' === $type) {
                 $response = \is_array($event['response'] ?? null) ? $event['response'] : [];
-                throw new RuntimeException($this->generateErrorMessage($this->extractStreamError($response)));
+                $error = $this->extractStreamError($response);
+                $message = $this->generateErrorMessage($error);
+
+                if ($this->isRateLimitError($error)) {
+                    throw new RateLimitExceededException(null, $message);
+                }
+
+                if ($this->isServerError($error)) {
+                    throw new ServerException(null, $message);
+                }
+
+                throw new RuntimeException($message);
             }
 
             if ('response.incomplete' === $type) {
@@ -330,6 +358,24 @@ final class ResultConverter implements ResultConverterInterface
     private function generateErrorMessage(array $error): string
     {
         return \sprintf('Error "%s"-%s (%s): "%s".', $error['code'] ?? '-', $error['type'] ?? '-', $error['param'] ?? '-', $error['message'] ?? '-');
+    }
+
+    /**
+     * @param Error $error
+     */
+    private function isRateLimitError(array $error): bool
+    {
+        return \in_array($error['code'], ['rate_limit_exceeded', 'rate_limit_error', 'too_many_requests'], true)
+            || \in_array($error['type'], ['rate_limit_exceeded', 'rate_limit_error', 'too_many_requests'], true);
+    }
+
+    /**
+     * @param Error $error
+     */
+    private function isServerError(array $error): bool
+    {
+        return \in_array($error['code'], ['server_error', 'internal_error'], true)
+            || \in_array($error['type'], ['server_error', 'internal_error'], true);
     }
 
     /**

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -19,7 +19,9 @@ use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -563,6 +565,48 @@ class ResultConverterTest extends TestCase
         ], 'OpenAI Responses stream ended incomplete (max_output_tokens).'];
     }
 
+    public function testStreamThrowsRateLimitExceptionOnRateLimitEvent()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], [[
+            'type' => 'error',
+            'code' => 'rate_limit_exceeded',
+            'message' => 'Rate limit reached for requests',
+        ]], $httpResponse), ['stream' => true]);
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded. Error "rate_limit_exceeded"-- (-): "Rate limit reached for requests".');
+
+        iterator_to_array($streamResult->getContent());
+    }
+
+    public function testStreamThrowsServerExceptionOnServerErrorEvent()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], [[
+            'type' => 'response.failed',
+            'response' => [
+                'error' => [
+                    'code' => 'server_error',
+                    'message' => 'The model failed to generate a response',
+                ],
+            ],
+        ]], $httpResponse), ['stream' => true]);
+
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error. Error "server_error"-- (-): "The model failed to generate a response".');
+
+        iterator_to_array($streamResult->getContent());
+    }
+
     public function testStreamThrowsExceptionOnErrorEvent()
     {
         $converter = new ResultConverter();
@@ -646,15 +690,15 @@ class ResultConverterTest extends TestCase
         $this->assertSame('The answer is 42.', $chunks[4]->getText());
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(500);
         $httpResponse->method('getContent')->willReturn('Service Unavailable');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }

--- a/src/platform/src/Bridge/OpenAi/Tests/TextToSpeech/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/TextToSpeech/ResultConverterTest.php
@@ -49,7 +49,7 @@ final class ResultConverterTest extends TestCase
         $result = $this->createStub(ResponseInterface::class);
         $result
             ->method('getStatusCode')
-            ->willReturn(500);
+            ->willReturn(403);
         $result
             ->method('getContent')
             ->willReturn('Hi Test!');

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Throw typed exceptions on rate limit and server error events mid-stream
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -80,6 +81,11 @@ final class ResultConverter implements ResultConverterInterface
         if (429 === $response->getStatusCode()) {
             $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
             throw new RateLimitExceededException(null, $errorMessage);
+        }
+
+        if (($code = $response->getStatusCode()) >= 500) {
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new ServerException($code, $errorMessage);
         }
 
         if ($options['stream'] ?? false) {
@@ -178,12 +184,34 @@ final class ResultConverter implements ResultConverterInterface
             $sawResponseEvent = true;
 
             if ('error' === $type) {
-                throw new RuntimeException($this->generateErrorMessage($this->extractStreamError($event)));
+                $error = $this->extractStreamError($event);
+                $message = $this->generateErrorMessage($error);
+
+                if ($this->isRateLimitError($error)) {
+                    throw new RateLimitExceededException(null, $message);
+                }
+
+                if ($this->isServerError($error)) {
+                    throw new ServerException(null, $message);
+                }
+
+                throw new RuntimeException($message);
             }
 
             if ('response.failed' === $type) {
                 $response = \is_array($event['response'] ?? null) ? $event['response'] : [];
-                throw new RuntimeException($this->generateErrorMessage($this->extractStreamError($response)));
+                $error = $this->extractStreamError($response);
+                $message = $this->generateErrorMessage($error);
+
+                if ($this->isRateLimitError($error)) {
+                    throw new RateLimitExceededException(null, $message);
+                }
+
+                if ($this->isServerError($error)) {
+                    throw new ServerException(null, $message);
+                }
+
+                throw new RuntimeException($message);
             }
 
             if ('response.incomplete' === $type) {
@@ -326,6 +354,24 @@ final class ResultConverter implements ResultConverterInterface
     private function generateErrorMessage(array $error): string
     {
         return \sprintf('Error "%s"-%s (%s): "%s".', $error['code'] ?? '-', $error['type'] ?? '-', $error['param'] ?? '-', $error['message'] ?? '-');
+    }
+
+    /**
+     * @param Error $error
+     */
+    private function isRateLimitError(array $error): bool
+    {
+        return \in_array($error['code'], ['rate_limit_exceeded', 'rate_limit_error', 'too_many_requests'], true)
+            || \in_array($error['type'], ['rate_limit_exceeded', 'rate_limit_error', 'too_many_requests'], true);
+    }
+
+    /**
+     * @param Error $error
+     */
+    private function isServerError(array $error): bool
+    {
+        return \in_array($error['code'], ['server_error', 'internal_error'], true)
+            || \in_array($error['type'], ['server_error', 'internal_error'], true);
     }
 
     /**

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -21,6 +21,7 @@ use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -783,6 +784,48 @@ final class ResultConverterTest extends TestCase
         ], 'Responses API stream ended incomplete (max_tokens).'];
     }
 
+    public function testStreamThrowsRateLimitExceptionOnRateLimitEvent()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], [[
+            'type' => 'error',
+            'code' => 'rate_limit_exceeded',
+            'message' => 'Rate limit reached for requests',
+        ]], $httpResponse), ['stream' => true]);
+
+        $this->expectException(RateLimitExceededException::class);
+        $this->expectExceptionMessage('Rate limit exceeded. Error "rate_limit_exceeded"-- (-): "Rate limit reached for requests".');
+
+        iterator_to_array($streamResult->getContent());
+    }
+
+    public function testStreamThrowsServerExceptionOnServerErrorEvent()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], [[
+            'type' => 'response.failed',
+            'response' => [
+                'error' => [
+                    'code' => 'server_error',
+                    'message' => 'The model failed to generate a response',
+                ],
+            ],
+        ]], $httpResponse), ['stream' => true]);
+
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error. Error "server_error"-- (-): "The model failed to generate a response".');
+
+        iterator_to_array($streamResult->getContent());
+    }
+
     public function testStreamThrowsExceptionOnErrorEvent()
     {
         $converter = new ResultConverter();
@@ -866,16 +909,19 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('The answer is 42.', $chunks[4]->getText());
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(500);
-        $httpResponse->method('getContent')->willReturn('Service Unavailable');
+        $httpResponse->method('getContent')->willReturn('{"error":{"message":"Service Unavailable"}}');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
-
-        $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+        try {
+            $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+            $this->fail('Expected a ServerException to be thrown.');
+        } catch (ServerException $e) {
+            $this->assertSame(500, $e->getStatusCode());
+            $this->assertStringContainsString('Service Unavailable', $e->getMessage());
+        }
     }
 }

--- a/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/OpenRouter/Tests/Rerank/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenRouter/Tests/Rerank/ResultConverterTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\Generic\CompletionsModel;
 use Symfony\AI\Platform\Bridge\OpenRouter\Rerank\ResultConverter;
 use Symfony\AI\Platform\Bridge\OpenRouter\RerankModel;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RerankingResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -47,8 +48,8 @@ final class ResultConverterTest extends TestCase
 
         $converter = new ResultConverter();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($response));
     }

--- a/src/platform/src/Bridge/OpenRouter/Tests/Speech/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenRouter/Tests/Speech/ResultConverterTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Generic\CompletionsModel;
 use Symfony\AI\Platform\Bridge\OpenRouter\Speech\ResultConverter;
 use Symfony\AI\Platform\Bridge\OpenRouter\SpeechModel;
-use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -47,8 +47,8 @@ final class ResultConverterTest extends TestCase
 
         $converter = new ResultConverter();
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($response));
     }

--- a/src/platform/src/Bridge/Perplexity/CHANGELOG.md
+++ b/src/platform/src/Bridge/Perplexity/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Perplexity/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Perplexity/Tests/ResultConverterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Perplexity\ResultConverter;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
@@ -215,15 +216,15 @@ final class ResultConverterTest extends TestCase
         $this->assertSame(['https://example.com/1'], $deferredResult->getMetadata()->get('citations'));
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(500);
         $httpResponse->method('getContent')->willReturn('Service Unavailable');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }

--- a/src/platform/src/Bridge/Scaleway/CHANGELOG.md
+++ b/src/platform/src/Bridge/Scaleway/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Scaleway/Llm/ResultConverter.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\Scaleway\Scaleway;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -38,6 +39,11 @@ final class ResultConverter implements ResultConverterInterface
 
     public function convert(RawResultInterface $result, array $options = []): ResultInterface
     {
+        if ($result instanceof RawHttpResult && ($code = $result->getObject()->getStatusCode()) >= 500) {
+            $errorMessage = json_decode($result->getObject()->getContent(false), true)['error']['message'] ?? null;
+            throw new ServerException($code, $errorMessage);
+        }
+
         if ($options['stream'] ?? false) {
             if ($result instanceof RawHttpResult && ($code = $result->getObject()->getStatusCode()) >= 400) {
                 throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $code, $result->getObject()->getContent(false)));

--- a/src/platform/src/Bridge/Scaleway/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Llm/ResultConverterTest.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Bridge\Scaleway\ScalewayResponses;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -305,15 +306,15 @@ final class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(500);
         $httpResponse->method('getContent')->willReturn('Service Unavailable');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }

--- a/src/platform/src/Bridge/VertexAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/VertexAi/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\VertexAi\Gemini;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -77,6 +78,11 @@ final class ResultConverter implements ResultConverterInterface
             ) {
                 throw new ExceedContextSizeException($errorMessage);
             }
+        }
+
+        if (($code = $response->getStatusCode()) >= 500) {
+            $errorMessage = json_decode($response->getContent(false), true)['error']['message'] ?? null;
+            throw new ServerException($code, $errorMessage);
         }
 
         if ($options['stream'] ?? false) {

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ResultConverter;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
-use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
@@ -520,15 +520,15 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('!', $items[3]->getText());
     }
 
-    public function testThrowsOnUnhandledHttpErrorStatusBeforeStreaming()
+    public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('getStatusCode')->willReturn(500);
         $httpResponse->method('getContent')->willReturn('Service Unavailable');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected response code 500');
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
     }

--- a/src/platform/src/Exception/ServerException.php
+++ b/src/platform/src/Exception/ServerException.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Exception;
+
+/**
+ * Thrown when a provider returns a transient server-side error (HTTP 5xx) or
+ * emits a server-side error event mid-stream (e.g. Anthropic "overloaded").
+ *
+ * These failures are usually transient, so consumers may want to retry the
+ * request. The status code is null for mid-stream error events, which carry no
+ * HTTP status.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ServerException extends RuntimeException
+{
+    public function __construct(
+        private readonly ?int $statusCode = null,
+        ?string $errorMessage = null,
+    ) {
+        $message = null !== $statusCode
+            ? \sprintf('Server error (HTTP %d).', $statusCode)
+            : 'Server error.';
+
+        if (null !== $errorMessage && '' !== $errorMessage) {
+            $message .= ' '.$errorMessage;
+        }
+
+        parent::__construct($message);
+    }
+
+    public function getStatusCode(): ?int
+    {
+        return $this->statusCode;
+    }
+}

--- a/src/platform/src/Result/HttpStatusErrorHandlingTrait.php
+++ b/src/platform/src/Result/HttpStatusErrorHandlingTrait.php
@@ -15,16 +15,17 @@ use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * Provides shared HTTP error handling for bridge result converters.
  *
- * Translates the common 4xx/429 responses returned by AI providers into
- * dedicated platform exceptions so consumers can react to auth failures,
- * bad requests, missing models and rate limits without parsing error bodies
- * themselves.
+ * Translates the common 4xx/429 and 5xx responses returned by AI providers
+ * into dedicated platform exceptions so consumers can react to auth failures,
+ * bad requests, missing models, rate limits and transient server errors
+ * without parsing error bodies themselves.
  *
  * Error bodies are parsed leniently: both the nested `error.message` shape
  * (OpenAI, Gemini, Perplexity) and the flat top-level `message` shape
@@ -57,6 +58,10 @@ trait HttpStatusErrorHandlingTrait
 
         if (429 === $status) {
             throw new RateLimitExceededException($this->extractRetryAfter($response), $this->extractErrorMessage($response));
+        }
+
+        if ($status >= 500) {
+            throw new ServerException($status, $this->extractErrorMessage($response));
         }
     }
 

--- a/src/platform/tests/Result/HttpStatusErrorHandlingTraitTest.php
+++ b/src/platform/tests/Result/HttpStatusErrorHandlingTraitTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -28,8 +29,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 final class HttpStatusErrorHandlingTraitTest extends TestCase
 {
     /**
-     * Any status outside the handled 400/401/404/429 set - success, redirect,
-     * server-error - is passed through untouched for the calling converter to handle.
+     * Any status outside the handled 400/401/404/429/5xx set - success,
+     * redirect - is passed through untouched for the calling converter to handle.
      */
     #[DataProvider('unhandledStatusCodes')]
     public function testDoesNotThrowForUnhandledStatusCodes(int $status)
@@ -49,8 +50,46 @@ final class HttpStatusErrorHandlingTraitTest extends TestCase
         yield '204 No Content' => [204];
         yield '301 Moved Permanently' => [301];
         yield '302 Found' => [302];
+    }
+
+    #[DataProvider('serverErrorStatusCodes')]
+    public function testThrowsServerExceptionOnServerErrorStatus(int $status)
+    {
+        $response = $this->response(json_encode([
+            'error' => [
+                'message' => 'Service down',
+            ],
+        ]), $status);
+
+        try {
+            $this->subject()->throwOnHttpError($response);
+            $this->fail('Expected ServerException.');
+        } catch (ServerException $e) {
+            $this->assertSame($status, $e->getStatusCode());
+            $this->assertStringContainsString('Service down', $e->getMessage());
+        }
+    }
+
+    /**
+     * @return iterable<array{int}>
+     */
+    public static function serverErrorStatusCodes(): iterable
+    {
         yield '500 Internal Server Error' => [500];
+        yield '502 Bad Gateway' => [502];
         yield '503 Service Unavailable' => [503];
+        yield '529 Overloaded' => [529];
+    }
+
+    public function testThrowsServerExceptionOn5xxWithEmptyBody()
+    {
+        try {
+            $this->subject()->throwOnHttpError($this->response('', 503));
+            $this->fail('Expected ServerException.');
+        } catch (ServerException $e) {
+            $this->assertSame(503, $e->getStatusCode());
+            $this->assertSame('Server error (HTTP 503).', $e->getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes-ish
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

Add `ServerException`, thrown on (transient) server errors (HTTP 5xx) by `HttpStatusErrorHandlingTrait` and the bridge converters so consumers can retry without parsing error messages.