### PR TITLE
[Platform] Add queries in case the model issued multiple searches in a single call

### DIFF
--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -225,9 +225,10 @@ class ResultConverter implements ResultConverterInterface
     private function convertWebSearchCall(array $item): array
     {
         $action = $item['action'] ?? [];
-        $query = $action['query'] ?? ($action['queries'][0] ?? null);
+        $queries = $action['queries'] ?? [];
+        $query = $action['query'] ?? ($queries[0] ?? null);
 
-        return [new WebSearchResult($query, $item['id'] ?? null, $item['status'] ?? null)];
+        return [new WebSearchResult($query, $item['id'] ?? null, $item['status'] ?? null, $queries)];
     }
 
     /**

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -273,7 +273,11 @@ final class ResultConverterTest extends TestCase
                     'type' => 'web_search_call',
                     'id' => 'ws_1',
                     'status' => 'completed',
-                    'action' => ['type' => 'search', 'query' => 'latest AI news'],
+                    'action' => [
+                        'type' => 'search',
+                        'query' => 'latest AI news',
+                        'queries' => ['latest AI news', 'AI industry developments today'],
+                    ],
                 ],
                 [
                     'type' => 'message',
@@ -298,9 +302,31 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('completed', $parts[0]->getStatus());
         $this->assertInstanceOf(TextResult::class, $parts[1]);
         $this->assertSame('The answer is 42.', $result->asText());
+        $this->assertSame(['latest AI news', 'AI industry developments today'], $parts[0]->getQueries());
     }
 
-    public function testConvertWebSearchCallReadsQueryFromQueriesList()
+    public function testConvertWebSearchCallReadsQuery()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'web_search_call',
+                    'id' => 'ws_2',
+                    'status' => 'completed',
+                    'action' => ['type' => 'search', 'query' => 'first query', 'queries' => ['second query', 'third query']],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(WebSearchResult::class, $result);
+        $this->assertSame('first query', $result->getQuery());
+    }
+
+    public function testConvertWebSearchCallReadsFallbackQueryFromQueriesList()
     {
         $converter = new ResultConverter();
         $httpResponse = $this->createMock(ResponseInterface::class);

--- a/src/platform/src/Message/Content/WebSearch.php
+++ b/src/platform/src/Message/Content/WebSearch.php
@@ -17,14 +17,16 @@ namespace Symfony\AI\Platform\Message\Content;
 final class WebSearch implements ContentInterface
 {
     /**
-     * @param string|null $query  The search query the model sent to the web search tool, or null when the action carried no query (e.g. opening or reading a page)
-     * @param string|null $id     Identifier of the web search call output item, as assigned by the provider (e.g. "ws_...")
-     * @param string|null $status Provider-reported status of the call, e.g. "completed", "searching" or "failed"
+     * @param string|null  $query   The search query the model sent to the web search tool, or null when the action carried no query (e.g. opening or reading a page)
+     * @param string|null  $id      Identifier of the web search call output item, as assigned by the provider (e.g. "ws_...")
+     * @param string|null  $status  Provider-reported status of the call, e.g. "completed", "searching" or "failed"
+     * @param list<string> $queries All queries when the model issued multiple searches in a single call
      */
     public function __construct(
         private readonly ?string $query = null,
         private readonly ?string $id = null,
         private readonly ?string $status = null,
+        private readonly array $queries = [],
     ) {
     }
 
@@ -41,5 +43,13 @@ final class WebSearch implements ContentInterface
     public function getStatus(): ?string
     {
         return $this->status;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getQueries(): array
+    {
+        return $this->queries;
     }
 }

