### PR TITLE
[Demo] Add movie RAG chat with tool search and structured-output cards

### DIFF
--- a/demo/assets/app.js
+++ b/demo/assets/app.js
@@ -10,3 +10,4 @@ import './styles/stream.css';
 import './styles/youtube.css';
 import './styles/video.css';
 import './styles/wikipedia.css';
+import './styles/movies.css';

--- a/demo/assets/controllers/movies_controller.js
+++ b/demo/assets/controllers/movies_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from '@hotwired/stimulus';
+import { getComponent } from '@symfony/ux-live-component';
+
+export default class extends Controller {
+    async initialize() {
+        this.component = await getComponent(this.element);
+        this.scrollToBottom();
+
+        this.component.on('loading.state:started', (e,r) => {
+            if (!r.actions.includes('submit')) {
+                return;
+            }
+
+            document
+                .getElementById('loading-message')
+                .getElementsByClassName('user-message')[0].innerHTML = this.component.getData('message');
+            document.getElementById('welcome')?.remove();
+            document.getElementById('loading-message').removeAttribute('class');
+            document.getElementById('chat-message').value = '';
+            this.scrollToBottom();
+        });
+
+        this.component.on('loading.state:finished', () => {
+            document.getElementById('loading-message').setAttribute('class', 'd-none');
+        });
+
+        this.component.on('render:finished', () => {
+            this.scrollToBottom();
+        });
+    };
+
+    scrollToBottom() {
+        const chatBody = document.getElementById('chat-body');
+        chatBody.scrollTop = chatBody.scrollHeight;
+    }
+}

--- a/demo/assets/icons/mdi/movie-open.svg
+++ b/demo/assets/icons/mdi/movie-open.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M18 4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4h-4z"/></svg>

--- a/demo/assets/styles/movies.css
+++ b/demo/assets/styles/movies.css
@@ -1,0 +1,114 @@
+.movies {
+    body&, .card-img-top {
+        background: #d97706;
+        background: linear-gradient(0deg, #d97706 0%, #7f1d1d 100%);
+    }
+
+    .card-img-top {
+        color: #ffffff;
+    }
+
+    &.chat {
+        .user-message {
+            background: #7f1d1d;
+            color: #fafafa;
+        }
+
+        .bot-message {
+            background: #ffffff;
+        }
+
+        .movie-suggestions {
+            margin-left: 4.5rem;
+        }
+
+        .movie-poster-btn {
+            display: block;
+            width: 9rem;
+            padding: 0;
+            border: 0;
+            border-radius: 0.5rem;
+            overflow: hidden;
+            background: transparent;
+            box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.25);
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+            cursor: pointer;
+
+            &:hover, &:focus-visible {
+                transform: translateY(-3px);
+                box-shadow: 0 0.6rem 1.1rem rgba(0, 0, 0, 0.35);
+            }
+        }
+
+        .movie-poster-caption {
+            width: 9rem;
+            line-height: 1.2;
+        }
+
+        .movie-modal-overlay {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1.5rem;
+            z-index: 1055;
+        }
+
+        .movie-modal-backdrop {
+            position: absolute;
+            inset: 0;
+            padding: 0;
+            border: 0;
+            background: rgba(10, 8, 8, 0.6);
+            cursor: pointer;
+        }
+
+        .movie-modal-panel {
+            position: relative;
+            z-index: 1;
+            width: min(72rem, 94vw);
+            max-height: 85vh;
+            overflow-y: auto;
+            padding: 1.5rem;
+            border-radius: 1rem;
+            background: #ffffff;
+            box-shadow: 0 1.25rem 3.75rem rgba(0, 0, 0, 0.4);
+        }
+
+        .movie-modal-close {
+            position: absolute;
+            top: 0.6rem;
+            right: 0.75rem;
+            width: 2rem;
+            height: 2rem;
+            border: 0;
+            border-radius: 1rem;
+            line-height: 1;
+            font-size: 1.5rem;
+            color: #7f1d1d;
+            background: #f3e7e7;
+
+            &:hover {
+                background: #7f1d1d;
+                border-color: #7f1d1d;
+                color: #ffffff;
+            }
+        }
+
+        #welcome h4 {
+            color: #7f1d1d;
+        }
+
+        .card-footer button {
+            &:hover {
+                background: #b45309;
+                border-color: #b45309;
+            }
+        }
+    }
+
+    footer, footer a {
+        color: #7f1d1d;
+    }
+}

--- a/demo/config/packages/ai.yaml
+++ b/demo/config/packages/ai.yaml
@@ -30,6 +30,24 @@ ai:
                   method: 'now'
             memory:
                 service: 'App\Blog\SymfonyVersionsMemory'
