### PR TITLE
[Chat] Normalize non-text AssistantMessage content in MessageNormalizer

### DIFF
--- a/src/chat/src/MessageNormalizer.php
+++ b/src/chat/src/MessageNormalizer.php
@@ -22,6 +22,7 @@ use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Content\Video;
 use Symfony\AI\Platform\Message\MessageInterface;
 use Symfony\AI\Platform\Message\SystemMessage;
 use Symfony\AI\Platform\Message\ToolCallMessage;
@@ -152,6 +153,8 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
                 $parts[] = ['type' => Thinking::class, 'content' => $part->getContent(), 'signature' => $part->getSignature()];
             } elseif ($part instanceof ToolCall) {
                 $parts[] = ['type' => ToolCall::class, 'toolCall' => $this->normalizer->normalize($part, $format, $context)];
+            } elseif ($part instanceof File || $part instanceof ImageUrl || $part instanceof DocumentUrl) {
+                $parts[] = self::normalizeContentParts([$part])[0];
             }
         }
 
@@ -173,7 +176,8 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
                     File::class,
                     Document::class,
                     Image::class,
-                    Audio::class => $content->asDataUrl(),
+                    Audio::class,
+                    Video::class => $content->asDataUrl(),
                     ImageUrl::class,
                     DocumentUrl::class => $content->getUrl(),
                     default => throw new LogicException(\sprintf('Unknown content type "%s".', $content::class)),
@@ -195,7 +199,8 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
                 File::class,
                 Document::class,
                 Image::class,
-                Audio::class => $part['type']::fromDataUrl($part['content']),
+                Audio::class,
+                Video::class => $part['type']::fromDataUrl($part['content']),
                 Text::class => new Text($part['content']),
                 ImageUrl::class => new ImageUrl($part['content']),
                 DocumentUrl::class => new DocumentUrl($part['content']),
@@ -223,7 +228,7 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
                         $part['toolCall']['function']['name'],
                         json_decode($part['toolCall']['function']['arguments'], true),
                     ),
-                    default => throw new LogicException(\sprintf('Unknown assistant part type "%s".', $part['type'])),
+                    default => self::denormalizeContentParts([$part])[0],
                 };
             }
 

--- a/src/chat/tests/MessageNormalizerTest.php
+++ b/src/chat/tests/MessageNormalizerTest.php
@@ -21,6 +21,7 @@ use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Content\WebSearch;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageInterface;
 use Symfony\AI\Platform\Message\Role;
@@ -217,6 +218,28 @@ final class MessageNormalizerTest extends TestCase
         $this->assertSame([], $toolCalls[1]->getArguments());
     }
 
+    public function testItCanNormalizeAndDenormalizeAssistantMessageWithImage()
+    {
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new ToolCallNormalizer(),
+            new MessageNormalizer(),
+        ], [new JsonEncoder()]);
+
+        $dataUrl = 'data:image/png;base64,SGVsbG8=';
+        $message = new AssistantMessage(Image::fromDataUrl($dataUrl));
+
+        $payload = $serializer->normalize($message);
+        $denormalized = $serializer->denormalize($payload, MessageInterface::class);
+
+        $this->assertInstanceOf(AssistantMessage::class, $denormalized);
+
+        $content = $denormalized->getContent();
+        $this->assertCount(1, $content);
+        $this->assertInstanceOf(Image::class, $content[0]);
+        $this->assertSame($dataUrl, $content[0]->asDataUrl());
+    }
+
     public function testItPreservesAssistantPartOrderingAcrossRoundtrip()
     {
         $serializer = new Serializer([
@@ -251,6 +274,67 @@ final class MessageNormalizerTest extends TestCase
         $this->assertSame('sig_2', $parts[3]->getSignature());
         $this->assertInstanceOf(Text::class, $parts[4]);
         $this->assertSame('Trailing text.', $parts[4]->getText());
+    }
+
+    public function testItPreservesMixedTextImageAndToolCallOrderingAcrossRoundtrip()
+    {
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new ToolCallNormalizer(),
+            new MessageNormalizer(),
+        ], [new JsonEncoder()]);
+
+        $dataUrl = 'data:image/png;base64,SGVsbG8=';
+        $message = new AssistantMessage(
+            new Text('Here is the chart you asked for:'),
+            Image::fromDataUrl($dataUrl),
+            new ToolCall('call-1', 'save_report', ['name' => 'chart.png']),
+            new ImageUrl('https://example.com/preview.png'),
+            new Text('Saved.'),
+        );
+
+        $payload = $serializer->normalize($message);
+        /** @var AssistantMessage $denormalized */
+        $denormalized = $serializer->denormalize($payload, MessageInterface::class);
+
+        $parts = $denormalized->getContent();
+        $this->assertCount(5, $parts);
+        $this->assertInstanceOf(Text::class, $parts[0]);
+        $this->assertSame('Here is the chart you asked for:', $parts[0]->getText());
+        $this->assertInstanceOf(Image::class, $parts[1]);
+        $this->assertSame($dataUrl, $parts[1]->asDataUrl());
+        $this->assertInstanceOf(ToolCall::class, $parts[2]);
+        $this->assertSame('call-1', $parts[2]->getId());
+        $this->assertInstanceOf(ImageUrl::class, $parts[3]);
+        $this->assertSame('https://example.com/preview.png', $parts[3]->getUrl());
+        $this->assertInstanceOf(Text::class, $parts[4]);
+        $this->assertSame('Saved.', $parts[4]->getText());
+    }
+
+    public function testItSkipsUnknownAssistantContentTypes()
+    {
+        $serializer = new Serializer([
+            new ArrayDenormalizer(),
+            new ToolCallNormalizer(),
+            new MessageNormalizer(),
+        ], [new JsonEncoder()]);
+
+        $message = new AssistantMessage(
+            new Text('Let me look that up.'),
+            new WebSearch(query: 'symfony ai'),
+            new Text('Found it.'),
+        );
+
+        $payload = $serializer->normalize($message);
+        /** @var AssistantMessage $denormalized */
+        $denormalized = $serializer->denormalize($payload, MessageInterface::class);
+
+        $parts = $denormalized->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(Text::class, $parts[0]);
+        $this->assertSame('Let me look that up.', $parts[0]->getText());
+        $this->assertInstanceOf(Text::class, $parts[1]);
+        $this->assertSame('Found it.', $parts[1]->getText());
     }
 
     public function testItCanNormalizeAndDenormalizeToolCallMessage()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2198
| License       | MIT

The original round-trip issue for `UserMessage` images (base64 vs. data URL mismatch) was already fixed by 8ca2ab09. This PR addresses the remaining case reported in the issue's follow-up: `AssistantMessage` content.

`MessageNormalizer::normalizeAssistantParts()` only handled `Text`, `Thinking` and `ToolCall` parts and **silently dropped** anything else. So an `AssistantMessage` carrying an `Image` (e.g. a generated image returned by Gemini) was lost on the way to the store and could not be read back.

`File`/`Document`/`Image`/`Audio` (as data URL) and `ImageUrl`/`DocumentUrl` parts are now handled on both the normalize and denormalize sides, mirroring what is already done for `UserMessage` content. Added a round-trip test for an `AssistantMessage` holding an `Image`.
