### PR TITLE
[Platform] Add ResultConvertedEvent and ResultErrorEvent

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -249,6 +249,33 @@ Provider-level events (:class:`Symfony\\AI\\Platform\\Event\\InvocationEvent` an
 :class:`Symfony\\AI\\Platform\\Event\\ResultEvent`) still fire inside the selected
 provider for per-invocation concerns.
 
+Result Conversion Events
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ResultEvent`` fires when the deferred result *object* is created, before the raw
+result is converted. Because :class:`Symfony\\AI\\Platform\\Result\\DeferredResult` is
+lazy, the actual result is only available later. To act on the resolved result, listen
+to :class:`Symfony\\AI\\Platform\\Event\\ResultConvertedEvent`, which is dispatched once
+the result has been converted (and :class:`Symfony\\AI\\Platform\\Event\\ResultErrorEvent`
+when conversion fails)::
+
+    use Symfony\AI\Platform\Event\ResultConvertedEvent;
+    use Symfony\AI\Platform\Event\ResultErrorEvent;
+
+    $eventDispatcher->addListener(ResultConvertedEvent::class, function (ResultConvertedEvent $event) {
+        // $event->getResult() is the resolved result; a listener may replace it via setResult()
+    });
+
+    $eventDispatcher->addListener(ResultErrorEvent::class, function (ResultErrorEvent $event) {
+        // $event->getError() carries the conversion exception (still rethrown to the caller)
+    });
+
+A listener exception from ``ResultConvertedEvent`` propagates to the caller and does
+not trigger ``ResultErrorEvent``, which fires only when the conversion itself fails.
+
+For a streamed result, ``ResultConvertedEvent`` fires when the stream result is created,
+not when it is fully consumed.
+
 Options
 -------
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Add `ResultConvertedEvent` and `ResultErrorEvent`, dispatched when the deferred result is actually converted (or conversion fails) instead of when the not-yet-resolved `ResultEvent` fires, so listeners can act on the resolved result
  * Add `provider` and `context` arguments to `#[Schema]` plus `SchemaProviderInterface` to contribute JSON Schema fragments computed at runtime (env, database, services) for tool parameters and structured output properties; `provider` accepts any container service ID and `context` is passed to `getSchemaFragment()`
  * Add `PartialJsonParser` for recovering partial JSON from streaming output
  * Add `DeferredResult::asPartialJsonStream()` yielding the largest recoverable JSON value from each streamed delta

--- a/src/platform/src/Event/ResultConvertedEvent.php
+++ b/src/platform/src/Event/ResultConvertedEvent.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Event;
+
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event dispatched after the deferred result has been converted into the actual result.
+ *
+ * Unlike ResultEvent, which fires when the deferred result object is created, this event
+ * is dispatched lazily once the raw result has actually been converted, so listeners can
+ * act on the resolved result.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ResultConvertedEvent extends Event
+{
+    /**
+     * @param array<string, mixed>               $options
+     * @param array<string, mixed>|string|object $input
+     */
+    public function __construct(
+        private readonly Model $model,
+        private ResultInterface $result,
+        private readonly array $options = [],
+        private readonly array|string|object $input = [],
+    ) {
+    }
+
+    public function getModel(): Model
+    {
+        return $this->model;
+    }
+
+    public function getResult(): ResultInterface
+    {
+        return $this->result;
+    }
+
+    public function setResult(ResultInterface $result): void
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @return array<string, mixed>|string|object
+     */
+    public function getInput(): array|string|object
+    {
+        return $this->input;
+    }
+}

