### PR TITLE
 Harden error handling in Deepgram and MiniMax bridges

### DIFF
--- a/src/platform/src/Bridge/Deepgram/DeepgramClient.php
+++ b/src/platform/src/Bridge/Deepgram/DeepgramClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Deepgram;
 
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -24,6 +25,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class DeepgramClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
     ) {
@@ -60,9 +63,12 @@ final class DeepgramClient implements ModelClientInterface
                 'model' => $model->getName(),
                 ...$options,
             ],
-            'json' => [
-                'text' => $payload->asTextToSpeechPayload(),
+            'headers' => [
+                'Content-Type' => 'application/json',
             ],
+            'body' => $this->encodeJsonBody([
+                'text' => $payload->asTextToSpeechPayload(),
+            ]),
         ]));
     }
 
@@ -81,9 +87,12 @@ final class DeepgramClient implements ModelClientInterface
         if ($payload->isUrlBased()) {
             return new RawHttpResult($this->httpClient->request('POST', 'listen', [
                 'query' => $query,
-                'json' => [
-                    'url' => $payload->getAudioUrl(),
+                'headers' => [
+                    'Content-Type' => 'application/json',
                 ],
+                'body' => $this->encodeJsonBody([
+                    'url' => $payload->getAudioUrl(),
+                ]),
             ]));
         }
 

--- a/src/platform/src/Bridge/Deepgram/DeepgramResultConverter.php
+++ b/src/platform/src/Bridge/Deepgram/DeepgramResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Deepgram;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -31,6 +32,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class DeepgramResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
     ) {
@@ -54,6 +57,8 @@ final class DeepgramResultConverter implements ResultConverterInterface
         $path = \is_string($path) ? $path : '';
 
         if (200 !== $response->getStatusCode()) {
+            $this->throwOnHttpError($response);
+
             throw new RuntimeException($this->extractErrorMessage($response));
         }
 

--- a/src/platform/src/Bridge/Deepgram/Tests/DeepgramResultConverterTest.php
+++ b/src/platform/src/Bridge/Deepgram/Tests/DeepgramResultConverterTest.php
@@ -16,7 +16,12 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Deepgram\Deepgram;
 use Symfony\AI\Platform\Bridge\Deepgram\DeepgramResultConverter;
 use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\BadRequestException;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
@@ -215,6 +220,50 @@ final class DeepgramResultConverterTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The Deepgram API returned a non-successful status code "500".');
+
+        (new DeepgramResultConverter($httpClient))->convert(new RawHttpResult($response));
+    }
+
+    /**
+     * @param class-string<\Throwable> $expectedException
+     */
+    #[DataProvider('provideTypedExceptionStatuses')]
+    public function testMapsHttpStatusToTypedException(int $statusCode, string $expectedException)
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['err_msg' => 'Something went wrong.'], ['http_code' => $statusCode]),
+        ], 'https://api.deepgram.com/v1/');
+
+        $response = $httpClient->request('POST', 'listen');
+
+        $this->expectException($expectedException);
+
+        (new DeepgramResultConverter($httpClient))->convert(new RawHttpResult($response));
+    }
+
+    /**
+     * @return iterable<string, array{int, class-string<\Throwable>}>
+     */
+    public static function provideTypedExceptionStatuses(): iterable
+    {
+        yield '400 bad request' => [400, BadRequestException::class];
+        yield '401 unauthorized' => [401, AuthenticationException::class];
+        yield '404 not found' => [404, ModelNotFoundException::class];
+        yield '429 rate limited' => [429, RateLimitExceededException::class];
+        yield '500 server error' => [500, ServerException::class];
+        yield '503 server error' => [503, ServerException::class];
+    }
+
+    public function testFallsBackToGenericExceptionOnUnhandledStatus()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['err_msg' => 'Payment required.'], ['http_code' => 402]),
+        ], 'https://api.deepgram.com/v1/');
+
+        $response = $httpClient->request('POST', 'listen');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The Deepgram API returned an error: "Payment required.".');
 
         (new DeepgramResultConverter($httpClient))->convert(new RawHttpResult($response));
     }

--- a/src/platform/src/Bridge/MiniMax/MiniMaxClient.php
+++ b/src/platform/src/Bridge/MiniMax/MiniMaxClient.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\MiniMax;
 
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -24,6 +25,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class MiniMaxClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         #[\SensitiveParameter] private readonly string $apiKey,
@@ -63,11 +66,14 @@ final class MiniMaxClient implements ModelClientInterface
 
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/chat/completions', $this->endpoint), [
             'auth_bearer' => $this->apiKey,
-            'json' => [
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'body' => $this->encodeJsonBody([
                 ...$options,
                 'model' => $model->getName(),
                 'messages' => $payload['messages'],
-            ],
+            ]),
         ]));
     }
 
@@ -91,7 +97,10 @@ final class MiniMaxClient implements ModelClientInterface
 
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/%s', $this->endpoint, $async ? 't2a_async_v2' : 't2a_v2'), [
             'auth_bearer' => $this->apiKey,
-            'json' => $json,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'body' => $this->encodeJsonBody($json),
         ]));
     }
 
