### PR TITLE
[Platform] Add MessageBag::isLastMessageFrom() and use it in demo chats

### DIFF
--- a/demo/src/Recipe/Chat.php
+++ b/demo/src/Recipe/Chat.php
@@ -16,7 +16,7 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Message\Role;
 use Symfony\AI\Platform\Result\Stream\Delta\PartialObjectDelta;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -66,13 +66,7 @@ final class Chat
      */
     public function isAwaitingRecipe(): bool
     {
-        $messages = $this->loadMessages()->getMessages();
-
-        if (0 === \count($messages)) {
-            return false;
-        }
-
-        return $messages[\count($messages) - 1] instanceof UserMessage;
+        return $this->loadMessages()->isLastMessageFrom(Role::User);
     }
 
     /**
@@ -83,6 +77,14 @@ final class Chat
      */
     public function getRecipeStream(MessageBag $messages): \Generator
     {
+        // Only generate a recipe when the latest message is still awaiting one. This guards
+        // against reconnecting, duplicate or stale SSE connections (e.g. after a stream error
+        // or a reset) that would otherwise call the model with no pending user message and
+        // trigger a provider "input required" error.
+        if (!$messages->isLastMessageFrom(Role::User)) {
+            return new Recipe();
+        }
+
         $stream = $this->agent->call($messages, [
             'stream' => true,
             'response_format' => Recipe::class,

--- a/demo/src/Stream/Chat.php
+++ b/demo/src/Stream/Chat.php
@@ -16,6 +16,7 @@ use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\Role;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -58,6 +59,14 @@ final class Chat
      */
     public function getAssistantResponse(MessageBag $messages): \Generator
     {
+        // Only answer when the latest message is still awaiting a reply. This guards against
+        // reconnecting, duplicate or stale SSE connections (e.g. after a stream error or a
+        // reset) that would otherwise call the model with no pending user message and trigger
+        // a provider "input required" error.
+        if (!$messages->isLastMessageFrom(Role::User)) {
+            return Message::ofAssistant('');
+        }
+
         $stream = $this->agent->call($messages, ['stream' => true])->getContent();
         \assert(is_iterable($stream));
 

--- a/demo/tests/Recipe/ChatTest.php
+++ b/demo/tests/Recipe/ChatTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Recipe;
+
+use App\Recipe\Chat;
+use App\Recipe\Data\Recipe;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\MockAgent;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\PartialObjectDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+final class ChatTest extends TestCase
+{
+    public function testGetRecipeStreamSkipsModelCallWithoutPendingUserMessage()
+    {
+        $agent = new MockAgent();
+        $chat = self::createChat($agent);
+
+        $recipes = iterator_to_array($chat->getRecipeStream(new MessageBag()));
+
+        // No user message to respond to (e.g. a reconnecting or stale SSE connection):
+        // the model must not be called, otherwise the provider rejects the empty input.
+        $this->assertSame([], $recipes);
+        $agent->assertNotCalled();
+    }
+
+    public function testGetRecipeStreamSkipsModelCallWhenLatestMessageIsAssistant()
+    {
+        $agent = new MockAgent();
+        $chat = self::createChat($agent);
+
+        $messages = new MessageBag(
+            Message::ofUser('A quick pasta'),
+            Message::ofAssistant('Here is your recipe.'),
+        );
+
+        $recipes = iterator_to_array($chat->getRecipeStream($messages));
+
+        $this->assertSame([], $recipes);
+        $agent->assertNotCalled();
+    }
+
+    public function testGetRecipeStreamGeneratesRecipeForPendingUserMessage()
+    {
+        $firstPartial = new Recipe();
+        $firstPartial->name = 'Pancakes';
+
+        $secondPartial = new Recipe();
+        $secondPartial->name = 'Pancakes';
+        $secondPartial->duration = 20;
+
+        $stream = new StreamResult((static function () use ($firstPartial, $secondPartial): \Generator {
+            yield new PartialObjectDelta($firstPartial, '{"name":"Pancakes"}');
+            yield new PartialObjectDelta($secondPartial, '{"name":"Pancakes","duration":20}');
+        })());
+
+        $agent = new MockAgent(['Give me pancakes' => $stream]);
+        $chat = self::createChat($agent);
+
+        $recipes = iterator_to_array($chat->getRecipeStream(new MessageBag(Message::ofUser('Give me pancakes'))));
+
+        $agent->assertCallCount(1);
+        $this->assertSame(['stream' => true, 'response_format' => Recipe::class], $agent->getLastCall()['options']);
+
+        $this->assertCount(2, $recipes);
+        $this->assertSame('Pancakes', $recipes[1]->name);
+        $this->assertSame(20, $recipes[1]->duration);
+    }
+
+    private static function createChat(MockAgent $agent): Chat
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->start();
+
+        $requestStack = new RequestStack();
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack->push($request);
+
+        return new Chat($requestStack, new ArrayAdapter(), $agent);
+    }
+}

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Add `MessageBag::isLastMessageFrom()` to check whether the last message has a given role
  * Add `MaxOutputTokensException` for completed responses truncated by output token limits
  * Convert OpenAI Responses built-in tool output items (`web_search_call`, `file_search_call`, `code_interpreter_call`, `image_generation_call`, `mcp_call`, `mcp_list_tools`, `mcp_approval_request`, `computer_call`, `local_shell_call`) into typed results instead of skipping them. Adds `Result\WebSearchResult`, `Result\FileSearchResult`, `Result\McpCallResult`, `Result\McpListToolsResult`, `Result\McpApprovalRequestResult`, `Result\ComputerCallResult`, and `Result\LocalShellCallResult` (code interpreter reuses `ExecutableCodeResult`/`CodeExecutionResult`, image generation reuses `BinaryResult`), plus the matching `Message\Content` classes so the results round-trip through `Message::ofAssistant()`. Benefits the OpenAI, Azure OpenAI, and Scaleway bridges.
  * [BC BREAK] Remove `Capability::INPUT_MULTIPLE` from all embedding models since every embedding bridge already accepts multiple inputs in a single API call

--- a/src/platform/src/Message/MessageBag.php
+++ b/src/platform/src/Message/MessageBag.php
@@ -207,6 +207,15 @@ class MessageBag implements \Countable, \IteratorAggregate
         return $message;
     }
 
+    public function isLastMessageFrom(Role $role): bool
+    {
+        if ([] === $this->messages) {
+            return false;
+        }
+
+        return $this->messages[\count($this->messages) - 1]->getRole() === $role;
+    }
+
     public function containsAudio(): bool
     {
         foreach ($this->messages as $message) {

--- a/src/platform/tests/Message/MessageBagTest.php
+++ b/src/platform/tests/Message/MessageBagTest.php
@@ -409,4 +409,26 @@ final class MessageBagTest extends TestCase
 
         $this->assertSame($latestMessageAsUser, $messageBag->latestAs(Role::User));
     }
+
+    public function testIsLastMessageFromReturnsFalseForEmptyBag()
+    {
+        $this->assertFalse((new MessageBag())->isLastMessageFrom(Role::User));
+    }
+
+    public function testIsLastMessageFromMatchesTheLastMessageRole()
+    {
+        $messageBag = new MessageBag(
+            Message::forSystem('System prompt.'),
+            Message::ofUser('Hello, world!'),
+        );
+
+        $this->assertTrue($messageBag->isLastMessageFrom(Role::User));
+        $this->assertFalse($messageBag->isLastMessageFrom(Role::Assistant));
+        $this->assertFalse($messageBag->isLastMessageFrom(Role::System));
+
+        $messageBag->add(Message::ofAssistant('Hi there!'));
+
+        $this->assertFalse($messageBag->isLastMessageFrom(Role::User));
+        $this->assertTrue($messageBag->isLastMessageFrom(Role::Assistant));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

Adds `MessageBag::isLastMessageFrom(Role $role): bool` to check the role of the last message in the bag, complementing the existing `latestAs(Role)`.

Uses it to simplify the streamed `recipe`/`stream` demo chats, replacing the hand-rolled "is the last message a `UserMessage`" checks (in `getRecipeStream()`, `getAssistantResponse()` and `isAwaitingRecipe()`) with a single, readable call. Those guards prevent the model from being invoked with no pending user message (reconnecting/stale SSE connections); a unit test covers the guard.