### PR TITLE
[Platform] Fix PHPStan errors in Schema attribute and TypeInfoDescriber

### DIFF
--- a/src/platform/src/Contract/JsonSchema/Attribute/Schema.php
+++ b/src/platform/src/Contract/JsonSchema/Attribute/Schema.php
@@ -78,7 +78,13 @@ final class Schema
         }
 
         if (\is_array($enum)) {
-            if (array_filter($enum, static fn (mixed $item) => null === $item || \is_int($item) || \is_float($item) || \is_string($item)) !== $enum) {
+            // Attribute arguments are not type-checked against the docblock at runtime, so guard explicitly.
+            /** @var mixed $item */
+            foreach ($enum as $item) {
+                if (null === $item || \is_int($item) || \is_float($item) || \is_string($item)) {
+                    continue;
+                }
+
                 throw new InvalidArgumentException('All enum values must be float, integer, strings, or null.');
             }
         }

--- a/src/platform/src/Contract/JsonSchema/Describer/TypeInfoDescriber.php
+++ b/src/platform/src/Contract/JsonSchema/Describer/TypeInfoDescriber.php
@@ -85,6 +85,8 @@ final class TypeInfoDescriber implements ObjectDescriberInterface, PropertyDescr
     }
 
     /**
+     * @param Type<*> $type
+     *
      * @return array<string, mixed>
      */
     private function getTypeSchema(Type $type): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Fixes two PHPStan errors on the `PHPStan / Component / Platform` CI job. Both are static-analysis-only; no behavior change.

### 1. `Schema` enum guard — `function.alreadyNarrowedType`

```
src/Contract/JsonSchema/Attribute/Schema.php
Call to function is_string() with string will always evaluate to true.
```

`$enum` is declared `list<int|float|string|null>`, so PHPStan considers the per-element `is_int/is_float/is_string` checks exhaustive and flags the guard as redundant. It is **not** redundant at runtime: PHP attribute arguments aren't validated against docblock generics, so e.g. `#[Schema(enum: [true])]` would slip a `bool` through. Rewrites the `array_filter(...) !== $enum` one-liner into an explicit `foreach` with the iterated value annotated as `mixed` — keeping the guard while satisfying PHPStan. Unlike the previous `@phpstan-ignore-next-line` (removed in 656a1686, then resurfaced), this is version-stable.

### 2. `TypeInfoDescriber::getTypeSchema()` — `missingType.generics`

```
src/Contract/JsonSchema/Describer/TypeInfoDescriber.php
parameter $type with generic class Symfony\Component\TypeInfo\Type does not specify its types: T
```

`symfony/type-info` made the base `Type` class generic (`@template T`), so the bare `Type $type` parameter triggers `missingType.generics` once CI installs the newer version. Annotates the parameter as `Type<*>`.
