### PR TITLE
[Agent] increase coverage of Toolbox

### DIFF
--- a/src/agent/tests/Fixtures/Tool/ToolConst.php
+++ b/src/agent/tests/Fixtures/Tool/ToolConst.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+final class ToolConst
+{
+    public function __invoke(
+        #[Schema(const: '1.0')]
+        string $version,
+    ): string {
+        return "Version: $version";
+    }
+}

--- a/src/agent/tests/Fixtures/Tool/ToolCrayon.php
+++ b/src/agent/tests/Fixtures/Tool/ToolCrayon.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+
+#[AsTool('tool_crayon', 'A crayon')]
+final class ToolCrayon
+{
+    public function __invoke(string $color): string
+    {
+        return \sprintf('Color is: %s', $color);
+    }
+}

--- a/src/agent/tests/Fixtures/Tool/ToolEnum.php
+++ b/src/agent/tests/Fixtures/Tool/ToolEnum.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+final class ToolEnum
+{
+    public function __invoke(
+        #[Schema(enum: ['red', 'green', 'blue'])]
+        string $color,
+    ): string {
+        return "Color: $color";
+    }
+}

--- a/src/agent/tests/Fixtures/Tool/ToolExclusiveMaximum.php
+++ b/src/agent/tests/Fixtures/Tool/ToolExclusiveMaximum.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+final class ToolExclusiveMaximum
+{
+    public function __invoke(
+        #[Schema(exclusiveMaximum: 10)]
+        int $value,
+    ): string {
+        return "Value: $value";
+    }
+}

--- a/src/agent/tests/Fixtures/Tool/ToolExclusiveMinimum.php
+++ b/src/agent/tests/Fixtures/Tool/ToolExclusiveMinimum.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+final class ToolExclusiveMinimum
+{
+    public function __invoke(
+        #[Schema(exclusiveMinimum: 5)]
+        int $value,
+    ): string {
+        return "Value: $value";
+    }
+}

--- a/src/agent/tests/Fixtures/Tool/ToolMaxLength.php
+++ b/src/agent/tests/Fixtures/Tool/ToolMaxLength.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+final class ToolMaxLength
+{
+    public function __invoke(
+        #[Schema(maxLength: 10)]
+        string $text,
+    ): string {
+        return "Text: $text";
+    }
+}

--- a/src/agent/tests/Fixtures/Tool/ToolMinLength.php
+++ b/src/agent/tests/Fixtures/Tool/ToolMinLength.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+final class ToolMinLength
+{
+    public function __invoke(
+        #[Schema(minLength: 5)]
+        string $text,
+    ): string {
+        return "Text: $text";
+    }
+}

--- a/src/agent/tests/Fixtures/Tool/ToolMultipleOf.php
+++ b/src/agent/tests/Fixtures/Tool/ToolMultipleOf.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+final class ToolMultipleOf
+{
+    public function __invoke(
+        #[Schema(multipleOf: 5)]
+        int $value,
+    ): string {
+        return "Value: $value";
+    }
+}

--- a/src/agent/tests/Fixtures/Tool/ToolWithExternalRef.php
+++ b/src/agent/tests/Fixtures/Tool/ToolWithExternalRef.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+#[AsTool('tool_with_external_ref', 'A tool with external schema provider')]
+final class ToolWithExternalRef
+{
+    public function __invoke(
+        #[Schema(provider: 'external_schema_provider')]
+        string $data,
+    ): string {
+        return "Data: $data";
+    }
+}

--- a/src/agent/tests/Toolbox/Event/ToolCallArgumentResolvedTest.php
+++ b/src/agent/tests/Toolbox/Event/ToolCallArgumentResolvedTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Toolbox\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Toolbox\Event\ToolCallArgumentsResolved;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\ExecutionReference;
+use Symfony\AI\Platform\Tool\Tool;
+
+final class ToolCallArgumentResolvedTest extends TestCase
+{
+    private ToolCall $toolCall;
+    private Tool $tool;
+
+    protected function setUp(): void
+    {
+        $this->toolCall = new ToolCall('call_123', 'my_tool', ['arg' => 'value']);
+        $this->tool = new Tool(new ExecutionReference(self::class, '__invoke'), 'my_tool', 'A test tool');
+    }
+
+    public function testGetTool()
+    {
+        $event = new ToolCallArgumentsResolved($this->toolCall, $this->tool, []);
+
+        $this->assertSame($this->toolCall, $event->getTool());
+    }
+
+    public function testGetDefinition()
+    {
+        $event = new ToolCallArgumentsResolved($this->toolCall, $this->tool, []);
+
+        $this->assertSame($this->tool, $event->getDefinition());
+    }
+
+    public function testGetArguments()
+    {
+        $event = new ToolCallArgumentsResolved($this->toolCall, $this->tool, ['arg1' => 'value1', 'arg2' => 22]);
+
+        $this->assertEqualsCanonicalizing(['arg1' => 'value1', 'arg2' => 22], $event->getArguments());
+    }
+}

