### PR TITLE
[Store] Add StoreInterface::clear() and implement it in all bridges

### DIFF
--- a/.github/workflows/tests-high-volume.yaml
+++ b/.github/workflows/tests-high-volume.yaml
@@ -1,0 +1,77 @@
+name: Tests (High Volume)
+
+# The store integration tests write a few hundred documents per bridge, which is enough to cross the
+# result limits engines apply by default, but not the hard server-side limits their clear() has to work
+# around - Weaviate truncating a batch delete at 10.000 objects, for example. Writing that many documents
+# is too slow for every pull request, so it runs on a schedule instead.
+
+on:
+    schedule:
+        -   cron: '0 4 * * *'
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+env:
+    REQUIRED_PHP_EXTENSIONS: 'mongodb, redis'
+    STORE_HIGH_VOLUME_TESTS: '1'
+
+jobs:
+    matrix:
+        name: Matrix
+        uses: ./.github/workflows/build-matrix.yaml
+
+    store-bridges-integration:
+        name: High Volume / Store / ${{ matrix.bridge }}
+        needs: matrix
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        strategy:
+            fail-fast: false
+            matrix:
+                bridge: ${{ fromJson(needs.matrix.outputs.store-bridges-integration) }}
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.4'
+                  tools: flex
+                  extensions: ${{ env.REQUIRED_PHP_EXTENSIONS }}
+
+            - name: Install root dependencies
+              uses: ramsey/composer-install@v4
+
+            - name: Build packages
+              run: php .github/build-packages.php
+
+            - name: Isolate Bridge
+              uses: ./.github/actions/isolate-bridge
+              with:
+                  component: store
+                  bridge: ${{ matrix.bridge }}
+                  target: tmp
+
+            - name: Install dependencies
+              uses: ramsey/composer-install@v4
+              with:
+                  working-directory: tmp/store/src/Bridge/${{ matrix.bridge }}
+
+            - name: Start Docker services
+              working-directory: tmp/store/src/Bridge/${{ matrix.bridge }}
+              run: docker compose up -d --wait || true
+
+            - name: Wait for services to be ready
+              run: sleep 15
+
+            - name: Run integration tests
+              run: cd tmp/store/src/Bridge/${{ matrix.bridge }} && vendor/bin/phpunit --group integration
+
+            - name: Stop Docker services
+              working-directory: tmp/store/src/Bridge/${{ matrix.bridge }}
+              run: docker compose down || true

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -79,6 +79,21 @@ Platform
 Store
 -----
 
+ * The `StoreInterface::clear()` method was added to the interface. It removes all documents from the store,
+   while keeping the underlying table, index or collection intact - in contrast to `ManagedStoreInterface::drop()`,
+   which removes the infrastructure itself. Custom stores need to implement the new method:
+
+   ```php
+   public function clear(array $options = []): void;
+
+   // Usage
+   $store->clear();
+   ```
+
+ * The Manticore Search `Store` now creates its `uuid` column as a `STRING` attribute instead of a `TEXT` field,
+   because removing documents by id is not supported on stored text fields and failed with a server error.
+   Existing tables need to be recreated (`drop()` + `setup()`) for `remove()` to work.
+
  * The `endpointUrl` and `apiKey` parameter for Typesense `Store` has been removed, use `StoreFactory` instead
  * The `accountId`, `apiKey`, and `endpointUrl` parameter for Cloudflare `Store` has been removed, use `StoreFactory` instead
  * The `endpoint` parameter for SurrealDB `Store` has been removed, use `StoreFactory` instead

--- a/docs/components/store.rst
+++ b/docs/components/store.rst
@@ -208,7 +208,8 @@ Commands
 --------
 
 While using the ``Store`` component in your Symfony application along with the ``AiBundle``,
-you can use the ``bin/console ai:store:setup`` command to initialize the store and ``bin/console ai:store:drop`` to clean up the store:
+you can use the ``bin/console ai:store:setup`` command to initialize the store and ``bin/console ai:store:drop`` to clean up the store.
+To remove all documents from a store without dropping it, use ``bin/console ai:store:clear``:
 
 .. code-block:: yaml
 
@@ -224,7 +225,8 @@ you can use the ``bin/console ai:store:setup`` command to initialize the store a
 .. code-block:: terminal
 
     $ php bin/console ai:store:setup symfonycon
-    $ php bin/console ai:store:drop symfonycon
+    $ php bin/console ai:store:clear symfonycon --force
+    $ php bin/console ai:store:drop symfonycon --force
 
 
 Implementing a Bridge
@@ -249,6 +251,11 @@ This leads to a store implementing the following methods::
         public function remove(string|array $ids, array $options = []): void
         {
             // Implementation to remove documents from the store
+        }
+
+        public function clear(array $options = []): void
+        {
+            // Implementation to remove all documents from the store
         }
 
         public function query(QueryInterface $query, array $options = []): iterable
@@ -289,6 +296,35 @@ This leads to a store implementing two methods::
             // Implementation to drop the store (and related vectors)
         }
     }
+
+Clearing a store
+----------------
+
+To get rid of all documents in a store without dropping it, use
+:method:`Symfony\\AI\\Store\\StoreInterface::clear`::
+
+    $store->clear();
+
+In contrast to ``ManagedStoreInterface::drop()``, the store stays usable: documents can be added
+again right away, without calling ``setup()`` first, which makes ``clear()`` the method of choice
+for re-indexing::
+
+    $store->clear();
+    $indexer->index($documents);
+
+Every store supports this operation, and almost all of them use the native mechanism of their backend
+to keep the table, index or collection in place - for example ``TRUNCATE TABLE`` for the SQL-based
+stores, ``_delete_by_query`` for Elasticsearch and OpenSearch, or ``deleteMany()`` for MongoDB.
+
+The stores whose backend has no delete-all operation list the documents and remove them in batches
+instead, which is the case for Azure AI Search, Cloudflare, ChromaDB and S3 Vectors, as does Neo4j,
+which deletes its nodes in batched transactions. All of them use a sensible default batch size, which
+can be changed with the ``batch_size`` option::
+
+    $store->clear(['batch_size' => 250]);
+
+The only exception is Vektor, which supports neither removing documents in bulk nor listing them.
+Its index is the storage directory itself, which is simply recreated.
 
 .. _`Retrieval Augmented Generation`: https://en.wikipedia.org/wiki/Retrieval-augmented_generation
 .. _`Basic Retriever Example`: https://github.com/symfony/ai/blob/main/examples/retriever/basic.php

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Add `AiAssertionsTrait` for functional tests based on Profiler data
+ * Register the `ai:store:clear` command to remove all documents from a store
  * Add `minimax` platform configuration for the MiniMax bridge
  * Autoconfigure `SchemaProviderInterface` implementations so they can be referenced from `#[Schema(provider: ...)]`, and validate those references on tools at container build time
  * Add support for `ScopingHttpClient` usage in `Typesense` store via `http_client` option

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -82,6 +82,7 @@ use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactory;
 use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactoryInterface;
 use Symfony\AI\Platform\StructuredOutput\Serializer as StructuredOutputSerializer;
 use Symfony\AI\Platform\StructuredOutput\Validator\ValidatorSubscriber;
+use Symfony\AI\Store\Command\ClearStoreCommand;
 use Symfony\AI\Store\Command\DropStoreCommand;
 use Symfony\AI\Store\Command\IndexCommand;
 use Symfony\AI\Store\Command\RetrieveCommand;
@@ -298,6 +299,11 @@ return static function (ContainerConfigurator $container): void {
             ])
             ->tag('console.command')
         ->set('ai.command.drop_store', DropStoreCommand::class)
+            ->args([
+                tagged_locator('ai.store', 'name'),
+            ])
+            ->tag('console.command')
+        ->set('ai.command.clear_store', ClearStoreCommand::class)
             ->args([
                 tagged_locator('ai.store', 'name'),
             ])

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 0.11
 ----
 
+ * [BC BREAK] Add `StoreInterface::clear()` method to remove all documents from a store while keeping table, index or collection intact
+ * Add `ai:store:clear` command to remove all documents from a store
  * Add `DirectoryLoader` that scans a directory and delegates each file to a per-extension sub-loader, with optional recursion
  * `Vectorizer` now always sends a single batched `Platform::invoke()` call when vectorizing multiple strings or documents, instead of consulting the model catalog and falling back to one call per item
 

--- a/src/store/src/Bridge/AzureSearch/SearchStore.php
+++ b/src/store/src/Bridge/AzureSearch/SearchStore.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\Query\QueryInterface;
@@ -27,6 +28,10 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class SearchStore implements StoreInterface
 {
+    private const BATCH_SIZE = 1000;
+    private const MAX_UNCHANGED_BATCHES = 10;
+    private const INDEX_CATCH_UP_DELAY = 200000;
+
     /**
      * @param string $vectorFieldName The name of the field int the index that contains the vector
      */
@@ -71,6 +76,47 @@ final class SearchStore implements StoreInterface
         ]);
     }
 
