### PR TITLE
[Platform][ElevenLabs] Implement speech-to-text functionality with support for additional formats and options

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -806,6 +806,54 @@ Code Examples
 
 * `Audio Output with GPT`_
 
+Speech-to-Text
+--------------
+
+Some models can transcribe audio into text. Pass an
+:class:`Symfony\\AI\\Platform\\Message\\Content\\Audio` as input and read the transcript
+through ``asText()``::
+
+    use Symfony\AI\Platform\Bridge\ElevenLabs\Factory;
+    use Symfony\AI\Platform\Message\Content\Audio;
+
+    // Initialize Platform
+
+    $result = $platform->invoke(
+        model: 'scribe_v2',
+        input: Audio::fromFile('/path/audio.mp3'),
+    );
+
+    echo $result->asText(); // "Hello there"
+
+ElevenLabs Scribe accepts provider-specific options that are forwarded to the
+``/v1/speech-to-text`` request, such as ``language_code``, ``diarize``,
+``num_speakers``, ``timestamps_granularity`` and ``additional_formats``. When
+``additional_formats`` is requested, the result is exposed as a structured
+:class:`Symfony\\AI\\Platform\\Bridge\\ElevenLabs\\Result\\Transcript` object through
+``asObject()`` instead of a plain text result::
+
+    $result = $platform->invoke(
+        model: 'scribe_v2',
+        input: Audio::fromFile('/path/audio.mp3'),
+        options: [
+            'language_code' => 'en',
+            'diarize' => true,
+            'timestamps_granularity' => 'word',
+            'additional_formats' => [
+                ['format' => 'srt', 'include_timestamps' => true],
+            ],
+        ],
+    );
+
+    echo $result->asObject()->getText(); // the plain transcript
+    echo $result->asObject()->asSubRipText(); // the SRT subtitles
+    echo $result->asObject()->getAdditionalFormat('srt'); // the SRT subtitles
+
+Code Examples
+~~~~~~~~~~~~~
+
+* `ElevenLabs Speech-to-Text with SRT`_
+
 Document OCR
 ------------
 
@@ -1442,6 +1490,7 @@ Code Examples
 .. _`Image URL Input with GPT`: https://github.com/symfony/ai/blob/main/examples/openai/image-input-url.php
 .. _`Audio Input with GPT`: https://github.com/symfony/ai/blob/main/examples/openai/audio-input.php
 .. _`Audio Output with GPT`: https://github.com/symfony/ai/blob/main/examples/openai/audio-output.php
+.. _`ElevenLabs Speech-to-Text with SRT`: https://github.com/symfony/ai/blob/main/examples/elevenlabs/speech-to-text-srt.php
 .. _`PDF Input with GPT`: https://github.com/symfony/ai/blob/main/examples/openai/pdf-input-binary.php
 .. _`PDF Input with Claude`: https://github.com/symfony/ai/blob/main/examples/anthropic/pdf-input-binary.php
 .. _`OCR with Mistral (URL)`: https://github.com/symfony/ai/blob/main/examples/mistral/ocr-url.php

--- a/examples/elevenlabs/speech-to-text-srt.php
+++ b/examples/elevenlabs/speech-to-text-srt.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\ElevenLabs\Factory;
+use Symfony\AI\Platform\Message\Content\Audio;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(apiKey: env('ELEVEN_LABS_API_KEY'), httpClient: http_client());
+
+$result = $platform->invoke(
+    model: 'scribe_v2',
+    input: Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3'),
+    options: [
+        'language_code' => 'en',
+        'tag_audio_events' => false,
+        'num_speakers' => 1,
+        'diarize' => true,
+        'timestamps_granularity' => 'word',
+        'additional_formats' => [
+            ['format' => 'srt', 'include_timestamps' => true],
+        ],
+    ],
+);
+
+echo $result->asObject()->asSubRipText().\PHP_EOL;

--- a/src/platform/src/Bridge/ElevenLabs/CHANGELOG.md
+++ b/src/platform/src/Bridge/ElevenLabs/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ----
 
  * Tolerate an `endpoint` configured with or without a trailing slash
