### PR TITLE
[Mate] Ask for the PHP binary in init and support containerized setups

### DIFF
--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -49,6 +49,12 @@ This creates:
 * ``mcp.json`` for MCP clients that support it (e.g. Claude Desktop)
 * ``bin/codex`` and ``bin/codex.bat`` wrappers for Codex runtime MCP injection
 
+While generating ``mcp.json``, ``mate init`` asks which PHP binary the coding agent should use to
+launch the server. The default is detected from the environment: for a containerized setup where
+a ``.ddev/`` directory is present, it defaults to ``ddev exec php`` so the host-side agent starts
+Mate inside the container; otherwise it defaults to ``php``. Accept the default or provide your own
+launch command (for example ``docker compose exec php php`` for a plain Docker Compose setup).
+
 It also updates your ``composer.json`` with the following configuration:
 
 .. code-block:: json

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Add PHP binary prompt to `mate init` (detects `.ddev/` and defaults the generated `mcp.json` launch command to `ddev exec php`, otherwise `php`) so the MCP server can be started from the host for containerized setups
+
 0.9
 ---
 

--- a/src/mate/resources/mcp.json
+++ b/src/mate/resources/mcp.json
@@ -1,12 +1,8 @@
 {
     "mcpServers": {
         "symfony-ai-mate": {
-            "command": "php",
-            "args": [
-                "./vendor/bin/mate",
-                "serve",
-                "--force-keep-alive"
-            ]
+            "command": "##PHP_BINARY##",
+            "args": ["##MATE_ARGS##"]
         }
     }
 }

--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -100,8 +100,16 @@ class InitCommand extends Command
             }
         }
 
-        // Create symlink from .mcp.json to mcp.json for compatibility
+        // Only prompt when the freshly written mcp.json still carries the
+        // placeholders; a kept existing file has nothing left to configure.
         $mcpJsonPath = $this->rootDir.'/mcp.json';