+    /**
+     * @param array{batch_size?: int} $options
+     */
+    public function clear(array $options = []): void
+    {
+        // Azure AI Search has no delete-all operation, so the documents are searched and deleted batch by
+        // batch until the index reports no documents left. Deletions are not visible immediately, so an
+        // already deleted document can show up in the search result again - it is simply deleted a second
+        // time. Only a batch that does not change at all is treated as the index not catching up, and the
+        // store waits for it instead of spinning on the same ids forever.
+        $batchSize = $this->getBatchSize($options);
+        $previousIds = null;
+        $unchangedBatches = 0;
+
+        while (true) {
+            $result = $this->request('search', [
+                'search' => '*',
+                'select' => 'id',
+                'top' => $batchSize,
+            ]);
+
+            $ids = array_column($result['value'], 'id');
+
+            if ([] === $ids) {
+                return;
+            }
+
+            $this->remove($ids);
+
+            if ($ids !== $previousIds) {
+                $unchangedBatches = 0;
+            } elseif (++$unchangedBatches >= self::MAX_UNCHANGED_BATCHES) {
+                throw new RuntimeException(\sprintf('The "%s" index still returns the same %d document(s) after deleting them repeatedly.', $this->indexName, \count($ids)));
+            } else {
+                usleep(self::INDEX_CATCH_UP_DELAY);
+            }
+
+            $previousIds = $ids;
+        }
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;
@@ -102,6 +148,24 @@ final class SearchStore implements StoreInterface
     }
 
     /**
+     * @param array{batch_size?: int} $options
+     */
+    private function getBatchSize(array $options): int
+    {
+        if ([] !== array_diff(array_keys($options), ['batch_size'])) {
+            throw new InvalidArgumentException('Only the "batch_size" option is supported.');
+        }
+
+        $batchSize = $options['batch_size'] ?? self::BATCH_SIZE;
+
+        if ($batchSize < 1) {
+            throw new InvalidArgumentException('The "batch_size" option must be a positive integer.');
+        }
+
+        return $batchSize;
+    }
+
+    /**
      * @param array<string, mixed> $payload
      *
      * @return array<string, mixed>
@@ -116,7 +180,22 @@ final class SearchStore implements StoreInterface
             throw new RuntimeException(\sprintf('Azure Search request failed: "%s"', $response->getContent(false)));
         }
 
-        return $response->toArray();
+        $result = $response->toArray();
+
+        // indexing actions are answered with 207 and a per-document status, so a failed delete or upload
+        // does not show up in the status code but only in the body
+        $failures = [];
+        foreach ($result['value'] ?? [] as $item) {
+            if (\is_array($item) && false === ($item['status'] ?? null)) {
+                $failures[] = \sprintf('%s: %s', $item['key'] ?? 'unknown', $item['errorMessage'] ?? 'unknown error');
+            }
+        }
+
+        if ([] !== $failures) {
+            throw new RuntimeException(\sprintf('Azure Search request failed for %d document(s): "%s".', \count($failures), implode('", "', $failures)));
+        }
+
+        return $result;
     }
 
     /**

--- a/src/store/src/Bridge/AzureSearch/Tests/SearchStoreTest.php
+++ b/src/store/src/Bridge/AzureSearch/Tests/SearchStoreTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\AzureSearch\SearchStore;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -270,6 +271,161 @@ final class SearchStoreTest extends TestCase
         $store = new SearchStore($httpClient, 'test-index');
 
         $store->remove('doc1');
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testClearSearchesAndDeletesAllDocuments()
+    {
+        $httpClient = new MockHttpClient([
+            function (string $method, string $url, array $options): JsonMockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://test.search.windows.net/indexes/test-index/docs/search', $url);
+
+                $this->assertArrayHasKey('body', $options);
+                $this->assertIsString($options['body']);
+                $body = json_decode($options['body'], true);
+                $this->assertIsArray($body);
+                $this->assertSame('*', $body['search']);
+                $this->assertSame('id', $body['select']);
+                $this->assertSame(1000, $body['top']);
+
+                return new JsonMockResponse([
+                    'value' => [
+                        ['id' => 'doc1'],
+                        ['id' => 'doc2'],
+                    ],
+                ], ['http_code' => 200]);
+            },
+            function (string $method, string $url, array $options): JsonMockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://test.search.windows.net/indexes/test-index/docs/index', $url);
+
+                $this->assertArrayHasKey('body', $options);
+                $this->assertIsString($options['body']);
+                $body = json_decode($options['body'], true);
+                $this->assertIsArray($body);
+                $this->assertCount(2, $body['value']);
+                $this->assertSame('doc1', $body['value'][0]['id']);
+                $this->assertSame('delete', $body['value'][0]['@search.action']);
+                $this->assertSame('doc2', $body['value'][1]['id']);
+                $this->assertSame('delete', $body['value'][1]['@search.action']);
+
+                return new JsonMockResponse(['value' => []], ['http_code' => 200]);
+            },
+            new JsonMockResponse(['value' => []], ['http_code' => 200]),
+        ], 'https://test.search.windows.net/');
+
+        $store = new SearchStore($httpClient, 'test-index');
+
+        $store->clear();
+
+        $this->assertSame(3, $httpClient->getRequestsCount());
+    }
+
+    public function testClearRetriesWhileTheIndexHasNotCaughtUp()
+    {
+        // an already deleted document can still show up in the search result, which must not be mistaken
+        // for an empty index - the store deletes it again until the index reports no documents left
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['value' => [['id' => 'doc1']]], ['http_code' => 200]),
+            new JsonMockResponse(['value' => []], ['http_code' => 200]),
+            new JsonMockResponse(['value' => [['id' => 'doc1']]], ['http_code' => 200]),
+            new JsonMockResponse(['value' => []], ['http_code' => 200]),
+            new JsonMockResponse(['value' => []], ['http_code' => 200]),
+        ], 'https://test.search.windows.net/');
+
+        $store = new SearchStore($httpClient, 'test-index');
+
+        $store->clear();
+
+        $this->assertSame(5, $httpClient->getRequestsCount());
+    }
+
+    public function testClearFailsWhenTheIndexKeepsReturningTheSameDocuments()
+    {
+        $responses = [];
+        for ($i = 0; $i < 24; ++$i) {
+            $responses[] = new JsonMockResponse(['value' => [['id' => 'doc1']]], ['http_code' => 200]);
+            $responses[] = new JsonMockResponse(['value' => []], ['http_code' => 200]);
+        }
+
+        $httpClient = new MockHttpClient($responses, 'https://test.search.windows.net/');
+
+        $store = new SearchStore($httpClient, 'test-index');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The "test-index" index still returns the same 1 document(s) after deleting them repeatedly.');
+
+        $store->clear();
+    }
+
+    public function testClearFailsOnPartiallyFailedDeletes()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['value' => [['id' => 'doc1']]], ['http_code' => 200]),
+            new JsonMockResponse(['value' => [
+                ['key' => 'doc1', 'status' => false, 'errorMessage' => 'Document not found'],
+            ]], ['http_code' => 207]),
+        ], 'https://test.search.windows.net/');
+
+        $store = new SearchStore($httpClient, 'test-index');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Azure Search request failed for 1 document(s): "doc1: Document not found".');
+
+        $store->clear();
+    }
+
+    public function testClearWithCustomBatchSize()
+    {
+        $httpClient = new MockHttpClient([
+            function (string $method, string $url, array $options): JsonMockResponse {
+                $this->assertIsString($options['body']);
+                $body = json_decode($options['body'], true);
+                $this->assertIsArray($body);
+                $this->assertSame(250, $body['top']);
+
+                return new JsonMockResponse(['value' => []], ['http_code' => 200]);
+            },
+        ], 'https://test.search.windows.net/');
+
+        $store = new SearchStore($httpClient, 'test-index');
+
+        $store->clear(['batch_size' => 250]);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testClearWithInvalidBatchSize()
+    {
+        $store = new SearchStore(new MockHttpClient(), 'test-index');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "batch_size" option must be a positive integer.');
+
+        $store->clear(['batch_size' => 0]);
+    }
+
+    public function testClearWithUnsupportedOption()
+    {
+        $store = new SearchStore(new MockHttpClient(), 'test-index');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only the "batch_size" option is supported.');
+
+        $store->clear(['foo' => 'bar']);
+    }
+
+    public function testClearWithEmptyIndex()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['value' => []], ['http_code' => 200]),
+        ], 'https://test.search.windows.net/');
+
+        $store = new SearchStore($httpClient, 'test-index');
+
+        $store->clear();
 
         $this->assertSame(1, $httpClient->getRequestsCount());
     }

--- a/src/store/src/Bridge/Cache/Store.php
+++ b/src/store/src/Bridge/Cache/Store.php
@@ -108,6 +108,18 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->cache->save($cacheItem);
     }
 
+    public function clear(array $options = []): void
+    {
+        if ([] !== $options) {
+            throw new InvalidArgumentException('No supported options.');
+        }
+
+        $cacheItem = $this->cache->getItem($this->cacheKey);
+        $cacheItem->set([]);
+
+        $this->cache->save($cacheItem);
+    }
+
     public function supports(string $queryClass): bool
     {
         return \in_array($queryClass, [

--- a/src/store/src/Bridge/Cache/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Cache/Tests/StoreTest.php
@@ -384,6 +384,40 @@ final class StoreTest extends TestCase
         $store->remove($id1->toRfc4122(), ['unsupported' => true]);
     }
 
+    public function testStoreCanClear()
+    {
+        $cache = new ArrayAdapter();
+        $store = new Store($cache);
+        $store->setup();
+
+        $store->add([
+            new VectorDocument(Uuid::v4(), new Vector([0.1, 0.1, 0.5])),
+            new VectorDocument(Uuid::v4(), new Vector([0.7, -0.3, 0.0])),
+        ]);
+
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $this->assertCount(2, $result);
+
+        $store->clear();
+
+        $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
+        $this->assertCount(0, $result);
+
+        $this->assertTrue($cache->hasItem('_vectors'));
+        $this->assertSame([], $cache->getItem('_vectors')->get());
+    }
+
+    public function testClearWithOptions()
+    {
+        $store = new Store(new ArrayAdapter());
+        $store->setup();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No supported options.');
+
+        $store->clear(['unsupported' => true]);
+    }
+
     public function testStoreCanSearchUsingTextQuery()
     {
         $store = new Store(new ArrayAdapter());

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -17,6 +17,7 @@ use Codewithkyrian\ChromaDB\Responses\QueryItemsResponse;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -30,6 +31,8 @@ use Symfony\AI\Store\StoreInterface;
  */
 final class Store implements ManagedStoreInterface, StoreInterface
 {
+    private const BATCH_SIZE = 1000;
+
     public function __construct(
         private readonly Client $client,
         private readonly string $collectionName,
@@ -93,6 +96,27 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $collection->delete(ids: $ids);
     }
 
+    /**
+     * @param array{batch_size?: int} $options
+     */
+    public function clear(array $options = []): void
+    {
+        $batchSize = $this->getBatchSize($options);
+        $collection = $this->client->getOrCreateCollection($this->collectionName);
+
+        // ChromaDb rejects a delete request that carries neither ids nor a filter, so the ids are fetched
+        // and deleted page by page - fetching them all at once would load the whole collection into memory
+        do {
+            $items = $collection->get(limit: $batchSize, include: []);
+
+            if ([] === $items->ids) {
+                return;
+            }
+
+            $collection->delete(ids: $items->ids);
+        } while ($batchSize === \count($items->ids));
+    }
+
     public function supports(string $queryClass): bool
     {
         return \in_array($queryClass, [
@@ -115,6 +139,24 @@ final class Store implements ManagedStoreInterface, StoreInterface
             $query instanceof TextQuery => $this->queryText($query, $options),
             default => throw new UnsupportedQueryTypeException($query::class, $this),
         };
+    }
+
+    /**
+     * @param array{batch_size?: int} $options
+     */
+    private function getBatchSize(array $options): int
+    {
+        if ([] !== array_diff(array_keys($options), ['batch_size'])) {
+            throw new InvalidArgumentException('Only the "batch_size" option is supported.');
+        }
+
+        $batchSize = $options['batch_size'] ?? self::BATCH_SIZE;
+
+        if ($batchSize < 1) {
+            throw new InvalidArgumentException('The "batch_size" option must be a positive integer.');
+        }
+
+        return $batchSize;
     }
 
     /**

--- a/src/store/src/Bridge/ChromaDb/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/IntegrationTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Store\Bridge\ChromaDb\Tests;
 
 use Codewithkyrian\ChromaDB\ChromaDB;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\AI\Store\Bridge\ChromaDb\StoreFactory;
 use Symfony\AI\Store\StoreInterface;
@@ -23,9 +24,22 @@ use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
 #[Group('integration')]
 final class IntegrationTest extends AbstractStoreIntegrationTestCase
 {
+    #[Depends('testAddDocuments')]
     public function testQueryDocumentsWithTextQuery()
     {
-        $this->markTestSkipped('ChromaDb TextQuery requires an embedding function to be configured.');
+        // ChromaDb TextQuery requires an embedding function to be configured, but this test must not
+        // be skipped, since the tests depending on it would be skipped as well, and the store would
+        // never get to the point of being removed from, cleared or dropped
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function getClearOptions(): array
+    {
+        // forces clear() to paginate through the volume test's documents in several rounds
+        return ['batch_size' => 100];
     }
 
     protected static function createStore(): StoreInterface

--- a/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Store\Bridge\ChromaDb\Tests;
 
 use Codewithkyrian\ChromaDB\Client;
 use Codewithkyrian\ChromaDB\Models\Collection;
+use Codewithkyrian\ChromaDB\Responses\GetItemsResponse;
 use Codewithkyrian\ChromaDB\Responses\QueryItemsResponse;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -20,6 +21,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\ChromaDb\StoreFactory;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
@@ -688,6 +690,128 @@ final class StoreTest extends TestCase
 
         $store = StoreFactory::create($client, 'test-collection');
         $store->remove([]);
+    }
+
+    public function testClearDeletesAllDocumentsOfCollection()
+    {
+        $collection = $this->createMock(Collection::class);
+        $client = $this->createMock(Client::class);
+
+        $client->expects($this->once())
+            ->method('getOrCreateCollection')
+            ->with('test-collection')
+            ->willReturn($collection);
+
+        $collection->expects($this->once())
+            ->method('get')
+            ->willReturn(new GetItemsResponse(
+                ids: ['01234567-89ab-cdef-0123-456789abcdef', 'abcdef01-2345-6789-abcd-ef0123456789'],
+                metadatas: null,
+                embeddings: null,
+                documents: null,
+            ));
+
+        $collection->expects($this->once())
+            ->method('delete')
+            ->with(['01234567-89ab-cdef-0123-456789abcdef', 'abcdef01-2345-6789-abcd-ef0123456789']);
+
+        $store = StoreFactory::create($client, 'test-collection');
+        $store->clear();
+    }
+
+    public function testClearPaginatesThroughLargeCollections()
+    {
+        // a full batch means there can be more documents, so the collection is fetched and deleted
+        // page by page instead of loading every id of the collection into memory at once
+        $firstBatch = array_map(static fn (int $i): string => \sprintf('id-%d', $i), range(1, 1000));
+        $secondBatch = ['id-1001'];
+
+        $collection = $this->createMock(Collection::class);
+        $client = $this->createMock(Client::class);
+
+        $client->expects($this->once())
+            ->method('getOrCreateCollection')
+            ->with('test-collection')
+            ->willReturn($collection);
+
+        $collection->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnOnConsecutiveCalls(
+                new GetItemsResponse(ids: $firstBatch, metadatas: null, embeddings: null, documents: null),
+                new GetItemsResponse(ids: $secondBatch, metadatas: null, embeddings: null, documents: null),
+            );
+
+        $deleted = [];
+        $collection->expects($this->exactly(2))
+            ->method('delete')
+            ->willReturnCallback(static function (array $ids) use (&$deleted): array {
+                $deleted[] = $ids;
+
+                return $ids;
+            });
+
+        $store = StoreFactory::create($client, 'test-collection');
+        $store->clear();
+
+        $this->assertSame([$firstBatch, $secondBatch], $deleted);
+    }
+
+    public function testClearWithCustomBatchSize()
+    {
+        $collection = $this->createMock(Collection::class);
+        $client = $this->createMock(Client::class);
+
+        $client->expects($this->once())
+            ->method('getOrCreateCollection')
+            ->with('test-collection')
+            ->willReturn($collection);
+
+        $collection->expects($this->once())
+            ->method('get')
+            ->with(null, null, null, 250, null, [])
+            ->willReturn(new GetItemsResponse(ids: [], metadatas: null, embeddings: null, documents: null));
+
+        $store = StoreFactory::create($client, 'test-collection');
+        $store->clear(['batch_size' => 250]);
+    }
+
+    public function testClearWithInvalidBatchSize()
+    {
+        $store = StoreFactory::create($this->createMock(Client::class), 'test-collection');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "batch_size" option must be a positive integer.');
+        $store->clear(['batch_size' => 0]);
+    }
+
+    public function testClearWithUnsupportedOption()
+    {
+        $store = StoreFactory::create($this->createMock(Client::class), 'test-collection');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only the "batch_size" option is supported.');
+        $store->clear(['foo' => 'bar']);
+    }
+
+    public function testClearWithEmptyCollection()
+    {
+        $collection = $this->createMock(Collection::class);
+        $client = $this->createMock(Client::class);
+
+        $client->expects($this->once())
+            ->method('getOrCreateCollection')
+            ->with('test-collection')
+            ->willReturn($collection);
+
+        $collection->expects($this->once())
+            ->method('get')
+            ->willReturn(new GetItemsResponse(ids: [], metadatas: null, embeddings: null, documents: null));
+
+        $collection->expects($this->never())
+            ->method('delete');
+
+        $store = StoreFactory::create($client, 'test-collection');
+        $store->clear();
     }
 
     public function testQueryWithTextQuery()

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -85,6 +85,11 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->execute('POST', 'TRUNCATE TABLE {{ table }}');
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;

--- a/src/store/src/Bridge/ClickHouse/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ClickHouse/Tests/StoreTest.php
@@ -287,6 +287,23 @@ final class StoreTest extends TestCase
         $store->remove([]);
     }
 
+    public function testClear()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame('POST', $method);
+            $this->assertSame('TRUNCATE TABLE test_table', $options['query']['query']);
+            $this->assertSame('test_db', $options['query']['database']);
+
+            return new MockResponse('', ['http_code' => 200]);
+        });
+
+        $store = new Store($httpClient, 'test_db', 'test_table');
+
+        $store->clear();
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = new Store(new MockHttpClient(), 'default', 'test_table');

--- a/src/store/src/Bridge/Cloudflare/Store.php
+++ b/src/store/src/Bridge/Cloudflare/Store.php
@@ -29,6 +29,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class Store implements ManagedStoreInterface, StoreInterface
 {
+    private const BATCH_SIZE = 1000;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly string $index,
@@ -86,6 +88,58 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
+    /**
+     * @param array{batch_size?: int} $options
+     */
+    public function clear(array $options = []): void
+    {
+        // Vectorize has no delete-all operation, so the vectors are listed and removed by id, page by page.
+        // Its deletes are asynchronous and take a few seconds to apply, so listing the first page again after
+        // every delete - as a store with synchronous deletes would - keeps returning the very same ids and
+        // never terminates. The cursor is walked once instead, and ends the loop when the listing is done.
+        //
+        // Note that clear() therefore returns before the index has caught up with the deletes it requested.
+        $batchSize = $this->getBatchSize($options);
+        $cursor = null;
+
+        do {
+            $query = ['count' => $batchSize];
+
+            if (null !== $cursor) {
+                $query['cursor'] = $cursor;
+            }
+
+            $response = $this->request('GET', \sprintf('vectorize/v2/indexes/%s/list', $this->index), [], $query);
+
+            $result = $response['result'] ?? null;
+            if (!\is_array($result)) {
+                throw new RuntimeException('The Cloudflare list response is malformed.');
+            }
+
+            $vectors = $result['vectors'] ?? null;
+            if (!\is_array($vectors)) {
+                throw new RuntimeException('The Cloudflare list response does not contain a vector set.');
+            }
+
+            $ids = [];
+            foreach ($vectors as $vector) {
+                if (!\is_array($vector) || !\is_string($vector['id'] ?? null)) {
+                    throw new RuntimeException('The Cloudflare list response contains an invalid vector.');
+                }
+
+                $ids[] = $vector['id'];
+            }
+
+            if ([] !== $ids) {
+                $this->remove($ids);
+            }
+
+            $cursor = true === ($result['isTruncated'] ?? false) && \is_string($result['nextCursor'] ?? null)
+                ? $result['nextCursor']
+                : null;
+        } while (null !== $cursor);
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;
@@ -124,11 +178,30 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
+     * @param array{batch_size?: int} $options
+     */
+    private function getBatchSize(array $options): int
+    {
+        if ([] !== array_diff(array_keys($options), ['batch_size'])) {
+            throw new InvalidArgumentException('Only the "batch_size" option is supported.');
+        }
+
+        $batchSize = $options['batch_size'] ?? self::BATCH_SIZE;
+
+        if ($batchSize < 1) {
+            throw new InvalidArgumentException('The "batch_size" option must be a positive integer.');
+        }
+
+        return $batchSize;
+    }
+
+    /**
      * @param array<string, mixed> $payload
+     * @param array<string, mixed> $query
      *
      * @return array<mixed>
      */
-    private function request(string $method, string $endpoint, \Closure|array $payload = []): array
+    private function request(string $method, string $endpoint, \Closure|array $payload = [], array $query = []): array
     {
         $options = [];
 
@@ -140,8 +213,12 @@ final class Store implements ManagedStoreInterface, StoreInterface
             $options['body'] = $payload();
         }
 
-        if (\is_array($payload)) {
+        if (\is_array($payload) && [] !== $payload) {
             $options['json'] = $payload;
+        }
+
+        if ([] !== $query) {
+            $options['query'] = $query;
         }
 
         $response = $this->httpClient->request($method, $endpoint, $options);

--- a/src/store/src/Bridge/Cloudflare/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Cloudflare/Tests/StoreTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Cloudflare\Store;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
@@ -111,6 +112,150 @@ final class StoreTest extends TestCase
         $store->drop();
 
         $this->assertSame(1, $mockHttpClient->getRequestsCount());
+    }
+
+    public function testStoreCannotClearWithExtraOptions()
+    {
+        $store = new Store(new MockHttpClient(), 'random');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only the "batch_size" option is supported.');
+        $this->expectExceptionCode(0);
+        $store->clear([
+            'foo' => 'bar',
+        ]);
+    }
+
+    public function testStoreCannotClearWithInvalidBatchSize()
+    {
+        $store = new Store(new MockHttpClient(), 'random');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "batch_size" option must be a positive integer.');
+        $store->clear(['batch_size' => 0]);
+    }
+
+    public function testStoreCanClearWithCustomBatchSize()
+    {
+        $mockHttpClient = new MockHttpClient([
+            function (string $method, string $url): JsonMockResponse {
+                $this->assertSame('https://api.cloudflare.com/client/v4/accounts/foo/vectorize/v2/indexes/random/list?count=250', $url);
+
+                return new JsonMockResponse([
+                    'result' => ['vectors' => [], 'isTruncated' => false],
+                    'success' => true,
+                ]);
+            },
+        ], self::BASE_URI);
+
+        $store = new Store($mockHttpClient, 'random');
+
+        $store->clear(['batch_size' => 250]);
+
+        $this->assertSame(1, $mockHttpClient->getRequestsCount());
+    }
+
+    public function testStoreCanClear()
+    {
+        $mockHttpClient = new MockHttpClient([
+            function (string $method, string $url): JsonMockResponse {
+                $this->assertSame('GET', $method);
+                $this->assertSame('https://api.cloudflare.com/client/v4/accounts/foo/vectorize/v2/indexes/random/list?count=1000', $url);
+
+                return new JsonMockResponse([
+                    'result' => [
+                        'vectors' => [['id' => 'foo'], ['id' => 'bar']],
+                        'isTruncated' => false,
+                    ],
+                    'success' => true,
+                ]);
+            },
+            function (string $method, string $url, array $options): JsonMockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.cloudflare.com/client/v4/accounts/foo/vectorize/v2/indexes/random/delete_by_ids', $url);
+
+                $this->assertIsString($options['body']);
+                $this->assertSame(['ids' => ['foo', 'bar']], json_decode($options['body'], true));
+
+                return new JsonMockResponse(['result' => [], 'success' => true]);
+            },
+        ], self::BASE_URI);
+
+        $store = new Store($mockHttpClient, 'random');
+
+        $store->clear();
+
+        $this->assertSame(2, $mockHttpClient->getRequestsCount());
+    }
+
+    public function testStoreClearsFollowingThePaginationCursor()
+    {
+        // the listing is a snapshot, so already deleted vectors keep showing up until the cursor is exhausted
+        $mockHttpClient = new MockHttpClient([
+            function (string $method, string $url): JsonMockResponse {
+                $this->assertSame('https://api.cloudflare.com/client/v4/accounts/foo/vectorize/v2/indexes/random/list?count=1000', $url);
+
+                return new JsonMockResponse([
+                    'result' => [
+                        'vectors' => [['id' => 'foo']],
+                        'isTruncated' => true,
+                        'nextCursor' => 'next-page',
+                    ],
+                    'success' => true,
+                ]);
+            },
+            new JsonMockResponse(['result' => [], 'success' => true]),
+            function (string $method, string $url): JsonMockResponse {
+                $this->assertSame('https://api.cloudflare.com/client/v4/accounts/foo/vectorize/v2/indexes/random/list?count=1000&cursor=next-page', $url);
+
+                return new JsonMockResponse([
+                    'result' => [
+                        'vectors' => [['id' => 'bar']],
+                        'isTruncated' => false,
+                    ],
+                    'success' => true,
+                ]);
+            },
+            new JsonMockResponse(['result' => [], 'success' => true]),
+        ], self::BASE_URI);
+
+        $store = new Store($mockHttpClient, 'random');
+
+        $store->clear();
+
+        $this->assertSame(4, $mockHttpClient->getRequestsCount());
+    }
+
+    public function testStoreCanClearEmptyIndex()
+    {
+        $mockHttpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'result' => [
+                    'vectors' => [],
+                    'isTruncated' => false,
+                ],
+                'success' => true,
+            ]),
+        ], self::BASE_URI);
+
+        $store = new Store($mockHttpClient, 'random');
+
+        $store->clear();
+
+        $this->assertSame(1, $mockHttpClient->getRequestsCount());
+    }
+
+    public function testStoreCannotClearOnMalformedListResponse()
+    {
+        $mockHttpClient = new MockHttpClient([
+            new JsonMockResponse(['success' => true]),
+        ], self::BASE_URI);
+
+        $store = new Store($mockHttpClient, 'random');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The Cloudflare list response is malformed.');
+        $store->clear();
     }
 
     public function testStoreCannotAddOnInvalidResponse()

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\Query\QueryInterface;
@@ -121,6 +122,22 @@ final class Store implements ManagedStoreInterface, StoreInterface
                 yield json_encode($documentToDelete($id)).\PHP_EOL;
             }
         });