@@ -111,7 +120,10 @@ final class MiniMaxClient implements ModelClientInterface
 
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/image_generation', $this->endpoint), [
             'auth_bearer' => $this->apiKey,
-            'json' => $json,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'body' => $this->encodeJsonBody($json),
         ]));
     }
 
@@ -135,7 +147,10 @@ final class MiniMaxClient implements ModelClientInterface
 
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/music_generation', $this->endpoint), [
             'auth_bearer' => $this->apiKey,
-            'json' => $json,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'body' => $this->encodeJsonBody($json),
         ]));
     }
 
@@ -151,7 +166,10 @@ final class MiniMaxClient implements ModelClientInterface
 
         return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/video_generation', $this->endpoint), [
             'auth_bearer' => $this->apiKey,
-            'json' => $json,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'body' => $this->encodeJsonBody($json),
         ]));
     }
 

--- a/src/platform/src/Bridge/MiniMax/MiniMaxResultConverter.php
+++ b/src/platform/src/Bridge/MiniMax/MiniMaxResultConverter.php
@@ -11,10 +11,13 @@
 
 namespace Symfony\AI\Platform\Bridge\MiniMax;
 
+use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
@@ -31,6 +34,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class MiniMaxResultConverter implements ResultConverterInterface
 {
+    use HttpStatusErrorHandlingTrait;
+
     /**
      * Delay, in seconds, between two polls of an asynchronous task.
      */
@@ -60,13 +65,17 @@ final class MiniMaxResultConverter implements ResultConverterInterface
         return $model instanceof MiniMax;
     }
 
-    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
     {
+        $response = $result->getObject();
+
+        $this->throwOnHttpError($response);
+
         if ($options['stream'] ?? false) {
             return new StreamResult($this->convertStream($result));
         }
 
-        $url = (string) $result->getObject()->getInfo('url');
+        $url = (string) $response->getInfo('url');
 
         return match (true) {
             str_contains($url, '/chat/completions') => new TextResult($result->getData()['choices'][0]['message']['content']),
@@ -89,9 +98,18 @@ final class MiniMaxResultConverter implements ResultConverterInterface
      */
     private function convertStream(RawResultInterface $result): \Generator
     {
+        $sawChunk = false;
+        $sawFinishReason = false;
+
         foreach ($result->getDataStream() as $chunk) {
             if (!\is_array($chunk)) {
                 continue;
+            }
+
+            $sawChunk = true;
+
+            if (null !== ($chunk['choices'][0]['finish_reason'] ?? null)) {
+                $sawFinishReason = true;
             }
 
             $content = $chunk['choices'][0]['delta']['content'] ?? '';
@@ -101,6 +119,10 @@ final class MiniMaxResultConverter implements ResultConverterInterface
             }
 
             yield new TextDelta($content);
+        }
+
+        if ($sawChunk && !$sawFinishReason) {
+            throw new IncompleteStreamException('The MiniMax stream ended before a finish reason.');
         }
     }
 
@@ -159,9 +181,13 @@ final class MiniMaxResultConverter implements ResultConverterInterface
         $fileId = $data['file_id'] ?? null;
 
         for ($poll = 0; $poll < $maxPolls; ++$poll) {
-            $status = $this->httpClient->request('GET', \sprintf('%s/%s?task_id=%s', $this->endpoint, $queryPath, $taskId), [
+            $response = $this->httpClient->request('GET', \sprintf('%s/%s?task_id=%s', $this->endpoint, $queryPath, $taskId), [
                 'auth_bearer' => $this->apiKey,
-            ])->toArray(false);
+            ]);
+
+            $this->throwOnHttpError($response);
+
+            $status = $response->toArray(false);
 
             $fileId = $status['file_id'] ?? $fileId;
             $state = strtolower((string) ($status['status'] ?? ''));
@@ -186,12 +212,20 @@ final class MiniMaxResultConverter implements ResultConverterInterface
             throw new RuntimeException('The MiniMax task did not return a file identifier.');
         }
 
-        $file = $this->httpClient->request('GET', \sprintf('%s/files/retrieve?file_id=%s', $this->endpoint, $fileId), [
+        $response = $this->httpClient->request('GET', \sprintf('%s/files/retrieve?file_id=%s', $this->endpoint, $fileId), [
             'auth_bearer' => $this->apiKey,
-        ])->toArray(false);
+        ]);
+
+        $this->throwOnHttpError($response);
+
+        $file = $response->toArray(false);
 
         $downloadUrl = $file['file']['download_url'] ?? throw new RuntimeException('The MiniMax file does not contain a download URL.');
 
-        return $this->httpClient->request('GET', $downloadUrl)->getContent();
+        $download = $this->httpClient->request('GET', $downloadUrl);
+
+        $this->throwOnHttpError($download);
+
+        return $download->getContent();
     }
 }

--- a/src/platform/src/Bridge/MiniMax/Tests/MiniMaxResultConverterTest.php
+++ b/src/platform/src/Bridge/MiniMax/Tests/MiniMaxResultConverterTest.php
@@ -15,6 +15,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\MiniMax\MiniMax;
 use Symfony\AI\Platform\Bridge\MiniMax\MiniMaxResultConverter;
 use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\RateLimitExceededException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -27,6 +31,7 @@ use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