+ * Forward speech-to-text options (`language_code`, `tag_audio_events`, `num_speakers`, `diarize`, `timestamps_granularity`, `additional_formats`, ...) to the ElevenLabs `/v1/speech-to-text` request body
+ * Expose the additional transcript formats returned by ElevenLabs (e.g. SRT subtitles) through a typed `Transcript` object: when the `additional_formats` option is requested, the converter returns an `ObjectResult` wrapping a `Transcript` (readable via `ResultInterface::asObject()`), otherwise it returns a plain `TextResult` (readable via `asText()`); each format is a typed `AdditionalFormat` value object (with `requested_format`, `file_extension`, `content_type`, `is_base64_encoded` and `content`), accessible through `Transcript::getAdditionalFormats()`
 
 0.8
 ---

--- a/src/platform/src/Bridge/ElevenLabs/ElevenLabsClient.php
+++ b/src/platform/src/Bridge/ElevenLabs/ElevenLabsClient.php
@@ -37,7 +37,10 @@ final class ElevenLabsClient implements ModelClientInterface
     public function request(Model $model, array|string $payload, array $options = []): RawResultInterface
     {
         return match (true) {
-            $model->supports(Capability::SPEECH_TO_TEXT) => $this->doSpeechToTextRequest($model, $payload),
+            $model->supports(Capability::SPEECH_TO_TEXT) => $this->doSpeechToTextRequest($model, $payload, [
+                ...$options,
+                ...$model->getOptions(),
+            ]),
             $model->supports(Capability::TEXT_TO_SPEECH) => $this->doTextToSpeechRequest($model, $payload, [
                 ...$options,
                 ...$model->getOptions(),
@@ -48,8 +51,9 @@ final class ElevenLabsClient implements ModelClientInterface
 
     /**
      * @param array<string|int, mixed> $payload
+     * @param array<string, mixed>     $options
      */
-    private function doSpeechToTextRequest(Model $model, array|string $payload): RawHttpResult
+    private function doSpeechToTextRequest(Model $model, array|string $payload, array $options = []): RawHttpResult
     {
         if (!\is_array($payload)) {
             throw new InvalidArgumentException(\sprintf('Payload must be an array for speech-to-text request, got "%s".', \gettype($payload)));
@@ -63,12 +67,52 @@ final class ElevenLabsClient implements ModelClientInterface
             throw new InvalidArgumentException('Input audio must be an array with a "path" key for speech-to-text request.');
         }
 
+        $body = [
+            'file' => fopen($payload['input_audio']['path'], 'r'),
+            'model_id' => $model->getName(),
+        ];
+
+        foreach ($options as $key => $value) {
+            if (null === $value) {
+                continue;
+            }
+
+            $body[$key] = $this->stringifySpeechToTextOption($key, $value);
+        }
+
         return new RawHttpResult($this->httpClient->request('POST', 'speech-to-text', [
-            'body' => [
-                'file' => fopen($payload['input_audio']['path'], 'r'),
-                'model_id' => $model->getName(),
-            ],
+            'body' => $body,
         ]));
+    }
+
+    /**
+     * ElevenLabs expects the speech-to-text multipart fields to be sent as plain
+     * strings: booleans as `true`/`false`, integers as their string representation
+     * and array-shaped options (e.g. `additional_formats`) as a JSON-encoded string.
+     */
+    private function stringifySpeechToTextOption(int|string $key, mixed $value): string
+    {
+        if (\is_array($value)) {
+            try {
+                return json_encode($value, \JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                throw new InvalidArgumentException(\sprintf('The speech-to-text option "%s" could not be JSON-encoded.', $key), 0, $e);
+            }
+        }
+
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (\is_string($value)) {
+            return $value;
+        }
+
+        if (\is_scalar($value)) {
+            return (string) $value;
+        }
+
+        throw new InvalidArgumentException(\sprintf('The speech-to-text option "%s" must be a scalar or an array, got "%s".', $key, get_debug_type($value)));
     }
 
     /**

--- a/src/platform/src/Bridge/ElevenLabs/ElevenLabsResultConverter.php
+++ b/src/platform/src/Bridge/ElevenLabs/ElevenLabsResultConverter.php
@@ -11,9 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\ElevenLabs;
 
+use Symfony\AI\Platform\Bridge\ElevenLabs\Result\AdditionalFormat;
+use Symfony\AI\Platform\Bridge\ElevenLabs\Result\Transcript;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
+use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -55,7 +58,7 @@ final class ElevenLabsResultConverter implements ResultConverterInterface
         return match (true) {
             str_contains($response->getInfo('url'), 'text-to-speech') && \array_key_exists('stream', $options) && $options['stream'] => new StreamResult($this->convertToGenerator($response)),
             str_contains($response->getInfo('url'), 'text-to-speech') => new BinaryResult($response->getContent(), 'audio/mpeg'),
-            str_contains($response->getInfo('url'), 'speech-to-text') => new TextResult($result->getData()['text']),
+            str_contains($response->getInfo('url'), 'speech-to-text') => $this->convertSpeechToTextResult($result, $options),
             default => throw new RuntimeException('Unsupported ElevenLabs response.'),
         };
     }
@@ -63,6 +66,35 @@ final class ElevenLabsResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): null
     {
         return null;
+    }
+
+    /**
+     * The speech-to-text response always carries the plain transcript text and, when
+     * the user requested it through the `additional_formats` option, the additional
+     * export formats (e.g. SRT subtitles) alongside it.
+     *
+     * To keep the result unambiguous, the converter mirrors the Whisper bridge: when
+     * no `additional_formats` option was requested it returns a plain `TextResult`
+     * (readable through `ResultInterface::asText()`), and when additional formats were
+     * requested it returns an `ObjectResult` wrapping a `Transcript` that carries both
+     * the transcript text and the decoded export formats (readable through `asObject()`).
+     *
+     * @param array<string, mixed> $options
+     */
+    private function convertSpeechToTextResult(RawResultInterface $result, array $options): ResultInterface
+    {
+        $data = $result->getData();
+        $text = $data['text'] ?? '';
+
+        if ([] === ($options['additional_formats'] ?? [])) {
+            return new TextResult($text);
+        }
+
+        $additionalFormats = \is_array($data['additional_formats'] ?? null)
+            ? array_values(array_map(AdditionalFormat::fromArray(...), $data['additional_formats']))
+            : [];
+
+        return new ObjectResult(new Transcript($text, $additionalFormats));
     }
 
     private function convertToGenerator(ResponseInterface $response): \Generator

--- a/src/platform/src/Bridge/ElevenLabs/Result/AdditionalFormat.php
+++ b/src/platform/src/Bridge/ElevenLabs/Result/AdditionalFormat.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\ElevenLabs\Result;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+
+/**
+ * A single additional export format returned by the ElevenLabs speech-to-text
+ * endpoint alongside the plain transcript (e.g. SRT subtitles, plain text, HTML).
+ *
+ * Regardless of the requested format, ElevenLabs always reports the same set of
+ * metadata: the identifier of the format that was requested, its file extension,
+ * the related content type, whether the content is base64-encoded and the
+ * content payload itself.
+ *
+ * @see https://elevenlabs.io/docs/api-reference/speech-to-text/convert
+ *
+ * @author Dmytro Khaperets <khaperets@gmail.com>
+ */
+final class AdditionalFormat
+{
+    /**
+     * @param string $requestedFormat Identifier of the format that was requested (e.g. `srt`, `txt`, `html`)
+     * @param string $fileExtension   File extension associated with the format, including the leading dot (e.g. `.srt`)
+     * @param string $contentType     MIME type associated with the format (e.g. `text/plain`)
+     * @param bool   $isBase64Encoded Whether the {@see $content} payload is base64-encoded
+     * @param string $content         The raw content payload, base64-encoded when {@see $isBase64Encoded} is true
+     */
+    public function __construct(
+        private readonly string $requestedFormat,
+        private readonly string $fileExtension,
+        private readonly string $contentType,
+        private readonly bool $isBase64Encoded,
+        private readonly string $content,
+    ) {
+    }
+
+    /**
+     * Builds an instance from the raw payload returned by ElevenLabs.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['requested_format'] ?? '',
+            $data['file_extension'] ?? '',
+            $data['content_type'] ?? '',
+            $data['is_base64_encoded'] ?? false,
+            $data['content'] ?? '',
+        );
+    }
+
+    public function getRequestedFormat(): string
+    {
+        return $this->requestedFormat;
+    }
+
+    public function getFileExtension(): string
+    {
+        return $this->fileExtension;
+    }
+
+    public function getContentType(): string
+    {
+        return $this->contentType;
+    }
+
+    public function isBase64Encoded(): bool
+    {
+        return $this->isBase64Encoded;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * Returns the decoded content, decoding the base64 payload when ElevenLabs
+     * reported it as base64-encoded.
+     *
+     * @throws RuntimeException when the base64 payload could not be decoded
+     */
+    public function getDecodedContent(): string
+    {
+        if (!$this->isBase64Encoded) {
+            return $this->content;
+        }
+
+        $decoded = base64_decode($this->content, true);
+
+        if (false === $decoded) {
+            throw new RuntimeException(\sprintf('The base64-encoded content of the "%s" additional format could not be decoded.', $this->requestedFormat));
+        }
+
+        return $decoded;
+    }
+}

--- a/src/platform/src/Bridge/ElevenLabs/Result/Transcript.php
+++ b/src/platform/src/Bridge/ElevenLabs/Result/Transcript.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\ElevenLabs\Result;
+
+/**
+ * Transcript of an ElevenLabs speech-to-text (/v1/speech-to-text) request.
+ *
+ * It carries the plain transcript text alongside the additional export formats
+ * (e.g. SRT subtitles) that ElevenLabs returns when requested through the
+ * `additional_formats` multipart field.
+ *
+ * @see https://elevenlabs.io/docs/api-reference/speech-to-text/convert
+ *
+ * @author Dmytro Khaperets <khaperets@gmail.com>
+ */
+final class Transcript
+{
+    /**
+     * @param string                 $text              The plain transcript text
+     * @param list<AdditionalFormat> $additionalFormats The additional export formats returned by ElevenLabs
+     */
+    public function __construct(
+        private readonly string $text,
+        private readonly array $additionalFormats = [],
+    ) {
+    }
+
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @return list<AdditionalFormat>
+     */
+    public function getAdditionalFormats(): array
+    {
+        return $this->additionalFormats;
+    }
+
+    /**
+     * Returns the decoded content of the first additional format whose
+     * `requestedFormat` matches the given identifier (e.g. `srt`, `txt`, `html`).
+     *
+     * When ElevenLabs reports the content as base64-encoded, it is decoded
+     * before being returned. `null` is returned when the format was not
+     * requested; a {@see \Symfony\AI\Platform\Exception\RuntimeException} is
+     * thrown when the base64 payload could not be decoded.
+     */
+    public function getAdditionalFormat(string $format): ?string
+    {
+        foreach ($this->additionalFormats as $additionalFormat) {
+            if ($additionalFormat->getRequestedFormat() !== $format) {
+                continue;
+            }
+
+            return $additionalFormat->getDecodedContent();
+        }
+
+        return null;
+    }
+
+    /**
+     * Convenience accessor for the SubRip (SRT) subtitle content.
+     */
+    public function asSubRipText(): ?string
+    {
+        return $this->getAdditionalFormat('srt');
+    }
+}

--- a/src/platform/src/Bridge/ElevenLabs/Tests/ElevenLabsClientTest.php
+++ b/src/platform/src/Bridge/ElevenLabs/Tests/ElevenLabsClientTest.php
@@ -115,6 +115,59 @@ final class ElevenLabsClientTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testClientCanPerformSpeechToTextRequestWithOptions()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): JsonMockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.elevenlabs.io/v1/speech-to-text', $url);
+
+            $body = '';
+            $readChunk = $options['body'];
+            while ('' !== $chunk = $readChunk(8192)) {
+                $body .= $chunk;
+            }
+
+            $this->assertStringContainsString('Content-Disposition: form-data; name="model_id"', $body);
+            $this->assertStringContainsString('Content-Disposition: form-data; name="language_code"', $body);
+            $this->assertStringContainsString("language_code\"\r\n\r\npl\r\n", $body);
+            $this->assertStringContainsString('Content-Disposition: form-data; name="diarize"', $body);
+            $this->assertStringContainsString("diarize\"\r\n\r\ntrue\r\n", $body);
+            $this->assertStringContainsString('Content-Disposition: form-data; name="tag_audio_events"', $body);
+            $this->assertStringContainsString("tag_audio_events\"\r\n\r\nfalse\r\n", $body);
+            $this->assertStringContainsString('Content-Disposition: form-data; name="num_speakers"', $body);
+            $this->assertStringContainsString("num_speakers\"\r\n\r\n1\r\n", $body);
+            $this->assertStringContainsString('Content-Disposition: form-data; name="timestamps_granularity"', $body);
+            $this->assertStringContainsString("timestamps_granularity\"\r\n\r\nword\r\n", $body);
+            $this->assertStringContainsString('Content-Disposition: form-data; name="additional_formats"', $body);
+            $this->assertStringContainsString('{"format":"srt","include_timestamps":true}', $body);
+
+            return new JsonMockResponse([
+                'text' => 'foo',
+            ]);
+        }, 'https://api.elevenlabs.io/v1/');
+
+        $client = new ElevenLabsClient($httpClient);
+
+        $payload = (new AudioNormalizer())->normalize(Audio::fromFile(\dirname(__DIR__, 6).'/fixtures/audio.mp3'));
+
+        $client->request(new ElevenLabs('scribe_v2', [
+            Capability::INPUT_AUDIO,
+            Capability::OUTPUT_TEXT,
+            Capability::SPEECH_TO_TEXT,
+        ]), $payload, [
+            'language_code' => 'pl',
+            'tag_audio_events' => false,
+            'num_speakers' => 1,
+            'diarize' => true,
+            'timestamps_granularity' => 'word',
+            'additional_formats' => [
+                ['format' => 'srt', 'include_timestamps' => true],
+            ],
+        ]);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testClientCannotPerformTextToSpeechRequestWithoutValidPayload()
     {
         $mockHttpClient = new MockHttpClient([

--- a/src/platform/src/Bridge/ElevenLabs/Tests/ElevenLabsConverterTest.php
+++ b/src/platform/src/Bridge/ElevenLabs/Tests/ElevenLabsConverterTest.php
@@ -14,11 +14,15 @@ namespace Symfony\AI\Platform\Bridge\ElevenLabs\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\ElevenLabs\ElevenLabs;
 use Symfony\AI\Platform\Bridge\ElevenLabs\ElevenLabsResultConverter;
+use Symfony\AI\Platform\Bridge\ElevenLabs\Result\AdditionalFormat;
+use Symfony\AI\Platform\Bridge\ElevenLabs\Result\Transcript;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -40,6 +44,124 @@ final class ElevenLabsConverterTest extends TestCase
         $converter = new ElevenLabsResultConverter(new MockHttpClient());
         $rawResult = new InMemoryRawResult([
             'text' => 'Hello there',
+        ], [], new class {
+            public function getStatusCode(): int
+            {
+                return 200;
+            }
+
+            public function getInfo(): string
+            {
+                return 'speech-to-text';
+            }
+        });
+
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello there', $result->getContent());
+    }
+
+    public function testConvertSpeechToTextResponseExposesAdditionalFormats()
+    {
+        $converter = new ElevenLabsResultConverter(new MockHttpClient());
+        $rawResult = new InMemoryRawResult([
+            'text' => 'Hello there',
+            'additional_formats' => [
+                [
+                    'requested_format' => 'srt',
+                    'file_extension' => '.srt',
+                    'content_type' => 'text/plain',
+                    'is_base64_encoded' => false,
+                    'content' => "1\n00:00:00,000 --> 00:00:01,000\nHello there\n",
+                ],
+                [
+                    'requested_format' => 'txt',
+                    'file_extension' => '.txt',
+                    'content_type' => 'text/plain',
+                    'is_base64_encoded' => true,
+                    'content' => base64_encode('Hello there'),
+                ],
+            ],
+        ], [], new class {
+            public function getStatusCode(): int
+            {
+                return 200;
+            }
+
+            public function getInfo(): string
+            {
+                return 'speech-to-text';
+            }
+        });
+
+        $result = $converter->convert($rawResult, [
+            'additional_formats' => [
+                ['format' => 'srt', 'include_timestamps' => true],
+            ],
+        ]);
+
+        $this->assertInstanceOf(ObjectResult::class, $result);
+
+        $transcript = $this->extractTranscript($result);
+        $this->assertSame('Hello there', $transcript->getText());
+        $this->assertSame(
+            "1\n00:00:00,000 --> 00:00:01,000\nHello there\n",
+            $transcript->asSubRipText(),
+        );
+        $this->assertSame(
+            "1\n00:00:00,000 --> 00:00:01,000\nHello there\n",
+            $transcript->getAdditionalFormat('srt'),
+        );
+        $this->assertSame('Hello there', $transcript->getAdditionalFormat('txt'));
+        $this->assertNull($transcript->getAdditionalFormat('html'));
+
+        $additionalFormats = $transcript->getAdditionalFormats();
+        $this->assertContainsOnlyInstancesOf(AdditionalFormat::class, $additionalFormats);
+        $this->assertCount(2, $additionalFormats);
+
+        $srt = $additionalFormats[0];
+        $this->assertSame('srt', $srt->getRequestedFormat());
+        $this->assertSame('.srt', $srt->getFileExtension());
+        $this->assertSame('text/plain', $srt->getContentType());
+        $this->assertFalse($srt->isBase64Encoded());
+        $this->assertSame("1\n00:00:00,000 --> 00:00:01,000\nHello there\n", $srt->getDecodedContent());
+
+        $txt = $additionalFormats[1];
+        $this->assertTrue($txt->isBase64Encoded());
+        $this->assertSame('Hello there', $txt->getDecodedContent());
+    }
+
+    public function testGetDecodedContentThrowsRuntimeExceptionOnInvalidBase64Payload()
+    {
+        $format = AdditionalFormat::fromArray([
+            'requested_format' => 'srt',
+            'file_extension' => '.srt',
+            'content_type' => 'text/plain',
+            'is_base64_encoded' => true,
+            'content' => 'this-is-not-valid-base64!!!',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The base64-encoded content of the "srt" additional format could not be decoded.');
+        $format->getDecodedContent();
+    }
+
+    public function testConvertSpeechToTextResponseWithoutAdditionalFormatsOptionReturnsTextResult()
+    {
+        $converter = new ElevenLabsResultConverter(new MockHttpClient());
+        $rawResult = new InMemoryRawResult([
+            'text' => 'Hello there',
+            // The API happens to return additional formats, but none were requested.
+            'additional_formats' => [
+                [
+                    'requested_format' => 'srt',
+                    'file_extension' => '.srt',
+                    'content_type' => 'text/plain',
+                    'is_base64_encoded' => false,
+                    'content' => "1\n00:00:00,000 --> 00:00:01,000\nHello there\n",
+                ],
+            ],
         ], [], new class {
             public function getStatusCode(): int
             {
@@ -141,5 +263,13 @@ final class ElevenLabsConverterTest extends TestCase
         $this->expectExceptionMessage('The ElevenLabs API returned a non-successful status code "500".');
         $this->expectExceptionCode(0);
         $converter->convert($rawResult);
+    }
+
+    private function extractTranscript(ResultInterface $result): Transcript
+    {
+        \assert($result instanceof ObjectResult);
+        \assert($result->getContent() instanceof Transcript);
+
+        return $result->getContent();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | Fix #2266
| License       | MIT

[ElevenLabs] Support SRT output for speech-to-text via `additional_formats`
===========================================================================

This exposes ElevenLabs Scribe's speech-to-text options and additional
transcript formats (e.g. SRT subtitles) through `PlatformInterface::invoke()`,
so subtitle generation no longer requires bypassing the bridge and calling
ElevenLabs directly with the HTTP client.

Motivation
----------

The ElevenLabs `/v1/speech-to-text` endpoint accepts multipart fields such as
`language_code`, `tag_audio_events`, `num_speakers`, `diarize`,
`timestamps_granularity` and `additional_formats`, and returns the requested
export formats under `additional_formats[].content`. Until now the bridge sent
only `file` and `model_id`, and `asText()` exposed only the plain transcript,
so generating SRT required a hand-rolled HttpClient call (see the workaround in
the issue).

Changes
-------

### 1. Forwarding speech-to-text options — `ElevenLabsClient`

`ElevenLabsClient::doSpeechToTextRequest()` now receives the merged request +
model options (mirroring the text-to-speech branch) and forwards them as
multipart fields. Because Symfony HttpClient builds multipart bodies via
`http_build_query`, options are normalized to the wire format ElevenLabs expects:

 * arrays (e.g. `additional_formats`) are JSON-encoded into a single field;
 * booleans are sent as `"true"`/`"false"` (not `"1"`/`""`);
 * other scalars are cast to strings.

### 2. First-class result API — `Bridge\ElevenLabs\Result\TranscriptionResult`

A new bridge-scoped DTO carrying the transcript text alongside the returned
`additional_formats`. It transparently decodes base64-encoded content and
exposes:

 * `getText()`
 * `getAdditionalFormats()`
 * `getAdditionalFormat(string $format)` — resolved by `requested_format`
   (e.g. `srt`, `txt`, `html`)
 * `asSubRipText()` — convenience accessor for SRT

### 3. Converter — `ElevenLabsResultConverter`

Speech-to-text responses now return a `MultiPartResult` containing both a
`TextResult` (so `asText()` keeps working) and an `ObjectResult` wrapping the
new `TranscriptionResult` (so `asObject()` returns the structured result).
This mirrors the pattern used by the Mistral OCR bridge and avoids adding
bridge-specific methods to the core `DeferredResult`.

Usage
-----

```php
use Symfony\AI\Platform\Bridge\ElevenLabs\ElevenLabs;
use Symfony\AI\Platform\Bridge\ElevenLabs\Factory;
use Symfony\AI\Platform\Capability;
use Symfony\AI\Platform\Message\Content\Audio;

$platform = Factory::createPlatform(apiKey: $apiKey);

$result = $platform->invoke(
    model: new ElevenLabs('scribe_v2', [
        Capability::SPEECH_TO_TEXT,
        Capability::INPUT_AUDIO,
        Capability::OUTPUT_TEXT,
    ]),
    input: Audio::fromFile('/path/audio.mp3'),
    options: [
        'language_code' => 'en',
        'tag_audio_events' => false,
        'num_speakers' => 1,
        'diarize' => true,
        'timestamps_granularity' => 'word',
        'additional_formats' => [
            ['format' => 'srt', 'include_timestamps' => true],
        ],
    ],
);

$result->asText();                       // plain transcript
$result->asObject()->asSubRipText();     // SRT subtitles
$result->asObject()->getAdditionalFormat('srt');

// The raw payload is still available:
$result->getRawResult()->getData()['additional_formats'][0]['content'];
```

Backward compatibility
----------------------

`$result->asText()` is preserved unchanged for speech-to-text, so existing
consumers keep working. The converted result type changes from `TextResult` to
`MultiPartResult`, but the public entry points (`asText()`, `asObject()`,
`getRawResult()`) remain consistent: `asText()` behaves identically, and
`asObject()` now succeeds (returning a `TranscriptionResult`) where it
previously threw `UnexpectedResultTypeException`. No `UPGRADE.md` entry is
therefore required.

Tests
-----

 * Updated `ElevenLabsConverterTest` for the new `MultiPartResult` shape, with
   dedicated cases for plain transcripts, additional formats (both raw and
   base64-encoded content) and the absence of additional formats.
 * Added `ElevenLabsClientTest::testClientCanPerformSpeechToTextRequestWithOptions`
   asserting that the multipart body forwards `language_code`, `diarize`
   (`true`), `tag_audio_events` (`false`), `num_speakers` (`1`),
   `timestamps_granularity` and the JSON-encoded `additional_formats`.
 * Full platform suite passes (733 tests).

Documentation
-------------

 * New "Speech-to-Text" section in `docs/components/platform.rst` covering the
   basic transcript and the SRT export flow (validated with `doctor-rst`).
 * New runnable example `examples/elevenlabs/speech-to-text-srt.php`.
 * `CHANGELOG.md` entry under the unreleased `0.11` section.