+    }
+
+    public function clear(array $options = []): void
+    {
+        // "conflicts=proceed" keeps a concurrent write from aborting the deletion halfway through,
+        // which would leave the store with an arbitrary subset of its documents removed
+        $result = $this->request('POST', \sprintf('%s/_delete_by_query?refresh=true&conflicts=proceed', $this->indexName), [
+            'query' => [
+                'match_all' => new \stdClass(),
+            ],
+        ]);
+
+        // a delete-by-query is answered with 200 even when deleting individual documents failed
+        if (\is_array($result['failures'] ?? null) && [] !== $result['failures']) {
+            throw new RuntimeException(\sprintf('Failed to delete %d document(s) while clearing the "%s" index.', \count($result['failures']), $this->indexName));
+        }
     }
 
     public function supports(string $queryClass): bool

--- a/src/store/src/Bridge/Elasticsearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Elasticsearch/Tests/StoreTest.php
@@ -197,6 +197,34 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testStoreCanClear()
+    {
+        $requestedMethod = null;
+        $requestedUrl = null;
+        $requestedBody = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$requestedMethod, &$requestedUrl, &$requestedBody): JsonMockResponse {
+            $requestedMethod = $method;
+            $requestedUrl = $url;
+            $requestedBody = $options['body'];
+
+            return new JsonMockResponse([
+                'took' => 10,
+                'timed_out' => false,
+                'deleted' => 2,
+            ], [
+                'http_code' => 200,
+            ]);
+        });
+
+        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
+        $store->clear();
+
+        $this->assertSame('POST', $requestedMethod);
+        $this->assertSame('http://127.0.0.1:9200/foo/_delete_by_query?refresh=true&conflicts=proceed', $requestedUrl);
+        $this->assertSame('{"query":{"match_all":{}}}', $requestedBody);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testStoreNormalizesTrailingSlashOnEndpoint()
     {
         $requestedUrl = null;

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -52,8 +52,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
             throw new InvalidArgumentException('No supported options.');
         }
 
+        // uuid needs to be a string attribute, not a text field, since documents are removed by
+        // an "equals" filter on it, which Manticore Search does not support on stored text fields
         $this->request('cli', \sprintf(
-            "CREATE TABLE %s (uuid TEXT, metadata JSON, %s FLOAT_VECTOR KNN_TYPE='%s' KNN_DIMS='%s' HNSW_SIMILARITY='%s' QUANTIZATION='%s')",
+            "CREATE TABLE %s (uuid STRING, metadata JSON, %s FLOAT_VECTOR KNN_TYPE='%s' KNN_DIMS='%s' HNSW_SIMILARITY='%s' QUANTIZATION='%s')",
             $this->table, $this->field, $this->type, $this->dimensions, $this->similarity, $this->quantization,
         ));
     }
@@ -125,6 +127,11 @@ final class Store implements ManagedStoreInterface, StoreInterface
                 }
             });
         }
+    }
+
+    public function clear(array $options = []): void
+    {
+        $this->request('cli', \sprintf('TRUNCATE TABLE %s', $this->table));
     }
 
     public function supports(string $queryClass): bool

--- a/src/store/src/Bridge/ManticoreSearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ManticoreSearch/Tests/StoreTest.php
@@ -201,6 +201,30 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testStoreCanClear()
+    {
+        $requestedMethod = null;
+        $requestedUrl = null;
+        $requestedBody = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$requestedMethod, &$requestedUrl, &$requestedBody): MockResponse {
+            $requestedMethod = $method;
+            $requestedUrl = $url;
+            $requestedBody = $options['body'];
+
+            return new MockResponse('Query OK, 0 rows affected (0.006 sec)'.\PHP_EOL, [
+                'http_code' => 200,
+            ]);
+        });
+
+        $store = new Store($httpClient, 'http://127.0.0.1:9308', 'bar', 'random');
+        $store->clear();
+
+        $this->assertSame('POST', $requestedMethod);
+        $this->assertSame('http://127.0.0.1:9308/cli', $requestedUrl);
+        $this->assertSame('TRUNCATE TABLE bar', $requestedBody);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testStoreNormalizesTrailingSlashOnEndpoint()
     {
         $requestedUrl = null;

--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -161,6 +161,11 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $statement->execute();
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->connection->exec(\sprintf('TRUNCATE TABLE %s', $this->tableName));
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;

--- a/src/store/src/Bridge/MariaDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/MariaDb/Tests/StoreTest.php
@@ -447,6 +447,20 @@ final class StoreTest extends TestCase
         $store->remove([]);
     }
 