+        movies:
+            platform: 'ai.platform.openai'
+            model: 'gpt-4.1'
+            prompt: |
+                You are a friendly movie expert helping users discover films from a curated collection.
+
+                To find movies you always use the 'movie_search' tool - never rely on your own memory and never
+                invent movies. Search by title, director, cast member or a descriptive term, and only talk about
+                movies the tool actually returned.
+
+                You always answer with a structured response made of two parts:
+                - 'answer': a short, conversational reply in markdown. Introduce your picks and add helpful context,
+                  but do not repeat the full plot or cast - those are shown on the movie cards.
+                - 'movies': the movies backing your answer, each referenced by the exact 'slug' returned by the tool,
+                  together with a one-sentence 'reason' why it fits. Leave this list empty when no movie is relevant
+                  (e.g. small-talk or no match) and say so in the answer.
+            tools:
+                - 'App\Movies\MovieSearch'
         stream:
             platform: 'ai.platform.openai'
             model: 'gpt-4.1'

--- a/demo/config/packages/ux_icons.yaml
+++ b/demo/config/packages/ux_icons.yaml
@@ -16,6 +16,7 @@ ux_icons:
         video: tabler:video-filled
         turbo: mdi:car-turbocharger
         document: mdi:file-document
+        movie: mdi:movie-open
         github: mdi:github
 
         # UI icons

--- a/demo/config/routes.yaml
+++ b/demo/config/routes.yaml
@@ -18,6 +18,13 @@ document:
         template:  'chat.html.twig'
         context: { chat: 'document' }
 
+movies:
+    path: '/movies'
+    controller: 'Symfony\Bundle\FrameworkBundle\Controller\TemplateController'
+    defaults:
+        template:  'chat.html.twig'
+        context: { chat: 'movies' }
+
 crop:
     path: '/crop'
     controller: 'Symfony\Bundle\FrameworkBundle\Controller\TemplateController'

--- a/demo/config/services.yaml
+++ b/demo/config/services.yaml
@@ -4,6 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    movies_dir: '%kernel.project_dir%/../fixtures/movies'
     app.document.samples:
         - { title: "Emancipation Proclamation, 1863 (handwritten, NARA)", url: "https://catalog.archives.gov/medialive/98/2999/299998/content/arcmedia/master/ARC299998.pdf" }
         - { title: "Civil War widow's pension file — USCT (15-page PDF)", url: "https://omeka-iaamcfh.s3.amazonaws.com/original/466438fd3594c782fcbf172a1fd2cfc66034bbf0.pdf" }

--- a/demo/src/Movies/Chat.php
+++ b/demo/src/Movies/Chat.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Movies;
+
+use App\Movies\Data\MovieAnswer;
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Session-backed movie chat that asks the agent for a structured {@see MovieAnswer}.
+ *
+ * The written answer is stored as the assistant message content, while the suggested movies are kept in
+ * the message metadata so the UI can render them as cards next to the text.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class Chat
+{
+    private const SESSION_KEY = 'movies-chat';
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        #[Autowire(service: 'ai.agent.movies')]
+        private readonly AgentInterface $agent,
+    ) {
+    }
+
+    public function loadMessages(): MessageBag
+    {
+        return $this->requestStack->getSession()->get(self::SESSION_KEY, new MessageBag());
+    }
+
+    public function submitMessage(string $message): void
+    {
+        $messages = $this->loadMessages();
+        $messages->add(Message::ofUser($message));
+
+        $result = $this->agent->call($messages, ['response_format' => MovieAnswer::class]);
+        \assert($result instanceof ObjectResult);
+
+        $answer = $result->getContent();
+        \assert($answer instanceof MovieAnswer);
+
+        $assistantMessage = Message::ofAssistant($answer->answer);
+        $assistantMessage->getMetadata()->add('movies', $answer->movies);
+        $messages->add($assistantMessage);
+
+        $this->saveMessages($messages);
+    }
+
+    public function reset(): void
+    {
+        $this->requestStack->getSession()->remove(self::SESSION_KEY);
+    }
+
+    private function saveMessages(MessageBag $messages): void
+    {
+        $this->requestStack->getSession()->set(self::SESSION_KEY, $messages);
+    }
+}

--- a/demo/src/Movies/Data/MovieAnswer.php
+++ b/demo/src/Movies/Data/MovieAnswer.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Movies\Data;
+
+/**
+ * Structured assistant reply combining a written answer with the movies to render as cards.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class MovieAnswer
+{
+    /**
+     * @var string The written, conversational answer to the user, formatted as markdown
+     */
+    public string $answer;
+
+    /**
+     * @var MovieSuggestion[] Movies to display as cards beneath the answer; empty when none are relevant
+     */
+    public array $movies = [];
+}

--- a/demo/src/Movies/Data/MovieSuggestion.php
+++ b/demo/src/Movies/Data/MovieSuggestion.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Movies\Data;
+
+/**
+ * One movie the assistant decided to surface as a card, identified by its slug.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class MovieSuggestion
+{
+    /**
+     * @var string The exact slug of a movie returned by the movie_search tool
+     */
+    public string $slug;
+
+    /**
+     * @var string One short sentence on why this movie fits the user's request
+     */
+    public string $reason;
+}

