### PR TITLE
[Platform] Fix #2274: Preserve cache and reasoning tokens in Generic completions usage

### DIFF
--- a/src/platform/src/Bridge/Generic/Completions/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/Generic/Completions/TokenUsageExtractor.php
@@ -41,11 +41,35 @@ final class TokenUsageExtractor implements TokenUsageExtractorInterface
      */
     public function extractFromArray(array $usage): TokenUsage
     {
+        $promptTokens = $usage['prompt_tokens'] ?? $usage['input_tokens'] ?? null;
+        $completionTokens = $usage['completion_tokens'] ?? $usage['output_tokens'] ?? null;
+        $totalTokens = $usage['total_tokens'] ?? null;
+        $completionTokensDetails = \is_array($usage['completion_tokens_details'] ?? null) ? $usage['completion_tokens_details'] : [];
+        $promptTokensDetails = \is_array($usage['prompt_tokens_details'] ?? null) ? $usage['prompt_tokens_details'] : [];
+
+        // DeepSeek: usage.completion_tokens_details.reasoning_tokens
+        $thinkingTokens = $completionTokensDetails['reasoning_tokens'] ?? null;
+
+        // DeepSeek: usage.prompt_cache_hit_tokens
+        // z.ai, llama.cpp, vLLM-compatible: usage.prompt_tokens_details.cached_tokens
+        $cacheRead = $usage['prompt_cache_hit_tokens']
+            ?? $promptTokensDetails['cached_tokens']
+            ?? null;
+
+        // num_cached_tokens / cached_tokens
+        $aggregateCached = $usage['num_cached_tokens']
+            ?? $usage['cached_tokens']
+            ?? null;
+
+        $effectiveCached = $aggregateCached ?? $cacheRead;
+
         return new TokenUsage(
-            promptTokens: $usage['prompt_tokens'] ?? null,
-            completionTokens: $usage['completion_tokens'] ?? null,
-            cachedTokens: $usage['num_cached_tokens'] ?? null,
-            totalTokens: $usage['total_tokens'] ?? null,
+            promptTokens: $promptTokens,
+            completionTokens: $completionTokens,
+            thinkingTokens: $thinkingTokens,
+            cachedTokens: $effectiveCached,
+            cacheReadTokens: $cacheRead,
+            totalTokens: $totalTokens,
         );
     }
 }

--- a/src/platform/src/Bridge/Generic/Tests/Completions/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/TokenUsageExtractorTest.php
@@ -50,6 +50,7 @@ final class TokenUsageExtractorTest extends TestCase
         $this->assertSame(10, $tokenUsage->getPromptTokens());
         $this->assertSame(20, $tokenUsage->getCompletionTokens());
         $this->assertSame(5, $tokenUsage->getCachedTokens());
+        $this->assertNull($tokenUsage->getCacheReadTokens());
         $this->assertSame(30, $tokenUsage->getTotalTokens());
     }
 
@@ -85,6 +86,88 @@ final class TokenUsageExtractorTest extends TestCase
         $this->assertSame(10, $tokenUsage->getPromptTokens());
         $this->assertSame(20, $tokenUsage->getCompletionTokens());
         $this->assertSame(5, $tokenUsage->getCachedTokens());
+        $this->assertNull($tokenUsage->getCacheReadTokens());
         $this->assertSame(30, $tokenUsage->getTotalTokens());
+    }
+
+    public function testItExtractsPromptTokensDetailsCachedTokens()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $tokenUsage = $extractor->extractFromArray([
+            'prompt_tokens' => 100,
+            'completion_tokens' => 50,
+            'prompt_tokens_details' => [
+                'cached_tokens' => 78,
+            ],
+            'total_tokens' => 150,
+        ]);
+
+        $this->assertSame(78, $tokenUsage->getCachedTokens());
+        $this->assertSame(78, $tokenUsage->getCacheReadTokens());
+        $this->assertNull($tokenUsage->getCacheCreationTokens());
+    }
+
+    public function testItExtractsDeepSeekPromptCacheHitTokens()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $tokenUsage = $extractor->extractFromArray([
+            'prompt_tokens' => 100,
+            'completion_tokens' => 50,
+            'prompt_cache_hit_tokens' => 60,
+            'total_tokens' => 150,
+        ]);
+
+        $this->assertSame(60, $tokenUsage->getCacheReadTokens());
+        $this->assertSame(60, $tokenUsage->getCachedTokens());
+    }
+
+    public function testItExtractsReasoningTokensFromCompletionTokensDetails()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $tokenUsage = $extractor->extractFromArray([
+            'prompt_tokens' => 100,
+            'completion_tokens' => 50,
+            'completion_tokens_details' => [
+                'reasoning_tokens' => 20,
+            ],
+            'total_tokens' => 150,
+        ]);
+
+        $this->assertSame(20, $tokenUsage->getThinkingTokens());
+    }
+
+    public function testItExtractsLlamaCppStylePromptTokensDetailsCachedTokens()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $tokenUsage = $extractor->extractFromArray([
+            'prompt_tokens' => 28,
+            'completion_tokens' => 1,
+            'total_tokens' => 29,
+            'prompt_tokens_details' => [
+                'cached_tokens' => 24,
+            ],
+        ]);
+
+        $this->assertSame(24, $tokenUsage->getCacheReadTokens());
+        $this->assertSame(24, $tokenUsage->getCachedTokens());
+    }
+
+    public function testItExtractsCachedTokensFieldAsAggregate()
+    {
+        $extractor = new TokenUsageExtractor();
+
+        $tokenUsage = $extractor->extractFromArray([
+            'prompt_tokens' => 50,
+            'completion_tokens' => 25,
+            'cached_tokens' => 30,
+            'total_tokens' => 75,
+        ]);
+
+        $this->assertSame(30, $tokenUsage->getCachedTokens());
+        $this->assertNull($tokenUsage->getCacheReadTokens());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2274
| License       | MIT

Generic/OpenAI-compatible completions usage conversion now preserves provider-reported cache and reasoning token details.                                                                                                    
                                                                                                                                                                                                                                
 The extractor now handles common usage shapes such as:                                                                                                                                                                       
                                                                                                                                                                                                                              
 - `prompt_tokens_details.cached_tokens`                                                                                                                                                                                      
 - `input_tokens_details.cached_tokens`                                                                                                                                                                                       
 - `prompt_cache_hit_tokens`                                                                                                                                                                                                  
 - `num_cached_tokens`                                                                                                                                                                                                        
 - `cached_tokens`                                                                                                                                                                                                            
 - `cache_read_tokens`                                                                                                                                                                                                        
 - `cache_read_input_tokens`                                                                                                                                                                                                  
 - `cache_creation_tokens`                                                                                                                                                                                                    
 - `cache_creation_input_tokens`                                                                                                                                                                                              
 - `completion_tokens_details.reasoning_tokens`                                                                                                                                                                               
 - `output_tokens_details.reasoning_tokens`                                                                                                                                                                                   
                                                                                                                                                                                                                              
 This keeps existing prompt/completion/total token behavior unchanged while exposing available cache-read/cache-creation/cached/reasoning token data when providers include it.