### PR TITLE
[Agent][Platform] Fix parallel tool calls being dropped

### DIFF
--- a/examples/anthropic/toolcall-parallel.php
+++ b/examples/anthropic/toolcall-parallel.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Toolbox\AgentProcessor;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Fixtures\TemperatureTool;
+use Symfony\AI\Platform\Bridge\Anthropic\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('ANTHROPIC_API_KEY'), httpClient: http_client());
+
+$temperature = new TemperatureTool();
+$toolbox = new Toolbox([$temperature], logger: logger());
+$processor = new AgentProcessor($toolbox);
+$agent = new Agent($platform, 'claude-sonnet-4-5-20250929', [$processor], [$processor]);
+
+$messages = new MessageBag(
+    Message::forSystem('Use the available tool to answer. Call it once per city, in a single turn.'),
+    Message::ofUser('What is the temperature in Berlin, Paris and Rome?'),
+);
+$result = $agent->call($messages);
+
+echo $result->getContent().\PHP_EOL.\PHP_EOL;
+
+// Claude requests all three cities in a single turn, so the tool runs three times.
+echo 'Tool executed for: '.implode(', ', $temperature->calledFor).\PHP_EOL;

--- a/fixtures/TemperatureTool.php
+++ b/fixtures/TemperatureTool.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Fixtures;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[AsTool('get_temperature', 'Returns the current temperature in degrees Celsius for a city.')]
+final class TemperatureTool
+{
+    /**
+     * Records every city the tool was invoked with, to make parallel tool calls observable.
+     *
+     * @var list<string>
+     */
+    public array $calledFor = [];
+
+    public function __invoke(string $city): string
+    {
+        $this->calledFor[] = $city;
+
+        return match ($city) {
+            'Berlin' => '12°C',
+            'Paris' => '15°C',
+            'Rome' => '19°C',
+            default => 'unknown',
+        };
+    }
+}

--- a/src/agent/src/Toolbox/AgentProcessor.php
+++ b/src/agent/src/Toolbox/AgentProcessor.php
@@ -88,7 +88,7 @@ final class AgentProcessor implements InputProcessorInterface, OutputProcessorIn
         }
 
         if ($result instanceof MultiPartResult) {
-            $result = array_find($result->getContent(), static fn (ResultInterface $part) => $part instanceof ToolCallResult);
+            $result = $result->asToolCallResult();
         }
 
         if (!$result instanceof ToolCallResult) {

--- a/src/agent/tests/Toolbox/AgentProcessorTest.php
+++ b/src/agent/tests/Toolbox/AgentProcessorTest.php
@@ -166,6 +166,42 @@ class AgentProcessorTest extends TestCase
         $this->assertSame('Final response', $output->getResult()->getContent());
     }
 
+    public function testProcessOutputWithMultiPartResultContainingSeveralToolCallParts()
+    {
+        $toolCall1 = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolCall2 = new ToolCall('id2', 'tool2', ['arg2' => 'value2']);
+
+        $executed = [];
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->expects($this->exactly(2))
+            ->method('execute')
+            ->willReturnCallback(static function (ToolCall $toolCall) use (&$executed) {
+                $executed[] = $toolCall->getName();
+
+                return new ToolResult($toolCall, 'Test response');
+            });
+
+        $messageBag = new MessageBag();
+        $result = new MultiPartResult([
+            new TextResult('Some text before tool calls'),
+            new ToolCallResult([$toolCall1]),
+            new ToolCallResult([$toolCall2]),
+        ]);
+
+        $agent = $this->createStub(AgentInterface::class);
+        $agent->method('call')->willReturn(new TextResult('Final response'));
+
+        $processor = new AgentProcessor($toolbox);
+        $processor->setAgent($agent);
+
+        $output = new Output('gpt-4', $result, $messageBag);
+
+        $processor->processOutput($output);
+
+        $this->assertSame(['tool1', 'tool2'], $executed);
+    }
+
     public function testProcessOutputWithMultiPartResultNotContainingToolCall()
     {
         $toolbox = $this->createMock(ToolboxInterface::class);

--- a/src/platform/src/Result/MultiPartResult.php
+++ b/src/platform/src/Result/MultiPartResult.php
@@ -41,4 +41,28 @@ final class MultiPartResult extends BaseResult implements \IteratorAggregate
     {
         return implode('', array_map(static fn (TextResult $result) => $result->getContent(), array_filter($this->results, static fn (ResultInterface $result) => $result instanceof TextResult)));
     }
+
+    /**
+     * Aggregates the tool calls of all tool call parts into a single result.
+     *
+     * Bridges of content block based APIs emit one tool call part per tool call, so parallel tool
+     * calls of one assistant turn are spread over several parts and need to be joined again.
+     */
+    public function asToolCallResult(): ?ToolCallResult
+    {
+        $toolCalls = [];
+        foreach ($this->results as $result) {
+            if ($result instanceof ToolCallResult) {
+                foreach ($result->getContent() as $toolCall) {
+                    $toolCalls[] = $toolCall;
+                }
+            }
+        }
+
+        if ([] === $toolCalls) {
+            return null;
+        }
+
+        return new ToolCallResult($toolCalls);
+    }
 }

