### PR TITLE
[Mate] Guard extension paths against directory traversal

### DIFF
--- a/src/mate/src/Agent/AgentInstructionsAggregator.php
+++ b/src/mate/src/Agent/AgentInstructionsAggregator.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Mate\Agent;
 
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
+use Symfony\AI\Mate\Discovery\PathGuard;
 
 /**
  * Aggregates agent instructions from all installed extensions.
@@ -86,6 +87,15 @@ final class AgentInstructionsAggregator
             return null;
         }
 
+        if (PathGuard::hasTraversal($instructionsPath)) {
+            $this->logger->warning('Invalid instructions path (contains path traversal)', [
+                'package' => $packageName,
+                'path' => $instructionsPath,
+            ]);
+
+            return null;
+        }
+
         $fullPath = $this->rootDir.'/vendor/'.$packageName.'/'.ltrim($instructionsPath, '/');
 
         return $this->readInstructionsFile($fullPath, $packageName);
@@ -99,6 +109,15 @@ final class AgentInstructionsAggregator
         $instructionsPath = $data['instructions'] ?? null;
 
         if (null === $instructionsPath) {
+            return null;
+        }
+
+        if (PathGuard::hasTraversal($instructionsPath)) {
+            $this->logger->warning('Invalid instructions path (contains path traversal)', [
+                'source' => 'root project',
+                'path' => $instructionsPath,
+            ]);
+
             return null;
         }
 

--- a/src/mate/src/Discovery/ComposerExtensionDiscovery.php
+++ b/src/mate/src/Discovery/ComposerExtensionDiscovery.php
@@ -264,7 +264,15 @@ final class ComposerExtensionDiscovery
 
         $validDirs = [];
         foreach ($scanDirs as $dir) {
-            if (!\is_string($dir) || '' === trim($dir) || str_contains($dir, '..')) {
+            if (!\is_string($dir) || '' === trim($dir)) {
+                continue;
+            }
+
+            if (PathGuard::hasTraversal($dir)) {
+                $this->logger->warning('Invalid scan directory (contains path traversal)', [
+                    'package' => $packageName,
+                    'directory' => $dir,
+                ]);
                 continue;
             }
 
@@ -318,7 +326,15 @@ final class ComposerExtensionDiscovery
 
         $validFiles = [];
         foreach ($includes as $file) {
-            if (!\is_string($file) || '' === trim($file) || str_contains($file, '..')) {
+            if (!\is_string($file) || '' === trim($file)) {
+                continue;
+            }
+
+            if (PathGuard::hasTraversal($file)) {
+                $this->logger->warning('Invalid include file (contains path traversal)', [
+                    'package' => $packageName,
+                    'file' => $file,
+                ]);
                 continue;
             }
 
@@ -361,9 +377,8 @@ final class ComposerExtensionDiscovery
             return null;
         }
 
-        // Security: prevent path traversal
-        if (str_contains($agentInstructions, '..')) {
-            $this->logger->warning('Invalid instructions path (contains "..")', [
+        if (PathGuard::hasTraversal($agentInstructions)) {
+            $this->logger->warning('Invalid instructions path (contains path traversal)', [
                 'package' => $packageName,
                 'path' => $agentInstructions,
             ]);

--- a/src/mate/src/Discovery/PathGuard.php
+++ b/src/mate/src/Discovery/PathGuard.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Discovery;
+
+/**
+ * Guards package-relative paths declared in composer.json against directory traversal.
+ *
+ * Extension paths (scan-dirs, includes, instructions) are declared by third-party
+ * Composer packages and joined onto the project's vendor directory. A path that
+ * escapes its base directory via a parent (..) segment must be rejected so a
+ * malicious package cannot reach files outside its own directory.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PathGuard
+{
+    /**
+     * Returns true when the relative path attempts to traverse out of its base
+     * directory via a parent (..) segment or contains a null byte.
+     *
+     * The check is segment-based on purpose: a substring match on ".." would also
+     * reject legitimate names such as "my..notes.md".
+     */
+    public static function hasTraversal(string $path): bool
+    {
+        if (str_contains($path, "\0")) {
+            return true;
+        }
+
+        $segments = preg_split('#[/\\\\]+#', $path);
+        if (false === $segments) {
+            return true;
+        }
+
+        foreach ($segments as $segment) {
+            if ('..' === $segment) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/mate/tests/Agent/AgentInstructionsAggregatorTest.php
+++ b/src/mate/tests/Agent/AgentInstructionsAggregatorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Agent;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\Mate\Agent\AgentInstructionsAggregator;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class AgentInstructionsAggregatorTest extends TestCase
+{
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir().'/mate-aggregator-'.uniqid();
+        mkdir($this->rootDir.'/vendor/acme/ext', 0777, true);
+        file_put_contents($this->rootDir.'/vendor/acme/ext/INSTRUCTIONS.md', '# Acme Instructions');
+        file_put_contents($this->rootDir.'/secret.md', '# Secret');
+    }
+
+    protected function tearDown(): void
+    {
+        $files = [
+            $this->rootDir.'/vendor/acme/ext/INSTRUCTIONS.md',
+            $this->rootDir.'/secret.md',
+        ];
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+        foreach ([$this->rootDir.'/vendor/acme/ext', $this->rootDir.'/vendor/acme', $this->rootDir.'/vendor', $this->rootDir] as $dir) {
+            if (is_dir($dir)) {
+                rmdir($dir);
+            }
+        }
+    }
+
+    public function testAggregatesExtensionInstructions()
+    {
+        $aggregator = new AgentInstructionsAggregator(
+            $this->rootDir,
+            ['acme/ext' => ['dirs' => [], 'includes' => [], 'instructions' => 'INSTRUCTIONS.md']],
+            new NullLogger(),
+        );
+
+        $result = $aggregator->aggregate();
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('Acme Instructions', $result);
+    }
+
+    public function testRejectsTraversingExtensionInstructions()
+    {
+        $aggregator = new AgentInstructionsAggregator(
+            $this->rootDir,
+            ['acme/ext' => ['dirs' => [], 'includes' => [], 'instructions' => '../../../secret.md']],
+            new NullLogger(),
+        );
+
+        $this->assertNull($aggregator->aggregate());
+    }
+
+    public function testRejectsTraversingRootProjectInstructions()
+    {
+        $aggregator = new AgentInstructionsAggregator(
+            $this->rootDir,
+            ['_custom' => ['dirs' => [], 'includes' => [], 'instructions' => '../secret.md']],
+            new NullLogger(),
+        );
+
+        $this->assertNull($aggregator->aggregate());
+    }
+}

--- a/src/mate/tests/Discovery/PathGuardTest.php
+++ b/src/mate/tests/Discovery/PathGuardTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Discovery;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Discovery\PathGuard;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PathGuardTest extends TestCase
+{
+    #[DataProvider('provideTraversalPaths')]
+    public function testRejectsTraversal(string $path)
+    {
+        $this->assertTrue(PathGuard::hasTraversal($path));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideTraversalPaths(): iterable
+    {
+        yield 'parent segment' => ['../config.php'];
+        yield 'nested parent segment' => ['config/../../secret.php'];
+        yield 'trailing parent segment' => ['config/..'];
+        yield 'leading parent segment' => ['..'];
+        yield 'backslash parent segment' => ['config\\..\\secret.php'];
+        yield 'null byte' => ["config.php\0.md"];
+    }
+
+    #[DataProvider('provideSafePaths')]
+    public function testAcceptsSafePaths(string $path)
+    {
+        $this->assertFalse(PathGuard::hasTraversal($path));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideSafePaths(): iterable
+    {
+        yield 'simple file' => ['INSTRUCTIONS.md'];
+        yield 'nested file' => ['config/config.php'];
+        yield 'dot in filename' => ['my..notes.md'];
+        yield 'double dot in filename' => ['archive..2024/file.php'];
+        yield 'literal percent-encoded sequence' => ['%2e%2e/config.php'];
+        yield 'hidden file' => ['.env.dist'];
+        yield 'empty string' => [''];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Mate discovers extensions from installed Composer packages and reads paths they declare under `extra.ai-mate` (`scan-dirs`, `includes`, `instructions`). Those package-relative paths are joined onto the project's `vendor/<package>/` directory and then read or included, so a malicious/compromised package using a parent (`..`) segment could reference files outside its own directory.

`ComposerExtensionDiscovery` already had a coarse `str_contains($path, '..')` check, but `AgentInstructionsAggregator` — which feeds the path read for the MCP `instructions` handshake — had **none**.

This PR:

- adds a shared, segment-based `PathGuard::hasTraversal()` and applies it across `ComposerExtensionDiscovery` (scan-dirs / includes / instructions) and `AgentInstructionsAggregator` (extension + root-project instructions);
- removes the duplicated `containsPathTraversal()` helper that previously lived in both classes;
- uses segment matching so legitimate names like `my..notes.md` are no longer rejected, while real `..` segments and null bytes still are.

`realpath()`-based containment was intentionally not used: the `./link` development workflow symlinks `vendor/symfony/ai-*` outside the project, which a `realpath` containment check would wrongly reject.

Tests are included for `PathGuard` (traversal vs. safe paths) and `AgentInstructionsAggregator` (traversing extension/root instructions are rejected, valid ones are aggregated).
