### PR TITLE
[Store] Add DirectoryLoader with per-extension sub-loaders

### DIFF
--- a/docs/components/store.rst
+++ b/docs/components/store.rst
@@ -157,6 +157,7 @@ Document loaders are responsible for fetching and preparing documents for indexi
 To help loading documents and integrate them into your RAG system, you can use the provided document loaders or create your own custom loaders to suit your specific needs:
 
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\CsvLoader`
+* :class:`Symfony\\AI\\Store\\Document\\Loader\\DirectoryLoader`
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\InMemoryLoader`
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\JsonFileLoader`
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\MarkdownLoader`
@@ -164,6 +165,23 @@ To help loading documents and integrate them into your RAG system, you can use t
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\RstLoader`
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\RstToctreeLoader`
 * :class:`Symfony\\AI\\Store\\Document\\Loader\\TextFileLoader`
+
+The :class:`Symfony\\AI\\Store\\Document\\Loader\\DirectoryLoader` scans a directory and delegates each
+file to a sub-loader chosen by its extension. The sub-loaders are injected as a map of file extension
+(without the leading dot) to a loader, and recursion into subdirectories can be toggled::
+
+    use Symfony\AI\Store\Document\Loader\DirectoryLoader;
+    use Symfony\AI\Store\Document\Loader\MarkdownLoader;
+    use Symfony\AI\Store\Document\Loader\TextFileLoader;
+
+    $loader = new DirectoryLoader([
+        'md' => new MarkdownLoader(),
+        'txt' => new TextFileLoader(),
+    ], recursive: false);
+
+    $documents = $loader->load('/path/to/directory');
+
+Files whose extension has no registered loader are skipped.
 
 Create a Custom Loader
 ----------------------

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Add `DirectoryLoader` that scans a directory and delegates each file to a per-extension sub-loader, with optional recursion
  * `Vectorizer` now always sends a single batched `Platform::invoke()` call when vectorizing multiple strings or documents, instead of consulting the model catalog and falling back to one call per item
 
 0.9

--- a/src/store/composer.json
+++ b/src/store/composer.json
@@ -59,6 +59,7 @@
         "symfony/dom-crawler": "^7.3|^8.0",
         "symfony/dependency-injection": "^7.3|^8.0",
         "symfony/filesystem": "^7.3|^8.0",
+        "symfony/finder": "^7.3|^8.0",
         "symfony/string": "^7.3|^8.0",
         "symfony/json-path": "^7.3|^8.0"
     },

--- a/src/store/src/Document/Loader/DirectoryLoader.php
+++ b/src/store/src/Document/Loader/DirectoryLoader.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Document\Loader;
+
+use Symfony\AI\Store\Document\LoaderInterface;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Scans a directory and delegates each file to a sub-loader chosen by its extension.
+ *
+ * The sub-loaders are injected as a map of lowercase file extension (without the leading dot) to a
+ * {@see LoaderInterface}, e.g. `['md' => new MarkdownLoader(), 'json' => new JsonFileLoader(...)]`.
+ * Files whose extension has no registered loader are skipped. Set `$recursive` to false to only load
+ * the files located directly in the given directory.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class DirectoryLoader implements LoaderInterface
+{
+    /**
+     * @var array<string, LoaderInterface>
+     */
+    private readonly array $loaders;
+
+    /**
+     * @param array<string, LoaderInterface> $loaders map of file extension (without leading dot) to the loader handling it
+     */
+    public function __construct(
+        array $loaders,
+        private readonly bool $recursive = true,
+    ) {
+        if ([] === $loaders) {
+            throw new InvalidArgumentException('DirectoryLoader requires at least one extension loader.');
+        }
+
+        $normalized = [];
+        foreach ($loaders as $extension => $loader) {
+            $normalized[strtolower($extension)] = $loader;
+        }
+
+        $this->loaders = $normalized;
+    }
+
+    public function load(?string $source = null, array $options = []): iterable
+    {
+        if (!class_exists(Finder::class)) {
+            throw new RuntimeException('For using the DirectoryLoader, the Symfony Finder component is required. Try running "composer require symfony/finder".');
+        }
+
+        if (null === $source || !is_dir($source)) {
+            throw new InvalidArgumentException(\sprintf('DirectoryLoader requires an existing directory as source, "%s" given.', $source ?? 'null'));
+        }
+
+        $finder = (new Finder())
+            ->files()
+            ->in($source)
+            ->sortByName();
+
+        if (!$this->recursive) {
+            $finder->depth(0);
+        }
+
+        foreach ($finder as $file) {
+            $extension = strtolower($file->getExtension());
+            if (!isset($this->loaders[$extension])) {
+                continue;
+            }
+
+            yield from $this->loaders[$extension]->load($file->getRealPath(), $options);
+        }
+    }
+}