+    public function testItCanClear()
+    {
+        $pdo = $this->createMock(\PDO::class);
+
+        $store = new Store($pdo, 'embeddings_table', 'embedding_index', 'embedding');
+
+        $pdo->expects($this->once())
+            ->method('exec')
+            ->with('TRUNCATE TABLE embeddings_table')
+            ->willReturn(1);
+
+        $store->clear();
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $connection = $this->createMock(\PDO::class);

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -95,6 +95,11 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->request('POST', \sprintf('indexes/%s/documents/delete-batch', $this->indexName), $ids);
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->request('DELETE', \sprintf('indexes/%s/documents', $this->indexName), []);
+    }
+
     public function supports(string $queryClass): bool
     {
         return \in_array($queryClass, [

--- a/src/store/src/Bridge/Meilisearch/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Meilisearch/Tests/IntegrationTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\Group;
 use Symfony\AI\Store\Bridge\Meilisearch\StoreFactory;
 use Symfony\AI\Store\StoreInterface;
 use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+use Symfony\Component\HttpClient\HttpClient;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -34,6 +35,26 @@ final class IntegrationTest extends AbstractStoreIntegrationTestCase
 
     protected function waitForIndexing(): void
     {
-        sleep(2);
+        // Meilisearch processes writes asynchronously, so a fixed sleep either wastes time or races the
+        // task queue - depending on how many documents the test at hand wrote. Wait for the queue instead.
+        $client = HttpClient::create();
+
+        for ($attempt = 0; $attempt < 300; ++$attempt) {
+            $response = $client->request('GET', 'http://127.0.0.1:7700/tasks', [
+                'auth_bearer' => 'changeMe',
+                'query' => [
+                    'indexUids' => 'test_index',
+                    'statuses' => 'enqueued,processing',
+                ],
+            ]);
+
+            if ([] === $response->toArray()['results']) {
+                return;
+            }
+
+            usleep(100_000);
+        }
+
+        $this->fail('Meilisearch did not finish processing its task queue in time.');
     }
 }

--- a/src/store/src/Bridge/Meilisearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Meilisearch/Tests/StoreTest.php
@@ -456,6 +456,34 @@ final class StoreTest extends TestCase
         $this->assertSame(0, $httpClient->getRequestsCount());
     }
 
+    public function testStoreCanClear()
+    {
+        $requestedMethod = null;
+        $requestedUrl = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedMethod, &$requestedUrl): JsonMockResponse {
+            $requestedMethod = $method;
+            $requestedUrl = $url;
+
+            return new JsonMockResponse([
+                'taskUid' => 5,
+                'indexUid' => 'test',
+                'status' => 'enqueued',
+                'type' => 'documentDeletion',
+                'enqueuedAt' => '2025-01-01T04:00:00Z',
+            ], [
+                'http_code' => 202,
+            ]);
+        }, 'http://127.0.0.1:7700');
+
+        $store = new Store($httpClient, 'test');
+
+        $store->clear();
+
+        $this->assertSame('DELETE', $requestedMethod);
+        $this->assertSame('http://127.0.0.1:7700/indexes/test/documents', $requestedUrl);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = new Store(new MockHttpClient(), 'test-index');

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\Query\QueryInterface;
@@ -128,6 +129,14 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->request('POST', 'v2/vectordb/entities/delete', [
+            'collectionName' => $this->collection,
+            'filter' => "id != ''",
+        ]);
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;
@@ -180,7 +189,17 @@ final class Store implements ManagedStoreInterface, StoreInterface
             'json' => $payload,
         ]);
 
-        return $result->toArray();
+        $response = $result->toArray();
+
+        // Milvus answers with 200 even when the operation failed, the error is carried in the body
+        $code = $response['code'] ?? 0;
+        if (\is_int($code) && 0 !== $code) {
+            $message = $response['message'] ?? 'Unknown error';
+
+            throw new RuntimeException(\sprintf('Milvus request failed with code %d: "%s".', $code, \is_string($message) ? $message : 'Unknown error'));
+        }
+
+        return $response;
     }
 
     /**

--- a/src/store/src/Bridge/Milvus/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Milvus/Tests/StoreTest.php
@@ -294,6 +294,25 @@ final class StoreTest extends TestCase
         $this->assertSame('id in ["a\\\\"," or id != \"x"]', $body['filter']);
     }
 
+    public function testStoreCanClear()
+    {
+        $requestedUrl = null;
+        $body = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$requestedUrl, &$body): JsonMockResponse {
+            $requestedUrl = $url;
+            $body = json_decode($options['body'] ?? '{}', true);
+
+            return new JsonMockResponse(['code' => 0], ['http_code' => 200]);
+        }, 'http://127.0.0.1:19530');
+
+        $store = new Store($httpClient, 'http://127.0.0.1:19530', 'test', 'test', 'test_collection');
+        $store->clear();
+
+        $this->assertSame('http://127.0.0.1:19530/v2/vectordb/entities/delete', $requestedUrl);
+        $this->assertSame('test_collection', $body['collectionName']);
+        $this->assertSame("id != ''", $body['filter']);
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = new Store(new MockHttpClient(), 'http://localhost:19530', 'test-api-key', 'default', 'test_collection');

--- a/src/store/src/Bridge/MongoDb/Store.php
+++ b/src/store/src/Bridge/MongoDb/Store.php
@@ -173,6 +173,11 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->getCollection()->deleteMany([]);
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;

--- a/src/store/src/Bridge/MongoDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/MongoDb/Tests/StoreTest.php
@@ -702,4 +702,31 @@ final class StoreTest extends TestCase
 
         $store->remove([]);
     }
+
+    public function testClear()
+    {
+        $collection = $this->createMock(Collection::class);
+        $client = $this->createMock(Client::class);
+
+        $client->expects($this->once())
+            ->method('getCollection')
+            ->with('test-db', 'test-collection')
+            ->willReturn($collection);
+
+        $collection->expects($this->once())
+            ->method('deleteMany')
+            ->with([]);
+
+        $collection->expects($this->never())
+            ->method('drop');
+
+        $store = new Store(
+            $client,
+            'test-db',
+            'test-collection',
+            'test-index',
+        );
+
+        $store->clear();
+    }
 }

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\Query\QueryInterface;
@@ -28,6 +29,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class Store implements ManagedStoreInterface, StoreInterface
 {
+    private const BATCH_SIZE = 10000;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly string $endpointUrl,
@@ -89,6 +92,22 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
+    /**
+     * @param array{batch_size?: int} $options
+     */
+    public function clear(array $options = []): void
+    {
+        // Deleting every node in one transaction runs out of heap on larger stores, so the deletion is
+        // committed in batches. This requires an implicit transaction, which "db/{name}/query/v2" is.
+        $this->request('POST', \sprintf('db/%s/query/v2', $this->databaseName), [
+            'statement' => \sprintf(
+                'MATCH (n:`%s`) CALL (n) { DETACH DELETE n } IN TRANSACTIONS OF %d ROWS',
+                $this->nodeName,
+                $this->getBatchSize($options),
+            ),
+        ]);
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;
@@ -121,6 +140,24 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
+     * @param array{batch_size?: int} $options
+     */
+    private function getBatchSize(array $options): int
+    {
+        if ([] !== array_diff(array_keys($options), ['batch_size'])) {
+            throw new InvalidArgumentException('Only the "batch_size" option is supported.');
+        }
+
+        $batchSize = $options['batch_size'] ?? self::BATCH_SIZE;
+
+        if ($batchSize < 1) {
+            throw new InvalidArgumentException('The "batch_size" option must be a positive integer.');
+        }
+
+        return $batchSize;
+    }
+
+    /**
      * @param array<string, mixed> $payload
      *
      * @return array<string, mixed>
@@ -134,7 +171,19 @@ final class Store implements ManagedStoreInterface, StoreInterface
             'json' => $payload,
         ]);
 
-        return $response->toArray();
+        $result = $response->toArray();
+
+        // the Query API answers with 202 whether the statement succeeded or not, the failure is in the body
+        if (\is_array($result['errors'] ?? null) && [] !== $result['errors']) {
+            $messages = array_map(
+                static fn (mixed $error): string => \is_array($error) && \is_string($error['message'] ?? null) ? $error['message'] : 'Unknown error',
+                $result['errors'],
+            );
+
+            throw new RuntimeException(\sprintf('Neo4j request failed: "%s".', implode('", "', $messages)));
+        }
+
+        return $result;
     }
 
     /**

--- a/src/store/src/Bridge/Neo4j/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Neo4j/Tests/IntegrationTest.php
@@ -23,6 +23,15 @@ use Symfony\Component\HttpClient\HttpClient;
 #[Group('integration')]
 final class IntegrationTest extends AbstractStoreIntegrationTestCase
 {
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function getClearOptions(): array
+    {
+        // forces clear() to delete the volume test's nodes in several transactions
+        return ['batch_size' => 100];
+    }
+
     protected static function createStore(): StoreInterface
     {
         return new Store(

--- a/src/store/src/Bridge/Neo4j/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Neo4j/Tests/StoreTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Neo4j\Store;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
@@ -115,6 +116,61 @@ final class StoreTest extends TestCase
         $store->drop();
 
         $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testStoreCanClear()
+    {
+        $body = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$body): JsonMockResponse {
+            $body = $options['body'] ?? null;
+
+            return new JsonMockResponse([], [
+                'http_code' => 200,
+            ]);
+        }, 'http://127.0.0.1:7474');
+
+        $store = new Store($httpClient, 'http://127.0.0.1:7474', 'symfony', 'symfony', 'symfony', 'symfony', 'document');
+
+        $store->clear();
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+        $this->assertSame('MATCH (n:`document`) CALL (n) { DETACH DELETE n } IN TRANSACTIONS OF 10000 ROWS', json_decode($body, true)['statement']);
+    }
+
+    public function testStoreCanClearWithCustomBatchSize()
+    {
+        $body = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$body): JsonMockResponse {
+            $body = $options['body'] ?? null;
+
+            return new JsonMockResponse([], [
+                'http_code' => 200,
+            ]);
+        }, 'http://127.0.0.1:7474');
+
+        $store = new Store($httpClient, 'http://127.0.0.1:7474', 'symfony', 'symfony', 'symfony', 'symfony', 'document');
+
+        $store->clear(['batch_size' => 500]);
+
+        $this->assertSame('MATCH (n:`document`) CALL (n) { DETACH DELETE n } IN TRANSACTIONS OF 500 ROWS', json_decode($body, true)['statement']);
+    }
+
+    public function testStoreCannotClearWithInvalidBatchSize()
+    {
+        $store = new Store(new MockHttpClient(), 'http://127.0.0.1:7474', 'symfony', 'symfony', 'symfony', 'symfony', 'document');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "batch_size" option must be a positive integer.');
+        $store->clear(['batch_size' => 0]);
+    }
+
+    public function testStoreCannotClearWithUnsupportedOption()
+    {
+        $store = new Store(new MockHttpClient(), 'http://127.0.0.1:7474', 'symfony', 'symfony', 'symfony', 'symfony', 'document');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only the "batch_size" option is supported.');
+        $store->clear(['foo' => 'bar']);
     }
 
     public function testStoreCanAdd()

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\Query\QueryInterface;
@@ -124,6 +125,22 @@ final class Store implements ManagedStoreInterface, StoreInterface
                 ]).\PHP_EOL;
             }
         });
+    }
+
+    public function clear(array $options = []): void
+    {
+        // "conflicts=proceed" keeps a concurrent write from aborting the deletion halfway through, and
+        // the scroll size is raised since OpenSearch defaults to 100, which means a lot of round trips
+        $result = $this->request('POST', \sprintf('%s/_delete_by_query?refresh=true&conflicts=proceed&scroll_size=1000', $this->indexName), [
+            'query' => [
+                'match_all' => new \stdClass(),
+            ],
+        ]);
+
+        // a delete-by-query is answered with 200 even when deleting individual documents failed
+        if (\is_array($result['failures'] ?? null) && [] !== $result['failures']) {
+            throw new RuntimeException(\sprintf('Failed to delete %d document(s) while clearing the "%s" index.', \count($result['failures']), $this->indexName));
+        }
     }
 
     public function supports(string $queryClass): bool

--- a/src/store/src/Bridge/OpenSearch/Tests/StoreTest.php
+++ b/src/store/src/Bridge/OpenSearch/Tests/StoreTest.php
@@ -199,6 +199,34 @@ final class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testStoreCanClear()
+    {
+        $requestedMethod = null;
+        $requestedUrl = null;
+        $requestedBody = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$requestedMethod, &$requestedUrl, &$requestedBody): JsonMockResponse {
+            $requestedMethod = $method;
+            $requestedUrl = $url;
+            $requestedBody = $options['body'];
+
+            return new JsonMockResponse([
+                'took' => 10,
+                'timed_out' => false,
+                'deleted' => 2,
+            ], [
+                'http_code' => 200,
+            ]);
+        });
+
+        $store = new Store($httpClient, 'http://127.0.0.1:9200', 'foo');
+        $store->clear();
+
+        $this->assertSame('POST', $requestedMethod);
+        $this->assertSame('http://127.0.0.1:9200/foo/_delete_by_query?refresh=true&conflicts=proceed&scroll_size=1000', $requestedUrl);
+        $this->assertSame('{"query":{"match_all":{}}}', $requestedBody);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testStoreNormalizesTrailingSlashOnEndpoint()
     {
         $requestedUrl = null;

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -116,6 +116,18 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->pinecone
+            ->data()
+            ->vectors()
+            ->delete(
+                [],
+                $this->namespace,
+                true,
+            );
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;

--- a/src/store/src/Bridge/Pinecone/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Pinecone/Tests/StoreTest.php
@@ -218,6 +218,30 @@ final class StoreTest extends TestCase
         self::createStore($client)->remove([]);
     }
 
+    public function testClear()
+    {
+        $vectorResource = $this->createMock(VectorResource::class);
+        $dataResource = $this->createMock(DataResource::class);
+        $client = $this->createMock(Client::class);
+
+        $dataResource->expects($this->once())
+            ->method('vectors')
+            ->willReturn($vectorResource);
+
+        $client->expects($this->once())
+            ->method('data')
+            ->willReturn($dataResource);
+
+        $vectorResource->expects($this->once())
+            ->method('delete')
+            ->with([],
+                'test-namespace',
+                true,
+            );
+
+        self::createStore($client, namespace: 'test-namespace')->clear();
+    }
+
     public function testQueryReturnsDocuments()
     {
         $vectorResource = $this->createMock(VectorResource::class);

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -130,6 +130,11 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $statement->execute();
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->connection->exec(\sprintf('TRUNCATE TABLE "%s"', $this->tableName));
+    }
+
     public function supports(string $queryClass): bool
     {
         return \in_array($queryClass, [

--- a/src/store/src/Bridge/Postgres/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Postgres/Tests/StoreTest.php
@@ -754,6 +754,23 @@ final class StoreTest extends TestCase
         $store->remove([]);
     }
 
+    public function testClear()
+    {
+        $pdo = $this->createMock(\PDO::class);
+
+        $store = new Store($pdo, 'embeddings_table', 'embedding');
+
+        $pdo->expects($this->once())
+            ->method('exec')
+            ->willReturnCallback(function (string $sql): int {
+                $this->assertSame('TRUNCATE TABLE "embeddings_table"', $sql);
+
+                return 0;
+            });
+
+        $store->clear();
+    }
+
     public function testStoreSupportsMultipleQueryTypes()
     {
         $pdo = $this->createMock(\PDO::class);

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -93,6 +93,20 @@ final class Store implements ManagedStoreInterface, StoreInterface
         );
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->request(
+            'POST',
+            \sprintf('collections/%s/points/delete', $this->collectionName),
+            [
+                'filter' => [
+                    'must' => [],
+                ],
+            ],
+            ['wait' => $this->async ? 'false' : 'true'],
+        );
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;

--- a/src/store/src/Bridge/Qdrant/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Qdrant/Tests/StoreTest.php
@@ -305,6 +305,57 @@ final class StoreTest extends TestCase
         }
     }
 
+    public function testStoreCanClear()
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): JsonMockResponse {
+            self::assertSame('POST', $method);
+            self::assertSame('http://127.0.0.1:6333/collections/test/points/delete?wait=true', $url);
+            self::assertSame('{"filter":{"must":[]}}', $options['body']);
+
+            return new JsonMockResponse([
+                'time' => 0.002,
+                'status' => 'ok',
+                'result' => [
+                    'status' => 'completed',
+                    'operation_id' => 1000000,
+                ],
+            ], [
+                'http_code' => 200,
+            ]);
+        }, 'http://127.0.0.1:6333');
+
+        $store = new Store($httpClient, 'test');
+
+        $store->clear();
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testStoreCanClearAsynchronously()
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): JsonMockResponse {
+            self::assertArrayHasKey('wait', $options['query']);
+            self::assertSame('false', $options['query']['wait']);
+
+            return new JsonMockResponse([
+                'time' => 0.002,
+                'status' => 'ok',
+                'result' => [
+                    'status' => 'acknowledged',
+                    'operation_id' => 1000000,
+                ],
+            ], [
+                'http_code' => 200,
+            ]);
+        }, 'http://127.0.0.1:6333');
+
+        $store = new Store($httpClient, 'test', async: true);
+
+        $store->clear();
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = StoreFactory::create('test', 'http://127.0.0.1:6333', 'test', new MockHttpClient());

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -131,6 +131,29 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->redis->clearLastError();
+
+        // Only the documents are deleted, the index definition created by setup() is kept intact.
+        // SCAN may return an empty batch while the cursor is not exhausted yet, so the loop runs
+        // until the cursor is back to 0 instead of stopping on the first empty batch.
+        $iterator = null;
+
+        do {
+            $keys = $this->redis->scan($iterator, $this->keyPrefix.'*', 1000);
+
+            if (\is_array($keys) && [] !== $keys) {
+                $this->redis->unlink($keys);
+            }
+        } while ($iterator > 0);
+
+        if ($error = $this->redis->getLastError()) {
+            $e = new \RedisException($error);
+            throw new RuntimeException(\sprintf('Failed to clear documents from Redis: "%s".', $e->getMessage()), 0, $e);
+        }
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;

--- a/src/store/src/Bridge/Redis/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Redis/Tests/StoreTest.php
@@ -519,6 +519,76 @@ final class StoreTest extends TestCase
         $this->assertCount(0, $results); // Should skip documents without required fields
     }
 
+    public function testClearDeletesAllKeysAndKeepsIndex()
+    {
+        $redis = $this->createMock(\Redis::class);
+        $store = new Store($redis, 'test_index', 'vector:');
+
+        // the injected connection is shared, so clear() must not change any of its options
+        $redis->expects($this->never())
+            ->method('setOption');
+
+        $scanCalls = 0;
+        $redis->expects($this->exactly(2))
+            ->method('scan')
+            ->willReturnCallback(function (&$iterator, string $pattern, int $count) use (&$scanCalls): array {
+                ++$scanCalls;
+
+                $this->assertSame('vector:*', $pattern);
+                $this->assertSame(1000, $count);
+
+                if (1 === $scanCalls) {
+                    $iterator = 12;
+
+                    return ['vector:id-1', 'vector:id-2'];
+                }
+
+                $iterator = 0;
+
+                return ['vector:id-3'];
+            });
+
+        $deletedKeys = [];
+        $redis->expects($this->exactly(2))
+            ->method('unlink')
+            ->willReturnCallback(static function (array $keys) use (&$deletedKeys): int {
+                $deletedKeys[] = $keys;
+
+                return \count($keys);
+            });
+
+        // The index definition must survive, so no FT.DROPINDEX is issued
+        $redis->expects($this->never())
+            ->method('rawCommand');
+
+        $store->clear();
+
+        $this->assertSame([['vector:id-1', 'vector:id-2'], ['vector:id-3']], $deletedKeys);
+    }
+
+    public function testClearFailureThrowsRuntimeException()
+    {
+        $redis = $this->createMock(\Redis::class);
+        $store = new Store($redis, 'test_index', 'vector:');
+
+        $redis->expects($this->once())
+            ->method('scan')
+            ->willReturnCallback(static function (&$iterator): array {
+                $iterator = 0;
+
+                return ['vector:id-1'];
+            });
+
+        $redis->expects($this->once())
+            ->method('getLastError')
+            ->willReturn('Connection lost');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Failed to clear documents from Redis: "Connection lost".');
+
+        $store->clear();
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $redis = $this->createMock(\Redis::class);

--- a/src/store/src/Bridge/S3Vectors/Store.php
+++ b/src/store/src/Bridge/S3Vectors/Store.php
@@ -33,6 +33,9 @@ use Symfony\AI\Store\StoreInterface;
  */
 final class Store implements ManagedStoreInterface, StoreInterface
 {
+    private const BATCH_SIZE = 500;
+    private const DELETE_MAX_KEYS = 500;
+
     /**
      * @param array<string, mixed> $filter
      */
@@ -176,6 +179,35 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
+     * @param array{batch_size?: int} $options
+     */
+    public function clear(array $options = []): void
+    {
+        // S3 Vectors has no delete-all operation, so the vectors are listed and deleted page by page. The
+        // pagination token must not be carried across those deletes: it encodes a position in the index, and
+        // deleting a page moves every later vector towards the start, so resuming at the token skips as many
+        // vectors as were just deleted. Listing the first page over and over deletes the index empty instead.
+        $batchSize = $this->getBatchSize($options);
+
+        do {
+            $result = $this->client->listVectors([
+                'vectorBucketName' => $this->vectorBucketName,
+                'indexName' => $this->indexName,
+                'maxResults' => $batchSize,
+            ]);
+
+            $keys = [];
+            foreach ($result->getVectors(true) as $vector) {
+                $keys[] = $vector->getKey();
+            }
+
+            if ([] !== $keys) {
+                $this->deleteKeys($keys);
+            }
+        } while ([] !== $keys);
+    }
+
+    /**
      * @param array{
      *     filter?: array<string, mixed>,
      *     topK?: int,
@@ -227,5 +259,38 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->client->deleteVectorBucket([
             'vectorBucketName' => $this->vectorBucketName,
         ]);
+    }
+
+    /**
+     * @param string[] $keys
+     */
+    private function deleteKeys(array $keys): void
+    {
+        // DeleteVectors accepts at most 500 keys per call, independently of how many were listed
+        foreach (array_chunk($keys, self::DELETE_MAX_KEYS) as $chunk) {
+            $this->client->deleteVectors([
+                'vectorBucketName' => $this->vectorBucketName,
+                'indexName' => $this->indexName,
+                'keys' => $chunk,
+            ]);
+        }
+    }
+
+    /**
+     * @param array{batch_size?: int} $options
+     */
+    private function getBatchSize(array $options): int
+    {
+        if ([] !== array_diff(array_keys($options), ['batch_size'])) {
+            throw new InvalidArgumentException('Only the "batch_size" option is supported.');
+        }
+
+        $batchSize = $options['batch_size'] ?? self::BATCH_SIZE;
+
+        if ($batchSize < 1) {
+            throw new InvalidArgumentException('The "batch_size" option must be a positive integer.');
+        }
+
+        return $batchSize;
     }
 }

--- a/src/store/src/Bridge/S3Vectors/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/S3Vectors/Tests/IntegrationTest.php
@@ -53,4 +53,15 @@ final class IntegrationTest extends AbstractStoreIntegrationTestCase
             'dimension' => 3,
         ];
     }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function getClearOptions(): array
