### PR TITLE
[Platform][Store] Streamline base URL handling across bridges

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -51,6 +51,31 @@ Platform
    `$model->supports(Capability::INPUT_MULTIPLE)` for an embedding model will now receive `false`; pass
    the full array of texts to `Platform::invoke()` directly instead — the bridge handles batching.
 
+ * Base URLs are now normalized across all bridges: a trailing slash on a configured base URL is
+   tolerated and no longer produces a double slash in request URLs.
+
+ * The Azure bridge now accepts a full base URL *with* scheme and no longer rejects it. A bare host
+   keeps working (the `https` scheme is assumed when none is given), so existing configurations are
+   unaffected, but you can now point it at an `http://` gateway:
+
+   ```diff
+   -// previously a scheme was rejected
+   -Factory::createPlatform('my-resource.openai.azure.com', ...);
+   +Factory::createPlatform('https://my-resource.openai.azure.com', ...); // also still: 'my-resource.openai.azure.com'
+   ```
+
+ * The `$hostUrl` argument of the Decart and Docker Model Runner factories and clients has been
+   renamed to `$baseUrl` for consistency with the other bridges. Positional usage is unaffected;
+   update named arguments:
+
+   ```diff
+   -Symfony\AI\Platform\Bridge\Decart\Factory::createPlatform($apiKey, hostUrl: 'https://api.decart.ai/v1');
+   +Symfony\AI\Platform\Bridge\Decart\Factory::createPlatform($apiKey, baseUrl: 'https://api.decart.ai/v1');
+   ```
+
+ * The Albert factory no longer throws when the base URL ends with a trailing slash; the slash is
+   stripped instead.
+
 Store
 -----
 
@@ -59,6 +84,24 @@ Store
  * The `apiKey` parameter for Typesense `Store` has been removed
  * A `StoreFactory` has been introduced for Typesense `Store`
  * The `accountId`, `apiKey`, and `endpointUrl` parameter for Cloudflare `Store` has been removed, use `StoreFactory` instead
+
+ * Endpoint URLs are now normalized across all HTTP store bridges: a trailing slash is tolerated, and
+   path-prefixed endpoints behind a reverse proxy keep their prefix.
+
+ * The endpoint constructor argument has been renamed to `$endpoint` for consistency across bridges.
+   Positional usage is unaffected; update named arguments:
+
+   ```diff
+   -new Symfony\AI\Store\Bridge\Supabase\Store($httpClient, url: $url, ...);
+   +new Symfony\AI\Store\Bridge\Supabase\Store($httpClient, endpoint: $url, ...);
+   ```
+
+   | Bridge          | Old argument   | New argument |
+   | --------------- | -------------- | ------------ |
+   | ManticoreSearch | `$host`        | `$endpoint`  |
+   | Milvus          | `$endpointUrl` | `$endpoint`  |
+   | Supabase        | `$url`         | `$endpoint`  |
+   | SurrealDb       | `$endpointUrl` | `$endpoint`  |
 
 UPGRADE FROM 0.9 to 0.10
 ========================

--- a/examples/rag/manticore.php
+++ b/examples/rag/manticore.php
@@ -31,7 +31,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 // initialize the store
 $store = new Store(
     httpClient: http_client(),
-    host: 'http://127.0.0.1:9308',
+    endpoint: 'http://127.0.0.1:9308',
     table: 'movies',
     field: '_movie_vectors',
 );

