### PR TITLE
[Platform] Convert OpenAI Responses built-in tool output items to typed results

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -1098,6 +1098,7 @@ Server Tools
 
 Some platforms provide built-in server-side tools for enhanced capabilities without custom implementations:
 
+* :doc:`platform/openai-server-tools` - Web Search, File Search, Code Interpreter, Image Generation, MCP, Computer Use
 * :doc:`platform/anthropic-server-tools` - Bash, Text Editor, Code Execution
 * :doc:`platform/gemini-server-tools` - URL Context, Google Search, Code Execution
 * :doc:`platform/vertexai-server-tools` - URL Context, Google Search, Code Execution

--- a/docs/components/platform/openai-server-tools.rst
+++ b/docs/components/platform/openai-server-tools.rst
@@ -1,0 +1,149 @@
+OpenAI Server Tools
+===================
+
+Server tools are built-in capabilities hosted by OpenAI that let the model perform actions without a custom tool implementation. They run on OpenAI's servers and are available through the Responses API used by the OpenAI (GPT), Azure OpenAI, and Scaleway bridges.
+
+Overview
+--------
+
+Built-in tools are enabled by passing the ``tools`` option to ``Platform::invoke()``. Each entry is an associative array with a ``type`` key, exactly as expected by the Responses API:
+
+- **Web Search** - Searches the web and grounds the answer with citations
+- **File Search** - Searches your uploaded files / vector stores
+- **Code Interpreter** - Runs code in a sandboxed environment
+- **Image Generation** - Generates images inline
+- **Hosted MCP** - Calls tools exposed by a remote MCP server
+- **Computer Use** / **Local Shell** - Requests client-side actions
+
+When a built-in tool runs, the model reports it as a dedicated output item next to the
+assistant message. Each item is converted into a typed result (see `Result Types`_), so a
+response that searched the web before answering returns a
+``Result\MultiPartResult`` containing a ``Result\WebSearchResult`` and the
+``Result\TextResult`` with the answer. ``$result->asText()`` still returns just the
+answer text.
+
+Available Server Tools
+----------------------
+
+Web Search
+~~~~~~~~~~
+
+::
+
+    $messages = new MessageBag(
+        Message::ofUser('What are the latest developments in quantum computing?')
+    );
+
+    $result = $platform->invoke('gpt-4o-mini', $messages, [
+        'tools' => [
+            ['type' => 'web_search'],
+        ],
+    ]);
+
+File Search
+~~~~~~~~~~~
+
+::
+
+    $result = $platform->invoke('gpt-4o-mini', $messages, [
+        'tools' => [
+            ['type' => 'file_search', 'vector_store_ids' => ['vs_1234']],
+        ],
+    ]);
+
+Code Interpreter
+~~~~~~~~~~~~~~~~
+
+::
+
+    $result = $platform->invoke('gpt-4o-mini', $messages, [
+        'tools' => [
+            ['type' => 'code_interpreter', 'container' => ['type' => 'auto']],
+        ],
+    ]);
+
+Image Generation
+~~~~~~~~~~~~~~~~
+
+::
+
+    $result = $platform->invoke('gpt-4o-mini', $messages, [
+        'tools' => [
+            ['type' => 'image_generation'],
+        ],
+    ]);
+
+Hosted MCP
+~~~~~~~~~~
+
+::
+
+    $result = $platform->invoke('gpt-4o-mini', $messages, [
+        'tools' => [
+            [
+                'type' => 'mcp',
+                'server_label' => 'deepwiki',
+                'server_url' => 'https://mcp.deepwiki.com/mcp',
+                'require_approval' => 'never',
+            ],
+        ],
+    ]);
+
+Computer Use and Local Shell
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Computer use and local shell ask the *client* to perform an action and send the result
+back. The corresponding output items are surfaced as ``Result\ComputerCallResult`` and
+``Result\LocalShellCallResult`` so you can inspect the requested action; executing it and
+replaying the output is left to your application.
+
+Using Multiple Server Tools
+---------------------------
+
+You can enable multiple built-in tools simultaneously::
+
+    $result = $platform->invoke('gpt-4o-mini', $messages, [
+        'tools' => [
+            ['type' => 'web_search'],
+            ['type' => 'code_interpreter', 'container' => ['type' => 'auto']],
+        ],
+    ]);
+
+Result Types
+------------
+
+Each built-in tool output item maps to a typed result:
+
+- ``web_search_call`` - ``Result\WebSearchResult``
+- ``file_search_call`` - ``Result\FileSearchResult``
+- ``code_interpreter_call`` - ``Result\ExecutableCodeResult`` (plus ``Result\CodeExecutionResult`` for the output)
+- ``image_generation_call`` - ``Result\BinaryResult``
+- ``mcp_call`` - ``Result\McpCallResult``
+- ``mcp_list_tools`` - ``Result\McpListToolsResult``
+- ``mcp_approval_request`` - ``Result\McpApprovalRequestResult``
+- ``computer_call`` - ``Result\ComputerCallResult``
+- ``local_shell_call`` - ``Result\LocalShellCallResult``
+
+Examples
+--------
+
+Complete working examples:
+
+- `examples/openai/web-search.php`_
+- `examples/openai/file-search.php`_ (requires an existing vector store)
+- `examples/openai/code-interpreter.php`_
+- `examples/openai/image-generation.php`_
+- `examples/openai/mcp.php`_ (hosted MCP server)
+
+Limitations
+-----------
+
+- Not every model supports every built-in tool; check the OpenAI documentation
+- Built-in tools may have usage quotas and additional billing
+- Streaming surfaces only text, reasoning, and (custom) tool-call deltas; built-in tool results are available on non-streamed responses
+
+.. _`examples/openai/web-search.php`: https://github.com/symfony/ai/blob/main/examples/openai/web-search.php
+.. _`examples/openai/file-search.php`: https://github.com/symfony/ai/blob/main/examples/openai/file-search.php
+.. _`examples/openai/code-interpreter.php`: https://github.com/symfony/ai/blob/main/examples/openai/code-interpreter.php
+.. _`examples/openai/image-generation.php`: https://github.com/symfony/ai/blob/main/examples/openai/image-generation.php
+.. _`examples/openai/mcp.php`: https://github.com/symfony/ai/blob/main/examples/openai/mcp.php

--- a/examples/openai/code-interpreter.php
+++ b/examples/openai/code-interpreter.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\CodeExecutionResult;
+use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::ofUser('Use Python to compute the 20th Fibonacci number and show the code you ran.'),
+);
+
+// Enable OpenAI's native, server-side code interpreter for this call.
+$result = $platform->invoke('gpt-4o-mini', $messages, [
+    'tools' => [
+        ['type' => 'code_interpreter', 'container' => ['type' => 'auto']],
+    ],
+]);
+
+echo $result->asText().\PHP_EOL;
+
+// The executed code and its output are surfaced as ExecutableCodeResult /
+// CodeExecutionResult next to the answer.
+$converted = $result->getResult();
+$parts = $converted instanceof MultiPartResult ? $converted->getContent() : [$converted];
+
+foreach ($parts as $part) {
+    if ($part instanceof ExecutableCodeResult) {
+        echo \PHP_EOL.'--- Code ('.($part->getLanguage() ?? 'unknown').') ---'.\PHP_EOL.$part->getContent().\PHP_EOL;
+    }
+    if ($part instanceof CodeExecutionResult) {
+        echo \PHP_EOL.'--- Output ---'.\PHP_EOL.($part->getContent() ?? '(none)').\PHP_EOL;
+    }
+}

