### PR TITLE
[Mate] Fix profiler tools crash from lazy formatter proxies

### DIFF
--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -61,35 +61,27 @@ return static function (ContainerConfigurator $configurator) {
 
         // Built-in collector formatters
         $services->set(RequestCollectorFormatter::class)
-            ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(ExceptionCollectorFormatter::class)
-            ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(MailerCollectorFormatter::class)
-            ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(TranslationCollectorFormatter::class)
-            ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(DoctrineCollectorFormatter::class)
-            ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(TimeCollectorFormatter::class)
-            ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(LoggerCollectorFormatter::class)
-            ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 
         $services->set(MemoryCollectorFormatter::class)
-            ->lazy()
             ->tag('ai_mate.profiler_collector_formatter');
 
         // MCP Capabilities


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2255
| License       | MIT

Calling any Symfony profiler tool (e.g. `symfony-profiler-list`) crashed with:

```
Error: Cannot generate lazy proxy for service
"Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RequestCollectorFormatter".
```

The eight profiler collector formatters in `src/Bridge/Symfony/config/config.php` were
registered with `->lazy()`, but Mate's standalone DI container is not wired to generate
lazy proxies at runtime — even with `symfony/var-exporter` installed. Resolving any
formatter therefore threw, crashing every profiler tool.

These formatters are tiny stateless services, so the lazy optimization bought nothing
here. This drops `->lazy()` from all eight formatter definitions so they instantiate
eagerly and the profiler tools work again.