+    {
+        // clear() lists the vectors page by page, and DeleteVectors only accepts 500 keys per call, so a
+        // page is deleted in several calls once it grows beyond that. A page of 1.000 keys covers that
+        // chunking in the high volume run, while the smaller page makes the regular run walk several pages.
+        return ['batch_size' => self::isHighVolumeRun() ? 1_000 : 100];
+    }
 }

--- a/src/store/src/Bridge/S3Vectors/Tests/StoreTest.php
+++ b/src/store/src/Bridge/S3Vectors/Tests/StoreTest.php
@@ -14,8 +14,11 @@ namespace Symfony\AI\Store\Bridge\S3Vectors\Tests;
 use AsyncAws\Core\Test\ResultMockFactory;
 use AsyncAws\S3Vectors\Enum\DataType;
 use AsyncAws\S3Vectors\Enum\DistanceMetric;
+use AsyncAws\S3Vectors\Result\DeleteVectorsOutput;
+use AsyncAws\S3Vectors\Result\ListVectorsOutput;
 use AsyncAws\S3Vectors\Result\QueryVectorsOutput;
 use AsyncAws\S3Vectors\S3VectorsClient;
+use AsyncAws\S3Vectors\ValueObject\ListOutputVector;
 use AsyncAws\S3Vectors\ValueObject\QueryOutputVector;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
@@ -140,6 +143,167 @@ final class StoreTest extends TestCase
             }));
 
         self::createStore($client)->remove(['id-1'], ['filter' => $filter]);
+    }
+
+    public function testClearListsAndDeletesAllVectors()
+    {
+        $client = $this->createMock(S3VectorsClient::class);
+
+        $pages = [
+            ResultMockFactory::create(ListVectorsOutput::class, [
+                'vectors' => [
+                    new ListOutputVector(['key' => 'vector-id-1']),
+                    new ListOutputVector(['key' => 'vector-id-2']),
+                ],
+                'nextToken' => null,
+            ]),
+            ResultMockFactory::create(ListVectorsOutput::class, [
+                'vectors' => [],
+                'nextToken' => null,
+            ]),
+        ];
+
+        $client->expects($this->exactly(2))
+            ->method('listVectors')
+            ->with($this->callback(static function ($input) {
+                return 'test-bucket' === $input['vectorBucketName']
+                    && 'test-index' === $input['indexName'];
+            }))
+            ->willReturnCallback(static function () use (&$pages) {
+                return array_shift($pages);
+            });
+
+        $client->expects($this->once())
+            ->method('deleteVectors')
+            ->with($this->callback(static function ($input) {
+                return 'test-bucket' === $input['vectorBucketName']
+                    && 'test-index' === $input['indexName']
+                    && ['vector-id-1', 'vector-id-2'] === $input['keys'];
+            }));
+
+        self::createStore($client)->clear();
+    }
+
+    public function testClearChunksDeletesToTheMaximumKeysPerCall()
+    {
+        // DeleteVectors accepts at most 500 keys, so a larger batch size must not end up in a single call
+        $client = $this->createMock(S3VectorsClient::class);
+
+        $vectors = [];
+        for ($i = 0; $i < 600; ++$i) {
+            $vectors[] = new ListOutputVector(['key' => \sprintf('vector-id-%d', $i)]);
+        }
+
+        $pages = [
+            ResultMockFactory::create(ListVectorsOutput::class, [
+                'vectors' => $vectors,
+                'nextToken' => null,
+            ]),
+            ResultMockFactory::create(ListVectorsOutput::class, [
+                'vectors' => [],
+                'nextToken' => null,
+            ]),
+        ];
+
+        $client->expects($this->exactly(2))
+            ->method('listVectors')
+            ->with($this->callback(static fn ($input): bool => 1000 === $input['maxResults']))
+            ->willReturnCallback(static function () use (&$pages) {
+                return array_shift($pages);
+            });
+
+        $deletedCounts = [];
+        $client->expects($this->exactly(2))
+            ->method('deleteVectors')
+            ->willReturnCallback(static function ($input) use (&$deletedCounts) {
+                $deletedCounts[] = \count($input['keys']);
+
+                return ResultMockFactory::create(DeleteVectorsOutput::class);
+            });
+
+        self::createStore($client)->clear(['batch_size' => 1000]);
+
+        $this->assertSame([500, 100], $deletedCounts);
+    }
+
+    public function testClearWithInvalidBatchSize()
+    {
+        $store = self::createStore($this->createMock(S3VectorsClient::class));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "batch_size" option must be a positive integer.');
+        $store->clear(['batch_size' => 0]);
+    }
+
+    public function testClearWithUnsupportedOption()
+    {
+        $store = self::createStore($this->createMock(S3VectorsClient::class));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only the "batch_size" option is supported.');
+        $store->clear(['foo' => 'bar']);
+    }
+
+    public function testClearIgnoresThePaginationTokenAndListsTheIndexEmpty()
+    {
+        $client = $this->createMock(S3VectorsClient::class);
+
+        // resuming at the token would skip whatever the previous round deleted, so clear() has to list the
+        // index from the start again after every delete, until nothing is left to delete
+        $pages = [
+            ResultMockFactory::create(ListVectorsOutput::class, [
+                'vectors' => [new ListOutputVector(['key' => 'vector-id-1'])],
+                'nextToken' => 'token-2',
+            ]),
+            ResultMockFactory::create(ListVectorsOutput::class, [
+                'vectors' => [new ListOutputVector(['key' => 'vector-id-2'])],
+                'nextToken' => 'token-3',
+            ]),
+            ResultMockFactory::create(ListVectorsOutput::class, [
+                'vectors' => [],
+                'nextToken' => null,
+            ]),
+        ];
+
+        $listInputs = [];
+        $client->expects($this->exactly(3))
+            ->method('listVectors')
+            ->willReturnCallback(static function ($input) use (&$listInputs, &$pages) {
+                $listInputs[] = $input;
+
+                return array_shift($pages);
+            });
+
+        $deleted = [];
+        $client->expects($this->exactly(2))
+            ->method('deleteVectors')
+            ->willReturnCallback(static function ($input) use (&$deleted) {
+                $deleted[] = $input['keys'];
+
+                return ResultMockFactory::create(DeleteVectorsOutput::class);
+            });
+
+        self::createStore($client)->clear();
+
+        $this->assertSame([['vector-id-1'], ['vector-id-2']], $deleted);
+
+        foreach ($listInputs as $listInput) {
+            $this->assertArrayNotHasKey('nextToken', $listInput);
+        }
+    }
+
+    public function testClearWithEmptyIndex()
+    {
+        $client = $this->createMock(S3VectorsClient::class);
+
+        $client->expects($this->once())
+            ->method('listVectors')
+            ->willReturn(ResultMockFactory::create(ListVectorsOutput::class, ['vectors' => [], 'nextToken' => null]));
+
+        $client->expects($this->never())
+            ->method('deleteVectors');
+
+        self::createStore($client)->clear();
     }
 
     public function testQueryReturnsDocuments()

