### PR TITLE
[Demo] Fix streamed recipe/chat SSE session handling and empty input

### DIFF
--- a/demo/src/Recipe/Chat.php
+++ b/demo/src/Recipe/Chat.php
@@ -83,6 +83,17 @@ final class Chat
      */
     public function getRecipeStream(MessageBag $messages): \Generator
     {
+        $messageList = $messages->getMessages();
+        $lastMessage = [] === $messageList ? null : $messageList[array_key_last($messageList)];
+
+        // Only generate a recipe when the latest message is still awaiting one. This guards
+        // against reconnecting, duplicate or stale SSE connections (e.g. after a stream error
+        // or a reset) that would otherwise call the model with no pending user message and
+        // trigger a provider "input required" error.
+        if (!$lastMessage instanceof UserMessage) {
+            return new Recipe();
+        }
+
         $stream = $this->agent->call($messages, [
             'stream' => true,
             'response_format' => Recipe::class,

--- a/demo/src/Recipe/TwigComponent.php
+++ b/demo/src/Recipe/TwigComponent.php
@@ -16,6 +16,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\EventStreamResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ServerEvent;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
@@ -71,14 +73,20 @@ final class TwigComponent extends AbstractController
 
     public function streamContent(Request $request): EventStreamResponse
     {
-        // The chat is kept in a session-scoped cache, so make sure the session id is
-        // available; the streamed body itself never touches the session, which lets the
-        // framework close (and unlock) it before the response is sent.
-        $request->getSession()->start();
-
+        // The chat is kept in a session-scoped cache, so load the messages while the real
+        // session is still available.
         $messages = $this->chat->loadMessages();
 
-        return new EventStreamResponse(function () use ($messages) {
+        $actualSession = $request->getSession();
+
+        // Overriding the session prevents the framework from calling save() on the actual
+        // session, which fixes the "Failed to start the session because headers have already
+        // been sent" error once the streamed body has started sending output.
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        return new EventStreamResponse(function () use ($request, $actualSession, $messages) {
+            $request->setSession($actualSession);
+
             foreach ($this->chat->getRecipeStream($messages) as $recipe) {
                 yield new ServerEvent(explode("\n", $this->renderBlockView('components/_recipe_stream.html.twig', 'update', ['recipe' => $recipe])));
             }

--- a/demo/src/Stream/Chat.php
+++ b/demo/src/Stream/Chat.php
@@ -58,6 +58,17 @@ final class Chat
      */
     public function getAssistantResponse(MessageBag $messages): \Generator
     {
+        $messageList = $messages->getMessages();
+        $lastMessage = [] === $messageList ? null : $messageList[array_key_last($messageList)];
+
+        // Only answer when the latest message is still awaiting a reply. This guards against
+        // reconnecting, duplicate or stale SSE connections (e.g. after a stream error or a
+        // reset) that would otherwise call the model with no pending user message and trigger
+        // a provider "input required" error.
+        if (!$lastMessage instanceof UserMessage) {
+            return Message::ofAssistant('');
+        }
+
         $stream = $this->agent->call($messages, ['stream' => true])->getContent();
         \assert(is_iterable($stream));
 

--- a/demo/src/Stream/TwigComponent.php
+++ b/demo/src/Stream/TwigComponent.php
@@ -16,6 +16,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\EventStreamResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ServerEvent;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -63,14 +65,20 @@ final class TwigComponent extends AbstractController
 
     public function streamContent(Request $request): EventStreamResponse
     {
-        // The chat is kept in a session-scoped cache, so make sure the session id is
-        // available; the streamed body itself never touches the session, which lets the
-        // framework close (and unlock) it before the response is sent.
-        $request->getSession()->start();
-
+        // The chat is kept in a session-scoped cache, so load the messages while the real
+        // session is still available.
         $messages = $this->chat->loadMessages();
 
-        return new EventStreamResponse(function () use ($messages) {
+        $actualSession = $request->getSession();
+
+        // Overriding the session prevents the framework from calling save() on the actual
+        // session, which fixes the "Failed to start the session because headers have already
+        // been sent" error once the streamed body has started sending output.
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        return new EventStreamResponse(function () use ($request, $actualSession, $messages) {
+            $request->setSession($actualSession);
+
             $response = $this->chat->getAssistantResponse($messages);
 
             foreach ($response as $partialMessage) {

--- a/demo/tests/Recipe/ChatTest.php
+++ b/demo/tests/Recipe/ChatTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Recipe;
+
+use App\Recipe\Chat;
+use App\Recipe\Data\Recipe;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\MockAgent;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\PartialObjectDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+final class ChatTest extends TestCase
+{
+    public function testGetRecipeStreamSkipsModelCallWithoutPendingUserMessage()
+    {
+        $agent = new MockAgent();
+        $chat = self::createChat($agent);
+
+        $recipes = iterator_to_array($chat->getRecipeStream(new MessageBag()));
+
+        // No user message to respond to (e.g. a reconnecting or stale SSE connection):
+        // the model must not be called, otherwise the provider rejects the empty input.
+        $this->assertSame([], $recipes);
+        $agent->assertNotCalled();
+    }
+
+    public function testGetRecipeStreamSkipsModelCallWhenLatestMessageIsAssistant()
+    {
+        $agent = new MockAgent();
+        $chat = self::createChat($agent);
+
+        $messages = new MessageBag(
+            Message::ofUser('A quick pasta'),
+            Message::ofAssistant('Here is your recipe.'),
+        );
+
+        $recipes = iterator_to_array($chat->getRecipeStream($messages));
+
+        $this->assertSame([], $recipes);
+        $agent->assertNotCalled();
+    }
+
+    public function testGetRecipeStreamGeneratesRecipeForPendingUserMessage()
+    {
+        $firstPartial = new Recipe();
+        $firstPartial->name = 'Pancakes';
+
+        $secondPartial = new Recipe();
+        $secondPartial->name = 'Pancakes';
+        $secondPartial->duration = 20;
+
+        $stream = new StreamResult((static function () use ($firstPartial, $secondPartial): \Generator {
+            yield new PartialObjectDelta($firstPartial, '{"name":"Pancakes"}');
+            yield new PartialObjectDelta($secondPartial, '{"name":"Pancakes","duration":20}');
+        })());
+
+        $agent = new MockAgent(['Give me pancakes' => $stream]);
+        $chat = self::createChat($agent);
+
+        $recipes = iterator_to_array($chat->getRecipeStream(new MessageBag(Message::ofUser('Give me pancakes'))));
+
+        $agent->assertCallCount(1);
+        $this->assertSame(['stream' => true, 'response_format' => Recipe::class], $agent->getLastCall()['options']);
+
+        $this->assertCount(2, $recipes);
+        $this->assertSame('Pancakes', $recipes[1]->name);
+        $this->assertSame(20, $recipes[1]->duration);
+    }
+
+    private static function createChat(MockAgent $agent): Chat
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->start();
+
+        $requestStack = new RequestStack();
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack->push($request);
+
+        return new Chat($requestStack, new ArrayAdapter(), $agent);
+    }
+}

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `InvalidArgumentException` when the request would be sent with an empty `input` and no `previous_response_id`, `prompt` or `conversation_id` option, instead of an opaque provider 400
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Throw typed exceptions on rate limit and server error events mid-stream
  * Normalize the `baseUrl` and tolerate a trailing slash in the model client

--- a/src/platform/src/Bridge/OpenResponses/Contract/Message/MessageBagNormalizer.php
+++ b/src/platform/src/Bridge/OpenResponses/Contract/Message/MessageBagNormalizer.php
@@ -12,7 +12,9 @@
 namespace Symfony\AI\Platform\Bridge\OpenResponses\Contract\Message;
 
 use Symfony\AI\Platform\Bridge\OpenResponses\ResponsesModel;
+use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Model;
@@ -54,6 +56,18 @@ final class MessageBagNormalizer extends ModelContractNormalizer implements Norm
 
         if ($data->getSystemMessage()) {
             $messages['instructions'] = $data->getSystemMessage()->getContent();
+        }
+
+        // The Responses API requires one of "input", "previous_response_id", "prompt" or
+        // "conversation_id". A message bag with only a system message (mapped to "instructions")
+        // yields an empty "input" and would otherwise fail with an opaque provider 400. Fail fast
+        // with a clear error unless the caller supplies an alternative input via options.
+        if ([] === $messages['input']) {
+            $options = $context[Contract::CONTEXT_OPTIONS] ?? [];
+
+            if (!isset($options['previous_response_id']) && !isset($options['prompt']) && !isset($options['conversation_id'])) {
+                throw new InvalidArgumentException('The message bag must contain at least one non-system message, or one of the "previous_response_id", "prompt" or "conversation_id" options must be provided.');
+            }
         }
 
         return $messages;

--- a/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/MessageBagNormalizerTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/MessageBagNormalizerTest.php
@@ -20,6 +20,7 @@ use Symfony\AI\Platform\Bridge\OpenResponses\Contract\Message\ToolCallMessageNor
 use Symfony\AI\Platform\Bridge\OpenResponses\Contract\ToolCallNormalizer;
 use Symfony\AI\Platform\Bridge\OpenResponses\Contract\ToolNormalizer;
 use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
@@ -35,19 +36,51 @@ class MessageBagNormalizerTest extends TestCase
     #[DataProvider('normalizeProvider')]
     public function testNormalize(MessageBag $messageBag, array $expected)
     {
-        $normalizer = new MessageBagNormalizer();
-        $normalizer->setNormalizer(new Serializer([
-            new Contract\Normalizer\Message\UserMessageNormalizer(),
-            new AssistantMessageNormalizer(),
-            new ToolCallMessageNormalizer(),
-            new ToolNormalizer(),
-            new ToolCallNormalizer(),
-            new Contract\Normalizer\Message\SystemMessageNormalizer(),
-        ]));
-
-        $actual = $normalizer->normalize($messageBag, null, [Contract::CONTEXT_MODEL => new Gpt('o3')]);
+        $actual = self::createNormalizer()->normalize($messageBag, null, [Contract::CONTEXT_MODEL => new Gpt('o3')]);
 
         $this->assertEquals($expected, $actual);
+    }
+
+    public function testNormalizeThrowsWhenInputIsEmptyAndNoAlternativeInputProvided()
+    {
+        $normalizer = self::createNormalizer();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The message bag must contain at least one non-system message, or one of the "previous_response_id", "prompt" or "conversation_id" options must be provided.');
+
+        $normalizer->normalize(
+            new MessageBag(Message::forSystem('You are a helpful assistant.')),
+            null,
+            [Contract::CONTEXT_MODEL => new Gpt('o3')],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    #[DataProvider('alternativeInputProvider')]
+    public function testNormalizeAllowsEmptyInputWithAlternativeInput(array $options)
+    {
+        $normalizer = self::createNormalizer();
+
+        $actual = $normalizer->normalize(
+            new MessageBag(Message::forSystem('You are a helpful assistant.')),
+            null,
+            [Contract::CONTEXT_MODEL => new Gpt('o3'), Contract::CONTEXT_OPTIONS => $options],
+        );
+
+        $this->assertSame([], $actual['input']);
+        $this->assertSame('You are a helpful assistant.', $actual['instructions']);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function alternativeInputProvider(): iterable
+    {
+        yield 'previous_response_id' => [['previous_response_id' => 'resp_123']];
+        yield 'prompt' => [['prompt' => ['id' => 'pmpt_123']]];
+        yield 'conversation_id' => [['conversation_id' => 'conv_123']];
     }
 
     public static function normalizeProvider(): \Generator
@@ -108,5 +141,20 @@ class MessageBagNormalizerTest extends TestCase
         yield 'supported' => [$messageBad, $gpt, true];
         yield 'unsupported model' => [$messageBad, new Model('foo'), false];
         yield 'unsupported data' => [new Text('foo'), $gpt, false];
+    }
+
+    private static function createNormalizer(): MessageBagNormalizer
+    {
+        $normalizer = new MessageBagNormalizer();
+        $normalizer->setNormalizer(new Serializer([
+            new Contract\Normalizer\Message\UserMessageNormalizer(),
+            new AssistantMessageNormalizer(),
+            new ToolCallMessageNormalizer(),
+            new ToolNormalizer(),
+            new ToolCallNormalizer(),
+            new Contract\Normalizer\Message\SystemMessageNormalizer(),
+        ]));
+
+        return $normalizer;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #2299
| License       | MIT

Restores the session-swap in the `recipe`/`stream` SSE `streamContent()` handlers (per @valtzu in #2299) to fix the "Failed to start the session because headers have already been sent" error, and guards `getRecipeStream()`/`getAssistantResponse()` against being called with no pending user message (reconnecting/stale SSE connections). Also hardens the OpenAI Responses `MessageBagNormalizer` to throw a clear `InvalidArgumentException` when a request would be sent with empty `input` and no `previous_response_id`/`prompt`/`conversation_id`, instead of an opaque provider 400.