### PR TITLE
[Platform] Default tool_choice to "auto" in Generic completions when tools are provided

### DIFF
--- a/src/platform/src/Bridge/Generic/Completions/ModelClient.php
+++ b/src/platform/src/Bridge/Generic/Completions/ModelClient.php
@@ -65,6 +65,12 @@ class ModelClient implements ModelClientInterface
             }
         }
 
+        // Some OpenAI-compatible providers do not default "tool_choice" to "auto" server-side,
+        // which makes the model answer with a text response instead of a proper tool call.
+        if ([] !== ($options['tools'] ?? [])) {
+            $options['tool_choice'] ??= 'auto';
+        }
+
         // cacheRetention is an internal Symfony AI option consumed by PromptCacheNormalizer
         // (Anthropic-only).  Strip it here so it is never forwarded to OpenAI-compatible
         // endpoints, which reject unknown request body fields with a 400 error.

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
@@ -159,4 +159,69 @@ final class ModelClientTest extends TestCase
         $modelClient = new ModelClient($httpClient, 'http://localhost:8000', 'sk-valid-api-key');
         $modelClient->request(new CompletionsModel('gpt-4o'), ['messages' => [['role' => 'user', 'content' => "tool output \xB1 here"]]]);
     }
+
+    public function testToolChoiceDefaultsToAutoWhenToolsAreProvided()
+    {
+        $capturedBody = $this->captureRequestBody(['tools' => $this->tools()]);
+
+        $this->assertSame('auto', $capturedBody['tool_choice']);
+    }
+
+    public function testToolChoiceIsNotOverriddenWhenExplicitlySet()
+    {
+        $capturedBody = $this->captureRequestBody(['tools' => $this->tools(), 'tool_choice' => 'required']);
+
+        $this->assertSame('required', $capturedBody['tool_choice']);
+    }
+
+    public function testToolChoiceIsNotSetWhenNoToolsAreProvided()
+    {
+        $capturedBody = $this->captureRequestBody([]);
+
+        $this->assertArrayNotHasKey('tool_choice', $capturedBody);
+    }
+
+    public function testToolChoiceIsNotSetWhenToolsAreEmpty()
+    {
+        $capturedBody = $this->captureRequestBody(['tools' => []]);
+
+        $this->assertArrayNotHasKey('tool_choice', $capturedBody);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function captureRequestBody(array $options): array
+    {
+        $capturedBody = null;
+
+        $httpClient = new MockHttpClient(static function ($method, $url, $httpOptions) use (&$capturedBody) {
+            $capturedBody = json_decode($httpOptions['body'], true);
+
+            return new MockResponse(json_encode([
+                'choices' => [['message' => ['role' => 'assistant', 'content' => 'Hello']]],
+            ]));
+        });
+
+        $modelClient = new ModelClient($httpClient, 'http://localhost:8000', 'sk-valid-api-key');
+        $modelClient->request(new CompletionsModel('gpt-4o'), [
+            'messages' => [['role' => 'user', 'content' => 'Hello']],
+        ], $options);
+
+        $this->assertIsArray($capturedBody);
+
+        return $capturedBody;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function tools(): array
+    {
+        return [
+            ['type' => 'function', 'function' => ['name' => 'tool_a', 'description' => 'First tool']],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2228
| License       | MIT

`Generic\Completions\ModelClient` (used by OpenAI-compatible bridges such as Albert via `GenericFactory`) never injects `tool_choice`. Several OpenAI-compatible providers do not apply a default of `auto` server-side, so the model returns a `TextResult` whose content literally contains `[tool_call]` instead of a proper `ToolCallResult`.

The Anthropic bridge already guards against this (`ModelClient.php`):

```php
if (isset($options['tools'])) {
    $options['tool_choice'] ??= ['type' => 'auto'];
}
```

This PR adds the equivalent guard to `Generic\Completions\ModelClient::request()` using the OpenAI-compatible string form:

```php
if (isset($options['tools'])) {
    $options['tool_choice'] ??= 'auto';
}
```

An explicit `tool_choice` is left untouched, and nothing changes when no tools are provided. Added `ModelClientTest` covering the three cases (default `auto`, explicit value preserved, no tools → no `tool_choice`).
