### PR TITLE
[Platform] Normalize finish_reason metadata across all bridges

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -529,6 +529,65 @@ The following delta types are available:
 * :class:`Symfony\\AI\\Platform\\Result\\Stream\\Delta\\ChoiceDelta` -- a choice delta (e.g. multiple completions)
 * :class:`Symfony\\AI\\Platform\\Result\\Stream\\Delta\\BinaryDelta` -- a chunk of binary data
 
+Finish Reason
+~~~~~~~~~~~~~
+
+Every bridge whose provider reports why generation stopped exposes it as the ``finish_reason``
+result metadata, for both buffered and streamed results. This is what tells a complete answer
+apart from one that was cut off by the output token limit::
+
+    use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+    $result = $platform->invoke($model, $messages, ['max_tokens' => 50]);
+
+    $finishReason = $result->getMetadata()->get('finish_reason');
+
+    if ($finishReason?->is(FinishReasonCase::LENGTH)) {
+        // the answer is truncated -- continue generation or raise the limit
+    }
+
+Providers spell the reason differently, so the value is a
+:class:`Symfony\\AI\\Platform\\FinishReason\\FinishReason` object that normalizes it into a
+:class:`Symfony\\AI\\Platform\\FinishReason\\FinishReasonCase` while keeping the provider's own
+wording available::
+
+    $finishReason->getCase(); // FinishReasonCase::LENGTH
+    $finishReason->getRaw();  // "max_tokens" on Anthropic, "MAX_TOKENS" on Gemini, "length" on OpenAI
+
+The normalized cases are ``STOP``, ``LENGTH``, ``TOOL_CALL``, ``CONTENT_FILTER``,
+``STOP_SEQUENCE`` and ``OTHER``. A provider-specific reason without an equivalent -- such as
+Gemini's ``RECITATION`` -- normalizes to ``OTHER``, and ``getRaw()`` tells those apart.
+
+The translation itself lives in the bridge, in a ``FinishReasonMapper`` next to its result converter,
+the same way ``TokenUsageExtractor`` is provided per bridge. A new bridge maps its own vocabulary onto
+the cases above without touching the Platform component.
+
+.. note::
+
+    The metadata is only set when the provider reports a reason, so guard against ``null``.
+    The normalized case reflects what the provider actually reported: a provider that ends a
+    tool-call turn with a plain ``stop`` surfaces as ``STOP``, not ``TOOL_CALL``.
+
+When streaming, the reason is only known once the stream has been consumed. It is emitted as
+the final ``MetadataDelta``, which ``asStream()`` promotes into the result metadata and skips
+from the visible deltas::
+
+    foreach ($result->asTextStream() as $delta) {
+        echo $delta;
+    }
+
+    // available after the stream has been fully consumed
+    $finishReason = $result->getMetadata()->get('finish_reason');
+
+.. note::
+
+    A streamed ``LENGTH`` is not surfaced by every bridge. Some providers -- Anthropic among them --
+    treat a truncation at the output token limit as an error mid-stream and throw a
+    :class:`Symfony\\AI\\Platform\\Exception\\MaxOutputTokensException` instead of emitting the reason,
+    so the same ``max_tokens`` case that surfaces as ``LENGTH`` on a buffered result raises an exception
+    when streamed. Wrap the consumption loop in a ``try``/``catch`` when you need to handle truncation
+    of a streamed response.
+
 Streaming in a Symfony Controller
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -14,6 +14,8 @@ use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\Exception\ExceptionInterface as AgentException;
 use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
 use Symfony\AI\Platform\Exception\ExceptionInterface as PlatformException;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\TokenUsage\TokenUsageAggregation;
 use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
@@ -150,6 +152,23 @@ function print_token_usage(?TokenUsageInterface $tokenUsage): void
     if ($tokenUsage instanceof TokenUsageAggregation) {
         output()->writeln(sprintf('<comment>Aggregated token usage from %d calls.</comment>', $tokenUsage->count()));
     }
+}
+
+function print_finish_reason(?FinishReason $finishReason): void
+{
+    if (null === $finishReason) {
+        output()->writeln('<error>No finish reason information available.</error>');
+        exit(1);
+    }
+
+    $table = new Table(output());
+    $table->setHeaderTitle('Finish Reason');
+    $table->setRows([
+        ['Normalized case', $finishReason->getCase()->value],
+        ['Raw provider value', $finishReason->getRaw()],
+        ['Truncated', $finishReason->is(FinishReasonCase::LENGTH) ? '<error>yes</error>' : 'no'],
+    ]);
+    $table->render();
 }
 
 function print_vectors(DeferredResult $result): void

--- a/examples/misc/finish-reason.php
+++ b/examples/misc/finish-reason.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Anthropic\Factory as AnthropicFactory;
+use Symfony\AI\Platform\Bridge\OpenAi\Factory as OpenAiFactory;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$messages = new MessageBag(
+    Message::forSystem('You are an encyclopedia.'),
+    Message::ofUser('Explain the history of the Roman Empire in great detail.'),
+);
+
+$platforms = [
+    'openai' => [OpenAiFactory::createPlatform(env('OPENAI_API_KEY'), http_client()), 'gpt-4o-mini', ['max_output_tokens' => 16]],
+    'anthropic' => [AnthropicFactory::createPlatform(env('ANTHROPIC_API_KEY'), http_client()), 'claude-sonnet-4-5-20250929', ['max_tokens' => 16]],
+];
+
+foreach ($platforms as $name => [$platform, $model, $options]) {
+    output()->writeln(sprintf('<info>%s</info>', $name));
+
+    $result = $platform->invoke($model, $messages, $options);
+    $result->asText();
+
+    $finishReason = $result->getMetadata()->get('finish_reason');
+
+    print_finish_reason($finishReason);
+
+    if ($finishReason->is(FinishReasonCase::LENGTH)) {
+        output()->writeln('<comment>The answer above is cut off -- raise the output token limit to see the rest.</comment>');
+    }
+}
+
+output()->writeln('<info>anthropic (streamed)</info>');
+
+[$platform, $model] = $platforms['anthropic'];
+$result = $platform->invoke($model, new MessageBag(Message::ofUser('Reply with a single short sentence.')), ['stream' => true, 'max_tokens' => 100]);
+
+foreach ($result->asTextStream() as $delta) {
+    echo $delta;
+}
+echo \PHP_EOL;
+
+print_finish_reason($result->getMetadata()->get('finish_reason'));

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -23,8 +23,8 @@ CHANGELOG
  * Add OpenAI image editing via the `images/edits` endpoint: pass the source image as a `Content\Image` through the `image` option of `Platform::invoke()`
  * [BC BREAK] Rename the OpenAI `DallE` bridge to `Image` (`Bridge\OpenAi\DallE` → `Bridge\OpenAi\Image`, and the `Bridge\OpenAi\DallE\*` namespace → `Bridge\OpenAi\Image\*`) and remove the `dall-e-2`/`dall-e-3` catalog entries retired by OpenAI
  * [BC BREAK] Replace the bridge-specific `ImageResult`, `Base64Image`, and `UrlImage` classes of the OpenAI image bridge with the generic `Result\BinaryResult` (single image) and `Result\MultiPartResult` (multiple images), matching the other multi-modal bridges
- * Add streamed Generic completions `finish_reason` values as result metadata
  * Add an exception is the `response_format` option looks like a class, but is not
+ * Add the `finish_reason` result metadata, exposing why a model stopped generating as a `FinishReason\FinishReason` object that normalizes the provider value (`length`, `max_tokens`, `MAX_TOKENS`, ...) into a `FinishReason\FinishReasonCase` while keeping the raw value. Set for buffered and streamed results by the OpenAI, Anthropic, Gemini, VertexAI, Amazon Bedrock, Azure, Ollama, Cohere, Mistral, DeepSeek, Cerebras, Scaleway, Docker Model Runner, Perplexity, MiniMax, amazee.ai and Generic bridges
 
 0.10
 ----

--- a/src/platform/phpstan.dist.neon
+++ b/src/platform/phpstan.dist.neon
@@ -31,6 +31,9 @@ parameters:
         -
             identifier: 'trait.unused'
             path: src/JsonBodyEncodingTrait.php # only used by bridges, which are excluded from analysis
+        -
+            identifier: 'trait.unused'
+            path: src/FinishReason/FinishReasonAwareTrait.php # only used by bridges, which are excluded from analysis
 
 services:
     - # Conditionally enabled by bleeding edge in phpstan/phpstan-phpunit 2.x

--- a/src/platform/src/Bridge/AmazeeAi/CompletionsResultConverter.php
+++ b/src/platform/src/Bridge/AmazeeAi/CompletionsResultConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\AmazeeAi;
 
+use Symfony\AI\Platform\Bridge\Generic\Completions\FinishReasonMapper;
 use Symfony\AI\Platform\Bridge\Generic\Completions\ResultConverter;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\TextResult;
@@ -43,18 +44,18 @@ class CompletionsResultConverter extends ResultConverter
     {
         if ('tool_calls' === $choice['finish_reason']) {
             if (isset($choice['message']['tool_calls'])) {
-                return new ToolCallResult(array_map([$this, 'convertToolCall'], $choice['message']['tool_calls']));
+                return $this->withFinishReason(new ToolCallResult(array_map([$this, 'convertToolCall'], $choice['message']['tool_calls'])), FinishReasonMapper::map($choice['finish_reason']));
             }
 
             // LiteLLM structured output: finish_reason is "tool_calls" but
             // content is in message.content instead of message.tool_calls
             if (isset($choice['message']['content'])) {
-                return new TextResult($choice['message']['content']);
+                return $this->withFinishReason(new TextResult($choice['message']['content']), FinishReasonMapper::map($choice['finish_reason']));
             }
         }
 
         if (\in_array($choice['finish_reason'], ['stop', 'length'], true)) {
-            return new TextResult($choice['message']['content']);
+            return $this->withFinishReason(new TextResult($choice['message']['content']), FinishReasonMapper::map($choice['finish_reason']));
         }
 
         throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));