--- a/src/store/tests/Document/Loader/DirectoryLoaderTest.php
+++ b/src/store/tests/Document/Loader/DirectoryLoaderTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests\Document\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Store\Document\EmbeddableDocumentInterface;
+use Symfony\AI\Store\Document\Loader\DirectoryLoader;
+use Symfony\AI\Store\Document\Loader\MarkdownLoader;
+use Symfony\AI\Store\Document\Loader\TextFileLoader;
+use Symfony\AI\Store\Document\LoaderInterface;
+use Symfony\AI\Store\Document\TextDocument;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class DirectoryLoaderTest extends TestCase
+{
+    private string $directory;
+    private Filesystem $fs;
+
+    protected function setUp(): void
+    {
+        $this->fs = new Filesystem();
+        $this->directory = sys_get_temp_dir().'/directory-loader-'.uniqid();
+        $this->fs->mkdir($this->directory);
+
+        $this->fs->dumpFile($this->directory.'/alpha.md', "# Alpha\n\nAlpha content.\n");
+        $this->fs->dumpFile($this->directory.'/beta.md', "# Beta\n\nBeta content.\n");
+        $this->fs->dumpFile($this->directory.'/UPPER.MD', "# Upper\n\nUpper content.\n");
+        $this->fs->dumpFile($this->directory.'/notes.txt', "Plain text notes.\n");
+        $this->fs->dumpFile($this->directory.'/data.csv', "col\nvalue\n");
+        $this->fs->dumpFile($this->directory.'/nested/gamma.md', "# Gamma\n\nGamma content.\n");
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs->remove($this->directory);
+    }
+
+    public function testLoadDispatchesByExtensionRecursivelyByDefault()
+    {
+        $loader = new DirectoryLoader([
+            'md' => new MarkdownLoader(),
+            'txt' => new TextFileLoader(),
+        ]);
+
+        $documents = iterator_to_array($loader->load($this->directory), false);
+
+        // 4 markdown files (incl. the nested one and the uppercase extension) + 1 text file; the .csv is skipped.
+        $this->assertCount(5, $documents);
+        $this->assertContainsOnlyInstancesOf(TextDocument::class, $documents);
+
+        $titles = $this->titlesOf($documents);
+        $this->assertSame(['Alpha', 'Beta', 'Gamma', 'Upper'], $titles);
+
+        $contents = array_map(static fn (EmbeddableDocumentInterface $d) => $d->getContent(), $documents);
+        $this->assertContains('Plain text notes.', $contents);
+    }
+
+    public function testNonRecursiveSkipsSubdirectories()
+    {
+        $loader = new DirectoryLoader(['md' => new MarkdownLoader()], recursive: false);
+
+        $documents = iterator_to_array($loader->load($this->directory), false);
+
+        $this->assertCount(3, $documents);
+        $this->assertNotContains('Gamma', $this->titlesOf($documents));
+    }
+
+    public function testSkipsFilesWithoutRegisteredLoader()
+    {
+        $loader = new DirectoryLoader(['md' => new MarkdownLoader()]);
+
+        $documents = iterator_to_array($loader->load($this->directory), false);
+
+        // Only markdown files are handled; the .txt and .csv are skipped.
+        $this->assertCount(4, $documents);
+        $contents = array_map(static fn (EmbeddableDocumentInterface $d) => $d->getContent(), $documents);
+        $this->assertNotContains('Plain text notes.', $contents);
+    }
+
+    public function testNormalizesExtensionKeysAndMatchesCaseInsensitively()
+    {
+        $loader = new DirectoryLoader(['MD' => new MarkdownLoader()], recursive: false);
+
+        $documents = iterator_to_array($loader->load($this->directory), false);
+
+        // alpha.md, beta.md and UPPER.MD all match the normalized "md" key.
+        $this->assertCount(3, $documents);
+        $this->assertContains('Upper', $this->titlesOf($documents));
+    }
+
+    public function testForwardsOptionsToSubLoaders()
+    {
+        $this->fs->dumpFile($this->directory.'/formatted.md', "# Formatted\n\n**bold** text.\n");
+
+        $loader = new DirectoryLoader(['md' => new MarkdownLoader()], recursive: false);
+
+        $documents = iterator_to_array($loader->load($this->directory, ['strip_formatting' => true]), false);
+
+        $formatted = null;
+        foreach ($documents as $document) {
+            if ('Formatted' === ($document->getMetadata()['title'] ?? null)) {
+                $formatted = $document;
+                break;
+            }
+        }
+
+        $this->assertInstanceOf(TextDocument::class, $formatted);
+        $this->assertStringNotContainsString('**', $formatted->getContent());
+    }
+
+    public function testDispatchPassesRealFilePathsToSubLoader()
+    {
+        $recording = new class implements LoaderInterface {
+            /**
+             * @var list<string>
+             */
+            public array $sources = [];
+
+            public function load(?string $source = null, array $options = []): iterable
+            {
+                $this->sources[] = (string) $source;
+
+                yield new TextDocument($source ?? '', 'document for '.$source);
+            }
+        };
+
+        $loader = new DirectoryLoader(['md' => $recording], recursive: false);
+
+        iterator_to_array($loader->load($this->directory), false);
+
+        $basenames = array_map('basename', $recording->sources);
+        sort($basenames);
+        $this->assertSame(['UPPER.MD', 'alpha.md', 'beta.md'], $basenames);
+    }
+
+    public function testConstructorThrowsOnEmptyLoaders()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('DirectoryLoader requires at least one extension loader.');
+
+        new DirectoryLoader([]);
+    }
+
+    public function testLoadThrowsWhenSourceIsNull()
+    {
+        $loader = new DirectoryLoader(['md' => new MarkdownLoader()]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('DirectoryLoader requires an existing directory as source, "null" given.');
+
+        iterator_to_array($loader->load(), false);
+    }
+
+    public function testLoadThrowsWhenSourceIsNotADirectory()
+    {
+        $loader = new DirectoryLoader(['md' => new MarkdownLoader()]);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        iterator_to_array($loader->load(__FILE__), false);
+    }
+
+    /**
+     * @param list<EmbeddableDocumentInterface> $documents
+     *
+     * @return list<string>
+     */
+    private function titlesOf(array $documents): array
+    {
+        $titles = [];
+        foreach ($documents as $document) {
+            $title = $document->getMetadata()['title'] ?? null;
+            if (null !== $title) {
+                $titles[] = $title;
+            }
+        }
+
+        sort($titles);
+
+        return $titles;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | 
| License       | MIT

Adds a built-in `DirectoryLoader` to the Store component that scans a directory and delegates each file to a per-extension sub-loader (e.g. `['md' => new MarkdownLoader(), 'txt' => new TextFileLoader()]`), with an optional `recursive` flag. Files with no registered loader are skipped. Generalizes the directory-scanning pattern previously written ad hoc in userland.