--- a/demo/src/Movies/Movie.php
+++ b/demo/src/Movies/Movie.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Movies;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class Movie
+{
+    /**
+     * @param list<array{name: string, role: string}> $cast
+     * @param list<string>                            $plot
+     */
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $title,
+        public readonly ?int $year,
+        public readonly ?string $director,
+        public readonly ?string $imdb,
+        public readonly array $cast,
+        public readonly array $plot,
+        public readonly string $rawMarkdown,
+    ) {
+    }
+
+    public static function fromFile(string $path): self
+    {
+        $slug = basename($path, '.md');
+        $content = file_get_contents($path);
+        $title = $slug;
+        $year = null;
+        if (preg_match('/^#\s+(.+?)(?:\s*\((\d{4})\))?\s*$/m', (string) $content, $matches)) {
+            $title = trim($matches[1]);
+            $year = isset($matches[2]) ? (int) $matches[2] : null;
+        }
+
+        $director = null;
+        if (preg_match('/^\*\*Director:\*\*\s*(.+?)\s*$/m', (string) $content, $matches)) {
+            $director = trim($matches[1]);
+        }
+
+        $imdb = null;
+        if (preg_match('/^\*\*IMDB\*\*:\s*(\S+)/m', (string) $content, $matches)) {
+            $imdb = trim($matches[1]);
+        }
+
+        $cast = [];
+        if (preg_match('/^##\s+Cast\s*$(.*?)(?=^##\s+|\z)/ms', (string) $content, $matches)) {
+            preg_match_all('/^-\s*\*\*(.+?)\*\*\s+as\s+(.+?)\s*$/m', $matches[1], $castMatches, \PREG_SET_ORDER);
+            foreach ($castMatches as $castMatch) {
+                $cast[] = [
+                    'name' => trim($castMatch[1]),
+                    'role' => trim($castMatch[2]),
+                ];
+            }
+        }
+
+        $plot = [];
+        if (preg_match('/^##\s+Plot\s*$(.*?)(?=^##\s+|\z)/ms', (string) $content, $matches)) {
+            foreach (preg_split('/\n{2,}/', trim($matches[1])) ?: [] as $paragraph) {
+                $paragraph = trim($paragraph);
+                if ('' !== $paragraph) {
+                    $plot[] = $paragraph;
+                }
+            }
+        }
+
+        return new self($slug, $title, $year, $director, $imdb, $cast, $plot, (string) $content);
+    }
+
+    public function hue(): int
+    {
+        return crc32($this->slug) % 360;
+    }
+}

--- a/demo/src/Movies/MovieCardComponent.php
+++ b/demo/src/Movies/MovieCardComponent.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Movies;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[AsTwigComponent('movie_card')]
+final class MovieCardComponent
+{
+    public Movie $movie;
+}

--- a/demo/src/Movies/MovieRepository.php
+++ b/demo/src/Movies/MovieRepository.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Movies;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class MovieRepository
+{
+    public function __construct(
+        #[Autowire('%movies_dir%')]
+        private readonly string $directory,
+    ) {
+    }
+
+    /**
+     * @return list<Movie>
+     */
+    public function all(): array
+    {
+        $finder = (new Finder())
+            ->files()
+            ->in($this->directory)
+            ->name('*.md')
+            ->sortByName();
+
+        $movies = [];
+        foreach ($finder as $file) {
+            $movies[] = Movie::fromFile($file->getRealPath());
+        }
+
+        return $movies;
+    }
+
+    public function find(string $slug): ?Movie
+    {
+        if ('' === $slug || str_contains($slug, '/') || str_contains($slug, '..')) {
+            return null;
+        }
+
+        $path = $this->directory.\DIRECTORY_SEPARATOR.$slug.'.md';
+        if (!is_file($path)) {
+            return null;
+        }
+
+        return Movie::fromFile($path);
+    }
+}

