### PR TITLE
[Platform] Derive VertexAI API host from location for regional and data-residency endpoints

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -76,6 +76,19 @@ Platform
  * The Albert factory no longer throws when the base URL ends with a trailing slash; the slash is
    stripped instead.
 
+ * The VertexAI bridge now derives the API host from the configured `location` instead of always
+   using `aiplatform.googleapis.com`. `null` and `global` keep the existing global host, but a
+   regional location (e.g. `europe-west1`) now targets `europe-west1-aiplatform.googleapis.com`,
+   and the data-residency values `eu`/`us` target `aiplatform.eu.rep.googleapis.com` /
+   `aiplatform.us.rep.googleapis.com`. Requests that previously reached the global endpoint while
+   configured with a regional location will now hit the regional endpoint. If you relied on the
+   global host for a regional location, pass `global` (or `null`) explicitly:
+
+   ```diff
+   -Factory::createPlatform('europe-west1', 'my-project'); // used aiplatform.googleapis.com
+   +Factory::createPlatform('global', 'my-project'); // keep the global host
+   ```
+
 Store
 -----
 

--- a/docs/components/platform/vertexai.rst
+++ b/docs/components/platform/vertexai.rst
@@ -151,6 +151,20 @@ Configure your location in your environment file:
     # Avoid: Global location has limited model availability
     # GOOGLE_CLOUD_LOCATION=global
 
+Regional and Data-Residency Endpoints
+-------------------------------------
+
+The API host is derived from the ``location`` passed to the factory:
+
+* ``null`` or ``global`` uses the global endpoint ``aiplatform.googleapis.com``.
+* A region such as ``europe-west1`` uses the matching regional endpoint
+  ``europe-west1-aiplatform.googleapis.com``.
+* The multi-region data-residency (jurisdictional) values ``eu`` and ``us`` use
+  ``aiplatform.eu.rep.googleapis.com`` and ``aiplatform.us.rep.googleapis.com``
+  respectively.
+
+See `Vertex AI locations`_ and `Vertex AI data residency`_ for the list of supported values.
+
 Token Usage Tracking
 --------------------
 
@@ -194,3 +208,5 @@ See the ``examples/vertexai/`` directory for complete working examples:
 .. _Setting up authentication for Vertex AI: https://cloud.google.com/vertex-ai/docs/authentication
 .. _Google Cloud Console for Vertex AI: https://console.cloud.google.com/vertex-ai
 .. _Vertex AI Studio (API keys): https://console.cloud.google.com/vertex-ai/studio/settings/api-keys
+.. _Vertex AI locations: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+.. _Vertex AI data residency: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/data-residency

--- a/src/platform/src/Bridge/VertexAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/VertexAi/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Derive the API host from the configured `location` to support regional and data-residency endpoints
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
 

--- a/src/platform/src/Bridge/VertexAi/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/VertexAi/Embeddings/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\VertexAi\Embeddings;
 
