### PR TITLE
[Demo] Fix streamed recipe/chat SSE session handling

### DIFF
--- a/demo/src/Recipe/TwigComponent.php
+++ b/demo/src/Recipe/TwigComponent.php
@@ -16,6 +16,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\EventStreamResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ServerEvent;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
@@ -71,14 +73,20 @@ final class TwigComponent extends AbstractController
 
     public function streamContent(Request $request): EventStreamResponse
     {
-        // The chat is kept in a session-scoped cache, so make sure the session id is
-        // available; the streamed body itself never touches the session, which lets the
-        // framework close (and unlock) it before the response is sent.
-        $request->getSession()->start();
-
+        // The chat is kept in a session-scoped cache, so load the messages while the real
+        // session is still available.
         $messages = $this->chat->loadMessages();
 
-        return new EventStreamResponse(function () use ($messages) {
+        $actualSession = $request->getSession();
+
+        // Overriding the session prevents the framework from calling save() on the actual
+        // session, which fixes the "Failed to start the session because headers have already
+        // been sent" error once the streamed body has started sending output.
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        return new EventStreamResponse(function () use ($request, $actualSession, $messages) {
+            $request->setSession($actualSession);
+
             foreach ($this->chat->getRecipeStream($messages) as $recipe) {
                 yield new ServerEvent(explode("\n", $this->renderBlockView('components/_recipe_stream.html.twig', 'update', ['recipe' => $recipe])));
             }

--- a/demo/src/Stream/TwigComponent.php
+++ b/demo/src/Stream/TwigComponent.php
@@ -16,6 +16,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\EventStreamResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ServerEvent;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -63,14 +65,20 @@ final class TwigComponent extends AbstractController
 
     public function streamContent(Request $request): EventStreamResponse
     {
-        // The chat is kept in a session-scoped cache, so make sure the session id is
-        // available; the streamed body itself never touches the session, which lets the
-        // framework close (and unlock) it before the response is sent.
-        $request->getSession()->start();
-
+        // The chat is kept in a session-scoped cache, so load the messages while the real
+        // session is still available.
         $messages = $this->chat->loadMessages();
 
-        return new EventStreamResponse(function () use ($messages) {
+        $actualSession = $request->getSession();
+
+        // Overriding the session prevents the framework from calling save() on the actual
+        // session, which fixes the "Failed to start the session because headers have already
+        // been sent" error once the streamed body has started sending output.
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        return new EventStreamResponse(function () use ($request, $actualSession, $messages) {
+            $request->setSession($actualSession);
+
             $response = $this->chat->getAssistantResponse($messages);
 
             foreach ($response as $partialMessage) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2299
| License       | MIT

The `recipe` and `stream` demos use Server-Sent Events, and the SSE endpoints broke after the session-handling change in 3bfb360: the framework saved the real session while the streamed body was already sending output ("Failed to start the session because headers have already been sent").

Restores the session-swap approach (thanks @valtzu) so the framework saves a throwaway session on `kernel.response`, while the real session is only used inside the streamed callback.

The related empty-message guard (skip the model call on reconnecting/stale SSE connections) is handled separately in #2304, which introduces the `MessageBag` helper it relies on.