--- a/demo/src/Movies/MovieSearch.php
+++ b/demo/src/Movies/MovieSearch.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Movies;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+
+/**
+ * Plain in-memory search over the movie collection, exposed to the agent as a tool.
+ *
+ * No vector store is involved: the agent calls this tool with a free-text query and gets the matching
+ * movies back - including their "slug", which it then reuses to reference movies in its structured answer.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[AsTool(
+    name: 'movie_search',
+    description: 'Search the movie collection by title, director or cast member. Returns the matching movies, each with a "slug" you must reuse to reference a movie in your answer. Pass an empty query to list the whole collection.',
+)]
+final class MovieSearch
+{
+    public function __construct(
+        private readonly MovieRepository $movies,
+    ) {
+    }
+
+    /**
+     * @param string $query Search term matched against title, director and cast; pass an empty string to list all movies
+     *
+     * @return list<array{slug: string, title: string, year: int|null, director: string|null, cast: list<string>, summary: string}>
+     */
+    public function __invoke(string $query = ''): array
+    {
+        $needle = mb_strtolower(trim($query));
+
+        $results = [];
+        foreach ($this->movies->all() as $movie) {
+            if ('' !== $needle && !$this->matches($movie, $needle)) {
+                continue;
+            }
+
+            $results[] = [
+                'slug' => $movie->slug,
+                'title' => $movie->title,
+                'year' => $movie->year,
+                'director' => $movie->director,
+                'cast' => array_map(static fn (array $member): string => $member['name'], $movie->cast),
+                'summary' => $movie->plot[0] ?? '',
+            ];
+        }
+
+        return $results;
+    }
+
+    private function matches(Movie $movie, string $needle): bool
+    {
+        if (str_contains(mb_strtolower($movie->title), $needle)) {
+            return true;
+        }
+
+        if (str_contains(mb_strtolower($movie->director ?? ''), $needle)) {
+            return true;
+        }
+
+        foreach ($movie->cast as $member) {
+            if (str_contains(mb_strtolower($member['name']), $needle)) {
+                return true;
+            }
+
+            if (str_contains(mb_strtolower($member['role']), $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/demo/src/Movies/TwigComponent.php
+++ b/demo/src/Movies/TwigComponent.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Movies;
+
+use Symfony\AI\Platform\Message\MessageInterface;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent('movies')]
+final class TwigComponent
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true)]
+    public ?string $message = null;
+
+    /**
+     * Slug of the movie whose details are shown in the modal, null when the modal is closed.
+     */
+    #[LiveProp]
+    public ?string $detailSlug = null;
+
+    public function __construct(
+        private readonly Chat $chat,
+        private readonly MovieRepository $movies,
+    ) {
+    }
+
+    /**
+     * @return MessageInterface[]
+     */
+    public function getMessages(): array
+    {
+        return $this->chat->loadMessages()->withoutSystemMessage()->withoutToolMessages()->getMessages();
+    }
+
+    /**
+     * Resolve the movie slugs stored on an assistant message to real movies, ready to render as cards.
+     *
+     * @return list<array{movie: Movie, reason: string}>
+     */
+    public function getMoviesFor(MessageInterface $message): array
+    {
+        if (!$message->getMetadata()->has('movies')) {
+            return [];
+        }
+
+        $suggestions = [];
+        foreach ($message->getMetadata()->get('movies') as $suggestion) {
+            $movie = $this->movies->find($suggestion->slug);
+            if (null !== $movie) {
+                $suggestions[] = ['movie' => $movie, 'reason' => $suggestion->reason];
+            }
+        }
+
+        return $suggestions;
+    }
+
+    public function getDetailMovie(): ?Movie
+    {
+        if (null === $this->detailSlug) {
+            return null;
+        }
+
+        return $this->movies->find($this->detailSlug);
+    }
+
+    #[LiveAction]
+    public function showDetails(#[LiveArg] string $slug): void
+    {
+        $this->detailSlug = $slug;
+    }
+
+    #[LiveAction]
+    public function closeDetails(): void
+    {
+        $this->detailSlug = null;
+    }
+
+    #[LiveAction]
+    public function submit(): void
+    {
+        if (null === $this->message || '' === trim($this->message)) {
+            return;
+        }
+
+        $this->chat->submitMessage($this->message);
+
+        $this->message = null;
+    }
+
+    #[LiveAction]
+    public function reset(): void
+    {
+        $this->chat->reset();
+        $this->detailSlug = null;
+    }
+}

--- a/demo/templates/base.html.twig
+++ b/demo/templates/base.html.twig
@@ -29,6 +29,9 @@
                             <a class="nav-link" href="{{ path('recipe') }}">{{ ux_icon('recipe') }} Recipe</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ path('movies') }}">{{ ux_icon('movie') }} Movies</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" href="{{ path('wikipedia') }}">{{ ux_icon('wikipedia') }} Wikipedia</a>
                         </li>
                         <li class="nav-item">
@@ -48,10 +51,6 @@
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="{{ path('stream') }}">{{ ux_icon('turbo') }} Turbo Stream</a>
-                        </li>
-                        <li class="nav-item"><span class="nav-link">|</span></li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="https://github.com/symfony/ai" target="_blank">{{ ux_icon('github') }} GitHub</a>
                         </li>
                     </ul>
                 </div>

--- a/demo/templates/components/_movie_poster.html.twig
+++ b/demo/templates/components/_movie_poster.html.twig
@@ -1,0 +1,25 @@
+{% set showText = showText|default(true) %}
+{% set aspect = aspect|default('4/3') %}
+{% set hue = movie.hue() %}
+{% set accent = (hue + 35) % 360 %}
+<div class="movie-poster d-flex flex-column justify-content-between p-3 text-white h-100"
+     style="aspect-ratio: {{ aspect }}; background: linear-gradient(135deg, hsl({{ hue }}, 65%, 42%) 0%, hsl({{ accent }}, 55%, 22%) 100%); text-shadow: 0 1px 2px rgba(0,0,0,.35);">
+    {% if showText %}
+        <div class="small fw-semibold text-uppercase" style="letter-spacing: .08em; opacity: .8;">
+            {% if movie.year %}{{ movie.year }}{% endif %}
+        </div>
+        <div>
+            <div class="fw-bold" style="font-size: 1.35rem; line-height: 1.15;">{{ movie.title }}</div>
+            {% if movie.director %}
+                <div class="small mt-1" style="opacity: .85;">{{ movie.director }}</div>
+            {% endif %}
+        </div>
+    {% else %}
+        <div class="display-6 fw-bold" style="opacity: .35; line-height: 1;">
+            {{ movie.title|slice(0, 1)|upper }}
+        </div>
+        {% if movie.year %}
+            <div class="small fw-semibold text-uppercase text-end" style="letter-spacing: .08em; opacity: .85;">{{ movie.year }}</div>
+        {% endif %}
+    {% endif %}
+</div>

