### PR TITLE
 Fix profiler crash on tool message rendering

### DIFF
--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -139,7 +139,13 @@
                                                             {% endfor %}
                                                         {% elseif 'tool' == message.role.value %}
                                                             <i>Result of tool call with ID {{ message.toolCall.id }}</i><br />
-                                                            {{ message.content|nl2br }}
+                                                            {% for item in message.content %}
+                                                                {% if item.text is defined %}
+                                                                    {{ item.text|nl2br }}
+                                                                {% else %}
+                                                                    {{ item }}
+                                                                {% endif %}
+                                                            {% endfor %}
                                                         {% elseif 'user' == message.role.value %}
                                                             {% for item in message.content %}
                                                                 {% if item.text is defined %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The AI profiler crashed with `nl2br(): Argument #1 ($string) must be of type string, array given` when rendering a tool result message, because `ToolCallMessage::getContent()` returns an array of `ContentInterface` objects, not a string. The template now iterates the content and renders each `Text` part, matching the `user` message branch.