--- a/src/platform/src/Bridge/Anthropic/FinishReasonMapper.php
+++ b/src/platform/src/Bridge/Anthropic/FinishReasonMapper.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Anthropic;
+
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+/**
+ * Maps the Anthropic Messages API `stop_reason`.
+ *
+ * Reused by the Amazon Bedrock Claude bridge, which speaks the same payload schema.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class FinishReasonMapper
+{
+    public static function map(?string $rawFinishReason): ?FinishReason
+    {
+        if (null === $rawFinishReason || '' === $rawFinishReason) {
+            return null;
+        }
+
+        return new FinishReason(match ($rawFinishReason) {
+            'end_turn' => FinishReasonCase::STOP,
+            'max_tokens' => FinishReasonCase::LENGTH,
+            'tool_use' => FinishReasonCase::TOOL_CALL,
+            'stop_sequence' => FinishReasonCase::STOP_SEQUENCE,
+            'refusal' => FinishReasonCase::CONTENT_FILTER,
+            default => FinishReasonCase::OTHER,
+        }, $rawFinishReason);
+    }
+}

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\Exception\MaxOutputTokensException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
@@ -26,6 +27,7 @@ use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
@@ -46,6 +48,8 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 class ResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Claude;
@@ -143,11 +147,10 @@ class ResultConverter implements ResultConverterInterface
             throw new RuntimeException('Response content does not contain any supported content.');
         }
 
-        if (1 === \count($results)) {
-            return $results[0];
-        }
-
-        return new MultiPartResult($results);
+        return $this->withFinishReason(
+            1 === \count($results) ? $results[0] : new MultiPartResult($results),
+            FinishReasonMapper::map($data['stop_reason'] ?? null),
+        );
     }
 
     public function getTokenUsageExtractor(): TokenUsageExtractor
@@ -323,6 +326,12 @@ class ResultConverter implements ResultConverterInterface
 
         if ($inMessage) {
             throw new IncompleteStreamException('Anthropic stream ended before message_stop.');
+        }
+
+        // Anthropic reports the stop reason on message_delta, before message_stop. A `max_tokens`
+        // truncation has already thrown above, so any reason reaching here is a normal completion.
+        if (null !== $stopReason) {
+            yield new MetadataDelta('finish_reason', FinishReasonMapper::map($stopReason));
         }
     }
 }

--- a/src/platform/src/Bridge/Anthropic/Tests/FinishReasonMapperTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/FinishReasonMapperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Anthropic\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Anthropic\FinishReasonMapper;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+final class FinishReasonMapperTest extends TestCase
+{
+    #[DataProvider('provideFinishReasons')]
+    public function testItMapsTheProviderVocabulary(string $raw, FinishReasonCase $expected)
+    {
+        $finishReason = FinishReasonMapper::map($raw);
+
+        $this->assertSame($expected, $finishReason->getCase());
+        $this->assertSame($raw, $finishReason->getRaw());
+    }
+
+    /**
+     * @return iterable<string, array{string, FinishReasonCase}>
+     */
+    public static function provideFinishReasons(): iterable
+    {
+        yield 'end_turn' => ['end_turn', FinishReasonCase::STOP];
+        yield 'max_tokens' => ['max_tokens', FinishReasonCase::LENGTH];
+        yield 'tool_use' => ['tool_use', FinishReasonCase::TOOL_CALL];
+        yield 'stop_sequence' => ['stop_sequence', FinishReasonCase::STOP_SEQUENCE];
+        yield 'refusal' => ['refusal', FinishReasonCase::CONTENT_FILTER];
+        yield 'unknown' => ['pause_turn', FinishReasonCase::OTHER];
+    }
+
+    public function testItReturnsNullForAMissingReason()
+    {
+        $this->assertNull(FinishReasonMapper::map(null));
+        $this->assertNull(FinishReasonMapper::map(''));
+    }
+}

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -19,12 +19,16 @@ use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\MaxOutputTokensException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
@@ -231,7 +235,7 @@ final class ResultConverterTest extends TestCase
         $this->assertInstanceOf(ToolInputDelta::class, $chunks[2]);
         $this->assertInstanceOf(ToolInputDelta::class, $chunks[3]);
 
-        $toolCallComplete = $chunks[\count($chunks) - 1];
+        $toolCallComplete = array_values(array_filter($chunks, static fn (DeltaInterface $delta) => $delta instanceof ToolCallComplete))[0] ?? null;
         $this->assertInstanceOf(ToolCallComplete::class, $toolCallComplete);
         $toolCalls = $toolCallComplete->getToolCalls();
         $this->assertCount(1, $toolCalls);
@@ -453,7 +457,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('Let me check ', $textDeltas[0]->getText());
         $this->assertSame('the weather.', $textDeltas[1]->getText());
 
-        $toolCallComplete = $chunks[\count($chunks) - 1];
+        $toolCallComplete = array_values(array_filter($chunks, static fn (DeltaInterface $delta) => $delta instanceof ToolCallComplete))[0] ?? null;
         $this->assertInstanceOf(ToolCallComplete::class, $toolCallComplete);
 
         $toolCalls = $toolCallComplete->getToolCalls();
@@ -555,7 +559,7 @@ final class ResultConverterTest extends TestCase
         $this->assertCount(1, $textDeltas);
         $this->assertSame('Let me search.', $textDeltas[0]->getText());
 
-        $toolCallComplete = $chunks[\count($chunks) - 1];
+        $toolCallComplete = array_values(array_filter($chunks, static fn (DeltaInterface $delta) => $delta instanceof ToolCallComplete))[0] ?? null;
         $this->assertInstanceOf(ToolCallComplete::class, $toolCallComplete);
         $this->assertSame('toolu_01', $toolCallComplete->getToolCalls()[0]->getId());
         $this->assertSame('search', $toolCallComplete->getToolCalls()[0]->getName());
@@ -740,6 +744,54 @@ final class ResultConverterTest extends TestCase
             $this->assertNotInstanceOf(ServerException::class, $e);
             $this->assertStringContainsString('Bad input', $e->getMessage());
         }
+    }
+
+    public function testConvertExposesStopReasonAsFinishReasonMetadata()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [['type' => 'text', 'text' => 'Truncated']],
+            'stop_reason' => 'max_tokens',
+        ]));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $finishReason = $result->getMetadata()->get('finish_reason');
+        $this->assertInstanceOf(FinishReason::class, $finishReason);
+        $this->assertTrue($finishReason->is(FinishReasonCase::LENGTH));
+        $this->assertSame('max_tokens', $finishReason->getRaw());
+    }
+
+    public function testConvertWithoutStopReasonOmitsFinishReasonMetadata()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'content' => [['type' => 'text', 'text' => 'Hello']],
+        ]));
+        $httpResponse = $httpClient->request('POST', 'https://api.anthropic.com/v1/messages');
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $this->assertFalse($result->getMetadata()->has('finish_reason'));
+    }
+
+    public function testStreamingExposesStopReasonAsFinishReasonMetadata()
+    {
+        $events = [
+            ['type' => 'message_start', 'message' => ['usage' => ['input_tokens' => 3]]],
+            ['type' => 'content_block_delta', 'delta' => ['text' => 'Hello']],
+            ['type' => 'message_delta', 'delta' => ['stop_reason' => 'end_turn'], 'usage' => ['output_tokens' => 1]],
+            ['type' => 'message_stop'],
+        ];
+
+        $streamResult = (new ResultConverter())->convert($this->createRawResult($events), ['stream' => true]);
+
+        $chunks = iterator_to_array($streamResult->getContent());
+        $metadataDelta = $chunks[\count($chunks) - 1];
+
+        $this->assertInstanceOf(MetadataDelta::class, $metadataDelta);
+        $this->assertSame('finish_reason', $metadataDelta->getKey());
+        $this->assertTrue($metadataDelta->getValue()->is(FinishReasonCase::STOP));
+        $this->assertSame('end_turn', $metadataDelta->getValue()->getRaw());
     }
 
     /**

--- a/src/platform/src/Bridge/Azure/Meta/LlamaResultConverter.php
+++ b/src/platform/src/Bridge/Azure/Meta/LlamaResultConverter.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\AI\Platform\Bridge\Azure\Meta;
 
+use Symfony\AI\Platform\Bridge\Generic\Completions\FinishReasonMapper;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
@@ -24,6 +26,8 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 final class LlamaResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Llama;
@@ -37,7 +41,7 @@ final class LlamaResultConverter implements ResultConverterInterface
             throw new RuntimeException('Response does not contain output.');
         }
 
-        return new TextResult($data['choices'][0]['message']['content']);
+        return $this->withFinishReason(new TextResult($data['choices'][0]['message']['content']), FinishReasonMapper::map($data['choices'][0]['finish_reason'] ?? null));
     }
 
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface

--- a/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeResultConverter.php
+++ b/src/platform/src/Bridge/Bedrock/Anthropic/ClaudeResultConverter.php
@@ -12,8 +12,10 @@
 namespace Symfony\AI\Platform\Bridge\Bedrock\Anthropic;
 
 use Symfony\AI\Platform\Bridge\Anthropic\Claude;
+use Symfony\AI\Platform\Bridge\Anthropic\FinishReasonMapper;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -30,6 +32,8 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 final class ClaudeResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Claude;
@@ -60,11 +64,10 @@ final class ClaudeResultConverter implements ResultConverterInterface
             throw new RuntimeException('Response content does not contain any supported content.');
         }
 
-        if (1 === \count($results)) {
-            return $results[0];
-        }
-
-        return new MultiPartResult($results);
+        return $this->withFinishReason(
+            1 === \count($results) ? $results[0] : new MultiPartResult($results),
+            FinishReasonMapper::map($data['stop_reason'] ?? null),
+        );
     }
 
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface

--- a/src/platform/src/Bridge/Bedrock/FinishReasonMapper.php
+++ b/src/platform/src/Bridge/Bedrock/FinishReasonMapper.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Bedrock;
+
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+/**
+ * Maps the Amazon Bedrock `stopReason` (Converse API, used by Nova) and the `stop_reason` of the
+ * Bedrock-hosted Meta Llama models.
+ *
+ * The Bedrock Claude bridge uses the Anthropic mapper instead, since it returns the Anthropic schema.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class FinishReasonMapper
+{
+    public static function map(?string $rawFinishReason): ?FinishReason
+    {
+        if (null === $rawFinishReason || '' === $rawFinishReason) {
+            return null;
+        }
+
+        return new FinishReason(match ($rawFinishReason) {
+            'end_turn', 'stop' => FinishReasonCase::STOP,
+            'max_tokens', 'length' => FinishReasonCase::LENGTH,
+            'tool_use' => FinishReasonCase::TOOL_CALL,
+            'stop_sequence' => FinishReasonCase::STOP_SEQUENCE,
+            'guardrail_intervened', 'content_filtered' => FinishReasonCase::CONTENT_FILTER,
+            default => FinishReasonCase::OTHER,
+        }, $rawFinishReason);
+    }
+}

--- a/src/platform/src/Bridge/Bedrock/Meta/LlamaResultConverter.php
+++ b/src/platform/src/Bridge/Bedrock/Meta/LlamaResultConverter.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\AI\Platform\Bridge\Bedrock\Meta;
 
+use Symfony\AI\Platform\Bridge\Bedrock\FinishReasonMapper;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Bridge\Meta\Llama;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
@@ -25,6 +27,8 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 class LlamaResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Llama;
@@ -38,7 +42,7 @@ class LlamaResultConverter implements ResultConverterInterface
             throw new RuntimeException('Response does not contain any content.');
         }
 
-        return new TextResult($data['generation']);
+        return $this->withFinishReason(new TextResult($data['generation']), FinishReasonMapper::map($data['stop_reason'] ?? null));
     }
 
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface

--- a/src/platform/src/Bridge/Bedrock/Nova/NovaResultConverter.php
+++ b/src/platform/src/Bridge/Bedrock/Nova/NovaResultConverter.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\AI\Platform\Bridge\Bedrock\Nova;
 
+use Symfony\AI\Platform\Bridge\Bedrock\FinishReasonMapper;
 use Symfony\AI\Platform\Bridge\Bedrock\RawBedrockResult;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
@@ -26,6 +28,8 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
  */
 class NovaResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Nova;
