### PR TITLE
[Platform][Anthropic] Extract prompt-caching injection into a reusable trait

### DIFF
--- a/src/platform/src/Bridge/Anthropic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Anthropic/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Add a `baseUrl` argument to `ModelClient` and the factory to target Anthropic-compatible endpoints
+ * Extract prompt-caching injection into a reusable `PromptCachingTrait` so alternative model clients can share it
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -26,6 +26,7 @@ final class ModelClient implements ModelClientInterface
 {
     use JsonBodyEncodingTrait;
     use JsonSchemaSanitizerTrait;
+    use PromptCachingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
     private readonly string $baseUrl;
@@ -68,12 +69,13 @@ final class ModelClient implements ModelClientInterface
             'content-type' => 'application/json',
         ];
 
-        $payload = $this->injectCacheControl($payload);
-        $payload = $this->injectSystemCacheControl($payload);
+        $cacheControl = $this->getCacheControl($this->cacheRetention);
+        $payload = $this->injectMessagesCacheControl($payload, $cacheControl);
+        $payload = $this->injectSystemCacheControl($payload, $cacheControl);
 
         if (isset($options['tools'])) {
             $options['tool_choice'] ??= ['type' => 'auto'];
-            $options['tools'] = $this->injectToolsCacheControl($options['tools']);
+            $options['tools'] = $this->injectToolsCacheControl($options['tools'], $cacheControl);
         }
 
         if (isset($options['thinking'])) {
@@ -100,122 +102,5 @@ final class ModelClient implements ModelClientInterface
             'headers' => $headers,
             'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));
-    }
-
-    /**
-     * Injects a prompt-caching marker on the last tool definition.
-     *
-     * This creates an additional cache breakpoint after all tool definitions,
-     * so the prefix "system → tools" can be cached independently of the
-     * messages that follow.  Tool definitions are typically identical across
-     * requests, making this a very effective caching target.
-     *
-     * @param list<array<string, mixed>> $tools Normalised tool definitions
-     *
-     * @return list<array<string, mixed>>
-     */
-    private function injectToolsCacheControl(array $tools): array
-    {
-        if ('none' === $this->cacheRetention || [] === $tools) {
-            return $tools;
-        }
-
-        $cacheControl = 'long' === $this->cacheRetention
-            ? ['type' => 'ephemeral', 'ttl' => '1h']
-            : ['type' => 'ephemeral'];
-
-        $tools[\count($tools) - 1]['cache_control'] = $cacheControl;
-
-        return $tools;
-    }
-
-    /**
-     * Injects a prompt-caching marker on the last system content block.
-     *
-     * The system prompt is typically the largest and most stable region of a
-     * request, making it the single most effective caching target. This creates
-     * a cache breakpoint after the system block so it can be cached independently
-     * of the tools and messages that follow.
-     *
-     * @param array<string, mixed> $payload
-     *
-     * @return array<string, mixed>
-     */
-    private function injectSystemCacheControl(array $payload): array
-    {
-        if ('none' === $this->cacheRetention || !isset($payload['system']) || !\is_array($payload['system']) || [] === $payload['system']) {
-            return $payload;
-        }
-
-        $payload['system'][\count($payload['system']) - 1]['cache_control'] = $this->getCacheControl();
-
-        return $payload;
-    }
-
-    /**
-     * Injects prompt-caching markers into the normalised message payload.
-     *
-     * Anthropic prompt caching requires a {"cache_control": {"type": "ephemeral"}}
-     * annotation on the last block of the last user message.
-     *
-     * @param array<string, mixed> $payload
-     *
-     * @return array<string, mixed>
-     */
-    private function injectCacheControl(array $payload): array
-    {
-        if ('none' === $this->cacheRetention) {
-            return $payload;
-        }
-
-        $messages = $payload['messages'] ?? [];
-
-        if ([] === $messages) {
-            return $payload;
-        }
-
-        $cacheControl = $this->getCacheControl();
-
-        for ($i = \count($messages) - 1; $i >= 0; --$i) {
-            if ('user' !== ($messages[$i]['role'] ?? '')) {
-                continue;
-            }
-
-            $content = $messages[$i]['content'] ?? null;
-
-            if (\is_string($content)) {
-                $messages[$i]['content'] = [
-                    ['type' => 'text', 'text' => $content, 'cache_control' => $cacheControl],
-                ];
-                break;
-            }
-
-            if (\is_array($content) && [] !== $content) {
-                $lastIdx = \count($content) - 1;
-                if (\is_array($content[$lastIdx])) {
-                    $content[$lastIdx]['cache_control'] = $cacheControl;
-                    $messages[$i]['content'] = $content;
-                }
-                break;
-            }
-        }
-
-        $payload['messages'] = $messages;
-
-        return $payload;
-    }
-
-    /**
-     * Builds the prompt-caching marker matching the configured retention.
-     *
-     * @return array{type: 'ephemeral', ttl?: '1h'}
-     */
-    private function getCacheControl(): array
-    {
-        if ('long' === $this->cacheRetention) {
-            return ['type' => 'ephemeral', 'ttl' => '1h'];
-        }
-
-        return ['type' => 'ephemeral'];
     }
 }

