### PR TITLE
[Platform][Store] Always batch embeddings, drop catalog coupling

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,6 +45,12 @@ Platform
    +$message->asText();
    ```
 
+ * `Capability::INPUT_MULTIPLE` has been removed from all embedding models in the model catalogs (it is
+   kept on reranking models). Every embedding bridge already accepts multiple inputs in a single API
+   call, so the capability no longer carried meaning for embeddings. Code that branched on
+   `$model->supports(Capability::INPUT_MULTIPLE)` for an embedding model will now receive `false`; pass
+   the full array of texts to `Platform::invoke()` directly instead — the bridge handles batching.
+
 Store
 -----
 

--- a/examples/openai/multiple-text-embeddings.php
+++ b/examples/openai/multiple-text-embeddings.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+$result = $platform->invoke('text-embedding-3-small', [
+    'Once upon a time, there was a country called Japan. It was a beautiful country with a lot of mountains and rivers.',
+    'The people of Japan were very kind and hardworking. They loved their country very much and took care of it.',
+    'The country was very peaceful and prosperous. The people lived happily ever after.',
+]);
+
+echo 'Dimensions Text 1: '.$result->asVectors()[0]->getDimensions().\PHP_EOL;
+echo 'Dimensions Text 2: '.$result->asVectors()[1]->getDimensions().\PHP_EOL;
+echo 'Dimensions Text 3: '.$result->asVectors()[2]->getDimensions().\PHP_EOL;

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * [BC BREAK] Remove `Capability::INPUT_MULTIPLE` from all embedding models since every embedding bridge already accepts multiple inputs in a single API call
  * Add `ResultConvertedEvent` and `ResultErrorEvent`, dispatched when the deferred result is actually converted (or conversion fails) instead of when the not-yet-resolved `ResultEvent` fires, so listeners can act on the resolved result
  * Add `provider` and `context` arguments to `#[Schema]` plus `SchemaProviderInterface` to contribute JSON Schema fragments computed at runtime (env, database, services) for tool parameters and structured output properties; `provider` accepts any container service ID and `context` is passed to `getSchemaFragment()`
  * Add `PartialJsonParser` for recovering partial JSON from streaming output

--- a/src/platform/src/Bridge/AiMlApi/ModelCatalog.php
+++ b/src/platform/src/Bridge/AiMlApi/ModelCatalog.php
@@ -1025,67 +1025,67 @@ final class ModelCatalog extends AbstractModelCatalog
             // Embedding models
             'text-embedding-3-small' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'text-embedding-3-large' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'text-embedding-ada-002' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'togethercomputer/m2-bert-80M-32k-retrieval' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'BAAI/bge-base-en-v1.5' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'BAAI/bge-large-en-v1.' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-large-2-instruct' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-finance-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-multilingual-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-law-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-code-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-large-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-2' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'textembedding-gecko@003' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'textembedding-gecko-multilingual@001' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'text-multilingual-embedding-002' => [
                 'class' => EmbeddingsModel::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
         ];
 

--- a/src/platform/src/Bridge/AiMlApi/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/AiMlApi/Tests/ModelCatalogTest.php
@@ -149,22 +149,22 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'zhipu/glm-4.5' => ['zhipu/glm-4.5', CompletionsModel::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING]];
 
         // Embedding models
