### PR TITLE
[Mate] Improve cache isolation, recursive cleanup, and cross-platform compatibility

### DIFF
--- a/src/mate/resources/mcp.json
+++ b/src/mate/resources/mcp.json
@@ -1,8 +1,9 @@
 {
     "mcpServers": {
         "symfony-ai-mate": {
-            "command": "./vendor/bin/mate",
+            "command": "php",
             "args": [
+                "./vendor/bin/mate",
                 "serve",
                 "--force-keep-alive"
             ]

--- a/src/mate/src/Command/ClearCacheCommand.php
+++ b/src/mate/src/Command/ClearCacheCommand.php
@@ -77,6 +77,13 @@ class ClearCacheCommand extends Command
             ++$count;
         }
 
+        // Clean up empty subdirectories
+        $dirFinder = new Finder();
+        $dirFinder->directories()->in($cacheDir);
+        foreach (array_reverse(iterator_to_array($dirFinder)) as $dir) {
+            @rmdir($dir->getRealPath());
+        }
+
         if ($count > 0) {
             $io->section('Cleared Files');
             $io->table(['File', 'Size'], $fileList);

--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -96,12 +96,18 @@ class InitCommand extends Command
                 unlink($mcpJsonSymlink);
             }
             if (!file_exists($mcpJsonSymlink)) {
-                symlink('mcp.json', $mcpJsonSymlink);
-                $actions[] = ['✓', 'Created', '.mcp.json (symlink to mcp.json)'];
+                if (@symlink('mcp.json', $mcpJsonSymlink)) {
+                    $actions[] = ['✓', 'Created', '.mcp.json (symlink to mcp.json)'];
+                } else {
+                    $actions[] = ['⚠', 'Warning', 'Could not create .mcp.json symlink (symlink failed). You may need to manually copy mcp.json to .mcp.json'];
+                }
             } elseif ($io->confirm(\sprintf('<question>%s already exists. Replace with symlink?</question>', $mcpJsonSymlink), false)) {
                 unlink($mcpJsonSymlink);
-                symlink('mcp.json', $mcpJsonSymlink);
-                $actions[] = ['✓', 'Updated', '.mcp.json (symlink to mcp.json)'];
+                if (@symlink('mcp.json', $mcpJsonSymlink)) {
+                    $actions[] = ['✓', 'Updated', '.mcp.json (symlink to mcp.json)'];
+                } else {
+                    $actions[] = ['⚠', 'Warning', 'Could not create .mcp.json symlink (symlink failed). You may need to manually copy mcp.json to .mcp.json'];
+                }
             } else {
                 $actions[] = ['○', 'Skipped', '.mcp.json (already exists)'];
             }

--- a/src/mate/src/Command/StopCommand.php
+++ b/src/mate/src/Command/StopCommand.php
@@ -47,16 +47,10 @@ class StopCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        if (!\function_exists('posix_kill')) {
-            $io->error('The "stop" command require the posix php extension.');
+        if (!is_dir($this->cacheDir)) {
+            $io->note('No running servers found.');
 
-            return Command::FAILURE;
-        }
-
-        if (!\defined('SIGUSR1')) {
-            $io->error('The "stop" command require the pcntl php extension.');
-
-            return Command::FAILURE;
+            return Command::SUCCESS;
         }
 
         $finder = new Finder();
@@ -64,11 +58,53 @@ class StopCommand extends Command
             ->in($this->cacheDir)
             ->name('server_*.pid');
 
-        foreach ($finder as $file) {
+        $files = iterator_to_array($finder);
+        if ([] === $files) {
+            $io->note('No running servers found.');
+
+            return Command::SUCCESS;
+        }
+
+        if ('Windows' !== \PHP_OS_FAMILY) {
+            if (!\function_exists('posix_kill')) {
+                $io->error('The "stop" command require the posix php extension.');
+
+                return Command::FAILURE;
+            }
+
+            if (!\defined('SIGUSR1')) {
+                $io->error('The "stop" command require the pcntl php extension.');
+
+                return Command::FAILURE;
+            }
+        }
+
+        $killedCount = 0;
+        foreach ($files as $file) {
             $pid = (int) file_get_contents($file->getRealPath());
-            posix_kill($pid, \SIGUSR1);
+            if ($this->stopProcess($pid)) {
+                ++$killedCount;
+            }
+            @unlink($file->getRealPath());
+        }
+
+        if ($killedCount > 0) {
+            $io->success(\sprintf('Stopped %d running server(s).', $killedCount));
+        } else {
+            $io->note('No running servers found.');
         }
 
         return Command::SUCCESS;
+    }
+
+    private function stopProcess(int $pid): bool
+    {
+        if ('Windows' === \PHP_OS_FAMILY) {
+            exec(\sprintf('taskkill /F /PID %d 2>&1', $pid), $execOutput, $resultCode);
+
+            return 0 === $resultCode;
+        }
+
+        return @posix_kill($pid, \SIGUSR1);
     }
 }

--- a/src/mate/src/Container/ContainerFactory.php
+++ b/src/mate/src/Container/ContainerFactory.php
@@ -61,6 +61,11 @@ final class ContainerFactory
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__)));
         $loader->load('default.config.php');
         $container->setParameter('mate.root_dir', $this->rootDir);