--- a/src/agent/tests/Toolbox/Event/ToolCallFailedTest.php
+++ b/src/agent/tests/Toolbox/Event/ToolCallFailedTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Toolbox\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Toolbox\Event\ToolCallFailed;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\ExecutionReference;
+use Symfony\AI\Platform\Tool\Tool;
+
+final class ToolCallFailedTest extends TestCase
+{
+    private ToolCall $toolCall;
+    private Tool $tool;
+
+    protected function setUp(): void
+    {
+        $this->toolCall = new ToolCall('call_123', 'my_tool', ['arg' => 'value']);
+        $this->tool = new Tool(new ExecutionReference(self::class, '__invoke'), 'my_tool', 'A test tool');
+    }
+
+    public function testGetTool()
+    {
+        $event = new ToolCallFailed($this->toolCall, $this->tool, [], new \Exception('Unexpected error!'));
+
+        $this->assertSame($this->toolCall, $event->getTool());
+    }
+
+    public function testGetDefinition()
+    {
+        $event = new ToolCallFailed($this->toolCall, $this->tool, [], new \Exception('Unexpected error!'));
+
+        $this->assertSame($this->tool, $event->getDefinition());
+    }
+
+    public function testGetArguments()
+    {
+        $event = new ToolCallFailed($this->toolCall, $this->tool, ['arg1' => 'value1', 'arg2' => 2], new \Exception('Unexpected error!'));
+
+        $this->assertEqualsCanonicalizing(['arg1' => 'value1', 'arg2' => 2], $event->getArguments());
+    }
+
+    public function testGetException()
+    {
+        $event = new ToolCallFailed($this->toolCall, $this->tool, [], new \Exception('Unexpected error!'));
+
+        $this->assertInstanceOf(\Exception::class, $event->getException());
+        $this->assertSame('Unexpected error!', $event->getException()->getMessage());
+    }
+}

--- a/src/agent/tests/Toolbox/Event/ToolCallSucceededTest.php
+++ b/src/agent/tests/Toolbox/Event/ToolCallSucceededTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Toolbox\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Toolbox\Event\ToolCallSucceeded;
+use Symfony\AI\Agent\Toolbox\ToolResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\ExecutionReference;
+use Symfony\AI\Platform\Tool\Tool;
+
+final class ToolCallSucceededTest extends TestCase
+{
+    private ToolCall $toolCall;
+    private Tool $tool;
+
+    protected function setUp(): void
+    {
+        $this->toolCall = new ToolCall('call_123', 'my_tool', ['arg' => 'value']);
+        $this->tool = new Tool(new ExecutionReference(self::class, '__invoke'), 'my_tool', 'A test tool');
+    }
+
+    public function testGetTool()
+    {
+        $event = new ToolCallSucceeded($this->toolCall, $this->tool, [], new ToolResult($this->toolCall, 'Result here!'));
+
+        $this->assertSame($this->toolCall, $event->getTool());
+    }
+
+    public function testGetDefinition()
+    {
+        $event = new ToolCallSucceeded($this->toolCall, $this->tool, [], new ToolResult($this->toolCall, 'Result here!'));
+
+        $this->assertSame($this->tool, $event->getDefinition());
+    }
+
+    public function testGetArguments()
+    {
+        $event = new ToolCallSucceeded($this->toolCall, $this->tool, ['arg1' => 'value1', 'arg2' => 22], new ToolResult($this->toolCall, 'Result here!'));
+
+        $this->assertEqualsCanonicalizing(['arg1' => 'value1', 'arg2' => 22], $event->getArguments());
+    }
+
+    public function testGetResult()
+    {
+        $event = new ToolCallSucceeded($this->toolCall, $this->tool, [], new ToolResult($this->toolCall, 'Result here!'));
+
+        $this->assertInstanceOf(ToolResult::class, $event->getResult());
+        $this->assertSame('Result here!', $event->getResult()->getResult());
+    }
+}

