### PR TITLE
[Platform] Add an exception is the `response_format` option looks like a class, but is not

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
  * [BC BREAK] Rename the OpenAI `DallE` bridge to `Image` (`Bridge\OpenAi\DallE` → `Bridge\OpenAi\Image`, and the `Bridge\OpenAi\DallE\*` namespace → `Bridge\OpenAi\Image\*`) and remove the `dall-e-2`/`dall-e-3` catalog entries retired by OpenAI
  * [BC BREAK] Replace the bridge-specific `ImageResult`, `Base64Image`, and `UrlImage` classes of the OpenAI image bridge with the generic `Result\BinaryResult` (single image) and `Result\MultiPartResult` (multiple images), matching the other multi-modal bridges
  * Add streamed Generic completions `finish_reason` values as result metadata
+ * Add an exception is the `response_format` option looks like a class, but is not
 
 0.10
 ----

--- a/src/platform/src/StructuredOutput/PlatformSubscriber.php
+++ b/src/platform/src/StructuredOutput/PlatformSubscriber.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\StructuredOutput;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Event\InvocationEvent;
 use Symfony\AI\Platform\Event\ResultEvent;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Exception\MissingModelSupportException;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -64,9 +65,15 @@ final class PlatformSubscriber implements EventSubscriberInterface
         if (\is_object($responseFormat)) {
             $this->objectToPopulate = $responseFormat;
             $className = $responseFormat::class;
-        } elseif (\is_string($responseFormat) && class_exists($responseFormat)) {
-            $this->objectToPopulate = null;
-            $className = $responseFormat;
+        } elseif (\is_string($responseFormat)) {
+            if (class_exists($responseFormat)) {
+                $this->objectToPopulate = null;
+                $className = $responseFormat;
+            } elseif (str_contains($responseFormat, '\\')) {
+                throw new InvalidArgumentException(\sprintf('The response format class "%s" does not exist.', $responseFormat));
+            } else {
+                return;
+            }
         } else {
             return;
         }

--- a/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
+++ b/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Event\InvocationEvent;
 use Symfony\AI\Platform\Event\ResultEvent;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Exception\MissingModelSupportException;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Metadata\Metadata;
@@ -377,6 +378,21 @@ final class PlatformSubscriberTest extends TestCase
         $processor->processInput($event);
 
         $this->assertSame(['response_format' => 'invalid-class-name'], $event->getOptions());
+    }
+
+    public function testProcessInputIgnoresNonObjectInvalidClass()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory());
+
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+        $event = new InvocationEvent($model, new MessageBag(), [
+            'response_format' => 'App\\Dto\\NonExistentClass',
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The response format class "App\\Dto\\NonExistentClass" does not exist.');
+
+        $processor->processInput($event);
     }
 
     public function testProcessInputIgnoresNonStructuredOutputResponseFormats()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        |
| License       | MIT

I'm not 100% sure about this one since I don't know all bridge APIs, but it could help a lot developpers to spot a missing class import
