### PR TITLE
[Mate] Scrub secrets from profiler exception collector messages

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/ExceptionCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/ExceptionCollectorFormatter.php
@@ -18,6 +18,11 @@ use Symfony\Component\HttpKernel\DataCollector\ExceptionDataCollector;
 /**
  * Formats exception collector data.
  *
+ * Exception messages frequently embed secrets (DSN/connection-string passwords,
+ * `token=...` fragments, Authorization headers), so high-confidence secret
+ * shapes are scrubbed before the message reaches the AI. The class, file, line
+ * and trace — the actionable parts — are kept as-is.
+ *
  * @author Johannes Wachter <johannes@sulu.io>
  *
  * @internal
@@ -26,6 +31,26 @@ use Symfony\Component\HttpKernel\DataCollector\ExceptionDataCollector;
  */
 final class ExceptionCollectorFormatter implements CollectorFormatterInterface
 {
+    /**
+     * Ordered regex => replacement pairs scrubbing high-confidence secret shapes
+     * from free-text exception messages.
+     *
+     * @var array<string, string>
+     */
+    private const SECRET_MESSAGE_PATTERNS = [
+        // DSN / URL userinfo password: scheme://[user]:pass@host (the user may be
+        // empty, e.g. Redis/AMQP DSNs like redis://:pass@host).
+        '#([a-z][a-z0-9+.\-]*://[^/\s:@]*:)[^/\s@]+(@)#i' => '$1***REDACTED***$2',
+        // Authorization scheme tokens (Bearer / Basic / Digest).
+        '/\b(Bearer|Basic|Digest)\s+[A-Za-z0-9+\/=._\-]+/i' => '$1 ***REDACTED***',
+        // sensitive key=value / key: value. The sensitive word may sit anywhere
+        // in the key (e.g. client_secret, secret_key); the separator allows the
+        // quoting of JSON (`"password":"x"`); the value may be a quoted run
+        // (incl. spaces) or an unquoted token up to the next delimiter. The colon
+        // must not be a `::` (PHP scope resolution) to avoid eating class names.
+        '/([\w.\-]*(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|signing[_-]?key|encryption[_-]?key|credential|authorization)[\w.\-]*)(["\']?\s*(?:=|:(?!:))\s*)(?:"[^"]*"|\'[^\']*\'|[^\s,;]+)/i' => '$1$2***REDACTED***',
+    ];
+
     public function getName(): string
     {
         return 'exception';
@@ -45,7 +70,7 @@ final class ExceptionCollectorFormatter implements CollectorFormatterInterface
 
         return [
             'has_exception' => true,
-            'message' => $collector->getMessage(),
+            'message' => $this->scrubMessage($collector->getMessage()),
             'status_code' => $collector->getStatusCode(),
             'class' => $exception->getClass(),
             'file' => $exception->getFile(),
@@ -68,9 +93,25 @@ final class ExceptionCollectorFormatter implements CollectorFormatterInterface
 
         return [
             'has_exception' => true,
-            'message' => $collector->getMessage(),
+            'message' => $this->scrubMessage($collector->getMessage()),
             'class' => $exception->getClass(),
         ];
+    }
+
+    private function scrubMessage(string $message): string
+    {
+        foreach (self::SECRET_MESSAGE_PATTERNS as $pattern => $replacement) {
+            $result = preg_replace($pattern, $replacement, $message);
+            if (null === $result) {
+                // PCRE failure (e.g. backtrack limit on a pathological message):
+                // fail closed rather than returning the original, un-scrubbed text.
+                return '***REDACTED*** (exception message withheld: scrubbing failed)';
+            }
+
+            $message = $result;
+        }
+
+        return $message;
     }
 
     /**

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/ExceptionCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/ExceptionCollectorFormatterTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\ExceptionCollectorFormatter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\ExceptionDataCollector;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ExceptionCollectorFormatterTest extends TestCase
+{
+    private ExceptionCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new ExceptionCollectorFormatter();
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('exception', $this->formatter->getName());
+    }
+
+    public function testFormatWithoutException()
+    {
+        $collector = new ExceptionDataCollector();
+        $collector->collect(new Request(), new Response());
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertFalse($result['has_exception']);
+    }
+
+    public function testFormatKeepsActionableFieldsAndScrubsSecretsFromMessage()
+    {
+        $message = 'Connection to mysql://app:s3cr3t-pw@db:3306 failed; token=ABC123DEF; Authorization: Bearer XYZ.789.abc';
+        $collector = $this->collect(new \RuntimeException($message));
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertTrue($result['has_exception']);
+        $this->assertStringContainsString('RuntimeException', $result['class']);
+        $this->assertArrayHasKey('file', $result);
+        $this->assertArrayHasKey('line', $result);
+        $this->assertIsArray($result['trace']);
+
+        // High-confidence secret shapes are scrubbed.
+        $this->assertStringContainsString('REDACTED', $result['message']);
+        $serialized = json_encode($result);
+        $this->assertStringNotContainsString('s3cr3t-pw', $serialized);
+        $this->assertStringNotContainsString('ABC123DEF', $serialized);
+        $this->assertStringNotContainsString('XYZ.789.abc', $serialized);
+
+        // Non-secret context in the message is preserved.
+        $this->assertStringContainsString('Connection to', $result['message']);
+        $this->assertStringContainsString('failed', $result['message']);
+    }
+
+    public function testFormatScrubsPasswordOnlyDsnAndCompoundSecretKeys()
+    {
+        $message = 'redis://:r3disPw@localhost:6379 down; client_secret=cs-LEAK, secret_key=sk-LEAK, private_key=pk-LEAK';
+        $collector = $this->collect(new \RuntimeException($message));
+
+        $result = $this->formatter->format($collector);
+
+        $serialized = json_encode($result);
+        $this->assertStringNotContainsString('r3disPw', $serialized);
+        $this->assertStringNotContainsString('cs-LEAK', $serialized);
+        $this->assertStringNotContainsString('sk-LEAK', $serialized);
+        $this->assertStringNotContainsString('pk-LEAK', $serialized);
+
+        // Non-secret context survives.
+        $this->assertStringContainsString('localhost', $result['message']);
+        $this->assertStringContainsString('down', $result['message']);
+    }
+
+    public function testFormatScrubsBasicAuthJsonAndQuotedValues()
+    {
+        $message = 'HTTP 401 Authorization: Basic dXNlcjpwYXNzd29yZA== body {"password":"jsonPW","user":"alice"} cfg password=\'my secret pw\'';
+        $collector = $this->collect(new \RuntimeException($message));
+
+        $result = $this->formatter->format($collector);
+
+        $serialized = json_encode($result);
+        $this->assertStringNotContainsString('dXNlcjpwYXNzd29yZA', $serialized);
+        $this->assertStringNotContainsString('jsonPW', $serialized);
+        $this->assertStringNotContainsString('my secret pw', $serialized);
+
+        // A non-secret JSON field next to the redacted one survives.
+        $this->assertStringContainsString('alice', $result['message']);
+    }
+
+    public function testFormatDoesNotRedactClassNameScopeResolution()
+    {
+        $collector = $this->collect(new \RuntimeException('Access denied by Security\\TokenStorage::getToken()'));
+
+        $result = $this->formatter->format($collector);
+
+        // `TokenStorage::getToken` must not be mistaken for a `token:` key=value.
+        $this->assertStringContainsString('TokenStorage::getToken', $result['message']);
+    }
+
+    public function testFormatLeavesPlainMessageUntouched()
+    {
+        $collector = $this->collect(new \RuntimeException('Call to undefined method App\\Service::handle()'));
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame('Call to undefined method App\\Service::handle()', $result['message']);
+    }
+
+    public function testGetSummaryScrubsSecretsFromMessage()
+    {
+        $collector = $this->collect(new \RuntimeException('auth failed: password=hunter2'));
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertTrue($result['has_exception']);
+        $this->assertStringNotContainsString('hunter2', json_encode($result));
+        $this->assertStringContainsString('REDACTED', $result['message']);
+    }
+
+    public function testGetSummaryWithoutException()
+    {
+        $collector = new ExceptionDataCollector();
+        $collector->collect(new Request(), new Response());
+
+        $result = $this->formatter->getSummary($collector);
+
+        $this->assertFalse($result['has_exception']);
+    }
+
+    private function collect(\Throwable $exception): ExceptionDataCollector
+    {
+        $collector = new ExceptionDataCollector();
+        $collector->collect(new Request(), new Response(), $exception);
+
+        return $collector;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT


The `exception` collector returned `getMessage()` verbatim. Exception messages
frequently embed secrets: DSN / connection-string passwords
(`mysql://user:pass@host`, `redis://:pass@host`), `token=`/`password=` fragments,
JSON bodies (`"password":"…"`), and Authorization headers (Bearer/Basic/Digest).

Scrub high-confidence secret shapes from the message in `format()` and
`getSummary()` (URL userinfo, auth-scheme tokens, and sensitive `key=value` /
quoted / JSON values), while keeping the class, file, line and trace — the
actionable parts. Scrubbing fails closed (a PCRE failure withholds the message
rather than leaking it), and `::` scope-resolution in class names is not mistaken
for a `key:value`. Adds the previously missing test coverage.

