### PR TITLE
[MCP Bundle] Add MCP Apps support (#[AsMcpApp] / #[AsMcpAppTool])

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -90,3 +90,9 @@ rules:
         min_version: '0.2'
     versionadded_directive_should_have_version: ~
     yaml_instead_of_yml_suffix: ~
+
+whitelist:
+    regex:
+        - '/MCP Apps/'         # proper noun: the "MCP Apps" extension (modelcontextprotocol/ext-apps)
+        - '/Interactive apps/' # section heading for that extension's interactive tools
+        - '/apps[.:]/'         # the `mcp.apps.*` configuration key

--- a/demo/README.md
+++ b/demo/README.md
@@ -95,7 +95,8 @@ symfony console ai:store:retrieve blog "Week of Symfony"
 
 ### MCP
 
-Demo MCP server added with a `current-time` tool to return the current time, with an optional format string.
+Demo MCP server exposing a `current-time` tool and a **Movies** MCP App — an interactive HTML UI (`#[AsMcpApp]`)
+that renders the movie collection as a searchable grid in hosts supporting [MCP Apps](https://github.com/modelcontextprotocol/ext-apps).
 
 To add the server, add the following configuration to your MCP Client's settings, e.g. your IDE:
 ```json

--- a/demo/src/Movies/Movie.php
+++ b/demo/src/Movies/Movie.php
@@ -14,7 +14,7 @@ namespace App\Movies;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class Movie
+final class Movie implements \JsonSerializable
 {
     /**
      * @param list<array{name: string, role: string}> $cast
@@ -80,5 +80,24 @@ final class Movie
     public function hue(): int
     {
         return crc32($this->slug) % 360;
+    }
+
+    /**
+     * The compact, model-facing projection used when a movie is returned by the `movie_search` tool:
+     * just enough for the agent to talk about it and to reference it by `slug` (no full plot or raw
+     * markdown). The UI reads the typed properties directly and is unaffected by this.
+     *
+     * @return array{slug: string, title: string, year: int|null, director: string|null, cast: list<string>, summary: string}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'slug' => $this->slug,
+            'title' => $this->title,
+            'year' => $this->year,
+            'director' => $this->director,
+            'cast' => array_map(static fn (array $member): string => $member['name'], $this->cast),
+            'summary' => $this->plot[0] ?? '',
+        ];
     }
 }

--- a/demo/src/Movies/MovieApp.php
+++ b/demo/src/Movies/MovieApp.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Movies;
+
+use Symfony\AI\McpBundle\Attribute\AsMcpApp;
+use Symfony\AI\McpBundle\Attribute\AsMcpAppTool;
+
+/**
+ * Interactive movie browser exposed as an MCP App.
+ *
+ * The markup is rendered by Twig — not built in JavaScript. Each tool returns a context array and the
+ * bundle renders the template named on the attribute into a server-rendered HTML fragment (the
+ * "HTML-over-the-wire" pattern) that the static iframe shell ({@see ../../templates/mcp/movies.html.twig})
+ * drops into place:
+ *
+ *  - `movie_search` (the app's primary tool) returns the result grid ({@see ../../templates/mcp/_movies_grid.html.twig});
+ *  - `movie_details` (an app-only follow-up tool) returns a movie's detail view ({@see ../../templates/mcp/_movie_detail.html.twig}).
+ *
+ * The iframe only wires events to `callTool(...)` and swaps the returned HTML in.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[AsMcpApp(
+    uri: 'ui://movies',
+    name: 'movie_search',
+    title: 'Movies',
+    description: 'Search the movie collection by title, director or cast and browse the results as an interactive grid.',
+    template: 'mcp/movies.html.twig',
+    toolTemplate: 'mcp/_movies_grid.html.twig',
+    prefersBorder: true,
+)]
+final class MovieApp
+{
+    public function __construct(
+        private readonly MovieSearch $movieSearch,
+        private readonly MovieRepository $movies,
+    ) {
+    }
+
+    /**
+     * Search movies and return the matching grid as a context for the result template.
+     *
+     * @param string $query search term matched against title, director and cast; empty returns all movies
+     *
+     * @return array{movies: list<Movie>, query: string}
+     */
+    public function render(string $query = ''): array
+    {
+        return [
+            'movies' => ($this->movieSearch)($query),
+            'query' => $query,
+        ];
+    }
+
+    /**
+     * Return a single movie's detail view as a context for the detail template.
+     *
+     * @param string $slug the movie slug identifier
+     *
+     * @return array{movie: Movie|null}
+     */
+    #[AsMcpAppTool(name: 'movie_details', description: 'Show the details of a single movie by its slug.', template: 'mcp/_movie_detail.html.twig', appOnly: true)]
+    public function showMovie(string $slug): array
+    {
+        return [
+            'movie' => $this->movies->findOne($slug),
+        ];
+    }
+}

--- a/demo/src/Movies/MovieRepository.php
+++ b/demo/src/Movies/MovieRepository.php
@@ -28,7 +28,7 @@ final class MovieRepository
     /**
      * @return list<Movie>
      */
-    public function all(): array
+    public function findAll(): array
     {
         $finder = (new Finder())
             ->files()
@@ -44,7 +44,7 @@ final class MovieRepository
         return $movies;
     }
 
-    public function find(string $slug): ?Movie
+    public function findOne(string $slug): ?Movie
     {
         if ('' === $slug || str_contains($slug, '/') || str_contains($slug, '..')) {
             return null;

--- a/demo/src/Movies/MovieSearch.php
+++ b/demo/src/Movies/MovieSearch.php
@@ -35,26 +35,19 @@ final class MovieSearch
     /**
      * @param string $query Search term matched against title, director and cast; pass an empty string to list all movies
      *
-     * @return list<array{slug: string, title: string, year: int|null, director: string|null, cast: list<string>, summary: string}>
+     * @return list<Movie> the matching movies (serialized to the model via {@see Movie::jsonSerialize()})
      */
     public function __invoke(string $query = ''): array
     {
         $needle = mb_strtolower(trim($query));
 
         $results = [];
-        foreach ($this->movies->all() as $movie) {
+        foreach ($this->movies->findAll() as $movie) {
             if ('' !== $needle && !$this->matches($movie, $needle)) {
                 continue;
             }
 
-            $results[] = [
-                'slug' => $movie->slug,
-                'title' => $movie->title,
-                'year' => $movie->year,
-                'director' => $movie->director,
-                'cast' => array_map(static fn (array $member): string => $member['name'], $movie->cast),
-                'summary' => $movie->plot[0] ?? '',
-            ];
+            $results[] = $movie;
         }
 
         return $results;

--- a/demo/src/Movies/TwigComponent.php
+++ b/demo/src/Movies/TwigComponent.php
@@ -59,7 +59,7 @@ final class TwigComponent
 
         $suggestions = [];
         foreach ($message->getMetadata()->get('movies') as $suggestion) {
-            $movie = $this->movies->find($suggestion->slug);
+            $movie = $this->movies->findOne($suggestion->slug);
             if (null !== $movie) {
                 $suggestions[] = ['movie' => $movie, 'reason' => $suggestion->reason];
             }
@@ -74,7 +74,7 @@ final class TwigComponent
             return null;
         }
 
-        return $this->movies->find($this->detailSlug);
+        return $this->movies->findOne($this->detailSlug);
     }
 
     #[LiveAction]

--- a/demo/templates/mcp/_movie_detail.html.twig
+++ b/demo/templates/mcp/_movie_detail.html.twig
@@ -1,0 +1,39 @@
+{#
+    Movie detail view for the movie MCP app. App\Movies\MovieApp::showMovie() (the `movie_details` tool)
+    returns the context; the bundle renders this template into the tool result and drops it into the
+    shell's #root container.
+
+    "Back" re-submits the shell's search form (`movie_search`); the IMDb link uses `data-open` so the
+    host opens it — no JS here.
+
+    Param: movie — App\Movies\Movie or null when the slug did not resolve
+#}
+<button class="back" type="submit" form="movie-search">&larr; Back</button>
+{% if movie is null %}
+    <p class="muted">Movie not found.</p>
+{% else %}
+    <div class="detail">
+        {% include 'mcp/_poster.html.twig' with { movie, portrait: true } only %}
+        <div>
+            <h1>{{ movie.title }}{% if movie.year %} <span>({{ movie.year }})</span>{% endif %}</h1>
+            <div class="meta">
+                {%- if movie.director %}Directed by {{ movie.director }}{% endif -%}
+                {%- if movie.imdb %} &middot; <span class="link" data-open="{{ movie.imdb }}">IMDb</span>{% endif -%}
+            </div>
+            {% if movie.cast is not empty %}
+                <h2>Cast</h2>
+                <ul>
+                    {% for member in movie.cast %}
+                        <li><b>{{ member.name }}</b> as {{ member.role }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+            {% if movie.plot is not empty %}
+                <h2>Plot</h2>
+                {% for paragraph in movie.plot %}
+                    {{ paragraph|markdown_to_html }}
+                {% endfor %}
+            {% endif %}
+        </div>
+    </div>
+{% endif %}

--- a/demo/templates/mcp/_movies_grid.html.twig
+++ b/demo/templates/mcp/_movies_grid.html.twig
@@ -1,0 +1,19 @@
+{#
+    Result grid for the movie MCP app. App\Movies\MovieApp::render() (the `movie_search` tool) returns
+    the context; the bundle renders this template into the tool result and drops it into the shell's
+    #root container. Each card declares `data-call="movie_details"` so the base template invokes that
+    tool (with the card's slug) and swaps in the detail view — no JS here.
+
+    Param: movies — list<App\Movies\Movie>
+#}
+{% if movies is empty %}
+    <p class="muted">No movies match your search.</p>
+{% else %}
+    <div class="grid">
+        {% for movie in movies %}
+            <button class="card" type="button" data-call="movie_details" data-arg-slug="{{ movie.slug }}" aria-label="Open {{ movie.title }}">
+                {% include 'mcp/_poster.html.twig' with { movie, showLabel: true } only %}
+            </button>
+        {% endfor %}
+    </div>
+{% endif %}

--- a/demo/templates/mcp/_poster.html.twig
+++ b/demo/templates/mcp/_poster.html.twig
@@ -1,0 +1,21 @@
+{#
+    Poster tile for the movie MCP app. The matching CSS (.poster / .initials / .label) lives in the
+    shell, mcp/movies.html.twig.
+
+    This is a deliberate standalone copy of components/_movie_poster.html.twig: the MCP app renders inside
+    a sandboxed iframe and cannot reuse the host app's Twig components or Bootstrap CSS, so it ships its
+    own self-contained markup + styling.
+
+    Params:
+      - movie:     the App\Movies\Movie to render
+      - showLabel: render the title/year overlay (grid cards); defaults to false (detail view)
+      - portrait:  use a 2/3 portrait ratio instead of the square grid tile; defaults to false
+#}
+{% set hue = movie.hue() %}
+{% set initials = movie.title|split(' ')|slice(0, 2)|map(word => word|first)|join|upper %}
+<div class="poster" style="background: linear-gradient(135deg, hsl({{ hue }}, 60%, 45%), hsl({{ (hue + 40) % 360 }}, 55%, 22%));{% if portrait|default(false) %} aspect-ratio: 2/3;{% endif %}">
+    <span class="initials">{{ initials }}</span>
+    {% if showLabel|default(false) %}
+        <span class="label">{{ movie.title }}{% if movie.year %}<span class="year">{{ movie.year }}</span>{% endif %}</span>
+    {% endif %}
+</div>

--- a/demo/templates/mcp/movies.html.twig
+++ b/demo/templates/mcp/movies.html.twig
@@ -1,0 +1,79 @@
+{#
+    MCP App shell for the movie browser (see App\Movies\MovieApp).
+
+    HTML-over-the-wire: the markup is rendered by Twig on the server (mcp/_movies_grid.html.twig and
+    mcp/_movie_detail.html.twig) and returned as the `html` field of the tool result, which the base
+    template drops into #root. There is no JS here: the search form and the cards/links in the fragments
+    use the base template's declarative `data-call` / `data-open` attributes to invoke `movie_search` /
+    `movie_details` and open links.
+#}
+{% extends '@Mcp/app/base.html.twig' %}
+
+{% block title %}Movies{% endblock %}
+
+{% block style %}
+    :root { color-scheme: dark; }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        color: #f3f4f6;
+        background:
+            radial-gradient(ellipse 140% 70% at 50% 0%, rgba(139, 20, 32, 0.45) 0%, transparent 55%),
+            linear-gradient(180deg, #0a0d12 0%, #12151c 45%, #0a0d12 100%);
+        background-attachment: fixed;
+        padding: 16px;
+    }
+    .bar { display: flex; gap: 8px; margin-bottom: 16px; }
+    .bar input {
+        flex: 1; padding: 10px 14px; border-radius: 999px; border: 1px solid rgba(255,255,255,.15);
+        background: rgba(255,255,255,.06); color: inherit; font-size: 14px; outline: none;
+    }
+    .bar input:focus { border-color: rgba(229,57,75,.7); }
+    .bar button {
+        padding: 10px 18px; border-radius: 999px; border: 0; cursor: pointer; font-weight: 600;
+        background: #e5394b; color: #fff; font-size: 14px;
+    }
+    .bar button:hover { background: #c8313f; }
+    .muted { color: #9ca3af; font-size: 14px; padding: 24px 4px; text-align: center; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 14px; }
+    .card {
+        text-align: left; border: 0; padding: 0; cursor: pointer; background: none; color: inherit;
+        border-radius: 12px; overflow: hidden; transition: transform .2s ease, box-shadow .2s ease;
+    }
+    .card:hover { transform: translateY(-4px) scale(1.02); }
+    .poster {
+        aspect-ratio: 1 / 1; border-radius: 12px; display: flex; align-items: flex-end; padding: 12px;
+        box-shadow: 0 10px 24px rgba(0,0,0,.45); position: relative; overflow: hidden;
+    }
+    .poster .initials {
+        position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+        font-size: 44px; font-weight: 800; color: rgba(255,255,255,.28); letter-spacing: 2px;
+    }
+    .poster .label { position: relative; font-size: 13px; font-weight: 700; line-height: 1.25;
+        text-shadow: 0 1px 6px rgba(0,0,0,.7); }
+    .poster .year { display: block; font-size: 11px; font-weight: 500; opacity: .8; margin-top: 2px; }
+
+    .detail { display: grid; grid-template-columns: 180px 1fr; gap: 20px; }
+    @media (max-width: 520px) { .detail { grid-template-columns: 1fr; } }
+    .detail h1 { font-size: 22px; line-height: 1.2; }
+    .detail h1 span { font-weight: 400; color: #9ca3af; }
+    .detail .meta { color: #9ca3af; font-size: 14px; margin: 6px 0 14px; }
+    .detail h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af;
+        margin: 16px 0 6px; }
+    .detail ul { list-style: none; font-size: 14px; }
+    .detail ul li { padding: 2px 0; }
+    .detail ul li b { font-weight: 600; }
+    .detail p { font-size: 14px; line-height: 1.55; margin-bottom: 10px; color: #d1d5db; }
+    .back { background: none; border: 1px solid rgba(255,255,255,.2); color: inherit; cursor: pointer;
+        border-radius: 999px; padding: 6px 14px; font-size: 13px; margin-bottom: 14px; }
+    .back:hover { background: rgba(255,255,255,.08); }
+    .link { color: #ef6b78; cursor: pointer; text-decoration: underline; }
+{% endblock %}
+
+{% block body %}
+    <form id="movie-search" class="bar" data-call="movie_search">
+        <input name="query" type="text" placeholder="Search movies by title, director or cast…" autocomplete="off">
+        <button type="submit">Search</button>
+    </form>
+    <div id="root"><p class="muted">Loading…</p></div>
+{% endblock %}

--- a/demo/tests/Movie/MovieAppTest.php
+++ b/demo/tests/Movie/MovieAppTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Movie;
+
+use App\Movies\Movie;
+use App\Movies\MovieApp;
+use App\Movies\MovieRepository;
+use App\Movies\MovieSearch;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MovieApp::class)]
+final class MovieAppTest extends TestCase
+{
+    private const FIXTURES_DIR = __DIR__.'/../../../fixtures/movies';
+
+    public function testRenderReturnsAllMoviesForEmptyQuery()
+    {
+        $result = $this->app()->render('');
+
+        $this->assertSame('', $result['query']);
+        $slugs = $this->slugs($result['movies']);
+        $this->assertContains('oppenheimer', $slugs);
+        $this->assertContains('forrest-gump', $slugs);
+    }
+
+    public function testRenderNarrowsByDirector()
+    {
+        $slugs = $this->slugs($this->app()->render('Tarantino')['movies']);
+
+        $this->assertContains('django-unchained', $slugs);
+        $this->assertNotContains('oppenheimer', $slugs);
+    }
+
+    public function testRenderNarrowsByCast()
+    {
+        // Cillian Murphy plays in Oppenheimer.
+        $slugs = $this->slugs($this->app()->render('Cillian')['movies']);
+
+        $this->assertContains('oppenheimer', $slugs);
+        $this->assertNotContains('forrest-gump', $slugs);
+    }
+
+    public function testShowMovieReturnsTheMovie()
+    {
+        $movie = $this->app()->showMovie('oppenheimer')['movie'];
+
+        $this->assertInstanceOf(Movie::class, $movie);
+        $this->assertSame('Oppenheimer', $movie->title);
+    }
+
+    public function testShowMovieHandlesUnknownSlug()
+    {
+        $this->assertNull($this->app()->showMovie('does-not-exist')['movie']);
+    }
+
+    /**
+     * @param list<Movie> $movies
+     *
+     * @return list<string>
+     */
+    private function slugs(array $movies): array
+    {
+        return array_map(static fn (Movie $movie): string => $movie->slug, $movies);
+    }
+
+    private function app(): MovieApp
+    {
+        $repository = new MovieRepository(self::FIXTURES_DIR);
+
+        return new MovieApp(new MovieSearch($repository), $repository);
+    }
+}

--- a/demo/tests/Movie/MovieRepositoryTest.php
+++ b/demo/tests/Movie/MovieRepositoryTest.php
@@ -43,7 +43,7 @@ final class MovieRepositoryTest extends TestCase
     {
         $repository = new MovieRepository($this->directory);
 
-        $movies = $repository->all();
+        $movies = $repository->findAll();
 
         $this->assertCount(2, $movies);
         /* @phpstan-ignore-next-line method.alreadyNarrowedTypy */
@@ -55,7 +55,7 @@ final class MovieRepositoryTest extends TestCase
     {
         $repository = new MovieRepository($this->directory);
 
-        $movie = $repository->find('alpha');
+        $movie = $repository->findOne('alpha');
 
         $this->assertNotNull($movie);
         $this->assertSame('Alpha', $movie->title);
@@ -66,15 +66,15 @@ final class MovieRepositoryTest extends TestCase
     {
         $repository = new MovieRepository($this->directory);
 
-        $this->assertNull($repository->find('gamma'));
+        $this->assertNull($repository->findOne('gamma'));
     }
 
     public function testFindRejectsEmptyAndTraversalSlugs()
     {
         $repository = new MovieRepository($this->directory);
 
-        $this->assertNull($repository->find(''));
-        $this->assertNull($repository->find('../secret'));
-        $this->assertNull($repository->find('nested/path'));
+        $this->assertNull($repository->findOne(''));
+        $this->assertNull($repository->findOne('../secret'));
+        $this->assertNull($repository->findOne('nested/path'));
     }
 }

--- a/demo/tests/Movie/MovieSearchTest.php
+++ b/demo/tests/Movie/MovieSearchTest.php
@@ -11,6 +11,7 @@
 
 namespace App\Tests\Movie;
 
+use App\Movies\Movie;
 use App\Movies\MovieRepository;
 use App\Movies\MovieSearch;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -23,13 +24,10 @@ final class MovieSearchTest extends TestCase
 
     public function testEmptyQueryReturnsWholeCollection()
     {
-        $results = ($this->search())('');
+        $slugs = $this->slugsFor('');
 
-        $this->assertNotSame([], $results);
-        $this->assertArrayHasKey('slug', $results[0]);
-        $this->assertArrayHasKey('title', $results[0]);
-        $this->assertArrayHasKey('cast', $results[0]);
-        $this->assertArrayHasKey('summary', $results[0]);
+        $this->assertNotSame([], $slugs);
+        $this->assertContains('the-matrix', $slugs);
     }
 
     public function testSearchMatchesTitle()
@@ -64,7 +62,7 @@ final class MovieSearchTest extends TestCase
      */
     private function slugsFor(string $query): array
     {
-        return array_map(static fn (array $result): string => $result['slug'], ($this->search())($query));
+        return array_map(static fn (Movie $movie): string => $movie->slug, ($this->search())($query));
     }
 
     private function search(): MovieSearch

--- a/demo/tests/Movie/MovieTest.php
+++ b/demo/tests/Movie/MovieTest.php
@@ -73,4 +73,20 @@ final class MovieTest extends TestCase
         $this->assertStringContainsString('## Plot', $movie->rawMarkdown);
         $this->assertStringContainsString('**Director:** The Wachowskis', $movie->rawMarkdown);
     }
+
+    public function testJsonSerializeReturnsCompactModelFacingProjection()
+    {
+        $movie = Movie::fromFile(self::FIXTURES_DIR.'/the-matrix.md');
+
+        $data = $movie->jsonSerialize();
+
+        // exactly the fields the agent needs — no full plot or raw markdown
+        $this->assertSame(['slug', 'title', 'year', 'director', 'cast', 'summary'], array_keys($data));
+        $this->assertSame('the-matrix', $data['slug']);
+        $this->assertSame('The Matrix', $data['title']);
+        $this->assertSame(1999, $data['year']);
+        $this->assertSame('The Wachowskis', $data['director']);
+        $this->assertSame('Keanu Reeves', $data['cast'][0]); // cast reduced to names only
+        $this->assertSame($movie->plot[0], $data['summary']); // summary is the first plot paragraph
+    }
 }

--- a/docs/bundles/mcp-bundle.rst
+++ b/docs/bundles/mcp-bundle.rst
@@ -149,6 +149,194 @@ The MCP SDK, and therefore the MCP Bundle, supports two patterns for placing att
         public function toolTwo(): string { }
     }
 
+MCP Apps
+........
+
+`MCP Apps`_ let a tool return an interactive HTML screen (an "app") that the host renders in a
+sandboxed iframe instead of plain text — for example a dashboard, a form, or a record viewer. The
+bundle registers the underlying UI resource for you and enables the MCP Apps server extension, so you
+only write the markup.
+
+A single class is the whole app (similar to a Symfony UX LiveComponent): the ``#[AsMcpApp]`` attribute
+carries the linked tool's identity (``name``/``description``) and the HTML shell (``template``), the
+constructor carries service dependencies, and a handler method (``render`` by default) produces the
+tool result::
+
+    // src/Mcp/WeatherApp.php
+    use Symfony\AI\McpBundle\Attribute\AsMcpApp;
+
+    #[AsMcpApp(
+        uri: 'ui://weather',
+        name: 'get_weather',                 // the linked tool's name (model-facing)
+        title: 'Weather',
+        description: 'Show the weather for a city as an interactive dashboard.',
+        template: 'mcp/weather.html.twig',
+    )]
+    class WeatherApp
+    {
+        public function __construct(private WeatherClient $weather)
+        {
+        }
+
+        // The returned value is the tool result, delivered to the iframe's JS render(model).
+        // The input schema is derived from the method signature.
+        public function render(string $city): array
+        {
+            return ['summary' => $this->weather->summaryFor($city)];
+        }
+    }
+
+The template extends the bundle's base template, which implements the MCP Apps ``postMessage``
+handshake, iframe size reporting and a ``render(model)`` hook:
+
+.. code-block:: html+twig
+
+    {# templates/mcp/weather.html.twig #}
+    {% extends '@Mcp/app/base.html.twig' %}
+
+    {% block style %}.card { font: 1rem system-ui; }{% endblock %}
+    {% block body %}<div id="root" class="card"></div>{% endblock %}
+
+    {% block app_script %}
+        // Called with the linked tool's result. The iframe shell is static HTML; the per-request
+        // data arrives at runtime via the tool-result message, not through Twig.
+        function render(model) {
+            document.getElementById('root').textContent = model.summary;
+        }
+    {% endblock %}
+
+The bundle registers the UI resource (with the required ``_meta.ui`` descriptor marker), registers the
+tool with its ``ui`` link auto-set to this app (``resourceUri`` plus visibility ``[model, app]``), and
+enables the MCP Apps extension. ``uri`` defaults to ``ui://<kebab-class-name>``; the tool ``name``
+defaults to that URI slug with dashes replaced by underscores, and the handler method defaults to
+``render`` (set the ``method`` argument to use another). The tool is registered only when the handler
+method exists — an app without it is a static, tool-less screen.
+
+The base template exposes the blocks ``title``, ``head``, ``style``, ``body`` and ``app_script``
+(override ``render(model)`` / ``onToolInput(params)`` there), plus ``sendRpc``, ``callTool`` and
+``openLink`` JavaScript helpers. The default ``render(model)`` implements the HTML-over-the-wire path
+described below, and interactions are wired declaratively via ``data-call`` / ``data-open`` attributes
+(see *Interactive apps* below) — so most apps write no JavaScript at all; override ``app_script`` only
+for a fully JS-driven UI.
+
+The template form requires ``symfony/twig-bundle``. For a dynamic shell, omit ``template`` and give the
+class an ``__invoke(): TextResourceContents`` method instead (inject
+``Symfony\AI\McpBundle\App\McpAppRenderer`` to render Twig with your own context); that method then owns
+the returned content and its ``_meta.ui``.
+
+You can declare CSP and permission requirements for the iframe directly on the attribute::
+
+    #[AsMcpApp(
+        uri: 'ui://weather',
+        name: 'get_weather',
+        template: 'mcp/weather.html.twig',
+        prefersBorder: true,
+        cspConnect: ['https://api.weather.example.com'],
+        geolocation: true,
+    )]
+
+The MCP Apps extension is enabled automatically as soon as one ``#[AsMcpApp]`` class exists. Use the
+``apps.enabled`` option to force it on or off:
+
+.. code-block:: yaml
+
+    # config/packages/mcp.yaml
+    mcp:
+        apps:
+            enabled: true # null (default) = auto-enable when an app is registered; true/false forces it
+
+Rendering with Twig (HTML-over-the-wire)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The recommended way to fill the screen is to render the markup with **Twig on the server** and ship it
+in the tool result, rather than building the DOM in JavaScript. The iframe shell stays static (the
+protocol reads the UI resource only once), but the per-request tool result can carry an ``html``
+string: the base template's default ``render(model)`` injects ``model.html`` into the ``#root`` element
+(which the default ``body`` block already provides), so you write **no** client-side rendering code.
+
+Name the fragment template on the attribute via ``toolTemplate`` and return a **context array** from the
+handler — the bundle renders that template into the ``html`` field for you, so the handler stays free of
+Twig::
+
+    #[AsMcpApp(
+        uri: 'ui://weather',
+        name: 'get_weather',
+        template: 'mcp/weather.html.twig',       // the static iframe shell
+        toolTemplate: 'mcp/_weather.html.twig',   // rendered into the tool result's `html`
+    )]
+    class WeatherApp
+    {
+        public function __construct(private WeatherService $weather)
+        {
+        }
+
+        // @return array{forecast: Forecast} — the Twig context, not HTML
+        public function render(string $city): array
+        {
+            return ['forecast' => $this->weather->forecastFor($city)];
+        }
+    }
+
+The shell only needs styling — the rendered fragment lands in ``#root`` automatically:
+
+.. code-block:: html+twig
+
+    {# templates/mcp/weather.html.twig #}
+    {% extends '@Mcp/app/base.html.twig' %}
+    {% block style %}.card { font: 1rem system-ui; }{% endblock %}
+    {# body defaults to <div id="root"></div>; the rendered `html` is injected there #}
+
+Because the markup is Twig, the fragment can ``{% include %}`` partials and use filters such as
+``markdown_to_html`` — the same building blocks as the rest of your application. Reach for the JS
+``render(model)`` override (shown above) only when you need rich client-side interactivity over a
+structured model; for that case inject ``McpAppRenderer`` and return
+``['html' => $renderer->renderFragment(...)]`` yourself, or build the DOM from the structured result.
+
+Interactive apps
+^^^^^^^^^^^^^^^^
+
+Beyond the initial screen, an app can drive further work itself. Declare follow-up tools with
+``#[AsMcpAppTool]`` on a method of the app class. Like the primary tool, set ``template`` to have the
+bundle render the returned context into ``html``; set ``appOnly: true`` to keep the tool callable from
+the app but hidden from the model's ``tools/list`` (the default exposes it to both the model and the
+app)::
+
+    use Symfony\AI\McpBundle\Attribute\AsMcpAppTool;
+
+    // ... on the same #[AsMcpApp] class, alongside render() ...
+
+    #[AsMcpAppTool(name: 'set_unit', template: 'mcp/_weather.html.twig', appOnly: true)]
+    public function setUnit(string $city, string $unit): array
+    {
+        return ['forecast' => $this->weather->forecastFor($city, $unit)];
+    }
+
+The tool name defaults to the method name in ``snake_case``, its input schema is derived from the method
+signature, and the ``ui`` link to the enclosing app is set automatically.
+
+Invoking such a tool from the iframe needs **no JavaScript**: the base template wires DOM attributes to
+tool calls. Put ``data-call="<tool>"`` on any control — a ``<button>``, a link, or a
+``<form data-call="<tool>">`` (submitted on enter or by a submit button, including one elsewhere bound
+via ``form="<id>"``) — and the returned HTML replaces ``#root`` automatically. Arguments come from
+``data-arg-*`` attributes (``data-arg-city`` → ``{ city }``) or, for a form, from its named fields.
+``data-open="https://…"`` opens an external link.
+
+.. code-block:: html+twig
+
+    <button data-call="set_unit" data-arg-city="{{ city }}" data-arg-unit="celsius">°C</button>
+
+    {# the result HTML lands in #root; the search form below re-runs its tool on submit #}
+    <form data-call="get_weather"><input name="city"><button>Go</button></form>
+
+The default ``render(model)`` also keeps the shell's forms in sync: after each result it writes any
+scalar context value into a form control of the same ``name``. So having the handler return the value it
+was called with (``['city' => $city, 'forecast' => ...]``) refills ``<input name="city">`` on every
+result — including the first render — with no extra wiring; a control the user is actively editing is
+left untouched.
+
+For full client-side control you can still call ``callTool(name, args)`` from your own ``app_script`` and
+render the result yourself, but the declarative attributes cover the common case.
+
 Transport Types
 ...............
 
@@ -301,6 +489,10 @@ Configuration
         discovery:
             scan_dirs: ['src/Mcp'] # limit discovery scanning to a directory where you can group all your tools, resources, prompts, etc ...
 
+        # MCP Apps (interactive HTML UI resources, registered with #[AsMcpApp])
+        apps:
+            enabled: ~ # null = auto-enable when at least one app exists; true/false forces it
+
         client_transports:
             stdio: true # Enable STDIO via command
             http: true # Enable HTTP transport via controller
@@ -416,6 +608,7 @@ You can create event listeners to respond to capability changes::
 The events are simple marker events that notify when lists have changed, but don't contain specific details about what was added or modified.
 
 .. _`Model Context Protocol`: https://modelcontextprotocol.io/
+.. _`MCP Apps`: https://github.com/modelcontextprotocol/ext-apps
 .. _`mcp/sdk`: https://github.com/modelcontextprotocol/php-sdk
 .. _`Claude Desktop`: https://claude.ai/download
 .. _`MCP Server List`: https://modelcontextprotocol.io/examples

--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 ----
 
  * Add `http.allowed_hosts` configuration to allow custom hosts or disable the DNS rebinding protection when exposing a public MCP server
+ * Add MCP Apps support via the `#[AsMcpApp]`/`#[AsMcpAppTool]` attributes: interactive HTML UI resources
+   whose tools return a context array the bundle renders server-side with Twig (HTML-over-the-wire);
+   configurable via `mcp.apps.enabled`
 
 0.8
 ---

--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -33,7 +33,8 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5.53",
-        "symfony/monolog-bundle": "^3.10 || ^4.0"
+        "symfony/monolog-bundle": "^3.10 || ^4.0",
+        "symfony/twig-bundle": "^7.3|^8.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/mcp-bundle/config/options.php
+++ b/src/mcp-bundle/config/options.php
@@ -51,6 +51,15 @@ return static function (DefinitionConfigurator $configurator): void {
                     ->end()
                 ->end()
             ->end()
+            ->arrayNode('apps')
+                ->addDefaultsIfNotSet()
+                ->info('MCP Apps support (interactive HTML UI resources). Apps are registered with the #[AsMcpApp] attribute.')
+                ->children()
+                    // null = auto: enable the MCP Apps server extension when at least one #[AsMcpApp]
+                    // exists. true/false forces the extension on/off.
+                    ->booleanNode('enabled')->defaultNull()->end()
+                ->end()
+            ->end()
             ->arrayNode('http')
                 ->addDefaultsIfNotSet()
                 ->children()

--- a/src/mcp-bundle/src/App/McpAppReferenceHandler.php
+++ b/src/mcp-bundle/src/App/McpAppReferenceHandler.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\App;
+
+use Mcp\Capability\Registry\ElementReference;
+use Mcp\Capability\Registry\ReferenceHandlerInterface;
+use Symfony\AI\McpBundle\Exception\LogicException;
+
+/**
+ * Decorates the SDK reference handler so MCP App tool methods can stay free of Twig.
+ *
+ * The wrapped (inner) handler invokes the real tool method — keeping the SDK's reflection-derived input
+ * schema and argument mapping intact. This decorator then, for a tool whose handler is registered with a
+ * fragment template (the primary tool's `AsMcpApp::$toolTemplate` or an {@see \Symfony\AI\McpBundle\Attribute\AsMcpAppTool}
+ * method's `template`), renders that template with the method's returned context array and injects the
+ * result as the `html` field (the HTML-over-the-wire path). Every other element — resources, prompts, and
+ * tools without a template — passes through unchanged.
+ *
+ * Registered only when at least one app tool declares a template; see {@see \Symfony\AI\McpBundle\DependencyInjection\McpPass}.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class McpAppReferenceHandler implements ReferenceHandlerInterface
+{
+    /**
+     * @param array<string, string> $templates map of "<serviceId>::<method>" => fragment template name
+     */
+    public function __construct(
+        private readonly ReferenceHandlerInterface $inner,
+        private readonly McpAppRenderer $renderer,
+        private readonly array $templates,
+    ) {
+    }
+
+    public function handle(ElementReference $reference, array $arguments): mixed
+    {
+        $result = $this->inner->handle($reference, $arguments);
+
+        $handler = $reference->handler;
+        if (!\is_array($handler) || !\is_string($handler[0])) {
+            return $result;
+        }
+
+        $key = $handler[0].'::'.$handler[1];
+        $template = $this->templates[$key] ?? null;
+        if (null === $template) {
+            return $result;
+        }
+
+        if (!\is_array($result) || (array_is_list($result) && [] !== $result)) {
+            throw new LogicException(\sprintf('The MCP App tool "%s" declares the template "%s" but returned "%s"; a template-bound tool method must return an array context.', $key, $template, get_debug_type($result)));
+        }
+
+        return ['html' => $this->renderer->renderFragment($template, $result)] + $result;
+    }
+}

--- a/src/mcp-bundle/src/App/McpAppRenderer.php
+++ b/src/mcp-bundle/src/App/McpAppRenderer.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\App;
+
+use Mcp\Schema\Content\TextResourceContents;
+use Mcp\Schema\Extension\Apps\McpApps;
+use Mcp\Schema\Extension\Apps\UiResourceContentMeta;
+use Twig\Environment;
+
+/**
+ * Renders a Twig template into the {@see TextResourceContents} body of an MCP App UI resource,
+ * with the MCP Apps mime type and (optional) content-level `_meta.ui` metadata.
+ *
+ * Registered only when Twig is available. Used by {@see McpAppResourceRenderer} to render template-based
+ * {@see \Symfony\AI\McpBundle\Attribute\AsMcpApp} apps; can also be injected into a custom handler to
+ * render with dynamic context.
+ */
+final class McpAppRenderer
+{
+    public const SERVICE_ID = 'mcp.app.renderer';
+
+    public function __construct(
+        private readonly Environment $twig,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function render(
+        string $uri,
+        string $template,
+        array $context = [],
+        ?UiResourceContentMeta $contentMeta = null,
+    ): TextResourceContents {
+        return new TextResourceContents(
+            uri: $uri,
+            mimeType: McpApps::MIME_TYPE,
+            text: $this->twig->render($template, $context),
+            meta: null !== $contentMeta ? ['ui' => $contentMeta] : null,
+        );
+    }
+
+    /**
+     * Renders a Twig template to a raw HTML string, for use as the `html` field of a tool result
+     * (the HTML-over-the-wire path: the base template's default `render(model)` injects `model.html`).
+     *
+     * @param array<string, mixed> $context
+     */
+    public function renderFragment(string $template, array $context = []): string
+    {
+        return $this->twig->render($template, $context);
+    }
+}

--- a/src/mcp-bundle/src/App/McpAppResourceRenderer.php
+++ b/src/mcp-bundle/src/App/McpAppResourceRenderer.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\App;
+
+use Mcp\Schema\Content\TextResourceContents;
+use Mcp\Schema\Extension\Apps\UiResourceContentMeta;
+use Symfony\AI\McpBundle\Exception\LogicException;
+
+/**
+ * Shared resource handler for all template-based MCP Apps.
+ *
+ * The MCP SDK resolves a manual resource handler's instance from the container by the handler's class
+ * name, so every template app shares this one service (keyed by its FQCN) rather than a per-app service.
+ * The SDK fills the `$uri` argument with the requested resource URI; this handler looks up the matching
+ * template and content metadata and renders it.
+ *
+ * @phpstan-type AppConfig array{template: string, contentMeta: ?UiResourceContentMeta}
+ */
+final class McpAppResourceRenderer
+{
+    /**
+     * @param array<string, AppConfig> $apps URI => template + content metadata, populated by the compiler pass
+     */
+    public function __construct(
+        private readonly McpAppRenderer $renderer,
+        private readonly array $apps,
+    ) {
+    }
+
+    public function __invoke(string $uri): TextResourceContents
+    {
+        if (!isset($this->apps[$uri])) {
+            throw new LogicException(\sprintf('No MCP App is registered for resource URI "%s".', $uri));
+        }
+
+        return $this->renderer->render($uri, $this->apps[$uri]['template'], [], $this->apps[$uri]['contentMeta']);
+    }
+}

--- a/src/mcp-bundle/src/Attribute/AsMcpApp.php
+++ b/src/mcp-bundle/src/Attribute/AsMcpApp.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Attribute;
+
+/**
+ * Registers a class as an MCP App: a UI resource (served as `text/html;profile=mcp-app`) that a host
+ * renders in an iframe, together with the tool that feeds it.
+ *
+ * The class is the single hub for the app (à la Symfony UX LiveComponent): the attribute carries the
+ * tool's identity (`$name`/`$description`) and the static HTML shell (`$template`), the constructor
+ * carries service dependencies, and a handler method (`$method`, default `render`) produces the tool
+ * result. The bundle registers the UI resource (including the `_meta.ui` resource-descriptor marker
+ * that a plain attribute cannot express), registers the tool with its `ui` link auto-set to this app
+ * (`resourceUri` + visibility `[model, app]`), and enables the MCP Apps server extension.
+ *
+ * The HTML body comes from `$template` (the common case; requires Twig) or, for a dynamic shell, from
+ * an `__invoke(): TextResourceContents` method on the class.
+ *
+ * The tool is registered only when the handler `$method` exists on the class; an app without it is a
+ * static screen with no tool. The tool's input schema is derived from the method signature.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsMcpApp
+{
+    /**
+     * @param string|null   $uri            the `ui://` resource URI; defaults to `ui://<kebab-short-class-name>`
+     * @param string|null   $name           the linked tool's name (model-facing); defaults to the URI slug with dashes replaced by underscores. The resource name is derived from the URI.
+     * @param string|null   $title          optional human-readable title shown by hosts (tool + resource)
+     * @param string|null   $description    the linked tool's description (model-facing)
+     * @param string|null   $template       Twig template name for the HTML shell (e.g. `@App/mcp/dashboard.html.twig`)
+     * @param string|null   $method         handler method producing the tool result; defaults to `render`. Set explicitly to require a differently-named method.
+     * @param string|null   $toolTemplate   Twig fragment template the bundle renders for the primary tool. When set, the handler
+     *                                      method returns a context array and the bundle injects the rendered HTML as the `html`
+     *                                      field of the tool result (the HTML-over-the-wire path) — no Twig in the handler.
+     *                                      See {@see AsMcpAppTool} for additional tool methods.
+     * @param bool|null     $prefersBorder  content-meta: hint that the host should render a border around the iframe
+     * @param string|null   $domain         content-meta: associated domain for the app
+     * @param string[]|null $cspConnect     content-meta CSP: domains allowed for network requests (fetch/XHR/WebSocket)
+     * @param string[]|null $cspResource    content-meta CSP: domains allowed for static resources (img/script/style)
+     * @param string[]|null $cspFrame       content-meta CSP: domains allowed for nested iframes
+     * @param string[]|null $cspBaseUri     content-meta CSP: domains allowed as base URI origins
+     * @param bool          $camera         content-meta permission: request camera access
+     * @param bool          $microphone     content-meta permission: request microphone access
+     * @param bool          $geolocation    content-meta permission: request geolocation access
+     * @param bool          $clipboardWrite content-meta permission: request clipboard-write access
+     */
+    public function __construct(
+        public ?string $uri = null,
+        public ?string $name = null,
+        public ?string $title = null,
+        public ?string $description = null,
+        public ?string $template = null,
+        public ?string $method = null,
+        public ?string $toolTemplate = null,
+        public ?bool $prefersBorder = null,
+        public ?string $domain = null,
+        public ?array $cspConnect = null,
+        public ?array $cspResource = null,
+        public ?array $cspFrame = null,
+        public ?array $cspBaseUri = null,
+        public bool $camera = false,
+        public bool $microphone = false,
+        public bool $geolocation = false,
+        public bool $clipboardWrite = false,
+    ) {
+    }
+}

--- a/src/mcp-bundle/src/Attribute/AsMcpAppTool.php
+++ b/src/mcp-bundle/src/Attribute/AsMcpAppTool.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Attribute;
+
+/**
+ * Declares an additional tool on an {@see AsMcpApp} class, beyond the app's primary tool.
+ *
+ * The annotated method is registered as a tool linked to the enclosing app (its `ui` link points at the
+ * app's `ui://` resource), and its input schema is derived from the method signature. When `$template`
+ * is set, the method returns a context array and the bundle renders that template into the `html` field
+ * of the tool result (the HTML-over-the-wire path) — so the developer writes no Twig in the handler.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final class AsMcpAppTool
+{
+    /**
+     * @param string|null $name        the tool name (model-facing); defaults to the method name converted to snake_case
+     * @param string|null $title       optional human-readable title shown by hosts
+     * @param string|null $description the tool description (model-facing)
+     * @param string|null $template    Twig fragment template the bundle renders into the result's `html` field; when set,
+     *                                 the method must return a context array
+     * @param bool        $appOnly     when true the tool is visible to the app only (`[app]`); otherwise to the model and
+     *                                 the app (`[model, app]`)
+     */
+    public function __construct(
+        public ?string $name = null,
+        public ?string $title = null,
+        public ?string $description = null,
+        public ?string $template = null,
+        public bool $appOnly = false,
+    ) {
+    }
+}

--- a/src/mcp-bundle/src/DependencyInjection/McpAppPass.php
+++ b/src/mcp-bundle/src/DependencyInjection/McpAppPass.php
@@ -1,0 +1,293 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\DependencyInjection;
+
+use Mcp\Schema\Extension\Apps\McpApps;
+use Mcp\Schema\Extension\Apps\ToolVisibility;
+use Mcp\Schema\Extension\Apps\UiResourceContentMeta;
+use Mcp\Schema\Extension\Apps\UiResourceCsp;
+use Mcp\Schema\Extension\Apps\UiResourcePermissions;
+use Mcp\Schema\Extension\Apps\UiToolMeta;
+use Symfony\AI\McpBundle\App\McpAppRenderer;
+use Symfony\AI\McpBundle\App\McpAppResourceRenderer;
+use Symfony\AI\McpBundle\Attribute\AsMcpApp;
+use Symfony\AI\McpBundle\Attribute\AsMcpAppTool;
+use Symfony\AI\McpBundle\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Wires classes carrying {@see AsMcpApp} into the MCP server builder.
+ *
+ * For each app it enables the MCP Apps server extension (once), registers the UI resource carrying the
+ * `_meta.ui` resource-descriptor marker (a `stdClass`, which a plain attribute cannot express), and —
+ * when the app declares a handler method — registers the linked tool with its `ui` link auto-set to
+ * this app.
+ *
+ * Template-based apps share a single {@see McpAppResourceRenderer} service (the SDK resolves a manual
+ * handler's instance by its class name, so a per-app service is not possible); the renderer dispatches
+ * on the requested URI. Must run BEFORE {@see McpPass}: the services it tags `mcp.tool`/`mcp.resource`
+ * here are what McpPass collects into the handler service locator.
+ */
+final class McpAppPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('mcp.server.builder')) {
+            return;
+        }
+
+        $enabledFlag = $container->hasParameter('mcp.apps.enabled')
+            ? $container->getParameter('mcp.apps.enabled')
+            : null;
+
+        // Hard-disabled: register nothing, even if apps are present.
+        if (false === $enabledFlag) {
+            return;
+        }
+
+        $appServiceIds = array_keys($container->findTaggedServiceIds('mcp.app'));
+        $builder = $container->getDefinition('mcp.server.builder');
+
+        if ((true === $enabledFlag || [] !== $appServiceIds) && !$this->extensionAlreadyEnabled($builder)) {
+            $builder->addMethodCall('enableExtension', [new Definition(McpApps::class)]);
+        }
+
+        $templateApps = [];
+        $toolTemplates = [];
+
+        foreach ($appServiceIds as $serviceId) {
+            $class = $this->resolveClass($container, $serviceId);
+            $app = $this->readAttribute($class, $serviceId);
+
+            $uri = $app->uri ?? 'ui://'.$this->kebab($class);
+            if (!str_starts_with($uri, McpApps::URI_SCHEME.'://')) {
+                throw new LogicException(\sprintf('The MCP App "%s" must use a "%s://" URI, got "%s".', $class, McpApps::URI_SCHEME, $uri));
+            }
+            $slug = substr($uri, \strlen(McpApps::URI_SCHEME.'://'));
+
+            $handler = $this->resolveResourceHandler($container, $serviceId, $class, $app, $uri, $templateApps);
+
+            $descriptorMarker = (new Definition(\stdClass::class))->setFactory([McpApps::class, 'resourceMarker']);
+
+            $builder->addMethodCall('addResource', [
+                $handler,
+                $uri,
+                $slug, // resource name, derived from the URI ($name is the tool's)
+                $app->title,
+                null, // resource description (the model-facing description is the tool's)
+                McpApps::MIME_TYPE,
+                null, // size
+                null, // annotations
+                null, // icons
+                ['ui' => $descriptorMarker],
+            ]);
+
+            $this->registerTool($container, $serviceId, $class, $app, $uri, $slug, $builder, $toolTemplates);
+            $this->registerAppToolMethods($container, $serviceId, $class, $app, $uri, $builder, $toolTemplates);
+        }
+
+        if ([] !== $templateApps) {
+            $container->register(McpAppResourceRenderer::class, McpAppResourceRenderer::class)
+                ->setArguments([new Reference(McpAppRenderer::SERVICE_ID), $templateApps])
+                ->addTag('mcp.resource');
+        }
+
+        if ([] !== $toolTemplates && !$container->hasDefinition(McpAppRenderer::SERVICE_ID)) {
+            throw new LogicException('An MCP App tool declares a Twig template but Twig is not available. Run "composer require symfony/twig-bundle".');
+        }
+
+        // Consumed by McpPass to wire the McpAppReferenceHandler that renders these templates into the
+        // tool result's `html` field (keeps Twig out of the developer's tool methods).
+        $container->setParameter('mcp.apps.tool_templates', $toolTemplates);
+    }
+
+    /**
+     * Resolves the resource (HTML body) handler for an app and, for template-based apps, records the
+     * template + content metadata into $templateApps for the shared {@see McpAppResourceRenderer}.
+     *
+     * @param array<string, array{template: string, contentMeta: ?Definition}> $templateApps
+     *
+     * @return array{0: string, 1: string} the resource handler callable [class, method]
+     */
+    private function resolveResourceHandler(ContainerBuilder $container, string $serviceId, string $class, AsMcpApp $app, string $uri, array &$templateApps): array
+    {
+        // A class-level __invoke owns the full response, including its own content metadata.
+        if (method_exists($class, '__invoke')) {
+            $container->getDefinition($serviceId)->addTag('mcp.resource');
+
+            return [$class, '__invoke'];
+        }
+
+        if (null === $app->template) {
+            throw new LogicException(\sprintf('The MCP App "%s" must either declare an __invoke() method or set a "template" on #[AsMcpApp].', $class));
+        }
+
+        if (!$container->hasDefinition(McpAppRenderer::SERVICE_ID)) {
+            throw new LogicException(\sprintf('The MCP App "%s" renders the Twig template "%s" but Twig is not available. Run "composer require symfony/twig-bundle".', $class, $app->template));
+        }
+
+        $templateApps[$uri] = ['template' => $app->template, 'contentMeta' => $this->buildContentMeta($app)];
+
+        return [McpAppResourceRenderer::class, '__invoke'];
+    }
+
+    /**
+     * Registers the app's linked tool from its handler method ($method, default "render"), auto-setting
+     * the `ui` link to this app. No-op when the method is absent (a static, tool-less app).
+     *
+     * @param array<string, string> $toolTemplates map of "<serviceId>::<method>" => fragment template, appended to here
+     */
+    private function registerTool(ContainerBuilder $container, string $serviceId, string $class, AsMcpApp $app, string $uri, string $slug, Definition $builder, array &$toolTemplates): void
+    {
+        $method = $app->method ?? 'render';
+
+        if (!method_exists($class, $method)) {
+            if (null !== $app->method) {
+                throw new LogicException(\sprintf('The MCP App "%s" declares tool method "%s" on #[AsMcpApp] but the class has no such method.', $class, $method));
+            }
+
+            return; // no default "render" method → static, tool-less app
+        }
+
+        // The primary tool is always visible to both the model and the app.
+        $this->addTool($container, $builder, $serviceId, $method, $app->name ?? str_replace('-', '_', $slug), $app->title, $app->description, $uri, false, $app->toolTemplate, $toolTemplates);
+    }
+
+    /**
+     * Registers each method carrying {@see AsMcpAppTool} as an additional tool linked to this app, with
+     * the `ui` link pointing at the app's resource and visibility derived from `appOnly`.
+     *
+     * @param array<string, string> $toolTemplates map of "<serviceId>::<method>" => fragment template, appended to here
+     */
+    private function registerAppToolMethods(ContainerBuilder $container, string $serviceId, string $class, AsMcpApp $app, string $uri, Definition $builder, array &$toolTemplates): void
+    {
+        $primaryMethod = $app->method ?? 'render';
+
+        foreach ((new \ReflectionClass($class))->getMethods(\ReflectionMethod::IS_PUBLIC) as $reflectionMethod) {
+            $attributes = $reflectionMethod->getAttributes(AsMcpAppTool::class);
+            if ([] === $attributes) {
+                continue;
+            }
+
+            $method = $reflectionMethod->getName();
+            if ($method === $primaryMethod) {
+                throw new LogicException(\sprintf('The MCP App "%s" method "%s" is the primary tool declared on #[AsMcpApp] and must not also carry #[AsMcpAppTool].', $class, $method));
+            }
+
+            $tool = $attributes[0]->newInstance();
+
+            $this->addTool($container, $builder, $serviceId, $method, $tool->name ?? $this->snake($method), $tool->title, $tool->description, $uri, $tool->appOnly, $tool->template, $toolTemplates);
+        }
+    }
+
+    /**
+     * Registers one tool on the server builder: tags the app service so {@see McpPass} adds it to the
+     * handler locator, links the tool's `ui` to the app resource (with model/app visibility), and records
+     * its fragment template (if any) for {@see \Symfony\AI\McpBundle\App\McpAppReferenceHandler}.
+     *
+     * @param array<string, string> $toolTemplates map of "<serviceId>::<method>" => fragment template, appended to here
+     */
+    private function addTool(ContainerBuilder $container, Definition $builder, string $serviceId, string $method, string $name, ?string $title, ?string $description, string $uri, bool $appOnly, ?string $template, array &$toolTemplates): void
+    {
+        $container->getDefinition($serviceId)->addTag('mcp.tool');
+
+        $visibility = $appOnly ? [ToolVisibility::App] : [ToolVisibility::Model, ToolVisibility::App];
+
+        $builder->addMethodCall('addTool', [
+            [$serviceId, $method],
+            $name,
+            $title,
+            $description,
+            null, // annotations
+            null, // inputSchema (derived from the method signature)
+            null, // icons
+            ['ui' => new Definition(UiToolMeta::class, [$uri, $visibility])],
+            null, // outputSchema
+        ]);
+
+        if (null !== $template) {
+            $toolTemplates[$serviceId.'::'.$method] = $template;
+        }
+    }
+
+    private function buildContentMeta(AsMcpApp $app): ?Definition
+    {
+        $cspDef = null;
+        if (null !== $app->cspConnect || null !== $app->cspResource || null !== $app->cspFrame || null !== $app->cspBaseUri) {
+            $cspDef = new Definition(UiResourceCsp::class, [$app->cspConnect, $app->cspResource, $app->cspFrame, $app->cspBaseUri]);
+        }
+
+        $permsDef = null;
+        if ($app->camera || $app->microphone || $app->geolocation || $app->clipboardWrite) {
+            $permsDef = new Definition(UiResourcePermissions::class, [$app->camera, $app->microphone, $app->geolocation, $app->clipboardWrite]);
+        }
+
+        if (null === $cspDef && null === $permsDef && null === $app->domain && null === $app->prefersBorder) {
+            return null;
+        }
+
+        return new Definition(UiResourceContentMeta::class, [$cspDef, $permsDef, $app->domain, $app->prefersBorder]);
+    }
+
+    private function extensionAlreadyEnabled(Definition $builder): bool
+    {
+        foreach ($builder->getMethodCalls() as [$method, $arguments]) {
+            if ('enableExtension' !== $method) {
+                continue;
+            }
+
+            foreach ($arguments as $argument) {
+                if ($argument instanceof Definition && McpApps::class === $argument->getClass()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function resolveClass(ContainerBuilder $container, string $serviceId): string
+    {
+        $class = $container->getDefinition($serviceId)->getClass() ?? $serviceId;
+
+        return $container->getParameterBag()->resolveValue($class);
+    }
+
+    private function readAttribute(string $class, string $serviceId): AsMcpApp
+    {
+        if (!class_exists($class)) {
+            throw new LogicException(\sprintf('The MCP App service "%s" maps to class "%s" which does not exist.', $serviceId, $class));
+        }
+
+        $attributes = (new \ReflectionClass($class))->getAttributes(AsMcpApp::class);
+        if ([] === $attributes) {
+            throw new LogicException(\sprintf('The MCP App service "%s" (class "%s") is tagged "mcp.app" but carries no #[AsMcpApp] attribute.', $serviceId, $class));
+        }
+
+        return $attributes[0]->newInstance();
+    }
+
+    private function kebab(string $class): string
+    {
+        $short = false !== ($pos = strrpos($class, '\\')) ? substr($class, $pos + 1) : $class;
+
+        return strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', $short));
+    }
+
+    private function snake(string $name): string
+    {
+        return strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name));
+    }
+}

--- a/src/mcp-bundle/src/DependencyInjection/McpPass.php
+++ b/src/mcp-bundle/src/DependencyInjection/McpPass.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\AI\McpBundle\DependencyInjection;
 
+use Mcp\Capability\Registry\ReferenceHandler;
+use Symfony\AI\McpBundle\App\McpAppReferenceHandler;
+use Symfony\AI\McpBundle\App\McpAppRenderer;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 final class McpPass implements CompilerPassInterface
@@ -46,5 +50,36 @@ final class McpPass implements CompilerPassInterface
 
         $serviceLocatorRef = ServiceLocatorTagPass::register($container, $serviceReferences);
         $container->getDefinition('mcp.server.builder')->addMethodCall('setContainer', [$serviceLocatorRef]);
+
+        $this->configureAppReferenceHandler($container, $serviceLocatorRef);
+    }
+
+    /**
+     * Wires the {@see McpAppReferenceHandler} that renders MCP App tool templates (declared via
+     * {@see \Symfony\AI\McpBundle\Attribute\AsMcpApp}::$toolTemplate or {@see \Symfony\AI\McpBundle\Attribute\AsMcpAppTool})
+     * into the tool result's `html` field. It decorates the SDK default handler, which keeps the
+     * reflection-derived input schema and argument mapping intact.
+     */
+    private function configureAppReferenceHandler(ContainerBuilder $container, Reference $serviceLocatorRef): void
+    {
+        $toolTemplates = $container->hasParameter('mcp.apps.tool_templates')
+            ? $container->getParameter('mcp.apps.tool_templates')
+            : [];
+
+        if ([] === $toolTemplates) {
+            return;
+        }
+
+        $innerHandler = new Definition(ReferenceHandler::class, [$serviceLocatorRef]);
+
+        $container->register('mcp.app.reference_handler', McpAppReferenceHandler::class)
+            ->setArguments([
+                $innerHandler,
+                new Reference(McpAppRenderer::SERVICE_ID),
+                $toolTemplates,
+            ]);
+
+        $container->getDefinition('mcp.server.builder')
+            ->addMethodCall('setReferenceHandler', [new Reference('mcp.app.reference_handler')]);
     }
 }