+
+        $userSuffix = (getenv('USER') ?: getenv('USERNAME')) ?: 'default';
+        $userSuffix = preg_replace('/[^a-zA-Z0-9]/', '', $userSuffix);
+        $projectHash = substr(md5($this->rootDir), 0, 8);
+        $container->setParameter('mate.cache_dir', sys_get_temp_dir().'/mate/'.$userSuffix.'_'.$projectHash);
     }
 
     private function loadExtensions(ContainerBuilder $container, ComposerExtensionDiscovery $extensionDiscovery, LoggerInterface $logger): void

--- a/src/mate/tests/Command/ClearCacheCommandTest.php
+++ b/src/mate/tests/Command/ClearCacheCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Command\ClearCacheCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ * @author Antigravity
+ */
+final class ClearCacheCommandTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir().'/mate-cache-test-'.uniqid();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            $this->removeDirectory($this->tempDir);
+        }
+    }
+
+    public function testExecuteClearsCacheFilesAndDirectories()
+    {
+        mkdir($this->tempDir, 0755, true);
+        mkdir($this->tempDir.'/sessions', 0755, true);
+        file_put_contents($this->tempDir.'/file1.txt', 'content1');
+        file_put_contents($this->tempDir.'/sessions/session1.txt', 'session_content');
+
+        $command = new ClearCacheCommand($this->tempDir);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Successfully cleared 2 cache files', $output);
+        $this->assertFileDoesNotExist($this->tempDir.'/file1.txt');
+        $this->assertDirectoryDoesNotExist($this->tempDir.'/sessions');
+        $this->assertDirectoryExists($this->tempDir);
+    }
+
+    public function testExecuteGracefullyHandlesMissingDirectory()
+    {
+        $command = new ClearCacheCommand($this->tempDir);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Cache directory does not exist. Nothing to clear.', $output);
+    }
+
+    public function testExecuteHandlesEmptyDirectory()
+    {
+        mkdir($this->tempDir, 0755, true);
+
+        $command = new ClearCacheCommand($this->tempDir);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Cache directory is already empty.', $output);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir.'/'.$file;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/src/mate/tests/Command/StopCommandTest.php
+++ b/src/mate/tests/Command/StopCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Command\StopCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ * @author Antigravity
+ */
+final class StopCommandTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir().'/mate-stop-test-'.uniqid();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            $this->removeDirectory($this->tempDir);
+        }
+    }
+
+    public function testExecuteGracefullyHandlesMissingDirectory()
+    {
+        $command = new StopCommand($this->tempDir);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('No running servers found.', $output);
+    }
+
+    public function testExecuteGracefullyHandlesEmptyDirectory()
+    {
+        mkdir($this->tempDir, 0755, true);
+
+        $command = new StopCommand($this->tempDir);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('No running servers found.', $output);
+    }
+
+    public function testExecuteFindsAndTerminatesPidFileProcess()
+    {
+        mkdir($this->tempDir, 0755, true);
+
+        // Write a PID file with a dummy PID that doesn't exist
+        // Note: posix_kill on a non-existent PID should be handled gracefully (warning suppressed)
+        file_put_contents($this->tempDir.'/server_12345.pid', '12345');
+
+        $command = new StopCommand($this->tempDir);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        // Verify PID file is deleted
+        $this->assertFileDoesNotExist($this->tempDir.'/server_12345.pid');
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir.'/'.$file;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | 
| License       | MIT

### Description

This Pull Request introduces several improvements and bug fixes for the `mate` component:

1. **Cache Directory Isolation:** Default cache directories are now isolated by system username and project path hash to avoid permissions conflicts and state/session leakage on multi-tenant or shared systems.
2. **Cross-Platform Compatibility & Portability:**
   - Modified generated `mcp.json` templates to run `./vendor/bin/mate` via `php` directly (making it more portable on Windows and non-executable filesystems).
   - Handled symlink creation failure gracefully on Windows (e.g. lack of developer mode/admin rights) during `init` by outputting a warning instead of raising a PHP warning and terminating.
   - Added native Windows support to `StopCommand` using `taskkill`.
3. **Recursive Cache Cleanup:** `ClearCacheCommand` now recursively deletes empty subdirectories (e.g., `sessions/`) inside the cache directory.
4. **Test Coverage:** Added new test suites for `ClearCacheCommand` and `StopCommand`.