--- a/demo/templates/components/movie_card.html.twig
+++ b/demo/templates/components/movie_card.html.twig
@@ -1,0 +1,32 @@
+<div {{ attributes.defaults({ class: 'row' }) }}>
+    <div class="col-4 movie-card-poster">
+        {% include 'components/_movie_poster.html.twig' with { movie, aspect: 'auto' } only %}
+    </div>
+    <div class="col-8 movie-card-scroll-body">
+        <h5 class="card-title mb-1">
+            {{ movie.title }}{% if movie.year %} <small class="text-muted">({{ movie.year }})</small>{% endif %}
+        </h5>
+        {% if movie.director %}
+            <p class="card-text text-muted mb-2"><strong>Director:</strong> {{ movie.director }}</p>
+        {% endif %}
+        {% if movie.imdb %}
+            <p class="card-text mb-3">
+                <a href="{{ movie.imdb }}" target="_blank" rel="noopener">IMDB &rarr;</a>
+            </p>
+        {% endif %}
+        {% if movie.plot|length > 0 %}
+            <h6 class="text-dark-emphasis">Plot</h6>
+            {% for paragraph in movie.plot %}
+                <p class="card-text small">{{ paragraph|markdown_to_html }}</p>
+            {% endfor %}
+        {% endif %}
+        {% if movie.cast|length > 0 %}
+            <h6 class="text-dark-emphasis mt-3">Cast</h6>
+            <ul class="list-unstyled small mb-0">
+                {% for member in movie.cast %}
+                    <li><strong>{{ member.name }}</strong> as {{ member.role }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </div>
+</div>

--- a/demo/templates/components/movies.html.twig
+++ b/demo/templates/components/movies.html.twig
@@ -1,0 +1,65 @@
+{% import "_message.html.twig" as message %}
+
+<div class="card mx-auto shadow-lg" {{ attributes.defaults(stimulus_controller('movies')) }}>
+    <div class="card-header p-2">
+        {{ ux_icon('movie') }}
+        <strong class="ms-1 pt-1 d-inline-block">Movie Bot</strong>
+        <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('cancel') }} Reset Chat</button>
+    </div>
+    <div id="chat-body" class="card-body p-4 overflow-auto">
+        {% for msg in this.messages %}
+            {% include '_message.html.twig' with { message: msg, latest: loop.last } %}
+            {% if msg.role.value == 'assistant' %}
+                {% set suggestions = this.getMoviesFor(msg) %}
+                {% if suggestions is not empty %}
+                    <div class="movie-suggestions d-flex flex-wrap gap-3 mb-4">
+                        {% for suggestion in suggestions %}
+                            <figure class="movie-suggestion mb-0 text-center">
+                                <button type="button"
+                                        class="movie-poster-btn"
+                                        title="{{ suggestion.reason }}"
+                                        {{ live_action('showDetails', { slug: suggestion.movie.slug }) }}>
+                                    {% include 'components/_movie_poster.html.twig' with { movie: suggestion.movie, aspect: '1 / 1', showText: false } only %}
+                                </button>
+                                <figcaption class="movie-poster-caption small mt-2">
+                                    <span class="fw-semibold d-block">{{ suggestion.movie.title }}</span>
+                                    {% if suggestion.movie.year %}<span class="text-muted">{{ suggestion.movie.year }}</span>{% endif %}
+                                </figcaption>
+                            </figure>
+                        {% endfor %}
+                    </div>
+                {% endif %}
+            {% endif %}
+        {% else %}
+            <div id="welcome" class="text-center mt-5 py-5 bg-white rounded-5 shadow-sm w-75 mx-auto">
+                {{ ux_icon('movie', { height: '200px', width: '200px' }) }}
+                <h4 class="mt-5">Chat about movies</h4>
+                <span class="text-muted">Search for movies in our collection by title, director, cast or vibe &mdash; matching movies appear as cards.</span>
+            </div>
+        {% endfor %}
+        <div id="loading-message" class="d-none">
+            {{ message.user([{text:''}]) }}
+            {{ message.bot('The Movie Bot is browsing the collection ...', true) }}
+        </div>
+    </div>
+    {% set detailMovie = this.detailMovie %}
+    {% if detailMovie %}
+        <div class="movie-modal-overlay">
+            <button type="button" class="movie-modal-backdrop" {{ live_action('closeDetails') }} aria-label="Close details"></button>
+            <div class="movie-modal-panel">
+                <button type="button" class="movie-modal-close" {{ live_action('closeDetails') }} aria-label="Close">&times;</button>
+                {{ component('movie_card', { movie: detailMovie }) }}
+            </div>
+        </div>
+    {% endif %}
+    <div class="card-footer p-2">
+        <form class="input-group" {{ live_action('submit:prevent') }}>
+            <input autofocus id="chat-message"
+                   data-model="norender|message"
+                   type="text" class="form-control border-0" placeholder="Write a message ...">
+            <button class="btn btn-outline-secondary border-0">
+                {{ ux_icon('send') }} Submit
+            </button>
+        </form>
+    </div>
+</div>

