### PR TITLE
[Demo] Stream recipe bot output step-by-step via SSE

### DIFF
--- a/demo/assets/styles/recipe.css
+++ b/demo/assets/styles/recipe.css
@@ -26,6 +26,17 @@
         }
     }
 
+    .recipe-loader {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background: rgba(255, 255, 255, 0.85);
+        z-index: 5;
+    }
+
     .share-overlay {
         position: fixed;
         inset: 0;

--- a/demo/config/routes.yaml
+++ b/demo/config/routes.yaml
@@ -31,6 +31,10 @@ recipe:
         template:  'chat.html.twig'
         context: { chat: 'recipe' }
 
+recipe_assistant_reply:
+    path: '/recipe/assistant-reply'
+    controller: 'App\Recipe\TwigComponent::streamContent'
+
 speech:
     path: '/speech'
     controller: 'Symfony\Bundle\FrameworkBundle\Controller\TemplateController'

--- a/demo/src/Recipe/Chat.php
+++ b/demo/src/Recipe/Chat.php
@@ -12,19 +12,23 @@
 namespace App\Recipe;
 
 use App\Recipe\Data\Recipe;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\AI\Platform\Result\ObjectResult;
+use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Result\Stream\Delta\PartialObjectDelta;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 final class Chat
 {
-    private const SESSION_KEY = 'recipe-chat';
+    private const CACHE_PREFIX = 'recipe-chat-';
+    private const CACHE_TTL = 3600;
 
     public function __construct(
         private readonly RequestStack $requestStack,
+        private readonly CacheItemPoolInterface $cache,
         #[Autowire(service: 'ai.agent.recipe')]
         private readonly AgentInterface $agent,
     ) {
@@ -52,33 +56,81 @@ final class Chat
         $messages = $this->loadMessages();
 
         $messages->add(Message::ofUser($message));
-        $result = $this->agent->call($messages, ['response_format' => Recipe::class]);
 
-        \assert($result instanceof ObjectResult);
+        $this->saveMessages($messages);
+    }
 
-        $recipe = $result->getContent();
+    /**
+     * Whether the latest user message is still awaiting its recipe, i.e. a stream
+     * should be (or is being) consumed for it.
+     */
+    public function isAwaitingRecipe(): bool
+    {
+        $messages = $this->loadMessages()->getMessages();
 
-        \assert($recipe instanceof Recipe);
+        if (0 === \count($messages)) {
+            return false;
+        }
+
+        return $messages[\count($messages) - 1] instanceof UserMessage;
+    }
+
+    /**
+     * Streams the recipe as it is generated, yielding a progressively populated Recipe
+     * for each partial snapshot and persisting the final recipe to the chat store.
+     *
+     * @return \Generator<int, Recipe, void, Recipe>
+     */
+    public function getRecipeStream(MessageBag $messages): \Generator
+    {
+        $stream = $this->agent->call($messages, [
+            'stream' => true,
+            'response_format' => Recipe::class,
+        ])->getContent();
+
+        \assert(is_iterable($stream));
+
+        $recipe = new Recipe();
+        foreach ($stream as $delta) {
+            if ($delta instanceof PartialObjectDelta) {
+                $recipe = $delta->getObject();
+                \assert($recipe instanceof Recipe);
+
+                yield $recipe;
+            }
+        }
 
         $assistantMessage = Message::ofAssistant($recipe->toString());
         $assistantMessage->getMetadata()->add('recipe', $recipe);
         $messages->add($assistantMessage);
 
         $this->saveMessages($messages);
+
+        return $recipe;
     }
 
     public function reset(): void
     {
-        $this->requestStack->getSession()->remove(self::SESSION_KEY);
+        $this->cache->deleteItem($this->cacheKey());
     }
 
-    private function loadMessages(): MessageBag
+    public function loadMessages(): MessageBag
     {
-        return $this->requestStack->getSession()->get(self::SESSION_KEY, new MessageBag());
+        $item = $this->cache->getItem($this->cacheKey());
+
+        return $item->isHit() ? $item->get() : new MessageBag();
     }
 
     private function saveMessages(MessageBag $messages): void
     {
-        $this->requestStack->getSession()->set(self::SESSION_KEY, $messages);
+        $item = $this->cache->getItem($this->cacheKey());
+        $item->set($messages)->expiresAfter(self::CACHE_TTL);
+
+        $this->cache->save($item);
+    }
+
+    private function cacheKey(): string
+    {
+        return self::CACHE_PREFIX.$this->requestStack->getSession()->getId();
     }
 }

--- a/demo/src/Recipe/Data/Ingredient.php
+++ b/demo/src/Recipe/Data/Ingredient.php
@@ -16,15 +16,15 @@ final class Ingredient
     /**
      * @var string Name of the ingredient
      */
-    public string $name;
+    public ?string $name = null;
 
     /**
      * @var string Quantity of the ingredient (e.g., "2 cups", "150g")
      */
-    public string $quantity;
+    public ?string $quantity = null;
 
     public function toString(): string
     {
-        return \sprintf('%s of %s', $this->quantity, $this->name);
+        return \sprintf('%s of %s', $this->quantity ?? '', $this->name ?? '');
     }
 }