--- a/src/agent/tests/Toolbox/Event/ToolCallsExecutedTest.php
+++ b/src/agent/tests/Toolbox/Event/ToolCallsExecutedTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Toolbox\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Toolbox\Event\ToolCallsExecuted;
+use Symfony\AI\Agent\Toolbox\ToolResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+
+final class ToolCallsExecutedTest extends TestCase
+{
+    public function testGetToolResults()
+    {
+        $toolResults = [
+            new ToolResult(new ToolCall('tool1', 'foo'), 'result1'),
+            new ToolResult(new ToolCall('tool2', 'bar'), 'result2'),
+        ];
+
+        $event = new ToolCallsExecuted($toolResults);
+
+        $this->assertSame($toolResults, $event->getToolResults());
+    }
+
+    public function testNoResultInitially()
+    {
+        $event = new ToolCallsExecuted([]);
+
+        $this->assertFalse($event->hasResult());
+    }
+
+    public function testSetAndGetResult()
+    {
+        $event = new ToolCallsExecuted([]);
+        $result = new TextResult('The quick brown fox jumps over the lazy dog');
+
+        $event->setResult($result);
+
+        $this->assertTrue($event->hasResult());
+        $this->assertSame($result, $event->getResult());
+    }
+}

--- a/src/agent/tests/Toolbox/EventListener/ValidateToolCallArgumentsListenerTest.php
+++ b/src/agent/tests/Toolbox/EventListener/ValidateToolCallArgumentsListenerTest.php
@@ -14,13 +14,24 @@ namespace Symfony\AI\Agent\Tests\Toolbox\EventListener;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\Recipe;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolConst;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolCrayon;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolEnum;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolExclusiveMaximum;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolExclusiveMinimum;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolMaxLength;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolMinLength;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolMultipleOf;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithConstraints;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithExternalRef;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithScalarConstraints;
 use Symfony\AI\Agent\Toolbox\Event\ToolCallArgumentsResolved;
 use Symfony\AI\Agent\Toolbox\EventListener\ValidateToolCallArgumentsListener;
 use Symfony\AI\Agent\Toolbox\Exception\InvalidToolCallArgumentsException;
 use Symfony\AI\Platform\Tool\ExecutionReference;
 use Symfony\AI\Platform\Tool\Tool;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validation;
 
 class ValidateToolCallArgumentsListenerTest extends TestCase
@@ -42,7 +53,25 @@ class ValidateToolCallArgumentsListenerTest extends TestCase
         $listener($event);
     }
 
-    public function testFailsValidation()
+    public function testInvokeWithScalarArguments()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $crayon = new ToolCrayon();
+
+        $event = new ToolCallArgumentsResolved(
+            $crayon,
+            new Tool(new ExecutionReference($crayon::class), 'get_crayon', 'Get a crayon'),
+            ['color' => 'blue'],
+        );
+
+        $listener($event);
+        $this->assertCount(1, $event->getArguments());
+        $this->assertSame('blue', $event->getArguments()['color']);
+    }
+
+    public function testWhenValidationHasFailed()
     {
         $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
         $listener = new ValidateToolCallArgumentsListener($validator);
@@ -55,9 +84,18 @@ class ValidateToolCallArgumentsListenerTest extends TestCase
             ['recipe' => new Recipe('salt')],
         );
 
-        $this->expectException(InvalidToolCallArgumentsException::class);
-        $this->expectExceptionMessage('Invalid arguments provided for "get_recipe" tool.');
-        $listener($event);
+        try {
+            $listener($event);
+            $this->fail('Should have thrown before!');
+        } catch (InvalidToolCallArgumentsException $ex) {
+            $this->assertSame('Invalid arguments provided for "get_recipe" tool.', $ex->getMessage());
+            $toolCallResult = $ex->getToolCallResult();
+            $this->assertInstanceOf(ConstraintViolationList::class, $toolCallResult);
+            $this->assertSame(1, $toolCallResult->count());
+            $violation = iterator_to_array($toolCallResult)[0];
+            $this->assertInstanceOf(ConstraintViolation::class, $violation);
+            $this->assertSame('The value must be one of "flour", "sugar", "butter".', $violation->getMessage());
+        }
     }
 
     #[DoesNotPerformAssertions]
