### PR TITLE
[Platform][Bedrock] Extract token usage from Claude results

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Extract token usage from Amazon Bedrock Claude results: `Bridge\Bedrock\Anthropic\ClaudeResultConverter` now returns the Anthropic `TokenUsageExtractor`, so `token_usage` is populated in the result metadata as it already is for the Anthropic API bridge
  * Add `provider` and `context` arguments to `#[Schema]` plus `SchemaProviderInterface` to contribute JSON Schema fragments computed at runtime (env, database, services) for tool parameters and structured output properties; `provider` accepts any container service ID and `context` is passed to `getSchemaFragment()`
  * Add `PartialJsonParser` for recovering partial JSON from streaming output
  * Add `DeferredResult::asPartialJsonStream()` yielding the largest recoverable JSON value from each streamed delta

--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeResultConverter.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Bedrock\Anthropic;
 
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
+use Symfony\AI\Platform\Bridge\Anthropic\TokenUsageExtractor;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
@@ -59,6 +60,8 @@ final class ClaudeResultConverter implements ResultConverterInterface
 
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
     {
-        return null;
+        // Bedrock returns Claude's usage in the same shape as the Anthropic API,
+        // so the Anthropic extractor reads it as-is.
+        return new TokenUsageExtractor();
     }
 }

--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeResultConverter.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeResultConverter.php
@@ -21,7 +21,6 @@ use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
-use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 
 /**
  * @author Björn Altmann
@@ -58,7 +57,7 @@ final class ClaudeResultConverter implements ResultConverterInterface
         return new TextResult($data['content'][0]['text']);
     }
 
-    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    public function getTokenUsageExtractor(): TokenUsageExtractor
     {
         // Bedrock returns Claude's usage in the same shape as the Anthropic API,
         // so the Anthropic extractor reads it as-is.

--- a/src/platform/src/Bridge/Bedrock/Tests/Anthropic/ClaudeResultConverterTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/Anthropic/ClaudeResultConverterTest.php
@@ -16,6 +16,7 @@ use AsyncAws\Core\Test\ResultMockFactory;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
+use Symfony\AI\Platform\Bridge\Anthropic\TokenUsageExtractor;
 use Symfony\AI\Platform\Bridge\Bedrock\Anthropic\ClaudeResultConverter;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -229,5 +230,68 @@ final class ClaudeResultConverterTest extends TestCase
 
         $this->assertInstanceOf(TextResult::class, $result);
         $this->assertSame('Valid text content', $result->getContent());
+    }
+
+    #[TestDox('Provides the Anthropic token usage extractor')]
+    public function testProvidesTokenUsageExtractor()
+    {
+        $converter = new ClaudeResultConverter();
+
+        $this->assertInstanceOf(TokenUsageExtractor::class, $converter->getTokenUsageExtractor());
+    }
+
+    #[TestDox('Extracts token usage from the Bedrock response')]
+    public function testExtractsTokenUsage()
+    {
+        $invokeResponse = ResultMockFactory::create(InvokeModelResponse::class, [
+            'body' => json_encode([
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Hello, world!',
+                    ],
+                ],
+                'usage' => [
+                    'input_tokens' => 100,
+                    'output_tokens' => 20,
+                    'cache_creation_input_tokens' => 5,
+                    'cache_read_input_tokens' => 900,
+                ],
+            ]),
+        ]);
+        $rawResult = new RawBedrockResult($invokeResponse);
+
+        $converter = new ClaudeResultConverter();
+        $extractor = $converter->getTokenUsageExtractor();
+        $this->assertNotNull($extractor);
+
+        $tokenUsage = $extractor->extract($rawResult);
+        $this->assertNotNull($tokenUsage);
+        $this->assertSame(100, $tokenUsage->getPromptTokens());
+        $this->assertSame(20, $tokenUsage->getCompletionTokens());
+        $this->assertSame(5, $tokenUsage->getCacheCreationTokens());
+        $this->assertSame(900, $tokenUsage->getCacheReadTokens());
+    }
+
+    #[TestDox('Returns no token usage when the response omits usage')]
+    public function testExtractsNoTokenUsageWhenAbsent()
+    {
+        $invokeResponse = ResultMockFactory::create(InvokeModelResponse::class, [
+            'body' => json_encode([
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Hello, world!',
+                    ],
+                ],
+            ]),
+        ]);
+        $rawResult = new RawBedrockResult($invokeResponse);
+
+        $converter = new ClaudeResultConverter();
+        $extractor = $converter->getTokenUsageExtractor();
+        $this->assertNotNull($extractor);
+
+        $this->assertNull($extractor->extract($rawResult));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | n/a
| License       | MIT

The Amazon Bedrock Claude result converter returned `null` from `getTokenUsageExtractor()`, so the platform never populated a `token_usage` entry in the result metadata. The direct Anthropic API bridge already does this via its `TokenUsageExtractor`.

Bedrock returns Claude's `usage` in the same shape as the Anthropic API (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`), so this returns the existing Anthropic `TokenUsageExtractor` instead of `null`. `DeferredResult` then promotes the extracted `TokenUsage` into the result metadata, just like for the Anthropic bridge.

```php
$result = $platform->invoke($model, $messages)->getResult();
$usage = $result->getMetadata()->get('token_usage'); // now populated for Bedrock Claude
```

The extractor already short-circuits to `null` when the response has no `usage` block or when `stream` is set, so non-streaming behavior is unaffected and streaming (handled via deltas) is untouched.

Added tests covering: the extractor is provided, usage is extracted from a Bedrock response, and `null` is returned when usage is absent.
