### PR TITLE
[Examples] Streamline binary file handling

### DIFF
--- a/examples/cartesia/text-to-speech.php
+++ b/examples/cartesia/text-to-speech.php
@@ -29,4 +29,4 @@ $result = $platform->invoke('sonic-3', new Text('Hello world'), [
     ],
 ]);
 
-echo $result->asBinary().\PHP_EOL;
+echo $result->asBinary();

--- a/examples/decart/.gitignore
+++ b/examples/decart/.gitignore
@@ -1,0 +1,4 @@
+animated-image.mp4
+image-editing.png
+text-to-image.png
+text-to-video.mp4

--- a/examples/decart/animated-image.php
+++ b/examples/decart/animated-image.php
@@ -23,4 +23,6 @@ $result = $platform->invoke('lucy-pro-i2v', Image::fromFile(dirname(__DIR__, 2).
     'prompt' => 'Make the man move from right to left while playing accordion',
 ]);
 
-echo $result->asBinary().\PHP_EOL;
+$result->asFile(__DIR__.'/animated-image.mp4');
+
+echo 'Video saved to animated-image.mp4'.\PHP_EOL;

--- a/examples/decart/image-editing.php
+++ b/examples/decart/image-editing.php
@@ -23,4 +23,6 @@ $result = $platform->invoke('lucy-pro-i2i', Image::fromFile(dirname(__DIR__, 2).
     'prompt' => 'Colorize the walls',
 ]);
 
-echo $result->asBinary().\PHP_EOL;
+$result->asFile(__DIR__.'/image-editing.png');
+
+echo 'Image saved to image-editing.png'.\PHP_EOL;