@@ -50,10 +54,10 @@ class NovaResultConverter implements ResultConverterInterface
             }
         }
         if ([] !== $toolCalls) {
-            return new ToolCallResult($toolCalls);
+            return $this->withFinishReason(new ToolCallResult($toolCalls), FinishReasonMapper::map($data['stopReason'] ?? null));
         }
 
-        return new TextResult($data['output']['message']['content'][0]['text']);
+        return $this->withFinishReason(new TextResult($data['output']['message']['content'][0]['text']), FinishReasonMapper::map($data['stopReason'] ?? null));
     }
 
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface

--- a/src/platform/src/Bridge/Bedrock/Tests/FinishReasonMapperTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/FinishReasonMapperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Bedrock\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Bedrock\FinishReasonMapper;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+final class FinishReasonMapperTest extends TestCase
+{
+    #[DataProvider('provideFinishReasons')]
+    public function testItMapsTheProviderVocabulary(string $raw, FinishReasonCase $expected)
+    {
+        $finishReason = FinishReasonMapper::map($raw);
+
+        $this->assertSame($expected, $finishReason->getCase());
+        $this->assertSame($raw, $finishReason->getRaw());
+    }
+
+    /**
+     * @return iterable<string, array{string, FinishReasonCase}>
+     */
+    public static function provideFinishReasons(): iterable
+    {
+        yield 'converse end_turn' => ['end_turn', FinishReasonCase::STOP];
+        yield 'llama stop' => ['stop', FinishReasonCase::STOP];
+        yield 'converse max_tokens' => ['max_tokens', FinishReasonCase::LENGTH];
+        yield 'llama length' => ['length', FinishReasonCase::LENGTH];
+        yield 'tool_use' => ['tool_use', FinishReasonCase::TOOL_CALL];
+        yield 'guardrail_intervened' => ['guardrail_intervened', FinishReasonCase::CONTENT_FILTER];
+        yield 'content_filtered' => ['content_filtered', FinishReasonCase::CONTENT_FILTER];
+    }
+
+    public function testItReturnsNullForAMissingReason()
+    {
+        $this->assertNull(FinishReasonMapper::map(null));
+        $this->assertNull(FinishReasonMapper::map(''));
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Llm/FinishReasonMapper.php
+++ b/src/platform/src/Bridge/Cohere/Llm/FinishReasonMapper.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Llm;
+
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+/**
+ * Maps the Cohere `finish_reason`.
+ *
+ * `ERROR` normalizes to OTHER, but in practice the converter raises an exception before it surfaces.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class FinishReasonMapper
+{
+    public static function map(?string $rawFinishReason): ?FinishReason
+    {
+        if (null === $rawFinishReason || '' === $rawFinishReason) {
+            return null;
+        }
+
+        return new FinishReason(match ($rawFinishReason) {
+            'COMPLETE' => FinishReasonCase::STOP,
+            'MAX_TOKENS' => FinishReasonCase::LENGTH,
+            'TOOL_CALL' => FinishReasonCase::TOOL_CALL,
+            'STOP_SEQUENCE' => FinishReasonCase::STOP_SEQUENCE,
+            default => FinishReasonCase::OTHER,
+        }, $rawFinishReason);
+    }
+}

--- a/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
@@ -15,11 +15,13 @@ use Symfony\AI\Platform\Bridge\Cohere\Cohere;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -33,6 +35,8 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     use HttpStatusErrorHandlingTrait;
 
     public function supports(Model $model): bool
@@ -77,11 +81,11 @@ final class ResultConverter implements ResultConverterInterface
         if ('COMPLETE' === $finishReason) {
             $text = $data['message']['content'][0]['text'] ?? '';
 
-            return new TextResult($text);
+            return $this->withFinishReason(new TextResult($text), FinishReasonMapper::map($finishReason));
         }
 
         if ('TOOL_CALL' === $finishReason) {
-            return new ToolCallResult(array_map($this->convertToolCall(...), $data['message']['tool_calls'] ?? []));
+            return $this->withFinishReason(new ToolCallResult(array_map($this->convertToolCall(...), $data['message']['tool_calls'] ?? [])), FinishReasonMapper::map($finishReason));
         }
 
         throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $finishReason));
@@ -94,6 +98,7 @@ final class ResultConverter implements ResultConverterInterface
 
     private function convertStream(RawResultInterface $result): \Generator
     {
+        $streamFinishReason = null;
         $toolCalls = [];
         $sawChunk = false;
         $sawMessageEnd = false;
@@ -142,11 +147,19 @@ final class ResultConverter implements ResultConverterInterface
                 if ([] !== $toolCalls) {
                     yield new ToolCallComplete(array_map($this->convertToolCall(...), $toolCalls));
                 }
+
+                if (null !== $finishReason) {
+                    $streamFinishReason = FinishReasonMapper::map($finishReason);
+                }
             }
         }
 
         if ($sawChunk && !$sawMessageEnd) {
             throw new IncompleteStreamException('Cohere stream ended before message-end.');
+        }
+
+        if (null !== $streamFinishReason) {
+            yield new MetadataDelta('finish_reason', $streamFinishReason);
         }
     }
 

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/FinishReasonMapperTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/FinishReasonMapperTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cohere\Tests\Llm;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cohere\Llm\FinishReasonMapper;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+final class FinishReasonMapperTest extends TestCase
+{
+    #[DataProvider('provideFinishReasons')]
+    public function testItMapsTheProviderVocabulary(string $raw, FinishReasonCase $expected)
+    {
+        $finishReason = FinishReasonMapper::map($raw);
+
+        $this->assertSame($expected, $finishReason->getCase());
+        $this->assertSame($raw, $finishReason->getRaw());
+    }
+
+    /**
+     * @return iterable<string, array{string, FinishReasonCase}>
+     */
+    public static function provideFinishReasons(): iterable
+    {
+        yield 'COMPLETE' => ['COMPLETE', FinishReasonCase::STOP];
+        yield 'MAX_TOKENS' => ['MAX_TOKENS', FinishReasonCase::LENGTH];
+        yield 'TOOL_CALL' => ['TOOL_CALL', FinishReasonCase::TOOL_CALL];
+        yield 'STOP_SEQUENCE' => ['STOP_SEQUENCE', FinishReasonCase::STOP_SEQUENCE];
+        yield 'ERROR' => ['ERROR', FinishReasonCase::OTHER];
+    }
+
+    public function testItReturnsNullForAMissingReason()
+    {
+        $this->assertNull(FinishReasonMapper::map(null));
+        $this->assertNull(FinishReasonMapper::map(''));
+    }
+}

--- a/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/DeepSeek/Tests/ResultConverterTest.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\InvalidRequestException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -259,7 +260,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('world!', $chunks[1]->getText());
         $this->assertInstanceOf(MetadataDelta::class, $chunks[2]);
         $this->assertSame('finish_reason', $chunks[2]->getKey());
-        $this->assertSame('stop', $chunks[2]->getValue());
+        $this->assertSame(FinishReasonCase::STOP, $chunks[2]->getValue()->getCase());
     }
 
     public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()

--- a/src/platform/src/Bridge/Gemini/Gemini/FinishReasonMapper.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/FinishReasonMapper.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Gemini\Gemini;
+
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+/**
+ * Maps the Gemini `candidates[].finishReason`.
+ *
+ * Reused by the Vertex AI Gemini bridge, which speaks the same payload schema. Gemini reports a plain
+ * `STOP` when the model stopped to call a function, so there is no TOOL_CALL mapping here.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class FinishReasonMapper
+{
+    public static function map(?string $rawFinishReason): ?FinishReason
+    {
+        if (null === $rawFinishReason || '' === $rawFinishReason) {
+            return null;
+        }
+
+        return new FinishReason(match ($rawFinishReason) {
+            'STOP' => FinishReasonCase::STOP,
+            'MAX_TOKENS' => FinishReasonCase::LENGTH,
+            'SAFETY', 'PROHIBITED_CONTENT', 'BLOCKLIST', 'SPII', 'IMAGE_SAFETY' => FinishReasonCase::CONTENT_FILTER,
+            default => FinishReasonCase::OTHER,
+        }, $rawFinishReason);
+    }
+}

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Bridge\Gemini\Gemini;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -27,6 +28,7 @@ use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\BinaryDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ChoiceDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -51,6 +53,8 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     use HttpStatusErrorHandlingTrait;
 
     public const OUTCOME_OK = 'OUTCOME_OK';
@@ -96,7 +100,10 @@ final class ResultConverter implements ResultConverterInterface
 
         $choices = array_map($this->convertChoice(...), $data['candidates']);
 
-        return 1 === \count($choices) ? $choices[0] : new ChoiceResult($choices);
+        return $this->withFinishReason(
+            1 === \count($choices) ? $choices[0] : new ChoiceResult($choices),
+            FinishReasonMapper::map($data['candidates'][0]['finishReason'] ?? null),
+        );
     }
 
     public function getTokenUsageExtractor(): TokenUsageExtractor
@@ -106,7 +113,15 @@ final class ResultConverter implements ResultConverterInterface
 
     private function convertStream(RawResultInterface $result): \Generator
     {
+        $finishReason = null;
+
         foreach ($result->getDataStream() as $data) {
+            // Gemini repeats the reason on every candidate of the terminal chunk; the leading one wins,
+            // matching the buffered path.
+            if (null !== ($data['candidates'][0]['finishReason'] ?? null)) {
+                $finishReason ??= FinishReasonMapper::map($data['candidates'][0]['finishReason']);
+            }
+
             $choices = array_values(array_filter(array_map($this->convertChoice(...), $data['candidates'] ?? [])));
 
             if (!$choices) {
@@ -119,6 +134,11 @@ final class ResultConverter implements ResultConverterInterface
             }
 
             yield $this->resultToDelta($choices[0]);
+        }
+
+        // Emitted last: the terminal chunk carries both the finish reason and its content parts.
+        if (null !== $finishReason) {
+            yield new MetadataDelta('finish_reason', $finishReason);
         }
     }
 

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/FinishReasonMapperTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/FinishReasonMapperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Gemini\Tests\Gemini;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Gemini\Gemini\FinishReasonMapper;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+final class FinishReasonMapperTest extends TestCase
+{
+    #[DataProvider('provideFinishReasons')]
+    public function testItMapsTheProviderVocabulary(string $raw, FinishReasonCase $expected)
+    {
+        $finishReason = FinishReasonMapper::map($raw);
+
+        $this->assertSame($expected, $finishReason->getCase());
+        $this->assertSame($raw, $finishReason->getRaw());
+    }
+
+    /**
+     * @return iterable<string, array{string, FinishReasonCase}>
+     */
+    public static function provideFinishReasons(): iterable
+    {
+        yield 'STOP' => ['STOP', FinishReasonCase::STOP];
+        yield 'MAX_TOKENS' => ['MAX_TOKENS', FinishReasonCase::LENGTH];
+        yield 'SAFETY' => ['SAFETY', FinishReasonCase::CONTENT_FILTER];
+        yield 'PROHIBITED_CONTENT' => ['PROHIBITED_CONTENT', FinishReasonCase::CONTENT_FILTER];
+        yield 'RECITATION has no equivalent' => ['RECITATION', FinishReasonCase::OTHER];
+        yield 'MALFORMED_FUNCTION_CALL is not a tool call' => ['MALFORMED_FUNCTION_CALL', FinishReasonCase::OTHER];
+    }
+
+    public function testItReturnsNullForAMissingReason()
+    {
+        $this->assertNull(FinishReasonMapper::map(null));
+        $this->assertNull(FinishReasonMapper::map(''));
+    }
+}

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -17,6 +17,8 @@ use Symfony\AI\Platform\Bridge\Gemini\Gemini\ResultConverter;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
@@ -24,6 +26,7 @@ use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\BinaryDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ChoiceDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -109,6 +112,49 @@ final class ResultConverterTest extends TestCase
         $toolCall = $result->getContent()[1]->getContent()[0];
         $this->assertInstanceOf(ToolCall::class, $toolCall);
         $this->assertSame('1234', $toolCall->getId());