--- a/examples/openai/file-search.php
+++ b/examples/openai/file-search.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\FileSearchResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+// File search runs against an existing vector store. Create one (and upload files to it)
+// via the OpenAI dashboard or API, then expose its id as OPENAI_VECTOR_STORE_ID.
+$vectorStoreId = env('OPENAI_VECTOR_STORE_ID');
+
+$messages = new MessageBag(
+    Message::ofUser('Based on the indexed documents, summarize what they say about deep research.'),
+);
+
+// Enable OpenAI's native, server-side file search tool for this call.
+$result = $platform->invoke('gpt-4o-mini', $messages, [
+    'tools' => [
+        ['type' => 'file_search', 'vector_store_ids' => [$vectorStoreId]],
+    ],
+]);
+
+echo $result->asText().\PHP_EOL;
+
+// The performed queries and the matched file chunks are surfaced as a FileSearchResult.
+$converted = $result->getResult();
+$parts = $converted instanceof MultiPartResult ? $converted->getContent() : [$converted];
+
+foreach ($parts as $part) {
+    if ($part instanceof FileSearchResult) {
+        echo \PHP_EOL.'File search ran '.count($part->getQueries()).' query/-ies and matched '.count($part->getContent()).' chunk(s).'.\PHP_EOL;
+    }
+}

--- a/examples/openai/image-generation.php
+++ b/examples/openai/image-generation.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::ofUser('Generate an image of a cartoon-style elephant with a long trunk and large ears.'),
+);
+
+// Enable OpenAI's native, server-side image generation tool for this call.
+$result = $platform->invoke('gpt-4.1', $messages, [
+    'tools' => [
+        ['type' => 'image_generation'],
+    ],
+]);
+
+// The generated image is surfaced as a BinaryResult.
+$converted = $result->getResult();
+$parts = $converted instanceof MultiPartResult ? $converted->getContent() : [$converted];
+
+foreach ($parts as $part) {
+    if ($part instanceof BinaryResult) {
+        $file = __DIR__.'/openai-image-generation.png';
+        $part->asFile($file);
+        echo 'Image saved to '.$file.\PHP_EOL;
+    }
+}

--- a/examples/openai/mcp.php
+++ b/examples/openai/mcp.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\McpCallResult;
+use Symfony\AI\Platform\Result\McpListToolsResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::ofUser('What transport protocols does the 2025 version of the MCP specification support?'),
+);
+
+// Let the model call tools on a hosted (remote) MCP server. "deepwiki" is a public
+// MCP server; "require_approval => never" skips the approval round-trip.
+$result = $platform->invoke('gpt-4o-mini', $messages, [
+    'tools' => [
+        [
+            'type' => 'mcp',
+            'server_label' => 'deepwiki',
+            'server_url' => 'https://mcp.deepwiki.com/mcp',
+            'require_approval' => 'never',
+        ],
+    ],
+]);
+
+echo $result->asText().\PHP_EOL;
+
+// The hosted MCP interactions are surfaced as McpListToolsResult / McpCallResult.
+$converted = $result->getResult();
+$parts = $converted instanceof MultiPartResult ? $converted->getContent() : [$converted];
+
+foreach ($parts as $part) {
+    if ($part instanceof McpListToolsResult) {
+        echo \PHP_EOL.'MCP server "'.$part->getServerLabel().'" exposes '.count($part->getContent()).' tool(s).'.\PHP_EOL;
+    }
+    if ($part instanceof McpCallResult) {
+        echo \PHP_EOL.'Called "'.$part->getName().'" on "'.$part->getServerLabel().'".'.\PHP_EOL;
+    }
+}

--- a/examples/openai/web-search.php
+++ b/examples/openai/web-search.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::forSystem('Use the web to answer the user with up-to-date information.'),
+    Message::ofUser('What are the latest developments in quantum computing?'),
+);
+
+// Enable OpenAI's native, server-side web search tool just for this call.
+$result = $platform->invoke('gpt-4o-mini', $messages, [
+    'tools' => [
+        ['type' => 'web_search'],
+    ],
+]);
+
+// The web search runs server-side and is surfaced as a WebSearchResult next to the
+// answer, so the result is a MultiPartResult. asText() still returns just the answer.
+echo $result->asText().\PHP_EOL;
+
+$converted = $result->getResult();
+$parts = $converted instanceof MultiPartResult ? $converted->getContent() : [$converted];
+
+foreach ($parts as $part) {
+    if ($part instanceof WebSearchResult) {
+        echo \PHP_EOL.'Web search query: '.($part->getQuery() ?? '(unknown)').\PHP_EOL;
+    }
+}

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Convert OpenAI Responses built-in tool output items (`web_search_call`, `file_search_call`, `code_interpreter_call`, `image_generation_call`, `mcp_call`, `mcp_list_tools`, `mcp_approval_request`, `computer_call`, `local_shell_call`) into typed results instead of skipping them. Adds `Result\WebSearchResult`, `Result\FileSearchResult`, `Result\McpCallResult`, `Result\McpListToolsResult`, `Result\McpApprovalRequestResult`, `Result\ComputerCallResult`, and `Result\LocalShellCallResult` (code interpreter reuses `ExecutableCodeResult`/`CodeExecutionResult`, image generation reuses `BinaryResult`), plus the matching `Message\Content` classes so the results round-trip through `Message::ofAssistant()`. Benefits the OpenAI, Azure OpenAI, and Scaleway bridges.
  * [BC BREAK] Remove `Capability::INPUT_MULTIPLE` from all embedding models since every embedding bridge already accepts multiple inputs in a single API call
  * Add `ResultConvertedEvent` and `ResultErrorEvent`, dispatched when the deferred result is actually converted (or conversion fails) instead of when the not-yet-resolved `ResultEvent` fires, so listeners can act on the resolved result
  * Add `provider` and `context` arguments to `#[Schema]` plus `SchemaProviderInterface` to contribute JSON Schema fragments computed at runtime (env, database, services) for tool parameters and structured output properties; `provider` accepts any container service ID and `context` is passed to `getSchemaFragment()`

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -22,7 +22,10 @@ use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\Result\CodeExecutionResult;
+use Symfony\AI\Platform\Result\ExecutableCodeResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\McpCallResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
@@ -34,6 +37,7 @@ use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
 use Symfony\AI\Platform\TokenUsage\TokenUsage;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -226,13 +230,18 @@ class ResultConverterTest extends TestCase
         $this->assertSame('final', $result->getContent());
     }
 
