### PR TITLE
[Platform] Skip built-in tool-call output items in OpenAI result converters

### DIFF
--- a/examples/gemini/server-tools.php
+++ b/examples/gemini/server-tools.php
@@ -10,9 +10,6 @@
  */
 
 use Symfony\AI\Agent\Agent;
-use Symfony\AI\Agent\Bridge\Clock\Clock;
-use Symfony\AI\Agent\Toolbox\AgentProcessor;
-use Symfony\AI\Agent\Toolbox\Toolbox;
 use Symfony\AI\Platform\Bridge\Gemini\Factory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;

--- a/src/platform/src/Bridge/OpenAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenAi/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Throw typed exceptions on rate limit and server error events mid-stream
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -152,6 +152,14 @@ final class ResultConverter implements ResultConverterInterface
         return match ($type) {
             'message' => $this->convertOutputMessage($item),
             'reasoning' => $this->convertReasoning($item),
+            // Built-in server-side tool calls (web search, file search, code
+            // interpreter, image generation, computer use, MCP, …) are reported
+            // as their own output items but carry no assistant-facing result.
+            // Skip them so the actual message item is still converted instead of
+            // aborting the whole response.
+            'web_search_call', 'file_search_call', 'code_interpreter_call',
+            'image_generation_call', 'computer_call', 'local_shell_call',
+            'mcp_call', 'mcp_list_tools', 'mcp_approval_request' => [],
             default => throw new RuntimeException(\sprintf('Unsupported output type "%s".', $type)),
         };
     }

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -224,6 +224,31 @@ class ResultConverterTest extends TestCase
         $this->assertSame('final', $result->getContent());
     }
 
+    public function testConvertSkipsBuiltInToolCallOutputItems()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                ['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed'],
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'The answer is 42.',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('The answer is 42.', $result->getContent());
+    }
+
     public function testContentFilterException()
     {
         $converter = new ResultConverter();

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Throw typed exceptions on rate limit and server error events mid-stream
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -161,6 +161,14 @@ final class ResultConverter implements ResultConverterInterface
         return match ($type) {
             'message' => $this->convertOutputMessage($item),
             'reasoning' => $this->convertReasoning($item),
+            // Built-in server-side tool calls (web search, file search, code
+            // interpreter, image generation, computer use, MCP, …) are reported
+            // as their own output items but carry no assistant-facing result.
+            // Skip them so the actual message item is still converted instead of
+            // aborting the whole response.
+            'web_search_call', 'file_search_call', 'code_interpreter_call',
+            'image_generation_call', 'computer_call', 'local_shell_call',
+            'mcp_call', 'mcp_list_tools', 'mcp_approval_request' => [],
             default => throw new RuntimeException(\sprintf('Unsupported output type "%s".', $type)),
         };
     }

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -252,6 +252,31 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('final', $result->getContent());
     }
 
+    public function testConvertSkipsBuiltInToolCallOutputItems()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                ['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed'],
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'The answer is 42.',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('The answer is 42.', $result->getContent());
+    }
+
     public function testThrowsRuntimeExceptionWhenIncompleteResponseHasNoContent()
     {
         $converter = new ResultConverter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

When a built-in server-side tool such as `web_search` runs, the OpenAI Responses API returns a `web_search_call` item in the response `output[]` array alongside the assistant `message`. Both the OpenAI (`Gpt`) and OpenResponses result converters only handled the `message` and `reasoning` output types and threw `RuntimeException: Unsupported output type "web_search_call"` on anything else, aborting conversion before the `message` item carrying the answer was read. As a result, any agent enabling a built-in tool failed.

This skips the built-in server-side tool-call output items (`web_search_call`, `file_search_call`, `code_interpreter_call`, `image_generation_call`, `computer_call`, `local_shell_call`, `mcp_call`, `mcp_list_tools`, `mcp_approval_request`) — they carry no assistant-facing result — so the assistant message is still converted. Tests added to both bridges' `ResultConverterTest`.