--- a/src/store/src/Bridge/Sqlite/Store.php
+++ b/src/store/src/Bridge/Sqlite/Store.php
@@ -176,6 +176,22 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->exec(\sprintf('DELETE FROM %s_fts', $this->tableName));
+            $this->connection->exec(\sprintf('DELETE FROM %s', $this->tableName));
+
+            $this->connection->commit();
+        } catch (\Throwable $e) {
+            $this->connection->rollBack();
+
+            throw $e;
+        }
+    }
+
     public function supports(string $queryClass): bool
     {
         return \in_array($queryClass, [

--- a/src/store/src/Bridge/Sqlite/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Sqlite/Tests/StoreTest.php
@@ -180,6 +180,35 @@ final class StoreTest extends TestCase
         $this->assertSame(1, (int) $result->fetchColumn());
     }
 
+    public function testClear()
+    {
+        $pdo = $this->createPdo();
+        $store = new Store($pdo, 'test_vectors');
+        $store->setup();
+
+        $metadata = new Metadata(['name' => 'test']);
+        $metadata->setText('Some text');
+
+        $store->add([
+            new VectorDocument('doc-1', new Vector([0.1, 0.2, 0.3]), $metadata),
+            new VectorDocument('doc-2', new Vector([0.4, 0.5, 0.6]), new Metadata(['name' => 'second'])),
+        ]);
+
+        $store->clear();
+
+        $result = $pdo->query('SELECT COUNT(*) FROM test_vectors');
+        $this->assertSame(0, (int) $result->fetchColumn());
+
+        $result = $pdo->query('SELECT COUNT(*) FROM test_vectors_fts');
+        $this->assertSame(0, (int) $result->fetchColumn());
+
+        $result = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='test_vectors'");
+        $this->assertSame('test_vectors', $result->fetchColumn());
+
+        $result = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='test_vectors_fts'");
+        $this->assertSame('test_vectors_fts', $result->fetchColumn());
+    }
+
     public function testQueryVector()
     {
         $store = $this->createStore();

--- a/src/store/src/Bridge/Sqlite/Tests/VecStoreTest.php
+++ b/src/store/src/Bridge/Sqlite/Tests/VecStoreTest.php
@@ -666,6 +666,40 @@ final class VecStoreTest extends TestCase
         $this->assertSame('doc-2', $results[0]->getId());
     }
 
+    public function testClear()
+    {
+        $pdo = $this->createPdo();
+
+        if (!VecStore::isExtensionAvailable($pdo)) {
+            $this->markTestSkipped('sqlite-vec extension is not available.');
+        }
+
+        $store = new VecStore($pdo, 'test_vectors', Distance::Cosine, 3);
+        $store->setup();
+
+        $metadata = new Metadata(['name' => 'test']);
+        $metadata->setText('Some text');
+
+        $store->add([
+            new VectorDocument('doc-1', new Vector([0.1, 0.2, 0.3]), $metadata),
+            new VectorDocument('doc-2', new Vector([0.4, 0.5, 0.6]), new Metadata(['name' => 'second'])),
+        ]);
+
+        $store->clear();
+
+        $results = iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])), ['maxItems' => 10]));
+        $this->assertCount(0, $results);
+
+        $result = $pdo->query('SELECT COUNT(*) FROM test_vectors_fts');
+        $this->assertSame(0, (int) $result->fetchColumn());
+
+        $result = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='test_vectors'");
+        $this->assertSame('test_vectors', $result->fetchColumn());
+
+        $result = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name='test_vectors_fts'");
+        $this->assertSame('test_vectors_fts', $result->fetchColumn());
+    }
+
     public function testUnsupportedQueryTypeThrows()
     {
         $pdo = $this->createPdo();

--- a/src/store/src/Bridge/Sqlite/VecStore.php
+++ b/src/store/src/Bridge/Sqlite/VecStore.php
@@ -206,6 +206,22 @@ final class VecStore implements ManagedStoreInterface, StoreInterface
         }
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->exec(\sprintf('DELETE FROM %s_fts', $this->tableName));
+            $this->connection->exec(\sprintf('DELETE FROM %s', $this->tableName));
+
+            $this->connection->commit();
+        } catch (\Throwable $e) {
+            $this->connection->rollBack();
+
+            throw $e;
+        }
+    }
+
     public function supports(string $queryClass): bool
     {
         return \in_array($queryClass, [

--- a/src/store/src/Bridge/Supabase/Store.php
+++ b/src/store/src/Bridge/Supabase/Store.php
@@ -133,6 +133,26 @@ final class Store implements StoreInterface
         }
     }
 
+    public function clear(array $options = []): void
+    {
+        // PostgREST refuses a DELETE without filter. Only the "is" operator treats "null" as SQL NULL,
+        // every other one binds it as the string "null" - which fails to cast on a uuid or bigint id.
+        $response = $this->httpClient->request(
+            'DELETE',
+            \sprintf('%s/rest/v1/%s', $this->endpoint, $this->table),
+            [
+                'headers' => $this->getHeaders(),
+                'query' => [
+                    'id' => 'not.is.null',
+                ],
+            ]
+        );
+
+        if ($response->getStatusCode() >= 400) {
+            throw new RuntimeException('Supabase clear failed: '.$response->getContent(false));
+        }
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;

--- a/src/store/src/Bridge/Supabase/Tests/Fixtures/init.sql
+++ b/src/store/src/Bridge/Supabase/Tests/Fixtures/init.sql
@@ -7,7 +7,7 @@ GRANT anon TO authenticator;
 GRANT USAGE ON SCHEMA public TO anon;
 
 CREATE TABLE documents (
-    id TEXT PRIMARY KEY,
+    id UUID PRIMARY KEY,
     embedding vector(3),
     metadata JSONB DEFAULT '{}'::JSONB
 );
@@ -20,7 +20,7 @@ CREATE OR REPLACE FUNCTION match_documents(
     match_threshold FLOAT DEFAULT 0.0
 )
 RETURNS TABLE (
-    id TEXT,
+    id UUID,
     embedding vector(3),
     metadata JSONB,
     score FLOAT

--- a/src/store/src/Bridge/Supabase/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Supabase/Tests/IntegrationTest.php
@@ -11,76 +11,23 @@
 
 namespace Symfony\AI\Store\Bridge\Supabase\Tests;
 
-use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\TestCase;
-use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Supabase\Store;
-use Symfony\AI\Store\Document\Metadata;
-use Symfony\AI\Store\Document\VectorDocument;
-use Symfony\AI\Store\Query\VectorQuery;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
 use Symfony\Component\HttpClient\HttpClient;
 
 /**
- * Does not extend {@see AbstractStoreIntegrationTestCase} because the Supabase
- * store does not implement {@see ManagedStoreInterface}. The database schema is
- * provisioned via the init.sql fixture, matching how Supabase users manage
- * schemas through migrations rather than through the REST API.
+ * The Supabase store does not implement {@see \Symfony\AI\Store\ManagedStoreInterface}: its schema is
+ * provisioned via the init.sql fixture, matching how Supabase users manage schemas through migrations
+ * rather than through the REST API. The shared test case skips setup() and drop() accordingly.
  *
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
 #[Group('integration')]
-final class IntegrationTest extends TestCase
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
 {
-    private const DOCUMENT_ID_1 = '367e550e-6c92-4f12-8a6b-3f3f1d5e8c9a';
-    private const DOCUMENT_ID_2 = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
-    private const DOCUMENT_ID_3 = '123e4567-e89b-12d3-a456-426614174000';
-
-    private static Store $store;
-
-    public function testAddDocuments()
-    {
-        self::$store = self::createStore();
-
-        self::$store->add(new VectorDocument(self::DOCUMENT_ID_1, new Vector([1.0, 0.0, 0.0]), new Metadata(['name' => 'first document'])));
-        self::$store->add([
-            new VectorDocument(self::DOCUMENT_ID_2, new Vector([0.0, 1.0, 0.0]), new Metadata(['name' => 'second document'])),
-            new VectorDocument(self::DOCUMENT_ID_3, new Vector([0.0, 0.0, 1.0]), new Metadata(['name' => 'third document'])),
-        ]);
-
-        $this->addToAssertionCount(1);
-    }
-
-    #[Depends('testAddDocuments')]
-    public function testQueryDocuments()
-    {
-        $results = self::$store->query(new VectorQuery(new Vector([0.0, 0.0, 1.0])));
-
-        $found = null;
-        foreach ($results as $result) {
-            if (self::DOCUMENT_ID_3 === $result->getId()) {
-                $found = $result;
-                break;
-            }
-        }
-
-        $this->assertNotNull($found);
-        $this->assertSame('third document', $found->getMetadata()['name']);
-    }
-
-    #[Depends('testQueryDocuments')]
-    public function testRemoveDocuments()
-    {
-        self::$store->remove(self::DOCUMENT_ID_3);
-
-        $results = self::$store->query(new VectorQuery(new Vector([0.0, 0.0, 1.0])));
-
-        foreach ($results as $result) {
-            $this->assertNotSame(self::DOCUMENT_ID_3, $result->getId());
-        }
-    }
-
-    private static function createStore(): Store
+    protected static function createStore(): StoreInterface
     {
         return new Store(
             HttpClient::create(),

--- a/src/store/src/Bridge/Supabase/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Supabase/Tests/StoreTest.php
@@ -310,6 +310,35 @@ class StoreTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testClearRemovesAllDocuments()
+    {
+        $requestedMethod = null;
+        $requestedUrl = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedMethod, &$requestedUrl): MockResponse {
+            $requestedMethod = $method;
+            $requestedUrl = $url;
+
+            return new MockResponse('', ['http_code' => 204]);
+        });
+        $store = $this->createStore($httpClient);
+
+        $store->clear();
+
+        $this->assertSame('DELETE', $requestedMethod);
+        $this->assertSame('https://test.supabase.co/rest/v1/documents?id=not.is.null', $requestedUrl);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testClearThrowsExceptionOnHttpError()
+    {
+        $httpClient = new MockHttpClient(new MockResponse('Clear failed', ['http_code' => 400]));
+        $store = $this->createStore($httpClient);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Supabase clear failed: Clear failed');
+        $store->clear();
+    }
+
     public function testStoreNormalizesTrailingSlashOnEndpoint()
     {
         $requestedUrl = null;

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -80,6 +80,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->request('POST', 'sql', \sprintf('DELETE %s;', implode(', ', $recordIds)));
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->authenticate();
+
+        $this->request('POST', 'sql', \sprintf('DELETE %s;', $this->table));
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;
@@ -168,7 +175,18 @@ final class Store implements ManagedStoreInterface, StoreInterface
             ],
         ]);
 
-        return $response->toArray();
+        $result = $response->toArray();
+
+        // a failing statement is answered with 200 and reported per statement in the body
+        foreach ($result as $statement) {
+            if (\is_array($statement) && isset($statement['status']) && 'OK' !== $statement['status']) {
+                $message = $statement['result'] ?? 'Unknown error';
+
+                throw new RuntimeException(\sprintf('SurrealDB statement failed: "%s".', \is_string($message) ? $message : 'Unknown error'));
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/store/src/Bridge/SurrealDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/SurrealDb/Tests/StoreTest.php
@@ -464,6 +464,36 @@ final class StoreTest extends TestCase
         $this->assertSame("DELETE type::thing('vectors', 'a\\'); DELETE vectors; --');", $body);
     }
 
+    public function testStoreCanClear()
+    {
+        $requests = [];
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$requests): JsonMockResponse {
+            $requests[] = ['url' => $url, 'body' => $options['body'] ?? null];
+
+            if (str_ends_with($url, '/signin')) {
+                return new JsonMockResponse([
+                    'code' => 200,
+                    'details' => 'Authentication succeeded.',
+                    'token' => 'bar',
+                ], [
+                    'http_code' => 200,
+                ]);
+            }
+
+            return new JsonMockResponse([], [
+                'http_code' => 200,
+            ]);
+        }, 'http://127.0.0.1:8000');
+
+        $store = new Store($httpClient, 'test', 'test', 'test', 'test');
+
+        $store->clear();
+
+        $this->assertSame(2, $httpClient->getRequestsCount());
+        $this->assertSame('http://127.0.0.1:8000/sql', $requests[1]['url']);
+        $this->assertSame('DELETE vectors;', $requests[1]['body']);
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = new Store(new MockHttpClient(), 'test', 'test', 'test_namespace', 'test_database', 'test_table');

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -101,6 +101,13 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ), []);
     }
 
+    public function clear(array $options = []): void
+    {
+        // "truncate" removes all documents while keeping the collection and its schema in place,
+        // in contrast to "filter_by" it does not walk the filter index.
+        $this->request('DELETE', \sprintf('collections/%s/documents?truncate=true', $this->collection), []);
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;

--- a/src/store/src/Bridge/Typesense/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Typesense/Tests/StoreTest.php
@@ -204,6 +204,25 @@ final class StoreTest extends TestCase
         $store->remove('1] || num_docs:>=0 || id:[2');
     }
 
+    public function testStoreCanClear()
+    {
+        $requestedMethod = null;
+        $url = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $u, array $options) use (&$requestedMethod, &$url): JsonMockResponse {
+            $requestedMethod = $method;
+            $url = $u;
+
+            return new JsonMockResponse(['num_deleted' => 2], ['http_code' => 200]);
+        }, 'http://127.0.0.1:8108');
+
+        $store = new Store($httpClient, 'test');
+        $store->clear();
+
+        $this->assertSame('DELETE', $requestedMethod);
+        $this->assertSame('http://127.0.0.1:8108/collections/test/documents?truncate=true', urldecode((string) $url));
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
     public function testStoreSupportsVectorQuery()
     {
         $store = new Store(new MockHttpClient(), 'test_collection');

--- a/src/store/src/Bridge/Vektor/Store.php
+++ b/src/store/src/Bridge/Vektor/Store.php
@@ -101,6 +101,19 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
+    public function clear(array $options = []): void
+    {
+        if ([] !== $options) {
+            throw new InvalidArgumentException('No supported options.');
+        }
+
+        // Vektor has no delete-all operation, but its index is the storage directory itself,
+        // which is recreated from the configured dimensions right away
+        $this->filesystem->remove($this->storagePath.'/vektor');
+
+        $this->setup();
+    }
+
     public function query(QueryInterface $query, array $options = []): iterable
     {
         if (!$query instanceof VectorQuery) {

--- a/src/store/src/Bridge/Vektor/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Vektor/Tests/StoreTest.php
@@ -72,6 +72,40 @@ final class StoreTest extends TestCase
         $store->drop();
     }
 
+    public function testStoreCannotClearWithOptions()
+    {
+        $store = new Store(sys_get_temp_dir());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No supported options.');
+        $this->expectExceptionCode(0);
+        $store->clear([
+            'foo' => 'bar',
+        ]);
+    }
+
+    public function testStoreCanClearAndStaysUsable()
+    {
+        $store = new Store(sys_get_temp_dir(), 3);
+        $store->setup();
+
+        $store->add([
+            new VectorDocument(Uuid::v4(), new Vector([0.1, 0.2, 0.3])),
+        ]);
+
+        $store->clear();
+
+        $this->assertCount(0, iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])))));
+
+        $store->add([
+            new VectorDocument(Uuid::v4(), new Vector([0.4, 0.5, 0.6])),
+        ]);
+
+        $this->assertCount(1, iterator_to_array($store->query(new VectorQuery(new Vector([0.4, 0.5, 0.6])))));
+
+        $store->drop();
+    }
+
     public function testStoreCanAddThenSearch()
     {
         $store = new Store(sys_get_temp_dir(), 3);

--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\Query\QueryInterface;
@@ -88,6 +89,33 @@ final class Store implements ManagedStoreInterface, StoreInterface
                 ],
             ],
         ]);
+    }
+
+    public function clear(array $options = []): void
+    {
+        // Weaviate's batch delete requires a "where" filter, so a wildcard on the id matches every object of the
+        // collection. A single call only deletes up to QUERY_MAXIMUM_RESULTS objects (10.000 by default, but
+        // configurable), so it is repeated until the collection reports no objects left to delete.
+        do {
+            $response = $this->request('DELETE', 'v1/batch/objects', [
+                'match' => [
+                    'class' => $this->collection,
+                    'where' => [
+                        'path' => ['id'],
+                        'operator' => 'Like',
+                        'valueText' => '*',
+                    ],
+                ],
+            ]);
+
+            $results = \is_array($response['results'] ?? null) ? $response['results'] : [];
+            $failed = \is_int($results['failed'] ?? null) ? $results['failed'] : 0;
+            $successful = \is_int($results['successful'] ?? null) ? $results['successful'] : 0;
+
+            if (0 !== $failed) {
+                throw new RuntimeException(\sprintf('Failed to delete %d object(s) while clearing the "%s" collection.', $failed, $this->collection));
+            }
+        } while (0 !== $successful);
     }
 
     public function supports(string $queryClass): bool

--- a/src/store/src/Bridge/Weaviate/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Weaviate/Tests/IntegrationTest.php
@@ -22,6 +22,14 @@ use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
 #[Group('integration')]
 final class IntegrationTest extends AbstractStoreIntegrationTestCase
 {
+    protected static function getHighVolumeDocumentCount(): int
+    {
+        // Weaviate truncates a batch delete at QUERY_MAXIMUM_RESULTS (10.000 by default) and reports the
+        // truncation nowhere, so clear() has to keep deleting until the server runs out of objects.
+        // Exceed that limit, otherwise the loop terminates before it ever hits the truncation.
+        return 11_000;
+    }
+
     protected static function createStore(): StoreInterface
     {
         return StoreFactory::create('TestCollection', 'http://127.0.0.1:8080', 'symfony');

--- a/src/store/src/Bridge/Weaviate/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Weaviate/Tests/StoreTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Weaviate\Store;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
@@ -247,6 +248,82 @@ final class StoreTest extends TestCase
 
         $this->assertCount(2, $results);
         $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testStoreCanClear()
+    {
+        $requestedMethod = null;
+        $requestedUrl = null;
+        $requestedBody = null;
+        $httpClient = new MockHttpClient([
+            static function (string $method, string $url, array $options) use (&$requestedMethod, &$requestedUrl, &$requestedBody): JsonMockResponse {
+                $requestedMethod = $method;
+                $requestedUrl = $url;
+                $requestedBody = $options['body'];
+
+                return new JsonMockResponse([
+                    'results' => ['matches' => 2, 'successful' => 2, 'failed' => 0],
+                ], ['http_code' => 200]);
+            },
+            new JsonMockResponse([
+                'results' => ['matches' => 0, 'successful' => 0, 'failed' => 0],
+            ], ['http_code' => 200]),
+        ], 'http://127.0.0.1:8080');
+
+        $store = new Store($httpClient, 'test');
+
+        $store->clear();
+
+        $this->assertSame('DELETE', $requestedMethod);
+        $this->assertSame('http://127.0.0.1:8080/v1/batch/objects', $requestedUrl);
+        $this->assertSame([
+            'match' => [
+                'class' => 'test',
+                'where' => [
+                    'path' => ['id'],
+                    'operator' => 'Like',
+                    'valueText' => '*',
+                ],
+            ],
+        ], json_decode((string) $requestedBody, true));
+        $this->assertSame(2, $httpClient->getRequestsCount());
+    }
+
+    public function testStoreClearsBeyondTheBatchDeleteLimit()
+    {
+        // Weaviate only deletes up to QUERY_MAXIMUM_RESULTS objects per call, so clear() has to repeat
+        // the batch delete until nothing matches anymore - otherwise documents would silently remain.
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse([
+                'results' => ['matches' => 11000, 'successful' => 10000, 'failed' => 0],
+            ], ['http_code' => 200]),
+            new JsonMockResponse([
+                'results' => ['matches' => 1000, 'successful' => 1000, 'failed' => 0],
+            ], ['http_code' => 200]),
+            new JsonMockResponse([
+                'results' => ['matches' => 0, 'successful' => 0, 'failed' => 0],
+            ], ['http_code' => 200]),
+        ], 'http://127.0.0.1:8080');
+
+        $store = new Store($httpClient, 'test');
+
+        $store->clear();
+
+        $this->assertSame(3, $httpClient->getRequestsCount());
+    }
+
+    public function testStoreCannotClearWithFailedDeletes()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'results' => ['matches' => 2, 'successful' => 1, 'failed' => 1],
+        ], ['http_code' => 200]), 'http://127.0.0.1:8080');
+
+        $store = new Store($httpClient, 'test');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Failed to delete 1 object(s) while clearing the "test" collection.');
+
+        $store->clear();
     }
 
     public function testStoreSupportsVectorQuery()

--- a/src/store/src/CombinedStore.php
+++ b/src/store/src/CombinedStore.php
@@ -53,6 +53,15 @@ final class CombinedStore implements StoreInterface
         }
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->vectorStore->clear($options);
+
+        if ($this->textStore !== $this->vectorStore) {
+            $this->textStore->clear($options);
+        }
+    }
+
     public function query(QueryInterface $query, array $options = []): iterable
     {
         if ($query instanceof HybridQuery) {

--- a/src/store/src/Command/ClearStoreCommand.php
+++ b/src/store/src/Command/ClearStoreCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Command;
+
+use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[AsCommand(name: 'ai:store:clear', description: 'Remove all documents from the store')]
+final class ClearStoreCommand extends Command
+{
+    /**
+     * @param ServiceLocator<StoreInterface> $stores
+     */
+    public function __construct(
+        private readonly ServiceLocator $stores,
+    ) {
+        parent::__construct();
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('store')) {
+            $suggestions->suggestValues($this->getStoreNames());
+        }
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('store', InputArgument::REQUIRED, 'Service name of the store to clear')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force clearing the store, required to actually remove the documents')
+            ->setHelp(<<<EOF
+The <info>%command.name%</info> command removes all documents from a store, but keeps the store usable.
+Since this cannot be undone, the <info>--force</info> option is required:
+
+    <info>php %command.full_name% <store> --force</info>
+
+In contrast to <info>ai:store:drop</info>, documents can be indexed again afterwards without running
+<info>ai:store:setup</info> first.
+EOF
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (0 === \count($this->getStoreNames())) {
+            throw new RuntimeException('No store is configured to be cleared.');
+        }
+
+        $storeName = $input->getArgument('store');
+        if (!$this->stores->has($storeName)) {
+            throw new RuntimeException(\sprintf('The "%s" store does not exist, use "%s".', $storeName, implode('", "', $this->getStoreNames())));
+        }
+
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$input->getOption('force')) {
+            $io->warning('The --force option is required to clear the store.');
+
+            return Command::FAILURE;
+        }
+
+        $store = $this->stores->get($storeName);
+
+        try {
+            $store->clear();
+            $io->success(\sprintf('The "%s" store was cleared successfully.', $storeName));
+        } catch (\Exception $e) {
+            throw new RuntimeException(\sprintf('An error occurred while clearing the "%s" store: ', $storeName).$e->getMessage(), previous: $e);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getStoreNames(): array
+    {
+        return array_keys($this->stores->getProvidedServices());
+    }
+}

--- a/src/store/src/InMemory/Store.php
+++ b/src/store/src/InMemory/Store.php
@@ -71,6 +71,15 @@ final class Store implements ManagedStoreInterface, StoreInterface, ResetInterfa
         }));
     }
 