--- a/demo/templates/index.html.twig
+++ b/demo/templates/index.html.twig
@@ -8,7 +8,7 @@
         <p class="my-4 text-dark">
             {{ 'home.intro'|trans }}<br />
             {{ 'home.intro_suffix'|trans }}<br />
-            Central to this demo are five chatbot examples that are implemented in <code>src/**/Chat.php</code> and AI
+            Central to this demo are six chatbot examples that are implemented in <code>src/**/Chat.php</code> and AI
             configuration can be found in <code>config/packages/ai.yaml</code>.
         </p>
         <h3 class="text-dark">{{ 'home.examples'|trans }}</h3>
@@ -90,6 +90,27 @@
                 </div>
             </div>
             <div class="col">
+                <div class="card movies bg-body shadow-sm">
+                    <div class="card-img-top py-2">
+                        {{ ux_icon('movie') }}
+                    </div>
+                    <div class="card-body">
+                        <h5 class="card-title">Movie Bot</h5>
+                        <p class="card-text">Search for movies in our collection, with structured output rendered as cards.</p>
+                        <a href="{{ path('movies') }}" class="btn btn-outline-dark d-block">Try Movie Bot</a>
+                    </div>
+                    {# Profiler route only available in dev #}
+                    {% if 'dev' == app.environment %}
+                        <div class="card-footer">
+                            {{ ux_icon('code') }}
+                            <a href="{{ path('_profiler_open_file', { file: 'src/Movies/Chat.php', line: 51 }) }}">See Implementation</a>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        <div class="row mt-2 row-cols-1 row-cols-md-5 g-3 justify-content-center">
+            <div class="col">
                 <div class="card speech bg-body shadow-sm">
                     <div class="card-img-top py-2">
                         {{ ux_icon('microphone') }}
@@ -108,8 +129,6 @@
                     {% endif %}
                 </div>
             </div>
-        </div>
-        <div class="row mt-2 row-cols-1 row-cols-md-5 g-3 justify-content-center">
             <div class="col">
                 <div class="card video bg-body shadow-sm">
                     <div class="card-img-top py-2">

--- a/demo/tests/Movie/MovieRepositoryTest.php
+++ b/demo/tests/Movie/MovieRepositoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Movie;
+
+use App\Movies\Movie;
+use App\Movies\MovieRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[CoversClass(MovieRepository::class)]
+final class MovieRepositoryTest extends TestCase
+{
+    private string $directory;
+    private Filesystem $fs;
+
+    protected function setUp(): void
+    {
+        $this->directory = sys_get_temp_dir().'/movie-repo-'.uniqid();
+        $this->fs = new Filesystem();
+        $this->fs->mkdir($this->directory);
+
+        $this->fs->dumpFile($this->directory.'/alpha.md', "# Alpha (2001)\n\n**Director:** Someone\n");
+        $this->fs->dumpFile($this->directory.'/beta.md', "# Beta (2002)\n\n**Director:** Another\n");
+        $this->fs->dumpFile($this->directory.'/notes.txt', 'should be ignored');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs->remove($this->directory);
+    }
+
+    public function testAllReturnsMoviesSortedByFilename()
+    {
+        $repository = new MovieRepository($this->directory);
+
+        $movies = $repository->all();
+
+        $this->assertCount(2, $movies);
+        /* @phpstan-ignore-next-line method.alreadyNarrowedTypy */
+        $this->assertContainsOnlyInstancesOf(Movie::class, $movies);
+        $this->assertSame(['alpha', 'beta'], array_map(static fn (Movie $m) => $m->slug, $movies));
+    }
+
+    public function testFindReturnsMovieWhenFilePresent()
+    {
+        $repository = new MovieRepository($this->directory);
+
+        $movie = $repository->find('alpha');
+
+        $this->assertNotNull($movie);
+        $this->assertSame('Alpha', $movie->title);
+        $this->assertSame(2001, $movie->year);
+    }
+
+    public function testFindReturnsNullForUnknownSlug()
+    {
+        $repository = new MovieRepository($this->directory);
+
+        $this->assertNull($repository->find('gamma'));
+    }
+
+    public function testFindRejectsEmptyAndTraversalSlugs()
+    {
+        $repository = new MovieRepository($this->directory);
+
+        $this->assertNull($repository->find(''));
+        $this->assertNull($repository->find('../secret'));
+        $this->assertNull($repository->find('nested/path'));
+    }
+}

--- a/demo/tests/Movie/MovieSearchTest.php
+++ b/demo/tests/Movie/MovieSearchTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Movie;
+
+use App\Movies\MovieRepository;
+use App\Movies\MovieSearch;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MovieSearch::class)]
+final class MovieSearchTest extends TestCase
+{
+    private const FIXTURES_DIR = __DIR__.'/../../../fixtures/movies';
+
+    public function testEmptyQueryReturnsWholeCollection()
+    {
+        $results = ($this->search())('');
+
+        $this->assertNotSame([], $results);
+        $this->assertArrayHasKey('slug', $results[0]);
+        $this->assertArrayHasKey('title', $results[0]);
+        $this->assertArrayHasKey('cast', $results[0]);
+        $this->assertArrayHasKey('summary', $results[0]);
+    }
+
+    public function testSearchMatchesTitle()
+    {
+        $slugs = $this->slugsFor('matrix');
+
+        $this->assertContains('the-matrix', $slugs);
+    }
+
+    public function testSearchMatchesDirector()
+    {
+        $slugs = $this->slugsFor('Wachowski');
+
+        $this->assertContains('the-matrix', $slugs);
+        $this->assertContains('cloud-atlas', $slugs);
+    }
+
+    public function testSearchMatchesCastMember()
+    {
+        $slugs = $this->slugsFor('Keanu Reeves');
+
+        $this->assertContains('the-matrix', $slugs);
+    }
+
+    public function testSearchReturnsEmptyArrayForNoMatch()
+    {
+        $this->assertSame([], ($this->search())('this-does-not-match-anything'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugsFor(string $query): array
+    {
+        return array_map(static fn (array $result): string => $result['slug'], ($this->search())($query));
+    }
+
+    private function search(): MovieSearch
+    {
+        return new MovieSearch(new MovieRepository(self::FIXTURES_DIR));
+    }
+}

--- a/demo/tests/Movie/MovieTest.php
+++ b/demo/tests/Movie/MovieTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Movie;
+
+use App\Movies\Movie;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Movie::class)]
+final class MovieTest extends TestCase
+{
+    private const FIXTURES_DIR = __DIR__.'/../../../fixtures/movies';
+
+    public function testFromFileParsesCloudAtlasFixture()
+    {
+        $movie = Movie::fromFile(self::FIXTURES_DIR.'/cloud-atlas.md');
+
+        $this->assertSame('cloud-atlas', $movie->slug);
+        $this->assertSame('Cloud Atlas', $movie->title);
+        $this->assertSame(2012, $movie->year);
+        $this->assertSame('The Wachowskis', $movie->director);
+        $this->assertSame('https://www.imdb.com/title/tt0443001/', $movie->imdb);
+        $this->assertSame(['name' => 'Tom Hanks', 'role' => 'Various Roles'], $movie->cast[0]);
+        $this->assertCount(4, $movie->cast);
+        $this->assertNotSame([], $movie->plot);
+    }
+
+    public function testFromFileParsesMatrixFixture()
+    {
+        $movie = Movie::fromFile(self::FIXTURES_DIR.'/the-matrix.md');
+
+        $this->assertSame('the-matrix', $movie->slug);
+        $this->assertSame('The Matrix', $movie->title);
+        $this->assertSame(1999, $movie->year);
+        $this->assertSame('The Wachowskis', $movie->director);
+        $this->assertCount(4, $movie->cast);
+        $this->assertSame('Keanu Reeves', $movie->cast[0]['name']);
+        $this->assertSame('Neo', $movie->cast[0]['role']);
+    }
+
+    public function testFromFileWithMinimalMarkdownLeavesOptionalFieldsNull()
+    {
+        $path = sys_get_temp_dir().'/movie-minimal-'.uniqid().'.md';
+        file_put_contents($path, "# Nameless\n\nJust a title, nothing else.\n");
+
+        try {
+            $movie = Movie::fromFile($path);
+
+            $this->assertSame('Nameless', $movie->title);
+            $this->assertNull($movie->year);
+            $this->assertNull($movie->director);
+            $this->assertNull($movie->imdb);
+            $this->assertSame([], $movie->cast);
+            $this->assertSame([], $movie->plot);
+        } finally {
+            unlink($path);
+        }
+    }
+
+    public function testFromFileExposesRawMarkdown()
+    {
+        $movie = Movie::fromFile(self::FIXTURES_DIR.'/cloud-atlas.md');
+
+        $this->assertStringContainsString('## Plot', $movie->rawMarkdown);
+        $this->assertStringContainsString('**Director:** The Wachowskis', $movie->rawMarkdown);
+    }
+}

--- a/demo/tests/SmokeTest.php
+++ b/demo/tests/SmokeTest.php
@@ -28,7 +28,7 @@ final class SmokeTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
         $this->assertSelectorTextContains('h1', 'Welcome to the Symfony AI Demo');
-        $this->assertSelectorCount(9, '.card');
+        $this->assertSelectorCount(10, '.card');
     }
 
     #[DataProvider('provideChats')]