--- a/src/platform/src/Message/Message.php
+++ b/src/platform/src/Message/Message.php
@@ -132,7 +132,7 @@ final class Message
         }
 
         if ($part instanceof WebSearchResult) {
-            return [new WebSearch($part->getQuery(), $part->getId(), $part->getStatus())];
+            return [new WebSearch($part->getQuery(), $part->getId(), $part->getStatus(), $part->getQueries())];
         }
 
         if ($part instanceof FileSearchResult) {

--- a/src/platform/src/Result/WebSearchResult.php
+++ b/src/platform/src/Result/WebSearchResult.php
@@ -20,14 +20,16 @@ namespace Symfony\AI\Platform\Result;
 final class WebSearchResult extends BaseResult
 {
     /**
-     * @param string|null $query  The search query the model sent to the web search tool, or null when the action carried no query (e.g. opening or reading a page)
-     * @param string|null $id     Identifier of the web search call output item, as assigned by the provider (e.g. "ws_...")
-     * @param string|null $status Provider-reported status of the call, e.g. "completed", "searching" or "failed"
+     * @param string|null  $query   The search query the model sent to the web search tool, or null when the action carried no query (e.g. opening or reading a page)
+     * @param string|null  $id      Identifier of the web search call output item, as assigned by the provider (e.g. "ws_...")
+     * @param string|null  $status  Provider-reported status of the call, e.g. "completed", "searching" or "failed"
+     * @param list<string> $queries All queries when the model issued multiple searches in a single call
      */
     public function __construct(
         private readonly ?string $query = null,
         private readonly ?string $id = null,
         private readonly ?string $status = null,
+        private readonly array $queries = [],
     ) {
     }
 
@@ -49,5 +51,13 @@ final class WebSearchResult extends BaseResult
     public function getStatus(): ?string
     {
         return $this->status;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getQueries(): array
+    {
+        return $this->queries;
     }
 }

--- a/src/platform/tests/Message/MessageTest.php
+++ b/src/platform/tests/Message/MessageTest.php
@@ -171,7 +171,7 @@ final class MessageTest extends TestCase
     public function testCreateAssistantMessageMapsServerToolResultTypes()
     {
         $result = new MultiPartResult([
-            new WebSearchResult('latest AI news', 'ws_1', 'completed'),
+            new WebSearchResult('latest AI news', 'ws_1', 'completed', ['latest AI news', 'OpenAI recent announcements']),
             new FileSearchResult(['q'], [['file_id' => 'file-1']], 'fs_1', 'completed'),
             new McpCallResult('deepwiki', 'ask', '{"q":1}', 'out', null, 'mcp_1', 'completed'),
             new McpListToolsResult('deepwiki', [['name' => 'ask']], 'mcpl_1'),
@@ -188,6 +188,7 @@ final class MessageTest extends TestCase
 
         $this->assertInstanceOf(WebSearch::class, $parts[0]);
         $this->assertSame('latest AI news', $parts[0]->getQuery());
+        $this->assertSame(['latest AI news', 'OpenAI recent announcements'], $parts[0]->getQueries());
 
         $this->assertInstanceOf(FileSearch::class, $parts[1]);
         $this->assertSame(['q'], $parts[1]->getQueries());

--- a/src/platform/tests/Result/WebSearchResultTest.php
+++ b/src/platform/tests/Result/WebSearchResultTest.php
@@ -18,12 +18,13 @@ final class WebSearchResultTest extends TestCase
 {
     public function testGetters()
     {
-        $result = new WebSearchResult('latest AI news', 'ws_1', 'completed');
+        $result = new WebSearchResult('latest AI news', 'ws_1', 'completed', ['latest AI news', 'OpenAI recent announcements']);
 
         $this->assertSame('latest AI news', $result->getContent());
         $this->assertSame('latest AI news', $result->getQuery());
         $this->assertSame('ws_1', $result->getId());
         $this->assertSame('completed', $result->getStatus());
+        $this->assertSame(['latest AI news', 'OpenAI recent announcements'], $result->getQueries());
     }
 
     public function testDefaultsToNull()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2149
| License       | MIT

In #2248, platform OpenAI's built-in tool responses got converted to typed objects. There was a minor issue regarding the Websearch-Result.

In case the model issues multiple websearch-subqueries, these are being added to the result as "queries". 
Example:
```
{
    "id": "ws_044e72e75901af5b006a3d2de1170481a4949087ed5d7589b9",
    "type": "web_search_call",
    "status": "completed",
    "action": {
        "type": "search",
        "queries": [
            "Hamburg events July August September 2026 festival HafenCity DOM 2026 Hamburg Jul Aug Sep",
            "Hamburg HafenCity DOM 2026 dates September 2026 Hamburger DOM 2026 dates",
            "MS Dockville 2026 Hamburg dates 2026",
            "Elbjazz 2026 Hamburg dates",
            "Reeperbahn Festival 2026 dates Hamburg September 2026",
            "Energy in Hamburg major concerts July August September 2026 Barclaycard Arena Hamburg schedule 2026",
            "Hamburg Marathon 2026 date",
            "Hafengeburtstag Hamburg 2026 date"
        ],
        "query": "Hamburg events July August September 2026 festival HafenCity DOM 2026 Hamburg Jul Aug Sep"
    }
}
```

The first element in "queries" always matches the "query". For that reason, it was used as fallback to fill the query of the WebSearchResult, in case the element "query" does not exist in the response. 
The other queries are being ignored at the moment.

To make sure to provide all existing data, the `WebSearchResult` got extended in this PR in order to contain the remaining queries in a dedicated property.