--- a/examples/rag/milvus.php
+++ b/examples/rag/milvus.php
@@ -31,7 +31,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 // initialize the store
 $store = new Store(
     httpClient: http_client(),
-    endpointUrl: env('MILVUS_HOST'),
+    endpoint: env('MILVUS_HOST'),
     apiKey: env('MILVUS_API_KEY'),
     database: env('MILVUS_DATABASE'),
     collection: 'movies',

--- a/examples/rag/supabase.php
+++ b/examples/rag/supabase.php
@@ -30,7 +30,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $store = new Store(
     httpClient: http_client(),
-    url: env('SUPABASE_URL'),
+    endpoint: env('SUPABASE_URL'),
     apiKey: env('SUPABASE_API_KEY'),
     table: env('SUPABASE_TABLE'),
     vectorFieldName: env('SUPABASE_VECTOR_FIELD'),

--- a/examples/rag/surrealdb.php
+++ b/examples/rag/surrealdb.php
@@ -31,7 +31,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 // initialize the store
 $store = new Store(
     httpClient: http_client(),
-    endpointUrl: env('SURREALDB_HOST'),
+    endpoint: env('SURREALDB_HOST'),
     user: env('SURREALDB_USER'),
     password: env('SURREALDB_PASS'),
     namespace: 'default',

--- a/src/platform/src/Bridge/Albert/CHANGELOG.md
+++ b/src/platform/src/Bridge/Albert/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Tolerate a trailing slash on the base URL instead of rejecting it
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Albert/Factory.php
+++ b/src/platform/src/Bridge/Albert/Factory.php
@@ -38,11 +38,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'albert',
     ): ProviderInterface {
+        $baseUrl = rtrim($baseUrl, '/');
+
         if (!str_starts_with($baseUrl, 'https://')) {
             throw new InvalidArgumentException('The Albert URL must start with "https://".');
-        }
-        if (str_ends_with($baseUrl, '/')) {
-            throw new InvalidArgumentException('The Albert URL must not end with a trailing slash.');
         }
         if (!preg_match('/\/v\d+$/', $baseUrl)) {
             throw new InvalidArgumentException('The Albert URL must include an API version (e.g., /v1, /v2).');

--- a/src/platform/src/Bridge/Albert/Tests/FactoryTest.php
+++ b/src/platform/src/Bridge/Albert/Tests/FactoryTest.php
@@ -60,19 +60,18 @@ final class FactoryTest extends TestCase
     }
 
     #[DataProvider('provideUrlsWithTrailingSlash')]
-    public function testThrowsExceptionForUrlsWithTrailingSlash(string $url)
+    public function testToleratesTrailingSlashes(string $url)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The Albert URL must not end with a trailing slash.');
+        $platform = Factory::createPlatform('test-key', $url);
 
-        Factory::createPlatform('test-key', $url);
+        $this->assertInstanceOf(Platform::class, $platform);
     }
 
     public static function provideUrlsWithTrailingSlash(): \Iterator
     {
-        yield 'with trailing slash only' => ['https://albert.example.com/'];
         yield 'with v1 and trailing slash' => ['https://albert.example.com/v1/'];
         yield 'with v2 and trailing slash' => ['https://albert.example.com/v2/'];
+        yield 'with multiple trailing slashes' => ['https://albert.example.com/v1///'];
     }
 
     #[DataProvider('provideUrlsWithoutVersion')]
@@ -87,6 +86,7 @@ final class FactoryTest extends TestCase
     public static function provideUrlsWithoutVersion(): \Iterator
     {
         yield 'without version' => ['https://albert.example.com'];
+        yield 'with trailing slash only' => ['https://albert.example.com/'];
         yield 'with vx path' => ['https://albert.example.com/vx'];
         yield 'with version path' => ['https://albert.example.com/version'];
         yield 'with api path' => ['https://albert.example.com/api'];

--- a/src/platform/src/Bridge/Azure/BaseUrlNormalizerTrait.php
+++ b/src/platform/src/Bridge/Azure/BaseUrlNormalizerTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Azure;
+
+/**
+ * Normalizes the base URL of an Azure resource.
+ *
+ * Accepts a full base URL with scheme (e.g. "https://my-resource.openai.azure.com") as well as a
+ * bare host (e.g. "my-resource.openai.azure.com"), in which case the "https" scheme is assumed. A
+ * trailing slash is tolerated and stripped in both cases.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+trait BaseUrlNormalizerTrait
+{
+    private function normalizeBaseUrl(string $baseUrl): string
+    {
+        $baseUrl = rtrim($baseUrl, '/');
+
+        if (str_starts_with($baseUrl, 'http://') || str_starts_with($baseUrl, 'https://')) {
+            return $baseUrl;
+        }
+
+        return 'https://'.$baseUrl;
+    }
+}

--- a/src/platform/src/Bridge/Azure/CHANGELOG.md
+++ b/src/platform/src/Bridge/Azure/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Accept a full base URL with scheme (a bare host still defaults to `https`) and tolerate a trailing slash, instead of rejecting any base URL that contains a protocol
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/Azure/Meta/LlamaModelClient.php
+++ b/src/platform/src/Bridge/Azure/Meta/LlamaModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\Meta;
 
+use Symfony\AI\Platform\Bridge\Azure\BaseUrlNormalizerTrait;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\JsonBodyEncodingTrait;
@@ -24,13 +25,21 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class LlamaModelClient implements ModelClientInterface
 {
+    use BaseUrlNormalizerTrait;
     use JsonBodyEncodingTrait;
 
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of the Azure resource; accepts a bare host (https assumed) or a
+     *                        full URL with scheme, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        private readonly string $baseUrl,
+        string $baseUrl,
         #[\SensitiveParameter] private readonly string $apiKey,
     ) {
+        $this->baseUrl = $this->normalizeBaseUrl($baseUrl);
     }
 
     public function supports(Model $model): bool
@@ -44,7 +53,7 @@ final class LlamaModelClient implements ModelClientInterface
             throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
         }
 
-        $url = \sprintf('https://%s/chat/completions', $this->baseUrl);
+        $url = $this->baseUrl.'/chat/completions';
 
         return new RawHttpResult($this->httpClient->request('POST', $url, [
             'headers' => [

--- a/src/platform/src/Bridge/Azure/OpenAi/EmbeddingsModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/EmbeddingsModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\OpenAi;
 
+use Symfony\AI\Platform\Bridge\Azure\BaseUrlNormalizerTrait;
 use Symfony\AI\Platform\Bridge\Generic\EmbeddingsModel;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
@@ -24,22 +25,24 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class EmbeddingsModelClient implements ModelClientInterface
 {
-    private readonly EventSourceHttpClient $httpClient;
+    use BaseUrlNormalizerTrait;
 
+    private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of the Azure resource; accepts a bare host (https assumed) or a
+     *                        full URL with scheme, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
-        private readonly string $baseUrl,
+        string $baseUrl,
         private readonly string $deployment,
         private readonly string $apiVersion,
         #[\SensitiveParameter] private readonly string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
-        if (str_starts_with($this->baseUrl, 'http://')) {
-            throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        }
-        if (str_starts_with($this->baseUrl, 'https://')) {
-            throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        }
+        $this->baseUrl = $this->normalizeBaseUrl($baseUrl);
         if ('' === $deployment) {
             throw new InvalidArgumentException('The deployment must not be empty.');
         }
@@ -58,7 +61,7 @@ final class EmbeddingsModelClient implements ModelClientInterface
 
     public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
     {
-        $url = \sprintf('https://%s/openai/deployments/%s/embeddings', $this->baseUrl, $this->deployment);
+        $url = \sprintf('%s/openai/deployments/%s/embeddings', $this->baseUrl, $this->deployment);
 
         return new RawHttpResult($this->httpClient->request('POST', $url, [
             'headers' => [

--- a/src/platform/src/Bridge/Azure/OpenAi/WhisperModelClient.php
+++ b/src/platform/src/Bridge/Azure/OpenAi/WhisperModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\OpenAi;
 
+use Symfony\AI\Platform\Bridge\Azure\BaseUrlNormalizerTrait;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper;
 use Symfony\AI\Platform\Bridge\OpenAi\Whisper\Task;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
@@ -25,22 +26,24 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class WhisperModelClient implements ModelClientInterface
 {
-    private readonly EventSourceHttpClient $httpClient;
+    use BaseUrlNormalizerTrait;
 
+    private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of the Azure resource; accepts a bare host (https assumed) or a
+     *                        full URL with scheme, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
-        private readonly string $baseUrl,
+        string $baseUrl,
         private readonly string $deployment,
         private readonly string $apiVersion,
         #[\SensitiveParameter] private readonly string $apiKey,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
-        if (str_starts_with($this->baseUrl, 'http://')) {
-            throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        }
-        if (str_starts_with($this->baseUrl, 'https://')) {
-            throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        }
+        $this->baseUrl = $this->normalizeBaseUrl($baseUrl);
         if ('' === $deployment) {
             throw new InvalidArgumentException('The deployment must not be empty.');
         }
@@ -65,7 +68,7 @@ final class WhisperModelClient implements ModelClientInterface
 
         $task = $options['task'] ?? Task::TRANSCRIPTION;
         $endpoint = Task::TRANSCRIPTION === $task ? 'transcriptions' : 'translations';
-        $url = \sprintf('https://%s/openai/deployments/%s/audio/%s', $this->baseUrl, $this->deployment, $endpoint);
+        $url = \sprintf('%s/openai/deployments/%s/audio/%s', $this->baseUrl, $this->deployment, $endpoint);
 
         unset($options['task']);
 

--- a/src/platform/src/Bridge/Azure/Responses/ModelClient.php
+++ b/src/platform/src/Bridge/Azure/Responses/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\Responses;
 
+use Symfony\AI\Platform\Bridge\Azure\BaseUrlNormalizerTrait;
 use Symfony\AI\Platform\Bridge\OpenResponses\ResponsesModel;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\JsonBodyEncodingTrait;
@@ -26,11 +27,16 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use BaseUrlNormalizerTrait;
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
     private readonly string $endpoint;
 
+    /**
+     * @param string $baseUrl Base URL of the Azure resource; accepts a bare host (https assumed) or a
+     *                        full URL with scheme, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
         string $baseUrl,
@@ -40,15 +46,12 @@ final class ModelClient implements ModelClientInterface
         if ('' === $baseUrl) {
             throw new InvalidArgumentException('The base URL must not be empty.');
         }
-        if (str_starts_with($baseUrl, 'http://') || str_starts_with($baseUrl, 'https://')) {
-            throw new InvalidArgumentException('The base URL must not contain the protocol.');
-        }
         if ('' === $apiKey) {
             throw new InvalidArgumentException('The API key must not be empty.');
         }
 
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
-        $this->endpoint = \sprintf('https://%s/openai/v1/responses', rtrim($baseUrl, '/'));
+        $this->endpoint = $this->normalizeBaseUrl($baseUrl).'/openai/v1/responses';
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/Azure/Tests/OpenAi/EmbeddingsModelClientTest.php
+++ b/src/platform/src/Bridge/Azure/Tests/OpenAi/EmbeddingsModelClientTest.php
@@ -24,16 +24,20 @@ use Symfony\Component\HttpClient\Response\MockResponse;
  */
 final class EmbeddingsModelClientTest extends TestCase
 {
-    #[TestWith(['http://test.azure.com', 'The base URL must not contain the protocol.'])]
-    #[TestWith(['https://test.azure.com', 'The base URL must not contain the protocol.'])]
-    #[TestWith(['http://test.azure.com/path', 'The base URL must not contain the protocol.'])]
-    #[TestWith(['https://test.azure.com:443', 'The base URL must not contain the protocol.'])]
-    public function testItThrowsExceptionWhenBaseUrlContainsProtocol(string $invalidUrl, string $expectedMessage)
+    #[TestWith(['test.azure.com', 'https://test.azure.com/openai/deployments/embeddings-deployment/embeddings?api-version=2023-12-01'])]
+    #[TestWith(['https://test.azure.com', 'https://test.azure.com/openai/deployments/embeddings-deployment/embeddings?api-version=2023-12-01'])]
+    #[TestWith(['https://test.azure.com/', 'https://test.azure.com/openai/deployments/embeddings-deployment/embeddings?api-version=2023-12-01'])]
+    #[TestWith(['http://localhost:8080', 'http://localhost:8080/openai/deployments/embeddings-deployment/embeddings?api-version=2023-12-01'])]
+    public function testItNormalizesTheBaseUrl(string $baseUrl, string $expectedUrl)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedMessage);
+        $resultCallback = function (string $method, string $url) use ($expectedUrl): MockResponse {
+            $this->assertSame($expectedUrl, $url);
 
-        new EmbeddingsModelClient(new MockHttpClient(), $invalidUrl, 'deployment', 'api-version', 'api-key');
+            return new MockResponse();
+        };
+
+        $client = new EmbeddingsModelClient(new MockHttpClient([$resultCallback]), $baseUrl, 'embeddings-deployment', '2023-12-01', 'test-api-key');
+        $client->request(new EmbeddingsModel('text-embedding-3-small'), 'Hello, world!');
     }
 
     public function testItThrowsExceptionWhenDeploymentIsEmpty()

--- a/src/platform/src/Bridge/Azure/Tests/OpenAi/WhisperModelClientTest.php
+++ b/src/platform/src/Bridge/Azure/Tests/OpenAi/WhisperModelClientTest.php
@@ -22,16 +22,20 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 final class WhisperModelClientTest extends TestCase
 {
-    #[TestWith(['http://test.azure.com', 'The base URL must not contain the protocol.'])]
-    #[TestWith(['https://test.azure.com', 'The base URL must not contain the protocol.'])]
-    #[TestWith(['http://test.azure.com:8080', 'The base URL must not contain the protocol.'])]
-    #[TestWith(['https://test.azure.com:443', 'The base URL must not contain the protocol.'])]
-    public function testItThrowsExceptionWhenBaseUrlContainsProtocol(string $invalidUrl, string $expectedMessage)
+    #[TestWith(['test.azure.com', 'https://test.azure.com/openai/deployments/whspr/audio/transcriptions?api-version=2023-12'])]
+    #[TestWith(['https://test.azure.com', 'https://test.azure.com/openai/deployments/whspr/audio/transcriptions?api-version=2023-12'])]
+    #[TestWith(['https://test.azure.com/', 'https://test.azure.com/openai/deployments/whspr/audio/transcriptions?api-version=2023-12'])]
+    #[TestWith(['http://localhost:8080', 'http://localhost:8080/openai/deployments/whspr/audio/transcriptions?api-version=2023-12'])]
+    public function testItNormalizesTheBaseUrl(string $baseUrl, string $expectedUrl)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedMessage);
+        $httpClient = new MockHttpClient([function (string $method, string $url) use ($expectedUrl): MockResponse {
+            $this->assertSame($expectedUrl, $url);
 
-        new WhisperModelClient(new MockHttpClient(), $invalidUrl, 'deployment', 'api-version', 'api-key');
+            return new MockResponse('{"text": "Hello World"}');
+        }]);
+
+        $client = new WhisperModelClient($httpClient, $baseUrl, 'whspr', '2023-12', 'test-key');
+        $client->request(new Whisper('whisper-1'), ['file' => 'audio-data']);
     }
 
     public function testItThrowsExceptionWhenDeploymentIsEmpty()

--- a/src/platform/src/Bridge/Azure/Tests/Responses/ModelClientTest.php
+++ b/src/platform/src/Bridge/Azure/Tests/Responses/ModelClientTest.php
@@ -29,16 +29,20 @@ final class ModelClientTest extends TestCase
         new ModelClient(new MockHttpClient(), '', 'api-key');
     }
 