@@ -75,8 +80,11 @@ final class MiniMaxResultConverterTest extends TestCase
             ['object' => 'chat.completion.chunk', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
         ];
 
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
         $converter = new MiniMaxResultConverter(new MockHttpClient(), 'key');
-        $result = $converter->convert(new InMemoryRawResult(dataStream: $events), ['stream' => true]);
+        $result = $converter->convert(new InMemoryRawResult([], $events, $httpResponse), ['stream' => true]);
 
         $this->assertInstanceOf(StreamResult::class, $result);
 
@@ -201,5 +209,84 @@ final class MiniMaxResultConverterTest extends TestCase
         $this->assertInstanceOf(BinaryResult::class, $result);
         $this->assertSame('FAKE_VIDEO', $result->getContent());
         $this->assertSame('video/mp4', $result->getMimeType());
+    }
+
+    public function testItThrowsAuthenticationExceptionOnUnauthorized()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['message' => 'Invalid API key.'], ['http_code' => 401]));
+        $raw = new RawHttpResult($httpClient->request('POST', 'https://api.minimax.io/v1/chat/completions'));
+        $converter = new MiniMaxResultConverter(new MockHttpClient(), 'key');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid API key.');
+
+        $converter->convert($raw);
+    }
+
+    public function testItThrowsRateLimitExceededExceptionOnTooManyRequests()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['message' => 'Slow down.'], ['http_code' => 429]));
+        $raw = new RawHttpResult($httpClient->request('POST', 'https://api.minimax.io/v1/chat/completions'));
+        $converter = new MiniMaxResultConverter(new MockHttpClient(), 'key');
+
+        $this->expectException(RateLimitExceededException::class);
+
+        $converter->convert($raw);
+    }
+
+    public function testItThrowsServerExceptionOnServerError()
+    {
+        $httpClient = new MockHttpClient(new MockResponse('Service Unavailable', ['http_code' => 503]));
+        $raw = new RawHttpResult($httpClient->request('POST', 'https://api.minimax.io/v1/chat/completions'));
+        $converter = new MiniMaxResultConverter(new MockHttpClient(), 'key');
+
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 503');
+
+        $converter->convert($raw);
+    }
+
+    public function testItThrowsServerExceptionBeforeStreaming()
+    {
+        $httpClient = new MockHttpClient(new MockResponse('Service Unavailable', ['http_code' => 503]));
+        $raw = new RawHttpResult($httpClient->request('POST', 'https://api.minimax.io/v1/chat/completions'));
+        $converter = new MiniMaxResultConverter(new MockHttpClient(), 'key');
+
+        $this->expectException(ServerException::class);
+
+        $converter->convert($raw, ['stream' => true]);
+    }
+
+    public function testItThrowsServerExceptionWhilePollingAsynchronousTask()
+    {
+        $createClient = new MockHttpClient(new JsonMockResponse(['task_id' => '123', 'file_id' => '456']));
+        $raw = new RawHttpResult($createClient->request('POST', 'https://api.minimax.io/v1/t2a_async_v2'));
+
+        $pollClient = new MockHttpClient(new MockResponse('Service Unavailable', ['http_code' => 503]));
+
+        $converter = new MiniMaxResultConverter($pollClient, 'key', 'https://api.minimax.io/v1', new MockClock());
+
+        $this->expectException(ServerException::class);
+
+        $converter->convert($raw);
+    }
+
+    public function testItThrowsIncompleteStreamWhenFinishReasonIsMissing()
+    {
+        $events = [
+            ['object' => 'chat.completion.chunk', 'choices' => [['index' => 0, 'delta' => ['content' => 'Generated ']]]],
+            // stream cut off: no chunk carrying a finish_reason
+        ];
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $converter = new MiniMaxResultConverter(new MockHttpClient(), 'key');
+        $result = $converter->convert(new InMemoryRawResult([], $events, $httpResponse), ['stream' => true]);
+
+        $this->expectException(IncompleteStreamException::class);
+        $this->expectExceptionMessage('The MiniMax stream ended before a finish reason.');
+
+        iterator_to_array($result->getContent());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Brings the late-joiner Deepgram and MiniMax bridges up to the v0.10/v0.11 error-handling baseline.

- **MiniMax**: adopts `HttpStatusErrorHandlingTrait`, validating HTTP status *before* parsing and *before* streaming (previously it parsed responses blindly, so a 401/429/5xx surfaced as an "undefined array key"). Also guards the async polling/download requests, throws `IncompleteStreamException` on truncated streams, and uses `JsonBodyEncodingTrait` for request bodies.
- **Deepgram**: adopts `HttpStatusErrorHandlingTrait` so non-2xx responses raise typed exceptions (`AuthenticationException`, `ServerException`, …) instead of a generic `RuntimeException`, while preserving its richer error-message extraction as a fallback. Also uses `JsonBodyEncodingTrait`.

Error-path tests added for both bridges. No CHANGELOG entries (bug fix, both bridges unreleased).