--- a/src/platform/tests/Result/MultiPartResultTest.php
+++ b/src/platform/tests/Result/MultiPartResultTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+
+final class MultiPartResultTest extends TestCase
+{
+    public function testAsTextFlattensOnlyTextParts()
+    {
+        $result = new MultiPartResult([
+            new ThinkingResult('Let me think.', 'sig_abc'),
+            new TextResult('Hello '),
+            new TextResult('world.'),
+        ]);
+
+        $this->assertSame('Hello world.', $result->asText());
+    }
+
+    public function testAsToolCallResultReturnsNullWithoutToolCallParts()
+    {
+        $result = new MultiPartResult([
+            new ThinkingResult('Let me think.', 'sig_abc'),
+            new TextResult('Hello world.'),
+        ]);
+
+        $this->assertNull($result->asToolCallResult());
+    }
+
+    public function testAsToolCallResultAggregatesSeveralToolCallParts()
+    {
+        $toolCall1 = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolCall2 = new ToolCall('id2', 'tool2', ['arg2' => 'value2']);
+
+        $result = new MultiPartResult([
+            new ThinkingResult('Let me think.', 'sig_abc'),
+            new TextResult('Looking both up.'),
+            new ToolCallResult([$toolCall1]),
+            new ToolCallResult([$toolCall2]),
+        ]);
+
+        $toolCallResult = $result->asToolCallResult();
+
+        $this->assertInstanceOf(ToolCallResult::class, $toolCallResult);
+        $this->assertSame([$toolCall1, $toolCall2], $toolCallResult->getContent());
+    }
+
+    public function testAsToolCallResultKeepsAlreadyAggregatedToolCalls()
+    {
+        $toolCall1 = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolCall2 = new ToolCall('id2', 'tool2', ['arg2' => 'value2']);
+
+        $result = new MultiPartResult([
+            new TextResult('Looking both up.'),
+            new ToolCallResult([$toolCall1, $toolCall2]),
+        ]);
+
+        $toolCallResult = $result->asToolCallResult();
+
+        $this->assertInstanceOf(ToolCallResult::class, $toolCallResult);
+        $this->assertSame([$toolCall1, $toolCall2], $toolCallResult->getContent());
+    }
+
+    public function testAsToolCallResultReturnsListWithGaplessKeys()
+    {
+        $toolCall1 = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolCall2 = new ToolCall('id2', 'tool2', ['arg2' => 'value2']);
+
+        $result = new MultiPartResult([
+            new ToolCallResult([$toolCall1]),
+            new TextResult('Interleaved text.'),
+            new ToolCallResult([$toolCall2]),
+        ]);
+
+        $toolCalls = $result->asToolCallResult()->getContent();
+
+        $this->assertSame([0, 1], array_keys($toolCalls));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Bridges of content block based APIs (Anthropic, Gemini, VertexAI, ClaudeCode, Codex) emit one `ToolCallResult` per tool call, so parallel tool calls of one assistant turn arrive as several parts of a `MultiPartResult`. `AgentProcessor` picked the first part via `array_find` and discarded the rest.

The agent loop hid this: after executing the first tool call, the model was asked again and re-requested the dropped ones, one round-trip at a time. Measured against Claude Sonnet 4.5 with three parallel tool calls:

* 4 HTTP round-trips instead of 2
* the assistant message was rewritten to contain only the surviving tool call
* calls are lost outright whenever the model does not ask again

Bridges of OpenAI shaped APIs are unaffected, they already aggregate all tool calls into one `ToolCallResult`. Streaming is unaffected too, `ToolCallComplete` aggregates.

`MultiPartResult::asToolCallResult()` now aggregates the tool calls of all tool call parts into a single result, or `null` when there is none. `examples/anthropic/toolcall-parallel.php` covers the case end to end.