### PR TITLE
[Mate] Redact sensitive context/extra in Monolog log entries

### DIFF
--- a/src/mate/src/Bridge/Monolog/Model/LogEntry.php
+++ b/src/mate/src/Bridge/Monolog/Model/LogEntry.php
@@ -32,6 +32,45 @@ final class LogEntry
     private const REGEX_BACKTRACK_LIMIT = 10000;
 
     /**
+     * Key-name substrings (case-insensitive) used to redact values in the log
+     * context/extra exposed to the AI. Application code routinely logs tokens,
+     * credentials, session identifiers and auth details there. Bare `KEY` and
+     * `AUTH` are excluded to avoid redacting common non-sensitive keys (`key`,
+     * `author`); the narrower `AUTHORIZATION`/`AUTHENTICATION`/`OAUTH` cover the
+     * real cases.
+     *
+     * @var array<string>
+     */
+    private const SENSITIVE_KEY_PATTERNS = [
+        'PASSWORD',
+        'PASSWD',
+        'PASSPHRASE',
+        'PWD',
+        'SECRET',
+        'TOKEN',
+        'JWT',
+        'API_KEY',
+        'APIKEY',
+        'ACCESS_KEY',
+        'SIGNING_KEY',
+        'ENCRYPTION_KEY',
+        'OAUTH',
+        'AUTHORIZATION',
+        'AUTHENTICATION',
+        'CREDENTIAL',
+        'PRIVATE',
+        'BEARER',
+        'CSRF',
+        'XSRF',
+        'SESSION',
+        'SESSID',
+        'SIGNATURE',
+        'SALT',
+        'COOKIE',
+        'OTP',
+    ];
+
+    /**
      * @param array<string, mixed> $context
      * @param array<string, mixed> $extra
      */
@@ -103,8 +142,8 @@ final class LogEntry
             'channel' => $this->channel,
             'level' => $this->level,
             'message' => $this->message,
-            'context' => $this->context,
-            'extra' => $this->extra,
+            'context' => $this->redactSensitive($this->context),
+            'extra' => $this->redactSensitive($this->extra),
             'source_file' => $this->sourceFile,
             'line_number' => $this->lineNumber,
         ];
@@ -149,5 +188,42 @@ final class LogEntry
         }
 
         return str_contains(strtolower(json_encode($contextValue) ?: ''), strtolower($value));
+    }
+
+    /**
+     * Recursively redact values whose key matches a sensitive pattern. Applied
+     * only to the AI-facing output; the raw context/extra remain searchable.
+     *
+     * @param array<array-key, mixed> $data
+     *
+     * @return array<array-key, mixed>
+     */
+    private function redactSensitive(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (\is_string($key) && $this->isSensitiveKey($key)) {
+                $data[$key] = '***REDACTED***';
+                continue;
+            }
+
+            if (\is_array($value)) {
+                $data[$key] = $this->redactSensitive($value);
+            }
+        }
+
+        return $data;
+    }
+
+    private function isSensitiveKey(string $key): bool
+    {
+        // Normalise hyphens to underscores so `api-key` matches the patterns too.
+        $upperKey = str_replace('-', '_', strtoupper($key));
+        foreach (self::SENSITIVE_KEY_PATTERNS as $pattern) {
+            if (str_contains($upperKey, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/mate/src/Bridge/Monolog/Tests/Model/LogEntryTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Model/LogEntryTest.php
@@ -38,4 +38,57 @@ final class LogEntryTest extends TestCase
         $this->assertFalse($result);
         $this->assertLessThan(1.0, $elapsed, 'ReDoS pattern must not stall preg_match');
     }
+
+    public function testToArrayRedactsSensitiveContextAndExtra()
+    {
+        $entry = new LogEntry(
+            new \DateTimeImmutable('2024-01-01T00:00:00+00:00'),
+            'security',
+            'INFO',
+            'Authentication attempt',
+            [
+                'user_id' => 7,
+                'author' => 'jane',
+                'password' => 'hunter2',
+                'access_token' => 'tok-secret',
+                'nested' => ['jwt' => 'jwt-secret', 'note' => 'visible'],
+            ],
+            ['session_id' => 'sess-secret', 'host' => 'web-1'],
+        );
+
+        $array = $entry->toArray();
+
+        // Non-sensitive keys (incl. the over-matchable `author`/`host`) survive.
+        $this->assertSame(7, $array['context']['user_id']);
+        $this->assertSame('jane', $array['context']['author']);
+        $this->assertSame('visible', $array['context']['nested']['note']);
+        $this->assertSame('web-1', $array['extra']['host']);
+        // Sensitive keys are redacted, recursively, in both context and extra.
+        $this->assertSame('***REDACTED***', $array['context']['password']);
+        $this->assertSame('***REDACTED***', $array['context']['access_token']);
+        $this->assertSame('***REDACTED***', $array['context']['nested']['jwt']);
+        $this->assertSame('***REDACTED***', $array['extra']['session_id']);
+
+        $serialized = json_encode($array);
+        $this->assertStringNotContainsString('hunter2', $serialized);
+        $this->assertStringNotContainsString('tok-secret', $serialized);
+        $this->assertStringNotContainsString('jwt-secret', $serialized);
+        $this->assertStringNotContainsString('sess-secret', $serialized);
+    }
+
+    public function testContextRemainsSearchableDespiteRedaction()
+    {
+        $entry = new LogEntry(
+            new \DateTimeImmutable('2024-01-01T00:00:00+00:00'),
+            'security',
+            'INFO',
+            'token issued',
+            ['access_token' => 'tok-secret'],
+        );
+
+        // Searching still matches the real (unredacted) value...
+        $this->assertTrue($entry->hasContextValue('access_token', 'tok-secret'));
+        // ...but the AI-facing output is redacted.
+        $this->assertSame('***REDACTED***', $entry->toArray()['context']['access_token']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT


The `monolog-search` / `monolog-context-search` / `monolog-tail` tools returned
each parsed log entry's `context` and `extra` verbatim via `LogEntry::toArray()`.
The same data the profiler logger collector exposes, but for the **file-based**
log path — reset tokens, credentials, session ids and PII reached the AI
unredacted (only wrapped as untrusted, which guards against prompt injection but
not data exposure).

Apply recursive key-based redaction to `context` and `extra` in `toArray()` (the
AI-facing output only). The raw values stay intact internally, so term/regex and
context-key search still match on the real data; the message is left untouched.

