### PR TITLE
[Platform][OpenAI] Skip responses built-in tool output items instead of throwing

### DIFF
--- a/examples/openai/web-search-open-responses.php
+++ b/examples/openai/web-search-open-responses.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenResponses\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+// Same web_search scenario as web-search.php, but driven through the generic
+// OpenResponses bridge pointed at the canonical OpenAI Responses endpoint. This
+// exercises the OpenResponses result converter against a real `web_search_call`
+// output item, proving both converters skip it instead of aborting.
+$platform = Factory::createPlatform('https://api.openai.com', env('OPENAI_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::ofUser('What is the latest stable Symfony version? Use web search to be sure.'),
+);
+
+$result = $platform->invoke('gpt-4o', $messages, [
+    'tools' => [['type' => 'web_search']],
+]);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/openai/web-search.php
+++ b/examples/openai/web-search.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::ofUser('What is the latest stable Symfony version? Use web search to be sure.'),
+);
+
+// `web_search` is OpenAI's built-in, server-side tool. It is passed as a raw
+// option array (the legacy alias is `web_search_preview`). The Responses API
+// runs the search itself and returns a `web_search_call` output item next to
+// the assistant message, which the result converter skips.
+$result = $platform->invoke('gpt-4o', $messages, [
+    'tools' => [['type' => 'web_search']],
+]);
+
+echo $result->asText().\PHP_EOL;

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Add `PartialJsonParser` for recovering partial JSON from streaming output
+ * Support OpenAI Responses built-in/server-side tool calls (e.g. `web_search`, `file_search`, `mcp_call`) in the OpenAI and OpenResponses result converters by skipping their `*_call` output items instead of throwing `Unsupported output type`
 
 0.10
 ----

--- a/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Gpt/ResultConverter.php
@@ -152,6 +152,13 @@ final class ResultConverter implements ResultConverterInterface
         return match ($type) {
             'message' => $this->convertOutputMessage($item),
             'reasoning' => $this->convertReasoning($item),
+            // Built-in server-side tool calls (web_search, file_search, code_interpreter,
+            // image generation, computer use, local shell, MCP, …) appear as their own
+            // output items but carry no assistant-facing result. Skip them so the actual
+            // message item is still converted instead of aborting the whole response.
+            'web_search_call', 'file_search_call', 'code_interpreter_call',
+            'image_generation_call', 'computer_call', 'local_shell_call',
+            'mcp_call', 'mcp_list_tools', 'mcp_approval_request' => [],
             default => throw new RuntimeException(\sprintf('Unsupported output type "%s".', $type)),
         };
     }

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -224,6 +224,100 @@ class ResultConverterTest extends TestCase
         $this->assertSame('final', $result->getContent());
     }
 
+    public function testConvertSkipsWebSearchToolCallAndReturnsMessage()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                // When a built-in tool such as web_search runs, the Responses API
+                // emits its own tool-call item before the assistant message.
+                ['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed'],
+                [
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'Berlin is the capital of Germany.',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Berlin is the capital of Germany.', $result->getContent());
+    }
+
+    /**
+     * @param non-empty-string $type
+     */
+    #[DataProvider('provideBuiltInToolCallTypes')]
+    public function testConvertSkipsBuiltInToolCallOutputItems(string $type)
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                ['type' => $type, 'id' => 'call_1', 'status' => 'completed'],
+                [
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'final answer',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('final answer', $result->getContent());
+    }
+
+    /**
+     * @return iterable<string, array{0: non-empty-string}>
+     */
+    public static function provideBuiltInToolCallTypes(): iterable
+    {
+        yield 'web_search_call' => ['web_search_call'];
+        yield 'file_search_call' => ['file_search_call'];
+        yield 'code_interpreter_call' => ['code_interpreter_call'];
+        yield 'image_generation_call' => ['image_generation_call'];
+        yield 'computer_call' => ['computer_call'];
+        yield 'local_shell_call' => ['local_shell_call'];
+        yield 'mcp_call' => ['mcp_call'];
+        yield 'mcp_list_tools' => ['mcp_list_tools'];
+        yield 'mcp_approval_request' => ['mcp_approval_request'];
+    }
+
+    public function testConvertStillThrowsOnUnknownOutputType()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                ['type' => 'totally_unknown_type', 'id' => 'x_1'],
+                [
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'unreachable',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported output type "totally_unknown_type".');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
     public function testContentFilterException()
     {
         $converter = new ResultConverter();

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -161,6 +161,13 @@ final class ResultConverter implements ResultConverterInterface
         return match ($type) {
             'message' => $this->convertOutputMessage($item),
             'reasoning' => $this->convertReasoning($item),
+            // Built-in server-side tool calls (web_search, file_search, code_interpreter,
+            // image generation, computer use, local shell, MCP, …) appear as their own
+            // output items but carry no assistant-facing result. Skip them so the actual
+            // message item is still converted instead of aborting the whole response.
+            'web_search_call', 'file_search_call', 'code_interpreter_call',
+            'image_generation_call', 'computer_call', 'local_shell_call',
+            'mcp_call', 'mcp_list_tools', 'mcp_approval_request' => [],
             default => throw new RuntimeException(\sprintf('Unsupported output type "%s".', $type)),
         };
     }

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -294,6 +294,100 @@ final class ResultConverterTest extends TestCase
         $converter->convert(new RawHttpResult($httpResponse));
     }
 
+    public function testConvertSkipsWebSearchToolCallAndReturnsMessage()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                // When a built-in tool such as web_search runs, the Responses API
+                // emits its own tool-call item before the assistant message.
+                ['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed'],
+                [
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'Berlin is the capital of Germany.',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Berlin is the capital of Germany.', $result->getContent());
+    }
+
+    /**
+     * @param non-empty-string $type
+     */
+    #[DataProvider('provideBuiltInToolCallTypes')]
+    public function testConvertSkipsBuiltInToolCallOutputItems(string $type)
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                ['type' => $type, 'id' => 'call_1', 'status' => 'completed'],
+                [
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'final answer',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('final answer', $result->getContent());
+    }
+
+    /**
+     * @return iterable<string, array{0: non-empty-string}>
+     */
+    public static function provideBuiltInToolCallTypes(): iterable
+    {
+        yield 'web_search_call' => ['web_search_call'];
+        yield 'file_search_call' => ['file_search_call'];
+        yield 'code_interpreter_call' => ['code_interpreter_call'];
+        yield 'image_generation_call' => ['image_generation_call'];
+        yield 'computer_call' => ['computer_call'];
+        yield 'local_shell_call' => ['local_shell_call'];
+        yield 'mcp_call' => ['mcp_call'];
+        yield 'mcp_list_tools' => ['mcp_list_tools'];
+        yield 'mcp_approval_request' => ['mcp_approval_request'];
+    }
+
+    public function testConvertStillThrowsOnUnknownOutputType()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                ['type' => 'totally_unknown_type', 'id' => 'x_1'],
+                [
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'unreachable',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported output type "totally_unknown_type".');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
     public function testContentFilterException()
     {
         $converter = new ResultConverter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | --
| License       | MIT

When a built-in server-side tool (web_search, file_search, MCP, …) runs, the OpenAI Responses API returns its own `*_call` item in the `output[]` array alongside the assistant message. The OpenAI and OpenResponses result converters only handled `message`, `reasoning` and `function_call` and threw `Unsupported output type` on everything else, aborting the whole response before the message that carries the answer was read.

Skip the known server-side tool-call markers so the actual message item is still converted, keeping the `default` throw for genuinely unknown types. Adds regression tests for both converters and runnable web-search examples for the OpenAI and OpenResponses bridges.