### PR TITLE
[Platform][Anthropic] Add a configurable base URL to target compatible endpoints

### DIFF
--- a/src/platform/src/Bridge/Anthropic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Anthropic/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Add a `baseUrl` argument to `ModelClient` and the factory to target Anthropic-compatible endpoints
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Anthropic/Factory.php
+++ b/src/platform/src/Bridge/Anthropic/Factory.php
@@ -40,12 +40,13 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $cacheRetention = 'short',
         string $name = 'anthropic',
+        string $baseUrl = 'https://api.anthropic.com',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Provider(
             $name,
-            [new ModelClient($httpClient, $apiKey, $cacheRetention)],
+            [new ModelClient($httpClient, $apiKey, $cacheRetention, $baseUrl)],
             [new ResultConverter()],
             $modelCatalog,
             $contract ?? AnthropicContract::create(),
@@ -66,9 +67,10 @@ final class Factory
         string $cacheRetention = 'short',
         string $name = 'anthropic',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://api.anthropic.com',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $cacheRetention, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $cacheRetention, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Anthropic/ModelClient.php
+++ b/src/platform/src/Bridge/Anthropic/ModelClient.php
@@ -28,23 +28,27 @@ final class ModelClient implements ModelClientInterface
     use JsonSchemaSanitizerTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
     /**
      * @param 'none'|'short'|'long' $cacheRetention Controls Anthropic prompt-caching retention:
      *                                              - 'short': 5-minute cache window (default Anthropic ephemeral TTL)
      *                                              - 'long':  1-hour cache window; only available on api.anthropic.com
      *                                              - 'none':  prompt caching disabled
+     * @param string                $baseUrl        Base URL of an Anthropic-compatible endpoint, without trailing slash
      */
     public function __construct(
         HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
         private readonly string $cacheRetention = 'short',
+        string $baseUrl = 'https://api.anthropic.com',
     ) {
         if (!\in_array($cacheRetention, ['none', 'short', 'long'], true)) {
             throw new InvalidArgumentException(\sprintf('Invalid cache retention "%s". Supported values are "none", "short" and "long".', $cacheRetention));
         }
 
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -92,7 +96,7 @@ final class ModelClient implements ModelClientInterface
             unset($options['beta_features']);
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.anthropic.com/v1/messages', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v1/messages', [
             'headers' => $headers,
             'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));

--- a/src/platform/src/Bridge/Anthropic/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ModelClientTest.php
@@ -266,6 +266,19 @@ class ModelClientTest extends TestCase
         $this->modelClient->request($this->model, $payload);
     }
 
+    public function testCustomBaseUrlIsUsedForTheRequest()
+    {
+        $this->httpClient = new MockHttpClient(function ($method, $url) {
+            $this->assertSame('https://anthropic.example.com/v1/messages', $url);
+
+            return new JsonMockResponse('{"success": true}');
+        });
+
+        $this->modelClient = new ModelClient($this->httpClient, 'test-api-key', 'short', 'https://anthropic.example.com/');
+
+        $this->modelClient->request($this->model, ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
+    }
+
     public function testNoneCacheRetentionDoesNotInject()
     {
         $this->httpClient = new MockHttpClient(function ($method, $url, $options) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

`ModelClient` currently hardcodes `https://api.anthropic.com`. But in practice, most production setups put an Anthropic-compatible gateway in front of the API (LiteLLM, Cloudflare AI Gateway, ...) for observability, caching, and key management. 

The OpenAI and Generic bridges already accept a base URL for exactly this.