+use Symfony\AI\Platform\Bridge\VertexAi\RegionAwareTrait;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -22,6 +23,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ModelClient implements ModelClientInterface
 {
+    use RegionAwareTrait;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly ?string $location = null,
@@ -40,9 +43,12 @@ final class ModelClient implements ModelClientInterface
      */
     public function request(BaseModel $model, array|string $payload, array $options = []): RawHttpResult
     {
+        $host = $this->resolveHost($this->location);
+
         if (null !== $this->location && null !== $this->projectId) {
             $url = \sprintf(
-                'https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:%s',
+                'https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s:%s',
+                $host,
                 $this->projectId,
                 $this->location,
                 $model->getName(),
@@ -50,7 +56,8 @@ final class ModelClient implements ModelClientInterface
             );
         } else {
             $url = \sprintf(
-                'https://aiplatform.googleapis.com/v1/publishers/google/models/%s:%s',
+                'https://%s/v1/publishers/google/models/%s:%s',
+                $host,
                 $model->getName(),
                 'predict',
             );

--- a/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\VertexAi\Gemini;
 
+use Symfony\AI\Platform\Bridge\VertexAi\RegionAwareTrait;
 use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -26,6 +27,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class ModelClient implements ModelClientInterface
 {
     use JsonBodyEncodingTrait;
+    use RegionAwareTrait;
 
     private readonly EventSourceHttpClient $httpClient;
 
@@ -51,9 +53,12 @@ final class ModelClient implements ModelClientInterface
         $isStream = $options['stream'] ?? false;
         $method = $isStream ? 'streamGenerateContent' : 'generateContent';
 
+        $host = $this->resolveHost($this->location);
+
         if (null !== $this->location && null !== $this->projectId) {
             $url = \sprintf(
-                'https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:%s',
+                'https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s:%s',
+                $host,
                 $this->projectId,
                 $this->location,
                 $model->getName(),
@@ -61,7 +66,8 @@ final class ModelClient implements ModelClientInterface
             );
         } else {
             $url = \sprintf(
-                'https://aiplatform.googleapis.com/v1/publishers/google/models/%s:%s',
+                'https://%s/v1/publishers/google/models/%s:%s',
+                $host,
                 $model->getName(),
                 $method,
             );

--- a/src/platform/src/Bridge/VertexAi/RegionAwareTrait.php
+++ b/src/platform/src/Bridge/VertexAi/RegionAwareTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\VertexAi;
+
+/**
+ * Derives the Vertex AI API host from the configured location so that regional
+ * and data-residency (jurisdictional) endpoints are used when required.
+ *
+ * @see https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+ * @see https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/data-residency
+ *
+ * @author Robbe Serry <robbeserry@gmail.com>
+ */
+trait RegionAwareTrait
+{
+    /**
+     * Multi-region data-residency (jurisdictional) endpoints keyed by location.
+     */
+    private const RESIDENCY_HOSTS = [
+        'eu' => 'aiplatform.eu.rep.googleapis.com',
+        'us' => 'aiplatform.us.rep.googleapis.com',
+    ];
+
+    private function resolveHost(?string $location): string
+    {
+        if (null === $location || 'global' === $location) {
+            return 'aiplatform.googleapis.com';
+        }
+
+        if (isset(self::RESIDENCY_HOSTS[$location])) {
+            return self::RESIDENCY_HOSTS[$location];
+        }
+
+        return \sprintf('%s-aiplatform.googleapis.com', $location);
+    }
+}

--- a/src/platform/src/Bridge/VertexAi/Tests/Embeddings/ModelClientTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Embeddings/ModelClientTest.php
@@ -37,4 +37,49 @@ final class ModelClientTest extends TestCase
 
         $this->assertSame($expectedResponse, $result->getData());
     }
+
+    public function testItUsesTheRegionalEndpointForARegionalLocation()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertSame(
+                'https://europe-west1-aiplatform.googleapis.com/v1/projects/test/locations/europe-west1/publishers/google/models/gemini-embedding-001:predict',
+                $url,
+            );
+
+            return new JsonMockResponse(['predictions' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'europe-west1', 'test');
+        $client->request(new Model('gemini-embedding-001'), 'test payload');
+    }
+
+    public function testItUsesTheResidencyEndpointForAJurisdictionalLocation()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertSame(
+                'https://aiplatform.us.rep.googleapis.com/v1/projects/test/locations/us/publishers/google/models/gemini-embedding-001:predict',
+                $url,
+            );
+
+            return new JsonMockResponse(['predictions' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'us', 'test');
+        $client->request(new Model('gemini-embedding-001'), 'test payload');
+    }
+
+    public function testItUsesTheGlobalHostWhenNoLocationIsProvided()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertStringStartsWith(
+                'https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-embedding-001:predict',
+                $url,
+            );
+
+            return new JsonMockResponse(['predictions' => []]);
+        });
+
+        $client = new ModelClient($httpClient, apiKey: 'test-key');
+        $client->request(new Model('gemini-embedding-001'), 'test payload');
+    }
 }

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
@@ -49,6 +49,51 @@ final class ModelClientTest extends TestCase
         $this->assertSame($expectedResponse, $data);
     }
 
+    public function testItUsesTheRegionalEndpointForARegionalLocation()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertSame(
+                'https://europe-west1-aiplatform.googleapis.com/v1/projects/test/locations/europe-west1/publishers/google/models/gemini-2.0-flash:generateContent',
+                $url,
+            );
+
+            return new JsonMockResponse(['candidates' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'europe-west1', 'test');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => []]);
+    }
+
+    public function testItUsesTheResidencyEndpointForAJurisdictionalLocation()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertSame(
+                'https://aiplatform.eu.rep.googleapis.com/v1/projects/test/locations/eu/publishers/google/models/gemini-2.0-flash:generateContent',
+                $url,
+            );
+
+            return new JsonMockResponse(['candidates' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'eu', 'test');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => []]);
+    }
+
+    public function testItUsesTheGlobalHostWhenNoLocationIsProvided()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertStringStartsWith(
+                'https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.0-flash:generateContent',
+                $url,
+            );
+
+            return new JsonMockResponse(['candidates' => []]);
+        });
+
+        $client = new ModelClient($httpClient, apiKey: 'test-key');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => []]);
+    }
+
     public function testRequestWithStreamAsksForSseFormat()
     {
         $httpClient = new MockHttpClient(function (string $method, string $url) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #2283 
| License       | MIT

The VertexAI bridge hardcoded `aiplatform.googleapis.com` for every request, so
regional and data-residency (jurisdictional) deployments could not be reached —
a blocker for anyone with data-residency requirements (e.g. EU healthcare/GDPR).

This derives the API host from the `location` already passed to the factory,
via a small `RegionAwareTrait::resolveHost()` helper shared by the Gemini and
Embeddings model clients:

- `null` / `global` → `aiplatform.googleapis.com` (unchanged)
- `eu` / `us` → `aiplatform.eu.rep.googleapis.com` / `aiplatform.us.rep.googleapis.com`
- any region, e.g. `europe-west1` → `europe-west1-aiplatform.googleapis.com`

```php
// Regional endpoint
Factory::createPlatform(location: 'europe-west1', projectId: 'my-project');

// EU data-residency endpoint
Factory::createPlatform(location: 'eu', projectId: 'my-project');