@@ -143,6 +181,159 @@ class ValidateToolCallArgumentsListenerTest extends TestCase
         );
 
         $this->expectException(InvalidToolCallArgumentsException::class);
+        $listener($event);
+    }
+
+    public function testExclusiveMinimumConstraint()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolExclusiveMinimum();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'invoke', 'Tool with exclusive minimum'),
+            ['value' => 5],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $listener($event);
+    }
+
+    public function testExclusiveMaximumConstraint()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolExclusiveMaximum();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'invoke', 'Tool with exclusive maximum'),
+            ['value' => 10],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $listener($event);
+    }
+
+    public function testMinLengthConstraint()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolMinLength();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'invoke', 'Tool with min length'),
+            ['text' => 'hi'],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $listener($event);
+    }
+
+    public function testMaxLengthConstraint()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolMaxLength();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'invoke', 'Tool with max length'),
+            ['text' => 'this is too long'],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $listener($event);
+    }
+
+    public function testMultipleOfConstraint()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolMultipleOf();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'invoke', 'Tool with multiple of'),
+            ['value' => 7],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $listener($event);
+    }
+
+    public function testEnumConstraint()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolEnum();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'invoke', 'Tool with enum'),
+            ['color' => 'purple'],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $listener($event);
+    }
+
+    public function testConstConstraint()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolConst();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'invoke', 'Tool with const'),
+            ['version' => '2.0'],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $listener($event);
+    }
+
+    public function testArgumentNotInParameters()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolCrayon();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'get_crayon', 'Get a crayon'),
+            ['color' => 'blue', 'extraParam' => 'should be ignored'],
+        );
+
+        $listener($event);
+        $this->assertCount(2, $event->getArguments());
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testSchemaWithExternalRef()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolWithExternalRef();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'invoke', 'Tool with external ref'),
+            ['data' => 'any value'],
+        );
+
         $listener($event);
     }
 }

--- a/src/agent/tests/Toolbox/FaultTolerantToolboxTest.php
+++ b/src/agent/tests/Toolbox/FaultTolerantToolboxTest.php
@@ -18,7 +18,9 @@ use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionException;
 use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
 use Symfony\AI\Agent\Toolbox\Exception\ToolNotFoundException;
 use Symfony\AI\Agent\Toolbox\FaultTolerantToolbox;
+use Symfony\AI\Agent\Toolbox\Toolbox;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
+use Symfony\AI\Agent\Toolbox\ToolFactory\ReflectionToolFactory;
 use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tool\ExecutionReference;
@@ -39,6 +41,7 @@ final class FaultTolerantToolboxTest extends TestCase
         $actual = $faultTolerantToolbox->execute($toolCall);
 
         $this->assertSame($expected, $actual->getResult());
+        $this->assertSame($toolCall, $actual->getToolCall());
     }
 
     public function testFaultyToolCall()
@@ -54,6 +57,7 @@ final class FaultTolerantToolboxTest extends TestCase
         $actual = $faultTolerantToolbox->execute($toolCall);
 
         $this->assertSame($expected, $actual->getResult());
+        $this->assertSame($toolCall, $actual->getToolCall());
     }
 
     public function testCustomToolExecutionException()
@@ -77,6 +81,23 @@ final class FaultTolerantToolboxTest extends TestCase
         $actual = $faultTolerantToolbox->execute($toolCall);
 
         $this->assertSame($expected, $actual->getResult());
+        $this->assertSame($toolCall, $actual->getToolCall());
+    }
+
+    public function testAbsentTool()
+    {
+        $absentTool = new Tool(new ExecutionReference(\stdClass::class, 'someMethod'), 'absent_tool', 'A tool that is not in the toolbox');
+        $toolbox = new FaultTolerantToolbox(new Toolbox([new ToolRequiredParams()], new ReflectionToolFactory()));
+
+        $toolCall = new ToolCall('call_1234', 'absent_tool');
+        $result = $toolbox->execute($toolCall);
+
+        $this->assertSame(
+            'Tool "absent_tool" was not found, please use one of these: tool_required_params',
+            $result->getResult()
+        );
+
+        $this->assertSame($toolCall, $result->getToolCall());
     }
 
     private function createFaultyToolbox(\Closure $exceptionFactory): ToolboxInterface