--- a/demo/src/Recipe/Data/Recipe.php
+++ b/demo/src/Recipe/Data/Recipe.php
@@ -18,35 +18,35 @@ final class Recipe
     /**
      * @var string Name of the recipe
      */
-    public string $name;
+    public ?string $name = null;
 
     /**
      * @var int Duration in minutes
      */
     #[Schema(minimum: 5, maximum: 240)]
-    public int $duration;
+    public ?int $duration = null;
 
     /**
      * @var string Difficulty level of the recipe
      */
     #[Schema(enum: ['Beginner', 'Intermediate', 'Advanced'])]
-    public string $level;
+    public ?string $level = null;
 
     /**
      * @var string Dietary preference
      */
     #[Schema(enum: ['Vegetarian', 'Vegan', 'Gluten-Free', 'Keto', 'Paleo'])]
-    public string $diet;
+    public ?string $diet = null;
 
     /**
      * @var Ingredient[] List of ingredients
      */
-    public array $ingredients;
+    public array $ingredients = [];
 
     /**
      * @var string[] Cooking instructions
      */
-    public array $steps;
+    public array $steps = [];
 
     public function toString(): string
     {

--- a/demo/src/Recipe/TwigComponent.php
+++ b/demo/src/Recipe/TwigComponent.php
@@ -12,6 +12,10 @@
 namespace App\Recipe;
 
 use App\Recipe\Data\Recipe;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\EventStreamResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\ServerEvent;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
@@ -20,7 +24,7 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
 #[AsLiveComponent('recipe')]
-final class TwigComponent
+final class TwigComponent extends AbstractController
 {
     use DefaultActionTrait;
 
@@ -48,6 +52,11 @@ final class TwigComponent
         }
     }
 
+    public function isAwaitingRecipe(): bool
+    {
+        return $this->chat->isAwaitingRecipe();
+    }
+
     #[LiveAction]
     public function submit(): void
     {
@@ -58,6 +67,24 @@ final class TwigComponent
         $this->chat->submitMessage($this->message);
 
         $this->message = null;
+    }
+
+    public function streamContent(Request $request): EventStreamResponse
+    {
+        // The chat is kept in a session-scoped cache, so make sure the session id is
+        // available; the streamed body itself never touches the session, which lets the
+        // framework close (and unlock) it before the response is sent.
+        $request->getSession()->start();
+
+        $messages = $this->chat->loadMessages();
+
+        return new EventStreamResponse(function () use ($messages) {
+            foreach ($this->chat->getRecipeStream($messages) as $recipe) {
+                yield new ServerEvent(explode("\n", $this->renderBlockView('components/_recipe_stream.html.twig', 'update', ['recipe' => $recipe])));
+            }
+
+            yield new ServerEvent(explode("\n", $this->renderBlockView('components/_recipe_stream.html.twig', 'end')));
+        });
     }
 
     #[LiveAction]

--- a/demo/src/Stream/Chat.php
+++ b/demo/src/Stream/Chat.php
@@ -11,6 +11,7 @@
 
 namespace App\Stream;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Message;
