### PR TITLE
[Platform] Validate empty input in OpenAI Responses normalizer

### DIFF
--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Throw `InvalidArgumentException` when the request would be sent with an empty `input` and no `previous_response_id`, `prompt` or `conversation_id` option, instead of an opaque provider 400
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Throw typed exceptions on rate limit and server error events mid-stream
  * Normalize the `baseUrl` and tolerate a trailing slash in the model client

--- a/src/platform/src/Bridge/OpenResponses/Contract/Message/MessageBagNormalizer.php
+++ b/src/platform/src/Bridge/OpenResponses/Contract/Message/MessageBagNormalizer.php
@@ -12,7 +12,9 @@
 namespace Symfony\AI\Platform\Bridge\OpenResponses\Contract\Message;
 
 use Symfony\AI\Platform\Bridge\OpenResponses\ResponsesModel;
+use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Model;
@@ -54,6 +56,18 @@ final class MessageBagNormalizer extends ModelContractNormalizer implements Norm
 
         if ($data->getSystemMessage()) {
             $messages['instructions'] = $data->getSystemMessage()->getContent();
+        }
+
+        // The Responses API requires one of "input", "previous_response_id", "prompt" or
+        // "conversation_id". A message bag with only a system message (mapped to "instructions")
+        // yields an empty "input" and would otherwise fail with an opaque provider 400. Fail fast
+        // with a clear error unless the caller supplies an alternative input via options.
+        if ([] === $messages['input']) {
+            $options = $context[Contract::CONTEXT_OPTIONS] ?? [];
+
+            if (!isset($options['previous_response_id']) && !isset($options['prompt']) && !isset($options['conversation_id'])) {
+                throw new InvalidArgumentException('The message bag must contain at least one non-system message, or one of the "previous_response_id", "prompt" or "conversation_id" options must be provided.');
+            }
         }
 
         return $messages;

--- a/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/MessageBagNormalizerTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/MessageBagNormalizerTest.php
@@ -20,6 +20,7 @@ use Symfony\AI\Platform\Bridge\OpenResponses\Contract\Message\ToolCallMessageNor
 use Symfony\AI\Platform\Bridge\OpenResponses\Contract\ToolCallNormalizer;
 use Symfony\AI\Platform\Bridge\OpenResponses\Contract\ToolNormalizer;
 use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
@@ -35,19 +36,51 @@ class MessageBagNormalizerTest extends TestCase
     #[DataProvider('normalizeProvider')]
     public function testNormalize(MessageBag $messageBag, array $expected)
     {
-        $normalizer = new MessageBagNormalizer();
-        $normalizer->setNormalizer(new Serializer([
-            new Contract\Normalizer\Message\UserMessageNormalizer(),
-            new AssistantMessageNormalizer(),
-            new ToolCallMessageNormalizer(),
-            new ToolNormalizer(),
-            new ToolCallNormalizer(),
-            new Contract\Normalizer\Message\SystemMessageNormalizer(),
-        ]));
-
-        $actual = $normalizer->normalize($messageBag, null, [Contract::CONTEXT_MODEL => new Gpt('o3')]);
+        $actual = self::createNormalizer()->normalize($messageBag, null, [Contract::CONTEXT_MODEL => new Gpt('o3')]);
 
         $this->assertEquals($expected, $actual);
+    }
+
+    public function testNormalizeThrowsWhenInputIsEmptyAndNoAlternativeInputProvided()
+    {
+        $normalizer = self::createNormalizer();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The message bag must contain at least one non-system message, or one of the "previous_response_id", "prompt" or "conversation_id" options must be provided.');
+
+        $normalizer->normalize(
+            new MessageBag(Message::forSystem('You are a helpful assistant.')),
+            null,
+            [Contract::CONTEXT_MODEL => new Gpt('o3')],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    #[DataProvider('alternativeInputProvider')]
+    public function testNormalizeAllowsEmptyInputWithAlternativeInput(array $options)
+    {
+        $normalizer = self::createNormalizer();
+
+        $actual = $normalizer->normalize(
+            new MessageBag(Message::forSystem('You are a helpful assistant.')),
+            null,
+            [Contract::CONTEXT_MODEL => new Gpt('o3'), Contract::CONTEXT_OPTIONS => $options],
+        );
+
+        $this->assertSame([], $actual['input']);
+        $this->assertSame('You are a helpful assistant.', $actual['instructions']);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function alternativeInputProvider(): iterable
+    {
+        yield 'previous_response_id' => [['previous_response_id' => 'resp_123']];
+        yield 'prompt' => [['prompt' => ['id' => 'pmpt_123']]];
+        yield 'conversation_id' => [['conversation_id' => 'conv_123']];
     }
 
     public static function normalizeProvider(): \Generator
@@ -108,5 +141,20 @@ class MessageBagNormalizerTest extends TestCase
         yield 'supported' => [$messageBad, $gpt, true];
         yield 'unsupported model' => [$messageBad, new Model('foo'), false];
         yield 'unsupported data' => [new Text('foo'), $gpt, false];
+    }
+
+    private static function createNormalizer(): MessageBagNormalizer
+    {
+        $normalizer = new MessageBagNormalizer();
+        $normalizer->setNormalizer(new Serializer([
+            new Contract\Normalizer\Message\UserMessageNormalizer(),
+            new AssistantMessageNormalizer(),
+            new ToolCallMessageNormalizer(),
+            new ToolNormalizer(),
+            new ToolCallNormalizer(),
+            new Contract\Normalizer\Message\SystemMessageNormalizer(),
+        ]));
+
+        return $normalizer;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

When a `MessageBag` produces no `input` for the OpenAI Responses API (e.g. only a system message, which maps to `instructions`), the request was sent anyway and rejected by the provider with an opaque `400` ("One of input / previous_response_id / prompt / conversation_id must be provided").

`MessageBagNormalizer` now fails fast with a clear `InvalidArgumentException` in that case, unless the caller supplies an alternative input via the `previous_response_id`, `prompt` or `conversation_id` option (so legitimate continuation calls still pass). Covered by unit tests for both the throwing case and the three alternative-input options.