--- a/src/mcp-bundle/src/Exception/ExceptionInterface.php
+++ b/src/mcp-bundle/src/Exception/ExceptionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Exception;
+
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/mcp-bundle/src/Exception/LogicException.php
+++ b/src/mcp-bundle/src/Exception/LogicException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Exception;
+
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -22,8 +22,11 @@ use Mcp\Server\Handler\Request\RequestHandlerInterface;
 use Mcp\Server\Session\FileSessionStore;
 use Mcp\Server\Session\InMemorySessionStore;
 use Mcp\Server\Session\Psr16SessionStore;
+use Symfony\AI\McpBundle\App\McpAppRenderer;
+use Symfony\AI\McpBundle\Attribute\AsMcpApp;
 use Symfony\AI\McpBundle\Command\McpCommand;
 use Symfony\AI\McpBundle\Controller\McpController;
+use Symfony\AI\McpBundle\DependencyInjection\McpAppPass;
 use Symfony\AI\McpBundle\DependencyInjection\McpPass;
 use Symfony\AI\McpBundle\Http\MiddlewareFactory;
 use Symfony\AI\McpBundle\Profiler\DataCollector;
@@ -40,6 +43,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use Twig\Environment;
 
 final class McpBundle extends AbstractBundle
 {
@@ -64,8 +68,10 @@ final class McpBundle extends AbstractBundle
         $builder->setParameter('mcp.instructions', $config['instructions']);
         $builder->setParameter('mcp.discovery.scan_dirs', $config['discovery']['scan_dirs']);
         $builder->setParameter('mcp.discovery.exclude_dirs', $config['discovery']['exclude_dirs']);
+        $builder->setParameter('mcp.apps.enabled', $config['apps']['enabled']);
 
         $this->registerMcpAttributes($builder);
+        $this->configureApps($builder);
 
         $builder->registerForAutoconfiguration(LoaderInterface::class)
             ->addTag('mcp.loader');
@@ -96,7 +102,28 @@ final class McpBundle extends AbstractBundle
 
     public function build(ContainerBuilder $container): void
     {
+        // McpAppPass runs before McpPass so the bound app-renderer handler services it creates are
+        // included in the handler service locator McpPass builds.
+        $container->addCompilerPass(new McpAppPass(), priority: 10);
         $container->addCompilerPass(new McpPass());
+    }
+
+    private function configureApps(ContainerBuilder $builder): void
+    {
+        $builder->registerAttributeForAutoconfiguration(
+            AsMcpApp::class,
+            static function (ChildDefinition $definition, AsMcpApp $attribute, \Reflector $reflector): void {
+                $definition->addTag('mcp.app');
+            }
+        );
+
+        // The Twig-backed renderer (used for template-based apps) is only available when Twig is.
+        // Aliased to its class so custom #[AsMcpApp] handlers can autowire it.
+        if (class_exists(Environment::class)) {
+            $builder->register(McpAppRenderer::SERVICE_ID, McpAppRenderer::class)
+                ->setArguments([new Reference('twig')]);
+            $builder->setAlias(McpAppRenderer::class, McpAppRenderer::SERVICE_ID);
+        }
     }
 
     private function registerMcpAttributes(ContainerBuilder $builder): void

--- a/src/mcp-bundle/templates/app/base.html.twig
+++ b/src/mcp-bundle/templates/app/base.html.twig
@@ -1,0 +1,206 @@
+{#
+    Base template for an MCP App (a "text/html;profile=mcp-app" UI resource rendered by the host in a
+    sandboxed iframe).
+
+    The iframe HTML is a STATIC shell. Per-request data is NOT rendered into it with Twig: the host
+    delivers the tool result at runtime via the `ui/notifications/tool-result` message, which calls
+    `render(model)`. There are two ways to turn that result into markup:
+
+    1. HTML-over-the-wire (default, recommended): your tool method returns a plain context array and
+       names its template on the attribute — `toolTemplate` on `#[AsMcpApp]` for the primary tool, or
+       `template` on `#[AsMcpAppTool]` for extra tools. The bundle renders that template with the array
+       and injects the result as the tool result's `html` field; the default `render()` below drops it
+       into `#root` and mirrors any scalar context values into matching form inputs (e.g. a `query`
+       field fills `<input name="query">`). You write no Twig call and no JS:
+
+           {% extends '@Mcp/app/base.html.twig' %}
+           {% block title %}My App{% endblock %}
+           {% block style %}.card { ... }{% endblock %}
+           (the body defaults to a <div id="root"></div>, where the tool result HTML lands)
+
+    2. JS-driven: override `app_script` with your own `render(model)` (it shadows the default) and build
+       the DOM from a structured model. Use this for rich client-side interactivity:
+
+           {% block body %}<div id="root"></div>{% endblock %}
+           {% block app_script %}
+               function render(model) { /* build the DOM from the structured tool result */ }
+           {% endblock %}
+
+    Either way, the Twig context here is only for static shell composition (branding, styles, app name).
+
+    Interactions need no JS either: the bridge wires DOM attributes to tool calls. An element with
+    `data-call="tool_name"` invokes that tool on activation (args from its `data-arg-*` attributes, e.g.
+    `data-arg-slug` -> `{ slug }`), a `<form data-call="tool_name">` sends its named fields as the args,
+    and the returned HTML is rendered automatically. `data-open="https://…"` opens an external link.
+
+           <button data-call="show_item" data-arg-id="42">Open</button>
+           <form data-call="search"><input name="q"><button>Go</button></form>
+
+    The `bridge` block below implements the MCP Apps postMessage protocol so you don't have to:
+    the ui/initialize -> ui/notifications/initialized -> size-changed handshake, request/response
+    plumbing (`sendRpc`/`sendNotification`), an `openLink(url)` helper (sandboxed iframes cannot open
+    links directly), the declarative `data-call`/`data-open` wiring above, and dispatch of
+    tool-result/tool-input to your `render`/`onToolInput` hooks.
+    Spec: https://github.com/modelcontextprotocol/ext-apps
+#}
+<!DOCTYPE html>
+<html lang="{% block lang %}en{% endblock %}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}MCP App{% endblock %}</title>
+    {% block head %}{% endblock %}
+    <style>{% block style %}{% endblock %}</style>
+</head>
+<body{% block body_attributes %}{% endblock %}>
+    {% block body %}<div id="root"></div>{% endblock %}
+    <script>
+        {% block bridge %}
+        // --- MCP Apps protocol bridge (iframe <-> host via postMessage) -------------------------
+        let requestId = 0;
+        const pending = new Map();
+
+        // Target origin is '*' because the iframe cannot know its parent's origin upfront; the host
+        // validates event.origin on its side.
+        function post(msg) { window.parent.postMessage(msg, '*'); }
+
+        function sendRpc(method, params) {
+            return new Promise((resolve, reject) => {
+                const id = ++requestId;
+                pending.set(id, { resolve, reject });
+                post({ jsonrpc: '2.0', id, method, params });
+            });
+        }
+
+        function sendNotification(method, params) {
+            post({ jsonrpc: '2.0', method, params });
+        }
+
+        // Ask the host to open an external link (raw <a target="_blank"> is blocked in the sandbox).
+        function openLink(url) {
+            sendRpc('ui/open-link', { url }).catch(() => window.open(url, '_blank'));
+        }
+
+        // Invoke a server tool from the app (e.g. a refresh button).
+        function callTool(name, args) {
+            return sendRpc('tools/call', { name: name, arguments: args || {} });
+        }
+
+        window.addEventListener('message', (event) => {
+            let msg = event.data;
+            if (typeof msg === 'string') {
+                try { msg = JSON.parse(msg); } catch { return; }
+            }
+            if (!msg || typeof msg !== 'object') return;
+
+            if (msg.id !== undefined && pending.has(msg.id)) {
+                const { resolve, reject } = pending.get(msg.id);
+                pending.delete(msg.id);
+                msg.error ? reject(msg.error) : resolve(msg.result);
+                return;
+            }
+            if (msg.method === 'ui/notifications/tool-result') {
+                try { render(extractModel(msg.params)); } catch (e) { /* ignore */ }
+            } else if (msg.method === 'ui/notifications/tool-input') {
+                try { onToolInput(msg.params); } catch (e) { /* ignore */ }
+            }
+        });
+
+        // Pull the structured model out of a tool-result payload.
+        function extractModel(params) {
+            if (!params) return null;
+            if (params.structuredContent && typeof params.structuredContent === 'object') {
+                return params.structuredContent;
+            }
+            const text = params.content && params.content[0] && params.content[0].text;
+            if (text) { try { return JSON.parse(text); } catch { return text; } }
+            return null;
+        }
+
+        // Spec-mandated handshake — hosts only forward tool-input / tool-result afterwards.
+        (async () => {
+            try {
+                await sendRpc('ui/initialize', {
+                    protocolVersion: '2026-01-26',
+                    capabilities: {},
+                    clientInfo: { name: '{{ app_name|default('mcp-app') }}', version: '1.0.0' },
+                });
+            } catch { /* degrade gracefully on non-conforming hosts */ }
+            sendNotification('ui/notifications/initialized', {});
+            reportSize();
+        })();
+
+        // Tell the host how tall the iframe should be.
+        let lastW = 0, lastH = 0;
+        function reportSize() {
+            const w = Math.ceil(document.documentElement.scrollWidth);
+            const h = Math.ceil(document.documentElement.scrollHeight);
+            if (w === lastW && h === lastH) return;
+            lastW = w; lastH = h;
+            sendNotification('ui/notifications/size-changed', { width: w, height: h });
+        }
+        new ResizeObserver(reportSize).observe(document.body);
+
+        // Default hooks. The default render() implements the HTML-over-the-wire path: when the tool
+        // result is (or carries) an HTML string, it is injected into #root and Twig owns all markup —
+        // no client-side DOM building. Override these in the app_script block for a JS-driven UI; an
+        // override's `function render` declaration shadows this one.
+        function render(model) {
+            const html = (model && typeof model.html === 'string') ? model.html
+                : (typeof model === 'string' ? model : null);
+            if (null !== html) {
+                const root = document.getElementById('root');
+                if (root) root.innerHTML = html;
+            }
+            // Mirror scalar model fields back into matching form controls (e.g. the `query` that produced
+            // this result fills <input name="query">), so the shell stays in sync on the first render too —
+            // without clobbering a field that is currently being edited.
+            if (model && typeof model === 'object') {
+                for (const field of document.querySelectorAll('input[name], textarea[name], select[name]')) {
+                    const value = model[field.getAttribute('name')];
+                    if ((typeof value === 'string' || typeof value === 'number') && field !== document.activeElement) {
+                        field.value = value;
+                    }
+                }
+            }
+        }
+        function onToolInput(params) {}
+
+        // --- Declarative actions (so apps need no JS) ---------------------------------------------
+        // Activating an element with [data-call="tool_name"] invokes that tool and renders the result
+        // through render() above; arguments come from its [data-arg-*] attributes (data-arg-slug ->
+        // { slug }). A <form data-call="tool_name"> sends its named fields as the arguments instead.
+        // [data-open="https://…"] asks the host to open an external link (sandbox-safe).
+        function callAndRender(name, args) {
+            return callTool(name, args).then((result) => render(extractModel(result)));
+        }
+        function dataArgs(el) {
+            const args = {};
+            for (const name of el.getAttributeNames()) {
+                if (name.startsWith('data-arg-')) {
+                    args[name.slice(9).replace(/-/g, '_')] = el.getAttribute(name);
+                }
+            }
+            return args;
+        }
+        document.addEventListener('click', (event) => {
+            const opener = event.target.closest('[data-open]');
+            if (opener) { event.preventDefault(); openLink(opener.getAttribute('data-open')); return; }
+            const trigger = event.target.closest('[data-call]');
+            if (trigger && 'FORM' !== trigger.tagName) {
+                event.preventDefault();
+                callAndRender(trigger.getAttribute('data-call'), dataArgs(trigger));
+            }
+        });
+        document.addEventListener('submit', (event) => {
+            const form = event.target.closest('form[data-call]');
+            if (!form) { return; }
+            event.preventDefault();
+            callAndRender(form.getAttribute('data-call'), Object.fromEntries(new FormData(form)));
+        });
+        {% endblock %}
+
+        {% block app_script %}{% endblock %}
+    </script>
+</body>
+</html>

--- a/src/mcp-bundle/tests/App/McpAppReferenceHandlerRoundTripTest.php
+++ b/src/mcp-bundle/tests/App/McpAppReferenceHandlerRoundTripTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\App;
+
+use Mcp\Capability\Registry;
+use Mcp\Capability\Registry\ReferenceHandler;
+use Mcp\Server\Builder;
+use Mcp\Server\Session\SessionInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Symfony\AI\McpBundle\App\McpAppReferenceHandler;
+use Symfony\AI\McpBundle\App\McpAppRenderer;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * Round-trips a template-bound app tool through the *real* SDK stack — Builder, Registry,
+ * ReflectedElementLoader, HandlerResolver and ReferenceHandler — with our decorator wrapping the SDK
+ * handler, rather than the hand-rolled inner handler used by {@see McpAppReferenceHandlerTest}.
+ *
+ * The point is to pin the contract our keying silently depends on: registering a tool the way
+ * {@see \Symfony\AI\McpBundle\DependencyInjection\McpAppPass} does — `addTool([$serviceId, $method], …)`
+ * — must yield a {@see Registry\ToolReference} whose `->handler` is exactly
+ * `[$serviceId, $method]`, the string on which {@see McpAppReferenceHandler} looks up the template. If a
+ * future SDK bump normalizes handlers (to an instance, a closure, …), the template map would silently
+ * miss and the iframe would render blank; these assertions turn that into a red test instead.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class McpAppReferenceHandlerRoundTripTest extends TestCase
+{
+    public function testSdkBuiltToolReferenceKeysAndRendersThroughTheDecorator()
+    {
+        $app = new RoundTripApp();
+        $container = $this->containerFor($app);
+
+        // Register the tool exactly as McpAppPass does: handler [$serviceId, $method], real SDK loaders.
+        $registry = new Registry();
+        (new Builder())
+            ->setContainer($container)
+            ->setRegistry($registry)
+            ->addTool([RoundTripApp::class, 'render'], 'movie_search', null, 'Search movies')
+            ->build();
+
+        $toolReference = $registry->getTool('movie_search');
+
+        // The contract McpAppReferenceHandler keys on (see McpAppPass::addTool()): if this shape ever
+        // drifts, the decorator below can no longer find its template.
+        $this->assertSame([RoundTripApp::class, 'render'], $toolReference->handler);
+
+        $decorator = new McpAppReferenceHandler(
+            new ReferenceHandler($container),
+            new McpAppRenderer(new Environment(new ArrayLoader(['grid.html.twig' => '<ul><li>{{ query }}</li><li>{{ count }}</li></ul>']))),
+            [RoundTripApp::class.'::render' => 'grid.html.twig'],
+        );
+
+        $result = $decorator->handle($toolReference, ['query' => 'Nolan', '_session' => $this->createStub(SessionInterface::class)]);
+
+        $this->assertIsArray($result);
+        $this->assertSame('<ul><li>Nolan</li><li>2</li></ul>', $result['html']); // rendered from the method's context
+        $this->assertSame('Nolan', $result['query']); // original context preserved alongside the html
+        $this->assertSame(2, $result['count']);
+    }
+
+    public function testSdkBuiltToolWithoutTemplatePassesThrough()
+    {
+        $app = new RoundTripApp();
+        $container = $this->containerFor($app);
+
+        $registry = new Registry();
+        (new Builder())
+            ->setContainer($container)
+            ->setRegistry($registry)
+            ->addTool([RoundTripApp::class, 'plainData'], 'plain_data')
+            ->build();
+
+        $decorator = new McpAppReferenceHandler(
+            new ReferenceHandler($container),
+            new McpAppRenderer(new Environment(new ArrayLoader([]))),
+            [], // no templates registered
+        );
+
+        $result = $decorator->handle($registry->getTool('plain_data'), ['_session' => $this->createStub(SessionInterface::class)]);
+
+        $this->assertSame(['ok' => true], $result); // untouched: no html injected
+    }
+
+    private function containerFor(RoundTripApp $app): ContainerInterface
+    {
+        return new class($app) implements ContainerInterface {
+            public function __construct(private readonly RoundTripApp $app)
+            {
+            }
+
+            public function get(string $id): RoundTripApp
+            {
+                if (RoundTripApp::class === $id) {
+                    return $this->app;
+                }
+
+                throw new class(\sprintf('Service "%s" not found.', $id)) extends \RuntimeException implements NotFoundExceptionInterface {};
+            }
+
+            public function has(string $id): bool
+            {
+                return RoundTripApp::class === $id;
+            }
+        };
+    }
+}
+
+final class RoundTripApp
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function render(string $query = ''): array
+    {
+        return ['query' => $query, 'count' => 2];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function plainData(): array
+    {
+        return ['ok' => true];
+    }
+}

--- a/src/mcp-bundle/tests/App/McpAppReferenceHandlerTest.php
+++ b/src/mcp-bundle/tests/App/McpAppReferenceHandlerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\App;
+
+use Mcp\Capability\Registry\ElementReference;
+use Mcp\Capability\Registry\ReferenceHandlerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\App\McpAppReferenceHandler;
+use Symfony\AI\McpBundle\App\McpAppRenderer;
+use Symfony\AI\McpBundle\Exception\LogicException;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class McpAppReferenceHandlerTest extends TestCase
+{
+    public function testRendersTemplateForRegisteredToolIntoHtml()
+    {
+        $handler = $this->handler(['name' => 'World'], ['App\\Foo::render' => 'frag.html.twig']);
+
+        $result = $handler->handle(new ElementReference(['App\\Foo', 'render']), []);
+
+        $this->assertSame('Hello World', $result['html']);
+        $this->assertSame('World', $result['name']); // original context preserved
+    }
+
+    public function testBundleRenderedHtmlOverridesAnyHtmlKeyInContext()
+    {
+        $handler = $this->handler(['html' => 'manual', 'name' => 'World'], ['App\\Foo::render' => 'frag.html.twig']);
+
+        $result = $handler->handle(new ElementReference(['App\\Foo', 'render']), []);
+
+        // the bundle's rendered fragment is authoritative for a template-bound tool
+        $this->assertSame('Hello World', $result['html']);
+    }
+
+    public function testUnregisteredHandlerPassesThrough()
+    {
+        $handler = $this->handler(['name' => 'World'], ['App\\Other::render' => 'frag.html.twig']);
+
+        $result = $handler->handle(new ElementReference(['App\\Foo', 'render']), []);
+
+        $this->assertSame(['name' => 'World'], $result);
+    }
+
+    public function testNonArrayHandlerPassesThrough()
+    {
+        $handler = $this->handler('plain text', ['App\\Foo::render' => 'frag.html.twig']);
+
+        $result = $handler->handle(new ElementReference('some_function'), []);
+
+        $this->assertSame('plain text', $result);
+    }
+
+    public function testRegisteredToolReturningNonArrayThrows()
+    {
+        $handler = $this->handler('not an array', ['App\\Foo::render' => 'frag.html.twig']);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/must return an array context/');
+
+        $handler->handle(new ElementReference(['App\\Foo', 'render']), []);
+    }
+
+    public function testRegisteredToolReturningListThrows()
+    {
+        $handler = $this->handler(['a', 'b'], ['App\\Foo::render' => 'frag.html.twig']);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/must return an array context/');
+
+        $handler->handle(new ElementReference(['App\\Foo', 'render']), []);
+    }
+
+    /**
+     * @param array<string, string> $templates
+     */
+    private function handler(mixed $innerResult, array $templates): McpAppReferenceHandler
+    {
+        $inner = new class($innerResult) implements ReferenceHandlerInterface {
+            public function __construct(private readonly mixed $result)
+            {
+            }
+
+            public function handle(ElementReference $reference, array $arguments): mixed
+            {
+                return $this->result;
+            }
+        };
+
+        $renderer = new McpAppRenderer(new Environment(new ArrayLoader(['frag.html.twig' => 'Hello {{ name }}'])));
+
+        return new McpAppReferenceHandler($inner, $renderer, $templates);
+    }
+}

--- a/src/mcp-bundle/tests/App/McpAppRendererTest.php
+++ b/src/mcp-bundle/tests/App/McpAppRendererTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\App;
+
+use Mcp\Schema\Extension\Apps\McpApps;
+use Mcp\Schema\Extension\Apps\UiResourceContentMeta;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\App\McpAppRenderer;
+use Twig\Environment;
+
+final class McpAppRendererTest extends TestCase
+{
+    public function testRenderProducesMcpAppResourceContents()
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('render')
+            ->with('app.html.twig', ['brand' => 'Acme'])
+            ->willReturn('<html>hi</html>');
+
+        $contents = (new McpAppRenderer($twig))->render('ui://acme', 'app.html.twig', ['brand' => 'Acme']);
+
+        $this->assertSame('ui://acme', $contents->uri);
+        $this->assertSame(McpApps::MIME_TYPE, $contents->mimeType);
+        $this->assertSame('<html>hi</html>', $contents->text);
+        $this->assertNull($contents->meta);
+    }
+
+    public function testRenderAttachesContentMeta()
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->method('render')->willReturn('<html></html>');
+
+        $meta = new UiResourceContentMeta(prefersBorder: true);
+        $contents = (new McpAppRenderer($twig))->render('ui://acme', 'app.html.twig', [], $meta);
+
+        $this->assertSame(['ui' => $meta], $contents->meta);
+    }
+
+    public function testRenderFragmentReturnsRenderedHtml()
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('render')
+            ->with('grid.html.twig', ['count' => 2])
+            ->willReturn('<div class="grid">…</div>');
+
+        $html = (new McpAppRenderer($twig))->renderFragment('grid.html.twig', ['count' => 2]);
+
+        $this->assertSame('<div class="grid">…</div>', $html);
+    }
+}

