### PR TITLE
[Platform] Add conversion to a dedicated websearch result in open-responses platform

### DIFF
--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -232,7 +232,7 @@ class ResultConverterTest extends TestCase
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('toArray')->willReturn([
             'output' => [
-                ['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed'],
+                ['type' => 'file_search_call', 'id' => 'fs_1', 'status' => 'completed'],
                 [
                     'type' => 'message',
                     'id' => 'msg_1',

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Throw typed exceptions on rate limit and server error events mid-stream
  * Normalize the `baseUrl` and tolerate a trailing slash in the model client
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+ * Return a `WebSearchResult` for `web_search_call` output items
 
 0.10
 ----

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -34,6 +34,7 @@ use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -45,6 +46,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * @phpstan-type Refusal array{type: 'refusal', refusal: string}
  * @phpstan-type FunctionCall array{id?: string|null, arguments: string, call_id?: string|null, name: string, type: 'function_call'}
  * @phpstan-type Thinking array{summary: list<array{type: string, text?: string}>, id: string}
+ * @phpstan-type WebSearchAction array{type: string, query?: string, queries?: list<string>}
+ * @phpstan-type WebSearchCall array{type: 'web_search_call', id: string, status: string, action: WebSearchAction}
  * @phpstan-type Error array{code?: string|null, type?: string|null, param?: string|null, message?: string|null}
  */
 class ResultConverter implements ResultConverterInterface
@@ -168,7 +171,7 @@ class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param OutputMessage|Thinking $item
+     * @param OutputMessage|Thinking|WebSearchCall $item
      *
      * @return iterable<ResultInterface>
      */
@@ -179,16 +182,27 @@ class ResultConverter implements ResultConverterInterface
         return match ($type) {
             'message' => $this->convertOutputMessage($item),
             'reasoning' => $this->convertReasoning($item),
-            // Built-in server-side tool calls (web search, file search, code
-            // interpreter, image generation, computer use, MCP, …) are reported
-            // as their own output items but carry no assistant-facing result.
-            // Skip them so the actual message item is still converted instead of
-            // aborting the whole response.
-            'web_search_call', 'file_search_call', 'code_interpreter_call',
+            'web_search_call' => $this->convertWebSearch($item),
+            // Built-in server-side tool calls (file search, code interpreter,
+            // image generation, computer use, MCP, …) are reported as their own
+            // output items but carry no assistant-facing result. Skip them so the
+            // actual message item is still converted instead of aborting the whole
+            // response.
+            'file_search_call', 'code_interpreter_call',
             'image_generation_call', 'computer_call', 'local_shell_call',
             'mcp_call', 'mcp_list_tools', 'mcp_approval_request' => [],
             default => throw new RuntimeException(\sprintf('Unsupported output type "%s".', $type)),
         };
+    }
+
+    /**
+     * @param WebSearchCall $item
+     *
+     * @return \Generator<WebSearchResult>
+     */
+    private function convertWebSearch(array $item): \Generator
+    {
+        yield new WebSearchResult($item['id'], $item['status'], $item['action']['query'] ?? null, $item['action']['queries'] ?? []);
     }
 
     private function convertStream(RawResultInterface|RawHttpResult $result): \Generator

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -35,6 +35,7 @@ use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
 use Symfony\AI\Platform\TokenUsage\TokenUsage;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -259,7 +260,7 @@ final class ResultConverterTest extends TestCase
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('toArray')->willReturn([
             'output' => [
-                ['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed'],
+                ['type' => 'file_search_call', 'id' => 'fs_1', 'status' => 'completed'],
                 [
                     'type' => 'message',
                     'id' => 'msg_1',
@@ -276,6 +277,48 @@ final class ResultConverterTest extends TestCase
 
         $this->assertInstanceOf(TextResult::class, $result);
         $this->assertSame('The answer is 42.', $result->getContent());
+    }
+
+    public function testConvertIncludesWebSearchResultForWebSearchCallOutputItem()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'web_search_call',
+                    'id' => 'ws_1',
+                    'status' => 'completed',
+                    'action' => [
+                        'type' => 'search',
+                        'query' => 'Latest AI news',
+                        'queries' => ['OpenAI recent announcements', 'AI industry developments today'],
+                    ],
+                ],
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'The answer is 42.',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(WebSearchResult::class, $parts[0]);
+        $this->assertSame('ws_1', $parts[0]->getId());
+        $this->assertSame('completed', $parts[0]->getStatus());
+        $this->assertSame('Latest AI news', $parts[0]->getQuery());
+        $this->assertSame(['OpenAI recent announcements', 'AI industry developments today'], $parts[0]->getQueries());
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('The answer is 42.', $parts[1]->getContent());
     }
 
     public function testThrowsRuntimeExceptionWhenIncompleteResponseHasNoContent()

--- a/src/platform/src/Result/WebSearchResult.php
+++ b/src/platform/src/Result/WebSearchResult.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * @author Paul Hußmann <paul@hussmann-cloud.de>
+ */
+final class WebSearchResult extends BaseResult
+{
+    /**
+     * @param list<string> $queries
+     */
+    public function __construct(
+        private readonly string $id,
+        private readonly string $status,
+        private readonly ?string $query,
+        private readonly array $queries,
+    ) {
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->query;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getQuery(): ?string
+    {
+        return $this->query;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getQueries(): array
+    {
+        return $this->queries;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | Fix #2149 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Added WebSearchResult — a new result type for the OpenResponses bridge that converts web_search_call output items into a structured object exposing the search id, status, query, and queries fields. Previously these items were
silently skipped; now they're surfaced to the caller.
