### PR TITLE
[Platform] Add Endpoint value object and expose it on Model

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * [BC BREAK] Add `ListenerInterface::onError()` and `Result\Stream\ErrorEvent`, dispatched when draining a `StreamResult` throws, so a listener can finalize on a failed stream where `onComplete()` never fires; `AbstractStreamListener` provides a no-op default
+ * Add `Endpoint` value object and expose it on `Model` (`getEndpoints()`, `hasEndpoints()`, `getDefaultEndpoint()`, `getEndpoint()`, `supportsEndpoint()`); catalogs declare a model's endpoints via the new `AbstractModelCatalog::endpointsForModel()` hook (defaults to none, fully backward-compatible)
 
 0.12
 ----

--- a/src/platform/src/Endpoint.php
+++ b/src/platform/src/Endpoint.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform;
+
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+
+/**
+ * Identifies one contract a model speaks (e.g. "anthropic.messages",
+ * "openai.chat_completions", "openai.responses") together with any
+ * contract-specific defaults that should be folded in at invocation time.
+ *
+ * The contract identifier is a free-form string by design: bridges and
+ * dynamic catalogs can register new ones without core changes.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ * @author Tac Tacelosky <tacman@gmail.com>
+ */
+final class Endpoint
+{
+    /**
+     * @param non-empty-string     $contract
+     * @param array<string, mixed> $defaults
+     */
+    public function __construct(
+        private readonly string $contract,
+        private readonly array $defaults = [],
+    ) {
+        if ('' === trim($contract)) {
+            throw new InvalidArgumentException('Endpoint contract cannot be empty.');
+        }
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getContract(): string
+    {
+        return $this->contract;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getDefaults(): array
+    {
+        return $this->defaults;
+    }
+}

--- a/src/platform/src/Model.php
+++ b/src/platform/src/Model.php
@@ -22,11 +22,13 @@ class Model
      * @param non-empty-string     $name
      * @param Capability[]         $capabilities
      * @param array<string, mixed> $options      The default options for the model usage
+     * @param Endpoint[]           $endpoints    Contracts the model speaks, in priority order; the first is the default
      */
     public function __construct(
         private readonly string $name,
         private readonly array $capabilities = [],
         private readonly array $options = [],
+        private readonly array $endpoints = [],
     ) {
         if ('' === trim($name)) {
             throw new InvalidArgumentException('Model name cannot be empty.');
@@ -60,5 +62,48 @@ class Model
     public function getOptions(): array
     {
         return $this->options;
+    }
+
+    /**
+     * @return Endpoint[]
+     */
+    public function getEndpoints(): array
+    {
+        return $this->endpoints;
+    }
+
+    public function hasEndpoints(): bool
+    {
+        return [] !== $this->endpoints;
+    }
+
+    /**
+     * The default endpoint is the first one declared.
+     */
+    public function getDefaultEndpoint(): ?Endpoint
+    {
+        return $this->endpoints[0] ?? null;
+    }
+
+    public function getEndpoint(string $contract): Endpoint
+    {
+        foreach ($this->endpoints as $endpoint) {
+            if ($endpoint->getContract() === $contract) {
+                return $endpoint;
+            }
+        }
+
+        throw new InvalidArgumentException(\sprintf('Model "%s" does not support endpoint "%s". Supported: "%s".', $this->name, $contract, implode(', ', array_map(static fn (Endpoint $e): string => $e->getContract(), $this->endpoints)) ?: '(none)'));
+    }
+
+    public function supportsEndpoint(string $contract): bool
+    {
+        foreach ($this->endpoints as $endpoint) {
+            if ($endpoint->getContract() === $contract) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/platform/src/ModelCatalog/AbstractModelCatalog.php
+++ b/src/platform/src/ModelCatalog/AbstractModelCatalog.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\ModelCatalog;
 
 use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Endpoint;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Model;
@@ -48,7 +49,8 @@ abstract class AbstractModelCatalog implements ModelCatalogInterface
             throw new InvalidArgumentException(\sprintf('Model class "%s" does not exist.', $modelClass));
         }
 
-        $model = new $modelClass($actualModelName, $modelConfig['capabilities'], $options);
+        $endpoints = $this->endpointsForModel($modelConfig);
+        $model = new $modelClass($actualModelName, $modelConfig['capabilities'], $options, $endpoints);
         if (!$model instanceof Model) {
             throw new InvalidArgumentException(\sprintf('Model class "%s" must extend "%s".', $modelClass, Model::class));
         }
@@ -62,6 +64,22 @@ abstract class AbstractModelCatalog implements ModelCatalogInterface
     public function getModels(): array
     {
         return $this->models;
+    }
+
+    /**
+     * Override to declare which contracts (endpoints) a catalog model speaks.
+     *
+     * The returned endpoints are passed to the {@see Model} constructor and
+     * exposed via {@see Model::getEndpoints()}. Defaults to no endpoints, so
+     * existing catalogs keep producing models unchanged.
+     *
+     * @param array{class: class-string, capabilities: list<Capability>} $modelConfig
+     *
+     * @return list<Endpoint>
+     */
+    protected function endpointsForModel(array $modelConfig): array
+    {
+        return [];
     }
 
     /**

--- a/src/platform/tests/EndpointTest.php
+++ b/src/platform/tests/EndpointTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Endpoint;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+
+final class EndpointTest extends TestCase
+{
+    public function testReturnsContract()
+    {
+        $endpoint = new Endpoint('anthropic.messages');
+
+        $this->assertSame('anthropic.messages', $endpoint->getContract());
+    }
+
+    public function testReturnsDefaults()
+    {
+        $defaults = ['temperature' => 0.7, 'max_tokens' => 1024];
+        $endpoint = new Endpoint('openai.chat_completions', $defaults);
+
+        $this->assertSame($defaults, $endpoint->getDefaults());
+    }
+
+    public function testReturnsEmptyDefaultsByDefault()
+    {
+        $endpoint = new Endpoint('openai.responses');
+
+        $this->assertSame([], $endpoint->getDefaults());
+    }
+
+    public function testThrowsOnEmptyContract()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Endpoint contract cannot be empty.');
+
+        new Endpoint('   ');
+    }
+}

--- a/src/platform/tests/ModelCatalog/AbstractModelCatalogTest.php
+++ b/src/platform/tests/ModelCatalog/AbstractModelCatalogTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Tests\ModelCatalog;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Endpoint;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\AbstractModelCatalog;
@@ -169,6 +170,42 @@ final class AbstractModelCatalogTest extends TestCase
         $this->assertSame(1e-5, $options['frequency_penalty']);
         $this->assertIsFloat($options['presence_penalty']);
         $this->assertSame(2.5E3, $options['presence_penalty']);
+    }
+
+    public function testGetModelHasNoEndpointsByDefault()
+    {
+        $catalog = $this->createTestCatalog();
+        $model = $catalog->getModel('test-model');
+
+        $this->assertSame([], $model->getEndpoints());
+        $this->assertFalse($model->hasEndpoints());
+    }
+
+    public function testEndpointsForModelHookPopulatesModelEndpoints()
+    {
+        $catalog = new class extends AbstractModelCatalog {
+            public function __construct()
+            {
+                $this->models = [
+                    'test-model' => [
+                        'class' => Model::class,
+                        'capabilities' => [Capability::INPUT_TEXT],
+                    ],
+                ];
+            }
+
+            protected function endpointsForModel(array $modelConfig): array
+            {
+                return [new Endpoint('test.contract', ['temperature' => 0.5])];
+            }
+        };
+
+        $model = $catalog->getModel('test-model');
+
+        $this->assertTrue($model->hasEndpoints());
+        $this->assertCount(1, $model->getEndpoints());
+        $this->assertSame('test.contract', $model->getDefaultEndpoint()->getContract());
+        $this->assertSame(['temperature' => 0.5], $model->getDefaultEndpoint()->getDefaults());
     }
 
     private function createTestCatalog(): AbstractModelCatalog

--- a/src/platform/tests/ModelTest.php
+++ b/src/platform/tests/ModelTest.php
@@ -13,6 +13,8 @@ namespace Symfony\AI\Platform\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Endpoint;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Model;
 
 final class ModelTest extends TestCase
@@ -63,5 +65,59 @@ final class ModelTest extends TestCase
         $model = new Model('gpt-4');
 
         $this->assertSame([], $model->getOptions());
+    }
+
+    public function testReturnsEmptyEndpointsByDefault()
+    {
+        $model = new Model('gpt-4');
+
+        $this->assertSame([], $model->getEndpoints());
+        $this->assertFalse($model->hasEndpoints());
+        $this->assertNull($model->getDefaultEndpoint());
+    }
+
+    public function testReturnsEndpoints()
+    {
+        $chat = new Endpoint('openai.chat_completions');
+        $responses = new Endpoint('openai.responses');
+        $model = new Model('gpt-4', [], [], [$chat, $responses]);
+
+        $this->assertSame([$chat, $responses], $model->getEndpoints());
+        $this->assertTrue($model->hasEndpoints());
+    }
+
+    public function testDefaultEndpointIsTheFirstDeclared()
+    {
+        $chat = new Endpoint('openai.chat_completions');
+        $responses = new Endpoint('openai.responses');
+        $model = new Model('gpt-4', [], [], [$chat, $responses]);
+
+        $this->assertSame($chat, $model->getDefaultEndpoint());
+    }
+
+    public function testGetEndpointReturnsMatchingContract()
+    {
+        $responses = new Endpoint('openai.responses');
+        $model = new Model('gpt-4', [], [], [new Endpoint('openai.chat_completions'), $responses]);
+
+        $this->assertSame($responses, $model->getEndpoint('openai.responses'));
+    }
+
+    public function testGetEndpointThrowsForUnknownContract()
+    {
+        $model = new Model('gpt-4', [], [], [new Endpoint('openai.chat_completions')]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Model "gpt-4" does not support endpoint "openai.responses". Supported: "openai.chat_completions".');
+
+        $model->getEndpoint('openai.responses');
+    }
+
+    public function testSupportsEndpoint()
+    {
+        $model = new Model('gpt-4', [], [], [new Endpoint('openai.chat_completions')]);
+
+        $this->assertTrue($model->supportsEndpoint('openai.chat_completions'));
+        $this->assertFalse($model->supportsEndpoint('openai.responses'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no <!-- new types are documented via their docblocks; no public guide yet -->
| Issues        | -
| License       | MIT

This carves out **slice 1** of @chr-hertel's endpoint refactor (#2029) as a small, self-contained, backward-compatible PR — the piece that PR explicitly marks as landable on its own:

> ### 1. Endpoint as a first-class concept on `Model`
> - New `Endpoint` value object (contract identifier + defaults).
> - `Model` gains `getEndpoints()`, `getDefaultEndpoint()`, `getEndpoint(string)`, `supportsEndpoint(string)`.
> - Catalogs declare endpoints via the new `AbstractModelCatalog::endpointsForModel()` hook.
> - *Minimum viable PR:* just the new types + the hook, no consumer changes. Backward-compatible; later PRs migrate consumers.

The intent is to let the `Endpoint` shape land and be iterated on now (it's also what batch routing — #1802 — and multi-contract models like OpenAI chat-completions vs. responses would hang off of), independently of the larger dispatch rework.

## What's here

**`Endpoint`** — a value object identifying one contract a model speaks, plus optional contract-specific defaults:

```php
namespace Symfony\AI\Platform;

final class Endpoint
{
    public function __construct(private readonly string $contract, private readonly array $defaults = []) { /* … */ }
    public function getContract(): string;
    public function getDefaults(): array;
}
```

**`Model`** — a new optional, last constructor parameter `array $endpoints = []`, and five accessors:

```php
$model->getEndpoints();         // Endpoint[]
$model->hasEndpoints();         // bool
$model->getDefaultEndpoint();   // ?Endpoint — the first declared
$model->getEndpoint('openai.responses');     // Endpoint, throws if unsupported
$model->supportsEndpoint('openai.responses'); // bool
```

**`AbstractModelCatalog`** — a new `endpointsForModel(array $modelConfig): array` hook (defaults to `[]`), called in `getModel()` and forwarded to the `Model` constructor, so a catalog can declare a model's endpoints by overriding one method.

## Backward compatibility

Fully additive:
- the new `Model` constructor parameter is optional and last;
- the catalog hook defaults to no endpoints, so existing catalogs produce identical models;
- **no consumer or bridge is changed** — models without endpoints behave exactly as today.

(Bridge `Model` subclasses with custom constructors — `Anthropic\Claude`, the OpenAI/Scaleway `Embeddings` — keep working unchanged; they'll opt into forwarding `$endpoints` if and when a catalog starts declaring endpoints for them, in a follow-up.)

## Tests

`EndpointTest` (construction, defaults, empty-contract guard), `ModelTest` (all five accessors incl. default-is-first and the unsupported-contract exception), and `AbstractModelCatalogTest` (default = no endpoints; the hook populates a model's endpoints). Full Platform suite green; PHPStan and CS-Fixer clean.

The `Endpoint` API here matches #2029 verbatim so it drops straight into that branch's later slices.
