### PR TITLE
[Platform] Throw when an Anthropic stream is truncated at the max output token limit

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Add `MaxOutputTokensException` for completed responses truncated by output token limits
  * Convert OpenAI Responses built-in tool output items (`web_search_call`, `file_search_call`, `code_interpreter_call`, `image_generation_call`, `mcp_call`, `mcp_list_tools`, `mcp_approval_request`, `computer_call`, `local_shell_call`) into typed results instead of skipping them. Adds `Result\WebSearchResult`, `Result\FileSearchResult`, `Result\McpCallResult`, `Result\McpListToolsResult`, `Result\McpApprovalRequestResult`, `Result\ComputerCallResult`, and `Result\LocalShellCallResult` (code interpreter reuses `ExecutableCodeResult`/`CodeExecutionResult`, image generation reuses `BinaryResult`), plus the matching `Message\Content` classes so the results round-trip through `Message::ofAssistant()`. Benefits the OpenAI, Azure OpenAI, and Scaleway bridges.
  * [BC BREAK] Remove `Capability::INPUT_MULTIPLE` from all embedding models since every embedding bridge already accepts multiple inputs in a single API call
  * Add `ResultConvertedEvent` and `ResultErrorEvent`, dispatched when the deferred result is actually converted (or conversion fails) instead of when the not-yet-resolved `ResultEvent` fires, so listeners can act on the resolved result

--- a/src/platform/src/Bridge/Anthropic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Anthropic/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `MaxOutputTokensException` when a stream stops at the output token limit
  * Add a `baseUrl` argument to `ModelClient` and the factory to target Anthropic-compatible endpoints
  * Extract prompt-caching injection into a reusable `PromptCachingTrait` so alternative model clients can share it
  * Throw `ServerException` on server errors (HTTP 5xx) and on `overloaded_error` / `api_error` events, including mid-stream, instead of a generic `RuntimeException`

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MaxOutputTokensException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
@@ -162,6 +163,8 @@ class ResultConverter implements ResultConverterInterface
         $currentThinking = null;
         $currentThinkingSignature = null;
         $inMessage = false;
+        $stopReason = null;
+        $outputTokens = null;
 
         foreach ($result->getDataStream() as $data) {
             $type = $data['type'] ?? '';
@@ -198,10 +201,15 @@ class ResultConverter implements ResultConverterInterface
                 yield $this->getTokenUsageExtractor()->extractFromArray($usage);
             }
 