--- a/src/agent/tests/Toolbox/MetadataFactory/MemoryFactoryTest.php
+++ b/src/agent/tests/Toolbox/MetadataFactory/MemoryFactoryTest.php
@@ -12,8 +12,10 @@
 namespace Symfony\AI\Agent\Tests\Toolbox\MetadataFactory;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolDate;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolNoAttribute1;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolNoAttribute2;
+use Symfony\AI\Agent\Toolbox\Exception\ToolConfigurationException;
 use Symfony\AI\Agent\Toolbox\Exception\ToolException;
 use Symfony\AI\Agent\Toolbox\ToolFactory\MemoryToolFactory;
 use Symfony\AI\Platform\Tool\Tool;
@@ -95,5 +97,17 @@ final class MemoryFactoryTest extends TestCase
             'additionalProperties' => false,
         ];
         $this->assertSame($expectedParams, $metadata[1]->getParameters());
+    }
+
+    public function testWrongToolMethodThrows()
+    {
+        try {
+            $factory = new MemoryToolFactory();
+            $factory->addTool(ToolDate::class, 'my_tool', 'Calculates date', 'calculateDate');
+            $this->fail('Should have thrown before!');
+        } catch (ToolConfigurationException $e) {
+            $this->assertSame('Method "calculateDate" not found in tool "Symfony\AI\Agent\Tests\Fixtures\Tool\ToolDate".', $e->getMessage());
+            $this->assertInstanceOf(\ReflectionException::class, $e->getPrevious());
+        }
     }
 }

--- a/src/agent/tests/Toolbox/Source/SourceCollectionTest.php
+++ b/src/agent/tests/Toolbox/Source/SourceCollectionTest.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Agent\Tests\Toolbox\Source;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Toolbox\Source\Source;
 use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Metadata\MergeableMetadataInterface;
 
 final class SourceCollectionTest extends TestCase
 {
@@ -107,5 +109,30 @@ final class SourceCollectionTest extends TestCase
 
         $sources = iterator_to_array($iterator);
         $this->assertSame([$source1, $source2], $sources);
+    }
+
+    public function testMergeDifferentCollectionTypesThrows()
+    {
+        $source1 = new SourceCollection();
+        $source1->add(new Source('#1', 'ref1', 'content1'));
+        $source1->add(new Source('#2', 'ref2', 'content2'));
+
+        $source2 = new class([new Source('#3', 'ref3', 'content3'), new Source('#4', 'ref4', 'content3')]) implements MergeableMetadataInterface {
+            /**
+             * @param Source[] $sources
+             */
+            public function __construct(public array $sources)
+            {
+            }
+
+            public function merge(MergeableMetadataInterface $other): self
+            {
+                return $this;
+            }
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot merge "%s" with "%s', $source1::class, $source2::class));
+        $source1->merge($source2);
     }
 }

--- a/src/agent/tests/Toolbox/ToolCallArgumentResolverTest.php
+++ b/src/agent/tests/Toolbox/ToolCallArgumentResolverTest.php
@@ -18,8 +18,10 @@ use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolArrayMultidimensional;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolDate;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolNoParams;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolObjectFloat;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolOptionalParam;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolScalarFloat;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithNullableClass;
+use Symfony\AI\Agent\Toolbox\Exception\ToolException;
 use Symfony\AI\Agent\Toolbox\ToolCallArgumentResolver;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\SomeStructure;
@@ -110,6 +112,30 @@ class ToolCallArgumentResolverTest extends TestCase
         $toolCall = new ToolCall('tool_id_1234', 'tool_scalar_float', ['height' => 1, 'weight' => 80]);
 
         $this->assertSame(['height' => 1.0, 'weight' => 80.0], $resolver->resolveArguments($metadata, $toolCall));
