### PR TITLE
[Platform] Fix asObject() after partial consumption of streamed structured output

### DIFF
--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -36,6 +36,12 @@ final class DeferredResult
     private ?\Throwable $conversionFailure = null;
 
     /**
+     * Shared stream generator so the one-shot stream is driven exactly once
+     * across asStream(), asStreamedObject() and asObject().
+     */
+    private ?\Generator $stream = null;
+
+    /**
      * @var list<\Closure(ResultInterface): ResultInterface>
      */
     private array $onConvert = [];
@@ -168,11 +174,18 @@ final class DeferredResult
             $finalResult = $listener->getFinalObjectResult();
 
             if (null === $finalResult) {
-                // Drain the stream so the listener fires its completion handler;
-                // consumers can also iterate asStreamedObject() beforehand and
-                // asObject() will then short-circuit on the cached final result.
-                foreach ($this->asStream() as $delta) {
-                    unset($delta);
+                // Pump the remainder via next() instead of re-iterating: the
+                // stream may be mid-flight (asStreamedObject() stopped early) and
+                // cannot be restarted without reprocessing deltas. This finishes
+                // it and fires the listener's completion handler.
+                $generator = $this->stream ??= $result->getContent();
+
+                try {
+                    while ($generator->valid()) {
+                        $generator->next();
+                    }
+                } finally {
+                    $this->getMetadata()->set($result->getMetadata()->all());
                 }
 
                 $finalResult = $listener->getFinalObjectResult();
@@ -267,9 +280,10 @@ final class DeferredResult
     public function asStream(): \Generator
     {
         $result = $this->as(StreamResult::class);
+        $generator = $this->stream ??= $result->getContent();
 
         try {
-            yield from $result->getContent();
+            yield from $generator;
         } finally {
             $this->getMetadata()->set($result->getMetadata()->all());
         }

--- a/src/platform/tests/Result/DeferredResultTest.php
+++ b/src/platform/tests/Result/DeferredResultTest.php
@@ -444,6 +444,55 @@ final class DeferredResultTest extends TestCase
         $this->assertSame('Berlin', $city->name);
     }
 
+    public function testAsObjectFinishesStreamAfterEarlyBreak()
+    {
+        $stream = new StreamResult((static function () {
+            yield new TextDelta('{"name":"Ber');
+            yield new TextDelta('lin","population":35');
+            yield new TextDelta('00000}');
+        })(), [new PartialObjectStreamListener(new Serializer(), City::class)]);
+
+        $deferred = new DeferredResult(new PlainConverter($stream), new InMemoryRawResult());
+
+        // Stop iterating after the first snapshot, mimicking a consumer that
+        // bails out early (e.g. once the object is "good enough").
+        foreach ($deferred->asStreamedObject() as $partial) {
+            $this->assertInstanceOf(City::class, $partial);
+            break;
+        }
+
+        // asObject() must finish draining the remainder of the stream and
+        // return the complete object, not throw or return a partial.
+        $city = $deferred->asObject();
+        $this->assertInstanceOf(City::class, $city);
+        $this->assertSame('Berlin', $city->name);
+        $this->assertSame(3500000, $city->population);
+    }
+
+    public function testAsObjectFinishesStreamAfterExceptionDuringIteration()
+    {
+        $stream = new StreamResult((static function () {
+            yield new TextDelta('{"name":"Ber');
+            yield new TextDelta('lin","population":35');
+            yield new TextDelta('00000}');
+        })(), [new PartialObjectStreamListener(new Serializer(), City::class)]);
+
+        $deferred = new DeferredResult(new PlainConverter($stream), new InMemoryRawResult());
+
+        try {
+            foreach ($deferred->asStreamedObject() as $partial) {
+                throw new \LogicException('rendering blew up');
+            }
+        } catch (\LogicException) {
+            // Swallowed: the consumer recovers and still wants the final object.
+        }
+
+        $city = $deferred->asObject();
+        $this->assertInstanceOf(City::class, $city);
+        $this->assertSame('Berlin', $city->name);
+        $this->assertSame(3500000, $city->population);
+    }
+
     /**
      * Workaround for low deps because mocking the ResponseInterface leads to an exception with
      * mock creation "Type Traversable|object|array|string|null contains both object and a class type"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Follow-up to #2116. When `stream: true` is combined with `response_format: SomeClass::class`, calling `asObject()` after iterating `asStreamedObject()` only **partially** — an early `break`, or an exception thrown inside the loop — threw a misleading `RuntimeException: Cannot json decode the streamed content.`

`asObject()` re-drained the stream via `asStream()`, restarting the one-shot generator and reprocessing the boundary delta, which corrupted the listener buffer into invalid JSON.

The fix caches the stream generator on the `DeferredResult` so it is driven exactly once, and has `asObject()` pump the remainder via `valid()/next()` (which resumes without reprocessing) instead of re-iterating. The stream is now finished to completion and the complete, validated object is returned — whether iteration never started or stopped halfway.

Two regression tests cover the early-`break` and exception-during-iteration cases.

cc @wachterjohannes 