-    #[TestWith(['http://test.openai.azure.com', 'The base URL must not contain the protocol.'])]
-    #[TestWith(['https://test.openai.azure.com', 'The base URL must not contain the protocol.'])]
-    #[TestWith(['http://test.openai.azure.com/openai', 'The base URL must not contain the protocol.'])]
-    #[TestWith(['https://test.openai.azure.com:443', 'The base URL must not contain the protocol.'])]
-    public function testItThrowsExceptionWhenBaseUrlContainsProtocol(string $invalidUrl, string $expectedMessage)
+    #[TestWith(['test.openai.azure.com', 'https://test.openai.azure.com/openai/v1/responses'])]
+    #[TestWith(['https://test.openai.azure.com', 'https://test.openai.azure.com/openai/v1/responses'])]
+    #[TestWith(['https://test.openai.azure.com/', 'https://test.openai.azure.com/openai/v1/responses'])]
+    #[TestWith(['http://localhost:8080', 'http://localhost:8080/openai/v1/responses'])]
+    public function testItNormalizesTheBaseUrl(string $baseUrl, string $expectedUrl)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedMessage);
+        $httpClient = new MockHttpClient([function (string $method, string $url) use ($expectedUrl): MockResponse {
+            $this->assertSame($expectedUrl, $url);
 
-        new ModelClient(new MockHttpClient(), $invalidUrl, 'api-key');
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, $baseUrl, 'test-api-key', 'gpt-4o');
+        $client->request(new ResponsesModel('gpt-4o'), ['input' => [['role' => 'user', 'content' => 'Hello']]]);
     }
 
     public function testItThrowsExceptionWhenApiKeyIsEmpty()

--- a/src/platform/src/Bridge/Cartesia/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cartesia/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Add a `baseUrl` argument to the model clients and the factory to target Cartesia-compatible endpoints
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Cartesia/CartesiaClient.php
+++ b/src/platform/src/Bridge/Cartesia/CartesiaClient.php
@@ -24,11 +24,18 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class CartesiaClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Cartesia-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
         private readonly string $version,
+        string $baseUrl = 'https://api.cartesia.ai',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -53,7 +60,7 @@ final class CartesiaClient implements ModelClientInterface
     {
         $text = \is_string($payload) ? $payload : ($payload['text'] ?? throw new RuntimeException('The payload must contain a "text" key.'));
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.cartesia.ai/tts/bytes', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/tts/bytes', [
             'auth_bearer' => $this->apiKey,
             'headers' => [
                 'Cartesia-Version' => $this->version,
@@ -77,7 +84,7 @@ final class CartesiaClient implements ModelClientInterface
      */
     private function doSpeechToText(Model $model, array|string $payload, array $options): RawHttpResult
     {
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.cartesia.ai/stt', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/stt', [
             'auth_bearer' => $this->apiKey,
             'headers' => [
                 'Cartesia-Version' => $this->version,

--- a/src/platform/src/Bridge/Cartesia/Factory.php
+++ b/src/platform/src/Bridge/Cartesia/Factory.php
@@ -39,12 +39,13 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'cartesia',
+        string $baseUrl = 'https://api.cartesia.ai',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Provider(
             $name,
-            [new CartesiaClient($httpClient, $apiKey, $version)],
+            [new CartesiaClient($httpClient, $apiKey, $version, $baseUrl)],
             [new CartesiaResultConverter()],
             $modelCatalog,
             $contract ?? CartesiaContract::create(),
@@ -64,9 +65,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'cartesia',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://api.cartesia.ai',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $version, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $version, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Cartesia/Tests/CartesiaClientTest.php
+++ b/src/platform/src/Bridge/Cartesia/Tests/CartesiaClientTest.php
@@ -143,6 +143,35 @@ final class CartesiaClientTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $audioFixture = Audio::fromFile(\dirname(__DIR__, 6).'/fixtures/audio.mp3');
+
+        $httpClient = new MockHttpClient(function (string $method, string $url) use ($audioFixture): MockResponse {
+            $this->assertSame('https://x.example.com/tts/bytes', $url);
+
+            return new MockResponse($audioFixture->asBinary());
+        });
+
+        $client = new CartesiaClient(
+            $httpClient,
+            'my-api-key',
+            'foo',
+            'https://x.example.com/',
+        );
+
+        $client->request(new Cartesia('sonic-3', [Capability::TEXT_TO_SPEECH]), 'bar', [
+            'voice' => '6ccbfb76-1fc6-48f7-b71d-91ac6298247b',
+            'output_format' => [
+                'container' => 'mp3',
+                'sample_rate' => 48000,
+                'bit_rate' => 192000,
+            ],
+        ]);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testClientCannotPerformSpeechToTextOnInvalidResponse()
     {
         $payload = Audio::fromFile(\dirname(__DIR__, 6).'/fixtures/audio.mp3');

--- a/src/platform/src/Bridge/Cerebras/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cerebras/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Add a `baseUrl` argument to the model client and the factory to target Cerebras-compatible endpoints
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Cerebras/Factory.php
+++ b/src/platform/src/Bridge/Cerebras/Factory.php
@@ -38,12 +38,13 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'cerebras',
+        string $baseUrl = 'https://api.cerebras.ai',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Provider(
             $name,
-            [new ModelClient($httpClient, $apiKey)],
+            [new ModelClient($httpClient, $apiKey, $baseUrl)],
             [new ResultConverter()],
             $modelCatalog,
             $contract ?? Contract::create([
@@ -64,9 +65,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'cerebras',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://api.cerebras.ai',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Cerebras/ModelClient.php
+++ b/src/platform/src/Bridge/Cerebras/ModelClient.php
@@ -27,10 +27,15 @@ final class ModelClient implements ModelClientInterface
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of a Cerebras-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.cerebras.ai',
     ) {
         if ('' === $apiKey) {
             throw new InvalidArgumentException('The API key must not be empty.');
@@ -41,6 +46,7 @@ final class ModelClient implements ModelClientInterface
         }
 
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(BaseModel $model): bool
@@ -56,7 +62,7 @@ final class ModelClient implements ModelClientInterface
 
         return new RawHttpResult(
             $this->httpClient->request(
-                'POST', 'https://api.cerebras.ai/v1/chat/completions',
+                'POST', $this->baseUrl.'/v1/chat/completions',
                 [
                     'headers' => [
                         'Content-Type' => 'application/json',

--- a/src/platform/src/Bridge/Cerebras/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Cerebras/Tests/ModelClientTest.php
@@ -87,6 +87,18 @@ class ModelClientTest extends TestCase
         $this->assertSame($expectedResponse, $data);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertSame('https://cerebras.example.com/v1/chat/completions', $url);
+
+            return new JsonMockResponse(['choices' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'csk-1234567890abcdef', 'https://cerebras.example.com/');
+        $client->request(new Model('llama-3.3-70b'), ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
+    }
+
     public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
     {
         $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {

--- a/src/platform/src/Bridge/Cohere/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cohere/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Add a `baseUrl` argument to the model clients and the factory to target Cohere-compatible endpoints
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Cohere/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Cohere/Embeddings/ModelClient.php
@@ -23,10 +23,17 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Cohere-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.cohere.com',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -48,7 +55,7 @@ final class ModelClient implements ModelClientInterface
             $body['embedding_types'] = $options['embedding_types'];
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.cohere.com/v2/embed', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v2/embed', [
             'auth_bearer' => $this->apiKey,
             'headers' => [
                 'Content-Type' => 'application/json',

--- a/src/platform/src/Bridge/Cohere/Factory.php
+++ b/src/platform/src/Bridge/Cohere/Factory.php
@@ -37,12 +37,13 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'cohere',
+        string $baseUrl = 'https://api.cohere.com',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Provider(
             $name,
-            [new Embeddings\ModelClient($httpClient, $apiKey), new Reranker\ModelClient($httpClient, $apiKey), new Llm\ModelClient($httpClient, $apiKey), new SpeechToText\ModelClient($httpClient, $apiKey)],
+            [new Embeddings\ModelClient($httpClient, $apiKey, $baseUrl), new Reranker\ModelClient($httpClient, $apiKey, $baseUrl), new Llm\ModelClient($httpClient, $apiKey, $baseUrl), new SpeechToText\ModelClient($httpClient, $apiKey, $baseUrl)],
             [new Embeddings\ResultConverter(), new Reranker\ResultConverter(), new Llm\ResultConverter(), new SpeechToText\ResultConverter()],
             $modelCatalog,
             $contract ?? Contract::create([new SpeechToText\AudioNormalizer()]),
@@ -61,9 +62,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'cohere',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://api.cohere.com',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Cohere/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ModelClient.php
@@ -27,10 +27,17 @@ final class ModelClient implements ModelClientInterface
 {
     use JsonBodyEncodingTrait;
 
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Cohere-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.cohere.com',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -44,7 +51,7 @@ final class ModelClient implements ModelClientInterface
             throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.cohere.com/v2/chat', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v2/chat', [
             'auth_bearer' => $this->apiKey,
             'headers' => [
                 'Content-Type' => 'application/json',

--- a/src/platform/src/Bridge/Cohere/Reranker/ModelClient.php
+++ b/src/platform/src/Bridge/Cohere/Reranker/ModelClient.php
@@ -23,10 +23,17 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Cohere-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.cohere.com',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -50,7 +57,7 @@ final class ModelClient implements ModelClientInterface
             $body['top_n'] = $options['top_n'];
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.cohere.com/v2/rerank', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v2/rerank', [
             'auth_bearer' => $this->apiKey,
             'headers' => [
                 'Content-Type' => 'application/json',

--- a/src/platform/src/Bridge/Cohere/SpeechToText/ModelClient.php
+++ b/src/platform/src/Bridge/Cohere/SpeechToText/ModelClient.php
@@ -23,10 +23,17 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Cohere-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.cohere.com',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -42,7 +49,7 @@ final class ModelClient implements ModelClientInterface
 
         $body = array_merge($options, $payload, ['model' => $model->getName()]);
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.cohere.com/v2/audio/transcriptions', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v2/audio/transcriptions', [
             'auth_bearer' => $this->apiKey,
             'headers' => ['Content-Type' => 'multipart/form-data'],
             'body' => $body,

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/ModelClientTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/ModelClientTest.php
@@ -54,6 +54,18 @@ final class ModelClientTest extends TestCase
         $client->request(new Cohere('command-a-03-2025'), ['model' => 'command-a-03-2025', 'messages' => []]);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $httpClient = new MockHttpClient([function (string $method, string $url): MockResponse {
+            $this->assertSame('https://x.example.com/v2/chat', $url);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key', 'https://x.example.com/');
+        $client->request(new Cohere('command-a-03-2025'), ['model' => 'command-a-03-2025', 'messages' => []]);
+    }
+
     public function testStringPayloadThrowsException()
     {
         $client = new ModelClient(new MockHttpClient(), 'test-key');

--- a/src/platform/src/Bridge/Decart/CHANGELOG.md
+++ b/src/platform/src/Bridge/Decart/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Normalize the base URL and tolerate a trailing slash
+ * [BC BREAK] Rename the `$hostUrl` constructor and factory argument to `$baseUrl`
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Decart/DecartClient.php
+++ b/src/platform/src/Bridge/Decart/DecartClient.php
@@ -24,11 +24,17 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class DecartClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Decart-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
-        private readonly string $hostUrl = 'https://api.decart.ai/v1',
+        string $baseUrl = 'https://api.decart.ai/v1',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -54,7 +60,7 @@ final class DecartClient implements ModelClientInterface
      */
     private function generate(Model $model, array|string $payload, array $options = []): RawResultInterface
     {
-        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/generate/%s', $this->hostUrl, $model->getName()), [
+        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/generate/%s', $this->baseUrl, $model->getName()), [
             'headers' => [
                 'x-api-key' => $this->apiKey,
             ],
@@ -71,7 +77,7 @@ final class DecartClient implements ModelClientInterface
      */
     private function edit(Model $model, array|string $payload, array $options): RawResultInterface
     {
-        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/generate/%s', $this->hostUrl, $model->getName()), [
+        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/generate/%s', $this->baseUrl, $model->getName()), [
             'headers' => [
                 'x-api-key' => $this->apiKey,
             ],

--- a/src/platform/src/Bridge/Decart/Factory.php
+++ b/src/platform/src/Bridge/Decart/Factory.php
@@ -33,7 +33,7 @@ final class Factory
      */
     public static function createProvider(
         #[\SensitiveParameter] string $apiKey,
-        ?string $hostUrl = 'https://api.decart.ai/v1',
+        ?string $baseUrl = 'https://api.decart.ai/v1',
         ?HttpClientInterface $httpClient = null,
         ModelCatalogInterface $modelCatalog = new ModelCatalog(),
         ?Contract $contract = null,
@@ -44,7 +44,7 @@ final class Factory
 
         return new Provider(
             $name,
-            [new DecartClient($httpClient, $apiKey, $hostUrl)],
+            [new DecartClient($httpClient, $apiKey, $baseUrl)],
             [new DecartResultConverter()],
             $modelCatalog,
             $contract ?? DecartContract::create(),
@@ -57,7 +57,7 @@ final class Factory
      */
     public static function createPlatform(
         #[\SensitiveParameter] string $apiKey,
-        ?string $hostUrl = 'https://api.decart.ai/v1',
+        ?string $baseUrl = 'https://api.decart.ai/v1',
         ?HttpClientInterface $httpClient = null,
         ModelCatalogInterface $modelCatalog = new ModelCatalog(),
         ?Contract $contract = null,
@@ -66,7 +66,7 @@ final class Factory
         ?ModelRouterInterface $modelRouter = null,
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $hostUrl, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $baseUrl, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
+++ b/src/platform/src/Bridge/DeepSeek/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Add a `baseUrl` argument to the model client and the factory to target DeepSeek-compatible endpoints
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/DeepSeek/Factory.php
+++ b/src/platform/src/Bridge/DeepSeek/Factory.php
@@ -34,12 +34,13 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'deepseek',
+        string $baseUrl = 'https://api.deepseek.com',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Provider(
             $name,
-            [new ModelClient($httpClient, $apiKey)],
+            [new ModelClient($httpClient, $apiKey, $baseUrl)],
             [new ResultConverter()],
             $modelCatalog,
             $contract ?? Contract::create(),
@@ -58,9 +59,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'deepseek',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://api.deepseek.com',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/DeepSeek/ModelClient.php
+++ b/src/platform/src/Bridge/DeepSeek/ModelClient.php
@@ -27,12 +27,18 @@ final class ModelClient implements ModelClientInterface
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of a DeepSeek-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.deepseek.com',
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -46,7 +52,7 @@ final class ModelClient implements ModelClientInterface
             throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.deepseek.com/chat/completions', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/chat/completions', [
             'auth_bearer' => $this->apiKey,
             'headers' => ['Content-Type' => 'application/json'],
             'body' => $this->encodeJsonBody(array_merge($options, $payload)),

--- a/src/platform/src/Bridge/DeepSeek/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/DeepSeek/Tests/ModelClientTest.php
@@ -62,6 +62,21 @@ final class ModelClientTest extends TestCase
         $this->assertTrue($requestMade);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $requestMade = false;
+        $httpClient = new MockHttpClient(static function ($method, $url) use (&$requestMade) {
+            $requestMade = true;
+            self::assertSame('https://deepseek.example.com/chat/completions', $url);
+
+            return new JsonMockResponse(['choices' => [['message' => ['content' => 'Hello'], 'finish_reason' => 'stop']]]);
+        });
+
+        $modelClient = new ModelClient($httpClient, 'test-api-key', 'https://deepseek.example.com/');
+        $modelClient->request(new DeepSeek('deepseek-chat'), ['messages' => [['role' => 'user', 'content' => 'Hi']]]);
+        $this->assertTrue($requestMade);
+    }
+
     public function testRequestMergesOptionsWithPayload()
     {
         $requestMade = false;

--- a/src/platform/src/Bridge/DockerModelRunner/CHANGELOG.md
+++ b/src/platform/src/Bridge/DockerModelRunner/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ----
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Normalize the base URL and tolerate a trailing slash
+ * [BC BREAK] Rename the `$hostUrl` constructor and factory argument to `$baseUrl`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/DockerModelRunner/Completions/ModelClient.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Completions/ModelClient.php
@@ -28,12 +28,17 @@ final class ModelClient implements ModelClientInterface
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of the Docker Model Runner instance, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
-        private readonly string $hostUrl,
+        string $baseUrl,
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -47,7 +52,7 @@ final class ModelClient implements ModelClientInterface
             throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/engines/v1/chat/completions', $this->hostUrl), [
+        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/engines/v1/chat/completions', $this->baseUrl), [
             'headers' => ['Content-Type' => 'application/json'],
             'body' => $this->encodeJsonBody(array_merge($options, $payload)),
         ]));

--- a/src/platform/src/Bridge/DockerModelRunner/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Embeddings/ModelClient.php
@@ -22,10 +22,16 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of the Docker Model Runner instance, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        private readonly string $hostUrl,
+        string $baseUrl,
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -35,7 +41,7 @@ final class ModelClient implements ModelClientInterface
 
     public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
     {
-        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/engines/v1/embeddings', $this->hostUrl), [
+        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/engines/v1/embeddings', $this->baseUrl), [
             'json' => array_merge($options, [
                 'model' => $model->getName(),
                 'input' => $payload,

--- a/src/platform/src/Bridge/DockerModelRunner/Factory.php
+++ b/src/platform/src/Bridge/DockerModelRunner/Factory.php
@@ -31,7 +31,7 @@ class Factory
      * @param non-empty-string $name
      */
     public static function createProvider(
-        string $hostUrl = 'http://localhost:12434',
+        string $baseUrl = 'http://localhost:12434',
         ?HttpClientInterface $httpClient = null,
         ModelCatalogInterface $modelCatalog = new ModelCatalog(),
         ?Contract $contract = null,
@@ -43,8 +43,8 @@ class Factory
         return new Provider(
             $name,
             [
-                new Completions\ModelClient($httpClient, $hostUrl),
-                new Embeddings\ModelClient($httpClient, $hostUrl),
+                new Completions\ModelClient($httpClient, $baseUrl),
+                new Embeddings\ModelClient($httpClient, $baseUrl),
             ],
             [
                 new Embeddings\ResultConverter(),
@@ -60,7 +60,7 @@ class Factory
      * @param non-empty-string $name
      */
     public static function createPlatform(
-        string $hostUrl = 'http://localhost:12434',
+        string $baseUrl = 'http://localhost:12434',
         ?HttpClientInterface $httpClient = null,
         ModelCatalogInterface $modelCatalog = new ModelCatalog(),
         ?Contract $contract = null,
@@ -69,7 +69,7 @@ class Factory
         ?ModelRouterInterface $modelRouter = null,
     ): Platform {
         return new Platform(
-            [self::createProvider($hostUrl, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($baseUrl, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/ElevenLabs/CHANGELOG.md
+++ b/src/platform/src/Bridge/ElevenLabs/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Tolerate an `endpoint` configured with or without a trailing slash
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/ElevenLabs/Factory.php
+++ b/src/platform/src/Bridge/ElevenLabs/Factory.php
@@ -41,6 +41,11 @@ final class Factory
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
+        // The endpoint carries a path prefix ("/v1"), against which the model clients resolve relative
+        // paths. A single trailing slash is required for that resolution, so normalize it here to
+        // tolerate an endpoint configured with or without it.
+        $endpoint = rtrim($endpoint, '/').'/';
+
         if (null !== $apiKey) {
             $httpClient = ScopingHttpClient::forBaseUri($httpClient, $endpoint, [
                 'headers' => [

--- a/src/platform/src/Bridge/ElevenLabs/Tests/FactoryTest.php
+++ b/src/platform/src/Bridge/ElevenLabs/Tests/FactoryTest.php
@@ -11,14 +11,31 @@
 
 namespace Symfony\AI\Platform\Bridge\ElevenLabs\Tests;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\ElevenLabs\Factory;
 use Symfony\AI\Platform\Bridge\ElevenLabs\ModelCatalog;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 
 final class FactoryTest extends TestCase
 {
+    #[TestWith(['https://api.elevenlabs.io/v1/'])]
+    #[TestWith(['https://api.elevenlabs.io/v1'])]
+    public function testEndpointTrailingSlashIsToleratedForRelativePathResolution(string $endpoint)
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url): JsonMockResponse {
+            $this->assertSame('https://api.elevenlabs.io/v1/models', $url);
+
+            return new JsonMockResponse([]);
+        });
+
+        $provider = Factory::createProvider($endpoint, apiKey: 'foo', httpClient: $httpClient);
+        $provider->getModelCatalog()->getModels();
+    }
+
     public function testProviderCanBeCreatedWithHttpClientAndRequiredInfos()
     {
         $provider = Factory::createProvider(apiKey: 'foo', httpClient: HttpClient::create());

--- a/src/platform/src/Bridge/Gemini/CHANGELOG.md
+++ b/src/platform/src/Bridge/Gemini/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Add a `baseUrl` argument to the model clients and the factory to target Gemini-compatible endpoints
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Gemini/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Embeddings/ModelClient.php
@@ -22,10 +22,17 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Gemini-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://generativelanguage.googleapis.com',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -35,7 +42,7 @@ final class ModelClient implements ModelClientInterface
 
     public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
     {
-        $url = \sprintf('https://generativelanguage.googleapis.com/v1beta/models/%s:%s', $model->getName(), 'batchEmbedContents');
+        $url = \sprintf('%s/v1beta/models/%s:%s', $this->baseUrl, $model->getName(), 'batchEmbedContents');
         $modelOptions = $model->getOptions();
 
         return new RawHttpResult($this->httpClient->request('POST', $url, [

--- a/src/platform/src/Bridge/Gemini/Factory.php
+++ b/src/platform/src/Bridge/Gemini/Factory.php
@@ -42,12 +42,13 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'gemini',
+        string $baseUrl = 'https://generativelanguage.googleapis.com',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Provider(
             $name,
-            [new EmbeddingsModelClient($httpClient, $apiKey), new GeminiModelClient($httpClient, $apiKey)],
+            [new EmbeddingsModelClient($httpClient, $apiKey, $baseUrl), new GeminiModelClient($httpClient, $apiKey, $baseUrl)],
             [new EmbeddingsResultConverter(), new GeminiResultConverter()],
             $modelCatalog,
             $contract ?? GeminiContract::create(),
@@ -66,9 +67,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'gemini',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://generativelanguage.googleapis.com',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ModelClient.php
@@ -30,12 +30,18 @@ final class ModelClient implements ModelClientInterface
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of a Gemini-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://generativelanguage.googleapis.com',
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -53,7 +59,8 @@ final class ModelClient implements ModelClientInterface
         }
 
         $url = \sprintf(
-            'https://generativelanguage.googleapis.com/v1beta/models/%s:%s',
+            '%s/v1beta/models/%s:%s',
+            $this->baseUrl,
             $model->getName(),
             $options['stream'] ?? false ? 'streamGenerateContent?alt=sse' : 'generateContent',
         );

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ModelClientTest.php
@@ -44,6 +44,18 @@ final class ModelClientTest extends TestCase
         $client->request(new Gemini('gemini-1.5-flash'), $payload);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url): JsonMockResponse {
+            $this->assertSame('https://gemini.example.com/v1beta/models/gemini-1.5-flash:generateContent', $url);
+
+            return new JsonMockResponse(['candidates' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'https://gemini.example.com/');
+        $client->request(new Gemini('gemini-1.5-flash'), ['contents' => []]);
+    }
+
     public function testRequestWithOptions()
     {
         $payload = ['contents' => []];

--- a/src/platform/src/Bridge/Generic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Generic/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Throw typed exceptions on rate limit and server error events mid-stream
+ * Normalize the `baseUrl` and tolerate a trailing slash in the completions and embeddings model clients
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Generic/Completions/ModelClient.php
+++ b/src/platform/src/Bridge/Generic/Completions/ModelClient.php
@@ -31,14 +31,19 @@ class ModelClient implements ModelClientInterface
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of an OpenAI-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
-        private readonly string $baseUrl,
+        string $baseUrl,
         #[\SensitiveParameter] private readonly ?string $apiKey = null,
         private readonly string $path = '/v1/chat/completions',
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/Generic/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Generic/Embeddings/ModelClient.php
@@ -25,12 +25,18 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class ModelClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of an OpenAI-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly ?HttpClientInterface $httpClient,
-        private readonly string $baseUrl,
+        string $baseUrl,
         #[\SensitiveParameter] private readonly ?string $apiKey = null,
         private readonly string $path = '/v1/embeddings',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
@@ -114,6 +114,8 @@ final class ModelClientTest extends TestCase
 
     #[TestWith(['https://api.inference.eu', 'https://api.inference.eu/v1/chat/completions'])]
     #[TestWith(['https://api.inference.com', 'https://api.inference.com/v1/chat/completions'])]
+    #[TestWith(['https://api.inference.com/', 'https://api.inference.com/v1/chat/completions'])]
+    #[TestWith(['https://api.inference.com///', 'https://api.inference.com/v1/chat/completions'])]
     public function testItUsesCorrectBaseUrl(string $baseUrl, string $expectedUrl)
     {
         $resultCallback = static function (string $method, string $url, array $options) use ($expectedUrl): HttpResponse {

--- a/src/platform/src/Bridge/HuggingFace/CHANGELOG.md
+++ b/src/platform/src/Bridge/HuggingFace/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Add a `baseUrl` argument to the model client and the factory to target a custom HuggingFace inference router
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/HuggingFace/Factory.php
+++ b/src/platform/src/Bridge/HuggingFace/Factory.php
@@ -39,12 +39,13 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'huggingface',
+        string $baseUrl = 'https://router.huggingface.co',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new PlatformProvider(
             $name,
-            [new ModelClient($httpClient, $provider, $apiKey)],
+            [new ModelClient($httpClient, $provider, $apiKey, $baseUrl)],
             [new ResultConverter()],
             $modelCatalog,
             $contract ?? HuggingFaceContract::create(),
@@ -64,9 +65,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'huggingface',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://router.huggingface.co',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $provider, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $provider, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/HuggingFace/ModelClient.php
+++ b/src/platform/src/Bridge/HuggingFace/ModelClient.php
@@ -26,13 +26,19 @@ final class ModelClient implements ModelClientInterface
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of the HuggingFace inference router, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
         private readonly string $provider,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://router.huggingface.co',
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -59,14 +65,14 @@ final class ModelClient implements ModelClientInterface
     {
         if (Task::CHAT_COMPLETION === $task) {
             if (Provider::HF_INFERENCE === $provider) {
-                return \sprintf('https://router.huggingface.co/%s/models/%s/v1/chat/completions', $provider, $model->getName());
+                return \sprintf('%s/%s/models/%s/v1/chat/completions', $this->baseUrl, $provider, $model->getName());
             }
 
             // Third-party providers use OpenAI-compatible endpoint
-            return \sprintf('https://router.huggingface.co/%s/v1/chat/completions', $provider);
+            return \sprintf('%s/%s/v1/chat/completions', $this->baseUrl, $provider);
         }
 
-        return \sprintf('https://router.huggingface.co/%s/models/%s', $provider, $model->getName());
+        return \sprintf('%s/%s/models/%s', $this->baseUrl, $provider, $model->getName());
     }
 
     /**

--- a/src/platform/src/Bridge/HuggingFace/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/HuggingFace/Tests/ModelClientTest.php
@@ -53,6 +53,18 @@ final class ModelClientTest extends TestCase
         $modelClient->request($model, 'test input', $options);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url): MockResponse {
+            $this->assertSame('https://hf.example.com/test-provider/models/test-model', $url);
+
+            return new MockResponse('{"result": "test"}');
+        });
+
+        $modelClient = new ModelClient($httpClient, 'test-provider', 'test-api-key', 'https://hf.example.com/');
+        $modelClient->request(new Model('test-model'), 'test input');
+    }
+
     public static function urlTestCases(): \Iterator
     {
         $messageBag = new MessageBag();

--- a/src/platform/src/Bridge/Mistral/CHANGELOG.md
+++ b/src/platform/src/Bridge/Mistral/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Add a `baseUrl` argument to the model clients and the factory to target Mistral-compatible endpoints
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
  * Add OCR support by `mistral-ocr-latest` model and `/v1/ocr` endpoint, returning a typed `OcrResult` with pages, layout images and annotations
 

--- a/src/platform/src/Bridge/Mistral/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Embeddings/ModelClient.php
@@ -24,12 +24,18 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class ModelClient implements ModelClientInterface
 {
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of a Mistral-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.mistral.ai',
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -39,7 +45,7 @@ final class ModelClient implements ModelClientInterface
 
     public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
     {
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.mistral.ai/v1/embeddings', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v1/embeddings', [
             'auth_bearer' => $this->apiKey,
             'headers' => [
                 'Content-Type' => 'application/json',

--- a/src/platform/src/Bridge/Mistral/Factory.php
+++ b/src/platform/src/Bridge/Mistral/Factory.php
@@ -41,12 +41,13 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'mistral',
+        string $baseUrl = 'https://api.mistral.ai',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Provider(
             $name,
-            [new Embeddings\ModelClient($httpClient, $apiKey), new Llm\ModelClient($httpClient, $apiKey), new Ocr\ModelClient($httpClient, $apiKey)],
+            [new Embeddings\ModelClient($httpClient, $apiKey, $baseUrl), new Llm\ModelClient($httpClient, $apiKey, $baseUrl), new Ocr\ModelClient($httpClient, $apiKey)],
             [new Embeddings\ResultConverter(), new Llm\ResultConverter(), new Ocr\ResultConverter()],
             $modelCatalog,
             $contract ?? Contract::create([
@@ -70,9 +71,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'mistral',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://api.mistral.ai',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ModelClient.php
@@ -28,12 +28,18 @@ final class ModelClient implements ModelClientInterface
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of a Mistral-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.mistral.ai',
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -47,7 +53,7 @@ final class ModelClient implements ModelClientInterface
             throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,
             'headers' => [
                 'Content-Type' => 'application/json',

--- a/src/platform/src/Bridge/Mistral/Tests/Llm/ModelClientTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Llm/ModelClientTest.php
@@ -37,6 +37,18 @@ final class ModelClientTest extends TestCase
         $client->request(new Mistral('mistral-large-latest'), ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $httpClient = new MockHttpClient([function (string $method, string $url): MockResponse {
+            $this->assertSame('https://mistral.example.com/v1/chat/completions', $url);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'https://mistral.example.com/');
+        $client->request(new Mistral('mistral-large-latest'), ['messages' => [['role' => 'user', 'content' => 'Hello']]]);
+    }
+
     public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
     {
         $httpClient = new MockHttpClient([function (string $method, string $url, array $options): MockResponse {

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Throw typed exceptions on rate limit and server error events mid-stream
+ * Normalize the `baseUrl` and tolerate a trailing slash in the model client
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/OpenResponses/ModelClient.php
+++ b/src/platform/src/Bridge/OpenResponses/ModelClient.php
@@ -30,14 +30,19 @@ class ModelClient implements ModelClientInterface
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of an Open Responses-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
-        private readonly string $baseUrl,
+        string $baseUrl,
         #[\SensitiveParameter] private readonly ?string $apiKey = null,
         private readonly string $path = '/v1/responses',
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool

--- a/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Add a `baseUrl` argument to the factory to target OpenRouter-compatible endpoints
 
 0.10
 ----

--- a/src/platform/src/Bridge/OpenRouter/Factory.php
+++ b/src/platform/src/Bridge/OpenRouter/Factory.php
@@ -42,15 +42,15 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'openrouter',
+        string $baseUrl = 'https://openrouter.ai/api',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
-        $baseUrl = 'https://openrouter.ai/api';
 
         $modelClients = [
             new Generic\Completions\ModelClient($httpClient, $baseUrl, $apiKey, '/v1/chat/completions'),
             new Generic\Embeddings\ModelClient($httpClient, $baseUrl, $apiKey, '/v1/embeddings'),
-            new RerankModelClient($httpClient, $apiKey),
-            new SpeechModelClient($httpClient, $apiKey),
+            new RerankModelClient($httpClient, $apiKey, $baseUrl),
+            new SpeechModelClient($httpClient, $apiKey, $baseUrl),
         ];
         $resultConverters = [
             new Generic\Completions\ResultConverter(),
@@ -73,9 +73,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'openrouter',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://openrouter.ai/api',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/OpenRouter/Rerank/ModelClient.php
+++ b/src/platform/src/Bridge/OpenRouter/Rerank/ModelClient.php
@@ -23,10 +23,17 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of an OpenRouter-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://openrouter.ai/api',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -50,7 +57,7 @@ final class ModelClient implements ModelClientInterface
             $body['top_n'] = $options['top_n'];
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://openrouter.ai/api/v1/rerank', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v1/rerank', [
             'auth_bearer' => $this->apiKey,
             'headers' => [
                 'Content-Type' => 'application/json',

--- a/src/platform/src/Bridge/OpenRouter/Speech/ModelClient.php
+++ b/src/platform/src/Bridge/OpenRouter/Speech/ModelClient.php
@@ -23,10 +23,17 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of an OpenRouter-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://openrouter.ai/api',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -66,7 +73,7 @@ final class ModelClient implements ModelClientInterface
             $body['provider'] = $options['provider'];
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://openrouter.ai/api/v1/audio/speech', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v1/audio/speech', [
             'auth_bearer' => $this->apiKey,
             'headers' => [
                 'Content-Type' => 'application/json',

--- a/src/platform/src/Bridge/OpenRouter/Tests/Rerank/ModelClientTest.php
+++ b/src/platform/src/Bridge/OpenRouter/Tests/Rerank/ModelClientTest.php
@@ -67,6 +67,21 @@ final class ModelClientTest extends TestCase
         ]);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url): MockResponse {
+            $this->assertSame('https://openrouter.example.com/v1/rerank', $url);
+
+            return new MockResponse();
+        });
+
+        $client = new ModelClient($httpClient, 'test-key', 'https://openrouter.example.com/');
+        $client->request(new RerankModel('cohere/rerank-v3.5'), [
+            'query' => 'What is AI?',
+            'texts' => ['Document about AI'],
+        ]);
+    }
+
     public function testItSendsTopNOption()
     {
         $httpClient = new MockHttpClient(function (

--- a/src/platform/src/Bridge/Perplexity/CHANGELOG.md
+++ b/src/platform/src/Bridge/Perplexity/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Add a `baseUrl` argument to the model client and the factory to target Perplexity-compatible endpoints
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Perplexity/Factory.php
+++ b/src/platform/src/Bridge/Perplexity/Factory.php
@@ -38,12 +38,13 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'perplexity',
+        string $baseUrl = 'https://api.perplexity.ai',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Provider(
             $name,
-            [new ModelClient($httpClient, $apiKey)],
+            [new ModelClient($httpClient, $apiKey, $baseUrl)],
             [new ResultConverter()],
             $modelCatalog,
             $contract ?? PerplexityContract::create(),
@@ -62,9 +63,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'perplexity',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://api.perplexity.ai',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Perplexity/ModelClient.php
+++ b/src/platform/src/Bridge/Perplexity/ModelClient.php
@@ -28,12 +28,18 @@ final class ModelClient implements ModelClientInterface
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of a Perplexity-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.perplexity.ai',
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
 
         if ('' === $apiKey) {
             throw new InvalidArgumentException('The API key must not be empty.');
@@ -55,7 +61,7 @@ final class ModelClient implements ModelClientInterface
             throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.perplexity.ai/chat/completions', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/chat/completions', [
             'auth_bearer' => $this->apiKey,
             'headers' => ['Content-Type' => 'application/json'],
             'body' => $this->encodeJsonBody(array_merge($options, $payload)),

--- a/src/platform/src/Bridge/Perplexity/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Perplexity/Tests/ModelClientTest.php
@@ -108,6 +108,18 @@ final class ModelClientTest extends TestCase
         $modelClient->request(new Perplexity('sonar'), ['model' => 'sonar', 'messages' => [['role' => 'user', 'content' => 'Hello']]]);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $resultCallback = static function (string $method, string $url): HttpResponse {
+            self::assertSame('https://perplexity.example.com/chat/completions', $url);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'pplx-api-key', 'https://perplexity.example.com/');
+        $modelClient->request(new Perplexity('sonar'), ['model' => 'sonar', 'messages' => [['role' => 'user', 'content' => 'Hello']]]);
+    }
+
     public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
     {
         $resultCallback = static function (string $method, string $url, array $options): HttpResponse {

--- a/src/platform/src/Bridge/Replicate/CHANGELOG.md
+++ b/src/platform/src/Bridge/Replicate/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Add a `baseUrl` argument to the client and the factory to target Replicate-compatible endpoints
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Replicate/Client.php
+++ b/src/platform/src/Bridge/Replicate/Client.php
@@ -24,11 +24,18 @@ final class Client
 {
     use JsonBodyEncodingTrait;
 
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Replicate-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly ClockInterface $clock,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.replicate.com',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     /**
@@ -37,7 +44,7 @@ final class Client
      */
     public function request(string $model, string $endpoint, array $body): ResponseInterface
     {
-        $url = \sprintf('https://api.replicate.com/v1/models/%s/%s', $model, $endpoint);
+        $url = \sprintf('%s/v1/models/%s/%s', $this->baseUrl, $model, $endpoint);
 
         $response = $this->httpClient->request('POST', $url, [
             'headers' => ['Content-Type' => 'application/json'],
@@ -66,7 +73,7 @@ final class Client
 
     private function getResponse(string $id): ResponseInterface
     {
-        $url = \sprintf('https://api.replicate.com/v1/predictions/%s', $id);
+        $url = \sprintf('%s/v1/predictions/%s', $this->baseUrl, $id);
 
         return $this->httpClient->request('GET', $url, [
             'headers' => ['Content-Type' => 'application/json'],

--- a/src/platform/src/Bridge/Replicate/Factory.php
+++ b/src/platform/src/Bridge/Replicate/Factory.php
@@ -39,10 +39,11 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'replicate',
+        string $baseUrl = 'https://api.replicate.com',
     ): ProviderInterface {
         return new Provider(
             $name,
-            [new LlamaModelClient(new Client($httpClient ?? HttpClient::create(), new Clock(), $apiKey))],
+            [new LlamaModelClient(new Client($httpClient ?? HttpClient::create(), new Clock(), $apiKey, $baseUrl))],
             [new LlamaResultConverter()],
             $modelCatalog,
             $contract ?? Contract::create([new LlamaMessageBagNormalizer()]),
@@ -61,9 +62,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'replicate',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://api.replicate.com',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Replicate/Tests/ClientTest.php
+++ b/src/platform/src/Bridge/Replicate/Tests/ClientTest.php
@@ -51,6 +51,18 @@ final class ClientTest extends TestCase
         $this->assertSame(['World'], $data['output']);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url): MockResponse {
+            $this->assertSame('https://replicate.example.com/v1/models/meta/llama-3.1-405b-instruct/predictions', $url);
+
+            return new MockResponse('{"status": "succeeded"}');
+        });
+
+        $client = new Client($httpClient, new MockClock(), 'test-api-key', 'https://replicate.example.com/');
+        $client->request('meta/llama-3.1-405b-instruct', 'predictions', ['prompt' => 'Hello']);
+    }
+
     public function testRequestAuthenticationHeader()
     {
         $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) {

--- a/src/platform/src/Bridge/Scaleway/CHANGELOG.md
+++ b/src/platform/src/Bridge/Scaleway/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
+ * Add a `baseUrl` argument to the model clients and the factory to target Scaleway-compatible endpoints
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 
 0.10

--- a/src/platform/src/Bridge/Scaleway/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Scaleway/Embeddings/ModelClient.php
@@ -23,13 +23,21 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Scaleway-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.scaleway.ai',
     ) {
         if ('' === $apiKey) {
             throw new InvalidArgumentException('The API key must not be empty.');
         }
+
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -39,7 +47,7 @@ final class ModelClient implements ModelClientInterface
 
     public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
     {
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.scaleway.ai/v1/embeddings', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v1/embeddings', [
             'auth_bearer' => $this->apiKey,
             'json' => array_merge($options, [
                 'model' => $model->getName(),

--- a/src/platform/src/Bridge/Scaleway/Factory.php
+++ b/src/platform/src/Bridge/Scaleway/Factory.php
@@ -44,15 +44,16 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'scaleway',
+        string $baseUrl = 'https://api.scaleway.ai',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Provider(
             $name,
             [
-                new OpenResponsesModelClient($httpClient, 'https://api.scaleway.ai', $apiKey),
-                new ScalewayModelClient($httpClient, $apiKey),
-                new ScalewayEmbeddingsModelClient($httpClient, $apiKey),
+                new OpenResponsesModelClient($httpClient, $baseUrl, $apiKey),
+                new ScalewayModelClient($httpClient, $apiKey, $baseUrl),
+                new ScalewayEmbeddingsModelClient($httpClient, $apiKey, $baseUrl),
             ],
             [
                 new OpenResponsesResultConverter(),
@@ -76,9 +77,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'scaleway',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://api.scaleway.ai',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Scaleway/Llm/ModelClient.php
+++ b/src/platform/src/Bridge/Scaleway/Llm/ModelClient.php
@@ -28,12 +28,18 @@ final class ModelClient implements ModelClientInterface
     use JsonBodyEncodingTrait;
 
     private readonly EventSourceHttpClient $httpClient;
+    private readonly string $baseUrl;
 
+    /**
+     * @param string $baseUrl Base URL of a Scaleway-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.scaleway.ai',
     ) {
         $this->httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -47,7 +53,7 @@ final class ModelClient implements ModelClientInterface
             throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', 'https://api.scaleway.ai/v1/chat/completions', [
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v1/chat/completions', [
             'auth_bearer' => $this->apiKey,
             'headers' => ['Content-Type' => 'application/json'],
             'body' => $this->encodeJsonBody(array_merge($options, $payload)),

--- a/src/platform/src/Bridge/Scaleway/Tests/Llm/ModelClientTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Llm/ModelClientTest.php
@@ -106,6 +106,18 @@ final class ModelClientTest extends TestCase
         $modelClient->request(new Scaleway('deepseek-r1-distill-llama-70b'), ['messages' => []], []);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $resultCallback = function (string $method, string $url): HttpResponse {
+            $this->assertSame('https://x.example.com/v1/chat/completions', $url);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'scaleway-api-key', 'https://x.example.com/');
+        $modelClient->request(new Scaleway('deepseek-r1-distill-llama-70b'), ['messages' => []]);
+    }
+
     public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
     {
         $resultCallback = static function (string $method, string $url, array $options): HttpResponse {

--- a/src/platform/src/Bridge/Voyage/CHANGELOG.md
+++ b/src/platform/src/Bridge/Voyage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Add a `baseUrl` argument to the model clients and the factory to target Voyage-compatible endpoints
+
 0.8
 ---
 

--- a/src/platform/src/Bridge/Voyage/Factory.php
+++ b/src/platform/src/Bridge/Voyage/Factory.php
@@ -38,12 +38,13 @@ final class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'voyage',
+        string $baseUrl = 'https://api.voyageai.com',
     ): ProviderInterface {
         $httpClient = $httpClient instanceof EventSourceHttpClient ? $httpClient : new EventSourceHttpClient($httpClient);
 
         return new Provider(
             $name,
-            [new ModelClient($httpClient, $apiKey)],
+            [new ModelClient($httpClient, $apiKey, $baseUrl)],
             [new ResultConverter()],
             $modelCatalog,
             $contract ?? VoyageContract::create(),
@@ -62,9 +63,10 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'voyage',
         ?ModelRouterInterface $modelRouter = null,
+        string $baseUrl = 'https://api.voyageai.com',
     ): Platform {
         return new Platform(
-            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name)],
+            [self::createProvider($apiKey, $httpClient, $modelCatalog, $contract, $eventDispatcher, $name, $baseUrl)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Voyage/ModelClient.php
+++ b/src/platform/src/Bridge/Voyage/ModelClient.php
@@ -22,10 +22,17 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Voyage-compatible endpoint, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.voyageai.com',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function supports(Model $model): bool
@@ -56,6 +63,6 @@ final class ModelClient implements ModelClientInterface
             $body['json']['encoding_format'] = $options['encoding'] ?? null;
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', \sprintf('https://api.voyageai.com/v1/%s', $endpoint), $body));
+        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/v1/%s', $this->baseUrl, $endpoint), $body));
     }
 }

--- a/src/platform/src/Bridge/Voyage/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Voyage/Tests/ModelClientTest.php
@@ -47,6 +47,18 @@ final class ModelClientTest extends TestCase
         ]);
     }
 
+    public function testCustomBaseUrlIsUsedAndTrailingSlashNormalized()
+    {
+        $httpClient = new MockHttpClient([function (string $method, string $url): MockResponse {
+            $this->assertSame('https://x.example.com/v1/embeddings', $url);
+
+            return new MockResponse();
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-api-key', 'https://x.example.com/');
+        $client->request(new Voyage('some-text-embedding-model', []), 'Hello, world!');
+    }
+
     public static function requestProvider(): \Generator
     {
         $textEmbeddingModel = new Voyage('some-text-embedding-model', []);

--- a/src/store/src/Bridge/AzureSearch/CHANGELOG.md
+++ b/src/store/src/Bridge/AzureSearch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Normalize the `endpoint` URL and tolerate a missing trailing slash on path-prefixed endpoints
+
 0.7
 ---
 

--- a/src/store/src/Bridge/AzureSearch/StoreFactory.php
+++ b/src/store/src/Bridge/AzureSearch/StoreFactory.php
@@ -39,6 +39,8 @@ final class StoreFactory
                 $defaultOptions['query']['api-version'] = $apiVersion;
             }
 
+            $endpoint = rtrim($endpoint, '/').'/';
+
             $httpClient = ScopingHttpClient::forBaseUri($httpClient ?? HttpClient::create(), $endpoint, $defaultOptions);
         }
 

--- a/src/store/src/Bridge/AzureSearch/Tests/StoreFactoryTest.php
+++ b/src/store/src/Bridge/AzureSearch/Tests/StoreFactoryTest.php
@@ -12,10 +12,15 @@
 namespace Symfony\AI\Store\Bridge\AzureSearch\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\AzureSearch\SearchStore;
 use Symfony\AI\Store\Bridge\AzureSearch\StoreFactory;
+use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\ScopingHttpClient;
+use Symfony\Component\Uid\Uuid;
 
 final class StoreFactoryTest extends TestCase
 {
@@ -37,5 +42,21 @@ final class StoreFactoryTest extends TestCase
         ]));
 
         $this->assertInstanceOf(SearchStore::class, $store);
+    }
+
+    public function testStoreKeepsPathPrefixWithoutTrailingSlash()
+    {
+        $resolvedUrl = null;
+
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$resolvedUrl): JsonMockResponse {
+            $resolvedUrl = $url;
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        });
+
+        $store = StoreFactory::create('foo', endpoint: 'https://test.search.windows.net/proxy', httpClient: $httpClient);
+        $store->add(new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2, 0.3])));
+
+        $this->assertSame('https://test.search.windows.net/proxy/indexes/foo/docs/index', $resolvedUrl);
     }
 }

--- a/src/store/src/Bridge/Elasticsearch/CHANGELOG.md
+++ b/src/store/src/Bridge/Elasticsearch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Normalize the `endpoint` URL and tolerate a trailing slash
+
 0.1
 ---
 

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -26,14 +26,20 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class Store implements ManagedStoreInterface, StoreInterface
 {
+    private readonly string $endpoint;
+
+    /**
+     * @param string $endpoint URL of the Elasticsearch instance, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        private readonly string $endpoint,
+        string $endpoint,
         private readonly string $indexName,
         private readonly string $vectorsField = '_vectors',
         private readonly int $dimensions = 1536,
         private readonly string $similarity = 'cosine',
     ) {
+        $this->endpoint = rtrim($endpoint, '/');
     }
 
     public function setup(array $options = []): void

--- a/src/store/src/Bridge/Elasticsearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Elasticsearch/Tests/StoreTest.php
@@ -197,6 +197,24 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testStoreNormalizesTrailingSlashOnEndpoint()
+    {
+        $requestedUrl = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedUrl): JsonMockResponse {
+            $requestedUrl = $url;
+
+            return new JsonMockResponse('', [
+                'http_code' => 200,
+            ]);
+        });
+
+        $store = new Store($httpClient, 'http://127.0.0.1:9200/', 'foo');
+        $store->setup();
+
+        $this->assertSame('http://127.0.0.1:9200/foo', $requestedUrl);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');

--- a/src/store/src/Bridge/ManticoreSearch/CHANGELOG.md
+++ b/src/store/src/Bridge/ManticoreSearch/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Normalize the `endpoint` URL and tolerate a trailing slash
+ * [BC BREAK] Rename the `$host` constructor argument to `$endpoint`
+
 0.1
 ---
 

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -28,9 +28,14 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class Store implements ManagedStoreInterface, StoreInterface
 {
+    private readonly string $endpoint;
+
+    /**
+     * @param string $endpoint URL of the ManticoreSearch instance, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        private readonly string $host,
+        string $endpoint,
         private readonly string $table,
         private readonly string $field = '_vectors',
         private readonly string $type = 'hnsw',
@@ -38,6 +43,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         private readonly int $dimensions = 1536,
         private readonly string $quantization = '8bit',
     ) {
+        $this->endpoint = rtrim($endpoint, '/');
     }
 
     public function setup(array $options = []): void
@@ -153,9 +159,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *
      * @return array<string, mixed>
      */
-    private function request(string $endpoint, \Closure|array|string $query): array
+    private function request(string $route, \Closure|array|string $query): array
     {
-        $options = match ($endpoint) {
+        $options = match ($route) {
             'cli' => [
                 'body' => $query,
             ],
@@ -168,12 +174,12 @@ final class Store implements ManagedStoreInterface, StoreInterface
             'search' => [
                 'json' => $query,
             ],
-            default => throw new InvalidArgumentException(\sprintf('The endpoint "%s" is not supported', $endpoint)),
+            default => throw new InvalidArgumentException(\sprintf('The endpoint "%s" is not supported', $route)),
         };
 
-        $response = $this->httpClient->request('POST', \sprintf('%s/%s', $this->host, $endpoint), $options);
+        $response = $this->httpClient->request('POST', \sprintf('%s/%s', $this->endpoint, $route), $options);
 
-        return 'cli' === $endpoint ? [
+        return 'cli' === $route ? [
             'result' => $response->getContent(),
         ] : $response->toArray();
     }

--- a/src/store/src/Bridge/ManticoreSearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ManticoreSearch/Tests/StoreTest.php
@@ -201,6 +201,24 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testStoreNormalizesTrailingSlashOnEndpoint()
+    {
+        $requestedUrl = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedUrl): MockResponse {
+            $requestedUrl = $url;
+
+            return new MockResponse('Query OK, 0 rows affected (0.006 sec)'.\PHP_EOL, [
+                'http_code' => 200,
+            ]);
+        });
+
+        $store = new Store($httpClient, 'http://127.0.0.1:9308/', 'bar', 'random');
+        $store->setup();
+
+        $this->assertSame('http://127.0.0.1:9308/cli', $requestedUrl);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = new Store(new MockHttpClient(), 'http://localhost:9308', 'test_index');

--- a/src/store/src/Bridge/Meilisearch/CHANGELOG.md
+++ b/src/store/src/Bridge/Meilisearch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Normalize the `endpoint` URL and tolerate a missing trailing slash on path-prefixed endpoints
+
 0.9
 ---
 

--- a/src/store/src/Bridge/Meilisearch/StoreFactory.php
+++ b/src/store/src/Bridge/Meilisearch/StoreFactory.php
@@ -38,6 +38,8 @@ final class StoreFactory
                 $defaultOptions['auth_bearer'] = $apiKey;
             }
 
+            $endpoint = rtrim($endpoint, '/').'/';
+
             $httpClient = ScopingHttpClient::forBaseUri($httpClient ?? HttpClient::create(), $endpoint, $defaultOptions);
         }
 

--- a/src/store/src/Bridge/Meilisearch/Tests/StoreFactoryTest.php
+++ b/src/store/src/Bridge/Meilisearch/Tests/StoreFactoryTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Store\Bridge\Meilisearch\Store;
 use Symfony\AI\Store\Bridge\Meilisearch\StoreFactory;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 
 final class StoreFactoryTest extends TestCase
@@ -33,5 +35,21 @@ final class StoreFactoryTest extends TestCase
         ]));
 
         $this->assertInstanceOf(Store::class, $store);
+    }
+
+    public function testStoreKeepsPathPrefixWithoutTrailingSlash()
+    {
+        $resolvedUrl = null;
+
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$resolvedUrl): JsonMockResponse {
+            $resolvedUrl = $url;
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        });
+
+        $store = StoreFactory::create('foo', 'http://localhost:7700/proxy', httpClient: $httpClient);
+        $store->drop();
+
+        $this->assertSame('http://localhost:7700/proxy/indexes/foo', $resolvedUrl);
     }
 }

--- a/src/store/src/Bridge/Milvus/CHANGELOG.md
+++ b/src/store/src/Bridge/Milvus/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Normalize the `endpoint` URL and tolerate a trailing slash
+ * [BC BREAK] Rename the `$endpointUrl` constructor/factory argument to `$endpoint`
+
 0.1
 ---
 

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -28,9 +28,14 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class Store implements ManagedStoreInterface, StoreInterface
 {
+    private readonly string $endpoint;
+
+    /**
+     * @param string $endpoint URL of the Milvus instance, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        private readonly string $endpointUrl,
+        string $endpoint,
         #[\SensitiveParameter] private readonly string $apiKey,
         private readonly string $database,
         private readonly string $collection,
@@ -38,6 +43,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         private readonly int $dimensions = 1536,
         private readonly string $metricType = 'COSINE',
     ) {
+        $this->endpoint = rtrim($endpoint, '/');
     }
 
     /**
@@ -168,7 +174,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
      */
     private function request(string $method, string $endpoint, array $payload): array
     {
-        $url = \sprintf('%s/%s', $this->endpointUrl, $endpoint);
+        $url = \sprintf('%s/%s', $this->endpoint, $endpoint);
         $result = $this->httpClient->request($method, $url, [
             'auth_bearer' => $this->apiKey,
             'json' => $payload,

--- a/src/store/src/Bridge/Milvus/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Milvus/Tests/StoreTest.php
@@ -81,6 +81,28 @@ final class StoreTest extends TestCase
         $this->assertSame(2, $httpClient->getRequestsCount());
     }
 
+    public function testStoreNormalizesTrailingSlashOnEndpoint()
+    {
+        $requestedUrl = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedUrl): JsonMockResponse {
+            $requestedUrl = $url;
+
+            return new JsonMockResponse(['code' => 0, 'data' => []]);
+        });
+
+        $store = new Store(
+            $httpClient,
+            'http://127.0.0.1:19530/',
+            'test',
+            'test',
+            'test',
+        );
+
+        $store->drop();
+
+        $this->assertSame('http://127.0.0.1:19530/v2/vectordb/databases/drop', $requestedUrl);
+    }
+
     public function testStoreCannotDropOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([

--- a/src/store/src/Bridge/OpenSearch/CHANGELOG.md
+++ b/src/store/src/Bridge/OpenSearch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Normalize the `endpoint` URL and tolerate a trailing slash
+
 0.1
 ---
 

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -28,14 +28,20 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class Store implements ManagedStoreInterface, StoreInterface
 {
+    private readonly string $endpoint;
+
+    /**
+     * @param string $endpoint URL of the OpenSearch instance, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        private readonly string $endpoint,
+        string $endpoint,
         private readonly string $indexName,
         private readonly string $vectorsField = '_vectors',
         private readonly int $dimensions = 1536,
         private readonly string $spaceType = 'l2',
     ) {
+        $this->endpoint = rtrim($endpoint, '/');
     }
 
     public function setup(array $options = []): void

--- a/src/store/src/Bridge/OpenSearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/OpenSearch/Tests/StoreTest.php
@@ -199,6 +199,24 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testStoreNormalizesTrailingSlashOnEndpoint()
+    {
+        $requestedUrl = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedUrl): JsonMockResponse {
+            $requestedUrl = $url;
+
+            return new JsonMockResponse('', [
+                'http_code' => 200,
+            ]);
+        });
+
+        $store = new Store($httpClient, 'http://127.0.0.1:9200/', 'foo');
+        $store->setup();
+
+        $this->assertSame('http://127.0.0.1:9200/foo', $requestedUrl);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = new Store(new MockHttpClient(), 'http://localhost:9200', 'test-index');

--- a/src/store/src/Bridge/Qdrant/CHANGELOG.md
+++ b/src/store/src/Bridge/Qdrant/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Normalize the `endpoint` URL and tolerate a missing trailing slash on path-prefixed endpoints
+
 0.6
 ---
 

--- a/src/store/src/Bridge/Qdrant/StoreFactory.php
+++ b/src/store/src/Bridge/Qdrant/StoreFactory.php
@@ -39,6 +39,8 @@ final class StoreFactory
                 ];
             }
 
+            $endpoint = rtrim($endpoint, '/').'/';
+
             $httpClient = ScopingHttpClient::forBaseUri($httpClient ?? HttpClient::create(), $endpoint, $defaultOptions);
         }
 

--- a/src/store/src/Bridge/Qdrant/Tests/StoreFactoryTest.php
+++ b/src/store/src/Bridge/Qdrant/Tests/StoreFactoryTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Store\Bridge\Qdrant\Store;
 use Symfony\AI\Store\Bridge\Qdrant\StoreFactory;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 
 final class StoreFactoryTest extends TestCase
@@ -35,5 +37,21 @@ final class StoreFactoryTest extends TestCase
         ]));
 
         $this->assertInstanceOf(Store::class, $store);
+    }
+
+    public function testStoreKeepsPathPrefixWithoutTrailingSlash()
+    {
+        $resolvedUrl = null;
+
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$resolvedUrl): JsonMockResponse {
+            $resolvedUrl = $url;
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        });
+
+        $store = StoreFactory::create('foo', 'http://localhost:6333/proxy', httpClient: $httpClient);
+        $store->drop();
+
+        $this->assertSame('http://localhost:6333/proxy/collections/foo', $resolvedUrl);
     }
 }

--- a/src/store/src/Bridge/Supabase/CHANGELOG.md
+++ b/src/store/src/Bridge/Supabase/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Normalize the `endpoint` URL and tolerate a trailing slash
+ * [BC BREAK] Rename the `$url` constructor/factory argument to `$endpoint`
+
 0.7
 ---
 

--- a/src/store/src/Bridge/Supabase/Store.php
+++ b/src/store/src/Bridge/Supabase/Store.php
@@ -40,15 +40,21 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class Store implements StoreInterface
 {
+    private readonly string $endpoint;
+
+    /**
+     * @param string $endpoint URL of the Supabase instance, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        private readonly string $url,
+        string $endpoint,
         private readonly string $apiKey,
         private readonly string $table = 'documents',
         private readonly string $vectorFieldName = 'embedding',
         private readonly int $vectorDimension = 1536,
         private readonly string $functionName = 'match_documents',
     ) {
+        $this->endpoint = rtrim($endpoint, '/');
     }
 
     public function add(VectorDocument|array $documents): void
@@ -80,7 +86,7 @@ final class Store implements StoreInterface
         foreach (array_chunk($rows, $chunkSize) as $chunk) {
             $response = $this->httpClient->request(
                 'POST',
-                \sprintf('%s/rest/v1/%s', $this->url, $this->table),
+                \sprintf('%s/rest/v1/%s', $this->endpoint, $this->table),
                 [
                     'headers' => $this->getHeaders() + ['Prefer' => 'resolution=merge-duplicates'],
                     'json' => $chunk,
@@ -112,7 +118,7 @@ final class Store implements StoreInterface
 
             $response = $this->httpClient->request(
                 'DELETE',
-                \sprintf('%s/rest/v1/%s', $this->url, $this->table),
+                \sprintf('%s/rest/v1/%s', $this->endpoint, $this->table),
                 [
                     'headers' => $this->getHeaders(),
                     'query' => [
@@ -155,7 +161,7 @@ final class Store implements StoreInterface
 
         $response = $this->httpClient->request(
             'POST',
-            \sprintf('%s/rest/v1/rpc/%s', $this->url, $this->functionName),
+            \sprintf('%s/rest/v1/rpc/%s', $this->endpoint, $this->functionName),
             [
                 'headers' => $this->getHeaders(),
                 'json' => [

--- a/src/store/src/Bridge/Supabase/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Supabase/Tests/StoreTest.php
@@ -310,6 +310,30 @@ class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testStoreNormalizesTrailingSlashOnEndpoint()
+    {
+        $requestedUrl = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedUrl): MockResponse {
+            $requestedUrl = $url;
+
+            return new MockResponse('', ['http_code' => 201]);
+        });
+
+        $store = new SupabaseStore(
+            $httpClient,
+            'https://test.supabase.co/',
+            'test-api-key',
+            'documents',
+            'embedding',
+            2,
+            'match_documents'
+        );
+
+        $store->add(new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2]), new Metadata([])));
+
+        $this->assertSame('https://test.supabase.co/rest/v1/documents', $requestedUrl);
+    }
+
     private function createStore(MockHttpClient $httpClient, ?int $vectorDimension = 2): SupabaseStore
     {
         return new SupabaseStore(

--- a/src/store/src/Bridge/SurrealDb/CHANGELOG.md
+++ b/src/store/src/Bridge/SurrealDb/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Normalize the `endpoint` URL and tolerate a trailing slash
+ * [BC BREAK] Rename the `$endpointUrl` constructor/factory argument to `$endpoint`
+
 0.1
 ---
 

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -31,9 +31,14 @@ final class Store implements ManagedStoreInterface, StoreInterface
 {
     private string $authenticationToken = '';
 
+    private readonly string $endpoint;
+
+    /**
+     * @param string $endpoint URL of the SurrealDB instance, with or without a trailing slash
+     */
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        private readonly string $endpointUrl,
+        string $endpoint,
         private readonly string $user,
         #[\SensitiveParameter] private readonly string $password,
         private readonly string $namespace,
@@ -44,6 +49,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         private readonly int $embeddingsDimension = 1536,
         private readonly bool $isNamespacedUser = false,
     ) {
+        $this->endpoint = rtrim($endpoint, '/');
     }
 
     public function setup(array $options = []): void
@@ -128,7 +134,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
      */
     private function request(string $method, string $endpoint, array|string $payload): array
     {
-        $url = \sprintf('%s/%s', $this->endpointUrl, $endpoint);
+        $url = \sprintf('%s/%s', $this->endpoint, $endpoint);
 
         $finalPayload = [];
 
@@ -210,7 +216,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             $authenticationPayload['db'] = $this->database;
         }
 
-        $authenticationResponse = $this->httpClient->request('POST', \sprintf('%s/signin', $this->endpointUrl), [
+        $authenticationResponse = $this->httpClient->request('POST', \sprintf('%s/signin', $this->endpoint), [
             'headers' => [
                 'Accept' => 'application/json',
             ],

--- a/src/store/src/Bridge/SurrealDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/SurrealDb/Tests/StoreTest.php
@@ -92,6 +92,29 @@ final class StoreTest extends TestCase
         $this->assertSame(2, $httpClient->getRequestsCount());
     }
 
+    public function testStoreNormalizesTrailingSlashOnEndpoint()
+    {
+        $requestedUrls = [];
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedUrls): JsonMockResponse {
+            $requestedUrls[] = $url;
+
+            if (str_ends_with($url, '/signin')) {
+                return new JsonMockResponse(['token' => 'bar'], ['http_code' => 200]);
+            }
+
+            return new JsonMockResponse([['result' => 'OK', 'status' => 'OK']], ['http_code' => 200]);
+        });
+
+        $store = new Store($httpClient, 'http://127.0.0.1:8000/', 'test', 'test', 'test', 'test');
+
+        $store->setup();
+
+        $this->assertSame([
+            'http://127.0.0.1:8000/signin',
+            'http://127.0.0.1:8000/sql',
+        ], $requestedUrls);
+    }
+
     public function testStoreCannotDropOnInvalidResponse()
     {
         $httpClient = new MockHttpClient([

--- a/src/store/src/Bridge/Typesense/CHANGELOG.md
+++ b/src/store/src/Bridge/Typesense/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Normalize the `endpoint` URL and tolerate a missing trailing slash on path-prefixed endpoints
  * Introduce a `StoreFactory`
  * [BC BREAK] Add support for `ScopingHttpClient` in `Store`
  * [BC BREAK] The `endpointUrl` parameter for `Store` has been removed

--- a/src/store/src/Bridge/Typesense/StoreFactory.php
+++ b/src/store/src/Bridge/Typesense/StoreFactory.php
@@ -40,6 +40,8 @@ final class StoreFactory
                 ];
             }
 
+            $endpoint = rtrim($endpoint, '/').'/';
+
             $httpClient = ScopingHttpClient::forBaseUri($httpClient, $endpoint, $defaultOptions);
         }
 

--- a/src/store/src/Bridge/Typesense/Tests/StoreFactoryTest.php
+++ b/src/store/src/Bridge/Typesense/Tests/StoreFactoryTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Store\Bridge\Typesense\Store;
 use Symfony\AI\Store\Bridge\Typesense\StoreFactory;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 
 final class StoreFactoryTest extends TestCase
@@ -35,5 +37,21 @@ final class StoreFactoryTest extends TestCase
         ]));
 
         $this->assertInstanceOf(Store::class, $store);
+    }
+
+    public function testStoreKeepsPathPrefixWithoutTrailingSlash()
+    {
+        $resolvedUrl = null;
+
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$resolvedUrl): JsonMockResponse {
+            $resolvedUrl = $url;
+
+            return new JsonMockResponse([], ['http_code' => 200]);
+        });
+
+        $store = StoreFactory::create('foo', 'http://localhost:8108/proxy', httpClient: $httpClient);
+        $store->drop();
+
+        $this->assertSame('http://localhost:8108/proxy/collections/foo', $resolvedUrl);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Generalizes the trailing-slash robustness from #2209 to every HTTP platform and store bridge, and makes base-URL/endpoint handling consistent.

- Canonical pattern everywhere: accept a base URL, store it `rtrim($baseUrl, '/')`, concatenate the path.
- Make previously-hardcoded platform bridges configurable via a `baseUrl` arg (Mistral, DeepSeek, Cerebras, Perplexity, Cohere, Voyage, Cartesia, Scaleway, Gemini, Replicate, HuggingFace, OpenRouter).
- Azure now accepts a full base URL *with* scheme (bare host still works, https assumed) instead of rejecting any protocol; shared `BaseUrlNormalizerTrait`.
- Standardize naming: platform `$hostUrl` → `$baseUrl` (Decart, DockerModelRunner); HTTP store endpoints → `$endpoint` (ManticoreSearch, Cloudflare, Milvus, Supabase, SurrealDb).
- Albert/ElevenLabs and ScopingHttpClient store bridges now tolerate a missing/extra trailing slash.

BC breaks documented in `UPGRADE.md`; per-bridge CHANGELOG entries added; affected RAG examples updated.

Deliberate exceptions (cloud-provider-specific endpoints): VertexAi, Bedrock, OpenAi (region-based), Anthropic (#2209), and HuggingFace's metadata host.

cc @Guikingone WDYT?