+    }
+
+    public function testThrowsWhenMandatoryParameterMissing()
+    {
+        $resolver = new ToolCallArgumentResolver();
+
+        $metadata = new Tool(new ExecutionReference(ToolOptionalParam::class, 'bar'), 'tool_optional_param', 'A tool with one optional parameter');
+        $toolCall = new ToolCall('invocation', 'tool_optional_param', ['number' => 5]);
+
+        $this->expectException(ToolException::class);
+        $this->expectExceptionMessage('Parameter "text" is mandatory for tool "tool_optional_param".');
+        $arguments = $resolver->resolveArguments($metadata, $toolCall);
+    }
+
+    public function testContinuesWhenOptionalParameterMissing()
+    {
+        $resolver = new ToolCallArgumentResolver();
+
+        $metadata = new Tool(new ExecutionReference(ToolOptionalParam::class, 'bar'), 'tool_optional_param', 'A tool with one optional parameter');
+        $toolCall = new ToolCall('invocation', 'tool_optional_param', ['text' => 'hello']);
+
+        $arguments = $resolver->resolveArguments($metadata, $toolCall);
+
+        $this->assertSame(['text' => 'hello'], $arguments);
     }
 
     /**

--- a/src/agent/tests/Toolbox/ToolboxTest.php
+++ b/src/agent/tests/Toolbox/ToolboxTest.php
@@ -31,6 +31,7 @@ use Symfony\AI\Agent\Toolbox\Exception\ToolNotFoundException;
 use Symfony\AI\Agent\Toolbox\Source\Source;
 use Symfony\AI\Agent\Toolbox\Tool\Subagent;
 use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Agent\Toolbox\ToolboxInterface;
 use Symfony\AI\Agent\Toolbox\ToolFactory\ChainFactory;
 use Symfony\AI\Agent\Toolbox\ToolFactory\MemoryToolFactory;
 use Symfony\AI\Agent\Toolbox\ToolFactory\ReflectionToolFactory;
@@ -170,10 +171,15 @@ final class ToolboxTest extends TestCase
 
     public function testExecuteWithException()
     {
-        $this->expectException(ToolExecutionException::class);
-        $this->expectExceptionMessage('Execution of tool "tool_exception" failed with error: Tool error.');
-
-        $this->toolbox->execute(new ToolCall('call_1234', 'tool_exception'));
+        try {
+            $this->toolbox->execute(new ToolCall('call_1234', 'tool_exception'));
+            $this->fail('Should have thrown before!');
+        } catch (ToolExecutionException $ex) {
+            $this->assertSame('Execution of tool "tool_exception" failed with error: Tool error.', $ex->getMessage());
+            $toolCall = $ex->getToolCall();
+            $this->assertInstanceOf(ToolCall::class, $toolCall);
+            $this->assertSame('call_1234', $toolCall->getId());
+        }
     }
 
     public function testExecuteWithCustomException()
@@ -416,5 +422,31 @@ final class ToolboxTest extends TestCase
         $result = $toolbox->execute(new ToolCall('call_1234', 'tool_required_params', ['text' => 'Hello', 'number' => 3]));
 
         $this->assertSame('Hello says "3".', $result->getResult());
+    }
+
+    public function testExceptionProvidesToolcall()
+    {
+        $toolbox = new class implements ToolboxInterface {
+            /** @return Tool[] */
+            public function getTools(): array
+            {
+                return [];
+            }
+
+            public function execute(ToolCall $toolCall): ToolResult
+            {
+                throw ToolNotFoundException::notFoundForToolCall($toolCall);
+            }
+        };
+
+        $toolCall = new ToolCall('4321_ABC', 'tool_xyz');
+
+        try {
+            $result = $toolbox->execute($toolCall);
+            $this->fail('Should have thrown before!');
+        } catch (ToolNotFoundException $ex) {
+            $this->assertSame('Tool not found for call: tool_xyz.', $ex->getMessage());
+            $this->assertSame('4321_ABC', $ex->getToolCall()->getId());
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

This PR is to increase coverage of `Toolbox` code to 100%. 

~Only change in non-test code was in `FaultTolerantToolbox` to use the exceptions `getToolCall` method for full coverage. Side-note: Noticing this brought me to the idea to simplify the exception hierarchy of the `Toolbox` (see https://github.com/symfony/ai/issues/2257 for details).~



---
**Before**
<img width="1160" height="830" alt="grafik" src="https://github.com/user-attachments/assets/6e4fb3cd-b856-428b-9280-fa489cbbac44" />

---
**After**

<img width="1215" height="874" alt="grafik" src="https://github.com/user-attachments/assets/295879c8-9135-4a6f-86a4-858b683928e7" />