### PR TITLE
[McpBundle] Add `http.allowed_hosts` configuration option for DNS rebinding protection

### DIFF
--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Add `http.allowed_hosts` configuration option to allow configuring permitted hosts for the HTTP transport's DNS rebinding protection middleware
+
 0.8
 ---
 

--- a/src/mcp-bundle/config/options.php
+++ b/src/mcp-bundle/config/options.php
@@ -55,6 +55,22 @@ return static function (DefinitionConfigurator $configurator): void {
                 ->addDefaultsIfNotSet()
                 ->children()
                     ->scalarNode('path')->defaultValue('/_mcp')->end()
+                    ->arrayNode('allowed_hosts')
+                        ->scalarPrototype()
+                            ->validate()
+                                ->ifTrue(static function (string $host): bool {
+                                    // IPv6 addresses like [::1] are valid (colons are part of the format)
+                                    if (str_starts_with($host, '[')) {
+                                        return false;
+                                    }
+
+                                    return str_contains($host, ':');
+                                })
+                                ->thenInvalid('Host "%s" must not contain a port number. For IPv6 addresses, use the bracketed form (e.g. "[::1]"). For regular hostnames, use the hostname only (e.g. "myapp.com").')
+                            ->end()
+                        ->end()
+                        ->defaultValue([])
+                    ->end()
                     ->arrayNode('session')
                         ->addDefaultsIfNotSet()
                         ->children()

--- a/src/mcp-bundle/src/Controller/McpController.php
+++ b/src/mcp-bundle/src/Controller/McpController.php
@@ -12,6 +12,9 @@
 namespace Symfony\AI\McpBundle\Controller;
 
 use Mcp\Server;
+use Mcp\Server\Transport\Http\Middleware\CorsMiddleware;
+use Mcp\Server\Transport\Http\Middleware\DnsRebindingProtectionMiddleware;
+use Mcp\Server\Transport\Http\Middleware\ProtocolVersionMiddleware;
 use Mcp\Server\Transport\StreamableHttpTransport;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -23,6 +26,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class McpController
 {
+    /**
+     * @param list<string> $allowedHosts
+     */
     public function __construct(
         private readonly Server $server,
         private readonly HttpMessageFactoryInterface $httpMessageFactory,
@@ -30,16 +36,27 @@ final class McpController
         private readonly ResponseFactoryInterface $responseFactory,
         private readonly StreamFactoryInterface $streamFactory,
         private readonly ?LoggerInterface $logger = null,
+        private readonly array $allowedHosts = [],
     ) {
     }
 
     public function handle(Request $request): Response
     {
+        $middleware = null;
+        if ([] !== $this->allowedHosts) {
+            $middleware = [
+                new CorsMiddleware(),
+                new DnsRebindingProtectionMiddleware($this->allowedHosts, $this->responseFactory, $this->streamFactory),
+                new ProtocolVersionMiddleware(null, $this->responseFactory, $this->streamFactory),
+            ];
+        }
+
         $transport = new StreamableHttpTransport(
             $this->httpMessageFactory->createRequest($request),
             $this->responseFactory,
             $this->streamFactory,
             logger: $this->logger,
+            middleware: $middleware,
         );
 
         $psrResponse = $this->server->run($transport);

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -118,8 +118,8 @@ final class McpBundle extends AbstractBundle
     }
 
     /**
-     * @param array{stdio: bool, http: bool}                                                                                      $transports
-     * @param array{path: string, session: array{store: string, directory: string, cache_pool: string, prefix: string, ttl: int}} $httpConfig
+     * @param array{stdio: bool, http: bool}                                                                                                                   $transports
+     * @param array{path: string, allowed_hosts: list<string>, session: array{store: string, directory: string, cache_pool: string, prefix: string, ttl: int}} $httpConfig
      */
     private function configureClient(array $transports, array $httpConfig, ContainerBuilder $container): void
     {
@@ -162,6 +162,7 @@ final class McpBundle extends AbstractBundle
                     new Reference('mcp.psr17_factory'),
                     new Reference('mcp.psr17_factory'),
                     new Reference('logger'),
+                    $httpConfig['allowed_hosts'],
                 ])
                 ->setPublic(true)
                 ->addTag('controller.service_arguments')

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -23,6 +23,7 @@ use Mcp\Server\Session\InMemorySessionStore;
 use Mcp\Server\Session\Psr16SessionStore;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\AI\McpBundle\McpBundle;
 use Symfony\AI\McpBundle\Session\FrameworkSessionStore;
 use Symfony\Component\Cache\Psr16Cache;
@@ -460,6 +461,65 @@ class McpBundleTest extends TestCase
         $this->assertSame('session.handler', (string) $arguments[0]);
         $this->assertSame('mcp-', $arguments[1]);
         $this->assertSame(1800, $arguments[2]);
+    }
+
+    public function testHttpAllowedHostsDefault()
+    {
+        $container = $this->buildContainer([
+            'mcp' => [
+                'client_transports' => [
+                    'http' => true,
+                ],
+            ],
+        ]);
+
+        $controllerDefinition = $container->getDefinition('mcp.server.controller');
+        $arguments = $controllerDefinition->getArguments();
+        $this->assertSame([], $arguments[6]);
+    }
+
+    public function testHttpAllowedHostsCustom()
+    {
+        $container = $this->buildContainer([
+            'mcp' => [
+                'client_transports' => [
+                    'http' => true,
+                ],
+                'http' => [
+                    'allowed_hosts' => ['mcp.myapp.com', 'api.internal'],
+                ],
+            ],
+        ]);
+
+        $controllerDefinition = $container->getDefinition('mcp.server.controller');
+        $arguments = $controllerDefinition->getArguments();
+        $this->assertSame(['mcp.myapp.com', 'api.internal'], $arguments[6]);
+    }
+
+    public function testHttpAllowedHostsRejectsHostWithPort()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches('/must not contain a port number/');
+
+        $this->buildContainer([
+            'mcp' => [
+                'client_transports' => ['http' => true],
+                'http' => ['allowed_hosts' => ['myapp.com:443']],
+            ],
+        ]);
+    }
+
+    public function testHttpAllowedHostsAcceptsIpv6WithBrackets()
+    {
+        $container = $this->buildContainer([
+            'mcp' => [
+                'client_transports' => ['http' => true],
+                'http' => ['allowed_hosts' => ['[::1]', '[2001:db8::1]']],
+            ],
+        ]);
+
+        $arguments = $container->getDefinition('mcp.server.controller')->getArguments();
+        $this->assertSame(['[::1]', '[2001:db8::1]'], $arguments[6]);
     }
 
     public function testDiscoveryDefaultConfiguration()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kinda
| New feature?  yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | Fix #2205 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

By default, the MCP PHP SDK's `DnsRebindingProtectionMiddleware` only allows `localhost`, `127.0.0.1`, and `[::1]`, making it impossible to expose an MCP server on a public or internal hostname.

This PR adds an `http.allowed_hosts` configuration option to the MCP Bundle that lets users pass their own list of permitted hosts directly to the SDK's `DnsRebindingProtectionMiddleware`.

When `allowed_hosts` is empty (default), the SDK's default middleware stack is used unchanged. When a non-empty list is provided, the bundle builds an explicit middleware stack using the configured hosts — no merging with the SDK defaults, since Symfony's environment-specific config already handles dev/prod differences cleanly.

```yaml
mcp:
  client_transports:
    http: true
  http:
    allowed_hosts:
      - 'mcp.myapp.com'
      - 'api.internal'
      - '[::1]'