### PR TITLE
[Mate] Redact sensitive log context in profiler logger collector

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/LoggerCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/LoggerCollectorFormatter.php
@@ -31,6 +31,44 @@ final class LoggerCollectorFormatter implements CollectorFormatterInterface
 {
     private const MAX_LOGS = 100;
 
+    /**
+     * Key-name substrings (case-insensitive) used to redact values in the log
+     * context, where application code routinely puts tokens, credentials, session
+     * identifiers and auth details. Bare `KEY` and `AUTH` are intentionally
+     * excluded to avoid redacting common non-sensitive keys (`key`, `author`);
+     * the narrower `AUTHORIZATION`/`AUTHENTICATION`/`OAUTH` cover the real cases.
+     *
+     * @var array<string>
+     */
+    private const SENSITIVE_CONTEXT_KEY_PATTERNS = [
+        'PASSWORD',
+        'PASSWD',
+        'PASSPHRASE',
+        'PWD',
+        'SECRET',
+        'TOKEN',
+        'JWT',
+        'API_KEY',
+        'APIKEY',
+        'ACCESS_KEY',
+        'SIGNING_KEY',
+        'ENCRYPTION_KEY',
+        'OAUTH',
+        'AUTHORIZATION',
+        'AUTHENTICATION',
+        'CREDENTIAL',
+        'PRIVATE',
+        'BEARER',
+        'CSRF',
+        'XSRF',
+        'SESSION',
+        'SESSID',
+        'SIGNATURE',
+        'SALT',
+        'COOKIE',
+        'OTP',
+    ];
+
     public function getName(): string
     {
         return 'logger';
@@ -85,6 +123,10 @@ final class LoggerCollectorFormatter implements CollectorFormatterInterface
                 $context = $context->getValue(true);
             }
 
+            if (\is_array($context)) {
+                $context = $this->redactContext($context);
+            }
+
             $formatted[] = [
                 'type' => $log['type'] ?? null,
                 'timestamp' => $log['timestamp'] ?? null,
@@ -98,5 +140,41 @@ final class LoggerCollectorFormatter implements CollectorFormatterInterface
         }
 
         return $formatted;
+    }
+
+    /**
+     * Recursively redact values whose key matches a sensitive pattern.
+     *
+     * @param array<array-key, mixed> $context
+     *
+     * @return array<array-key, mixed>
+     */
+    private function redactContext(array $context): array
+    {
+        foreach ($context as $key => $value) {
+            if (\is_string($key) && $this->isSensitiveContextKey($key)) {
+                $context[$key] = '***REDACTED***';
+                continue;
+            }
+
+            if (\is_array($value)) {
+                $context[$key] = $this->redactContext($value);
+            }
+        }
+
+        return $context;
+    }
+
+    private function isSensitiveContextKey(string $key): bool
+    {
+        // Normalise hyphens to underscores so `api-key` matches the patterns too.
+        $upperKey = str_replace('-', '_', strtoupper($key));
+        foreach (self::SENSITIVE_CONTEXT_KEY_PATTERNS as $pattern) {
+            if (str_contains($upperKey, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/LoggerCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/LoggerCollectorFormatterTest.php
@@ -107,6 +107,62 @@ final class LoggerCollectorFormatterTest extends TestCase
         $this->assertFalse($result['logs_truncated']);
     }
 
+    public function testFormatRedactsSensitiveContextValues()
+    {
+        $context = $this->createMock(Data::class);
+        $context->method('getValue')->with(true)->willReturn([
+            'user_id' => 42,
+            'author' => 'jane',
+            'password' => 'hunter2',
+            'access_token' => 'tok-secret',
+            'jwt' => 'jwt-secret',
+            'session_id' => 'sess-secret',
+            'cookie' => 'cookie-secret',
+            'nested' => ['api_key' => 'k-secret', 'note' => 'visible'],
+        ]);
+
+        $collector = $this->createMock(LoggerDataCollector::class);
+        $collector->method('countErrors')->willReturn(0);
+        $collector->method('countWarnings')->willReturn(0);
+        $collector->method('countDeprecations')->willReturn(0);
+        $collector->method('countScreams')->willReturn(0);
+        $collector->method('getProcessedLogs')->willReturn([
+            [
+                'type' => 'info',
+                'timestamp' => 1234567890.0,
+                'priority' => 200,
+                'priorityName' => 'INFO',
+                'channel' => 'security',
+                'message' => 'Authentication attempt',
+                'context' => $context,
+                'errorCount' => 0,
+            ],
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $logContext = $result['logs'][0]['context'];
+        // Non-sensitive keys stay visible, including the easily-over-matched `author`.
+        $this->assertSame(42, $logContext['user_id']);
+        $this->assertSame('jane', $logContext['author']);
+        $this->assertSame('visible', $logContext['nested']['note']);
+        // Sensitive keys (incl. jwt/session/cookie) are redacted, recursively.
+        $this->assertSame('***REDACTED***', $logContext['password']);
+        $this->assertSame('***REDACTED***', $logContext['access_token']);
+        $this->assertSame('***REDACTED***', $logContext['jwt']);
+        $this->assertSame('***REDACTED***', $logContext['session_id']);
+        $this->assertSame('***REDACTED***', $logContext['cookie']);
+        $this->assertSame('***REDACTED***', $logContext['nested']['api_key']);
+
+        $serialized = json_encode($result);
+        $this->assertStringNotContainsString('hunter2', $serialized);
+        $this->assertStringNotContainsString('tok-secret', $serialized);
+        $this->assertStringNotContainsString('jwt-secret', $serialized);
+        $this->assertStringNotContainsString('sess-secret', $serialized);
+        $this->assertStringNotContainsString('cookie-secret', $serialized);
+        $this->assertStringNotContainsString('k-secret', $serialized);
+    }
+
     public function testFormatTruncatesAt100Logs()
     {
         $logs = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT


The `logger` collector returned each entry's full `context` array verbatim (up
to 100 entries). The Symfony security channel logs authentication events and
application code routinely puts reset tokens, credentials, session ids and PII
into the context, so secrets reached the AI directly.

Apply recursive key-based redaction to the context, masking values whose key
matches a sensitive pattern (incl. `jwt`/`session`/`cookie`/`signature`;
hyphenated keys normalised; bare `KEY`/`AUTH` excluded so `key`/`author`
survive). The log message is left intact as free-text diagnostic signal.

