### PR TITLE
[Store][Postgres] Quote table and column name

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -101,6 +101,9 @@ Store
    | Supabase        | `$url`         | `$endpoint`  |
    | SurrealDb       | `$endpointUrl` | `$endpoint`  |
 
+ * Postgres Store now uses quoted identifiers for table and column names, so they are case-sensitive. If you relied on
+   implicit lowercasing of unquoted identifiers, adopt them so they match the case of your table and column names.
+
 UPGRADE FROM 0.9 to 0.10
 ========================
 

--- a/src/store/src/Bridge/Postgres/CHANGELOG.md
+++ b/src/store/src/Bridge/Postgres/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * [BC BREAK] Quote table and column name
+   > Quoting an identifier also makes it case-sensitive, whereas unquoted names are always folded to lower case. For example, the identifiers FOO, foo, and "foo" are considered the same by PostgreSQL, but "Foo" and "FOO" are different from these three and each other. (The folding of unquoted names to lower case in PostgreSQL is incompatible with the SQL standard, which says that unquoted names should be folded to upper case. Thus, foo should be equivalent to "FOO" not "foo" according to the standard. If you want to write portable applications you are advised to always quote a particular name or never quote it.)
+
 0.9
 ---
  * Introduce `StoreFactory`

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -54,10 +54,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $this->connection->exec(
             \sprintf(
-                'CREATE TABLE IF NOT EXISTS %s (
+                'CREATE TABLE IF NOT EXISTS "%s" (
                     id UUID PRIMARY KEY,
                     metadata JSONB,
-                    %s %s(%d) NOT NULL
+                    "%s" %s(%d) NOT NULL
                 )',
                 $this->tableName,
                 $this->vectorFieldName,
@@ -67,7 +67,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
         $this->connection->exec(
             \sprintf(
-                'CREATE INDEX IF NOT EXISTS %s_%s_idx ON %s USING %s (%s %s)',
+                'CREATE INDEX IF NOT EXISTS "%s_%s_idx" ON "%s" USING %s ("%s" %s)',
                 $this->tableName,
                 $this->vectorFieldName,
                 $this->tableName,
@@ -80,7 +80,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function drop(array $options = []): void
     {
-        $this->connection->exec(\sprintf('DROP TABLE IF EXISTS %s', $this->tableName));
+        $this->connection->exec(\sprintf('DROP TABLE IF EXISTS "%s"', $this->tableName));
     }
 
     public function add(VectorDocument|array $documents): void
@@ -91,9 +91,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
         $statement = $this->connection->prepare(
             \sprintf(
-                'INSERT INTO %1$s (id, metadata, %2$s)
+                'INSERT INTO "%1$s" (id, metadata, "%2$s")
                 VALUES (:id, :metadata, :vector)
-                ON CONFLICT (id) DO UPDATE SET metadata = EXCLUDED.metadata, %2$s = EXCLUDED.%2$s',
+                ON CONFLICT (id) DO UPDATE SET metadata = EXCLUDED.metadata, "%2$s" = EXCLUDED."%2$s"',
                 $this->tableName,
                 $this->vectorFieldName,
             ),
@@ -119,7 +119,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
 
         $placeholders = implode(',', array_fill(0, \count($ids), '?'));
-        $sql = \sprintf('DELETE FROM %s WHERE id IN (%s)', $this->tableName, $placeholders);
+        $sql = \sprintf('DELETE FROM "%s" WHERE id IN (%s)', $this->tableName, $placeholders);
 
         $statement = $this->connection->prepare($sql);
 
@@ -163,7 +163,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $params = ['embedding' => $this->toPgvector($query->getVector())];
 
         if (isset($options['maxScore'])) {
-            $whereClauses[] = \sprintf('(%s %s :embedding) <= :maxScore', $this->vectorFieldName, $this->distance->getComparisonSign());
+            $whereClauses[] = \sprintf('("%s" %s :embedding) <= :maxScore', $this->vectorFieldName, $this->distance->getComparisonSign());
             $params['maxScore'] = $options['maxScore'];
         }
 
@@ -179,8 +179,8 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $where = [] !== $whereClauses ? 'WHERE '.implode(' AND ', $whereClauses) : '';
 
         $sql = \sprintf(<<<SQL
-            SELECT id, %s AS embedding, metadata, (%s %s :embedding) AS score
-            FROM %s
+            SELECT id, "%s" AS embedding, metadata, ("%s" %s :embedding) AS score
+            FROM "%s"
             %s
             ORDER BY score ASC
             LIMIT %d
@@ -233,9 +233,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $tsvectorExpression = \sprintf("to_tsvector('%s', metadata->>'_text')", $this->lang);
 
         $sql = \sprintf(<<<SQL
-            SELECT id, %s AS embedding, metadata,
+            SELECT id, "%s" AS embedding, metadata,
                    ts_rank(%s, %s) AS score
-            FROM %s
+            FROM "%s"
             WHERE %s @@ (%s)
             ORDER BY score DESC
             LIMIT %d
@@ -294,7 +294,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $where = \sprintf('WHERE %s @@ %s', $tsvectorExpression, $tsqueryExpression);
 
         if (isset($options['maxScore'])) {
-            $where .= \sprintf(' AND ((:semantic_ratio * (1 - (%s %s :embedding))) + (:keyword_ratio * ts_rank(%s, %s))) >= :maxScore',
+            $where .= \sprintf(' AND ((:semantic_ratio * (1 - ("%s" %s :embedding))) + (:keyword_ratio * ts_rank(%s, %s))) >= :maxScore',
                 $this->vectorFieldName,
                 $this->distance->getComparisonSign(),
                 $tsvectorExpression,
@@ -304,10 +304,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
 
         $sql = \sprintf(<<<SQL
-            SELECT id, %s AS embedding, metadata,
-                   ((:semantic_ratio * (1 - (%s %s :embedding))) +
+            SELECT id, "%s" AS embedding, metadata,
+                   ((:semantic_ratio * (1 - ("%s" %s :embedding))) +
                     (:keyword_ratio * ts_rank(%s, %s))) AS score
-            FROM %s
+            FROM "%s"
             %s
             ORDER BY score DESC
             LIMIT %d

--- a/src/store/src/Bridge/Postgres/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Postgres/Tests/StoreTest.php
@@ -34,9 +34,9 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = 'INSERT INTO embeddings_table (id, metadata, embedding)
+        $expectedQuery = 'INSERT INTO "embeddings_table" (id, metadata, "embedding")
                 VALUES (:id, :metadata, :vector)
-                ON CONFLICT (id) DO UPDATE SET metadata = EXCLUDED.metadata, embedding = EXCLUDED.embedding';
+                ON CONFLICT (id) DO UPDATE SET metadata = EXCLUDED.metadata, "embedding" = EXCLUDED."embedding"';
 
         $pdo->expects($this->once())
             ->method('prepare')
@@ -121,8 +121,8 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = 'SELECT id, embedding AS embedding, metadata, (embedding <-> :embedding) AS score
-             FROM embeddings_table
+        $expectedQuery = 'SELECT id, "embedding" AS embedding, metadata, ("embedding" <-> :embedding) AS score
+             FROM "embeddings_table"
 
              ORDER BY score ASC
              LIMIT 5';
@@ -173,8 +173,8 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding', Distance::Cosine);
 
-        $expectedQuery = 'SELECT id, embedding AS embedding, metadata, (embedding <=> :embedding) AS score
-             FROM embeddings_table
+        $expectedQuery = 'SELECT id, "embedding" AS embedding, metadata, ("embedding" <=> :embedding) AS score
+             FROM "embeddings_table"
 
              ORDER BY score ASC
              LIMIT 5';
@@ -225,9 +225,9 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = 'SELECT id, embedding AS embedding, metadata, (embedding <-> :embedding) AS score
-             FROM embeddings_table
-             WHERE (embedding <-> :embedding) <= :maxScore
+        $expectedQuery = 'SELECT id, "embedding" AS embedding, metadata, ("embedding" <-> :embedding) AS score
+             FROM "embeddings_table"
+             WHERE ("embedding" <-> :embedding) <= :maxScore
              ORDER BY score ASC
              LIMIT 5';
 
@@ -275,9 +275,9 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding', Distance::Cosine);
 
-        $expectedQuery = 'SELECT id, embedding AS embedding, metadata, (embedding <=> :embedding) AS score
-             FROM embeddings_table
-             WHERE (embedding <=> :embedding) <= :maxScore
+        $expectedQuery = 'SELECT id, "embedding" AS embedding, metadata, ("embedding" <=> :embedding) AS score
+             FROM "embeddings_table"
+             WHERE ("embedding" <=> :embedding) <= :maxScore
              ORDER BY score ASC
              LIMIT 5';
 
@@ -325,8 +325,8 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = 'SELECT id, embedding AS embedding, metadata, (embedding <-> :embedding) AS score
-             FROM embeddings_table
+        $expectedQuery = 'SELECT id, "embedding" AS embedding, metadata, ("embedding" <-> :embedding) AS score
+             FROM "embeddings_table"
 
              ORDER BY score ASC
              LIMIT 10';
@@ -364,8 +364,8 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'custom_vector');
 
-        $expectedQuery = 'SELECT id, custom_vector AS embedding, metadata, (custom_vector <-> :embedding) AS score
-             FROM embeddings_table
+        $expectedQuery = 'SELECT id, "custom_vector" AS embedding, metadata, ("custom_vector" <-> :embedding) AS score
+             FROM "embeddings_table"
 
              ORDER BY score ASC
              LIMIT 5';
@@ -407,10 +407,10 @@ final class StoreTest extends TestCase
                 if (1 === $callCount) {
                     $this->assertSame('CREATE EXTENSION IF NOT EXISTS vector', $sql);
                 } elseif (2 === $callCount) {
-                    $this->assertStringContainsString('CREATE TABLE IF NOT EXISTS embeddings_table', $sql);
-                    $this->assertStringContainsString('embedding vector(1536) NOT NULL', $sql);
+                    $this->assertStringContainsString('CREATE TABLE IF NOT EXISTS "embeddings_table"', $sql);
+                    $this->assertStringContainsString('"embedding" vector(1536) NOT NULL', $sql);
                 } else {
-                    $this->assertStringContainsString('CREATE INDEX IF NOT EXISTS embeddings_table_embedding_idx', $sql);
+                    $this->assertStringContainsString('CREATE INDEX IF NOT EXISTS "embeddings_table_embedding_idx"', $sql);
                 }
 
                 return 0;
@@ -428,7 +428,7 @@ final class StoreTest extends TestCase
         $pdo->expects($this->once())
             ->method('exec')
             ->willReturnCallback(function (string $sql): int {
-                $this->assertSame('DROP TABLE IF EXISTS embeddings_table', $sql);
+                $this->assertSame('DROP TABLE IF EXISTS "embeddings_table"', $sql);
 
                 return 0;
             });
@@ -450,7 +450,7 @@ final class StoreTest extends TestCase
                 ++$callCount;
 
                 if (2 === $callCount) {
-                    $this->assertStringContainsString('embedding vector(768) NOT NULL', $sql);
+                    $this->assertStringContainsString('"embedding" vector(768) NOT NULL', $sql);
                 }
 
                 return 0;
@@ -523,8 +523,8 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = 'SELECT id, embedding AS embedding, metadata, (embedding <-> :embedding) AS score
-             FROM embeddings_table
+        $expectedQuery = 'SELECT id, "embedding" AS embedding, metadata, ("embedding" <-> :embedding) AS score
+             FROM "embeddings_table"
              WHERE metadata->>\'category\' = \'products\'
              ORDER BY score ASC
              LIMIT 5';
@@ -562,9 +562,9 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = 'SELECT id, embedding AS embedding, metadata, (embedding <-> :embedding) AS score
-             FROM embeddings_table
-             WHERE (embedding <-> :embedding) <= :maxScore AND (metadata->>\'active\' = \'true\')
+        $expectedQuery = 'SELECT id, "embedding" AS embedding, metadata, ("embedding" <-> :embedding) AS score
+             FROM "embeddings_table"
+             WHERE ("embedding" <-> :embedding) <= :maxScore AND (metadata->>\'active\' = \'true\')
              ORDER BY score ASC
              LIMIT 5';
 
@@ -615,8 +615,8 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = 'SELECT id, embedding AS embedding, metadata, (embedding <-> :embedding) AS score
-             FROM embeddings_table
+        $expectedQuery = 'SELECT id, "embedding" AS embedding, metadata, ("embedding" <-> :embedding) AS score
+             FROM "embeddings_table"
              WHERE metadata->>\'crawlId\' = :crawlId AND id != :currentId
              ORDER BY score ASC
              LIMIT 5';
@@ -685,7 +685,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = 'DELETE FROM embeddings_table WHERE id IN (?)';
+        $expectedQuery = 'DELETE FROM "embeddings_table" WHERE id IN (?)';
 
         $pdo->expects($this->once())
             ->method('prepare')
@@ -711,7 +711,7 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = 'DELETE FROM embeddings_table WHERE id IN (?,?,?)';
+        $expectedQuery = 'DELETE FROM "embeddings_table" WHERE id IN (?,?,?)';
 
         $pdo->expects($this->once())
             ->method('prepare')
@@ -771,9 +771,9 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = "SELECT id, embedding AS embedding, metadata,
+        $expectedQuery = "SELECT id, \"embedding\" AS embedding, metadata,
                    ts_rank(to_tsvector('english', metadata->>'_text'), plainto_tsquery('english', :search_text_0)) AS score
-            FROM embeddings_table
+            FROM \"embeddings_table\"
             WHERE to_tsvector('english', metadata->>'_text') @@ (plainto_tsquery('english', :search_text_0))
             ORDER BY score DESC
             LIMIT 5";
@@ -811,10 +811,10 @@ final class StoreTest extends TestCase
 
         $store = new Store($pdo, 'embeddings_table', 'embedding');
 
-        $expectedQuery = "SELECT id, embedding AS embedding, metadata,
-                   ((:semantic_ratio * (1 - (embedding <-> :embedding))) +
+        $expectedQuery = "SELECT id, \"embedding\" AS embedding, metadata,
+                   ((:semantic_ratio * (1 - (\"embedding\" <-> :embedding))) +
                     (:keyword_ratio * ts_rank(to_tsvector('english', metadata->>'_text'), (plainto_tsquery('english', :search_text_0))))) AS score
-            FROM embeddings_table
+            FROM \"embeddings_table\"
             WHERE to_tsvector('english', metadata->>'_text') @@ (plainto_tsquery('english', :search_text_0))
             ORDER BY score DESC
             LIMIT 5";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        |
| License       | MIT

The default table name is `default` and it's a reserved keyword.
Let's fix that