-        yield 'text-embedding-3-small' => ['text-embedding-3-small', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'text-embedding-3-large' => ['text-embedding-3-large', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'text-embedding-ada-002' => ['text-embedding-ada-002', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'togethercomputer/m2-bert-80M-32k-retrieval' => ['togethercomputer/m2-bert-80M-32k-retrieval', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'BAAI/bge-base-en-v1.5' => ['BAAI/bge-base-en-v1.5', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'BAAI/bge-large-en-v1.' => ['BAAI/bge-large-en-v1.', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-large-2-instruct' => ['voyage-large-2-instruct', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-finance-2' => ['voyage-finance-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-multilingual-2' => ['voyage-multilingual-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-law-2' => ['voyage-law-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-code-2' => ['voyage-code-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-large-2' => ['voyage-large-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-2' => ['voyage-2', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'textembedding-gecko@003' => ['textembedding-gecko@003', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'textembedding-gecko-multilingual@001' => ['textembedding-gecko-multilingual@001', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'text-multilingual-embedding-002' => ['text-multilingual-embedding-002', EmbeddingsModel::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'text-embedding-3-small' => ['text-embedding-3-small', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'text-embedding-3-large' => ['text-embedding-3-large', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'text-embedding-ada-002' => ['text-embedding-ada-002', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'togethercomputer/m2-bert-80M-32k-retrieval' => ['togethercomputer/m2-bert-80M-32k-retrieval', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'BAAI/bge-base-en-v1.5' => ['BAAI/bge-base-en-v1.5', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'BAAI/bge-large-en-v1.' => ['BAAI/bge-large-en-v1.', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-large-2-instruct' => ['voyage-large-2-instruct', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-finance-2' => ['voyage-finance-2', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-multilingual-2' => ['voyage-multilingual-2', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-law-2' => ['voyage-law-2', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-code-2' => ['voyage-code-2', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-large-2' => ['voyage-large-2', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-2' => ['voyage-2', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'textembedding-gecko@003' => ['textembedding-gecko@003', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'textembedding-gecko-multilingual@001' => ['textembedding-gecko-multilingual@001', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'text-multilingual-embedding-002' => ['text-multilingual-embedding-002', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/AmazeeAi/ModelApiCatalog.php
+++ b/src/platform/src/Bridge/AmazeeAi/ModelApiCatalog.php
@@ -88,7 +88,7 @@ final class ModelApiCatalog extends AbstractModelCatalog
             if ('embedding' === $mode) {
                 yield $name => [
                     'class' => EmbeddingsModel::class,
-                    'capabilities' => $this->buildEmbeddingCapabilities($info),
+                    'capabilities' => [Capability::EMBEDDINGS, Capability::INPUT_TEXT],
                 ];
             } else {
                 yield $name => [
@@ -97,22 +97,6 @@ final class ModelApiCatalog extends AbstractModelCatalog
                 ];
             }
         }
-    }
-
-    /**
-     * @param array<string, mixed> $info
-     *
-     * @return list<Capability>
-     */
-    private function buildEmbeddingCapabilities(array $info): array
-    {
-        $capabilities = [Capability::EMBEDDINGS, Capability::INPUT_TEXT];
-
-        if ($info['supports_multiple_inputs'] ?? true) {
-            $capabilities[] = Capability::INPUT_MULTIPLE;
-        }
-
-        return $capabilities;
     }
 
     /**

--- a/src/platform/src/Bridge/AmazeeAi/Tests/ModelApiCatalogTest.php
+++ b/src/platform/src/Bridge/AmazeeAi/Tests/ModelApiCatalogTest.php
@@ -94,7 +94,6 @@ final class ModelApiCatalogTest extends TestCase
 
         $this->assertContains(Capability::EMBEDDINGS, $capabilities);
         $this->assertContains(Capability::INPUT_TEXT, $capabilities);
-        $this->assertContains(Capability::INPUT_MULTIPLE, $capabilities);
     }
 
     public function testModelNotFound()

--- a/src/platform/src/Bridge/Cohere/ModelCatalog.php
+++ b/src/platform/src/Bridge/Cohere/ModelCatalog.php
@@ -161,35 +161,35 @@ final class ModelCatalog extends AbstractModelCatalog
             'embed-english-light-v3.0' => [
                 'class' => Embeddings::class,
                 'capabilities' => [
-                    Capability::INPUT_MULTIPLE,
+                    Capability::INPUT_TEXT,
                     Capability::EMBEDDINGS,
                 ],
             ],
             'embed-english-v3.0' => [
                 'class' => Embeddings::class,
                 'capabilities' => [
-                    Capability::INPUT_MULTIPLE,
+                    Capability::INPUT_TEXT,
                     Capability::EMBEDDINGS,
                 ],
             ],
             'embed-multilingual-light-v3.0' => [
                 'class' => Embeddings::class,
                 'capabilities' => [
-                    Capability::INPUT_MULTIPLE,
+                    Capability::INPUT_TEXT,
                     Capability::EMBEDDINGS,
                 ],
             ],
             'embed-multilingual-v3.0' => [
                 'class' => Embeddings::class,
                 'capabilities' => [
-                    Capability::INPUT_MULTIPLE,
+                    Capability::INPUT_TEXT,
                     Capability::EMBEDDINGS,
                 ],
             ],
             'embed-v4.0' => [
                 'class' => Embeddings::class,
                 'capabilities' => [
-                    Capability::INPUT_MULTIPLE,
+                    Capability::INPUT_TEXT,
                     Capability::INPUT_MULTIMODAL,
                     Capability::EMBEDDINGS,
                 ],

--- a/src/platform/src/Bridge/Cohere/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/ModelCatalogTest.php
@@ -38,11 +38,11 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'c4ai-aya-vision-32b' => ['c4ai-aya-vision-32b', Cohere::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING]];
 
         // Embedding models
-        yield 'embed-v4.0' => ['embed-v4.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::INPUT_MULTIMODAL, Capability::EMBEDDINGS]];
-        yield 'embed-english-v3.0' => ['embed-english-v3.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'embed-multilingual-v3.0' => ['embed-multilingual-v3.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'embed-english-light-v3.0' => ['embed-english-light-v3.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'embed-multilingual-light-v3.0' => ['embed-multilingual-light-v3.0', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'embed-v4.0' => ['embed-v4.0', Embeddings::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIMODAL, Capability::EMBEDDINGS]];
+        yield 'embed-english-v3.0' => ['embed-english-v3.0', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'embed-multilingual-v3.0' => ['embed-multilingual-v3.0', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'embed-english-light-v3.0' => ['embed-english-light-v3.0', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'embed-multilingual-light-v3.0' => ['embed-multilingual-light-v3.0', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
 
         // Reranking models
         yield 'rerank-v4.0-pro' => ['rerank-v4.0-pro', Reranker::class, [Capability::INPUT_MULTIPLE, Capability::RERANKING]];

--- a/src/platform/src/Bridge/Mistral/ModelCatalog.php
+++ b/src/platform/src/Bridge/Mistral/ModelCatalog.php
@@ -165,7 +165,7 @@ final class ModelCatalog extends AbstractModelCatalog
             'mistral-embed' => [
                 'class' => Embeddings::class,
                 'capabilities' => [
-                    Capability::INPUT_MULTIPLE,
+                    Capability::INPUT_TEXT,
                     Capability::EMBEDDINGS,
                 ],
             ],

--- a/src/platform/src/Bridge/Mistral/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/ModelCatalogTest.php
@@ -40,7 +40,7 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'pixtral-12b-latest' => ['pixtral-12b-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::INPUT_IMAGE, Capability::TOOL_CALLING]];
         yield 'voxtral-small-latest' => ['voxtral-small-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::INPUT_AUDIO, Capability::TOOL_CALLING]];
         yield 'voxtral-mini-latest' => ['voxtral-mini-latest', Mistral::class, [Capability::INPUT_MESSAGES, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::OUTPUT_STRUCTURED, Capability::INPUT_AUDIO, Capability::TOOL_CALLING]];
-        yield 'mistral-embed' => ['mistral-embed', Embeddings::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'mistral-embed' => ['mistral-embed', Embeddings::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
         yield 'mistral-ocr-latest' => ['mistral-ocr-latest', Ocr::class, [Capability::INPUT_PDF, Capability::INPUT_IMAGE, Capability::OUTPUT_TEXT]];
     }
 

--- a/src/platform/src/Bridge/VertexAi/ModelCatalog.php
+++ b/src/platform/src/Bridge/VertexAi/ModelCatalog.php
@@ -151,7 +151,6 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => EmbeddingsModel::class,
                 'capabilities' => [
                     Capability::INPUT_TEXT,
-                    Capability::INPUT_MULTIPLE,
                     Capability::EMBEDDINGS,
                 ],
             ],
@@ -159,7 +158,6 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => EmbeddingsModel::class,
                 'capabilities' => [
                     Capability::INPUT_TEXT,
-                    Capability::INPUT_MULTIPLE,
                     Capability::EMBEDDINGS,
                 ],
             ],
@@ -167,7 +165,6 @@ final class ModelCatalog extends AbstractModelCatalog
                 'class' => EmbeddingsModel::class,
                 'capabilities' => [
                     Capability::INPUT_TEXT,
-                    Capability::INPUT_MULTIPLE,
                     Capability::EMBEDDINGS,
                 ],
             ],

--- a/src/platform/src/Bridge/VertexAi/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/ModelCatalogTest.php
@@ -36,9 +36,9 @@ final class ModelCatalogTest extends ModelCatalogTestCase
         yield 'gemini-2.0-flash-lite' => ['gemini-2.0-flash-lite', GeminiModel::class, [Capability::INPUT_MESSAGES, Capability::INPUT_IMAGE, Capability::INPUT_AUDIO, Capability::INPUT_PDF, Capability::OUTPUT_TEXT, Capability::OUTPUT_STREAMING, Capability::TOOL_CALLING]];
 
         // Embeddings models
-        yield 'gemini-embedding-001' => ['gemini-embedding-001', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'text-embedding-005' => ['text-embedding-005', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'text-multilingual-embedding-002' => ['text-multilingual-embedding-002', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
+        yield 'gemini-embedding-001' => ['gemini-embedding-001', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'text-embedding-005' => ['text-embedding-005', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'text-multilingual-embedding-002' => ['text-multilingual-embedding-002', EmbeddingsModel::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/platform/src/Bridge/Voyage/ModelCatalog.php
+++ b/src/platform/src/Bridge/Voyage/ModelCatalog.php
@@ -24,48 +24,48 @@ final class ModelCatalog extends AbstractModelCatalog
         $defaultModels = [
             'voyage-3.5' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-3.5-lite' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-3' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-3-lite' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-3-large' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-finance-2' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-multilingual-2' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-law-2' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-code-3' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-code-2' => [
                 'class' => Voyage::class,
-                'capabilities' => [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS],
+                'capabilities' => [Capability::INPUT_TEXT, Capability::EMBEDDINGS],
             ],
             'voyage-multimodal-3' => [
                 'class' => Voyage::class,
                 'capabilities' => [
-                    Capability::INPUT_MULTIPLE,
+                    Capability::INPUT_TEXT,
                     Capability::INPUT_MULTIMODAL,
                     Capability::EMBEDDINGS,
                 ],

--- a/src/platform/src/Bridge/Voyage/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Voyage/Tests/ModelCatalogTest.php
@@ -21,17 +21,17 @@ final class ModelCatalogTest extends ModelCatalogTestCase
 {
     public static function modelsProvider(): iterable
     {
-        yield 'voyage-3.5' => ['voyage-3.5', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-3.5-lite' => ['voyage-3.5-lite', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-3' => ['voyage-3', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-3-lite' => ['voyage-3-lite', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-3-large' => ['voyage-3-large', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-finance-2' => ['voyage-finance-2', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-multilingual-2' => ['voyage-multilingual-2', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-law-2' => ['voyage-law-2', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-code-3' => ['voyage-code-3', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-code-2' => ['voyage-code-2', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::EMBEDDINGS]];
-        yield 'voyage-multimodal-3' => ['voyage-multimodal-3', Voyage::class, [Capability::INPUT_MULTIPLE, Capability::INPUT_MULTIMODAL, Capability::EMBEDDINGS]];
+        yield 'voyage-3.5' => ['voyage-3.5', Voyage::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-3.5-lite' => ['voyage-3.5-lite', Voyage::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-3' => ['voyage-3', Voyage::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-3-lite' => ['voyage-3-lite', Voyage::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-3-large' => ['voyage-3-large', Voyage::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-finance-2' => ['voyage-finance-2', Voyage::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-multilingual-2' => ['voyage-multilingual-2', Voyage::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-law-2' => ['voyage-law-2', Voyage::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-code-3' => ['voyage-code-3', Voyage::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-code-2' => ['voyage-code-2', Voyage::class, [Capability::INPUT_TEXT, Capability::EMBEDDINGS]];
+        yield 'voyage-multimodal-3' => ['voyage-multimodal-3', Voyage::class, [Capability::INPUT_TEXT, Capability::INPUT_MULTIMODAL, Capability::EMBEDDINGS]];
     }
 
     protected function createModelCatalog(): ModelCatalogInterface

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * `Vectorizer` now always sends a single batched `Platform::invoke()` call when vectorizing multiple strings or documents, instead of consulting the model catalog and falling back to one call per item
+
 0.9
 ---
 

--- a/src/store/src/Document/Vectorizer.php
+++ b/src/store/src/Document/Vectorizer.php
@@ -13,7 +13,6 @@ namespace Symfony\AI\Store\Document;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Exception\ExceptionInterface;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Vector\Vector;
@@ -134,26 +133,8 @@ final class Vectorizer implements VectorizerInterface
         // Convert all values to strings
         $stringValues = array_map(static fn (string|\Stringable $s) => (string) $s, $strings);
 
-        if ($this->platform->getModelCatalog()->getModel($this->model)->supports(Capability::INPUT_MULTIPLE)) {
-            $this->logger->debug('Using batch vectorization with model that supports multiple inputs');
-            $result = $this->platform->invoke($this->model, $stringValues, $options);
-
-            $vectors = $result->asVectors();
-            $this->logger->debug('Batch vectorization completed', ['vector_count' => \count($vectors)]);
-        } else {
-            $this->logger->debug('Using sequential vectorization for model without multiple input support');
-            $results = [];
-            foreach ($stringValues as $i => $string) {
-                $this->logger->debug('Vectorizing string', ['string_index' => $i]);
-                $results[] = $this->platform->invoke($this->model, $string, $options);
-            }
-
-            $vectors = [];
-            foreach ($results as $result) {
-                $vectors = array_merge($vectors, $result->asVectors());
-            }
-            $this->logger->debug('Sequential vectorization completed', ['vector_count' => \count($vectors)]);
-        }
+        $result = $this->platform->invoke($this->model, $stringValues, $options);
+        $vectors = $result->asVectors();
 
         $this->logger->info('Vectorization process completed', ['string_count' => $stringCount, 'vector_count' => \count($vectors)]);
 
@@ -171,26 +152,8 @@ final class Vectorizer implements VectorizerInterface
         $documentCount = \count($documents);
         $this->logger->info('Starting vectorization process', ['document_count' => $documentCount]);
 
-        if ($this->platform->getModelCatalog()->getModel($this->model)->supports(Capability::INPUT_MULTIPLE)) {
-            $this->logger->debug('Using batch vectorization with model that supports multiple inputs');
-            $result = $this->platform->invoke($this->model, array_map(static fn (EmbeddableDocumentInterface $document) => $document->getContent(), $documents), $options);
-
-            $vectors = $result->asVectors();
-            $this->logger->debug('Batch vectorization completed', ['vector_count' => \count($vectors)]);
-        } else {
-            $this->logger->debug('Using sequential vectorization for model without multiple input support');
-            $results = [];
-            foreach ($documents as $i => $document) {
-                $this->logger->debug('Vectorizing document', ['document_index' => $i, 'document_id' => $document->getId()]);
-                $results[] = $this->platform->invoke($this->model, $document->getContent(), $options);
-            }
-
-            $vectors = [];
-            foreach ($results as $result) {
-                $vectors = array_merge($vectors, $result->asVectors());
-            }
-            $this->logger->debug('Sequential vectorization completed', ['vector_count' => \count($vectors)]);
-        }
+        $result = $this->platform->invoke($this->model, array_map(static fn (EmbeddableDocumentInterface $document) => $document->getContent(), $documents), $options);
+        $vectors = $result->asVectors();
 
         $vectorDocuments = [];
         foreach ($documents as $i => $document) {

--- a/src/store/tests/Document/VectorizerTest.php
+++ b/src/store/tests/Document/VectorizerTest.php
@@ -14,11 +14,6 @@ namespace Symfony\AI\Store\Tests\Document;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
-use Symfony\AI\Platform\Bridge\OpenAi\Embeddings;
-use Symfony\AI\Platform\Capability;
-use Symfony\AI\Platform\Model;
-use Symfony\AI\Platform\ModelCatalog\AbstractModelCatalog;
-use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -36,7 +31,7 @@ use Symfony\Component\Uid\Uuid;
 #[TestDox('Tests for the Vectorizer class')]
 final class VectorizerTest extends TestCase
 {
-    public function testVectorizeDocumentsWithBatchSupport()
+    public function testVectorizeDocumentsUsesSingleBatchedInvoke()
     {
         $documents = [
             new TextDocument(Uuid::v4()->toString(), 'First document content', new Metadata(['source' => 'test1'])),
@@ -50,22 +45,19 @@ final class VectorizerTest extends TestCase
             new Vector([0.7, 0.8, 0.9]),
         ];
 
-        // Create a test model catalog WITH INPUT_MULTIPLE capability
-        $modelCatalog = new class extends AbstractModelCatalog {
-            protected array $models = [
-                'test-embedding-with-batch' => [
-                    'class' => Model::class,
-                    'capabilities' => [
-                        Capability::INPUT_TEXT,
-                        Capability::INPUT_MULTIPLE,  // Explicitly including batch support
-                    ],
-                ],
-            ];
-        };
+        // All embedding models batch multiple texts into a single API call, so the
+        // Vectorizer must invoke the platform exactly once with the full array of contents.
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->once())
+            ->method('invoke')
+            ->with(
+                $this->equalTo('text-embedding-3-small'),
+                $this->equalTo(['First document content', 'Second document content', 'Third document content']),
+                $this->equalTo([])
+            )
+            ->willReturn(new DeferredResult(new PlainConverter(new VectorResult($vectors)), $this->createMock(RawResultInterface::class)));
 
-        $platform = PlatformTestHandler::createPlatform(new VectorResult($vectors), $modelCatalog);
-
-        $vectorizer = new Vectorizer($platform, 'test-embedding-with-batch');
+        $vectorizer = new Vectorizer($platform, 'text-embedding-3-small');
         $vectorDocuments = $vectorizer->vectorize($documents);
 
         $this->assertCount(3, $vectorDocuments);
@@ -245,41 +237,6 @@ final class VectorizerTest extends TestCase
         }
     }
 
-    public function testVectorizeDocumentsWithoutBatchSupportUsesNonBatchMode()
-    {
-        $documents = [
-            new TextDocument(Uuid::v4()->toString(), 'Document 1'),
-            new TextDocument(Uuid::v4()->toString(), 'Document 2'),
-        ];
-
-        $vectors = [
-            new Vector([0.1, 0.2]),
-            new Vector([0.3, 0.4]),
-        ];
-
-        // Create a test model catalog that explicitly does NOT have INPUT_MULTIPLE capability
-        $modelCatalog = new class extends AbstractModelCatalog {
-            protected array $models = [
-                'test-embedding-no-batch' => [
-                    'class' => Model::class,
-                    'capabilities' => [
-                        Capability::INPUT_TEXT,
-                        // Explicitly excluding INPUT_MULTIPLE capability
-                    ],
-                ],
-            ];
-        };
-
-        $platform = PlatformTestHandler::createPlatform(new VectorResult($vectors), $modelCatalog);
-
-        $vectorizer = new Vectorizer($platform, 'test-embedding-no-batch');
-        $vectorDocuments = $vectorizer->vectorize($documents);
-
-        $this->assertCount(2, $vectorDocuments);
-        $this->assertEquals($vectors[0], $vectorDocuments[0]->getVector());
-        $this->assertEquals($vectors[1], $vectorDocuments[1]->getVector());
-    }
-
     public function testVectorizeString()
     {
         $text = 'This is a test string to vectorize';
@@ -446,10 +403,8 @@ final class VectorizerTest extends TestCase
         $vector = new Vector([0.1, 0.2, 0.3]);
         $options = ['max_tokens' => 1000, 'temperature' => 0.5];
 
-        // Use FallbackModelCatalog which provides all capabilities including INPUT_MULTIPLE
-        // This ensures batch mode is used and the test expectation matches the behavior
         $platform = PlatformTestHandler::createPlatform(new VectorResult([$vector]));
-        $vectorizer = new Vectorizer($platform, 'test-embedding-with-batch');
+        $vectorizer = new Vectorizer($platform, 'text-embedding-3-small');
         $result = $vectorizer->vectorize($documents, $options);
 
         $this->assertCount(1, $result);
@@ -464,10 +419,8 @@ final class VectorizerTest extends TestCase
 
         $vector = new Vector([0.1, 0.2, 0.3]);
 
-        // Use FallbackModelCatalog which provides all capabilities including INPUT_MULTIPLE
-        // This ensures batch mode is used and the test expectation matches the behavior
         $platform = PlatformTestHandler::createPlatform(new VectorResult([$vector]));
-        $vectorizer = new Vectorizer($platform, 'test-embedding-with-batch');
+        $vectorizer = new Vectorizer($platform, 'text-embedding-3-small');
         $result = $vectorizer->vectorize($documents);
 
         $this->assertCount(1, $result);
@@ -589,42 +542,5 @@ final class VectorizerTest extends TestCase
         $this->assertTrue($result[1]->getMetadata()->hasText());
         $this->assertSame('First content', $result[0]->getMetadata()->getText());
         $this->assertSame('Second content', $result[1]->getMetadata()->getText());
-    }
-
-    public function testVectorizeTextDocumentsWithoutBatchSupportPassesOptions()
-    {
-        $documents = [
-            new TextDocument(Uuid::v4()->toString(), 'Document 1'),
-            new TextDocument(Uuid::v4()->toString(), 'Document 2'),
-        ];
-
-        $vectors = [
-            new Vector([0.1, 0.2]),
-            new Vector([0.3, 0.4]),
-        ];
-
-        $options = ['max_tokens' => 2000];
-
-        // Create a test model catalog without INPUT_MULTIPLE capability
-        $modelCatalog = new class extends AbstractModelCatalog {
-            protected array $models = [
-                'test-embedding-no-batch-with-options' => [
-                    'class' => Model::class,
-                    'capabilities' => [
-                        Capability::INPUT_TEXT,
-                        // No INPUT_MULTIPLE capability
-                    ],
-                ],
-            ];
-        };
-
-        $platform = PlatformTestHandler::createPlatform(new VectorResult($vectors), $modelCatalog);
-
-        $vectorizer = new Vectorizer($platform, 'test-embedding-no-batch-with-options');
-        $result = $vectorizer->vectorize($documents, $options);
-
-        $this->assertCount(2, $result);
-        $this->assertEquals($vectors[0], $result[0]->getVector());
-        $this->assertEquals($vectors[1], $result[1]->getVector());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2127
| License       | MIT

Every embedding bridge already accepts an array and issues a single API call, so `Store\Vectorizer` no longer consults `Platform->getModelCatalog()` / `Capability::INPUT_MULTIPLE` to choose batch vs. per-document mode — it always batches. This also fixes providers (OpenAI, Gemini, Azure, Scaleway, DockerModelRunner) that lacked the capability and were silently embedded one call per document.

`Capability::INPUT_MULTIPLE` is removed from embedding model catalog entries (kept on reranking models). BC break documented in `UPGRADE.md` — needs the `BC Break` label.