### PR TITLE
[Platform][Generic] Fix #2194: expose streamed finish_reason as metadata

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * Add OpenAI image editing via the `images/edits` endpoint: pass the source image as a `Content\Image` through the `image` option of `Platform::invoke()`
  * [BC BREAK] Rename the OpenAI `DallE` bridge to `Image` (`Bridge\OpenAi\DallE` → `Bridge\OpenAi\Image`, and the `Bridge\OpenAi\DallE\*` namespace → `Bridge\OpenAi\Image\*`) and remove the `dall-e-2`/`dall-e-3` catalog entries retired by OpenAI
  * [BC BREAK] Replace the bridge-specific `ImageResult`, `Base64Image`, and `UrlImage` classes of the OpenAI image bridge with the generic `Result\BinaryResult` (single image) and `Result\MultiPartResult` (multiple images), matching the other multi-modal bridges
+ * Add streamed Generic completions `finish_reason` values as result metadata
 
 0.10
 ----

--- a/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterTest.php
@@ -21,6 +21,7 @@ use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
@@ -251,11 +252,14 @@ final class ResultConverterTest extends TestCase
             $chunks[] = $part;
         }
 
-        $this->assertCount(2, $chunks);
+        $this->assertCount(3, $chunks);
         $this->assertInstanceOf(TextDelta::class, $chunks[0]);
         $this->assertSame('Hello, ', $chunks[0]->getText());
         $this->assertInstanceOf(TextDelta::class, $chunks[1]);
         $this->assertSame('world!', $chunks[1]->getText());
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[2]);
+        $this->assertSame('finish_reason', $chunks[2]->getKey());
+        $this->assertSame('stop', $chunks[2]->getValue());
     }
 
     public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()

--- a/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
+++ b/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
@@ -68,6 +69,7 @@ trait CompletionsConversionTrait
             // It is null on every non-final chunk, and a trailing usage-only chunk has choices: [].
             if (null !== ($data['choices'][0]['finish_reason'] ?? null)) {
                 $sawFinishReason = true;
+                yield new MetadataDelta('finish_reason', $data['choices'][0]['finish_reason']);
             }
 
             if (isset($data['usage'])) {

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
@@ -23,8 +23,10 @@ use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\ChoiceResult;
+use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
@@ -537,8 +539,13 @@ class ResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($streamResult->getContent());
 
-        $this->assertCount(2, $chunks);
-        $this->assertContainsOnlyInstancesOf(TextDelta::class, $chunks);
+        $textDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof TextDelta));
+        $metadataDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof MetadataDelta));
+
+        $this->assertCount(2, $textDeltas);
+        $this->assertCount(1, $metadataDeltas);
+        $this->assertSame('finish_reason', $metadataDeltas[0]->getKey());
+        $this->assertSame('stop', $metadataDeltas[0]->getValue());
     }
 
     public function testStreamingDoesNotThrowWithUsageOnlyFinalChunk()
@@ -610,6 +617,82 @@ class ResultConverterTest extends TestCase
         $this->expectExceptionMessage('Rate limit exceeded. Stream error: "Too many requests".');
 
         iterator_to_array($streamResult->getContent());
+    }
+
+    public function testStreamingExposesFinishReasonLengthAsMetadataDelta()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'Hello']]]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'length']]],
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+
+        $chunks = iterator_to_array($streamResult->getContent());
+        $metadataDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof MetadataDelta));
+
+        $this->assertCount(1, $metadataDeltas);
+        $this->assertSame('finish_reason', $metadataDeltas[0]->getKey());
+        $this->assertSame('length', $metadataDeltas[0]->getValue());
+    }
+
+    public function testStreamingExposesFinishReasonContentFilterAsMetadataDelta()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'Hi']]]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'content_filter']]],
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+
+        $metadataDeltas = array_values(array_filter(iterator_to_array($streamResult->getContent()), static fn ($c) => $c instanceof MetadataDelta));
+
+        $this->assertCount(1, $metadataDeltas);
+        $this->assertSame('content_filter', $metadataDeltas[0]->getValue());
+    }
+
+    public function testStreamingPromotesFinishReasonToResultMetadata()
+    {
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'Hello']]]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'length']]],
+        ];
+
+        $deferredResult = new DeferredResult(
+            new ResultConverter(),
+            new InMemoryRawResult([], $events, $this->httpResponseStub()),
+            ['stream' => true],
+        );
+
+        $chunks = iterator_to_array($deferredResult->asStream());
+
+        $this->assertCount(1, $chunks);
+        $this->assertInstanceOf(TextDelta::class, $chunks[0]);
+        $this->assertSame('Hello', $chunks[0]->getText());
+        $this->assertTrue($deferredResult->getMetadata()->has('finish_reason'));
+        $this->assertSame('length', $deferredResult->getMetadata()->get('finish_reason'));
+    }
+
+    public function testStreamingDoesNotEmitFinishReasonMetadataForUsageOnlyFinalChunk()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'Hi']]]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
+            ['choices' => [], 'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2]],
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+        $chunks = iterator_to_array($streamResult->getContent());
+
+        $metadataDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof MetadataDelta));
+        $this->assertCount(1, $metadataDeltas);
+        $this->assertSame('stop', $metadataDeltas[0]->getValue());
     }
 
     private function httpResponseStub(): object


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #2194
| License       | MIT

Generic/OpenAI-compatible streamed completions now expose the provider `finish_reason` as result metadata.                                                                                                             
                                                                                                                                                                                                                                
This allows consumers to distinguish terminal reasons such as `stop`, `length`, `content_filter`, and `tool_calls` after consuming a streamed result, while preserving the existing incomplete-stream guard and visible stream deltas.