--- a/examples/decart/text-to-image.php
+++ b/examples/decart/text-to-image.php
@@ -21,4 +21,6 @@ $platform = Factory::createPlatform(
 
 $result = $platform->invoke('lucy-pro-t2i', new Text('A cat on a kitchen table'));
 
-echo $result->asBinary().\PHP_EOL;
+$result->asFile(__DIR__.'/text-to-image.png');
+
+echo 'Image saved to text-to-image.png'.\PHP_EOL;

--- a/examples/decart/text-to-video.php
+++ b/examples/decart/text-to-video.php
@@ -21,4 +21,6 @@ $platform = Factory::createPlatform(
 
 $result = $platform->invoke('lucy-pro-t2v', new Text('A serene ocean with dolphins jumping at sunset'));
 
-echo $result->asBinary();
+$result->asFile(__DIR__.'/text-to-video.mp4');
+
+echo 'Video saved to text-to-video.mp4'.\PHP_EOL;

--- a/examples/deepgram/text-to-speech.php
+++ b/examples/deepgram/text-to-speech.php
@@ -18,4 +18,4 @@ $platform = Factory::createPlatform(apiKey: env('DEEPGRAM_API_KEY'), httpClient:
 
 $result = $platform->invoke('aura-2-thalia-en', new Text('Hello world'));
 
-file_put_contents('php://stdout', $result->asBinary());
+echo $result->asBinary();

--- a/examples/elevenlabs/text-to-speech-as-stream.php
+++ b/examples/elevenlabs/text-to-speech-as-stream.php
@@ -22,12 +22,8 @@ $result = $platform->invoke('eleven_multilingual_v2', new Text('The first move i
     'stream' => true,
 ]);
 
-$content = '';
-
 foreach ($result->asStream() as $chunk) {
     if ($chunk instanceof BinaryDelta) {
         echo $chunk->getData();
     }
 }
-
-echo \PHP_EOL;

--- a/examples/elevenlabs/text-to-speech.php
+++ b/examples/elevenlabs/text-to-speech.php
@@ -20,4 +20,4 @@ $result = $platform->invoke('eleven_multilingual_v2', new Text('Hello world'), [
     'voice' => 'pqHfZKP75CvOlQylNhV4', // Bill
 ]);
 
-echo $result->asBinary().\PHP_EOL;
+echo $result->asBinary();

--- a/examples/gemini/multi-speaker-voice.php
+++ b/examples/gemini/multi-speaker-voice.php
@@ -52,4 +52,4 @@ $result = $platform->invoke('gemini-2.5-flash-preview-tts', $messages, [
 // php examples/gemini/multi-speaker-voice.php > out.pcm
 // ffmpeg -f s16le -ar 24000 -ac 1 -i out.pcm out.wav
 
-echo $result->asBinary().\PHP_EOL;
+echo $result->asBinary();

--- a/examples/gemini/single-speaker-voice.php
+++ b/examples/gemini/single-speaker-voice.php
@@ -35,4 +35,4 @@ $result = $platform->invoke('gemini-2.5-flash-preview-tts', $messages, [
 // php examples/gemini/single-speaker-voice.php > out.pcm
 // ffmpeg -f s16le -ar 24000 -ac 1 -i out.pcm out.wav
 
-echo $result->asBinary().\PHP_EOL;
+echo $result->asBinary();

--- a/examples/minimax/.gitignore
+++ b/examples/minimax/.gitignore
@@ -1,1 +1,2 @@
 minimax-video.mp4
+text-to-image.jpg

--- a/examples/minimax/music.php
+++ b/examples/minimax/music.php
@@ -25,4 +25,4 @@ $result = $platform->invoke('music-1.5', new Text('A cheerful pop song with an u
     ],
 ]);
 
-echo $result->asBinary().\PHP_EOL;
+echo $result->asBinary();

--- a/examples/minimax/text-to-image.php
+++ b/examples/minimax/text-to-image.php
@@ -20,4 +20,6 @@ $result = $platform->invoke('image-01', new Text('A cat on a kitchen table'), [
     'aspect_ratio' => '16:9',
 ]);
 
-echo $result->asBinary().\PHP_EOL;
+$result->asFile(__DIR__.'/text-to-image.jpg');
+
+echo 'Image saved to text-to-image.jpg'.\PHP_EOL;

--- a/examples/minimax/text-to-speech-async.php
+++ b/examples/minimax/text-to-speech-async.php
@@ -33,4 +33,4 @@ $result = $platform->invoke('speech-2.6-hd', new Text('The real danger is not th
     ],
 ]);
 
-echo $result->asBinary().\PHP_EOL;
+echo $result->asBinary();

--- a/examples/minimax/text-to-speech.php
+++ b/examples/minimax/text-to-speech.php
@@ -31,4 +31,4 @@ $result = $platform->invoke('speech-2.6-hd', new Text('The real danger is not th
     ],
 ]);
 
-echo $result->asBinary().\PHP_EOL;
+echo $result->asBinary();

--- a/examples/minimax/text-to-video.php
+++ b/examples/minimax/text-to-video.php
@@ -22,6 +22,6 @@ $result = $platform->invoke('MiniMax-Hailuo-02', new Text('A cat playing the pia
     'resolution' => '768P',
 ]);
 
-file_put_contents(__DIR__.'/minimax-video.mp4', $result->asBinary());
+$result->asFile(__DIR__.'/minimax-video.mp4');
 
-echo 'Video written to minimax-video.mp4'.\PHP_EOL;
+echo 'Video saved to minimax-video.mp4'.\PHP_EOL;

--- a/examples/openai/.gitignore
+++ b/examples/openai/.gitignore
@@ -1,0 +1,2 @@
+gpt-image-1-edit.png
+gpt-image-1.png

--- a/examples/openai/image-editing-gpt-image-1.php
+++ b/examples/openai/image-editing-gpt-image-1.php
@@ -28,7 +28,7 @@ $result = $platform->invoke(
 
 assert($result instanceof BinaryResult);
 
-$file = sys_get_temp_dir().'/openai-gpt-image-1-edit.png';
+$file = __DIR__.'/gpt-image-1-edit.png';
 $result->asFile($file);
 
 echo 'Edited image saved to '.$file.\PHP_EOL;

--- a/examples/openai/image-output-gpt-image-1.php
+++ b/examples/openai/image-output-gpt-image-1.php
@@ -23,7 +23,7 @@ $result = $platform->invoke(
 
 assert($result instanceof BinaryResult);
 
-$file = sys_get_temp_dir().'/openai-gpt-image-1.png';
+$file = __DIR__.'/gpt-image-1.png';
 $result->asFile($file);
 
 echo 'Image saved to '.$file.\PHP_EOL;

--- a/examples/openrouter/speech.php
+++ b/examples/openrouter/speech.php
@@ -21,5 +21,4 @@ $result = $platform->invoke('google/gemini-3.1-flash-tts-preview', 'Hello world 
     'response_format' => 'pcm',
 ]);
 
-$result->asFile('/tmp/openrouter-speech.pcm');
-output()->writeln('Audio content saved to <comment>/tmp/openrouter-speech.pcm</comment>');
+echo $result->asBinary();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Standardize how examples handle generated binary output: audio is echoed to stdout (dropping the corrupting trailing newline), while image/video examples use `asFile()` writing into the example directory, with matching `.gitignore` entries.