+        if ($this->mcpJsonNeedsPhpBinary($mcpJsonPath)) {
+            $phpBinary = $this->resolvePhpBinary($io);
+            $this->applyPhpBinaryToMcpJson($mcpJsonPath, $phpBinary);
+            $actions[] = ['✓', 'Configured', \sprintf('mcp.json launch command ("%s")', $phpBinary)];
+        }
+
+        // Create symlink from .mcp.json to mcp.json for compatibility
         $mcpJsonSymlink = $this->rootDir.'/.mcp.json';
         if (file_exists($mcpJsonPath)) {
             if (is_link($mcpJsonSymlink)) {
@@ -186,6 +194,58 @@ class InitCommand extends Command
         if (\in_array($template, self::SENSITIVE_FILES, true)) {
             @chmod($destination, FilePermissions::FILE);
         }
+    }
+
+    /**
+     * PHP binary the agent uses to launch Mate, defaulted by environment
+     * detection (containers such as DDEV need a wrapper) and confirmed by the user.
+     */
+    private function resolvePhpBinary(SymfonyStyle $io): string
+    {
+        $default = is_dir($this->rootDir.'/.ddev') ? 'ddev exec php' : 'php';
+
+        return trim($io->ask('PHP binary to run Mate for your coding agent', $default) ?? $default);
+    }
+
+    /**
+     * Whether the mcp.json at the given path still holds the unresolved
+     * placeholders, i.e. it was just written from the template this run.
+     */
+    private function mcpJsonNeedsPhpBinary(string $mcpJsonPath): bool
+    {
+        $contents = @file_get_contents($mcpJsonPath);
+
+        return \is_string($contents) && str_contains($contents, '##PHP_BINARY##');
+    }
+
+    /**
+     * Replace the mcp.json placeholders with the PHP binary. A multi-word binary
+     * (e.g. "ddev exec php") is split into the command and its leading args.
+     */
+    private function applyPhpBinaryToMcpJson(string $mcpJsonPath, string $phpBinary): void
+    {
+        $parts = preg_split('/\s+/', trim($phpBinary), -1, \PREG_SPLIT_NO_EMPTY);
+        $contents = file_get_contents($mcpJsonPath);
+        if (false === $parts || [] === $parts || false === $contents) {
+            return;
+        }
+
+        $command = array_shift($parts);
+        $args = [...$parts, './vendor/bin/mate', 'serve', '--force-keep-alive'];
+        $encodedArgs = implode(', ', array_map(
+            static fn (string $arg): string => json_encode($arg, \JSON_UNESCAPED_SLASHES),
+            $args
+        ));
+
+        // The args placeholder is quoted in the template so it stays valid JSON;
+        // the encoded fragment brings its own quotes, so the quotes are replaced too.
+        $contents = str_replace(
+            ['##PHP_BINARY##', '"##MATE_ARGS##"'],
+            [$command, $encodedArgs],
+            $contents
+        );
+
+        file_put_contents($mcpJsonPath, $contents);
     }
 
     /**

--- a/src/mate/tests/Command/InitCommandTest.php
+++ b/src/mate/tests/Command/InitCommandTest.php
@@ -139,6 +139,92 @@ final class InitCommandTest extends TestCase
         $this->assertFileExists($this->tempDir.'/mate/config.php');
     }
 
+    public function testMcpJsonUsesPhpBinaryByDefault()
+    {
+        $command = $this->createCommand();
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        $mcpJson = $this->readMcpJson();
+        $this->assertSame('php', $mcpJson['mcpServers']['symfony-ai-mate']['command']);
+        $this->assertSame(
+            ['./vendor/bin/mate', 'serve', '--force-keep-alive'],
+            $mcpJson['mcpServers']['symfony-ai-mate']['args']
+        );
+    }
+
+    public function testMcpJsonDefaultsToDdevWrapperWhenDdevDetected()
+    {
+        mkdir($this->tempDir.'/.ddev', 0755, true);
+
+        $command = $this->createCommand();
+        $tester = new CommandTester($command);
+
+        // Accept the detected default by submitting an empty answer.
+        $tester->setInputs(['']);
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        $mcpJson = $this->readMcpJson();
+        $this->assertSame('ddev', $mcpJson['mcpServers']['symfony-ai-mate']['command']);
+        $this->assertSame(
+            ['exec', 'php', './vendor/bin/mate', 'serve', '--force-keep-alive'],
+            $mcpJson['mcpServers']['symfony-ai-mate']['args']
+        );
+    }
+
+    public function testMcpJsonUsesProvidedPhpBinary()
+    {
+        $command = $this->createCommand();
+        $tester = new CommandTester($command);
+
+        $tester->setInputs(['docker compose exec php php']);
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        $mcpJson = $this->readMcpJson();
+        $this->assertSame('docker', $mcpJson['mcpServers']['symfony-ai-mate']['command']);
+        $this->assertSame(
+            ['compose', 'exec', 'php', 'php', './vendor/bin/mate', 'serve', '--force-keep-alive'],
+            $mcpJson['mcpServers']['symfony-ai-mate']['args']
+        );
+    }
+
+    public function testKeepsExistingMcpJsonUntouchedWhenOverwriteDeclined()
+    {
+        $existing = <<<'JSON'
+            {
+                "mcpServers": {
+                    "symfony-ai-mate": {
+                        "command": "my-custom-php",
+                        "args": ["./vendor/bin/mate", "serve"]
+                    }
+                }
+            }
+            JSON;
+        file_put_contents($this->tempDir.'/mcp.json', $existing);
+
+        $command = $this->createCommand();
+        $tester = new CommandTester($command);
+
+        // Decline overwriting the existing mcp.json; no PHP binary prompt should follow.
+        $tester->setInputs(['no']);
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        // The user's file is left exactly as-is, with no placeholder resolution.
+        $this->assertSame($existing, file_get_contents($this->tempDir.'/mcp.json'));
+        // And the command neither prompts for a binary nor claims it configured one.
+        $display = $tester->getDisplay();
+        $this->assertStringNotContainsString('PHP binary to run Mate', $display);
+        $this->assertStringNotContainsString('Configured', $display);
+    }
+
     public function testSetsExtensionFalseByDefault()
     {
         // Create composer.json without ai-mate config
@@ -186,6 +272,20 @@ final class InitCommandTest extends TestCase
         $materializer = new AgentInstructionsMaterializer($this->tempDir, $aggregator, $logger);
 
         return new InitCommand($this->tempDir, $materializer);
+    }
+
+    /**
+     * @return array{mcpServers: array{symfony-ai-mate: array{command: string, args: list<string>}}}
+     */
+    private function readMcpJson(): array
+    {
+        $content = file_get_contents($this->tempDir.'/mcp.json');
+        $this->assertIsString($content);
+
+        $decoded = json_decode($content, true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
     }
 
     private function removeDirectory(string $dir): void


### PR DESCRIPTION
| Q             | A
  | ------------- | ---
  | Bug fix?      | no
  | New feature?  | yes
  | Docs?         | yes
  | Issues        | Fix #2264
  | License       | MIT

  `mate init` generates an `mcp.json` that the coding agent launches on the **host**. In a
  containerized setup (DDEV, and Docker-based envs generally) PHP only exists inside the
  container, so the default `./vendor/bin/mate` command can't start and Claude Code shows the
  server as failed. Reported in #2264.

  This makes `init` ask which PHP binary the agent should use to launch Mate, and detects a
  sensible default from the environment:

  - if a `.ddev/` directory is present → default `ddev exec php`
  - otherwise → default `php`

  The prompt is offered interactively (accept the default or override); under
  `--no-interaction` the detected default is used, so CI/scripted runs don't block. The
  answer is written into the generated `mcp.json` — the first token becomes `command` and the
  rest are prepended to `args`.

  ### Example

  DDEV project (`.ddev/` detected):

      $ vendor/bin/mate init
       PHP binary to run Mate for your coding agent [ddev exec php]:
       >

  produces:

  ```json
  {
      "mcpServers": {
          "symfony-ai-mate": {
              "command": "ddev",
              "args": ["exec", "php", "vendor/bin/mate", "serve", "--force-keep-alive"]
          }
      }
  }

  A plain Docker Compose user can instead type e.g. docker compose exec php php.

  Note

  The non-container default now emits php vendor/bin/mate … rather than the previous
  ./vendor/bin/mate …. It's functionally equivalent (and a bit more portable), but happy to
  special-case plain php back to ./vendor/bin/mate if you'd prefer zero change for the
  common case.

  I don't use DDEV enough to be sure the detection covers every layout — the .ddev/ check is
  deliberately minimal; generic Docker/Sail/Lando are left to the manual override for now.