+    }
+
+    public function testConvertExposesFinishReasonAsMetadata()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => ['parts' => [['text' => 'Truncated']]],
+                    'finishReason' => 'MAX_TOKENS',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $finishReason = $result->getMetadata()->get('finish_reason');
+        $this->assertInstanceOf(FinishReason::class, $finishReason);
+        $this->assertTrue($finishReason->is(FinishReasonCase::LENGTH));
+        $this->assertSame('MAX_TOKENS', $finishReason->getRaw());
+    }
+
+    public function testConvertNormalizesGeminiSpecificFinishReasonToOther()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => ['parts' => [['text' => 'Quoted']]],
+                    'finishReason' => 'RECITATION',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $finishReason = $result->getMetadata()->get('finish_reason');
+        $this->assertTrue($finishReason->is(FinishReasonCase::OTHER));
+        $this->assertSame('RECITATION', $finishReason->getRaw());
     }
 
     public function testConvertsInlineDataToBinaryResult()
@@ -281,9 +327,15 @@ final class ResultConverterTest extends TestCase
         $this->assertInstanceOf(StreamResult::class, $result);
 
         $items = iterator_to_array($result->getContent());
-        $this->assertCount(1, $items);
+        $this->assertCount(2, $items);
         $this->assertInstanceOf(TextDelta::class, $items[0]);
         $this->assertSame('Hello', $items[0]->getText());
+
+        // The content-less candidate is skipped, but still contributes its finish reason.
+        $this->assertInstanceOf(MetadataDelta::class, $items[1]);
+        $this->assertSame('finish_reason', $items[1]->getKey());
+        $this->assertTrue($items[1]->getValue()->is(FinishReasonCase::STOP));
+        $this->assertSame('STOP', $items[1]->getValue()->getRaw());
     }
 
     /**

--- a/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
+++ b/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
@@ -38,12 +39,14 @@ use Symfony\AI\Platform\TokenUsage\TokenUsage;
  */
 trait CompletionsConversionTrait
 {
+    use FinishReasonAwareTrait;
+
     protected function convertStream(RawResultInterface $result): \Generator
     {
         $toolCalls = [];
         $reasoning = '';
         $sawChunk = false;
-        $sawFinishReason = false;
+        $finishReason = null;
 
         foreach ($result->getDataStream() as $data) {
             if (isset($data['error'])) {
@@ -67,9 +70,10 @@ trait CompletionsConversionTrait
 
             // A non-null finish_reason on the leading choice marks the terminal content chunk.
             // It is null on every non-final chunk, and a trailing usage-only chunk has choices: [].
+            // With n > 1 every choice terminates in its own chunk; the leading one wins, matching
+            // the buffered path where the metadata of the first choice surfaces on the result.
             if (null !== ($data['choices'][0]['finish_reason'] ?? null)) {
-                $sawFinishReason = true;
-                yield new MetadataDelta('finish_reason', $data['choices'][0]['finish_reason']);
+                $finishReason ??= FinishReasonMapper::map($data['choices'][0]['finish_reason']);
             }
 
             if (isset($data['usage'])) {
@@ -108,8 +112,14 @@ trait CompletionsConversionTrait
             yield new ThinkingComplete($reasoning);
         }
 
-        if ($sawChunk && !$sawFinishReason) {
+        if ($sawChunk && null === $finishReason) {
             throw new IncompleteStreamException('Completions stream ended before a finish reason was received.');
+        }
+
+        // Emitted last so the reason never precedes the visible deltas of the chunk that carried it:
+        // providers such as Mistral bundle the final content token and the finish_reason in one chunk.
+        if (null !== $finishReason) {
+            yield new MetadataDelta('finish_reason', $finishReason);
         }
     }
 
@@ -220,11 +230,11 @@ trait CompletionsConversionTrait
     protected function convertChoice(array $choice): ToolCallResult|TextResult
     {
         if ('tool_calls' === $choice['finish_reason']) {
-            return new ToolCallResult(array_map([$this, 'convertToolCall'], $choice['message']['tool_calls']));
+            return $this->withFinishReason(new ToolCallResult(array_map([$this, 'convertToolCall'], $choice['message']['tool_calls'])), FinishReasonMapper::map($choice['finish_reason']));
         }
 
         if (\in_array($choice['finish_reason'], ['stop', 'length'], true)) {
-            return new TextResult($choice['message']['content']);
+            return $this->withFinishReason(new TextResult($choice['message']['content']), FinishReasonMapper::map($choice['finish_reason']));
         }
 
         throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));

--- a/src/platform/src/Bridge/Generic/Completions/FinishReasonMapper.php
+++ b/src/platform/src/Bridge/Generic/Completions/FinishReasonMapper.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Generic\Completions;
+
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+/**
+ * Maps the `choices[].finish_reason` of OpenAI-compatible chat completions APIs.
+ *
+ * Shared by every bridge speaking that schema, including the ones that only reuse this vocabulary
+ * through their own converter (Azure Meta).
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class FinishReasonMapper
+{
+    public static function map(?string $rawFinishReason): ?FinishReason
+    {
+        if (null === $rawFinishReason || '' === $rawFinishReason) {
+            return null;
+        }
+
+        return new FinishReason(match ($rawFinishReason) {
+            'stop' => FinishReasonCase::STOP,
+            'length' => FinishReasonCase::LENGTH,
+            'tool_calls', 'function_call' => FinishReasonCase::TOOL_CALL,
+            'content_filter' => FinishReasonCase::CONTENT_FILTER,
+            default => FinishReasonCase::OTHER,
+        }, $rawFinishReason);
+    }
+}

--- a/src/platform/src/Bridge/Generic/Tests/Completions/FinishReasonMapperTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/FinishReasonMapperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Generic\Tests\Completions;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Generic\Completions\FinishReasonMapper;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+final class FinishReasonMapperTest extends TestCase
+{
+    #[DataProvider('provideFinishReasons')]
+    public function testItMapsTheProviderVocabulary(string $raw, FinishReasonCase $expected)
+    {
+        $finishReason = FinishReasonMapper::map($raw);
+
+        $this->assertSame($expected, $finishReason->getCase());
+        $this->assertSame($raw, $finishReason->getRaw());
+    }
+
+    /**
+     * @return iterable<string, array{string, FinishReasonCase}>
+     */
+    public static function provideFinishReasons(): iterable
+    {
+        yield 'stop' => ['stop', FinishReasonCase::STOP];
+        yield 'length' => ['length', FinishReasonCase::LENGTH];
+        yield 'tool_calls' => ['tool_calls', FinishReasonCase::TOOL_CALL];
+        yield 'legacy function_call' => ['function_call', FinishReasonCase::TOOL_CALL];
+        yield 'content_filter' => ['content_filter', FinishReasonCase::CONTENT_FILTER];
+        yield 'unknown' => ['invented_next_year', FinishReasonCase::OTHER];
+    }
+
+    public function testItReturnsNullForAMissingReason()
+    {
+        $this->assertNull(FinishReasonMapper::map(null));
+        $this->assertNull(FinishReasonMapper::map(''));
+    }
+}

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
@@ -22,10 +22,13 @@ use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
@@ -612,13 +615,12 @@ class ResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($streamResult->getContent());
 
-        $textDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof TextDelta));
-        $metadataDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof MetadataDelta));
-
-        $this->assertCount(2, $textDeltas);
-        $this->assertCount(1, $metadataDeltas);
-        $this->assertSame('finish_reason', $metadataDeltas[0]->getKey());
-        $this->assertSame('stop', $metadataDeltas[0]->getValue());
+        $this->assertCount(3, $chunks);
+        $this->assertInstanceOf(TextDelta::class, $chunks[0]);
+        $this->assertInstanceOf(TextDelta::class, $chunks[1]);
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[2]);
+        $this->assertSame('finish_reason', $chunks[2]->getKey());
+        $this->assertSame(FinishReasonCase::STOP, $chunks[2]->getValue()->getCase());
     }
 
     public function testStreamingDoesNotThrowWithUsageOnlyFinalChunk()
@@ -692,40 +694,75 @@ class ResultConverterTest extends TestCase
         iterator_to_array($streamResult->getContent());
     }
 
-    public function testStreamingExposesFinishReasonLengthAsMetadataDelta()
+    #[DataProvider('provideStreamedFinishReasons')]
+    public function testStreamingExposesFinishReasonAsMetadataDelta(string $rawFinishReason, FinishReasonCase $expectedCase)
     {
         $converter = new ResultConverter();
 
         $events = [
             ['choices' => [['index' => 0, 'delta' => ['content' => 'Hello']]]],
-            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'length']]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => $rawFinishReason]]],
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+
+        $metadataDeltas = array_values(array_filter(iterator_to_array($streamResult->getContent()), static fn (DeltaInterface $delta) => $delta instanceof MetadataDelta));
+
+        $this->assertCount(1, $metadataDeltas);
+        $this->assertSame('finish_reason', $metadataDeltas[0]->getKey());
+        $this->assertSame($expectedCase, $metadataDeltas[0]->getValue()->getCase());
+        $this->assertSame($rawFinishReason, $metadataDeltas[0]->getValue()->getRaw());
+    }
+
+    /**
+     * @return iterable<string, array{string, FinishReasonCase}>
+     */
+    public static function provideStreamedFinishReasons(): iterable
+    {
+        yield 'stop' => ['stop', FinishReasonCase::STOP];
+        yield 'length' => ['length', FinishReasonCase::LENGTH];
+        yield 'content_filter' => ['content_filter', FinishReasonCase::CONTENT_FILTER];
+    }
+
+    public function testStreamingEmitsFinishReasonAfterTheToolCallItTerminates()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['tool_calls' => [['id' => 'call_1', 'function' => ['name' => 'get_weather', 'arguments' => '{}']]]]]]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'tool_calls']]],
         ];
 
         $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
 
         $chunks = iterator_to_array($streamResult->getContent());
