### PR TITLE
[Platform][Generic] Treat empty-string streamed tool-call id as a continuation

### DIFF
--- a/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
+++ b/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
@@ -132,7 +132,11 @@ trait CompletionsConversionTrait
         }
 
         foreach ($data['choices'][0]['delta']['tool_calls'] as $i => $toolCall) {
-            if (isset($toolCall['id'])) {
+            // A new tool call starts only on a NON-EMPTY id. OpenAI omits the id on continuation
+            // deltas, but some compatible providers (Alibaba Cloud Qwen / DashScope) repeat it as an
+            // empty string — isset() is true for "", so the empty-string case must be excluded or each
+            // continuation is misread as a start (losing the name and clobbering accumulated arguments).
+            if (isset($toolCall['id']) && '' !== $toolCall['id']) {
                 // initialize tool call
                 $toolCalls[$i] = [
                     'id' => $toolCall['id'],
@@ -163,7 +167,7 @@ trait CompletionsConversionTrait
     protected function yieldToolCallDeltas(array $toolCalls, array $data): \Generator
     {
         foreach ($data['choices'][0]['delta']['tool_calls'] ?? [] as $i => $toolCall) {
-            if (isset($toolCall['id'])) {
+            if (isset($toolCall['id']) && '' !== $toolCall['id']) {
                 yield new ToolCallStart($toolCall['id'], $toolCall['function']['name']);
             } elseif (isset($toolCall['function']['arguments'])) {
                 yield new ToolInputDelta($toolCalls[$i]['id'] ?? '', $toolCalls[$i]['function']['name'] ?? '', $toolCall['function']['arguments']);

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
@@ -461,6 +461,50 @@ class ResultConverterTest extends TestCase
         $this->assertSame(['city' => 'Beijing'], $completed[0]->getArguments());
     }
 
+    public function testStreamingToolCallsWithEmptyStringIdOnContinuationChunks()
+    {
+        // Some OpenAI-compatible providers (e.g. Alibaba Cloud Qwen / DashScope) send the tool-call
+        // id ONLY on the first delta as a real value and then repeat it as an EMPTY STRING on every
+        // continuation chunk (OpenAI itself omits the key entirely). `isset()` is true for "", so a
+        // start must be keyed on a NON-EMPTY id — otherwise each continuation is misread as a new
+        // tool-call start, the name is read from a delta that has none (Undefined array key "name"),
+        // and the accumulated arguments are clobbered.
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['tool_calls' => [
+                ['id' => 'call_1', 'type' => 'function', 'index' => 0, 'function' => ['name' => 'get_weather', 'arguments' => '']],
+            ]]]]],
+            ['choices' => [['index' => 0, 'delta' => ['tool_calls' => [
+                ['id' => '', 'type' => 'function', 'index' => 0, 'function' => ['arguments' => '{"city":']],
+            ]]]]],
+            ['choices' => [['index' => 0, 'delta' => ['tool_calls' => [
+                ['id' => '', 'type' => 'function', 'index' => 0, 'function' => ['arguments' => '"Beijing"}']],
+            ]]]]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'tool_calls']]],
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+
+        $chunks = [];
+        foreach ($streamResult->getContent() as $part) {
+            $chunks[] = $part;
+        }
+
+        $toolCallStarts = array_values(array_filter($chunks, static fn ($c) => $c instanceof ToolCallStart));
+        $this->assertCount(1, $toolCallStarts, 'an empty-string id on continuation chunks must not start a new tool call');
+        $this->assertSame('call_1', $toolCallStarts[0]->getId());
+        $this->assertSame('get_weather', $toolCallStarts[0]->getName());
+
+        $toolCallCompletes = array_values(array_filter($chunks, static fn ($c) => $c instanceof ToolCallComplete));
+        $this->assertCount(1, $toolCallCompletes);
+        $completed = $toolCallCompletes[0]->getToolCalls();
+        $this->assertCount(1, $completed);
+        $this->assertSame('call_1', $completed[0]->getId());
+        $this->assertSame('get_weather', $completed[0]->getName());
+        $this->assertSame(['city' => 'Beijing'], $completed[0]->getArguments());
+    }
+
     public function testStreamingThrowsWhenFinishReasonIsMissing()
     {
         $converter = new ResultConverter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

OpenAI sends a streamed tool call's `id` and `function.name` only on the first delta and omits `id` on the continuation (arguments) deltas. Some OpenAI-compatible providers (Alibaba Cloud Qwen / DashScope) instead repeat the id as an **empty string** on every continuation delta.

The stream converter keyed "is this a new tool-call start?" on `isset($toolCall['id'])`, which is `true` for `""`, so each continuation was misread as a new start: it read `function.name` from a delta that has none (`Undefined array key "name"`) and clobbered the accumulated arguments.

Fix: start a tool call only on a **non-empty** id, in both `convertStreamToToolCalls()` and `yieldToolCallDeltas()`.

A regression test (`testStreamingToolCallsWithEmptyStringIdOnContinuationChunks`) reproduces the DashScope-style stream and asserts a single `ToolCallStart`/`ToolCallComplete` with intact name and accumulated arguments.
