### PR TITLE
[Mate] Escape package names when writing extensions.php

### DIFF
--- a/src/mate/src/Service/ExtensionConfigSynchronizer.php
+++ b/src/mate/src/Service/ExtensionConfigSynchronizer.php
@@ -125,7 +125,9 @@ final class ExtensionConfigSynchronizer
 
         foreach ($extensions as $packageName => $config) {
             $enabled = $config['enabled'] ? 'true' : 'false';
-            $content .= "    '$packageName' => ['enabled' => $enabled],\n";
+            // Package names originate from third-party composer.json files and are written into a
+            // PHP file that is later included; var_export() escapes them safely to prevent code injection.
+            $content .= \sprintf("    %s => ['enabled' => %s],\n", var_export($packageName, true), $enabled);
         }
 
         $content .= "];\n";

--- a/src/mate/tests/Service/ExtensionConfigSynchronizerTest.php
+++ b/src/mate/tests/Service/ExtensionConfigSynchronizerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Service\ExtensionConfigSynchronizer;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ExtensionConfigSynchronizerTest extends TestCase
+{
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir().'/mate-synchronizer-'.uniqid();
+        mkdir($this->rootDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->rootDir.'/mate/extensions.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+        foreach ([$this->rootDir.'/mate', $this->rootDir] as $dir) {
+            if (is_dir($dir)) {
+                rmdir($dir);
+            }
+        }
+    }
+
+    public function testWritesValidPackageNames()
+    {
+        $synchronizer = new ExtensionConfigSynchronizer($this->rootDir);
+
+        $synchronizer->synchronize(['vendor/package-a' => ['dirs' => [], 'includes' => []]]);
+
+        $extensions = include $this->rootDir.'/mate/extensions.php';
+
+        $this->assertSame(['vendor/package-a' => ['enabled' => true]], $extensions);
+    }
+
+    public function testMaliciousPackageNameCannotInjectCode()
+    {
+        $synchronizer = new ExtensionConfigSynchronizer($this->rootDir);
+
+        // A crafted package name that would break out of the single-quoted string literal
+        // and inject additional array entries / PHP code under naive interpolation.
+        $maliciousName = "evil', 'injected' => ['enabled' => true], 'x";
+
+        $synchronizer->synchronize([$maliciousName => ['dirs' => [], 'includes' => []]]);
+
+        $extensions = include $this->rootDir.'/mate/extensions.php';
+
+        // The whole crafted string must round-trip as a single key, and no extra entry is created.
+        $this->assertSame([$maliciousName => ['enabled' => true]], $extensions);
+        $this->assertArrayNotHasKey('injected', $extensions);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

`ExtensionConfigSynchronizer::writeExtensionsFile()` interpolated the package name raw into the generated `mate/extensions.php`:

```php
$content .= "    '$packageName' => ['enabled' => $enabled],\n";
```

That file is later `include`d. Package names come from third-party `composer.json` files, so a package whose name contains a single quote could break out of the string literal and inject arbitrary PHP, e.g. a name like `evil', 'injected' => ['enabled' => true], 'x`.

The fix emits the name through `var_export($packageName, true)`, which produces a correctly escaped PHP string literal for any input:

```php
$content .= \sprintf("    %s => ['enabled' => %s],\n", var_export($packageName, true), $enabled);
```

This fully closes the sink — no regex allow-listing or manual quote-escaping needed. A test feeds a crafted injecting name and asserts it round-trips as a single array key with no extra entry, and that the generated file stays valid PHP.