-        $metadataDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof MetadataDelta));
 
-        $this->assertCount(1, $metadataDeltas);
-        $this->assertSame('finish_reason', $metadataDeltas[0]->getKey());
-        $this->assertSame('length', $metadataDeltas[0]->getValue());
+        $this->assertCount(3, $chunks);
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[1]);
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[2]);
+        $this->assertSame(FinishReasonCase::TOOL_CALL, $chunks[2]->getValue()->getCase());
     }
 
-    public function testStreamingExposesFinishReasonContentFilterAsMetadataDelta()
+    public function testStreamingEmitsFinishReasonAfterTheContentOfTheChunkThatCarriedIt()
     {
         $converter = new ResultConverter();
 
+        // Mistral and other compatible providers bundle the final content token with the finish_reason.
         $events = [
-            ['choices' => [['index' => 0, 'delta' => ['content' => 'Hi']]]],
-            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'content_filter']]],
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'Hel']]]],
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'lo!'], 'finish_reason' => 'stop']]],
         ];
 
         $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
 
-        $metadataDeltas = array_values(array_filter(iterator_to_array($streamResult->getContent()), static fn ($c) => $c instanceof MetadataDelta));
+        $chunks = iterator_to_array($streamResult->getContent());
 
-        $this->assertCount(1, $metadataDeltas);
-        $this->assertSame('content_filter', $metadataDeltas[0]->getValue());
+        $this->assertCount(3, $chunks);
+        $this->assertInstanceOf(TextDelta::class, $chunks[0]);
+        $this->assertInstanceOf(TextDelta::class, $chunks[1]);
+        $this->assertSame('lo!', $chunks[1]->getText());
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[2]);
     }
 
     public function testStreamingPromotesFinishReasonToResultMetadata()
@@ -747,10 +784,14 @@ class ResultConverterTest extends TestCase
         $this->assertInstanceOf(TextDelta::class, $chunks[0]);
         $this->assertSame('Hello', $chunks[0]->getText());
         $this->assertTrue($deferredResult->getMetadata()->has('finish_reason'));
-        $this->assertSame('length', $deferredResult->getMetadata()->get('finish_reason'));
+
+        $finishReason = $deferredResult->getMetadata()->get('finish_reason');
+        $this->assertInstanceOf(FinishReason::class, $finishReason);
+        $this->assertTrue($finishReason->is(FinishReasonCase::LENGTH));
+        $this->assertSame('length', $finishReason->getRaw());
     }
 
-    public function testStreamingDoesNotEmitFinishReasonMetadataForUsageOnlyFinalChunk()
+    public function testStreamingEmitsFinishReasonOnlyOnceWithUsageOnlyFinalChunk()
     {
         $converter = new ResultConverter();
 
@@ -763,9 +804,27 @@ class ResultConverterTest extends TestCase
         $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
         $chunks = iterator_to_array($streamResult->getContent());
 
-        $metadataDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof MetadataDelta));
+        $metadataDeltas = array_values(array_filter($chunks, static fn (DeltaInterface $delta) => $delta instanceof MetadataDelta));
         $this->assertCount(1, $metadataDeltas);
-        $this->assertSame('stop', $metadataDeltas[0]->getValue());
+        $this->assertSame(FinishReasonCase::STOP, $metadataDeltas[0]->getValue()->getCase());
+    }
+
+    public function testBufferedResultCarriesFinishReasonMetadata()
+    {
+        $converter = new ResultConverter();
+
+        $data = [
+            'choices' => [
+                ['index' => 0, 'finish_reason' => 'length', 'message' => ['role' => 'assistant', 'content' => 'Truncated']],
+            ],
+        ];
+
+        $result = $converter->convert(new InMemoryRawResult($data, [], $this->httpResponseStub()));
+
+        $finishReason = $result->getMetadata()->get('finish_reason');
+        $this->assertInstanceOf(FinishReason::class, $finishReason);
+        $this->assertTrue($finishReason->is(FinishReasonCase::LENGTH));
+        $this->assertSame('length', $finishReason->getRaw());
     }
 
     private function httpResponseStub(): object

--- a/src/platform/src/Bridge/MiniMax/FinishReasonMapper.php
+++ b/src/platform/src/Bridge/MiniMax/FinishReasonMapper.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\MiniMax;
+
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+/**
+ * Maps the MiniMax `choices[].finish_reason`.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class FinishReasonMapper
+{
+    public static function map(?string $rawFinishReason): ?FinishReason
+    {
+        if (null === $rawFinishReason || '' === $rawFinishReason) {
+            return null;
+        }
+
+        return new FinishReason(match ($rawFinishReason) {
+            'stop' => FinishReasonCase::STOP,
+            'length', 'max_tokens' => FinishReasonCase::LENGTH,
+            'tool_calls' => FinishReasonCase::TOOL_CALL,
+            'content_filter' => FinishReasonCase::CONTENT_FILTER,
+            default => FinishReasonCase::OTHER,
+        }, $rawFinishReason);
+    }
+}

--- a/src/platform/src/Bridge/MiniMax/MiniMaxResultConverter.php
+++ b/src/platform/src/Bridge/MiniMax/MiniMaxResultConverter.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\MiniMax;
 
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -20,6 +21,7 @@ use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -34,6 +36,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class MiniMaxResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     use HttpStatusErrorHandlingTrait;
 
     /**
@@ -78,7 +82,10 @@ final class MiniMaxResultConverter implements ResultConverterInterface
         $url = (string) $response->getInfo('url');
 
         return match (true) {
-            str_contains($url, '/chat/completions') => new TextResult($result->getData()['choices'][0]['message']['content']),
+            str_contains($url, '/chat/completions') => $this->withFinishReason(
+                new TextResult($result->getData()['choices'][0]['message']['content']),
+                FinishReasonMapper::map($result->getData()['choices'][0]['finish_reason'] ?? null),
+            ),
             str_contains($url, '/t2a_async_v2') => $this->handleAsyncTask($result->getData(), 'query/t2a_async_query_v2', 'audio/mpeg', self::MAX_AUDIO_POLLS),
             str_contains($url, '/t2a_v2') => new BinaryResult($this->decodeHexAudio($result->getData()), 'audio/mpeg'),
             str_contains($url, '/image_generation') => $this->convertImage($result->getData()),
@@ -94,12 +101,12 @@ final class MiniMaxResultConverter implements ResultConverterInterface
     }
 
     /**
-     * @return \Generator<int, TextDelta>
+     * @return \Generator<int, TextDelta|MetadataDelta>
      */
     private function convertStream(RawResultInterface $result): \Generator
     {
         $sawChunk = false;
-        $sawFinishReason = false;
+        $finishReason = null;
 
         foreach ($result->getDataStream() as $chunk) {
             if (!\is_array($chunk)) {
@@ -109,7 +116,7 @@ final class MiniMaxResultConverter implements ResultConverterInterface
             $sawChunk = true;
 
             if (null !== ($chunk['choices'][0]['finish_reason'] ?? null)) {
-                $sawFinishReason = true;
+                $finishReason ??= FinishReasonMapper::map($chunk['choices'][0]['finish_reason']);
             }
 
             $content = $chunk['choices'][0]['delta']['content'] ?? '';
@@ -121,8 +128,12 @@ final class MiniMaxResultConverter implements ResultConverterInterface
             yield new TextDelta($content);
         }
 
-        if ($sawChunk && !$sawFinishReason) {
+        if ($sawChunk && null === $finishReason) {
             throw new IncompleteStreamException('The MiniMax stream ended before a finish reason.');
+        }
+
+        if (null !== $finishReason) {
+            yield new MetadataDelta('finish_reason', $finishReason);
         }
     }
 

--- a/src/platform/src/Bridge/MiniMax/Tests/FinishReasonMapperTest.php
+++ b/src/platform/src/Bridge/MiniMax/Tests/FinishReasonMapperTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\MiniMax\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\MiniMax\FinishReasonMapper;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+final class FinishReasonMapperTest extends TestCase
+{
+    #[DataProvider('provideFinishReasons')]
+    public function testItMapsTheProviderVocabulary(string $raw, FinishReasonCase $expected)
+    {
+        $finishReason = FinishReasonMapper::map($raw);
+
+        $this->assertSame($expected, $finishReason->getCase());
+        $this->assertSame($raw, $finishReason->getRaw());
+    }
+
+    /**
+     * @return iterable<string, array{string, FinishReasonCase}>
+     */
+    public static function provideFinishReasons(): iterable
+    {
+        yield 'stop' => ['stop', FinishReasonCase::STOP];
+        yield 'length' => ['length', FinishReasonCase::LENGTH];
+        yield 'max_tokens' => ['max_tokens', FinishReasonCase::LENGTH];
+        yield 'tool_calls' => ['tool_calls', FinishReasonCase::TOOL_CALL];
+        yield 'content_filter' => ['content_filter', FinishReasonCase::CONTENT_FILTER];
+    }
+
+    public function testItReturnsNullForAMissingReason()
+    {
+        $this->assertNull(FinishReasonMapper::map(null));
+        $this->assertNull(FinishReasonMapper::map(''));
+    }
+}

--- a/src/platform/src/Bridge/MiniMax/Tests/MiniMaxResultConverterTest.php
+++ b/src/platform/src/Bridge/MiniMax/Tests/MiniMaxResultConverterTest.php
@@ -19,11 +19,13 @@ use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -90,11 +92,14 @@ final class MiniMaxResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($result->getContent());
 
-        $this->assertCount(2, $chunks);
+        $this->assertCount(3, $chunks);
         $this->assertInstanceOf(TextDelta::class, $chunks[0]);
         $this->assertInstanceOf(TextDelta::class, $chunks[1]);
         $this->assertSame('Generated ', $chunks[0]->getText());
         $this->assertSame('text', $chunks[1]->getText());
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[2]);
+        $this->assertSame('finish_reason', $chunks[2]->getKey());
+        $this->assertTrue($chunks[2]->getValue()->is(FinishReasonCase::STOP));
     }
 
     public function testItConvertsSynchronousSpeech()

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Mistral\Llm;
 
 use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
+use Symfony\AI\Platform\Bridge\Generic\Completions\FinishReasonMapper;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -106,11 +107,11 @@ final class ResultConverter implements ResultConverterInterface
     protected function convertChoice(array $choice): ToolCallResult|TextResult
     {
         if ('tool_calls' === $choice['finish_reason']) {
-            return new ToolCallResult(array_map([$this, 'convertToolCall'], $choice['message']['tool_calls']));
+            return $this->withFinishReason(new ToolCallResult(array_map([$this, 'convertToolCall'], $choice['message']['tool_calls'])), FinishReasonMapper::map($choice['finish_reason']));
         }
 
         if ('stop' === $choice['finish_reason']) {
-            return new TextResult($choice['message']['content']);
+            return $this->withFinishReason(new TextResult($choice['message']['content']), FinishReasonMapper::map($choice['finish_reason']));
         }
 
         throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));