--- a/src/mcp-bundle/tests/DependencyInjection/McpAppPassTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpAppPassTest.php
@@ -1,0 +1,384 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\DependencyInjection;
+
+use Mcp\Schema\Content\TextResourceContents;
+use Mcp\Schema\Extension\Apps\McpApps;
+use Mcp\Schema\Extension\Apps\ToolVisibility;
+use Mcp\Schema\Extension\Apps\UiResourceContentMeta;
+use Mcp\Schema\Extension\Apps\UiToolMeta;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\App\McpAppRenderer;
+use Symfony\AI\McpBundle\App\McpAppResourceRenderer;
+use Symfony\AI\McpBundle\Attribute\AsMcpApp;
+use Symfony\AI\McpBundle\Attribute\AsMcpAppTool;
+use Symfony\AI\McpBundle\DependencyInjection\McpAppPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class McpAppPassTest extends TestCase
+{
+    public function testTemplateAppEnablesExtensionAndAddsResource()
+    {
+        $container = $this->containerWithBuilder(withRenderer: true);
+        $container->setDefinition(StaticTemplateApp::class, (new Definition(StaticTemplateApp::class))->addTag('mcp.app'));
+
+        (new McpAppPass())->process($container);
+
+        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+
+        $enable = $this->callsNamed($calls, 'enableExtension');
+        $this->assertCount(1, $enable);
+        $this->assertInstanceOf(Definition::class, $enable[0][1][0]);
+        $this->assertSame(McpApps::class, $enable[0][1][0]->getClass());
+
+        $resources = $this->callsNamed($calls, 'addResource');
+        $this->assertCount(1, $resources);
+        $args = $resources[0][1];
+
+        // uri defaults to the kebab-cased short class name; resource name is the URI slug
+        $this->assertSame('ui://static-template-app', $args[1]);
+        $this->assertSame('static-template-app', $args[2]);
+        $this->assertSame(McpApps::MIME_TYPE, $args[5]);
+
+        // descriptor marker is a stdClass produced by McpApps::resourceMarker()
+        $marker = $args[9]['ui'];
+        $this->assertInstanceOf(Definition::class, $marker);
+        $this->assertSame(\stdClass::class, $marker->getClass());
+        $this->assertSame([McpApps::class, 'resourceMarker'], $marker->getFactory());
+
+        // template apps share one URI-dispatched renderer service (keyed by its FQCN)
+        $this->assertSame([McpAppResourceRenderer::class, '__invoke'], $args[0]);
+        $this->assertTrue($container->hasDefinition(McpAppResourceRenderer::class));
+        $rendererDef = $container->getDefinition(McpAppResourceRenderer::class);
+        $this->assertArrayHasKey('mcp.resource', $rendererDef->getTags());
+
+        // the renderer's URI => {template, contentMeta} map carries this app
+        $map = $rendererDef->getArgument(1);
+        $this->assertArrayHasKey('ui://static-template-app', $map);
+        $this->assertSame('dashboard.html.twig', $map['ui://static-template-app']['template']);
+
+        // content-meta built from the attribute (csp connect + geolocation + prefersBorder)
+        $contentMeta = $map['ui://static-template-app']['contentMeta'];
+        $this->assertInstanceOf(Definition::class, $contentMeta);
+        $this->assertSame(UiResourceContentMeta::class, $contentMeta->getClass());
+        $this->assertNull($contentMeta->getArgument(2)); // domain
+        $this->assertTrue($contentMeta->getArgument(3)); // prefersBorder
+    }
+
+    public function testCustomInvokeAppUsesClassHandlerAndNeedsNoRenderer()
+    {
+        $container = $this->containerWithBuilder(withRenderer: false);
+        $container->setDefinition(CustomHandlerApp::class, (new Definition(CustomHandlerApp::class))->addTag('mcp.app'));
+
+        (new McpAppPass())->process($container);
+
+        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $resources = $this->callsNamed($calls, 'addResource');
+        $this->assertCount(1, $resources);
+        $this->assertSame([CustomHandlerApp::class, '__invoke'], $resources[0][1][0]);
+        $this->assertSame('ui://custom', $resources[0][1][1]);
+
+        // the user class itself is tagged mcp.resource so McpPass adds it to the locator
+        $this->assertArrayHasKey('mcp.resource', $container->getDefinition(CustomHandlerApp::class)->getTags());
+    }
+
+    public function testExtensionEnabledOnlyOnceForMultipleApps()
+    {
+        $container = $this->containerWithBuilder(withRenderer: true);
+        $container->setDefinition(StaticTemplateApp::class, (new Definition(StaticTemplateApp::class))->addTag('mcp.app'));
+        $container->setDefinition(CustomHandlerApp::class, (new Definition(CustomHandlerApp::class))->addTag('mcp.app'));
+
+        (new McpAppPass())->process($container);
+
+        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $this->assertCount(1, $this->callsNamed($calls, 'enableExtension'));
+        $this->assertCount(2, $this->callsNamed($calls, 'addResource'));
+    }
+
+    public function testDisabledFlagRegistersNothing()
+    {
+        $container = $this->containerWithBuilder(withRenderer: true);
+        $container->setParameter('mcp.apps.enabled', false);
+        $container->setDefinition(StaticTemplateApp::class, (new Definition(StaticTemplateApp::class))->addTag('mcp.app'));
+
+        (new McpAppPass())->process($container);
+
+        $this->assertEmpty($container->getDefinition('mcp.server.builder')->getMethodCalls());
+    }
+
+    public function testForcedEnabledWithoutAppsEnablesExtensionOnly()
+    {
+        $container = $this->containerWithBuilder(withRenderer: false);
+        $container->setParameter('mcp.apps.enabled', true);
+
+        (new McpAppPass())->process($container);
+
+        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $this->assertCount(1, $this->callsNamed($calls, 'enableExtension'));
+        $this->assertCount(0, $this->callsNamed($calls, 'addResource'));
+    }
+
+    public function testAutoModeWithoutAppsDoesNothing()
+    {
+        $container = $this->containerWithBuilder(withRenderer: false);
+
+        (new McpAppPass())->process($container);
+
+        $this->assertEmpty($container->getDefinition('mcp.server.builder')->getMethodCalls());
+    }
+
+    public function testTemplateAppWithoutTwigThrows()
+    {
+        $container = $this->containerWithBuilder(withRenderer: false);
+        $container->setDefinition(StaticTemplateApp::class, (new Definition(StaticTemplateApp::class))->addTag('mcp.app'));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/Twig is not available/');
+
+        (new McpAppPass())->process($container);
+    }
+
+    public function testRenderMethodRegistersLinkedTool()
+    {
+        $container = $this->containerWithBuilder(withRenderer: true);
+        $container->setDefinition(WidgetApp::class, (new Definition(WidgetApp::class))->addTag('mcp.app'));
+
+        (new McpAppPass())->process($container);
+
+        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $tools = $this->callsNamed($calls, 'addTool');
+        $this->assertCount(1, $tools);
+
+        $args = $tools[0][1];
+        $this->assertSame([WidgetApp::class, 'render'], $args[0]);
+        $this->assertSame('do_widget', $args[1]);     // tool name (from #[AsMcpApp] name)
+        $this->assertSame('Widget', $args[2]);         // title
+        $this->assertSame('Does a widget', $args[3]);  // tool description
+
+        // ui link auto-set to this app
+        $ui = $args[7]['ui'];
+        $this->assertInstanceOf(Definition::class, $ui);
+        $this->assertSame(UiToolMeta::class, $ui->getClass());
+        $this->assertSame('ui://widget', $ui->getArgument(0));
+        $this->assertSame([ToolVisibility::Model, ToolVisibility::App], $ui->getArgument(1));
+
+        // app service tagged mcp.tool so McpPass adds it to the handler locator
+        $this->assertArrayHasKey('mcp.tool', $container->getDefinition(WidgetApp::class)->getTags());
+    }
+
+    public function testTemplateAppWithoutRenderMethodRegistersNoTool()
+    {
+        $container = $this->containerWithBuilder(withRenderer: true);
+        $container->setDefinition(StaticTemplateApp::class, (new Definition(StaticTemplateApp::class))->addTag('mcp.app'));
+
+        (new McpAppPass())->process($container);
+
+        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $this->assertCount(0, $this->callsNamed($calls, 'addTool'));
+    }
+
+    public function testExplicitMissingToolMethodThrows()
+    {
+        $container = $this->containerWithBuilder(withRenderer: true);
+        $container->setDefinition(BadMethodApp::class, (new Definition(BadMethodApp::class))->addTag('mcp.app'));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/has no such method/');
+
+        (new McpAppPass())->process($container);
+    }
+
+    public function testToolTemplateAndAppToolTemplatesAreExported()
+    {
+        $container = $this->containerWithBuilder(withRenderer: true);
+        $container->setDefinition(MultiToolApp::class, (new Definition(MultiToolApp::class))->addTag('mcp.app'));
+
+        (new McpAppPass())->process($container);
+
+        $templates = $container->getParameter('mcp.apps.tool_templates');
+        $this->assertSame('grid.html.twig', $templates[MultiToolApp::class.'::render']);
+        $this->assertSame('detail.html.twig', $templates[MultiToolApp::class.'::showDetail']);
+        $this->assertArrayNotHasKey(MultiToolApp::class.'::plain', $templates); // no template declared
+    }
+
+    public function testAppToolMethodsRegisterAdditionalLinkedTools()
+    {
+        $container = $this->containerWithBuilder(withRenderer: true);
+        $container->setDefinition(MultiToolApp::class, (new Definition(MultiToolApp::class))->addTag('mcp.app'));
+
+        (new McpAppPass())->process($container);
+
+        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $byName = [];
+        foreach ($this->callsNamed($calls, 'addTool') as $tool) {
+            $byName[$tool[1][1]] = $tool[1];
+        }
+
+        // primary tool + two #[AsMcpAppTool] methods
+        $this->assertSame(['do_multi', 'detail', 'plain'], array_keys($byName));
+
+        // follow-up tool inherits the app URI and is app-only
+        $detailUi = $byName['detail'][7]['ui'];
+        $this->assertSame(UiToolMeta::class, $detailUi->getClass());
+        $this->assertSame('ui://multi', $detailUi->getArgument(0));
+        $this->assertSame([ToolVisibility::App], $detailUi->getArgument(1));
+        $this->assertSame([MultiToolApp::class, 'showDetail'], $byName['detail'][0]);
+
+        // default tool name is the snake_cased method; default visibility is model + app
+        $this->assertSame([ToolVisibility::Model, ToolVisibility::App], $byName['plain'][7]['ui']->getArgument(1));
+    }
+
+    public function testPrimaryMethodWithAppToolAttributeThrows()
+    {
+        $container = $this->containerWithBuilder(withRenderer: true);
+        $container->setDefinition(CollidingToolApp::class, (new Definition(CollidingToolApp::class))->addTag('mcp.app'));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/primary tool/');
+
+        (new McpAppPass())->process($container);
+    }
+
+    public function testToolTemplateWithoutTwigThrows()
+    {
+        $container = $this->containerWithBuilder(withRenderer: false);
+        $container->setDefinition(InvokeWithToolTemplateApp::class, (new Definition(InvokeWithToolTemplateApp::class))->addTag('mcp.app'));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/Twig is not available/');
+
+        (new McpAppPass())->process($container);
+    }
+
+    public function testDoesNothingWhenNoServerBuilder()
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition(StaticTemplateApp::class, (new Definition(StaticTemplateApp::class))->addTag('mcp.app'));
+
+        (new McpAppPass())->process($container);
+
+        $this->assertFalse($container->hasDefinition('mcp.server.builder'));
+    }
+
+    private function containerWithBuilder(bool $withRenderer): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('mcp.server.builder', new Definition());
+        if ($withRenderer) {
+            $container->setDefinition(McpAppRenderer::SERVICE_ID, new Definition(McpAppRenderer::class));
+        }
+
+        return $container;
+    }
+
+    /**
+     * @param array<array{0: string, 1: array<mixed>}> $calls
+     *
+     * @return array<array{0: string, 1: array<mixed>}>
+     */
+    private function callsNamed(array $calls, string $name): array
+    {
+        return array_values(array_filter($calls, static fn ($call) => $name === $call[0]));
+    }
+}
+
+#[AsMcpApp(template: 'dashboard.html.twig', prefersBorder: true, cspConnect: ['https://api.example.com'], geolocation: true)]
+class StaticTemplateApp
+{
+}
+
+#[AsMcpApp(uri: 'ui://custom')]
+class CustomHandlerApp
+{
+    public function __invoke(): TextResourceContents
+    {
+        return new TextResourceContents('ui://custom', McpApps::MIME_TYPE, '<html></html>');
+    }
+}
+
+#[AsMcpApp(uri: 'ui://widget', name: 'do_widget', title: 'Widget', description: 'Does a widget', template: 'widget.html.twig')]
+class WidgetApp
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function render(int $id): array
+    {
+        return ['id' => $id];
+    }
+}
+
+#[AsMcpApp(template: 'bad.html.twig', method: 'missing')]
+class BadMethodApp
+{
+}
+
+#[AsMcpApp(uri: 'ui://multi', name: 'do_multi', title: 'Multi', description: 'Primary', template: 'shell.html.twig', toolTemplate: 'grid.html.twig')]
+class MultiToolApp
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function render(string $query = ''): array
+    {
+        return ['query' => $query];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[AsMcpAppTool(name: 'detail', description: 'Show details', template: 'detail.html.twig', appOnly: true)]
+    public function showDetail(string $slug): array
+    {
+        return ['slug' => $slug];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[AsMcpAppTool]
+    public function plain(): array
+    {
+        return [];
+    }
+}
+
+#[AsMcpApp(uri: 'ui://collide', name: 'collide', template: 'shell.html.twig')]
+class CollidingToolApp
+{
+    /**
+     * @return array<string, mixed>
+     */
+    #[AsMcpAppTool]
+    public function render(): array
+    {
+        return [];
+    }
+}
+
+#[AsMcpApp(uri: 'ui://inv', toolTemplate: 'grid.html.twig')]
+class InvokeWithToolTemplateApp
+{
+    public function __invoke(): TextResourceContents
+    {
+        return new TextResourceContents('ui://inv', McpApps::MIME_TYPE, '<html></html>');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function render(): array
+    {
+        return [];
+    }
+}

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -23,6 +23,8 @@ use Mcp\Server\Session\InMemorySessionStore;
 use Mcp\Server\Session\Psr16SessionStore;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\App\McpAppRenderer;
+use Symfony\AI\McpBundle\Attribute\AsMcpApp;
 use Symfony\AI\McpBundle\McpBundle;
 use Symfony\AI\McpBundle\Session\FrameworkSessionStore;
 use Symfony\Component\Cache\Psr16Cache;
@@ -589,6 +591,37 @@ class McpBundleTest extends TestCase
         $this->assertArrayHasKey(NotificationHandlerInterface::class, $autoconfigured);
         $definition = $autoconfigured[NotificationHandlerInterface::class];
         $this->assertTrue($definition->hasTag('mcp.notification_handler'));
+    }
+
+    public function testAppsDefaultConfiguration()
+    {
+        $container = $this->buildContainer([]);
+
+        $this->assertNull($container->getParameter('mcp.apps.enabled'));
+    }
+
+    public function testAppsEnabledFlag()
+    {
+        $container = $this->buildContainer(['mcp' => ['apps' => ['enabled' => true]]]);
+
+        $this->assertTrue($container->getParameter('mcp.apps.enabled'));
+    }
+
+    public function testAsMcpAppAttributeAutoconfiguration()
+    {
+        $container = $this->buildContainer([]);
+
+        $attributeAutoconfigurators = $container->getAttributeAutoconfigurators();
+        $this->assertArrayHasKey(AsMcpApp::class, $attributeAutoconfigurators);
+    }
+
+    public function testAppRendererRegisteredWhenTwigAvailable()
+    {
+        $container = $this->buildContainer([]);
+
+        // Twig is a dev dependency of the bundle, so the renderer must be registered.
+        $this->assertTrue(class_exists(\Twig\Environment::class));
+        $this->assertTrue($container->hasDefinition(McpAppRenderer::SERVICE_ID));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | —
| License       | MIT

## What is this?

Wire your Symfony services + Twig into **MCP Apps** — interactive HTML UIs an MCP host renders in a sandboxed iframe instead of a plain-text tool result. One class is the whole app: `#[AsMcpApp]` registers the UI resource, the linked tool and the MCP Apps server extension, and the bundle ships the iframe bridge (`@Mcp/app/base.html.twig`). You write a tool method and a Twig template — no protocol plumbing, no client JS.

## A minimal app (single template)

The tool method returns a context array; the bundle renders `toolTemplate` into the result over the wire, so no Twig touches your handler:

```php
#[AsMcpApp(
    uri: 'ui://weather',
    name: 'get_weather',
    template: 'mcp/weather.html.twig',      // static iframe shell
    toolTemplate: 'mcp/_weather.html.twig', // rendered into the tool result
)]
final class WeatherApp
{
    public function __construct(private WeatherClient $weather) {}

    public function render(string $city): array
    {
        return ['forecast' => $this->weather->forecastFor($city)];
    }
}
```

```twig
{# mcp/weather.html.twig — extends the bundle base; the rendered fragment lands in #root #}
{% extends '@Mcp/app/base.html.twig' %}
{% block body %}<div id="root"></div>{% endblock %}
```

## Adding interactive tools

Declare follow-up tools with `#[AsMcpAppTool]` (server side) and trigger them from the markup with the base template's declarative attributes (client side) — still no JavaScript:

```php
#[AsMcpAppTool(name: 'set_unit', template: 'mcp/_weather.html.twig', appOnly: true)]
public function setUnit(string $city, string $unit): array
{
    return ['forecast' => $this->weather->forecastFor($city, $unit)];
}
```

```twig
<button data-call="set_unit" data-arg-city="{{ city }}" data-arg-unit="celsius">°C</button>
<form data-call="get_weather"><input name="city"><button>Go</button></form>
```

`data-call` invokes the tool and swaps the returned HTML into `#root`; `data-open` opens an external link. It works on buttons, submit buttons (incl. the cross-DOM `form="…"` pattern) and anchors — verified with a jsdom harness.

## Notes

- A `ReferenceHandler` decorator renders the template into the tool result while keeping the SDK's reflection-derived input schema intact; `mcp.apps.enabled` toggles the extension.
- `demo/` exposes the movie collection as an MCP App (`MovieApp` — searchable grid + detail), reusing the existing `movie_search` agent tool (`Movie` is now `JsonSerializable`, so it serves both the agent and the UI).

## Demo

[Screencast from 2026-06-25 10-07-36.webm](https://github.com/user-attachments/assets/9ca81e21-54e2-46f5-9965-d402b75bc3e2)