--- a/src/platform/src/Bridge/Anthropic/PromptCachingTrait.php
+++ b/src/platform/src/Bridge/Anthropic/PromptCachingTrait.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Anthropic;
+
+/**
+ * Injects Anthropic prompt-caching markers into request payloads.
+ *
+ * Anthropic prompt caching requires a {"cache_control": {...}} annotation on
+ * the last block of the cached region: the last system block, the last tool
+ * definition, and the last block of the last user message. Each region can be
+ * cached independently, so callers may inject any subset.
+ *
+ * The cache-control marker itself (retention window, endpoint support) is
+ * resolved by the caller and passed in, so different model clients (e.g. the
+ * default API client and the Claude Code OAuth client) can share the injection
+ * logic while keeping their own marker resolution.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+trait PromptCachingTrait
+{
+    /**
+     * Builds the cache-control marker matching the configured retention.
+     *
+     * The 1h window selected by the "long" retention is an Anthropic-native
+     * beta only guaranteed on the official API endpoint; callers talking to a
+     * gateway or proxy that may not implement it should pass
+     * $extendedTtlSupported = false, in which case "long" degrades to the
+     * default 5-minute window instead.
+     *
+     * @return array{type: 'ephemeral', ttl?: '1h'}|null Null when caching is disabled
+     */
+    private function getCacheControl(string $cacheRetention, bool $extendedTtlSupported = true): ?array
+    {
+        if ('none' === $cacheRetention) {
+            return null;
+        }
+
+        if ('long' === $cacheRetention && $extendedTtlSupported) {
+            return ['type' => 'ephemeral', 'ttl' => '1h'];
+        }
+
+        return ['type' => 'ephemeral'];
+    }
+
+    /**
+     * Annotates the last block of the last user message.
+     *
+     * @param array<int|string, mixed>                  $payload
+     * @param array{type: 'ephemeral', ttl?: '1h'}|null $cacheControl Null disables caching
+     *
+     * @return array<int|string, mixed>
+     */
+    private function injectMessagesCacheControl(array $payload, ?array $cacheControl): array
+    {
+        if (null === $cacheControl) {
+            return $payload;
+        }
+
+        $messages = $payload['messages'] ?? [];
+
+        if ([] === $messages) {
+            return $payload;
+        }
+
+        for ($i = \count($messages) - 1; $i >= 0; --$i) {
+            if ('user' !== ($messages[$i]['role'] ?? '')) {
+                continue;
+            }
+
+            $content = $messages[$i]['content'] ?? null;
+
+            if (\is_string($content)) {
+                $messages[$i]['content'] = [
+                    ['type' => 'text', 'text' => $content, 'cache_control' => $cacheControl],
+                ];
+                break;
+            }
+
+            if (\is_array($content) && [] !== $content) {
+                $lastIdx = \count($content) - 1;
+                if (\is_array($content[$lastIdx])) {
+                    $content[$lastIdx]['cache_control'] = $cacheControl;
+                    $messages[$i]['content'] = $content;
+                }
+                break;
+            }
+        }
+
+        $payload['messages'] = $messages;
+
+        return $payload;
+    }
+
+    /**
+     * Annotates the last system content block.
+     *
+     * @param array<int|string, mixed>                  $payload
+     * @param array{type: 'ephemeral', ttl?: '1h'}|null $cacheControl Null disables caching
+     *
+     * @return array<int|string, mixed>
+     */
+    private function injectSystemCacheControl(array $payload, ?array $cacheControl): array
+    {
+        if (null === $cacheControl || !isset($payload['system']) || !\is_array($payload['system']) || [] === $payload['system']) {
+            return $payload;
+        }
+
+        $payload['system'][\count($payload['system']) - 1]['cache_control'] = $cacheControl;
+
+        return $payload;
+    }
+
+    /**
+     * Annotates the last tool definition.
+     *
+     * @param list<array<string, mixed>>                $tools
+     * @param array{type: 'ephemeral', ttl?: '1h'}|null $cacheControl Null disables caching
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function injectToolsCacheControl(array $tools, ?array $cacheControl): array
+    {
+        if (null === $cacheControl || [] === $tools) {
+            return $tools;
+        }
+
+        $tools[\count($tools) - 1]['cache_control'] = $cacheControl;
+
+        return $tools;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

Extract prompt-caching injection into a reusable `PromptCachingTrait` so "alternative" model clients can share it