--- a/src/platform/src/Bridge/Ollama/FinishReasonMapper.php
+++ b/src/platform/src/Bridge/Ollama/FinishReasonMapper.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Ollama;
+
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+/**
+ * Maps the Ollama `done_reason`.
+ *
+ * `load` and `unload` report a model lifecycle event rather than a generation outcome, so they
+ * normalize to OTHER.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class FinishReasonMapper
+{
+    public static function map(?string $rawFinishReason): ?FinishReason
+    {
+        if (null === $rawFinishReason || '' === $rawFinishReason) {
+            return null;
+        }
+
+        return new FinishReason(match ($rawFinishReason) {
+            'stop' => FinishReasonCase::STOP,
+            'length' => FinishReasonCase::LENGTH,
+            default => FinishReasonCase::OTHER,
+        }, $rawFinishReason);
+    }
+}

--- a/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
+++ b/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
@@ -13,9 +13,11 @@ namespace Symfony\AI\Platform\Bridge\Ollama;
 
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
@@ -34,6 +36,8 @@ use Symfony\AI\Platform\Vector\Vector;
  */
 final class OllamaResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     public function supports(Model $model): bool
     {
         return $model instanceof Ollama;
@@ -77,10 +81,10 @@ final class OllamaResultConverter implements ResultConverterInterface
         }
 
         if ([] !== $toolCalls) {
-            return new ToolCallResult($toolCalls);
+            return $this->withFinishReason(new ToolCallResult($toolCalls), FinishReasonMapper::map($data['done_reason'] ?? null));
         }
 
-        return new TextResult($data['message']['content']);
+        return $this->withFinishReason(new TextResult($data['message']['content']), FinishReasonMapper::map($data['done_reason'] ?? null));
     }
 
     /**
@@ -105,6 +109,7 @@ final class OllamaResultConverter implements ResultConverterInterface
         $toolCalls = [];
         $sawChunk = false;
         $sawDone = false;
+        $finishReason = null;
         foreach ($result->getDataStream() as $data) {
             // Ollama emits {"error": "..."} on HTTP 200 in practice; not part of the
             // documented schema, so this guard is defensive.
@@ -116,6 +121,10 @@ final class OllamaResultConverter implements ResultConverterInterface
 
             if (isset($data['done']) && true === $data['done']) {
                 $sawDone = true;
+
+                if (null !== ($data['done_reason'] ?? null)) {
+                    $finishReason = FinishReasonMapper::map($data['done_reason']);
+                }
             }
 
             if ($this->streamIsToolCall($data)) {
@@ -144,6 +153,10 @@ final class OllamaResultConverter implements ResultConverterInterface
 
         if ($sawChunk && !$sawDone) {
             throw new IncompleteStreamException('Ollama stream ended before a "done" message.');
+        }
+
+        if (null !== $finishReason) {
+            yield new MetadataDelta('finish_reason', $finishReason);
         }
     }
 

--- a/src/platform/src/Bridge/Ollama/Tests/FinishReasonMapperTest.php
+++ b/src/platform/src/Bridge/Ollama/Tests/FinishReasonMapperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Ollama\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Ollama\FinishReasonMapper;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+final class FinishReasonMapperTest extends TestCase
+{
+    #[DataProvider('provideFinishReasons')]
+    public function testItMapsTheProviderVocabulary(string $raw, FinishReasonCase $expected)
+    {
+        $finishReason = FinishReasonMapper::map($raw);
+
+        $this->assertSame($expected, $finishReason->getCase());
+        $this->assertSame($raw, $finishReason->getRaw());
+    }
+
+    /**
+     * @return iterable<string, array{string, FinishReasonCase}>
+     */
+    public static function provideFinishReasons(): iterable
+    {
+        yield 'stop' => ['stop', FinishReasonCase::STOP];
+        yield 'length' => ['length', FinishReasonCase::LENGTH];
+        yield 'load is a lifecycle event' => ['load', FinishReasonCase::OTHER];
+        yield 'unload is a lifecycle event' => ['unload', FinishReasonCase::OTHER];
+    }
+
+    public function testItReturnsNullForAMissingReason()
+    {
+        $this->assertNull(FinishReasonMapper::map(null));
+        $this->assertNull(FinishReasonMapper::map(''));
+    }
+}

--- a/src/platform/src/Bridge/Ollama/Tests/OllamaResultConverterTest.php
+++ b/src/platform/src/Bridge/Ollama/Tests/OllamaResultConverterTest.php
@@ -16,10 +16,12 @@ use Symfony\AI\Platform\Bridge\Ollama\Ollama;
 use Symfony\AI\Platform\Bridge\Ollama\OllamaResultConverter;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
@@ -179,7 +181,7 @@ final class OllamaResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($result->getContent());
 
-        $this->assertCount(3, $chunks);
+        $this->assertCount(4, $chunks);
         $this->assertInstanceOf(TextDelta::class, $chunks[0]);
         $this->assertSame('Hello', $chunks[0]->getText());
         $this->assertInstanceOf(TextDelta::class, $chunks[1]);
@@ -187,6 +189,9 @@ final class OllamaResultConverterTest extends TestCase
         $this->assertInstanceOf(TokenUsageInterface::class, $chunks[2]);
         $this->assertSame(42, $chunks[2]->getPromptTokens());
         $this->assertSame(17, $chunks[2]->getCompletionTokens());
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[3]);
+        $this->assertSame('finish_reason', $chunks[3]->getKey());
+        $this->assertTrue($chunks[3]->getValue()->is(FinishReasonCase::STOP));
     }
 
     public function testConvertThinkingStreamingResponse()
@@ -200,7 +205,7 @@ final class OllamaResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($result->getContent());
 
-        $this->assertCount(5, $chunks);
+        $this->assertCount(6, $chunks);
         $this->assertInstanceOf(ThinkingDelta::class, $chunks[0]);
         $this->assertSame('Thinking', $chunks[0]->getThinking());
         $this->assertInstanceOf(ThinkingDelta::class, $chunks[1]);
@@ -212,6 +217,8 @@ final class OllamaResultConverterTest extends TestCase
         $this->assertInstanceOf(TokenUsageInterface::class, $chunks[4]);
         $this->assertSame(42, $chunks[4]->getPromptTokens());
         $this->assertSame(17, $chunks[4]->getCompletionTokens());
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[5]);
+        $this->assertTrue($chunks[5]->getValue()->is(FinishReasonCase::STOP));
     }
 
     public function testItPromotesTokenUsageMetadataFromStreamingResponse()
@@ -241,7 +248,7 @@ final class OllamaResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($result->getContent());
 
-        $this->assertCount(2, $chunks);
+        $this->assertCount(3, $chunks);
         $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
         $toolCalls = $chunks[0]->getToolCalls();
         $this->assertCount(1, $toolCalls);
@@ -250,6 +257,8 @@ final class OllamaResultConverterTest extends TestCase
         $this->assertInstanceOf(TokenUsageInterface::class, $chunks[1]);
         $this->assertSame(11, $chunks[1]->getPromptTokens());
         $this->assertSame(4, $chunks[1]->getCompletionTokens());
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[2]);
+        $this->assertTrue($chunks[2]->getValue()->is(FinishReasonCase::STOP));
     }
 
     public function testConvertStreamingThrowsWhenDoneIsMissing()

--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -22,12 +22,14 @@ use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\McpCallResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
@@ -530,8 +532,10 @@ class ResultConverterTest extends TestCase
         $streamResult = $converter->convert($raw, ['stream' => true]);
         $chunks = iterator_to_array($streamResult->getContent());
 
-        $this->assertCount(1, $chunks);
+        $this->assertCount(2, $chunks);
         $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[1]);
+        $this->assertTrue($chunks[1]->getValue()->is(FinishReasonCase::TOOL_CALL));
         $this->assertSame('call_123', $chunks[0]->getToolCalls()[0]->getId());
         $this->assertSame('get_weather', $chunks[0]->getToolCalls()[0]->getName());
         $this->assertSame(['city' => 'Berlin'], $chunks[0]->getToolCalls()[0]->getArguments());
@@ -567,8 +571,10 @@ class ResultConverterTest extends TestCase
         $streamResult = $converter->convert($raw, ['stream' => true]);
         $chunks = iterator_to_array($streamResult->getContent());
 
-        $this->assertCount(1, $chunks);
+        $this->assertCount(2, $chunks);
         $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[1]);
+        $this->assertTrue($chunks[1]->getValue()->is(FinishReasonCase::TOOL_CALL));
         $this->assertSame('call_123', $chunks[0]->getToolCalls()[0]->getId());
         $this->assertSame('get_weather', $chunks[0]->getToolCalls()[0]->getName());
         $this->assertSame(['city' => 'Berlin'], $chunks[0]->getToolCalls()[0]->getArguments());
@@ -767,7 +773,7 @@ class ResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($streamResult->getContent());
 
-        $this->assertCount(5, $chunks);
+        $this->assertCount(6, $chunks);
         $this->assertInstanceOf(ThinkingStart::class, $chunks[0]);
         $this->assertInstanceOf(ThinkingDelta::class, $chunks[1]);
         $this->assertSame('Let me think', $chunks[1]->getThinking());

--- a/src/platform/src/Bridge/OpenResponses/FinishReasonMapper.php
+++ b/src/platform/src/Bridge/OpenResponses/FinishReasonMapper.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenResponses;
+
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+/**
+ * Maps the Responses API completion state.
+ *
+ * Unlike chat completions there is no per-choice `finish_reason`: a successful response reports
+ * `status: completed`, an aborted one `status: incomplete` plus an `incomplete_details.reason`.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class FinishReasonMapper
+{
+    /**
+     * The Responses API reports `completed` even when the model stopped to call a function, so a
+     * tool call in the output upgrades an otherwise clean stop to TOOL_CALL. It never overrides a
+     * `LENGTH` or `CONTENT_FILTER` reason: a truncated response stays truncated even if the partial
+     * output happens to contain a tool call.
+     *
+     * The raw provider value is preserved as reported either way.
+     */
+    public static function map(?string $rawFinishReason, bool $stoppedForToolCall = false): ?FinishReason
+    {
+        if (null === $rawFinishReason || '' === $rawFinishReason) {
+            return null;
+        }
+
+        $case = match ($rawFinishReason) {
+            'completed' => FinishReasonCase::STOP,
+            'max_output_tokens' => FinishReasonCase::LENGTH,
+            'content_filter' => FinishReasonCase::CONTENT_FILTER,
+            default => FinishReasonCase::OTHER,
+        };
+
+        if ($stoppedForToolCall && FinishReasonCase::STOP === $case) {
+            $case = FinishReasonCase::TOOL_CALL;
+        }
+
+        return new FinishReason($case, $rawFinishReason);
+    }
+}

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -33,6 +33,7 @@ use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
@@ -146,7 +147,9 @@ class ResultConverter implements ResultConverterInterface
             throw new RuntimeException('Response does not contain any content.');
         }
 