--- a/src/platform/src/Event/ResultErrorEvent.php
+++ b/src/platform/src/Event/ResultErrorEvent.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Event;
+
+use Symfony\AI\Platform\Model;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event dispatched when converting the deferred result failed.
+ *
+ * Dispatched lazily once the conversion of the raw result throws, so listeners can
+ * observe the failure (e.g. to release resources). The underlying exception is still
+ * rethrown to the caller afterwards.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ResultErrorEvent extends Event
+{
+    /**
+     * @param array<string, mixed>               $options
+     * @param array<string, mixed>|string|object $input
+     */
+    public function __construct(
+        private readonly Model $model,
+        private readonly \Throwable $error,
+        private readonly array $options = [],
+        private readonly array|string|object $input = [],
+    ) {
+    }
+
+    public function getModel(): Model
+    {
+        return $this->model;
+    }
+
+    public function getError(): \Throwable
+    {
+        return $this->error;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @return array<string, mixed>|string|object
+     */
+    public function getInput(): array|string|object
+    {
+        return $this->input;
+    }
+}

--- a/src/platform/src/Provider.php
+++ b/src/platform/src/Provider.php
@@ -12,12 +12,15 @@
 namespace Symfony\AI\Platform;
 
 use Symfony\AI\Platform\Event\InvocationEvent;
+use Symfony\AI\Platform\Event\ResultConvertedEvent;
+use Symfony\AI\Platform\Event\ResultErrorEvent;
 use Symfony\AI\Platform\Event\ResultEvent;
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -107,7 +110,25 @@ final class Provider implements ProviderInterface
         $resultEvent = new ResultEvent($model, $result, $options, $input);
         $this->eventDispatcher?->dispatch($resultEvent);
 
-        return $resultEvent->getDeferredResult();
+        // Register on the deferred result the ResultEvent listeners ultimately produced, since a
+        // listener may swap it out via setDeferredResult(). A listener that resolves the result
+        // eagerly (defeating the laziness) would therefore convert before these are registered and
+        // miss ResultConvertedEvent.
+        $deferredResult = $resultEvent->getDeferredResult();
+
+        if (null !== $this->eventDispatcher) {
+            $deferredResult->onConvert(function (ResultInterface $result) use ($model, $options, $input): ResultInterface {
+                $event = new ResultConvertedEvent($model, $result, $options, $input);
+                $this->eventDispatcher->dispatch($event);
+
+                return $event->getResult();
+            });
+            $deferredResult->onError(function (\Throwable $error) use ($model, $options, $input): void {
+                $this->eventDispatcher->dispatch(new ResultErrorEvent($model, $error, $options, $input));
+            });
+        }
+
+        return $deferredResult;
     }
 
     public function getModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -34,6 +34,16 @@ final class DeferredResult
     private ?\Throwable $conversionFailure = null;
 
     /**
+     * @var list<\Closure(ResultInterface): ResultInterface>
+     */
+    private array $onConvert = [];
+
+    /**
+     * @var list<\Closure(\Throwable): void>
+     */
+    private array $onError = [];
+
+    /**
      * @param array<string, mixed> $options
      */
     public function __construct(
@@ -41,6 +51,31 @@ final class DeferredResult
         private readonly RawResultInterface $rawResult,
         private readonly array $options = [],
     ) {
+    }
+
+    /**
+     * Registers a callback invoked with the converted result once conversion succeeds.
+     *
+     * The callback may return a replacement result, which is then used as the converted result
+     * and handed to any subsequently registered callback. Callbacks run in registration order.
+     *
+     * @param \Closure(ResultInterface): ResultInterface $callback
+     */
+    public function onConvert(\Closure $callback): void
+    {
+        $this->onConvert[] = $callback;
+    }
+
+    /**
+     * Registers a callback invoked with the thrown exception when conversion fails.
+     *
+     * Callbacks run in registration order.
+     *
+     * @param \Closure(\Throwable): void $callback
+     */
+    public function onError(\Closure $callback): void
+    {
+        $this->onError[] = $callback;
     }
 
     /**
@@ -84,7 +119,19 @@ final class DeferredResult
             $this->isConverted = true;
         } catch (\Throwable $exception) {
             $this->conversionFailure = $exception;
+
+            foreach ($this->onError as $callback) {
+                $callback($exception);
+            }
+
             throw $exception;
+        }
+
+        // Run conversion callbacks outside the try/catch: conversion has already
+        // succeeded, so a throwing callback must not be reported as a conversion
+        // failure nor leave the result in a half-converted state.
+        foreach ($this->onConvert as $callback) {
+            $this->convertedResult = $callback($this->convertedResult);
         }
 
         return $this->convertedResult;

--- a/src/platform/tests/Event/ResultConvertedEventTest.php
+++ b/src/platform/tests/Event/ResultConvertedEventTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Event\ResultConvertedEvent;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\TextResult;
+
+final class ResultConvertedEventTest extends TestCase
+{
+    public function testGettersReturnConstructorValues()
+    {
+        $model = new Model('test-model', [Capability::OUTPUT_TEXT]);
+        $result = new TextResult('Hello');
+        $options = ['temperature' => 0.7];
+
+        $event = new ResultConvertedEvent($model, $result, $options, 'Hello?');
+
+        $this->assertSame($model, $event->getModel());
+        $this->assertSame($result, $event->getResult());
+        $this->assertSame($options, $event->getOptions());
+        $this->assertSame('Hello?', $event->getInput());
+    }
+
+    public function testSetResultOverridesResolvedResult()
+    {
+        $event = new ResultConvertedEvent(new Model('test-model', [Capability::OUTPUT_TEXT]), new TextResult('Hello'));
+
+        $newResult = new TextResult('World');
+        $event->setResult($newResult);
+
+        $this->assertSame($newResult, $event->getResult());
+    }
+}

--- a/src/platform/tests/Event/ResultErrorEventTest.php
+++ b/src/platform/tests/Event/ResultErrorEventTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Event\ResultErrorEvent;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+
+final class ResultErrorEventTest extends TestCase
+{
+    public function testGettersReturnConstructorValues()
+    {
+        $model = new Model('test-model', [Capability::OUTPUT_TEXT]);
+        $error = new RuntimeException('conversion failed');
+        $options = ['temperature' => 0.7];
+
+        $event = new ResultErrorEvent($model, $error, $options, 'Hello?');
+
+        $this->assertSame($model, $event->getModel());
+        $this->assertSame($error, $event->getError());
+        $this->assertSame($options, $event->getOptions());
+        $this->assertSame('Hello?', $event->getInput());
+    }
+}

--- a/src/platform/tests/ProviderTest.php
+++ b/src/platform/tests/ProviderTest.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Platform\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Event\InvocationEvent;
+use Symfony\AI\Platform\Event\ResultConvertedEvent;
+use Symfony\AI\Platform\Event\ResultErrorEvent;
 use Symfony\AI\Platform\Event\ResultEvent;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -211,6 +213,85 @@ final class ProviderTest extends TestCase
         $this->assertCount(2, $dispatchedEvents);
         $this->assertInstanceOf(InvocationEvent::class, $dispatchedEvents[0]);
         $this->assertInstanceOf(ResultEvent::class, $dispatchedEvents[1]);
+    }
+
+    public function testInvokeDispatchesResultConvertedEventOnConversion()
+    {
+        $model = new Model('gpt-4o', [Capability::INPUT_MESSAGES]);
+        $textResult = new TextResult('Hello');
+
+        $catalog = $this->createStub(ModelCatalogInterface::class);
+        $catalog->method('getModel')->willReturn($model);
+
+        $modelClient = $this->createStub(ModelClientInterface::class);
+        $modelClient->method('supports')->willReturn(true);
+        $modelClient->method('request')->willReturn($this->createStub(RawResultInterface::class));
+
+        $resultConverter = $this->createStub(ResultConverterInterface::class);
+        $resultConverter->method('supports')->willReturn(true);
+        $resultConverter->method('convert')->willReturn($textResult);
+
+        $dispatchedEvents = [];
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')
+            ->willReturnCallback(static function ($event) use (&$dispatchedEvents) {
+                $dispatchedEvents[] = $event;
+
+                return $event;
+            });
+
+        $provider = new Provider('openai', [$modelClient], [$resultConverter], $catalog, null, $eventDispatcher);
+
+        $deferredResult = $provider->invoke('gpt-4o', 'Hello');
+
+        // The converted event is only dispatched once the result is actually converted.
+        $this->assertCount(2, $dispatchedEvents);
+
+        $deferredResult->getResult();
+
+        $this->assertCount(3, $dispatchedEvents);
+        $this->assertInstanceOf(ResultConvertedEvent::class, $dispatchedEvents[2]);
+        $this->assertSame($textResult, $dispatchedEvents[2]->getResult());
+    }
+
+    public function testInvokeDispatchesResultErrorEventOnConversionFailure()
+    {
+        $model = new Model('gpt-4o', [Capability::INPUT_MESSAGES]);
+        $exception = new RuntimeException('conversion failed');
+
+        $catalog = $this->createStub(ModelCatalogInterface::class);
+        $catalog->method('getModel')->willReturn($model);
+
+        $modelClient = $this->createStub(ModelClientInterface::class);
+        $modelClient->method('supports')->willReturn(true);
+        $modelClient->method('request')->willReturn($this->createStub(RawResultInterface::class));
+
+        $resultConverter = $this->createStub(ResultConverterInterface::class);
+        $resultConverter->method('supports')->willReturn(true);
+        $resultConverter->method('convert')->willThrowException($exception);
+
+        $dispatchedEvents = [];
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')
+            ->willReturnCallback(static function ($event) use (&$dispatchedEvents) {
+                $dispatchedEvents[] = $event;
+
+                return $event;
+            });
+
+        $provider = new Provider('openai', [$modelClient], [$resultConverter], $catalog, null, $eventDispatcher);
+
+        $deferredResult = $provider->invoke('gpt-4o', 'Hello');
+
+        try {
+            $deferredResult->getResult();
+            $this->fail('Expected RuntimeException to be thrown.');
+        } catch (RuntimeException $thrown) {
+            $this->assertSame($exception, $thrown);
+        }
+
+        $this->assertInstanceOf(ResultErrorEvent::class, $dispatchedEvents[2]);
+        $this->assertSame($exception, $dispatchedEvents[2]->getError());
     }
 
     public function testGetModelCatalog()

--- a/src/platform/tests/Result/DeferredResultTest.php
+++ b/src/platform/tests/Result/DeferredResultTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Tests\Result;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\Result\BaseResult;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -262,6 +263,120 @@ final class DeferredResultTest extends TestCase
         $deferredResult = new DeferredResult(new PlainConverter($result), new InMemoryRawResult());
 
         $this->assertSame([], iterator_to_array($deferredResult->asPartialJsonStream(), false));
+    }
+
+    public function testOnConvertCallbackReceivesConvertedResultOnce()
+    {
+        $textResult = new TextResult('test content');
+        $deferredResult = new DeferredResult(new PlainConverter($textResult), new InMemoryRawResult());
+
+        $received = [];
+        $deferredResult->onConvert(static function (ResultInterface $result) use (&$received): ResultInterface {
+            $received[] = $result;
+
+            return $result;
+        });
+
+        $deferredResult->getResult();
+        $deferredResult->getResult();
+
+        $this->assertCount(1, $received);
+        $this->assertSame($textResult, $received[0]);
+    }
+
+    public function testOnConvertCallbackCanReplaceConvertedResult()
+    {
+        $replacement = new TextResult('replaced');
+        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('original')), new InMemoryRawResult());
+
+        $deferredResult->onConvert(static fn (ResultInterface $result): ResultInterface => $replacement);
+
+        $this->assertSame($replacement, $deferredResult->getResult());
+    }
+
+    public function testOnConvertCallbacksRunInRegistrationOrderAndChain()
+    {
+        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('original')), new InMemoryRawResult());
+
+        $order = [];
+        $received = [];
+        $first = new TextResult('first');
+        $second = new TextResult('second');
+
+        $deferredResult->onConvert(static function (ResultInterface $result) use (&$order, &$received, $first): ResultInterface {
+            $order[] = 'a';
+            $received[] = $result;
+
+            return $first;
+        });
+        $deferredResult->onConvert(static function (ResultInterface $result) use (&$order, &$received, $second): ResultInterface {
+            $order[] = 'b';
+            $received[] = $result;
+
+            return $second;
+        });
+
+        $this->assertSame($second, $deferredResult->getResult());
+        $this->assertSame(['a', 'b'], $order);
+        // The second callback receives the replacement returned by the first.
+        $this->assertSame($first, $received[1]);
+    }
+
+    public function testOnConvertCallbackExceptionDoesNotTriggerOnError()
+    {
+        $textResult = new TextResult('test content');
+        $deferredResult = new DeferredResult(new PlainConverter($textResult), new InMemoryRawResult());
+
+        $failure = new RuntimeException('listener failed');
+        $deferredResult->onConvert(static function () use ($failure): ResultInterface {
+            throw $failure;
+        });
+
+        $onErrorCalled = false;
+        $deferredResult->onError(static function () use (&$onErrorCalled): void {
+            $onErrorCalled = true;
+        });
+
+        try {
+            $deferredResult->getResult();
+            $this->fail('Expected the listener exception to propagate.');
+        } catch (RuntimeException $thrown) {
+            $this->assertSame($failure, $thrown);
+        }
+
+        $this->assertFalse($onErrorCalled);
+
+        // Conversion succeeded, so the result stays accessible and the callback does not run again.
+        $this->assertSame($textResult, $deferredResult->getResult());
+    }
+
+    public function testOnErrorCallbackReceivesExceptionOnce()
+    {
+        $rawHttpResult = new RawHttpResult($this->createStub(SymfonyHttpResponse::class));
+        $exception = new RateLimitExceededException();
+
+        $resultConverter = $this->createMock(ResultConverterInterface::class);
+        $resultConverter->expects($this->once())
+            ->method('convert')
+            ->willThrowException($exception);
+
+        $deferredResult = new DeferredResult($resultConverter, $rawHttpResult);
+
+        $received = [];
+        $deferredResult->onError(static function (\Throwable $error) use (&$received): void {
+            $received[] = $error;
+        });
+
+        for ($i = 0; $i < 2; ++$i) {
+            try {
+                $deferredResult->getResult();
+                $this->fail('Expected RateLimitExceededException.');
+            } catch (RateLimitExceededException) {
+            }
+        }
+
+        $this->assertCount(1, $received);
+        $this->assertSame($exception, $received[0]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1519
| License       | MIT

Adds `ResultConvertedEvent` and `ResultErrorEvent`, dispatched lazily when the deferred result is actually converted (or conversion fails), instead of relying on `ResultEvent` which fires before the result is resolved. `Provider` wires `onConvert`/`onError` callbacks on the final `DeferredResult` so the events fire at the real conversion point in `DeferredResult::getResult()`.

```php
$dispatcher->addListener(ResultConvertedEvent::class, function (ResultConvertedEvent $event) {
    $event->getResult(); // resolved result; can be replaced via setResult()
});
$dispatcher->addListener(ResultErrorEvent::class, function (ResultErrorEvent $event) {
    $event->getError(); // conversion exception (still rethrown)
});
```