### PR TITLE
[Platform][Albert] Align bridge `base_url` convention with Generic bridge

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,21 @@
+UPGRADE FROM 0.11 to 0.12
+=========================
+
+Platform
+--------
+
+ * The Albert bridge now follows the same `base_url` convention as the Generic bridge:
+   the API version must **not** be included in `baseUrl`, it is part of the path instead.
+   Remove the version segment from your configured URL:
+
+   ```diff
+   -Symfony\AI\Platform\Bridge\Albert\Factory::createPlatform($apiKey, 'https://albert.api.etalab.gouv.fr/v1');
+   +Symfony\AI\Platform\Bridge\Albert\Factory::createPlatform($apiKey, 'https://albert.api.etalab.gouv.fr');
+   ```
+
+   This also applies to `Albert\ApiClient`, which now appends `/v1/models` (instead of `/models`)
+   to the configured URL when listing models.
+
 UPGRADE FROM 0.10 to 0.11
 =========================
 

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -8950,7 +8950,7 @@ class AiBundleTest extends TestCase
                     ],
                     'albert' => [
                         'api_key' => 'albert-test-key',
-                        'base_url' => 'https://albert.api.etalab.gouv.fr/v1',
+                        'base_url' => 'https://albert.api.etalab.gouv.fr',
                     ],
                     'azure' => [
                         'my_azure_instance' => [

--- a/src/platform/src/Bridge/Albert/ApiClient.php
+++ b/src/platform/src/Bridge/Albert/ApiClient.php
@@ -33,7 +33,7 @@ final class ApiClient
      */
     public function getModels(): array
     {
-        $result = $this->httpClient->request('GET', \sprintf('%s/models', $this->apiUrl), [
+        $result = $this->httpClient->request('GET', \sprintf('%s/v1/models', rtrim($this->apiUrl, '/')), [
             'auth_bearer' => $this->apiKey,
         ]);
 

--- a/src/platform/src/Bridge/Albert/CHANGELOG.md
+++ b/src/platform/src/Bridge/Albert/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * [BC BREAK] The `baseUrl` must no longer include the API version (e.g. use `https://albert.api.etalab.gouv.fr`
+   instead of `https://albert.api.etalab.gouv.fr/v1`), aligning with the Generic bridge convention
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/Albert/Factory.php
+++ b/src/platform/src/Bridge/Albert/Factory.php
@@ -38,13 +38,8 @@ final class Factory
         ?EventDispatcherInterface $eventDispatcher = null,
         string $name = 'albert',
     ): ProviderInterface {
-        $baseUrl = rtrim($baseUrl, '/');
-
         if (!str_starts_with($baseUrl, 'https://')) {
             throw new InvalidArgumentException('The Albert URL must start with "https://".');
-        }
-        if (!preg_match('/\/v\d+$/', $baseUrl)) {
-            throw new InvalidArgumentException('The Albert URL must include an API version (e.g., /v1, /v2).');
         }
         if ('' === $apiKey) {
             throw new InvalidArgumentException('The API key must not be empty.');
@@ -58,8 +53,6 @@ final class Factory
             httpClient: $httpClient,
             modelCatalog: $modelCatalog,
             eventDispatcher: $eventDispatcher,
-            completionsPath: '/chat/completions',
-            embeddingsPath: '/embeddings',
             name: $name,
         );
     }

--- a/src/platform/src/Bridge/Albert/Tests/ApiClientTest.php
+++ b/src/platform/src/Bridge/Albert/Tests/ApiClientTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Albert\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Albert\ApiClient;
+use Symfony\AI\Platform\Model;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ApiClientTest extends TestCase
+{
+    #[DataProvider('provideBaseUrls')]
+    public function testGetModelsRequestsVersionedModelsEndpoint(string $baseUrl)
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url): JsonMockResponse {
+            $this->assertSame('GET', $method);
+            $this->assertSame('https://albert.example.com/v1/models', $url);
+
+            return new JsonMockResponse([
+                'data' => [
+                    ['id' => 'albert-large'],
+                    ['id' => 'albert-small'],
+                ],
+            ]);
+        });
+
+        $apiClient = new ApiClient($baseUrl, 'test-key', $httpClient);
+        $models = $apiClient->getModels();
+
+        $this->assertCount(2, $models);
+        $this->assertContainsOnlyInstancesOf(Model::class, $models);
+        $this->assertSame('albert-large', $models[0]->getName());
+        $this->assertSame('albert-small', $models[1]->getName());
+    }
+
+    public static function provideBaseUrls(): \Iterator
+    {
+        yield 'base url without version' => ['https://albert.example.com'];
+        yield 'base url with trailing slash' => ['https://albert.example.com/'];
+    }
+}

--- a/src/platform/src/Bridge/Albert/Tests/FactoryTest.php
+++ b/src/platform/src/Bridge/Albert/Tests/FactoryTest.php
@@ -21,7 +21,7 @@ final class FactoryTest extends TestCase
 {
     public function testCreatesPlatformWithCorrectBaseUrl()
     {
-        $platform = Factory::createPlatform('test-key', 'https://albert.example.com/v1');
+        $platform = Factory::createPlatform('test-key', 'https://albert.example.com');
 
         $this->assertInstanceOf(Platform::class, $platform);
     }
@@ -36,11 +36,8 @@ final class FactoryTest extends TestCase
 
     public static function provideValidUrls(): \Iterator
     {
-        yield 'with v1 path' => ['https://albert.example.com/v1'];
-        yield 'with v2 path' => ['https://albert.example.com/v2'];
-        yield 'with v3 path' => ['https://albert.example.com/v3'];
-        yield 'with v10 path' => ['https://albert.example.com/v10'];
-        yield 'with v99 path' => ['https://albert.example.com/v99'];
+        yield 'base url without version' => ['https://albert.example.com'];
+        yield 'base url with trailing slash' => ['https://albert.example.com/'];
     }
 
     public function testThrowsExceptionForNonHttpsUrl()
@@ -56,41 +53,6 @@ final class FactoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The API key must not be empty.');
 
-        Factory::createPlatform('', 'https://albert.example.com/v2');
-    }
-
-    #[DataProvider('provideUrlsWithTrailingSlash')]
-    public function testToleratesTrailingSlashes(string $url)
-    {
-        $platform = Factory::createPlatform('test-key', $url);
-
-        $this->assertInstanceOf(Platform::class, $platform);
-    }
-
-    public static function provideUrlsWithTrailingSlash(): \Iterator
-    {
-        yield 'with v1 and trailing slash' => ['https://albert.example.com/v1/'];
-        yield 'with v2 and trailing slash' => ['https://albert.example.com/v2/'];
-        yield 'with multiple trailing slashes' => ['https://albert.example.com/v1///'];
-    }
-
-    #[DataProvider('provideUrlsWithoutVersion')]
-    public function testThrowsExceptionForUrlsWithoutVersion(string $url)
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The Albert URL must include an API version (e.g., /v1, /v2).');
-
-        Factory::createPlatform('test-key', $url);
-    }
-
-    public static function provideUrlsWithoutVersion(): \Iterator
-    {
-        yield 'without version' => ['https://albert.example.com'];
-        yield 'with trailing slash only' => ['https://albert.example.com/'];
-        yield 'with vx path' => ['https://albert.example.com/vx'];
-        yield 'with version path' => ['https://albert.example.com/version'];
-        yield 'with api path' => ['https://albert.example.com/api'];
-        yield 'with v path only' => ['https://albert.example.com/v'];
-        yield 'with v- path' => ['https://albert.example.com/v-1'];
+        Factory::createPlatform('', 'https://albert.example.com');
     }
 }


### PR DESCRIPTION
The Albert bridge was requiring the API version in the base URL (e.g. https://example.com/v1) and overriding completionsPath/embeddingsPath to compensate, while Generic and all other bridges expect a bare base URL and include the version in the path (/v1/chat/completions).

Drop the version validation and the path overrides so Albert delegates entirely to Generic defaults, aligning both conventions.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no 
| Issues        | Fix #2240
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).

CHANGELOG.md/UPGRADE.md checks enforced on every PR:
 - A bug fix only (New feature? = no) must not change any CHANGELOG.md/UPGRADE.md, unless it's a BC break (then add the "BC Break" label + an UPGRADE.md entry).
 - A backward-compatibility break needs an UPGRADE.md entry AND the "BC Break" label (the two go together).
 - Only add entries to the upcoming (unreleased) version section.
-->