-        return 1 === \count($results) ? array_pop($results) : new MultiPartResult(array_values($results));
+        $converted = 1 === \count($results) ? array_pop($results) : new MultiPartResult(array_values($results));
+
+        return $this->withResponsesFinishReason($converted, $data['incomplete_details']['reason'] ?? $data['status'] ?? null);
     }
 
     public function getTokenUsageExtractor(): TokenUsageExtractor
@@ -163,6 +166,49 @@ class ResultConverter implements ResultConverterInterface
     protected function extractRateLimitReset(ResponseInterface $response): ?int
     {
         return null;
+    }
+
+    /**
+     * The Responses API has no per-choice `finish_reason`: a successful response reports `status: completed`
+     * and an aborted one `status: incomplete` plus an `incomplete_details.reason` such as `max_output_tokens`.
+     *
+     * It also reports `completed` when the model stopped to call a function, so the normalized case is derived
+     * from the converted output while the raw provider value is preserved as reported.
+     *
+     * @template T of ResultInterface
+     *
+     * @param T $result
+     *
+     * @return T
+     */
+    private function withResponsesFinishReason(ResultInterface $result, ?string $rawFinishReason): ResultInterface
+    {
+        if (null === $rawFinishReason || '' === $rawFinishReason) {
+            return $result;
+        }
+
+        $result->getMetadata()->add('finish_reason', FinishReasonMapper::map($rawFinishReason, $this->containsToolCall($result)));
+
+        return $result;
+    }
+
+    private function containsToolCall(ResultInterface $result): bool
+    {
+        if ($result instanceof ToolCallResult) {
+            return true;
+        }
+
+        if (!$result instanceof MultiPartResult) {
+            return false;
+        }
+
+        foreach ($result->getContent() as $part) {
+            if ($part instanceof ToolCallResult) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -371,6 +417,7 @@ class ResultConverter implements ResultConverterInterface
         $toolCalls = [];
         $sawResponseEvent = false;
         $sawResponseCompleted = false;
+        $sawToolCallComplete = false;
 
         foreach ($result->getDataStream() as $event) {
             $type = $event['type'] ?? '';
@@ -453,14 +500,22 @@ class ResultConverter implements ResultConverterInterface
             [$toolCallResult] = $this->extractFunctionCalls($event['response'][self::KEY_OUTPUT] ?? []);
 
             if ($toolCallResult) {
+                $sawToolCallComplete = true;
                 yield new ToolCallComplete($toolCallResult->getContent());
             } elseif ([] !== $toolCalls) {
+                $sawToolCallComplete = true;
                 yield new ToolCallComplete(array_values($toolCalls));
             }
         }
 
         if ($sawResponseEvent && !$sawResponseCompleted) {
             throw new IncompleteStreamException('Responses API stream ended before response.completed.');
+        }
+
+        // A stream that reaches response.completed always finished cleanly: response.incomplete and
+        // response.failed throw above. Only the tool-call case needs to be told apart from a plain stop.
+        if ($sawResponseCompleted) {
+            yield new MetadataDelta('finish_reason', FinishReasonMapper::map('completed', $sawToolCallComplete));
         }
     }
 

--- a/src/platform/src/Bridge/OpenResponses/Tests/FinishReasonMapperTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/FinishReasonMapperTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenResponses\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\OpenResponses\FinishReasonMapper;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+final class FinishReasonMapperTest extends TestCase
+{
+    #[DataProvider('provideFinishReasons')]
+    public function testItMapsTheProviderVocabulary(string $raw, FinishReasonCase $expected)
+    {
+        $finishReason = FinishReasonMapper::map($raw);
+
+        $this->assertSame($expected, $finishReason->getCase());
+        $this->assertSame($raw, $finishReason->getRaw());
+    }
+
+    /**
+     * @return iterable<string, array{string, FinishReasonCase}>
+     */
+    public static function provideFinishReasons(): iterable
+    {
+        yield 'completed' => ['completed', FinishReasonCase::STOP];
+        yield 'max_output_tokens' => ['max_output_tokens', FinishReasonCase::LENGTH];
+        yield 'content_filter' => ['content_filter', FinishReasonCase::CONTENT_FILTER];
+        yield 'unknown' => ['incomplete', FinishReasonCase::OTHER];
+    }
+
+    public function testItReturnsNullForAMissingReason()
+    {
+        $this->assertNull(FinishReasonMapper::map(null));
+        $this->assertNull(FinishReasonMapper::map(''));
+    }
+
+    public function testAToolCallUpgradesACleanStop()
+    {
+        // The Responses API reports `completed` for tool calls too.
+        $finishReason = FinishReasonMapper::map('completed', true);
+
+        $this->assertSame(FinishReasonCase::TOOL_CALL, $finishReason->getCase());
+        $this->assertSame('completed', $finishReason->getRaw());
+    }
+
+    public function testAToolCallNeverOverridesATruncation()
+    {
+        // A truncated response stays truncated even if the partial output contains a tool call.
+        $finishReason = FinishReasonMapper::map('max_output_tokens', true);
+
+        $this->assertSame(FinishReasonCase::LENGTH, $finishReason->getCase());
+    }
+
+    public function testAToolCallNeverOverridesAContentFilter()
+    {
+        $finishReason = FinishReasonMapper::map('content_filter', true);
+
+        $this->assertSame(FinishReasonCase::CONTENT_FILTER, $finishReason->getCase());
+    }
+}

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -22,6 +22,8 @@ use Symfony\AI\Platform\Exception\IncompleteStreamException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ComputerCallResult;
@@ -35,6 +37,7 @@ use Symfony\AI\Platform\Result\McpListToolsResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
@@ -558,6 +561,79 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('call_1', $result->getCallId());
     }
 
+    public function testConvertExposesIncompleteReasonAsFinishReasonMetadata()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'status' => 'incomplete',
+            'incomplete_details' => ['reason' => 'max_output_tokens'],
+            'output' => [
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [['type' => 'output_text', 'text' => 'Truncated']],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $finishReason = $result->getMetadata()->get('finish_reason');
+        $this->assertInstanceOf(FinishReason::class, $finishReason);
+        $this->assertTrue($finishReason->is(FinishReasonCase::LENGTH));
+        $this->assertSame('max_output_tokens', $finishReason->getRaw());
+    }
+
+    public function testConvertReportsCompletedResponseAsStop()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'status' => 'completed',
+            'output' => [
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [['type' => 'output_text', 'text' => 'Hello']],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $finishReason = $result->getMetadata()->get('finish_reason');
+        $this->assertTrue($finishReason->is(FinishReasonCase::STOP));
+        $this->assertSame('completed', $finishReason->getRaw());
+    }
+
+    public function testConvertReportsCompletedToolCallResponseAsToolCall()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'status' => 'completed',
+            'output' => [
+                [
+                    'type' => 'function_call',
+                    'id' => 'fc_1',
+                    'call_id' => 'call_1',
+                    'name' => 'get_weather',
+                    'arguments' => '{"city":"Berlin"}',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        // The Responses API reports `completed` for tool calls too; the normalized case still says TOOL_CALL.
+        $finishReason = $result->getMetadata()->get('finish_reason');
+        $this->assertTrue($finishReason->is(FinishReasonCase::TOOL_CALL));
+        $this->assertSame('completed', $finishReason->getRaw());
+    }
+
     public function testThrowsRuntimeExceptionWhenIncompleteResponseHasNoContent()
     {
         $converter = new ResultConverter();
@@ -921,8 +997,10 @@ final class ResultConverterTest extends TestCase
             $chunks[] = $part;
         }
 
-        $this->assertCount(1, $chunks);
+        $this->assertCount(2, $chunks);
         $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[1]);
+        $this->assertTrue($chunks[1]->getValue()->is(FinishReasonCase::TOOL_CALL));
         $toolCalls = $chunks[0]->getToolCalls();
         $this->assertCount(1, $toolCalls);
         $this->assertSame('call_456', $toolCalls[0]->getId());
@@ -960,8 +1038,10 @@ final class ResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($streamResult->getContent());
 
-        $this->assertCount(1, $chunks);
+        $this->assertCount(2, $chunks);
         $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[1]);
+        $this->assertTrue($chunks[1]->getValue()->is(FinishReasonCase::TOOL_CALL));
         $toolCalls = $chunks[0]->getToolCalls();
         $this->assertCount(1, $toolCalls);
         $this->assertSame('call_456', $toolCalls[0]->getId());
@@ -1000,8 +1080,10 @@ final class ResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($streamResult->getContent());
 
-        $this->assertCount(1, $chunks);
+        $this->assertCount(2, $chunks);
         $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[1]);
+        $this->assertTrue($chunks[1]->getValue()->is(FinishReasonCase::TOOL_CALL));
         $toolCalls = $chunks[0]->getToolCalls();
         $this->assertCount(1, $toolCalls);
         $this->assertSame('call_789', $toolCalls[0]->getId());
@@ -1202,7 +1284,7 @@ final class ResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($streamResult->getContent());
 
-        $this->assertCount(5, $chunks);
+        $this->assertCount(6, $chunks);
         $this->assertInstanceOf(ThinkingStart::class, $chunks[0]);
         $this->assertInstanceOf(ThinkingDelta::class, $chunks[1]);
         $this->assertSame('Let me think', $chunks[1]->getThinking());

--- a/src/platform/src/Bridge/Perplexity/FinishReasonMapper.php
+++ b/src/platform/src/Bridge/Perplexity/FinishReasonMapper.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Perplexity;
+
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+/**
+ * Maps the Perplexity `finish_reason`, which only ever reports a clean stop or a truncation.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class FinishReasonMapper
+{
+    public static function map(?string $rawFinishReason): ?FinishReason
+    {
+        if (null === $rawFinishReason || '' === $rawFinishReason) {
+            return null;
+        }
+
+        return new FinishReason(match ($rawFinishReason) {
+            'stop' => FinishReasonCase::STOP,
+            'length' => FinishReasonCase::LENGTH,
+            default => FinishReasonCase::OTHER,
+        }, $rawFinishReason);
+    }
+}

--- a/src/platform/src/Bridge/Perplexity/ResultConverter.php
+++ b/src/platform/src/Bridge/Perplexity/ResultConverter.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Perplexity;
 
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
@@ -30,6 +31,8 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     use HttpStatusErrorHandlingTrait;
 
     public function supports(Model $model): bool
@@ -92,10 +95,20 @@ final class ResultConverter implements ResultConverterInterface
 
     private function convertStream(RawResultInterface $result): \Generator
     {
+        $finishReason = null;
+
         foreach ($result->getDataStream() as $data) {
+            if (null !== ($data['choices'][0]['finish_reason'] ?? null)) {
+                $finishReason ??= FinishReasonMapper::map($data['choices'][0]['finish_reason']);
+            }
+
             if (isset($data['choices'][0]['delta']['content'])) {
                 yield new TextDelta($data['choices'][0]['delta']['content']);
             }
+        }
+
+        if (null !== $finishReason) {
+            yield new MetadataDelta('finish_reason', $finishReason);
         }
 
         if (isset($data['search_results'])) {
@@ -127,6 +140,6 @@ final class ResultConverter implements ResultConverterInterface
             throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));
         }
 
-        return new TextResult($choice['message']['content']);
+        return $this->withFinishReason(new TextResult($choice['message']['content']), FinishReasonMapper::map($choice['finish_reason']));
     }
 }

--- a/src/platform/src/Bridge/Perplexity/Tests/FinishReasonMapperTest.php
+++ b/src/platform/src/Bridge/Perplexity/Tests/FinishReasonMapperTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Perplexity\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Perplexity\FinishReasonMapper;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+final class FinishReasonMapperTest extends TestCase
+{
+    #[DataProvider('provideFinishReasons')]
+    public function testItMapsTheProviderVocabulary(string $raw, FinishReasonCase $expected)
+    {
+        $finishReason = FinishReasonMapper::map($raw);
+
+        $this->assertSame($expected, $finishReason->getCase());
+        $this->assertSame($raw, $finishReason->getRaw());
+    }
+
+    /**
+     * @return iterable<string, array{string, FinishReasonCase}>
+     */
+    public static function provideFinishReasons(): iterable
+    {
+        yield 'stop' => ['stop', FinishReasonCase::STOP];
+        yield 'length' => ['length', FinishReasonCase::LENGTH];
+        yield 'unknown' => ['unsupported_reason', FinishReasonCase::OTHER];
+    }
+
+    public function testItReturnsNullForAMissingReason()
+    {
+        $this->assertNull(FinishReasonMapper::map(null));
+        $this->assertNull(FinishReasonMapper::map(''));
+    }
+}

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\AI\Platform\Bridge\VertexAi\Gemini;
 
