### PR TITLE
[Demo] Fix PHPStan error in image Resampler

### DIFF
--- a/demo/src/Crop/Image/Resampler.php
+++ b/demo/src/Crop/Image/Resampler.php
@@ -65,7 +65,9 @@ final readonly class Resampler
 
     private function encode(\GdImage $image, string $mimeType): string
     {
-        ob_start();
+        if (false === ob_start()) {
+            throw new \RuntimeException('Failed to start output buffering.');
+        }
 
         $ok = match ($mimeType) {
             'image/png' => imagepng($image),
@@ -78,7 +80,7 @@ final readonly class Resampler
 
         $bytes = ob_get_clean();
 
-        if (false === $ok || false === $bytes) {
+        if (false === $ok) {
             throw new \RuntimeException('Failed to encode the image.');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

`PHPStan / Demo` is red on `main`: level 8 flags a strict comparison in
`demo/src/Crop/Image/Resampler.php` as always false —

```
src/Crop/Image/Resampler.php:81
Strict comparison using === between false and string will always evaluate to false.
```

After a successful `ob_start()`, `ob_get_clean()` is typed as `string`, so the
`false === $bytes` guard is unused code. The call that can actually fail is
`ob_start()`, whose return value was being ignored — check that instead and drop
the impossible `$bytes` comparison. `cd demo && vendor/bin/phpstan` is green
again.