--- a/fixtures/movies/django-unchained.md
+++ b/fixtures/movies/django-unchained.md
@@ -1,0 +1,25 @@
+# Django Unchained (2012)
+
+**IMDB**: https://www.imdb.com/title/tt1853728/
+
+**Director:** Quentin Tarantino
+
+## Cast
+
+- **Jamie Foxx** as Django
+- **Christoph Waltz** as Dr. King Schultz
+- **Leonardo DiCaprio** as Calvin Candie
+- **Kerry Washington** as Broomhilda von Shaft
+- **Samuel L. Jackson** as Stephen
+
+## Plot
+
+With the help of a German bounty hunter, a freed slave sets out to rescue his wife from a brutal Mississippi plantation owner.
+
+**Django**, a slave in the American South, is freed by **Dr. King Schultz**, a former dentist turned bounty hunter, who needs Django's help to identify a trio of wanted outlaws. In exchange, Schultz offers to train Django in his trade and help him rescue his wife **Broomhilda** from the clutches of the charming but sadistic plantation owner **Calvin Candie**.
+
+Their journey takes them across the antebellum South in a blend of western iconography, biting satire, and operatic violence. Candie's loyal head house slave **Stephen** proves to be an unexpectedly dangerous adversary once Django and Schultz arrive at the sprawling Candyland estate.
+
+The film explores themes of *slavery*, *revenge*, *friendship*, and *moral compromise* through Tarantino's signature blend of stylized dialogue and genre homage.
+
+**Connections**: Directed by Quentin Tarantino, who also directed *Pulp Fiction*, *Reservoir Dogs*, and *Kill Bill: Vol. 1*. Samuel L. Jackson also stars in *Pulp Fiction*.