-            if ('message_delta' === $type && isset($data['usage'])) {
-                yield $this->getTokenUsageExtractor()->extractFromArray([
-                    'output_tokens' => $data['usage']['output_tokens'] ?? 0,
-                ]);
+            if ('message_delta' === $type) {
+                $stopReason = $data['delta']['stop_reason'] ?? $stopReason;
+
+                if (isset($data['usage'])) {
+                    $outputTokens = $data['usage']['output_tokens'] ?? $outputTokens;
+                    yield $this->getTokenUsageExtractor()->extractFromArray([
+                        'output_tokens' => $outputTokens ?? 0,
+                    ]);
+                }
             }
 
             // Handle text content deltas
@@ -297,6 +305,15 @@ class ResultConverter implements ResultConverterInterface
             // Handle message stop - yield tool calls if any were collected
             if ('message_stop' === $type) {
                 $inMessage = false;
+
+                if ('max_tokens' === $stopReason) {
+                    $message = 'Anthropic truncated the response after reaching the output token limit. Raise the output token budget (max_tokens) or reduce the request scope.';
+                    if (null !== $outputTokens) {
+                        $message = \sprintf('Anthropic truncated the response after reaching the maximum of %d output tokens. Raise the output token budget (max_tokens) or reduce the request scope.', $outputTokens);
+                    }
+
+                    throw new MaxOutputTokensException($message);
+                }
 
                 if ([] !== $toolCalls) {
                     yield new ToolCallComplete($toolCalls);

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\Anthropic\ResultConverter;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MaxOutputTokensException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
@@ -307,6 +308,87 @@ final class ResultConverterTest extends TestCase
         $this->expectExceptionMessage('Anthropic stream ended before message_stop.');
 
         iterator_to_array($streamResult->getContent());
+    }
+
+    public function testStreamingThrowsWhenTruncatedAtMaxTokens()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $raw = new InMemoryRawResult([], [
+            ['type' => 'message_start', 'message' => ['id' => 'msg_123', 'type' => 'message', 'role' => 'assistant', 'content' => []]],
+            ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_01ABC123', 'name' => 'write_file']],
+            ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'input_json_delta', 'partial_json' => '{"path":"foo.md","content":"partial']],
+            ['type' => 'message_delta', 'delta' => ['stop_reason' => 'max_tokens'], 'usage' => ['output_tokens' => 16000]],
+            ['type' => 'message_stop'],
+        ], $httpResponse);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $this->expectException(MaxOutputTokensException::class);
+        $this->expectExceptionMessage('reaching the maximum of 16000 output tokens');
+
+        iterator_to_array($streamResult->getContent());
+    }
+
+    public function testStreamingThrowsBeforeYieldingToolCallWhenTruncatedAtMaxTokens()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $raw = new InMemoryRawResult([], [
+            ['type' => 'message_start', 'message' => ['id' => 'msg_123', 'type' => 'message', 'role' => 'assistant', 'content' => []]],
+            ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_01ABC123', 'name' => 'write_file']],
+            ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'input_json_delta', 'partial_json' => '{"path":"foo.md"}']],
+            ['type' => 'content_block_stop', 'index' => 0],
+            ['type' => 'message_delta', 'delta' => ['stop_reason' => 'max_tokens'], 'usage' => ['output_tokens' => 16000]],
+            ['type' => 'message_stop'],
+        ], $httpResponse);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $chunks = [];
+        $thrown = false;
+
+        try {
+            foreach ($streamResult->getContent() as $chunk) {
+                $chunks[] = $chunk;
+            }
+        } catch (MaxOutputTokensException $e) {
+            $thrown = true;
+            $this->assertStringContainsString('reaching the maximum of 16000 output tokens', $e->getMessage());
+        }
+
+        $this->assertTrue($thrown, 'Expected a max output tokens exception.');
+        $this->assertSame([], array_values(array_filter($chunks, static fn ($chunk): bool => $chunk instanceof ToolCallComplete)));
+    }
+
+    public function testStreamingDoesNotThrowOnCleanStopReason()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $raw = new InMemoryRawResult([], [
+            ['type' => 'message_start', 'message' => ['id' => 'msg_123', 'type' => 'message', 'role' => 'assistant', 'content' => []]],
+            ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'text', 'text' => '']],
+            ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'text_delta', 'text' => 'Done.']],
+            ['type' => 'content_block_stop', 'index' => 0],
+            ['type' => 'message_delta', 'delta' => ['stop_reason' => 'end_turn'], 'usage' => ['output_tokens' => 5]],
+            ['type' => 'message_stop'],
+        ], $httpResponse);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $deltas = iterator_to_array($streamResult->getContent());
+
+        $textDeltas = array_filter($deltas, static fn ($d): bool => $d instanceof TextDelta);
+        $this->assertSame('Done.', array_values($textDeltas)[0]->getText());
     }
 
     public function testStreamingTextAndToolCallsYieldsBoth()

--- a/src/platform/src/Exception/MaxOutputTokensException.php
+++ b/src/platform/src/Exception/MaxOutputTokensException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Exception;
+
+/**
+ * Thrown when a provider truncates a response because it reached the maximum
+ * number of output tokens.
+ *
+ * Unlike an incomplete stream, the response completed normally at the token
+ * ceiling: retrying the identical request would truncate again, so consumers
+ * should surface the error and let the user raise the output budget or reduce
+ * the request scope instead of retrying.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class MaxOutputTokensException extends RuntimeException
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
 - Features and deprecations must be submitted against branch main.
 - Update/add documentation as required (we can help!)
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).

CHANGELOG.md/UPGRADE.md checks enforced on every PR:
 - A bug fix only (New feature? = no) must not change any CHANGELOG.md/UPGRADE.md, unless it's a BC break (then add the "BC Break" label + an UPGRADE.md entry).
 - A backward-compatibility break needs an UPGRADE.md entry AND the "BC Break" label (the two go together).
 - Only add entries to the upcoming (unreleased) version section.
-->
