### PR TITLE
[MCP Bundle] Extract HTTP middleware resolution into a factory

### DIFF
--- a/src/mcp-bundle/src/Controller/McpController.php
+++ b/src/mcp-bundle/src/Controller/McpController.php
@@ -12,12 +12,11 @@
 namespace Symfony\AI\McpBundle\Controller;
 
 use Mcp\Server;
-use Mcp\Server\Transport\Http\Middleware\DnsRebindingProtectionMiddleware;
 use Mcp\Server\Transport\StreamableHttpTransport;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\AI\McpBundle\Http\MiddlewareFactory;
 use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,19 +24,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class McpController
 {
-    /**
-     * @param list<string>|false|null $allowedHosts Hostnames allowed by the DNS rebinding protection: null keeps the
-     *                                              SDK default (localhost only), an array restricts it to those hosts,
-     *                                              false disables the protection entirely
-     */
     public function __construct(
         private readonly Server $server,
         private readonly HttpMessageFactoryInterface $httpMessageFactory,
         private readonly HttpFoundationFactoryInterface $httpFoundationFactory,
         private readonly ResponseFactoryInterface $responseFactory,
         private readonly StreamFactoryInterface $streamFactory,
+        private readonly MiddlewareFactory $middlewareFactory,
         private readonly ?LoggerInterface $logger = null,
-        private readonly array|false|null $allowedHosts = null,
     ) {
     }
 
@@ -48,43 +42,12 @@ final class McpController
             $this->responseFactory,
             $this->streamFactory,
             logger: $this->logger,
-            middleware: $this->resolveMiddleware(),
+            middleware: $this->middlewareFactory->create(),
         );
 
         $psrResponse = $this->server->run($transport);
         $streamed = 'text/event-stream' === strtolower($psrResponse->getHeaderLine('Content-Type'));
 
         return $this->httpFoundationFactory->createResponse($psrResponse, $streamed);
-    }
-
-    /**
-     * Returns null to keep the SDK secure defaults, or a tailored middleware stack when the DNS
-     * rebinding protection needs to be disabled or restricted to custom hosts.
-     *
-     * @return list<MiddlewareInterface>|null
-     */
-    private function resolveMiddleware(): ?array
-    {
-        // Unset: keep the SDK secure defaults (DNS rebinding protection limited to localhost).
-        if (null === $this->allowedHosts) {
-            return null;
-        }
-
-        $middleware = [];
-        foreach (StreamableHttpTransport::defaultMiddleware() as $defaultMiddleware) {
-            if ($defaultMiddleware instanceof DnsRebindingProtectionMiddleware) {
-                // false: disable the protection entirely to expose a public MCP server.
-                if (false === $this->allowedHosts) {
-                    continue;
-                }
-
-                // array: restrict the protection to the configured hosts.
-                $defaultMiddleware = new DnsRebindingProtectionMiddleware($this->allowedHosts);
-            }
-
-            $middleware[] = $defaultMiddleware;
-        }
-
-        return $middleware;
     }
 }

--- a/src/mcp-bundle/src/Http/MiddlewareFactory.php
+++ b/src/mcp-bundle/src/Http/MiddlewareFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Http;
+
+use Mcp\Server\Transport\Http\Middleware\DnsRebindingProtectionMiddleware;
+use Mcp\Server\Transport\StreamableHttpTransport;
+use Psr\Http\Server\MiddlewareInterface;
+
+/**
+ * Resolves the middleware stack for the streamable HTTP transport based on the configured DNS
+ * rebinding protection: the SDK secure defaults are kept, restricted to custom hosts, or disabled.
+ *
+ * @author Christopher Hertel
+ */
+final class MiddlewareFactory
+{
+    /**
+     * @param list<string>|false|null $allowedHosts Hostnames allowed by the DNS rebinding protection: null keeps the
+     *                                              SDK default (localhost only), an array restricts it to those hosts,
+     *                                              false disables the protection entirely
+     */
+    public function __construct(
+        private readonly array|false|null $allowedHosts = null,
+    ) {
+    }
+
+    /**
+     * Returns null to keep the SDK secure defaults, or a tailored middleware stack when the DNS
+     * rebinding protection needs to be disabled or restricted to custom hosts.
+     *
+     * @return list<MiddlewareInterface>|null
+     */
+    public function create(): ?array
+    {
+        // Unset: keep the SDK secure defaults (DNS rebinding protection limited to localhost).
+        if (null === $this->allowedHosts) {
+            return null;
+        }
+
+        $middleware = [];
+        foreach (StreamableHttpTransport::defaultMiddleware() as $defaultMiddleware) {
+            if ($defaultMiddleware instanceof DnsRebindingProtectionMiddleware) {
+                // false: disable the protection entirely to expose a public MCP server.
+                if (false === $this->allowedHosts) {
+                    continue;
+                }
+
+                // array: restrict the protection to the configured hosts.
+                $defaultMiddleware = new DnsRebindingProtectionMiddleware($this->allowedHosts);
+            }
+
+            $middleware[] = $defaultMiddleware;
+        }
+
+        return $middleware;
+    }
+}

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -25,6 +25,7 @@ use Mcp\Server\Session\Psr16SessionStore;
 use Symfony\AI\McpBundle\Command\McpCommand;
 use Symfony\AI\McpBundle\Controller\McpController;
 use Symfony\AI\McpBundle\DependencyInjection\McpPass;
+use Symfony\AI\McpBundle\Http\MiddlewareFactory;
 use Symfony\AI\McpBundle\Profiler\DataCollector;
 use Symfony\AI\McpBundle\Profiler\TraceableRegistry;
 use Symfony\AI\McpBundle\Routing\RouteLoader;