--- a/fixtures/movies/forrest-gump.md
+++ b/fixtures/movies/forrest-gump.md
@@ -1,0 +1,25 @@
+# Forrest Gump (1994)
+
+**IMDB**: https://www.imdb.com/title/tt0109830/
+
+**Director:** Robert Zemeckis
+
+## Cast
+
+- **Tom Hanks** as Forrest Gump
+- **Robin Wright** as Jenny Curran
+- **Gary Sinise** as Lieutenant Dan Taylor
+- **Mykelti Williamson** as Benjamin Buford 'Bubba' Blue
+- **Sally Field** as Mrs. Gump
+
+## Plot
+
+A slow-witted but kind-hearted man from Alabama witnesses and unwittingly influences several defining events of the late 20th century in the United States.
+
+**Forrest Gump**, born with a below-average IQ and leg braces as a child, grows up in small-town Greenbow, Alabama, where his mother instills in him the belief that he is no different from anyone else. Through sheer sincerity and a knack for being in the right place at the right time, Forrest becomes a college football star, a decorated Vietnam War veteran, a ping-pong champion, and an accidental entrepreneur.
+
+Throughout his life, Forrest never stops loving his childhood friend **Jenny**, whose turbulent path contrasts sharply with his own seemingly charmed journey. His bond with **Lieutenant Dan**, a bitter commanding officer whose life Forrest saves in Vietnam, becomes another emotional anchor of the story.
+
+The film explores themes of *fate vs. free will*, *innocence*, *perseverance*, and the American experience across several decades.
+
+**Connections**: Tom Hanks also stars in *Cloud Atlas* and *The Green Mile*.

--- a/fixtures/movies/oppenheimer.md
+++ b/fixtures/movies/oppenheimer.md
@@ -1,0 +1,25 @@
+# Oppenheimer (2023)
+
+**IMDB**: https://www.imdb.com/title/tt15398776/
+
+**Director:** Christopher Nolan
+
+## Cast
+
+- **Cillian Murphy** as J. Robert Oppenheimer
+- **Emily Blunt** as Katherine 'Kitty' Oppenheimer
+- **Robert Downey Jr.** as Lewis Strauss
+- **Matt Damon** as Leslie Groves
+- **Florence Pugh** as Jean Tatlock
+
+## Plot
+
+The story of American scientist J. Robert Oppenheimer and his role in the development of the atomic bomb.
+
+The film traces **J. Robert Oppenheimer** from his early years as a brilliant but troubled theoretical physicist, through his leadership of the Manhattan Project at Los Alamos, to the political reckoning that follows the creation of the weapon he helped bring into the world. As director of the secret wartime laboratory, Oppenheimer gathers a generation of physicists to race Nazi Germany to the bomb.
+
+After the war, his calls for international control of nuclear weapons collide with the rising paranoia of the early Cold War, and his past associations make him a target in a closed-door security hearing orchestrated by **Lewis Strauss**. The narrative weaves between Oppenheimer's subjective memories and Strauss's Senate confirmation hearings, gradually exposing the personal cost of his choices.
+
+The film explores themes of *scientific responsibility*, *power*, *guilt*, and the *moral ambiguity* of the nuclear age.
+
+**Connections**: Directed by Christopher Nolan, who also directed *Inception*, *Interstellar*, *The Prestige*, *The Dark Knight*, and *Memento*. Cillian Murphy also appears in *Inception* and *The Dark Knight*.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no (demo only)
| Docs?         | no
| Issues        | -
| License       | MIT

Adds a standalone movie chat demo to the demo app: a `movie_search` `#[AsTool]` doing plain in-memory search over the markdown fixtures (no vector store), and a `movies` agent returning structured output (`MovieAnswer { answer, movies[] }`). The written answer renders as chat text while suggested movies are resolved by slug from the repository and shown as cards.