### PR TITLE
[Mate] Create scaffolded secrets and log files with restrictive permissions

### DIFF
--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Mate\Command;
 
 use HelgeSverre\Toon\Toon;
 use Symfony\AI\Mate\Agent\AgentInstructionsMaterializer;
+use Symfony\AI\Mate\Service\FilePermissions;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,6 +30,17 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand('init', 'Initialize Mate configuration and directory structure')]
 class InitCommand extends Command
 {
+    /**
+     * Scaffolded files that may contain secrets or local configuration and must not be
+     * world-readable.
+     *
+     * @var list<string>
+     */
+    private const SENSITIVE_FILES = [
+        'mate/.env',
+        'mate/config.php',
+    ];
+
     public function __construct(
         private string $rootDir,
         private AgentInstructionsMaterializer $instructionsMaterializer,
@@ -58,7 +70,7 @@ class InitCommand extends Command
 
         $mateDir = $this->rootDir.'/mate';
         if (!is_dir($mateDir)) {
-            mkdir($mateDir, 0755, true);
+            mkdir($mateDir, FilePermissions::DIRECTORY, true);
             $actions[] = ['✓', 'Created', 'mate/ directory'];
         }
 
@@ -109,7 +121,7 @@ class InitCommand extends Command
 
         $mateSrcDir = $this->rootDir.'/mate/src';
         if (!is_dir($mateSrcDir)) {
-            mkdir($mateSrcDir, 0755, true);
+            mkdir($mateSrcDir, FilePermissions::DIRECTORY, true);
             file_put_contents($mateSrcDir.'/.gitignore', '');
             $actions[] = ['✓', 'Created', 'mate/src/ directory (for custom MCP tools)'];
         } else {
@@ -149,7 +161,7 @@ class InitCommand extends Command
     {
         $directory = \dirname($destination);
         if (!is_dir($directory)) {
-            mkdir($directory, 0755, true);
+            mkdir($directory, FilePermissions::DIRECTORY, true);
         }
 
         copy(__DIR__.'/../../resources/'.$template, $destination);
@@ -157,11 +169,17 @@ class InitCommand extends Command
 
     private function postCopyTemplateAction(string $template, string $destination): void
     {
-        if ('bin/codex' !== $template) {
+        if ('bin/codex' === $template) {
+            chmod($destination, FilePermissions::EXECUTABLE);
+
             return;
         }
 
-        chmod($destination, 0755);
+        // Restrict files that may contain secrets or local configuration so they are not
+        // readable by other users on shared hosts.
+        if (\in_array($template, self::SENSITIVE_FILES, true)) {
+            @chmod($destination, FilePermissions::FILE);
+        }
     }
 
     /**

--- a/src/mate/src/Service/FilePermissions.php
+++ b/src/mate/src/Service/FilePermissions.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Service;
+
+/**
+ * Permission modes for files and directories created by Mate.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class FilePermissions
+{
+    /**
+     * Owner read/write, group read, no access for others. Used for files that may hold secrets
+     * or local configuration (mate/.env, mate/config.php, log files).
+     */
+    public const FILE = 0640;
+
+    /**
+     * Owner read/write/execute, group read/execute, no access for others. Used for directories
+     * created by Mate so the files they contain are not exposed to other users on shared hosts.
+     */
+    public const DIRECTORY = 0750;
+
+    /**
+     * Owner read/write/execute, group and others read/execute. Used for generated executables
+     * such as bin/codex.
+     */
+    public const EXECUTABLE = 0755;
+}

--- a/src/mate/src/Service/Logger.php
+++ b/src/mate/src/Service/Logger.php
@@ -49,6 +49,8 @@ class Logger extends AbstractLogger
         if ($this->fileLogEnabled || !\defined('STDERR')) {
             $this->ensureDirectoryExists($this->logFile);
 
+            $isNewFile = !is_file($this->logFile);
+
             $result = @file_put_contents($this->logFile, $logMessage, \FILE_APPEND);
             if (false === $result) {
                 $errorMessage = \sprintf('Failed to write to log file: "%s"', $this->logFile);
@@ -59,6 +61,10 @@ class Logger extends AbstractLogger
                 }
 
                 throw new FileWriteException($errorMessage);
+            }
+
+            if ($isNewFile) {
+                @chmod($this->logFile, FilePermissions::FILE);
             }
         } else {
             fwrite(\STDERR, $logMessage);
@@ -116,7 +122,7 @@ class Logger extends AbstractLogger
         $directory = \dirname($filePath);
 
         if (!is_dir($directory)) {
-            if (!@mkdir($directory, 0755, true) && !is_dir($directory)) {
+            if (!@mkdir($directory, FilePermissions::DIRECTORY, true) && !is_dir($directory)) {
                 throw new FileWriteException(\sprintf('Failed to create log directory: "%s"', $directory));
             }
         }

--- a/src/mate/tests/Command/InitCommandTest.php
+++ b/src/mate/tests/Command/InitCommandTest.php
@@ -162,6 +162,23 @@ final class InitCommandTest extends TestCase
         $this->assertFalse($composerJson['extra']['ai-mate']['extension']);
     }
 
+    public function testScaffoldsSensitiveFilesWithSecurePermissions()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Permission-based tests are not reliable on Windows');
+        }
+
+        $command = $this->createCommand();
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertSame(0750, fileperms($this->tempDir.'/mate') & 0777);
+        $this->assertSame(0640, fileperms($this->tempDir.'/mate/.env') & 0777);
+        $this->assertSame(0640, fileperms($this->tempDir.'/mate/config.php') & 0777);
+    }
+
     private function createCommand(): InitCommand
     {
         $logger = new NullLogger();

--- a/src/mate/tests/Service/LoggerTest.php
+++ b/src/mate/tests/Service/LoggerTest.php
@@ -218,6 +218,33 @@ final class LoggerTest extends TestCase
         $this->assertStringContainsString('Stringable level message', $content);
     }
 
+    public function testLogFileIsCreatedWithSecurePermissions()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Permission-based tests are not reliable on Windows');
+        }
+
+        $logger = new Logger($this->logFile, fileLogEnabled: true);
+        $logger->info('Test message');
+
+        $this->assertFileExists($this->logFile);
+        $this->assertSame(0640, fileperms($this->logFile) & 0777);
+    }
+
+    public function testLogDirectoryIsCreatedWithSecurePermissions()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Permission-based tests are not reliable on Windows');
+        }
+
+        $logDir = $this->tempDir.'/nested/logs';
+        $logger = new Logger($logDir.'/app.log', fileLogEnabled: true);
+        $logger->info('Test message');
+
+        $this->assertDirectoryExists($logDir);
+        $this->assertSame(0750, fileperms($logDir) & 0777);
+    }
+
     private function removeDirectory(string $dir): void
     {
         if (!is_dir($dir)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Files written by Mate that can hold secrets or local configuration were created with the process default umask (typically world-readable `0644`). On a shared/multi-user host, other users could read `mate/.env` (secrets), `mate/config.php`, and the debug log.

This PR makes those files owner/group-only:

- `mate init` creates `mate/.env` and `mate/config.php` with `0640` and the `mate/` (and `mate/src/`) directories with `0750`;
- `Logger` creates its log file with `0640` (only on first creation) and its log directory with `0750`.

The permission modes live in a single `Symfony\AI\Mate\Service\FilePermissions` holder (`FILE`, `DIRECTORY`, `EXECUTABLE`) used by both classes, so there are no duplicated constants or magic mode literals. Non-sensitive scaffolded files (`mcp.json`, `AGENTS.md`, `AGENT_INSTRUCTIONS.md`, `.gitignore`) are left at the default — they are typically committed and contain no secrets; `bin/codex` stays executable (`0755`).

Hardening is best-effort (`@chmod`), so it is a no-op on platforms without POSIX permissions rather than a hard failure. Tests assert the resulting permissions for the scaffolded files/directories and the log file/directory (skipped on Windows).