@@ -154,6 +155,9 @@ final class McpBundle extends AbstractBundle
         }
 
         if ($transports['http']) {
+            $container->register('mcp.middleware_factory', MiddlewareFactory::class)
+                ->setArguments([$httpConfig['allowed_hosts']]);
+
             $container->register('mcp.server.controller', McpController::class)
                 ->setArguments([
                     new Reference('mcp.server'),
@@ -161,8 +165,8 @@ final class McpBundle extends AbstractBundle
                     new Reference('mcp.http_foundation_factory'),
                     new Reference('mcp.psr17_factory'),
                     new Reference('mcp.psr17_factory'),
+                    new Reference('mcp.middleware_factory'),
                     new Reference('logger'),
-                    $httpConfig['allowed_hosts'],
                 ])
                 ->setPublic(true)
                 ->addTag('controller.service_arguments')

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -355,9 +355,9 @@ class McpBundleTest extends TestCase
             ],
         ]);
 
-        $controllerDefinition = $container->getDefinition('mcp.server.controller');
-        $arguments = $controllerDefinition->getArguments();
-        $this->assertNull($arguments[6]); // No allowed hosts configured: keep the SDK default (localhost only)
+        $factoryDefinition = $container->getDefinition('mcp.middleware_factory');
+        $arguments = $factoryDefinition->getArguments();
+        $this->assertNull($arguments[0]); // No allowed hosts configured: keep the SDK default (localhost only)
     }
 
     public function testDnsRebindingProtectionWithAllowedHosts()
@@ -373,9 +373,9 @@ class McpBundleTest extends TestCase
             ],
         ]);
 
-        $controllerDefinition = $container->getDefinition('mcp.server.controller');
-        $arguments = $controllerDefinition->getArguments();
-        $this->assertSame(['example.com', 'mcp.example.com'], $arguments[6]);
+        $factoryDefinition = $container->getDefinition('mcp.middleware_factory');
+        $arguments = $factoryDefinition->getArguments();
+        $this->assertSame(['example.com', 'mcp.example.com'], $arguments[0]);
     }
 
     public function testDnsRebindingProtectionDisabled()
@@ -391,9 +391,9 @@ class McpBundleTest extends TestCase
             ],
         ]);
 
-        $controllerDefinition = $container->getDefinition('mcp.server.controller');
-        $arguments = $controllerDefinition->getArguments();
-        $this->assertFalse($arguments[6]);
+        $factoryDefinition = $container->getDefinition('mcp.middleware_factory');
+        $arguments = $factoryDefinition->getArguments();
+        $this->assertFalse($arguments[0]);
     }
 
     public function testSessionStoreFileConfiguration()

--- a/src/mcp-bundle/tests/Http/MiddlewareFactoryTest.php
+++ b/src/mcp-bundle/tests/Http/MiddlewareFactoryTest.php
@@ -9,22 +9,22 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\AI\McpBundle\Tests\Controller;
+namespace Symfony\AI\McpBundle\Tests\Http;
 
 use Mcp\Server\Transport\Http\Middleware\DnsRebindingProtectionMiddleware;
 use PHPUnit\Framework\TestCase;
-use Symfony\AI\McpBundle\Controller\McpController;
+use Symfony\AI\McpBundle\Http\MiddlewareFactory;
 
-class McpControllerTest extends TestCase
+class MiddlewareFactoryTest extends TestCase
 {
     public function testKeepsSecureDefaultsWhenAllowedHostsIsUnset()
     {
-        $this->assertNull($this->resolveMiddleware(null));
+        $this->assertNull((new MiddlewareFactory(null))->create());
     }
 
     public function testRestrictsDnsRebindingProtectionToConfiguredHosts()
     {
-        $middleware = $this->resolveMiddleware(['example.com', 'mcp.example.com']);
+        $middleware = (new MiddlewareFactory(['example.com', 'mcp.example.com']))->create();
 
         $this->assertIsArray($middleware);
 
@@ -44,7 +44,7 @@ class McpControllerTest extends TestCase
 
     public function testRemovesDnsRebindingProtectionWhenAllowedHostsIsFalse()
     {
-        $middleware = $this->resolveMiddleware(false);
+        $middleware = (new MiddlewareFactory(false))->create();
 
         $this->assertIsArray($middleware);
         $this->assertNotSame([], $middleware);
@@ -52,19 +52,5 @@ class McpControllerTest extends TestCase
         foreach ($middleware as $entry) {
             $this->assertNotInstanceOf(DnsRebindingProtectionMiddleware::class, $entry);
         }
-    }
-
-    /**
-     * @param list<string>|false|null $allowedHosts
-     *
-     * @return list<object>|null
-     */
-    private function resolveMiddleware(array|false|null $allowedHosts): ?array
-    {
-        $controller = (new \ReflectionClass(McpController::class))->newInstanceWithoutConstructor();
-
-        (new \ReflectionProperty(McpController::class, 'allowedHosts'))->setValue($controller, $allowedHosts);
-
-        return (new \ReflectionMethod(McpController::class, 'resolveMiddleware'))->invoke($controller);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Follow-up to #2250. Moves the DNS rebinding protection middleware resolution out of `McpController` and into a dedicated `MiddlewareFactory`.

The controller no longer decides the middleware stack — it delegates to the injected factory and stays focused on `Request`<->PSR translation. Behavior is unchanged (`null` keeps the SDK defaults, a list restricts hosts, `false` disables the protection).

Since the factory is a plain, dependency-free unit, the resolution logic is now tested directly instead of through reflection on the controller's private method.