@@ -22,10 +23,12 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 final class Chat
 {
-    private const SESSION_KEY = 'stream-chat';
+    private const CACHE_PREFIX = 'stream-chat-';
+    private const CACHE_TTL = 3600;
 
     public function __construct(
         private readonly RequestStack $requestStack,
+        private readonly CacheItemPoolInterface $cache,
         #[Autowire(service: 'ai.agent.stream')]
         private readonly AgentInterface $agent,
     ) {
@@ -33,7 +36,9 @@ final class Chat
 
     public function loadMessages(): MessageBag
     {
-        return $this->requestStack->getSession()->get(self::SESSION_KEY, new MessageBag());
+        $item = $this->cache->getItem($this->cacheKey());
+
+        return $item->isHit() ? $item->get() : new MessageBag();
     }
 
     public function submitMessage(string $message): UserMessage
@@ -72,11 +77,19 @@ final class Chat
 
     public function reset(): void
     {
-        $this->requestStack->getSession()->remove(self::SESSION_KEY);
+        $this->cache->deleteItem($this->cacheKey());
     }
 
     private function saveMessages(MessageBag $messages): void
     {
-        $this->requestStack->getSession()->set(self::SESSION_KEY, $messages);
+        $item = $this->cache->getItem($this->cacheKey());
+        $item->set($messages)->expiresAfter(self::CACHE_TTL);
+
+        $this->cache->save($item);
+    }
+
+    private function cacheKey(): string
+    {
+        return self::CACHE_PREFIX.$this->requestStack->getSession()->getId();
     }
 }

--- a/demo/src/Stream/TwigComponent.php
+++ b/demo/src/Stream/TwigComponent.php
@@ -16,8 +16,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\EventStreamResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ServerEvent;
-use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -65,16 +63,14 @@ final class TwigComponent extends AbstractController
 
     public function streamContent(Request $request): EventStreamResponse
     {
+        // The chat is kept in a session-scoped cache, so make sure the session id is
+        // available; the streamed body itself never touches the session, which lets the
+        // framework close (and unlock) it before the response is sent.
+        $request->getSession()->start();
+
         $messages = $this->chat->loadMessages();
 
-        $actualSession = $request->getSession();
-
-        // Overriding session will prevent the framework calling save() on the actual session.
-        // This fixes "Failed to start the session because headers have already been sent" error.
-        $request->setSession(new Session(new MockArraySessionStorage()));
-
-        return new EventStreamResponse(function () use ($request, $actualSession, $messages) {
-            $request->setSession($actualSession);
+        return new EventStreamResponse(function () use ($messages) {
             $response = $this->chat->getAssistantResponse($messages);
 
             foreach ($response as $partialMessage) {

--- a/demo/templates/components/_recipe_card.html.twig
+++ b/demo/templates/components/_recipe_card.html.twig
@@ -1,0 +1,79 @@
+<h2 class="mb-4 pb-3 border-bottom">{{ recipe.name }}</h2>
+<div class="row mb-4">
+    <div class="col-md-4 text-center">
+        <div class="row">
+            {% if recipe.duration %}
+                <div class="col-md-4">
+                    <div class="info-box p-2 bg-light rounded">
+                        {{ ux_icon('clock', { height: '24px', width: '24px', class: 'text-primary' }) }}
+                        <p class="mb-0 mt-2 small">
+                            <strong>{{ recipe.duration }}</strong><br>
+                            <span class="text-muted">minutes</span>
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
+            {% if recipe.level %}
+                <div class="col-md-4">
+                    <div class="info-box p-2 bg-light rounded">
+                        {{ ux_icon('difficulty', { height: '24px', width: '24px', class: 'text-warning' }) }}
+                        <p class="mb-0 mt-2 small">
+                            <strong>{{ recipe.level }}</strong><br>
+                            <span class="text-muted">difficulty</span>
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
+            {% if recipe.diet %}
+                <div class="col-md-4">
+                    <div class="info-box p-2 bg-light rounded">
+                        {{ ux_icon('vegetarian', { height: '24px', width: '24px', class: 'text-success' }) }}
+                        <p class="mb-0 mt-2 small">
+                            <strong>{{ recipe.diet }}</strong><br>
+                            <span class="text-muted">diet</span>
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+
+        <!-- Ingredients Section -->
+        <div class="mb-4 text-start mt-4">
+            <h5 class="mb-3">
+                {{ ux_icon('ingredients', { class: 'me-2' }) }}
+                Ingredients
+            </h5>
+            <div class="d-flex flex-wrap gap-2">
+                {% for ingredient in recipe.ingredients %}
+                    <span class="badge text-start bg-success bg-opacity-50 text-white py-2 px-3">
+                        <strong>{{ ingredient.name }}</strong><br />
+                        <small>{{ ingredient.quantity }}</small>
+                    </span>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    <div class="col-md-8 text-start">
+        <h5 class="mb-3">
+            {{ ux_icon('steps', { class: 'me-2' }) }}
+            Instructions
+        </h5>
+        <div class="">
+            {% for step in recipe.steps %}
+                <div class="d-flex mb-2 bg-light-subtle p-2 rounded">
+                    <div class="bg-dark text-white rounded-circle d-flex align-items-center justify-content-center me-3" style="min-width: 32px; width: 32px; height: 32px;">
+                        <small class="fw-bold">{{ loop.index }}</small>
+                    </div>
+                    {{ step }}
+                </div>
+            {% endfor %}
+        </div>
+        <div class="mt-4 border-top pt-3 d-flex align-items-center justify-content-between">
+            <div class="fw-semibold text-muted">Share this recipe</div>
+            <button class="btn btn-outline-secondary" {{ live_action('openShare') }}>
+                {{ ux_icon('email', { class: 'me-1' }) }}
+                Share
+            </button>
+        </div>
+    </div>
+</div>

--- a/demo/templates/components/_recipe_stream.html.twig
+++ b/demo/templates/components/_recipe_stream.html.twig
@@ -1,0 +1,8 @@
+{% block update %}
+    <twig:Turbo:Stream:Update target="#recipe-stream-target">{{ include('components/_recipe_card.html.twig', { recipe: recipe }) }}</twig:Turbo:Stream:Update>
+    <twig:Turbo:Stream:Remove target="#recipe-loader"/>
+{% endblock %}
+
+{% block end %}
+    <twig:Turbo:Stream:Remove target="#recipe-stream-source"/>
+{% endblock %}

--- a/demo/templates/components/recipe.html.twig
+++ b/demo/templates/components/recipe.html.twig
@@ -4,100 +4,30 @@
         <strong class="ms-1 pt-1 d-inline-block">Recipe Bot</strong>
         <button {{ live_action('reset') }} class="btn btn-sm btn-outline-secondary float-end">{{ ux_icon('cancel') }} Reset Chat</button>
     </div>
-    <div id="chat-body" class="card-body p-4 overflow-auto">
-        {% if this.recipe %}
-            {% set recipe = this.recipe %}
-            <div data-loading="hide">
-                <h2 class="mb-4 pb-3 border-bottom">{{ recipe.name }}</h2>
-                <div class="row mb-4">
-                    <div class="col-md-4 text-center">
-                        <div class="row">
-                            <div class="col-md-4">
-                                <div class="info-box p-2 bg-light rounded">
-                                    {{ ux_icon('clock', { height: '24px', width: '24px', class: 'text-primary' }) }}
-                                    <p class="mb-0 mt-2 small">
-                                        <strong>{{ recipe.duration }}</strong><br>
-                                        <span class="text-muted">minutes</span>
-                                    </p>
-                                </div>
-                            </div>
-                            <div class="col-md-4">
-                                <div class="info-box p-2 bg-light rounded">
-                                    {{ ux_icon('difficulty', { height: '24px', width: '24px', class: 'text-warning' }) }}
-                                    <p class="mb-0 mt-2 small">
-                                        <strong>{{ recipe.level }}</strong><br>
-                                        <span class="text-muted">difficulty</span>
-                                    </p>
-                                </div>
-                            </div>
-                            <div class="col-md-4">
-                                <div class="info-box p-2 bg-light rounded">
-                                    {{ ux_icon('vegetarian', { height: '24px', width: '24px', class: 'text-success' }) }}
-                                    <p class="mb-0 mt-2 small">
-                                        <strong>{{ recipe.diet }}</strong><br>
-                                        <span class="text-muted">diet</span>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Ingredients Section -->
-                        <div class="mb-4 text-start mt-4">
-                            <h5 class="mb-3">
-                                {{ ux_icon('ingredients', { class: 'me-2' }) }}
-                                Ingredients
-                            </h5>
-                            <div class="d-flex flex-wrap gap-2">
-                                {% for ingredient in recipe.ingredients %}
-                                    <span class="badge text-start bg-success bg-opacity-50 text-white py-2 px-3">
-                                        <strong>{{ ingredient.name }}</strong><br />
-                                        <small>{{ ingredient.quantity }}</small>
-                                    </span>
-                                {% endfor %}
-                            </div>
-                        </div>
+    <div id="chat-body" class="card-body p-4 overflow-auto position-relative">
+        {% if this.awaitingRecipe %}
+            <div id="recipe-stream-target"></div>
+            <turbo-stream-source src="{{ path('recipe_assistant_reply') }}" id="recipe-stream-source"></turbo-stream-source>
+            <div id="recipe-loader" class="recipe-loader">
+                <div class="d-flex flex-column align-items-center justify-content-center">
+                    <div class="spinner-border text-success mb-4" style="width: 60px; height: 60px;">
+                        <span class="visually-hidden">Loading...</span>
                     </div>
-                    <div class="col-md-8 text-start">
-                        <h5 class="mb-3">
-                            {{ ux_icon('steps', { class: 'me-2' }) }}
-                            Instructions
-                        </h5>
-                        <div class="">
-                            {% for step in recipe.steps %}
-                                <div class="d-flex mb-2 bg-light-subtle p-2 rounded">
-                                    <div class="bg-dark text-white rounded-circle d-flex align-items-center justify-content-center me-3" style="min-width: 32px; width: 32px; height: 32px;">
-                                        <small class="fw-bold">{{ loop.index }}</small>
-                                    </div>
-                                    {{ step }}
-                                </div>
-                            {% endfor %}
-                        </div>
-                        <div class="mt-4 border-top pt-3 d-flex align-items-center justify-content-between">
-                            <div class="fw-semibold text-muted">Share this recipe</div>
-                            <button class="btn btn-outline-secondary" {{ live_action('openShare') }}>
-                                {{ ux_icon('email', { class: 'me-1' }) }}
-                                Share
-                            </button>
-                        </div>
-                    </div>
+                    <h4 class="text-muted mb-2">The bot is cooking your recipe...</h4>
+                    <p class="text-secondary small">This may take a moment</p>
                 </div>
             </div>
+        {% elseif this.recipe %}
+            <div id="recipe-stream-target">
+                {{ include('components/_recipe_card.html.twig', { recipe: this.recipe }) }}
+            </div>
         {% else %}
-            <div data-loading="hide" class="text-center mt-5 py-5 bg-white rounded-5 shadow-sm w-75 mx-auto">
+            <div class="text-center mt-5 py-5 bg-white rounded-5 shadow-sm w-75 mx-auto">
                 {{ ux_icon('recipe', { height: '200px', width: '200px' }) }}
                 <h4 class="mt-5">Cooking Recipes</h4>
                 <span class="text-muted">Please provide your preferences for a recipe.</span>
             </div>
         {% endif %}
-        <div id="loading-message" data-loading>
-            <div class="d-flex flex-column align-items-center justify-content-center w-100">
-                <div class="spinner-border text-success mb-4" style="width: 60px; height: 60px;">
-                    <span class="visually-hidden">Loading...</span>
-                </div>
-                <h4 class="text-muted mb-2">The bot is cooking your recipe...</h4>
-                <p class="text-secondary small">This may take a moment</p>
-            </div>
-        </div>
     </div>
     <div id="recipe-share-overlay" class="share-overlay {{ this.shareOpen ? 'is-open' : '' }}">
         <div class="share-panel">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no (demo only)
| Docs?         | no
| Issues        | -
| License       | MIT

Uses the new streaming structured output support (#2116) in the demo's recipe bot. The recipe now streams over SSE — the name, ingredients, and steps appear progressively as the model generates them, instead of all at once after a blocking call. Mirrors the existing `/stream` demo pattern (`EventStreamResponse` + Turbo Streams, no custom JS).