-    public function testConvertSkipsBuiltInToolCallOutputItems()
+    public function testConvertWebSearchCallIntoTypedResultAlongsideMessage()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('toArray')->willReturn([
             'output' => [
-                ['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed'],
+                [
+                    'type' => 'web_search_call',
+                    'id' => 'ws_1',
+                    'status' => 'completed',
+                    'action' => ['type' => 'search', 'query' => 'latest AI news'],
+                ],
                 [
                     'type' => 'message',
                     'id' => 'msg_1',
@@ -247,8 +256,63 @@ class ResultConverterTest extends TestCase
 
         $result = $converter->convert(new RawHttpResult($httpResponse));
 
-        $this->assertInstanceOf(TextResult::class, $result);
-        $this->assertSame('The answer is 42.', $result->getContent());
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertInstanceOf(WebSearchResult::class, $parts[0]);
+        $this->assertSame('latest AI news', $parts[0]->getQuery());
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('The answer is 42.', $result->asText());
+    }
+
+    public function testConvertCodeInterpreterCall()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'code_interpreter_call',
+                    'id' => 'ci_1',
+                    'status' => 'completed',
+                    'code' => "print('hi')",
+                    'outputs' => [['type' => 'logs', 'logs' => "hi\n"]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertInstanceOf(ExecutableCodeResult::class, $parts[0]);
+        $this->assertSame('python', $parts[0]->getLanguage());
+        $this->assertInstanceOf(CodeExecutionResult::class, $parts[1]);
+        $this->assertSame("hi\n", $parts[1]->getContent());
+    }
+
+    public function testConvertMcpCall()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'mcp_call',
+                    'id' => 'mcp_1',
+                    'status' => 'completed',
+                    'server_label' => 'deepwiki',
+                    'name' => 'ask_question',
+                    'arguments' => '{"q":"hi"}',
+                    'output' => 'the answer',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(McpCallResult::class, $result);
+        $this->assertSame('deepwiki', $result->getServerLabel());
+        $this->assertSame('the answer', $result->getContent());
     }
 
     public function testContentFilterException()

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -20,6 +20,15 @@ use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\CodeExecutionResult;
+use Symfony\AI\Platform\Result\ComputerCallResult;
+use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\FileSearchResult;
+use Symfony\AI\Platform\Result\LocalShellCallResult;
+use Symfony\AI\Platform\Result\McpApprovalRequestResult;
+use Symfony\AI\Platform\Result\McpCallResult;
+use Symfony\AI\Platform\Result\McpListToolsResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -34,6 +43,7 @@ use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -46,6 +56,16 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * @phpstan-type FunctionCall array{id?: string|null, arguments: string, call_id?: string|null, name: string, type: 'function_call'}
  * @phpstan-type Thinking array{summary: list<array{type: string, text?: string}>, id: string}
  * @phpstan-type Error array{code?: string|null, type?: string|null, param?: string|null, message?: string|null}
+ * @phpstan-type WebSearchCall array{type: 'web_search_call', id?: string, status?: string, action?: array{type?: string, query?: string, queries?: list<string>}}
+ * @phpstan-type FileSearchCall array{type: 'file_search_call', id?: string, status?: string, queries?: list<string>, results?: list<array<string, mixed>>|null}
+ * @phpstan-type CodeInterpreterCall array{type: 'code_interpreter_call', id?: string, status?: string, code?: string|null, outputs?: list<array{type?: string, logs?: string, url?: string}>|null}
+ * @phpstan-type ImageGenerationCall array{type: 'image_generation_call', id?: string, status?: string, result?: string|null}
+ * @phpstan-type McpCall array{type: 'mcp_call', id?: string, status?: string, server_label?: string, name?: string, arguments?: string, output?: string|null, error?: string|null}
+ * @phpstan-type McpListTools array{type: 'mcp_list_tools', id?: string, server_label?: string, tools?: list<array<string, mixed>>}
+ * @phpstan-type McpApprovalRequest array{type: 'mcp_approval_request', id?: string, server_label?: string, name?: string, arguments?: string}
+ * @phpstan-type ComputerCall array{type: 'computer_call', id?: string, status?: string, call_id?: string, action?: array<string, mixed>, pending_safety_checks?: list<array{id: string, code?: string|null, message?: string|null}>}
+ * @phpstan-type LocalShellCall array{type: 'local_shell_call', id?: string, status?: string, call_id?: string, action?: array{type?: string, command?: list<string>}}
+ * @phpstan-type OutputItem OutputMessage|FunctionCall|Thinking|WebSearchCall|FileSearchCall|CodeInterpreterCall|ImageGenerationCall|McpCall|McpListTools|McpApprovalRequest|ComputerCall|LocalShellCall
  */
 class ResultConverter implements ResultConverterInterface
 {
@@ -146,7 +166,7 @@ class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param array<OutputMessage|FunctionCall|Thinking> $output
+     * @param array<OutputItem> $output
      *
      * @return ResultInterface[]
      */
@@ -168,7 +188,7 @@ class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param OutputMessage|Thinking $item
+     * @param OutputItem $item
      *
      * @return iterable<ResultInterface>
      */
@@ -176,19 +196,171 @@ class ResultConverter implements ResultConverterInterface
     {
         $type = $item['type'] ?? null;
 
+        // Built-in server-side tool calls (web search, file search, code
+        // interpreter, image generation, computer use, local shell, hosted MCP)
+        // are reported as their own output items next to the assistant message.
+        // Convert them into typed results so consumers can introspect what the
+        // model did, while the message item is still converted as usual.
         return match ($type) {
             'message' => $this->convertOutputMessage($item),
             'reasoning' => $this->convertReasoning($item),
-            // Built-in server-side tool calls (web search, file search, code
-            // interpreter, image generation, computer use, MCP, …) are reported
-            // as their own output items but carry no assistant-facing result.
-            // Skip them so the actual message item is still converted instead of
-            // aborting the whole response.
-            'web_search_call', 'file_search_call', 'code_interpreter_call',
-            'image_generation_call', 'computer_call', 'local_shell_call',
-            'mcp_call', 'mcp_list_tools', 'mcp_approval_request' => [],
+            'web_search_call' => $this->convertWebSearchCall($item),
+            'file_search_call' => $this->convertFileSearchCall($item),
+            'code_interpreter_call' => $this->convertCodeInterpreterCall($item),
+            'image_generation_call' => $this->convertImageGenerationCall($item),
+            'computer_call' => $this->convertComputerCall($item),
+            'local_shell_call' => $this->convertLocalShellCall($item),
+            'mcp_call' => $this->convertMcpCall($item),
+            'mcp_list_tools' => $this->convertMcpListTools($item),
+            'mcp_approval_request' => $this->convertMcpApprovalRequest($item),
             default => throw new RuntimeException(\sprintf('Unsupported output type "%s".', $type)),
         };
+    }
+
+    /**
+     * @param WebSearchCall $item
+     *
+     * @return list<WebSearchResult>
+     */
+    private function convertWebSearchCall(array $item): array
+    {
+        $action = $item['action'] ?? [];
+        $query = $action['query'] ?? ($action['queries'][0] ?? null);
+
+        return [new WebSearchResult($query, $item['id'] ?? null, $item['status'] ?? null)];
+    }
+
+    /**
+     * @param FileSearchCall $item
+     *
+     * @return list<FileSearchResult>
+     */
+    private function convertFileSearchCall(array $item): array
+    {
+        return [new FileSearchResult(
+            array_values($item['queries'] ?? []),
+            array_values($item['results'] ?? []),
+            $item['id'] ?? null,
+            $item['status'] ?? null,
+        )];
+    }
+
+    /**
+     * @param CodeInterpreterCall $item
+     *
+     * @return list<ExecutableCodeResult|CodeExecutionResult>
+     */
+    private function convertCodeInterpreterCall(array $item): array
+    {
+        $id = $item['id'] ?? null;
+        $results = [new ExecutableCodeResult($item['code'] ?? '', 'python', $id)];
+
+        $outputs = $item['outputs'] ?? null;
+        if (null !== $outputs && [] !== $outputs) {
+            $logs = '';
+            foreach ($outputs as $output) {
+                if ('logs' === ($output['type'] ?? null) && isset($output['logs'])) {
+                    $logs .= $output['logs'];
+                }
+            }
+
+            $results[] = new CodeExecutionResult('failed' !== ($item['status'] ?? null), '' !== $logs ? $logs : null, $id);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param ImageGenerationCall $item
+     *
+     * @return list<BinaryResult>
+     */
+    private function convertImageGenerationCall(array $item): array
+    {
+        $result = $item['result'] ?? null;
+        if (null === $result || '' === $result) {
+            return [];
+        }
+
+        return [BinaryResult::fromBase64($result, 'image/png')];
+    }
+
+    /**
+     * @param ComputerCall $item
+     *
+     * @return list<ComputerCallResult>
+     */
+    private function convertComputerCall(array $item): array
+    {
+        return [new ComputerCallResult(
+            $item['action'] ?? [],
+            $item['call_id'] ?? null,
+            array_values($item['pending_safety_checks'] ?? []),
+            $item['id'] ?? null,
+            $item['status'] ?? null,
+        )];
+    }
+
+    /**
+     * @param LocalShellCall $item
+     *
+     * @return list<LocalShellCallResult>
+     */
+    private function convertLocalShellCall(array $item): array
+    {
+        return [new LocalShellCallResult(
+            array_values($item['action']['command'] ?? []),
+            $item['call_id'] ?? null,
+            $item['id'] ?? null,
+            $item['status'] ?? null,
+        )];
+    }
+
+    /**
+     * @param McpCall $item
+     *
+     * @return list<McpCallResult>
+     */
+    private function convertMcpCall(array $item): array
+    {
+        return [new McpCallResult(
+            $item['server_label'] ?? '',
+            $item['name'] ?? '',
+            $item['arguments'] ?? null,
+            $item['output'] ?? null,
+            $item['error'] ?? null,
+            $item['id'] ?? null,
+            $item['status'] ?? null,
+        )];
+    }
+
+    /**
+     * @param McpListTools $item
+     *
+     * @return list<McpListToolsResult>
+     */
+    private function convertMcpListTools(array $item): array
+    {
+        return [new McpListToolsResult(
+            $item['server_label'] ?? '',
+            array_values($item['tools'] ?? []),
+            $item['id'] ?? null,
+        )];
+    }
+
+    /**
+     * @param McpApprovalRequest $item
+     *
+     * @return list<McpApprovalRequestResult>
+     */
+    private function convertMcpApprovalRequest(array $item): array
+    {
+        return [new McpApprovalRequestResult(
+            $item['server_label'] ?? '',
+            $item['name'] ?? '',
+            $item['arguments'] ?? null,
+            $item['id'] ?? null,
+        )];
     }
 
     private function convertStream(RawResultInterface|RawHttpResult $result): \Generator
@@ -292,9 +464,9 @@ class ResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @param array<OutputMessage|FunctionCall|Thinking> $output
+     * @param array<OutputItem> $output
      *
-     * @return list<ToolCallResult|array<OutputMessage|Thinking>|null>
+     * @return list<ToolCallResult|array<OutputItem>|null>
      */
     private function extractFunctionCalls(array $output): array
     {

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -22,7 +22,16 @@ use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\CodeExecutionResult;
+use Symfony\AI\Platform\Result\ComputerCallResult;
+use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\FileSearchResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\LocalShellCallResult;
+use Symfony\AI\Platform\Result\McpApprovalRequestResult;
+use Symfony\AI\Platform\Result\McpCallResult;
+use Symfony\AI\Platform\Result\McpListToolsResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -35,6 +44,7 @@ use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
 use Symfony\AI\Platform\TokenUsage\TokenUsage;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -253,13 +263,18 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('final', $result->getContent());
     }
 
-    public function testConvertSkipsBuiltInToolCallOutputItems()
+    public function testConvertWebSearchCallIntoTypedResultAlongsideMessage()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('toArray')->willReturn([
             'output' => [
-                ['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed'],
+                [
+                    'type' => 'web_search_call',
+                    'id' => 'ws_1',
+                    'status' => 'completed',
+                    'action' => ['type' => 'search', 'query' => 'latest AI news'],
+                ],
                 [
                     'type' => 'message',
                     'id' => 'msg_1',
@@ -274,8 +289,247 @@ final class ResultConverterTest extends TestCase
 
         $result = $converter->convert(new RawHttpResult($httpResponse));
 
-        $this->assertInstanceOf(TextResult::class, $result);
-        $this->assertSame('The answer is 42.', $result->getContent());
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(WebSearchResult::class, $parts[0]);
+        $this->assertSame('latest AI news', $parts[0]->getQuery());
+        $this->assertSame('ws_1', $parts[0]->getId());
+        $this->assertSame('completed', $parts[0]->getStatus());
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('The answer is 42.', $result->asText());
+    }
+
+    public function testConvertWebSearchCallReadsQueryFromQueriesList()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'web_search_call',
+                    'id' => 'ws_2',
+                    'status' => 'completed',
+                    'action' => ['type' => 'search', 'queries' => ['first query', 'second query']],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(WebSearchResult::class, $result);
+        $this->assertSame('first query', $result->getQuery());
+    }
+
+    public function testConvertFileSearchCall()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'file_search_call',
+                    'id' => 'fs_1',
+                    'status' => 'completed',
+                    'queries' => ['What is deep research?'],
+                    'results' => [['file_id' => 'file-1', 'filename' => 'doc.pdf', 'text' => 'lorem', 'score' => 0.9]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(FileSearchResult::class, $result);
+        $this->assertSame(['What is deep research?'], $result->getQueries());
+        $this->assertSame([['file_id' => 'file-1', 'filename' => 'doc.pdf', 'text' => 'lorem', 'score' => 0.9]], $result->getContent());
+        $this->assertSame('fs_1', $result->getId());
+        $this->assertSame('completed', $result->getStatus());
+    }
+
+    public function testConvertCodeInterpreterCall()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'code_interpreter_call',
+                    'id' => 'ci_1',
+                    'status' => 'completed',
+                    'code' => "print('hi')",
+                    'outputs' => [['type' => 'logs', 'logs' => "hi\n"]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertInstanceOf(ExecutableCodeResult::class, $parts[0]);
+        $this->assertSame("print('hi')", $parts[0]->getContent());
+        $this->assertSame('python', $parts[0]->getLanguage());
+        $this->assertSame('ci_1', $parts[0]->getId());
+        $this->assertInstanceOf(CodeExecutionResult::class, $parts[1]);
+        $this->assertTrue($parts[1]->isSucceeded());
+        $this->assertSame("hi\n", $parts[1]->getContent());
+    }
+
+    public function testConvertCodeInterpreterCallWithoutOutputs()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                ['type' => 'code_interpreter_call', 'id' => 'ci_2', 'status' => 'in_progress', 'code' => 'x = 1'],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ExecutableCodeResult::class, $result);
+        $this->assertSame('x = 1', $result->getContent());
+    }
+
+    public function testConvertImageGenerationCall()
+    {
+        $converter = new ResultConverter();
+        $base64 = base64_encode('image-bytes');
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                ['type' => 'image_generation_call', 'id' => 'ig_1', 'status' => 'completed', 'result' => $base64],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(BinaryResult::class, $result);
+        $this->assertSame('image-bytes', $result->getContent());
+        $this->assertSame('image/png', $result->getMimeType());
+    }
+
+    public function testConvertMcpCall()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'mcp_call',
+                    'id' => 'mcp_1',
+                    'status' => 'completed',
+                    'server_label' => 'deepwiki',
+                    'name' => 'ask_question',
+                    'arguments' => '{"q":"hi"}',
+                    'output' => 'the answer',
+                    'error' => null,
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(McpCallResult::class, $result);
+        $this->assertSame('deepwiki', $result->getServerLabel());
+        $this->assertSame('ask_question', $result->getName());
+        $this->assertSame('{"q":"hi"}', $result->getArguments());
+        $this->assertSame('the answer', $result->getContent());
+        $this->assertNull($result->getError());
+    }
+
+    public function testConvertMcpListTools()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'mcp_list_tools',
+                    'id' => 'mcpl_1',
+                    'server_label' => 'deepwiki',
+                    'tools' => [['name' => 'ask_question', 'description' => 'Ask.']],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(McpListToolsResult::class, $result);
+        $this->assertSame('deepwiki', $result->getServerLabel());
+        $this->assertSame([['name' => 'ask_question', 'description' => 'Ask.']], $result->getContent());
+    }
+
+    public function testConvertMcpApprovalRequest()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'mcp_approval_request',
+                    'id' => 'mcpr_1',
+                    'server_label' => 'deepwiki',
+                    'name' => 'ask_question',
+                    'arguments' => '{"q":"hi"}',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(McpApprovalRequestResult::class, $result);
+        $this->assertSame('deepwiki', $result->getServerLabel());
+        $this->assertSame('ask_question', $result->getName());
+        $this->assertSame('{"q":"hi"}', $result->getArguments());
+    }
+
+    public function testConvertComputerCall()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'computer_call',
+                    'id' => 'cu_1',
+                    'call_id' => 'call_1',
+                    'status' => 'completed',
+                    'action' => ['type' => 'click', 'button' => 'left', 'x' => 1, 'y' => 2],
+                    'pending_safety_checks' => [['id' => 'cu_sc_1', 'code' => 'x', 'message' => 'y']],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ComputerCallResult::class, $result);
+        $this->assertSame(['type' => 'click', 'button' => 'left', 'x' => 1, 'y' => 2], $result->getContent());
+        $this->assertSame('call_1', $result->getCallId());
+        $this->assertSame([['id' => 'cu_sc_1', 'code' => 'x', 'message' => 'y']], $result->getPendingSafetyChecks());
+    }
+
+    public function testConvertLocalShellCall()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'local_shell_call',
+                    'id' => 'lsh_1',
+                    'call_id' => 'call_1',
+                    'status' => 'completed',
+                    'action' => ['type' => 'exec', 'command' => ['bash', '-lc', 'ls']],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(LocalShellCallResult::class, $result);
+        $this->assertSame(['bash', '-lc', 'ls'], $result->getContent());
+        $this->assertSame('call_1', $result->getCallId());
     }
 
     public function testThrowsRuntimeExceptionWhenIncompleteResponseHasNoContent()

