### PR TITLE
[Mate][Symfony][Monolog] Bump helgesverre/toon to ^3.2.1

### DIFF
--- a/src/mate/composer.json
+++ b/src/mate/composer.json
@@ -41,7 +41,7 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
-        "helgesverre/toon": "^3.1",
+        "helgesverre/toon": "^3.2.1",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",

--- a/src/mate/src/Bridge/Monolog/composer.json
+++ b/src/mate/src/Bridge/Monolog/composer.json
@@ -31,7 +31,7 @@
         "symfony/ai-mate": "^0.10"
     },
     "require-dev": {
-        "helgesverre/toon": "^3.1",
+        "helgesverre/toon": "^3.2.1",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.13|^3.0",
-        "helgesverre/toon": "^3.1",
+        "helgesverre/toon": "^3.2.1",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

`Mate\Encoding\ResponseEncoder` round-trips arbitrary tool, log and profiler
data through `Toon::encode()` and `Toon::decode()`. Older `helgesverre/toon`
releases fail on that data:

- **3.1.x** rejects strings containing C0 control characters with an
  `InvalidArgumentException`. This is reachable in practice: the Monolog
  `LogSearchTool` and the Symfony profiler bridge encode log/profiler output,
  which frequently carries ANSI escape sequences (ESC, `0x1B`).
- **3.2.0** escapes control characters on encode, but a decoder regression
  makes any quoted value containing `[` or `{` (including those ANSI escapes)
  throw `SyntaxException: Unterminated quoted string` on decode — so the
  round-trip fails.

```php
$data = ['log' => "start\e[31merr\e[0m"]; // \e is ESC (0x1B)

// helgesverre/toon 3.1.x
ResponseEncoder::encode($data); // InvalidArgumentException: unsupported control characters

// helgesverre/toon 3.2.0
$toon = ResponseEncoder::encode($data);   // ok, escapes ESC as \uXXXX
ResponseEncoder::decode($toon);           // SyntaxException: Unterminated quoted string

// helgesverre/toon 3.2.1
ResponseEncoder::decode(ResponseEncoder::encode($data)) === $data; // true
```

This raises the minimum of the optional (`require-dev`) `helgesverre/toon`
constraint from `^3.1` to `^3.2.1` in `ai-mate` and its Monolog and Symfony
bridges, excluding the affected 3.1.x and 3.2.0 releases. The dependency stays
optional and guarded by `class_exists(Toon::class)`; no `suggest` entry is
added (per #1913).

Upstream fix / release notes: https://github.com/HelgeSverre/toon-php/releases/tag/v3.2.1