+use Symfony\AI\Platform\Bridge\Gemini\Gemini\FinishReasonMapper;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -27,6 +29,7 @@ use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\BinaryDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ChoiceDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -52,6 +55,8 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
+    use FinishReasonAwareTrait;
+
     public const OUTCOME_OK = 'OUTCOME_OK';
     public const OUTCOME_FAILED = 'OUTCOME_FAILED';
     public const OUTCOME_DEADLINE_EXCEEDED = 'OUTCOME_DEADLINE_EXCEEDED';
@@ -105,7 +110,10 @@ final class ResultConverter implements ResultConverterInterface
 
         $choices = array_map($this->convertChoice(...), $data['candidates']);
 
-        return 1 === \count($choices) ? $choices[0] : new ChoiceResult($choices);
+        return $this->withFinishReason(
+            1 === \count($choices) ? $choices[0] : new ChoiceResult($choices),
+            FinishReasonMapper::map($data['candidates'][0]['finishReason'] ?? null),
+        );
     }
 
     public function getTokenUsageExtractor(): TokenUsageExtractor
@@ -118,9 +126,17 @@ final class ResultConverter implements ResultConverterInterface
      */
     private function convertStream(RawResultInterface $result): \Generator
     {
+        $finishReason = null;
+
         foreach ($result->getDataStream() as $data) {
             if (isset($data['usageMetadata']['totalTokenCount']) && 0 < $data['usageMetadata']['totalTokenCount']) {
                 yield $this->getTokenUsageExtractor()->fromUsageMetadata($data['usageMetadata']);
+            }
+
+            // Gemini repeats the reason on every candidate of the terminal chunk; the leading one wins,
+            // matching the buffered path.
+            if (null !== ($data['candidates'][0]['finishReason'] ?? null)) {
+                $finishReason ??= FinishReasonMapper::map($data['candidates'][0]['finishReason']);
             }
 
             $choices = array_values(array_filter(array_map($this->convertChoice(...), $data['candidates'] ?? [])));
@@ -135,6 +151,11 @@ final class ResultConverter implements ResultConverterInterface
             }
 
             yield $this->resultToDelta($choices[0]);
+        }
+
+        // Emitted last: the terminal chunk carries both the finish reason and its content parts.
+        if (null !== $finishReason) {
+            yield new MetadataDelta('finish_reason', $finishReason);
         }
     }
 

--- a/src/platform/src/FinishReason/FinishReason.php
+++ b/src/platform/src/FinishReason/FinishReason.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\FinishReason;
+
+/**
+ * Why a model stopped generating, normalized across providers.
+ *
+ * Exposed as the `finish_reason` result metadata by every bridge whose provider reports it, for both
+ * buffered and streamed results:
+ *
+ *     $finishReason = $result->getMetadata()->get('finish_reason');
+ *
+ *     if ($finishReason?->is(FinishReasonCase::LENGTH)) {
+ *         // the response was truncated by the output token limit
+ *     }
+ *
+ * Providers spell the reason differently. Translating their wording into a {@see FinishReasonCase} is
+ * the responsibility of the bridge, which knows its provider's vocabulary — see the `FinishReasonMapper`
+ * next to each bridge's result converter, mirroring how `TokenUsageExtractor` is done per bridge.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class FinishReason implements \JsonSerializable, \Stringable
+{
+    /**
+     * @param string $raw the untouched value reported by the provider, in its own wording
+     */
+    public function __construct(
+        private readonly FinishReasonCase $case,
+        private readonly string $raw,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->raw;
+    }
+
+    public function getCase(): FinishReasonCase
+    {
+        return $this->case;
+    }
+
+    public function getRaw(): string
+    {
+        return $this->raw;
+    }
+
+    public function is(FinishReasonCase ...$cases): bool
+    {
+        return \in_array($this->case, $cases, true);
+    }
+
+    /**
+     * @return array{case: string, raw: string}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'case' => $this->case->value,
+            'raw' => $this->raw,
+        ];
+    }
+}

--- a/src/platform/src/FinishReason/FinishReasonAwareTrait.php
+++ b/src/platform/src/FinishReason/FinishReasonAwareTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\FinishReason;
+
+use Symfony\AI\Platform\Result\ResultInterface;
+
+/**
+ * Attaches the provider finish reason to a buffered result.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+trait FinishReasonAwareTrait
+{
+    /**
+     * Adds the `finish_reason` metadata, so a clean stop can be told apart from a truncation or a
+     * content filter intervention after the fact.
+     *
+     * Providers omit the reason on some responses; the metadata is then left unset rather than guessed,
+     * which is why a null reason is accepted here and every bridge mapper returns null for a missing value.
+     *
+     * @template T of ResultInterface
+     *
+     * @param T $result
+     *
+     * @return T
+     */
+    protected function withFinishReason(ResultInterface $result, ?FinishReason $finishReason): ResultInterface
+    {
+        if (null !== $finishReason) {
+            $result->getMetadata()->add('finish_reason', $finishReason);
+        }
+
+        return $result;
+    }
+}

--- a/src/platform/src/FinishReason/FinishReasonCase.php
+++ b/src/platform/src/FinishReason/FinishReasonCase.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\FinishReason;
+
+use OskarStark\Enum\Trait\Comparable;
+
+/**
+ * Normalized reason why a model stopped generating.
+ *
+ * This is the vocabulary consumers can rely on across bridges. Each bridge maps its provider's own
+ * wording onto these cases; the untouched provider value stays available via {@see FinishReason::getRaw()}.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+enum FinishReasonCase: string
+{
+    use Comparable;
+
+    /**
+     * The model finished generating on its own.
+     */
+    case STOP = 'stop';
+
+    /**
+     * Generation was truncated by an output token limit.
+     *
+     * The content is incomplete and consumers may want to continue generation.
+     */
+    case LENGTH = 'length';
+
+    /**
+     * The model stopped in order to call one or more tools.
+     */
+    case TOOL_CALL = 'tool-call';
+
+    /**
+     * Generation was stopped by a safety filter or guardrail.
+     */
+    case CONTENT_FILTER = 'content-filter';
+
+    /**
+     * The model hit one of the caller-supplied stop sequences.
+     */
+    case STOP_SEQUENCE = 'stop-sequence';
+
+    /**
+     * The provider reported a reason without a normalized equivalent.
+     *
+     * Inspect {@see FinishReason::getRaw()} to tell those cases apart.
+     */
+    case OTHER = 'other';
+}

--- a/src/platform/tests/FinishReason/FinishReasonTest.php
+++ b/src/platform/tests/FinishReason/FinishReasonTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\FinishReason;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+
+final class FinishReasonTest extends TestCase
+{
+    public function testItKeepsTheNormalizedCaseAndTheRawProviderValue()
+    {
+        $finishReason = new FinishReason(FinishReasonCase::LENGTH, 'MAX_TOKENS');
+
+        $this->assertSame(FinishReasonCase::LENGTH, $finishReason->getCase());
+        $this->assertSame('MAX_TOKENS', $finishReason->getRaw());
+    }
+
+    public function testItComparesCases()
+    {
+        $finishReason = new FinishReason(FinishReasonCase::LENGTH, 'max_tokens');
+
+        $this->assertTrue($finishReason->is(FinishReasonCase::LENGTH));
+        $this->assertTrue($finishReason->is(FinishReasonCase::STOP, FinishReasonCase::LENGTH));
+        $this->assertFalse($finishReason->is(FinishReasonCase::STOP));
+        $this->assertFalse($finishReason->is());
+    }
+
+    public function testItSerializesToJson()
+    {
+        $this->assertSame(
+            '{"case":"length","raw":"MAX_TOKENS"}',
+            json_encode(new FinishReason(FinishReasonCase::LENGTH, 'MAX_TOKENS')),
+        );
+    }
+
+    public function testItCastsToTheRawProviderValue()
+    {
+        $this->assertSame('end_turn', (string) new FinishReason(FinishReasonCase::STOP, 'end_turn'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #2194
| License       | MIT

Follow-up to #2276, which exposed the raw streamed `finish_reason` for the OpenAI-compatible bridges only.

- Adds `FinishReason\FinishReason` + `FinishReason\FinishReasonCase`, normalizing the divergent provider vocabularies (`length` / `max_tokens` / `MAX_TOKENS` / `max_output_tokens`) into `STOP`, `LENGTH`, `TOOL_CALL`, `CONTENT_FILTER`, `STOP_SEQUENCE`, `OTHER` while `getRaw()` keeps the provider value.
- Exposes it as `finish_reason` result metadata for **buffered and streamed** results across OpenAI, Anthropic, Gemini, VertexAI, Bedrock, Azure, Ollama, Cohere, Mistral, DeepSeek, Cerebras, Scaleway, Docker Model Runner, Perplexity, MiniMax, amazee.ai and Generic.
- Streams now emit the reason as the final `MetadataDelta`, after the deltas of the chunk that carried it (providers such as Mistral bundle the last content token with `finish_reason`).

```php
$finishReason = $result->getMetadata()->get('finish_reason');

if ($finishReason?->is(FinishReasonCase::LENGTH)) {
    // truncated by the output token limit
}
```

Docs in `docs/components/platform.rst`, runnable example in `examples/misc/finish-reason.php`.

Known gap: the OpenAI Responses API signals a truncated stream with `response.incomplete`, which the bridge raises as an exception, so there is no result left to carry the reason. Left as-is; changing it is a behavior change beyond this PR.