+    public function clear(array $options = []): void
+    {
+        if ([] !== $options) {
+            throw new InvalidArgumentException('No supported options.');
+        }
+
+        $this->documents = [];
+    }
+
     public function supports(string $queryClass): bool
     {
         return \in_array($queryClass, [

--- a/src/store/src/StoreInterface.php
+++ b/src/store/src/StoreInterface.php
@@ -21,17 +21,30 @@ use Symfony\AI\Store\Query\QueryInterface;
 interface StoreInterface
 {
     /**
+     * Adds documents to the store, so they can be queried afterwards.
+     *
      * @param VectorDocument|VectorDocument[] $documents
      */
     public function add(VectorDocument|array $documents): void;
 
     /**
+     * Removes the documents with the given ids from the store.
+     *
      * @param string|array<string> $ids
      * @param array<string, mixed> $options
      */
     public function remove(string|array $ids, array $options = []): void;
 
     /**
+     * Removes all documents from the store, but keeps the store usable.
+     *
+     * @param array<string, mixed> $options
+     */
+    public function clear(array $options = []): void;
+
+    /**
+     * Returns the documents of the store matching the given query.
+     *
      * @param array<string, mixed> $options
      *
      * @return iterable<VectorDocument>
@@ -41,6 +54,8 @@ interface StoreInterface
     public function query(QueryInterface $query, array $options = []): iterable;
 
     /**
+     * Tells whether the store supports the given query type.
+     *
      * @param class-string<QueryInterface> $queryClass The query class to check
      */
     public function supports(string $queryClass): bool;

--- a/src/store/src/Test/AbstractStoreIntegrationTestCase.php
+++ b/src/store/src/Test/AbstractStoreIntegrationTestCase.php
@@ -22,12 +22,15 @@ use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
 use Symfony\AI\Store\StoreInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
 abstract class AbstractStoreIntegrationTestCase extends TestCase
 {
+    private const WRITE_CHUNK_SIZE = 500;
+
     private const DOCUMENT_ID_1 = '367e550e-6c92-4f12-8a6b-3f3f1d5e8c9a';
     private const DOCUMENT_ID_2 = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
     private const DOCUMENT_ID_3 = '123e4567-e89b-12d3-a456-426614174000';
@@ -38,11 +41,11 @@ abstract class AbstractStoreIntegrationTestCase extends TestCase
     {
         self::$store = static::createStore();
 
-        if (!self::$store instanceof ManagedStoreInterface) {
-            $this->markTestSkipped('Store does not implement ManagedStoreInterface.');
+        // this test must not be skipped, since the tests depending on it would be skipped as well, and
+        // a store provisioning its schema outside of setup() would never get tested at all
+        if (self::$store instanceof ManagedStoreInterface) {
+            self::$store->setup(static::getSetupOptions());
         }
-
-        self::$store->setup(static::getSetupOptions());
 
         $this->addToAssertionCount(1);
     }
@@ -105,8 +108,12 @@ abstract class AbstractStoreIntegrationTestCase extends TestCase
     #[Depends('testAddDocuments')]
     public function testQueryDocumentsWithTextQuery()
     {
+        // this test must not be skipped, since the tests depending on it would be skipped as well,
+        // and the store would never get to the point of being removed from, cleared or dropped
         if (!self::$store->supports(TextQuery::class)) {
-            $this->markTestSkipped('Store does not support TextQuery.');
+            $this->addToAssertionCount(1);
+
+            return;
         }
 
         // Search for text that should match the third document
@@ -129,7 +136,9 @@ abstract class AbstractStoreIntegrationTestCase extends TestCase
     public function testQueryDocumentsWithHybridQuery()
     {
         if (!self::$store->supports(HybridQuery::class)) {
-            $this->markTestSkipped('Store does not support HybridQuery.');
+            $this->addToAssertionCount(1);
+
+            return;
         }
 
         // Hybrid query combining vector [0,0,1] (matches doc 3) with text "machine learning" (matches doc 2)
@@ -164,7 +173,11 @@ abstract class AbstractStoreIntegrationTestCase extends TestCase
         try {
             self::$store->remove(self::DOCUMENT_ID_3);
         } catch (UnsupportedFeatureException) {
-            $this->markTestSkipped('Store does not support remove().');
+            // this test must not be skipped, since the tests depending on it would be skipped as well,
+            // and the store would never get to the point of being cleared or dropped
+            $this->addToAssertionCount(1);
+
+            return;
         }
 
         $this->waitForIndexing();
@@ -177,6 +190,80 @@ abstract class AbstractStoreIntegrationTestCase extends TestCase
     }
 
     #[Depends('testRemoveDocuments')]
+    public function testClearStore()
+    {
+        self::$store->clear();
+
+        $this->waitForIndexing();
+
+        $results = self::$store->query(new VectorQuery(new Vector([1.0, 0.0, 0.0])));
+
+        $this->assertCount(0, iterator_to_array($results, false));
+    }
+
+    #[Depends('testClearStore')]
+    public function testStoreIsReusableAfterClear()
+    {
+        // in contrast to drop(), clear() keeps the underlying table/index/collection intact,
+        // so documents can be added and queried again without another setup() call
+        self::$store->add(new VectorDocument(
+            self::DOCUMENT_ID_1,
+            new Vector([1.0, 0.0, 0.0]),
+            new Metadata(['name' => 'document after clear'])
+        ));
+
+        $this->waitForIndexing();
+
+        $results = self::$store->query(new VectorQuery(new Vector([1.0, 0.0, 0.0])));
+
+        $found = null;
+        foreach ($results as $result) {
+            if (self::DOCUMENT_ID_1 === $result->getId()) {
+                $found = $result;
+                break;
+            }
+        }
+
+        $this->assertNotNull($found);
+        $this->assertSame('document after clear', $found->getMetadata()['name']);
+    }
+
+    #[Depends('testStoreIsReusableAfterClear')]
+    public function testClearRemovesDocumentsBeyondASingleBatch()
+    {
+        $documentCount = static::getVolumeDocumentCount();
+
+        // written in chunks, so the high volume tier below does not turn the whole set into one huge request
+        for ($written = 0; $written < $documentCount; $written += self::WRITE_CHUNK_SIZE) {
+            $documents = [];
+            for ($i = $written; $i < min($written + self::WRITE_CHUNK_SIZE, $documentCount); ++$i) {
+                $documents[] = new VectorDocument(
+                    Uuid::v4()->toRfc4122(),
+                    new Vector([1.0, $i / $documentCount, 0.0]),
+                    new Metadata(['name' => \sprintf('bulk document %d', $i)])
+                );
+            }
+
+            self::$store->add($documents);
+        }
+
+        $this->waitForIndexing();
+
+        // guard against a vacuous assertion: clearing an already-empty store would pass the check below
+        $results = self::$store->query(new VectorQuery(new Vector([1.0, 0.0, 0.0])));
+
+        $this->assertNotCount(0, iterator_to_array($results, false));
+
+        self::$store->clear(static::getClearOptions());
+
+        $this->waitForIndexing();
+
+        $results = self::$store->query(new VectorQuery(new Vector([1.0, 0.0, 0.0])));
+
+        $this->assertCount(0, iterator_to_array($results, false));
+    }
+
+    #[Depends('testClearRemovesDocumentsBeyondASingleBatch')]
     public function testDropStore()
     {
         if (!self::$store instanceof ManagedStoreInterface) {
@@ -194,6 +281,51 @@ abstract class AbstractStoreIntegrationTestCase extends TestCase
      * @return array<string, mixed>
      */
     protected static function getSetupOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * Number of documents written by testClearRemovesDocumentsBeyondASingleBatch().
+     *
+     * High enough to exceed the result limits engines apply by default, so a clear() that only wipes
+     * the first page of documents gets caught, but still cheap enough to run on every pull request.
+     */
+    protected static function getVolumeDocumentCount(): int
+    {
+        if (self::isHighVolumeRun()) {
+            return static::getHighVolumeDocumentCount();
+        }
+
+        return 250;
+    }
+
+    /**
+     * Number of documents written once STORE_HIGH_VOLUME_TESTS=1 is set.
+     *
+     * Engines also truncate bulk operations at hard server-side limits, which sit far above what a
+     * per-pull-request run can afford to write. Stores whose clear() has to work around such a limit
+     * should raise this until it exceeds theirs, and get covered by the scheduled high volume build.
+     */
+    protected static function getHighVolumeDocumentCount(): int
+    {
+        return 10_000;
+    }
+
+    protected static function isHighVolumeRun(): bool
+    {
+        return '1' === getenv('STORE_HIGH_VOLUME_TESTS');
+    }
+
+    /**
+     * Options passed to clear() by testClearRemovesDocumentsBeyondASingleBatch().
+     *
+     * Stores paginating their clear() should lower "batch_size" here, so the volume test above forces
+     * several iterations instead of wiping everything in one round-trip.
+     *
+     * @return array<string, mixed>
+     */
+    protected static function getClearOptions(): array
     {
         return [];
     }

--- a/src/store/src/TraceableStore.php
+++ b/src/store/src/TraceableStore.php
@@ -89,6 +89,17 @@ final class TraceableStore implements StoreInterface, ManagedStoreInterface, Res
         $this->store->remove($ids, $options);
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->calls[] = [
+            'method' => 'clear',
+            'options' => $options,
+            'called_at' => $this->clock->now(),
+        ];
+
+        $this->store->clear($options);
+    }
+
     public function supports(string $queryClass): bool
     {
         return $this->store->supports($queryClass);

--- a/src/store/tests/Command/ClearStoreCommandTest.php
+++ b/src/store/tests/Command/ClearStoreCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Store\Command\ClearStoreCommand;
+use Symfony\AI\Store\Exception\RuntimeException;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+final class ClearStoreCommandTest extends TestCase
+{
+    public function testCommandIsConfigured()
+    {
+        $command = new ClearStoreCommand(new ServiceLocator([]));
+
+        $this->assertSame('ai:store:clear', $command->getName());
+        $this->assertSame('Remove all documents from the store', $command->getDescription());
+
+        $definition = $command->getDefinition();
+        $this->assertTrue($definition->hasArgument('store'));
+        $this->assertTrue($definition->hasOption('force'));
+
+        $storeArgument = $definition->getArgument('store');
+        $this->assertSame('Service name of the store to clear', $storeArgument->getDescription());
+        $this->assertTrue($storeArgument->isRequired());
+
+        $forceOption = $definition->getOption('force');
+        $this->assertSame('Force clearing the store, required to actually remove the documents', $forceOption->getDescription());
+        $this->assertFalse($forceOption->acceptValue());
+    }
+
+    public function testCommandCannotClearWithoutStores()
+    {
+        $command = new ClearStoreCommand(new ServiceLocator([]));
+
+        $tester = new CommandTester($command);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No store is configured to be cleared.');
+        $this->expectExceptionCode(0);
+        $tester->execute([
+            'store' => 'foo',
+        ]);
+    }
+
+    public function testCommandCannotClearUndefinedStore()
+    {
+        $command = new ClearStoreCommand(new ServiceLocator([
+            'bar' => fn (): object => $this->createMock(StoreInterface::class),
+        ]));
+
+        $tester = new CommandTester($command);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The "foo" store does not exist, use "bar".');
+        $this->expectExceptionCode(0);
+        $tester->execute([
+            'store' => 'foo',
+        ]);
+    }
+
+    public function testCommandCannotClearStoreWithException()
+    {
+        $store = $this->createMock(StoreInterface::class);
+        $store->expects($this->once())->method('clear')->willThrowException(new RuntimeException('foo'));
+
+        $command = new ClearStoreCommand(new ServiceLocator([
+            'foo' => static fn (): object => $store,
+        ]));
+
+        $tester = new CommandTester($command);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('An error occurred while clearing the "foo" store: foo');
+        $this->expectExceptionCode(0);
+        $tester->execute([
+            'store' => 'foo',
+            '--force' => true,
+        ]);
+    }
+
+    public function testCommandCannotBeClearedWithoutForceOption()
+    {
+        $store = $this->createMock(StoreInterface::class);
+        $store->expects($this->never())->method('clear');
+
+        $command = new ClearStoreCommand(new ServiceLocator([
+            'foo' => static fn (): object => $store,
+        ]));
+
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'store' => 'foo',
+        ]);
+
+        $this->assertStringContainsString('The --force option is required to clear the store.', $tester->getDisplay());
+    }
+
+    public function testCommandCanClear()
+    {
+        $store = $this->createMock(StoreInterface::class);
+        $store->expects($this->once())->method('clear');
+
+        $command = new ClearStoreCommand(new ServiceLocator([
+            'foo' => static fn (): object => $store,
+        ]));
+
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'store' => 'foo',
+            '--force' => true,
+        ]);
+
+        $this->assertStringContainsString('The "foo" store was cleared successfully.', $tester->getDisplay());
+    }
+}

--- a/src/store/tests/Double/TestStore.php
+++ b/src/store/tests/Double/TestStore.php
@@ -42,6 +42,11 @@ final class TestStore implements StoreInterface
         throw new UnsupportedFeatureException('Method not implemented yet.');
     }
 
+    public function clear(array $options = []): void
+    {
+        $this->documents = [];
+    }
+
     public function supports(string $queryClass): bool
     {
         return VectorQuery::class === $queryClass;

--- a/src/store/tests/TraceableStoreTest.php
+++ b/src/store/tests/TraceableStoreTest.php
@@ -84,6 +84,27 @@ final class TraceableStoreTest extends TestCase
         ], $traceableStore->getCalls());
     }
 
+    public function testStoreCanRetrieveDataOnClear()
+    {
+        $clock = new MockClock('2020-01-01 10:00:00');
+
+        $store = new Store();
+        $store->add(new VectorDocument(Uuid::v7()->toRfc4122(), new Vector([0.1, 0.2, 0.3])));
+
+        $traceableStore = new TraceableStore($store, $clock);
+
+        $traceableStore->clear();
+
+        $this->assertEquals([
+            [
+                'method' => 'clear',
+                'options' => [],
+                'called_at' => $clock->now(),
+            ],
+        ], $traceableStore->getCalls());
+        $this->assertSame([], iterator_to_array($store->query(new VectorQuery(new Vector([0.1, 0.2, 0.3])))));
+    }
+
     public function testSetupDelegatesToManagedStore()
     {
         $innerStore = new class implements StoreInterface, ManagedStoreInterface {
@@ -111,6 +132,10 @@ final class TraceableStoreTest extends TestCase
             }
 
             public function remove(array|string $ids, array $options = []): void
+            {
+            }
+
+            public function clear(array $options = []): void
             {
             }
 
@@ -166,6 +191,10 @@ final class TraceableStoreTest extends TestCase
             }
 
             public function remove(array|string $ids, array $options = []): void
+            {
+            }
+
+            public function clear(array $options = []): void
             {
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Adds `StoreInterface::clear()` to remove all documents from a store while keeping the underlying table, index or collection intact - in contrast to `ManagedStoreInterface::drop()`, which removes the infrastructure itself.

```php
$store->clear();      // documents gone, index still there - re-index without setup()
$store->drop();       // infrastructure gone
```

`clear()` follows the PHP/Symfony idiom (PSR-6 `CacheItemPoolInterface::clear()`, Doctrine `Collection::clear()`) and is vendor-neutral, unlike `truncate` (SQL-table vocabulary, SQLite has no such keyword) or `purge` (means reclaiming already-deleted rows in InnoDB/Solr).

* Implemented in all 25 stores with the native mechanism of each backend: `TRUNCATE TABLE` (Postgres, MariaDB, ClickHouse, Manticore), `_delete_by_query` (Elasticsearch, OpenSearch), `deleteMany({})` (MongoDB), label-scoped `DETACH DELETE` (Neo4j), match-all filters (Qdrant, Weaviate, Typesense), `deleteAll` (Pinecone), `SCAN` + `DEL` (Redis), ...
* AzureSearch and S3Vectors have no delete-all API and enumerate-then-delete in batches. Cloudflare Vectorize supports neither listing nor bulk delete, so it recreates the index - documented.
* Adds `ai:store:clear` command next to `ai:store:setup` and `ai:store:drop`.

Verified with the docker compose runtimes and the store integration tests, which now cover `clear()` and that the store stays usable afterwards.

Two bugs surfaced while doing so:

* `testRemoveDocuments` depended on the optional text/hybrid query tests, and PHPUnit skips dependents of a skipped test - so `remove()` and `drop()` were never actually run for stores without `TextQuery` support. The optional query tests now pass through instead of skipping.
* That uncovered a broken `remove()` in the Manticore Search store: `uuid` was created as a `TEXT` field, but documents are removed by an `equals` filter, which Manticore rejects on stored text fields ("unsupported column 'uuid' (stored field, NOT attribute)"). It is now a `STRING` attribute - existing tables need to be recreated, see UPGRADE.md.