--- a/src/platform/src/Message/Content/ComputerCall.php
+++ b/src/platform/src/Message/Content/ComputerCall.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message\Content;
+
+/**
+ * @phpstan-type SafetyCheck array{id: string, code?: string|null, message?: string|null}
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class ComputerCall implements ContentInterface
+{
+    /**
+     * @param array<string, mixed> $action              The computer-use action the model asks the client to perform (e.g. a "click", "type" or "screenshot") together with its parameters
+     * @param string|null          $callId              Identifier to echo back in the matching "computer_call_output" when returning the action result
+     * @param list<SafetyCheck>    $pendingSafetyChecks Safety checks the client must acknowledge before executing the action
+     * @param string|null          $id                  Identifier of the computer call output item (e.g. "cu_...")
+     * @param string|null          $status              Provider-reported status of the call, e.g. "completed", "in_progress" or "incomplete"
+     */
+    public function __construct(
+        private readonly array $action = [],
+        private readonly ?string $callId = null,
+        private readonly array $pendingSafetyChecks = [],
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getAction(): array
+    {
+        return $this->action;
+    }
+
+    public function getCallId(): ?string
+    {
+        return $this->callId;
+    }
+
+    /**
+     * @return list<SafetyCheck>
+     */
+    public function getPendingSafetyChecks(): array
+    {
+        return $this->pendingSafetyChecks;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/src/Message/Content/FileSearch.php
+++ b/src/platform/src/Message/Content/FileSearch.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message\Content;
+
+/**
+ * @phpstan-type FileSearchEntry array{
+ *     file_id?: string,
+ *     filename?: string,
+ *     text?: string,
+ *     score?: float,
+ *     attributes?: array<string, mixed>,
+ * }
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class FileSearch implements ContentInterface
+{
+    /**
+     * @param list<string>          $queries The search queries the model ran against the configured vector store(s)
+     * @param list<FileSearchEntry> $results The matched file chunks, each with the source file id, filename, text snippet, relevance score and custom attributes
+     * @param string|null           $id      Identifier of the file search call output item (e.g. "fs_...")
+     * @param string|null           $status  Provider-reported status of the call, e.g. "completed", "searching", "incomplete" or "failed"
+     */
+    public function __construct(
+        private readonly array $queries = [],
+        private readonly array $results = [],
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getQueries(): array
+    {
+        return $this->queries;
+    }
+
+    /**
+     * @return list<FileSearchEntry>
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/src/Message/Content/LocalShellCall.php
+++ b/src/platform/src/Message/Content/LocalShellCall.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message\Content;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class LocalShellCall implements ContentInterface
+{
+    /**
+     * @param list<string> $command The shell command (as an argv list) the model asks the client to execute
+     * @param string|null  $callId  Identifier to echo back in the matching "local_shell_call_output" when returning the command result
+     * @param string|null  $id      Identifier of the local shell call output item (e.g. "lsh_...")
+     * @param string|null  $status  Provider-reported status of the call, e.g. "completed", "in_progress" or "incomplete"
+     */
+    public function __construct(
+        private readonly array $command = [],
+        private readonly ?string $callId = null,
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getCommand(): array
+    {
+        return $this->command;
+    }
+
+    public function getCallId(): ?string
+    {
+        return $this->callId;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/src/Message/Content/McpApprovalRequest.php
+++ b/src/platform/src/Message/Content/McpApprovalRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message\Content;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class McpApprovalRequest implements ContentInterface
+{
+    /**
+     * @param string      $serverLabel Label of the hosted MCP server requesting approval before the tool runs
+     * @param string      $name        Name of the MCP tool the model wants to call
+     * @param string|null $arguments   JSON-encoded arguments the tool would be called with
+     * @param string|null $id          Identifier of the approval request, referenced when sending the approval response back (e.g. "mcpr_...")
+     */
+    public function __construct(
+        private readonly string $serverLabel,
+        private readonly string $name,
+        private readonly ?string $arguments = null,
+        private readonly ?string $id = null,
+    ) {
+    }
+
+    public function getServerLabel(): string
+    {
+        return $this->serverLabel;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getArguments(): ?string
+    {
+        return $this->arguments;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/src/platform/src/Message/Content/McpCall.php
+++ b/src/platform/src/Message/Content/McpCall.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message\Content;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class McpCall implements ContentInterface
+{
+    /**
+     * @param string      $serverLabel Label of the hosted MCP server the invoked tool belongs to
+     * @param string      $name        Name of the MCP tool that was invoked
+     * @param string|null $arguments   JSON-encoded arguments the tool was called with
+     * @param string|null $output      Output returned by the tool, or null when the call produced none or failed
+     * @param string|null $error       Error message when the call failed, otherwise null
+     * @param string|null $id          Identifier of the MCP call output item (e.g. "mcp_...")
+     * @param string|null $status      Provider-reported status of the call, e.g. "completed", "calling" or "failed"
+     */
+    public function __construct(
+        private readonly string $serverLabel,
+        private readonly string $name,
+        private readonly ?string $arguments = null,
+        private readonly ?string $output = null,
+        private readonly ?string $error = null,
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    public function getServerLabel(): string
+    {
+        return $this->serverLabel;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getArguments(): ?string
+    {
+        return $this->arguments;
+    }
+
+    public function getOutput(): ?string
+    {
+        return $this->output;
+    }
+
+    public function getError(): ?string
+    {
+        return $this->error;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/src/Message/Content/McpListTools.php
+++ b/src/platform/src/Message/Content/McpListTools.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message\Content;
+
+/**
+ * @phpstan-type McpTool array{
+ *     name: string,
+ *     description?: string|null,
+ *     input_schema?: array<string, mixed>,
+ *     annotations?: array<string, mixed>|null,
+ * }
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class McpListTools implements ContentInterface
+{
+    /**
+     * @param string        $serverLabel Label of the hosted MCP server whose tools were listed
+     * @param list<McpTool> $tools       Tools exposed by the server, each with its name, optional description and JSON Schema input definition
+     * @param string|null   $id          Identifier of the list-tools output item (e.g. "mcpl_...")
+     */
+    public function __construct(
+        private readonly string $serverLabel,
+        private readonly array $tools = [],
+        private readonly ?string $id = null,
+    ) {
+    }
+
+    public function getServerLabel(): string
+    {
+        return $this->serverLabel;
+    }
+
+    /**
+     * @return list<McpTool>
+     */
+    public function getTools(): array
+    {
+        return $this->tools;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/src/platform/src/Message/Content/WebSearch.php
+++ b/src/platform/src/Message/Content/WebSearch.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message\Content;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class WebSearch implements ContentInterface
+{
+    /**
+     * @param string|null $query  The search query the model sent to the web search tool, or null when the action carried no query (e.g. opening or reading a page)
+     * @param string|null $id     Identifier of the web search call output item, as assigned by the provider (e.g. "ws_...")
+     * @param string|null $status Provider-reported status of the call, e.g. "completed", "searching" or "failed"
+     */
+    public function __construct(
+        private readonly ?string $query = null,
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    public function getQuery(): ?string
+    {
+        return $this->query;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/src/Message/Message.php
+++ b/src/platform/src/Message/Message.php
@@ -13,18 +13,32 @@ namespace Symfony\AI\Platform\Message;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\ComputerCall;
 use Symfony\AI\Platform\Message\Content\ContentInterface;
 use Symfony\AI\Platform\Message\Content\ExecutableCode;
+use Symfony\AI\Platform\Message\Content\FileSearch;
+use Symfony\AI\Platform\Message\Content\LocalShellCall;
+use Symfony\AI\Platform\Message\Content\McpApprovalRequest;
+use Symfony\AI\Platform\Message\Content\McpCall;
+use Symfony\AI\Platform\Message\Content\McpListTools;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Content\WebSearch;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
+use Symfony\AI\Platform\Result\ComputerCallResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\FileSearchResult;
+use Symfony\AI\Platform\Result\LocalShellCallResult;
+use Symfony\AI\Platform\Result\McpApprovalRequestResult;
+use Symfony\AI\Platform\Result\McpCallResult;
+use Symfony\AI\Platform\Result\McpListToolsResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -115,6 +129,34 @@ final class Message
 
         if ($part instanceof CodeExecutionResult) {
             return [new CodeExecution($part->isSucceeded(), $part->getContent(), $part->getId())];
+        }
+
+        if ($part instanceof WebSearchResult) {
+            return [new WebSearch($part->getQuery(), $part->getId(), $part->getStatus())];
+        }
+
+        if ($part instanceof FileSearchResult) {
+            return [new FileSearch($part->getQueries(), $part->getContent(), $part->getId(), $part->getStatus())];
+        }
+
+        if ($part instanceof McpCallResult) {
+            return [new McpCall($part->getServerLabel(), $part->getName(), $part->getArguments(), $part->getContent(), $part->getError(), $part->getId(), $part->getStatus())];
+        }
+
+        if ($part instanceof McpListToolsResult) {
+            return [new McpListTools($part->getServerLabel(), $part->getContent(), $part->getId())];
+        }
+
+        if ($part instanceof McpApprovalRequestResult) {
+            return [new McpApprovalRequest($part->getServerLabel(), $part->getName(), $part->getArguments(), $part->getId())];
+        }
+
+        if ($part instanceof ComputerCallResult) {
+            return [new ComputerCall($part->getContent(), $part->getCallId(), $part->getPendingSafetyChecks(), $part->getId(), $part->getStatus())];
+        }
+
+        if ($part instanceof LocalShellCallResult) {
+            return [new LocalShellCall($part->getContent(), $part->getCallId(), $part->getId(), $part->getStatus())];
         }
 
         if ($part instanceof MultiPartResult) {

--- a/src/platform/src/Result/ComputerCallResult.php
+++ b/src/platform/src/Result/ComputerCallResult.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * Computer-use action requested by the model, to be executed by the client
+ * (e.g. the OpenAI Responses `computer_call` output item).
+ *
+ * @phpstan-type SafetyCheck array{id: string, code?: string|null, message?: string|null}
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class ComputerCallResult extends BaseResult
+{
+    /**
+     * @param array<string, mixed> $action              The computer-use action the model asks the client to perform (e.g. a "click", "type" or "screenshot") together with its parameters
+     * @param string|null          $callId              Identifier to echo back in the matching "computer_call_output" when returning the action result
+     * @param list<SafetyCheck>    $pendingSafetyChecks Safety checks the client must acknowledge before executing the action
+     * @param string|null          $id                  Identifier of the computer call output item (e.g. "cu_...")
+     * @param string|null          $status              Provider-reported status of the call, e.g. "completed", "in_progress" or "incomplete"
+     */
+    public function __construct(
+        private readonly array $action = [],
+        private readonly ?string $callId = null,
+        private readonly array $pendingSafetyChecks = [],
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContent(): array
+    {
+        return $this->action;
+    }
+
+    public function getCallId(): ?string
+    {
+        return $this->callId;
+    }
+
+    /**
+     * @return list<SafetyCheck>
+     */
+    public function getPendingSafetyChecks(): array
+    {
+        return $this->pendingSafetyChecks;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/src/Result/FileSearchResult.php
+++ b/src/platform/src/Result/FileSearchResult.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * Result of a built-in file search performed server-side by the model
+ * (e.g. the OpenAI Responses `file_search_call` output item).
+ *
+ * @phpstan-type FileSearchResultEntry array{
+ *     file_id?: string,
+ *     filename?: string,
+ *     text?: string,
+ *     score?: float,
+ *     attributes?: array<string, mixed>,
+ * }
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class FileSearchResult extends BaseResult
+{
+    /**
+     * @param list<string>                $queries The search queries the model ran against the configured vector store(s)
+     * @param list<FileSearchResultEntry> $results The matched file chunks, each with the source file id, filename, text snippet, relevance score and custom attributes
+     * @param string|null                 $id      Identifier of the file search call output item (e.g. "fs_...")
+     * @param string|null                 $status  Provider-reported status of the call, e.g. "completed", "searching", "incomplete" or "failed"
+     */
+    public function __construct(
+        private readonly array $queries = [],
+        private readonly array $results = [],
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    /**
+     * @return list<FileSearchResultEntry>
+     */
+    public function getContent(): array
+    {
+        return $this->results;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getQueries(): array
+    {
+        return $this->queries;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/src/Result/LocalShellCallResult.php
+++ b/src/platform/src/Result/LocalShellCallResult.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * Local shell command requested by the model, to be executed by the client
+ * (e.g. the OpenAI Responses `local_shell_call` output item).
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class LocalShellCallResult extends BaseResult
+{
+    /**
+     * @param list<string> $command The shell command (as an argv list) the model asks the client to execute
+     * @param string|null  $callId  Identifier to echo back in the matching "local_shell_call_output" when returning the command result
+     * @param string|null  $id      Identifier of the local shell call output item (e.g. "lsh_...")
+     * @param string|null  $status  Provider-reported status of the call, e.g. "completed", "in_progress" or "incomplete"
+     */
+    public function __construct(
+        private readonly array $command = [],
+        private readonly ?string $callId = null,
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getContent(): array
+    {
+        return $this->command;
+    }
+
+    public function getCallId(): ?string
+    {
+        return $this->callId;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/src/Result/McpApprovalRequestResult.php
+++ b/src/platform/src/Result/McpApprovalRequestResult.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * Approval request emitted by the model before invoking a hosted MCP tool
+ * (e.g. the OpenAI Responses `mcp_approval_request` output item).
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class McpApprovalRequestResult extends BaseResult
+{
+    /**
+     * @param string      $serverLabel Label of the hosted MCP server requesting approval before the tool runs
+     * @param string      $name        Name of the MCP tool the model wants to call
+     * @param string|null $arguments   JSON-encoded arguments the tool would be called with
+     * @param string|null $id          Identifier of the approval request, referenced when sending the approval response back (e.g. "mcpr_...")
+     */
+    public function __construct(
+        private readonly string $serverLabel,
+        private readonly string $name,
+        private readonly ?string $arguments = null,
+        private readonly ?string $id = null,
+    ) {
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->arguments;
+    }
+
+    public function getServerLabel(): string
+    {
+        return $this->serverLabel;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getArguments(): ?string
+    {
+        return $this->arguments;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/src/platform/src/Result/McpCallResult.php
+++ b/src/platform/src/Result/McpCallResult.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * Result of a hosted MCP tool invocation performed server-side by the model
+ * (e.g. the OpenAI Responses `mcp_call` output item).
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class McpCallResult extends BaseResult
+{
+    /**
+     * @param string      $serverLabel Label of the hosted MCP server the invoked tool belongs to
+     * @param string      $name        Name of the MCP tool that was invoked
+     * @param string|null $arguments   JSON-encoded arguments the tool was called with
+     * @param string|null $output      Output returned by the tool, or null when the call produced none or failed
+     * @param string|null $error       Error message when the call failed, otherwise null
+     * @param string|null $id          Identifier of the MCP call output item (e.g. "mcp_...")
+     * @param string|null $status      Provider-reported status of the call, e.g. "completed", "calling" or "failed"
+     */
+    public function __construct(
+        private readonly string $serverLabel,
+        private readonly string $name,
+        private readonly ?string $arguments = null,
+        private readonly ?string $output = null,
+        private readonly ?string $error = null,
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->output;
+    }
+
+    public function getServerLabel(): string
+    {
+        return $this->serverLabel;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getArguments(): ?string
+    {
+        return $this->arguments;
+    }
+
+    public function getError(): ?string
+    {
+        return $this->error;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/src/Result/McpListToolsResult.php
+++ b/src/platform/src/Result/McpListToolsResult.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * Result listing the tools exposed by a hosted MCP server, reported server-side
+ * by the model (e.g. the OpenAI Responses `mcp_list_tools` output item).
+ *
+ * @phpstan-type McpTool array{
+ *     name: string,
+ *     description?: string|null,
+ *     input_schema?: array<string, mixed>,
+ *     annotations?: array<string, mixed>|null,
+ * }
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class McpListToolsResult extends BaseResult
+{
+    /**
+     * @param string        $serverLabel Label of the hosted MCP server whose tools were listed
+     * @param list<McpTool> $tools       Tools exposed by the server, each with its name, optional description and JSON Schema input definition
+     * @param string|null   $id          Identifier of the list-tools output item (e.g. "mcpl_...")
+     */
+    public function __construct(
+        private readonly string $serverLabel,
+        private readonly array $tools = [],
+        private readonly ?string $id = null,
+    ) {
+    }
+
+    /**
+     * @return list<McpTool>
+     */
+    public function getContent(): array
+    {
+        return $this->tools;
+    }
+
+    public function getServerLabel(): string
+    {
+        return $this->serverLabel;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/src/platform/src/Result/WebSearchResult.php
+++ b/src/platform/src/Result/WebSearchResult.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * Result of a built-in web search performed server-side by the model
+ * (e.g. the OpenAI Responses `web_search_call` output item).
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class WebSearchResult extends BaseResult
+{
+    /**
+     * @param string|null $query  The search query the model sent to the web search tool, or null when the action carried no query (e.g. opening or reading a page)
+     * @param string|null $id     Identifier of the web search call output item, as assigned by the provider (e.g. "ws_...")
+     * @param string|null $status Provider-reported status of the call, e.g. "completed", "searching" or "failed"
+     */
+    public function __construct(
+        private readonly ?string $query = null,
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->query;
+    }
+
+    public function getQuery(): ?string
+    {
+        return $this->query;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/tests/Message/MessageTest.php
+++ b/src/platform/tests/Message/MessageTest.php
@@ -14,20 +14,34 @@ namespace Symfony\AI\Platform\Tests\Message;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\Content\CodeExecution;
+use Symfony\AI\Platform\Message\Content\ComputerCall;
 use Symfony\AI\Platform\Message\Content\ContentInterface;
 use Symfony\AI\Platform\Message\Content\ExecutableCode;
+use Symfony\AI\Platform\Message\Content\FileSearch;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
+use Symfony\AI\Platform\Message\Content\LocalShellCall;
+use Symfony\AI\Platform\Message\Content\McpApprovalRequest;
+use Symfony\AI\Platform\Message\Content\McpCall;
+use Symfony\AI\Platform\Message\Content\McpListTools;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Content\WebSearch;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
+use Symfony\AI\Platform\Result\ComputerCallResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
+use Symfony\AI\Platform\Result\FileSearchResult;
+use Symfony\AI\Platform\Result\LocalShellCallResult;
+use Symfony\AI\Platform\Result\McpApprovalRequestResult;
+use Symfony\AI\Platform\Result\McpCallResult;
+use Symfony\AI\Platform\Result\McpListToolsResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Result\WebSearchResult;
 
 final class MessageTest extends TestCase
 {
@@ -152,6 +166,51 @@ final class MessageTest extends TestCase
         $this->assertTrue($parts[4]->isSucceeded());
         $this->assertSame('hi', $parts[4]->getOutput());
         $this->assertSame('srvtoolu_1', $parts[4]->getId());
+    }
+
+    public function testCreateAssistantMessageMapsServerToolResultTypes()
+    {
+        $result = new MultiPartResult([
+            new WebSearchResult('latest AI news', 'ws_1', 'completed'),
+            new FileSearchResult(['q'], [['file_id' => 'file-1']], 'fs_1', 'completed'),
+            new McpCallResult('deepwiki', 'ask', '{"q":1}', 'out', null, 'mcp_1', 'completed'),
+            new McpListToolsResult('deepwiki', [['name' => 'ask']], 'mcpl_1'),
+            new McpApprovalRequestResult('deepwiki', 'ask', '{"q":1}', 'mcpr_1'),
+            new ComputerCallResult(['type' => 'click'], 'call_1', [], 'cu_1', 'completed'),
+            new LocalShellCallResult(['bash', '-lc', 'ls'], 'call_2', 'lsh_1', 'completed'),
+            new TextResult('Visible answer.'),
+        ]);
+
+        $message = Message::ofAssistant($result);
+
+        $parts = $message->getContent();
+        $this->assertCount(8, $parts);
+
+        $this->assertInstanceOf(WebSearch::class, $parts[0]);
+        $this->assertSame('latest AI news', $parts[0]->getQuery());
+
+        $this->assertInstanceOf(FileSearch::class, $parts[1]);
+        $this->assertSame(['q'], $parts[1]->getQueries());
+        $this->assertSame([['file_id' => 'file-1']], $parts[1]->getResults());
+
+        $this->assertInstanceOf(McpCall::class, $parts[2]);
+        $this->assertSame('deepwiki', $parts[2]->getServerLabel());
+        $this->assertSame('out', $parts[2]->getOutput());
+
+        $this->assertInstanceOf(McpListTools::class, $parts[3]);
+        $this->assertSame([['name' => 'ask']], $parts[3]->getTools());
+
+        $this->assertInstanceOf(McpApprovalRequest::class, $parts[4]);
+        $this->assertSame('ask', $parts[4]->getName());
+
+        $this->assertInstanceOf(ComputerCall::class, $parts[5]);
+        $this->assertSame(['type' => 'click'], $parts[5]->getAction());
+        $this->assertSame('call_1', $parts[5]->getCallId());
+
+        $this->assertInstanceOf(LocalShellCall::class, $parts[6]);
+        $this->assertSame(['bash', '-lc', 'ls'], $parts[6]->getCommand());
+
+        $this->assertInstanceOf(Text::class, $parts[7]);
     }
 
     public function testCreateAssistantMessageFromUnsupportedResultThrows()

--- a/src/platform/tests/Result/ComputerCallResultTest.php
+++ b/src/platform/tests/Result/ComputerCallResultTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\ComputerCallResult;
+
+final class ComputerCallResultTest extends TestCase
+{
+    public function testGetters()
+    {
+        $action = ['type' => 'click', 'button' => 'left', 'x' => 510, 'y' => 372];
+        $safetyChecks = [['id' => 'cu_sc_1', 'code' => 'malicious_instructions', 'message' => 'careful']];
+        $result = new ComputerCallResult($action, 'call_1', $safetyChecks, 'cu_1', 'completed');
+
+        $this->assertSame($action, $result->getContent());
+        $this->assertSame('call_1', $result->getCallId());
+        $this->assertSame($safetyChecks, $result->getPendingSafetyChecks());
+        $this->assertSame('cu_1', $result->getId());
+        $this->assertSame('completed', $result->getStatus());
+    }
+
+    public function testDefaults()
+    {
+        $result = new ComputerCallResult();
+
+        $this->assertSame([], $result->getContent());
+        $this->assertSame([], $result->getPendingSafetyChecks());
+        $this->assertNull($result->getCallId());
+        $this->assertNull($result->getId());
+        $this->assertNull($result->getStatus());
+    }
+}

--- a/src/platform/tests/Result/FileSearchResultTest.php
+++ b/src/platform/tests/Result/FileSearchResultTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\FileSearchResult;
+
+final class FileSearchResultTest extends TestCase
+{
+    public function testGetters()
+    {
+        $results = [['file_id' => 'file-1', 'filename' => 'doc.pdf', 'text' => 'lorem', 'score' => 0.9]];
+        $result = new FileSearchResult(['What is deep research?'], $results, 'fs_1', 'completed');
+
+        $this->assertSame($results, $result->getContent());
+        $this->assertSame(['What is deep research?'], $result->getQueries());
+        $this->assertSame('fs_1', $result->getId());
+        $this->assertSame('completed', $result->getStatus());
+    }
+
+    public function testDefaults()
+    {
+        $result = new FileSearchResult();
+
+        $this->assertSame([], $result->getContent());
+        $this->assertSame([], $result->getQueries());
+        $this->assertNull($result->getId());
+        $this->assertNull($result->getStatus());
+    }
+}

--- a/src/platform/tests/Result/LocalShellCallResultTest.php
+++ b/src/platform/tests/Result/LocalShellCallResultTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\LocalShellCallResult;
+
+final class LocalShellCallResultTest extends TestCase
+{
+    public function testGetters()
+    {
+        $command = ['bash', '-lc', 'ls -la /tmp'];
+        $result = new LocalShellCallResult($command, 'call_1', 'lsh_1', 'completed');
+
+        $this->assertSame($command, $result->getContent());
+        $this->assertSame('call_1', $result->getCallId());
+        $this->assertSame('lsh_1', $result->getId());
+        $this->assertSame('completed', $result->getStatus());
+    }
+
+    public function testDefaults()
+    {
+        $result = new LocalShellCallResult();
+
+        $this->assertSame([], $result->getContent());
+        $this->assertNull($result->getCallId());
+        $this->assertNull($result->getId());
+        $this->assertNull($result->getStatus());
+    }
+}

--- a/src/platform/tests/Result/McpApprovalRequestResultTest.php
+++ b/src/platform/tests/Result/McpApprovalRequestResultTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\McpApprovalRequestResult;
+
+final class McpApprovalRequestResultTest extends TestCase
+{
+    public function testGetters()
+    {
+        $result = new McpApprovalRequestResult('deepwiki', 'ask_question', '{"q":"hi"}', 'mcpr_1');
+
+        $this->assertSame('{"q":"hi"}', $result->getContent());
+        $this->assertSame('deepwiki', $result->getServerLabel());
+        $this->assertSame('ask_question', $result->getName());
+        $this->assertSame('{"q":"hi"}', $result->getArguments());
+        $this->assertSame('mcpr_1', $result->getId());
+    }
+}

--- a/src/platform/tests/Result/McpCallResultTest.php
+++ b/src/platform/tests/Result/McpCallResultTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\McpCallResult;
+
+final class McpCallResultTest extends TestCase
+{
+    public function testGetters()
+    {
+        $result = new McpCallResult('deepwiki', 'ask_question', '{"q":"hi"}', 'the answer', null, 'mcp_1', 'completed');
+
+        $this->assertSame('the answer', $result->getContent());
+        $this->assertSame('deepwiki', $result->getServerLabel());
+        $this->assertSame('ask_question', $result->getName());
+        $this->assertSame('{"q":"hi"}', $result->getArguments());
+        $this->assertNull($result->getError());
+        $this->assertSame('mcp_1', $result->getId());
+        $this->assertSame('completed', $result->getStatus());
+    }
+
+    public function testError()
+    {
+        $result = new McpCallResult('deepwiki', 'ask_question', null, null, 'boom', 'mcp_2', 'failed');
+
+        $this->assertNull($result->getContent());
+        $this->assertSame('boom', $result->getError());
+    }
+}

--- a/src/platform/tests/Result/McpListToolsResultTest.php
+++ b/src/platform/tests/Result/McpListToolsResultTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\McpListToolsResult;
+
+final class McpListToolsResultTest extends TestCase
+{
+    public function testGetters()
+    {
+        $tools = [['name' => 'ask_question', 'description' => 'Ask a question.']];
+        $result = new McpListToolsResult('deepwiki', $tools, 'mcpl_1');
+
+        $this->assertSame($tools, $result->getContent());
+        $this->assertSame('deepwiki', $result->getServerLabel());
+        $this->assertSame('mcpl_1', $result->getId());
+    }
+
+    public function testDefaults()
+    {
+        $result = new McpListToolsResult('deepwiki');
+
+        $this->assertSame([], $result->getContent());
+        $this->assertNull($result->getId());
+    }
+}

--- a/src/platform/tests/Result/WebSearchResultTest.php
+++ b/src/platform/tests/Result/WebSearchResultTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\WebSearchResult;
+
+final class WebSearchResultTest extends TestCase
+{
+    public function testGetters()
+    {
+        $result = new WebSearchResult('latest AI news', 'ws_1', 'completed');
+
+        $this->assertSame('latest AI news', $result->getContent());
+        $this->assertSame('latest AI news', $result->getQuery());
+        $this->assertSame('ws_1', $result->getId());
+        $this->assertSame('completed', $result->getStatus());
+    }
+
+    public function testDefaultsToNull()
+    {
+        $result = new WebSearchResult();
+
+        $this->assertNull($result->getContent());
+        $this->assertNull($result->getQuery());
+        $this->assertNull($result->getId());
+        $this->assertNull($result->getStatus());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #2149
| License       | MIT

When OpenAI's Responses API runs a built-in / server-side tool (web search, file search,
code interpreter, image generation, hosted MCP, computer use, local shell), it reports a
dedicated output item (`web_search_call`, `mcp_call`, …) next to the assistant message.
Until now `OpenResponses\ResultConverter` **skipped** these items (it originally threw on
them, see #2149). As suggested in the issue, this PR converts them into typed results
instead — mirroring the Anthropic/Gemini bridges.

Because `OpenAi\Gpt\ResultConverter`, the Azure OpenAI bridge, and the Scaleway bridge
all build on `OpenResponses\ResultConverter`, every platform mentioned in the issue
benefits.

### Mapping

| `output` item | Result |
| --- | --- |
| `web_search_call` | `Result\WebSearchResult` *(new)* |
| `file_search_call` | `Result\FileSearchResult` *(new)* |
| `code_interpreter_call` | `Result\ExecutableCodeResult` (+ `Result\CodeExecutionResult`) — reused |
| `image_generation_call` | `Result\BinaryResult` — reused |
| `mcp_call` | `Result\McpCallResult` *(new)* |
| `mcp_list_tools` | `Result\McpListToolsResult` *(new)* |
| `mcp_approval_request` | `Result\McpApprovalRequestResult` *(new)* |
| `computer_call` | `Result\ComputerCallResult` *(new)* |
| `local_shell_call` | `Result\LocalShellCallResult` *(new)* |

A response that searches the web before answering now returns a
`MultiPartResult([WebSearchResult, TextResult])` (just like Anthropic returns
`MultiPartResult([ExecutableCodeResult, …, TextResult])`). `MultiPartResult::asText()`
still returns only the answer text.

Each new result also has a matching `Message\Content\*` class and a `Message::toContent()`
mapping, so the results round-trip through `Message::ofAssistant()` without throwing
`Unsupported assistant message part` — following the existing `ExecutableCode`/`CodeExecution`
precedent.

### Usage

```php
$messages = new MessageBag(
    Message::forSystem('Use the web to answer with up-to-date information.'),
    Message::ofUser('What are the latest developments in quantum computing?'),
);

// Enable OpenAI's native, server-side web search tool just for this call.
$result = $platform->invoke('gpt-4o-mini', $messages, [
    'tools' => [
        ['type' => 'web_search'],
    ],
]);

echo $result->asText().\PHP_EOL;

foreach ($result->getResult() as $part) {
    if ($part instanceof WebSearchResult) {
        echo 'Searched for: '.$part->getQuery().\PHP_EOL;
    }
}
```

### Notes

- Streaming is intentionally unchanged (no new `Delta` types): like the Anthropic bridge it surfaces only text/reasoning/tool-call deltas. Built-in tool results are available on non-streamed responses.
- `image_generation_call` reuses `Result\BinaryResult`, which (as today) has no `Message::toContent()` mapping, so round-tripping a generated image into an assistant message still throws — unchanged behavior, out of scope here.
- Docs: new `docs/components/platform/openai-server-tools.rst` + a runnable `examples/openai/web-search.php`.
- CHANGELOG updated; full Platform test suite, PHPStan, and PHP-CS-Fixer pass.
