### PR TITLE
[Platform] Add Agent Client Protocol (ACP) platform Bridge

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -109,6 +109,10 @@ deptrac:
       collectors:
         - type: classLike
           value: ^Symfony\\AI\\Platform\\(?!Bridge\\).*
+    - name: AcpPlatform
+      collectors:
+        - type: classLike
+          value: Symfony\\AI\\Platform\\Bridge\\Acp\\.*
     - name: AiMlApiPlatform
       collectors:
         - type: classLike
@@ -435,6 +439,8 @@ deptrac:
       - ChatComponent
       - PlatformComponent
     PlatformComponent: ~
+    AcpPlatform:
+      - PlatformComponent
     AiMlApiPlatform:
       - PlatformComponent
       - GenericPlatform

--- a/examples/.env
+++ b/examples/.env
@@ -225,3 +225,8 @@ SYMFONY_DOCS_MAX_DEPTH=2
 
 # MiniMax (platform)
 MINI_MAX_API_KEY=
+
+# Agent Client Protocol (ACP)
+ACP_BINARY=
+ACP_HOST=
+ACP_PORT=

--- a/examples/acp/chat.php
+++ b/examples/acp/chat.php
@@ -19,9 +19,6 @@ $platform = Factory::createPlatform(
     workingDirectory: dirname(__DIR__, 2),
     command: env('ACP_BINARY'),
     logger: logger(),
-    onStatus: static function (string $status): void {
-        output()->writeln(sprintf('<info>[acp] %s</info>', $status));
-    },
 );
 
 $messages = new MessageBag(
@@ -34,6 +31,7 @@ echo $result->asText().\PHP_EOL;
 
 $tokenUsage = $result->getMetadata()->get('token_usage');
 if (null !== $tokenUsage) {
+    echo \PHP_EOL;
     print_token_usage($tokenUsage);
     echo \PHP_EOL;
 }

--- a/examples/acp/chat.php
+++ b/examples/acp/chat.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Acp\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(
+    workingDirectory: dirname(__DIR__, 2),
+    command: $_SERVER['ACP_BINARY'] ?? $_ENV['ACP_BINARY'] ?? 'opencode acp',
+    logger: logger(),
+    onStatus: static function (string $status): void {
+        output()->writeln(sprintf('<info>[acp] %s</info>', $status));
+    },
+);
+
+$messages = new MessageBag(
+    Message::ofUser('Explain the architecture of this project in 3 sentences.'),
+);
+
+$result = $platform->invoke('acp-v1', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/acp/chat.php
+++ b/examples/acp/chat.php
@@ -31,3 +31,9 @@ $messages = new MessageBag(
 $result = $platform->invoke('acp-v1', $messages);
 
 echo $result->asText().\PHP_EOL;
+
+$tokenUsage = $result->getMetadata()->get('token_usage');
+if (null !== $tokenUsage) {
+    print_token_usage($tokenUsage);
+    echo \PHP_EOL;
+}

--- a/examples/acp/chat.php
+++ b/examples/acp/chat.php
@@ -17,7 +17,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = Factory::createPlatform(
     workingDirectory: dirname(__DIR__, 2),
-    command: $_SERVER['ACP_BINARY'] ?? $_ENV['ACP_BINARY'] ?? 'opencode acp',
+    command: env('ACP_BINARY'),
     logger: logger(),
     onStatus: static function (string $status): void {
         output()->writeln(sprintf('<info>[acp] %s</info>', $status));

--- a/examples/acp/socket-chat.php
+++ b/examples/acp/socket-chat.php
@@ -18,8 +18,8 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = Factory::createPlatform(
     workingDirectory: dirname(__DIR__, 2),
     transport: 'socket',
-    host: $_SERVER['ACP_HOST'] ?? $_ENV['ACP_HOST'] ?? '127.0.0.1',
-    port: (int) ($_SERVER['ACP_PORT'] ?? $_ENV['ACP_PORT'] ?? 3000),
+    host: env('ACP_HOST'),
+    port: (int) env('ACP_PORT'),
     logger: logger(),
     onStatus: static function (string $status): void {
         output()->writeln(sprintf('<info>[acp] %s</info>', $status));

--- a/examples/acp/socket-chat.php
+++ b/examples/acp/socket-chat.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Acp\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(
+    workingDirectory: dirname(__DIR__, 2),
+    transport: 'socket',
+    host: $_SERVER['ACP_HOST'] ?? $_ENV['ACP_HOST'] ?? '127.0.0.1',
+    port: (int) ($_SERVER['ACP_PORT'] ?? $_ENV['ACP_PORT'] ?? 3000),
+    logger: logger(),
+    onStatus: static function (string $status): void {
+        output()->writeln(sprintf('<info>[acp] %s</info>', $status));
+    },
+);
+
+$messages = new MessageBag(
+    Message::ofUser('Explain the architecture of this project in 3 sentences.'),
+);
+
+$result = $platform->invoke('acp-v1', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/examples/acp/socket-chat.php
+++ b/examples/acp/socket-chat.php
@@ -21,9 +21,6 @@ $platform = Factory::createPlatform(
     host: env('ACP_HOST'),
     port: (int) env('ACP_PORT'),
     logger: logger(),
-    onStatus: static function (string $status): void {
-        output()->writeln(sprintf('<info>[acp] %s</info>', $status));
-    },
 );
 
 $messages = new MessageBag(

--- a/examples/acp/socket-stream.php
+++ b/examples/acp/socket-stream.php
@@ -18,8 +18,8 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = Factory::createPlatform(
     workingDirectory: dirname(__DIR__, 2),
     transport: 'socket',
-    host: $_SERVER['ACP_HOST'] ?? $_ENV['ACP_HOST'] ?? '127.0.0.1',
-    port: (int) ($_SERVER['ACP_PORT'] ?? $_ENV['ACP_PORT'] ?? 3000),
+    host: env('ACP_HOST'),
+    port: (int) env('ACP_PORT'),
     logger: logger(),
 );
 

--- a/examples/acp/socket-stream.php
+++ b/examples/acp/socket-stream.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Acp\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(
+    workingDirectory: dirname(__DIR__, 2),
+    transport: 'socket',
+    host: $_SERVER['ACP_HOST'] ?? $_ENV['ACP_HOST'] ?? '127.0.0.1',
+    port: (int) ($_SERVER['ACP_PORT'] ?? $_ENV['ACP_PORT'] ?? 3000),
+    logger: logger(),
+);
+
+$messages = new MessageBag(
+    Message::ofUser('What is Symfony? Explain in 3 sentences.'),
+);
+
+$result = $platform->invoke('acp-v1', $messages, ['stream' => true]);
+
+foreach ($result->asTextStream() as $delta) {
+    echo $delta;
+}
+
+echo \PHP_EOL;

--- a/examples/acp/socket-toolcall-stream.php
+++ b/examples/acp/socket-toolcall-stream.php
@@ -23,8 +23,8 @@ require_once dirname(__DIR__).'/bootstrap.php';
 $platform = Factory::createPlatform(
     workingDirectory: dirname(__DIR__, 2),
     transport: 'socket',
-    host: $_SERVER['ACP_HOST'] ?? $_ENV['ACP_HOST'] ?? '127.0.0.1',
-    port: (int) ($_SERVER['ACP_PORT'] ?? $_ENV['ACP_PORT'] ?? 3000),
+    host: env('ACP_HOST'),
+    port: (int) env('ACP_PORT'),
     logger: logger(),
 );
 

--- a/examples/acp/socket-toolcall-stream.php
+++ b/examples/acp/socket-toolcall-stream.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Acp\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(
+    workingDirectory: dirname(__DIR__, 2),
+    transport: 'socket',
+    host: $_SERVER['ACP_HOST'] ?? $_ENV['ACP_HOST'] ?? '127.0.0.1',
+    port: (int) ($_SERVER['ACP_PORT'] ?? $_ENV['ACP_PORT'] ?? 3000),
+    logger: logger(),
+);
+
+$messages = new MessageBag(
+    Message::ofUser('Read the top-level README.md and summarize it in two sentences. Tell me which tool you plan to use before calling it.'),
+);
+
+$result = $platform->invoke('acp-v1', $messages, ['stream' => true]);
+
+foreach ($result->asStream() as $delta) {
+    if ($delta instanceof TextDelta) {
+        echo $delta;
+        continue;
+    }
+
+    if ($delta instanceof ThinkingDelta) {
+        output()->write('<fg=#999999>'.$delta->getThinking().'</>');
+        continue;
+    }
+
+    if ($delta instanceof ToolCallStart) {
+        output()->writeln(\PHP_EOL.'<info>[tool-call started: '.$delta->getName().']</info>');
+        continue;
+    }
+
+    if ($delta instanceof ToolInputDelta) {
+        output()->write('<fg=#999999>'.$delta->getPartialJson().'</>');
+        continue;
+    }
+
+    if ($delta instanceof ToolCallComplete) {
+        output()->writeln(\PHP_EOL.'<info>[tool-calls ready: '.count($delta->getToolCalls()).']</info>');
+    }
+}
+
+echo \PHP_EOL;

--- a/examples/acp/stream.php
+++ b/examples/acp/stream.php
@@ -17,7 +17,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = Factory::createPlatform(
     workingDirectory: dirname(__DIR__, 2),
-    command: $_SERVER['ACP_BINARY'] ?? $_ENV['ACP_BINARY'] ?? 'opencode acp',
+    command: env('ACP_BINARY'),
     logger: logger(),
 );
 

--- a/examples/acp/stream.php
+++ b/examples/acp/stream.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Acp\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(
+    workingDirectory: dirname(__DIR__, 2),
+    command: $_SERVER['ACP_BINARY'] ?? $_ENV['ACP_BINARY'] ?? 'opencode acp',
+    logger: logger(),
+);
+
+$messages = new MessageBag(
+    Message::ofUser('What is Symfony? Explain in 3 sentences.'),
+);
+
+$result = $platform->invoke('acp-v1', $messages, ['stream' => true]);
+
+foreach ($result->asTextStream() as $delta) {
+    echo $delta;
+}
+
+echo \PHP_EOL;

--- a/examples/acp/toolcall-stream.php
+++ b/examples/acp/toolcall-stream.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Acp\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(
+    workingDirectory: dirname(__DIR__, 2),
+    command: $_SERVER['ACP_BINARY'] ?? $_ENV['ACP_BINARY'] ?? 'opencode acp',
+    logger: logger(),
+);
+
+$messages = new MessageBag(
+    Message::ofUser('Read the top-level README.md and summarize it in two sentences. Tell me which tool you plan to use before calling it.'),
+);
+
+$result = $platform->invoke('acp-v1', $messages, ['stream' => true]);
+
+foreach ($result->asStream() as $delta) {
+    if ($delta instanceof TextDelta) {
+        echo $delta;
+        continue;
+    }
+
+    if ($delta instanceof ThinkingDelta) {
+        output()->write('<fg=#999999>'.$delta->getThinking().'</>');
+        continue;
+    }
+
+    if ($delta instanceof ToolCallStart) {
+        output()->writeln(\PHP_EOL.'<info>[tool-call started: '.$delta->getName().']</info>');
+        continue;
+    }
+
+    if ($delta instanceof ToolInputDelta) {
+        output()->write('<fg=#999999>'.$delta->getPartialJson().'</>');
+        continue;
+    }
+
+    if ($delta instanceof ToolCallComplete) {
+        output()->writeln(\PHP_EOL.'<info>[tool-calls ready: '.count($delta->getToolCalls()).']</info>');
+    }
+}
+
+echo \PHP_EOL;

--- a/examples/acp/toolcall-stream.php
+++ b/examples/acp/toolcall-stream.php
@@ -22,7 +22,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = Factory::createPlatform(
     workingDirectory: dirname(__DIR__, 2),
-    command: $_SERVER['ACP_BINARY'] ?? $_ENV['ACP_BINARY'] ?? 'opencode acp',
+    command: env('ACP_BINARY'),
     logger: logger(),
 );
 

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -5,6 +5,7 @@
     "type": "project",
     "require": {
         "php": ">=8.2",
+        "symfony/ai-acp-platform": "dev-main",
         "symfony/ai-agent": "^0.12",
         "symfony/ai-ai-ml-api-platform": "^0.12",
         "symfony/ai-albert-platform": "^0.12",
@@ -94,6 +95,12 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-strict-rules": "^2.0"
     },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../src/platform/src/Bridge/Acp"
+        }
+    ],
     "minimum-stability": "dev",
     "autoload": {
         "psr-4": {

--- a/splitsh.json
+++ b/splitsh.json
@@ -40,6 +40,7 @@
         "ai-platform": {
             "prefixes": [{ "from": "src/platform", "to": "", "excludes": ["src/Bridge"] }]
         },
+        "ai-acp-platform": "src/platform/src/Bridge/Acp",
         "ai-ai-ml-api-platform": "src/platform/src/Bridge/AiMlApi",
         "ai-albert-platform": "src/platform/src/Bridge/Albert",
         "ai-amazee-ai-platform": "src/platform/src/Bridge/AmazeeAi",

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Add support for `ScopingHttpClient` usage in `SurrealDB` store via `http_client` option
  * Register `StringToMessageBagListener` in DI to enable string-to-MessageBag upcasting by default
  * Command `ai:platform:invoke` now adds choices when model is not provided as argument
+ * Add `acp` platform configuration for the ACP bridge
 
 0.10
 ----

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Add `acp` platform configuration for the ACP bridge
+
 0.11
 ----
 
@@ -15,7 +20,6 @@ CHANGELOG
  * Add support for `ScopingHttpClient` usage in `SurrealDB` store via `http_client` option
  * Register `StringToMessageBagListener` in DI to enable string-to-MessageBag upcasting by default
  * Command `ai:platform:invoke` now adds choices when model is not provided as argument
- * Add `acp` platform configuration for the ACP bridge
 
 0.10
 ----

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-0.12
+0.13
 ----
 
  * Add `acp` platform configuration for the ACP bridge

--- a/src/ai-bundle/composer.json
+++ b/src/ai-bundle/composer.json
@@ -34,6 +34,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5.53",
+        "symfony/ai-acp-platform": "dev-main",
         "symfony/ai-agent": "^0.12",
         "symfony/ai-ai-ml-api-platform": "^0.12",
         "symfony/ai-albert-platform": "^0.12",
@@ -109,6 +110,12 @@
         "symfony/translation": "^7.3|^8.0",
         "symfony/validator": "^7.3|^8.0"
     },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../platform/src/Bridge/Acp"
+        }
+    ],
     "minimum-stability": "dev",
     "autoload": {
         "psr-4": {

--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -28,6 +28,7 @@ return static function (DefinitionConfigurator $configurator): void {
         ->children()
             ->arrayNode('platform')
                 ->children()
+                    ->append($import('platform/acp'))
                     ->append($import('platform/albert'))
                     ->append($import('platform/amazeeai'))
                     ->append($import('platform/anthropic'))

--- a/src/ai-bundle/config/platform/acp.php
+++ b/src/ai-bundle/config/platform/acp.php
@@ -14,12 +14,28 @@ namespace Symfony\Component\Config\Definition\Configurator;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
 return (new ArrayNodeDefinition('acp'))
+    ->validate()
+        ->ifTrue(static function (array $value): bool {
+            if ('socket' === ($value['transport'] ?? 'process')) {
+                return !(isset($value['host'], $value['port']));
+            }
+
+            return false;
+        })
+        ->thenInvalid('ACP socket transport requires both "host" and "port".')
+    ->end()
     ->children()
         ->stringNode('name')
             ->defaultValue('acp')
             ->cannotBeEmpty()
         ->end()
+        ->enumNode('transport')
+            ->values(['process', 'socket'])
+            ->defaultValue('process')
+        ->end()
         ->stringNode('command')->end()
+        ->stringNode('host')->end()
+        ->integerNode('port')->min(1)->max(65535)->end()
         ->stringNode('working_directory')->end()
         ->arrayNode('environment')
             ->useAttributeAsKey('name')

--- a/src/ai-bundle/config/platform/acp.php
+++ b/src/ai-bundle/config/platform/acp.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition\Configurator;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+return (new ArrayNodeDefinition('acp'))
+    ->children()
+        ->stringNode('name')
+            ->defaultValue('acp')
+            ->cannotBeEmpty()
+        ->end()
+        ->stringNode('command')->end()
+        ->stringNode('working_directory')->end()
+        ->arrayNode('environment')
+            ->useAttributeAsKey('name')
+            ->scalarPrototype()->end()
+        ->end()
+    ->end();

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -439,6 +439,10 @@ final class AiBundle extends AbstractBundle
                     new Definition('Symfony\\AI\\Platform\\Bridge\\Acp\\ModelCatalog'),
                     null,
                     new Reference('event_dispatcher'),
+                    null,
+                    $platform['transport'],
+                    $platform['host'] ?? null,
+                    $platform['port'] ?? null,
                 ])
                 ->addTag('ai.platform', ['name' => 'acp']);
 

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -52,6 +52,7 @@ use Symfony\AI\Chat\ChatInterface;
 use Symfony\AI\Chat\InMemory\Store as InMemoryMessageStore;
 use Symfony\AI\Chat\ManagedStoreInterface as ManagedMessageStoreInterface;
 use Symfony\AI\Chat\MessageStoreInterface;
+use Symfony\AI\Platform\Bridge\Acp\Factory as AcpFactory;
 use Symfony\AI\Platform\Bridge\Albert\Factory as AlbertFactory;
 use Symfony\AI\Platform\Bridge\AmazeeAi\Factory as AmazeeAiFactory;
 use Symfony\AI\Platform\Bridge\AmazeeAi\ModelApiCatalog as AmazeeAiModelApiCatalog;
@@ -418,6 +419,34 @@ final class AiBundle extends AbstractBundle
      */
     private function processPlatformConfig(string $type, array $platform, ContainerBuilder $container): void
     {
+        if ('acp' === $type) {
+            if (!ContainerBuilder::willBeAvailable('symfony/ai-acp-platform', AcpFactory::class, ['symfony/ai-bundle'])) {
+                throw new RuntimeException('ACP platform configuration requires "symfony/ai-acp-platform" package. Try running "composer require symfony/ai-acp-platform".');
+            }
+
+            $platformId = 'ai.platform.acp';
+            $definition = (new Definition(Platform::class))
+                ->setFactory(AcpFactory::class.'::createPlatform')
+                ->setLazy(true)
+                ->addTag('proxy', ['interface' => PlatformInterface::class])
+                ->setArguments([
+                    $platform['name'],
+                    $platform['command'] ?? null,
+                    $platform['working_directory'] ?? null,
+                    $platform['environment'],
+                    null,
+                    new Reference(LoggerInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                    new Definition('Symfony\\AI\\Platform\\Bridge\\Acp\\ModelCatalog'),
+                    null,
+                    new Reference('event_dispatcher'),
+                ])
+                ->addTag('ai.platform', ['name' => 'acp']);
+
+            $container->setDefinition($platformId, $definition);
+
+            return;
+        }
+
         if ('albert' === $type) {
             if (!ContainerBuilder::willBeAvailable('symfony/ai-albert-platform', AlbertFactory::class, ['symfony/ai-bundle'])) {
                 throw new RuntimeException('Albert platform configuration requires "symfony/ai-albert-platform" package. Try running "composer require symfony/ai-albert-platform".');

--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -434,7 +434,6 @@ final class AiBundle extends AbstractBundle
                     $platform['command'] ?? null,
                     $platform['working_directory'] ?? null,
                     $platform['environment'],
-                    null,
                     new Reference(LoggerInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
                     new Definition('Symfony\\AI\\Platform\\Bridge\\Acp\\ModelCatalog'),
                     null,

--- a/src/ai-bundle/tests/DependencyInjection/BridgeConfigCompilationTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/BridgeConfigCompilationTest.php
@@ -297,6 +297,7 @@ class BridgeConfigCompilationTest extends TestCase
     public static function providePlatformConfigs(): iterable
     {
         yield 'acp' => ['acp', ['command' => 'opencode acp'], 'ai.platform.acp'];
+        yield 'acp_socket' => ['acp', ['transport' => 'socket', 'host' => '127.0.0.1', 'port' => 3000], 'ai.platform.acp'];
         yield 'albert' => ['albert', ['api_key' => 'k', 'base_url' => 'https://albert.example.com'], 'ai.platform.albert'];
         yield 'amazeeai' => ['amazeeai', ['api_key' => 'k', 'base_url' => 'https://amazeeai.example.com'], 'ai.platform.amazeeai'];
         yield 'anthropic' => ['anthropic', ['api_key' => 'k'], 'ai.platform.anthropic'];

--- a/src/ai-bundle/tests/DependencyInjection/BridgeConfigCompilationTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/BridgeConfigCompilationTest.php
@@ -296,6 +296,7 @@ class BridgeConfigCompilationTest extends TestCase
      */
     public static function providePlatformConfigs(): iterable
     {
+        yield 'acp' => ['acp', ['command' => 'opencode acp'], 'ai.platform.acp'];
         yield 'albert' => ['albert', ['api_key' => 'k', 'base_url' => 'https://albert.example.com'], 'ai.platform.albert'];
         yield 'amazeeai' => ['amazeeai', ['api_key' => 'k', 'base_url' => 'https://amazeeai.example.com'], 'ai.platform.amazeeai'];
         yield 'anthropic' => ['anthropic', ['api_key' => 'k'], 'ai.platform.anthropic'];

--- a/src/platform/composer.json
+++ b/src/platform/composer.json
@@ -64,12 +64,10 @@
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {
-        "amphp/process": "2.x-dev",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5.53",
-        "revolt/event-loop": "^1.0@dev",
         "symfony/cache": "^7.3|^8.0",
         "symfony/console": "^7.3|^8.0",
         "symfony/dotenv": "^7.3|^8.0",

--- a/src/platform/composer.json
+++ b/src/platform/composer.json
@@ -64,10 +64,12 @@
         "symfony/uid": "^7.3|^8.0"
     },
     "require-dev": {
+        "amphp/process": "2.x-dev",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5.53",
+        "revolt/event-loop": "^1.0@dev",
         "symfony/cache": "^7.3|^8.0",
         "symfony/console": "^7.3|^8.0",
         "symfony/dotenv": "^7.3|^8.0",

--- a/src/platform/src/Bridge/Acp/.gitattributes
+++ b/src/platform/src/Bridge/Acp/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.php text eol=lf

--- a/src/platform/src/Bridge/Acp/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/platform/src/Bridge/Acp/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead:
+https://github.com/symfony/ai
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!

--- a/src/platform/src/Bridge/Acp/.github/workflows/close-pull-request.yml
+++ b/src/platform/src/Bridge/Acp/.github/workflows/close-pull-request.yml
@@ -1,0 +1,20 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thanks for your Pull Request! We love contributions.
+
+          However, you should instead open your PR on the main repository:
+          https://github.com/symfony/ai
+
+          This repository is what we call a "subtree split": a read-only subset of that main repository.
+          We're looking forward to your PR there!

--- a/src/platform/src/Bridge/Acp/.gitignore
+++ b/src/platform/src/Bridge/Acp/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+phpunit.xml
+.phpunit.result.cache

--- a/src/platform/src/Bridge/Acp/Acp.php
+++ b/src/platform/src/Bridge/Acp/Acp.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp;
+
+use Symfony\AI\Platform\Model;
+
+/**
+ * ACP model with protocol version and capabilities.
+ */
+final class Acp extends Model
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public array $clientCapabilities = [];
+
+    /**
+     * @var list<string>
+     */
+    public array $requiredAgentCapabilities = [];
+
+    public int $protocolVersion = 1;
+}

--- a/src/platform/src/Bridge/Acp/CHANGELOG.md
+++ b/src/platform/src/Bridge/Acp/CHANGELOG.md
@@ -1,7 +1,7 @@
-# Changelog
+CHANGELOG
+=========
 
-All notable changes to this project will be documented in this file.
+Unreleased
+----------
 
-## [Unreleased]
-
-- Initial implementation of ACP bridge for Symfony AI Platform
+* Add the bridge

--- a/src/platform/src/Bridge/Acp/CHANGELOG.md
+++ b/src/platform/src/Bridge/Acp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+- Initial implementation of ACP bridge for Symfony AI Platform

--- a/src/platform/src/Bridge/Acp/CHANGELOG.md
+++ b/src/platform/src/Bridge/Acp/CHANGELOG.md
@@ -1,7 +1,8 @@
 CHANGELOG
 =========
 
-Unreleased
-----------
+0.13
+----
 
 * Add the bridge
+

--- a/src/platform/src/Bridge/Acp/Dto/Message/AbstractJsonRpcNotification.php
+++ b/src/platform/src/Bridge/Acp/Dto/Message/AbstractJsonRpcNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Dto\Message;
+
+/**
+ * Abstract JSON-RPC notification.
+ */
+abstract class AbstractJsonRpcNotification
+{
+    public string $jsonrpc = '2.0';
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    public ?array $params = null;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    public ?array $meta = null;
+}

--- a/src/platform/src/Bridge/Acp/Dto/Message/JsonRpcRequest.php
+++ b/src/platform/src/Bridge/Acp/Dto/Message/JsonRpcRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Dto\Message;
+
+/**
+ * JSON-RPC Request.
+ */
+final class JsonRpcRequest
+{
+    public string $jsonrpc = '2.0';
+
+    public int|string|null $id = null;
+
+    public string $method = '';
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    public ?array $params = null;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    public ?array $meta = null;
+}

--- a/src/platform/src/Bridge/Acp/Dto/Notification/MessageStreamNotification.php
+++ b/src/platform/src/Bridge/Acp/Dto/Notification/MessageStreamNotification.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Dto\Notification;
+
+use Symfony\AI\Platform\Bridge\Acp\Dto\Message\AbstractJsonRpcNotification;
+use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+
+/**
+ * JSON-RPC notification: agent/messageStream.
+ */
+final class MessageStreamNotification extends AbstractJsonRpcNotification
+{
+    public string $method = 'agent/messageStream';
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    public ?array $content = null;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function setContent(array $data): void
+    {
+        $this->content = $data;
+    }
+
+    public function toDelta(): ?DeltaInterface
+    {
+        $type = $this->content['type'] ?? 'text';
+        $text = $this->content['text'] ?? '';
+
+        return match ($type) {
+            'text' => new TextDelta($text),
+            'thought' => new ThinkingDelta($text),
+            default => null,
+        };
+    }
+}

--- a/src/platform/src/Bridge/Acp/Dto/Notification/MessageStreamNotification.php
+++ b/src/platform/src/Bridge/Acp/Dto/Notification/MessageStreamNotification.php
@@ -38,8 +38,8 @@ final class MessageStreamNotification extends AbstractJsonRpcNotification
 
     public function toDelta(): ?DeltaInterface
     {
-        $type = $this->content['type'] ?? 'text';
-        $text = $this->content['text'] ?? '';
+        $type = $this->content ? ($this->content['type'] ?? 'text') : 'text';
+        $text = $this->content ? ($this->content['text'] ?? '') : '';
 
         return match ($type) {
             'text' => new TextDelta($text),

--- a/src/platform/src/Bridge/Acp/Dto/Notification/SessionUpdateNotification.php
+++ b/src/platform/src/Bridge/Acp/Dto/Notification/SessionUpdateNotification.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Dto\Notification;
+
+use Symfony\AI\Platform\Bridge\Acp\Dto\Message\AbstractJsonRpcNotification;
+use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
+
+/**
+ * JSON-RPC notification: session/update.
+ */
+final class SessionUpdateNotification extends AbstractJsonRpcNotification
+{
+    public string $method = 'session/update';
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    public ?array $update = null;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function setUpdate(array $data): void
+    {
+        $this->update = $data;
+    }
+
+    public function getUpdateType(): string
+    {
+        return $this->update['sessionUpdate'] ?? '';
+    }
+
+    public function getToolCallId(): ?string
+    {
+        return $this->update['toolCallId'] ?? null;
+    }
+
+    public function toDelta(): ?DeltaInterface
+    {
+        $type = $this->getUpdateType();
+
+        if ('agent_thought_chunk' === $type) {
+            $content = $this->update['content'] ?? [];
+            $text = \is_array($content) ? (string) ($content['text'] ?? '') : '';
+
+            return new ThinkingDelta($text);
+        }
+
+        if ('tool_call' === $type) {
+            $id = $this->getToolCallId();
+            $title = $this->update['title'] ?? '';
+
+            return \is_string($id) ? new ToolCallStart($id, $title) : null;
+        }
+
+        if ('tool_call_update' === $type) {
+            return $this->parseToolCallUpdate();
+        }
+
+        if (\in_array($type, ['agent_message_chunk', 'agent_message'], true)) {
+            $content = $this->update['content'] ?? [];
+            $contentType = \is_array($content) ? ($content['type'] ?? 'text') : 'text';
+            $text = \is_array($content) ? (string) ($content['text'] ?? '') : '';
+
+            return match ($contentType) {
+                'text' => new TextDelta($text),
+                'thought' => new ThinkingDelta($text),
+                default => null,
+            };
+        }
+
+        return null;
+    }
+
+    /**
+     * @return ToolCallComplete|ToolInputDelta|null
+     */
+    private function parseToolCallUpdate(): ?DeltaInterface
+    {
+        $id = $this->getToolCallId();
+        $title = $this->update['title'] ?? '';
+        $status = $this->update['status'] ?? '';
+
+        if (!\is_string($id)) {
+            return null;
+        }
+
+        if ('in_progress' === $status) {
+            $rawInput = $this->update['rawInput'] ?? [];
+            $json = \is_array($rawInput) ? json_encode($rawInput, \JSON_THROW_ON_ERROR) : (string) $rawInput;
+
+            return new ToolInputDelta($id, $title, $json);
+        }
+
+        if ('completed' === $status || 'failed' === $status) {
+            $arguments = [];
+            $rawOutput = $this->update['rawOutput'] ?? [];
+
+            if (\is_array($rawOutput) && isset($rawOutput['output'])) {
+                if (\is_array($rawOutput['output'])) {
+                    $arguments = $rawOutput['output'];
+                } else {
+                    $json = json_encode($rawOutput['output'], \JSON_THROW_ON_ERROR);
+                    if (json_validate($json)) {
+                        $arguments = json_decode($json, true, 512, \JSON_THROW_ON_ERROR) ?: [];
+                    }
+                }
+            }
+
+            $toolCall = new \Symfony\AI\Platform\Result\ToolCall($id, $title, $arguments);
+
+            return new ToolCallComplete([$toolCall]);
+        }
+
+        return null;
+    }
+}

--- a/src/platform/src/Bridge/Acp/Dto/Notification/SessionUpdateNotification.php
+++ b/src/platform/src/Bridge/Acp/Dto/Notification/SessionUpdateNotification.php
@@ -41,7 +41,7 @@ final class SessionUpdateNotification extends AbstractJsonRpcNotification
 
     public function getUpdateType(): string
     {
-        return $this->update['sessionUpdate'] ?? '';
+        return $this->update ? ($this->update['sessionUpdate'] ?? '') : '';
     }
 
     public function getToolCallId(): ?string
@@ -114,10 +114,7 @@ final class SessionUpdateNotification extends AbstractJsonRpcNotification
                 if (\is_array($rawOutput['output'])) {
                     $arguments = $rawOutput['output'];
                 } else {
-                    $json = json_encode($rawOutput['output'], \JSON_THROW_ON_ERROR);
-                    if (json_validate($json)) {
-                        $arguments = json_decode($json, true, 512, \JSON_THROW_ON_ERROR) ?: [];
-                    }
+                    $arguments = ['output' => $rawOutput['output']];
                 }
             }
 

--- a/src/platform/src/Bridge/Acp/Exception/CliNotFoundException.php
+++ b/src/platform/src/Bridge/Acp/Exception/CliNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Exception;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+
+/**
+ * Thrown when the ACP binary is not found or not executable.
+ */
+final class CliNotFoundException extends RuntimeException
+{
+}

--- a/src/platform/src/Bridge/Acp/Exception/ProtocolException.php
+++ b/src/platform/src/Bridge/Acp/Exception/ProtocolException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Exception;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+
+/**
+ * ACP protocol error.
+ */
+final class ProtocolException extends RuntimeException
+{
+}

--- a/src/platform/src/Bridge/Acp/Exception/TransportException.php
+++ b/src/platform/src/Bridge/Acp/Exception/TransportException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Exception;
+
+use Symfony\AI\Platform\Exception\RuntimeException;
+
+/**
+ * ACP transport error.
+ */
+final class TransportException extends RuntimeException
+{
+}

--- a/src/platform/src/Bridge/Acp/Factory.php
+++ b/src/platform/src/Bridge/Acp/Factory.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Bridge\Acp;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\AI\Platform\Bridge\Acp\Exception\TransportException;
 use Symfony\AI\Platform\Bridge\Acp\Transport\ProcessTransport;
 use Symfony\AI\Platform\Bridge\Acp\Transport\SocketTransport;
 use Symfony\AI\Platform\Contract;
@@ -48,14 +49,19 @@ class Factory
         ?int $port = null,
     ): ProviderInterface {
         $logger ??= new NullLogger();
-        $transportInstance = 'socket' === $transport
-            ? new SocketTransport(\sprintf('tcp://%s:%d', $host, $port), $logger)
-            : new ProcessTransport(
-                trim(($command ?? ($_ENV['ACP_BINARY'] ?? '')).' '.($_ENV['ACP_ARGS'] ?? '')),
+        if ('socket' === $transport) {
+            if (null === $host || null === $port) {
+                throw new TransportException('ACP socket transport requires both "host" and "port".');
+            }
+            $transportInstance = new SocketTransport(\sprintf('tcp://%s:%d', $host, $port), $logger);
+        } else {
+            $transportInstance = new ProcessTransport(
+                trim($command ?? ''),
                 $workingDirectory,
                 $environment,
                 $logger,
             );
+        }
 
         $modelClient = new ModelClient(
             command: $command ?? '',

--- a/src/platform/src/Bridge/Acp/Factory.php
+++ b/src/platform/src/Bridge/Acp/Factory.php
@@ -13,6 +13,8 @@ namespace Symfony\AI\Platform\Bridge\Acp;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\AI\Platform\Bridge\Acp\Transport\ProcessTransport;
+use Symfony\AI\Platform\Bridge\Acp\Transport\SocketTransport;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\ModelRouter\CatalogBasedModelRouter;
@@ -41,17 +43,27 @@ class Factory
         ModelCatalogInterface $modelCatalog = new ModelCatalog(),
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
+        string $transport = 'process',
+        ?string $host = null,
+        ?int $port = null,
     ): ProviderInterface {
-        $command = $command ?? ($_ENV['ACP_BINARY'] ?? 'opencode acp');
-        $args = $_ENV['ACP_ARGS'] ?? '';
-        $fullCommand = trim("$command $args");
+        $logger ??= new NullLogger();
+        $transportInstance = 'socket' === $transport
+            ? new SocketTransport(\sprintf('tcp://%s:%d', $host, $port), $logger)
+            : new ProcessTransport(
+                trim(($command ?? ($_ENV['ACP_BINARY'] ?? 'opencode acp')).' '.($_ENV['ACP_ARGS'] ?? '')),
+                $workingDirectory,
+                $environment,
+                $logger,
+            );
 
         $modelClient = new ModelClient(
-            command: $fullCommand,
+            command: $command ?? '',
             workingDirectory: $workingDirectory,
             environment: $environment,
             onStatus: $onStatus,
-            logger: $logger ?? new NullLogger(),
+            logger: $logger,
+            transport: $transportInstance,
         );
 
         return new Provider(
@@ -79,9 +91,12 @@ class Factory
         ?Contract $contract = null,
         ?EventDispatcherInterface $eventDispatcher = null,
         ?ModelRouterInterface $modelRouter = null,
+        string $transport = 'process',
+        ?string $host = null,
+        ?int $port = null,
     ): Platform {
         return new Platform(
-            [self::createProvider($name, $command, $workingDirectory, $environment, $onStatus, $logger, $modelCatalog, $contract, $eventDispatcher)],
+            [self::createProvider($name, $command, $workingDirectory, $environment, $onStatus, $logger, $modelCatalog, $contract, $eventDispatcher, $transport, $host, $port)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Acp/Factory.php
+++ b/src/platform/src/Bridge/Acp/Factory.php
@@ -51,7 +51,7 @@ class Factory
         $transportInstance = 'socket' === $transport
             ? new SocketTransport(\sprintf('tcp://%s:%d', $host, $port), $logger)
             : new ProcessTransport(
-                trim(($command ?? ($_ENV['ACP_BINARY'] ?? 'opencode acp')).' '.($_ENV['ACP_ARGS'] ?? '')),
+                trim(($command ?? ($_ENV['ACP_BINARY'] ?? '')).' '.($_ENV['ACP_ARGS'] ?? '')),
                 $workingDirectory,
                 $environment,
                 $logger,

--- a/src/platform/src/Bridge/Acp/Factory.php
+++ b/src/platform/src/Bridge/Acp/Factory.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\ModelRouter\CatalogBasedModelRouter;
+use Symfony\AI\Platform\ModelRouterInterface;
+use Symfony\AI\Platform\Platform;
+use Symfony\AI\Platform\Provider;
+use Symfony\AI\Platform\ProviderInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Factory for creating ACP provider and platform.
+ */
+class Factory
+{
+    /**
+     * @param non-empty-string      $name
+     * @param array<string, string> $environment
+     */
+    public static function createProvider(
+        string $name = 'acp',
+        ?string $command = null,
+        ?string $workingDirectory = null,
+        array $environment = [],
+        ?callable $onStatus = null,
+        ?LoggerInterface $logger = null,
+        ModelCatalogInterface $modelCatalog = new ModelCatalog(),
+        ?Contract $contract = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+    ): ProviderInterface {
+        $command = $command ?? ($_ENV['ACP_BINARY'] ?? 'opencode acp');
+        $args = $_ENV['ACP_ARGS'] ?? '';
+        $fullCommand = trim("$command $args");
+
+        $modelClient = new ModelClient(
+            command: $fullCommand,
+            workingDirectory: $workingDirectory,
+            environment: $environment,
+            onStatus: $onStatus,
+            logger: $logger ?? new NullLogger(),
+        );
+
+        return new Provider(
+            $name,
+            [$modelClient],
+            [new ResultConverter()],
+            $modelCatalog,
+            $contract ?? Contract::create(),
+            $eventDispatcher,
+        );
+    }
+
+    /**
+     * @param non-empty-string      $name
+     * @param array<string, string> $environment
+     */
+    public static function createPlatform(
+        string $name = 'acp',
+        ?string $command = null,
+        ?string $workingDirectory = null,
+        array $environment = [],
+        ?callable $onStatus = null,
+        ?LoggerInterface $logger = null,
+        ModelCatalogInterface $modelCatalog = new ModelCatalog(),
+        ?Contract $contract = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+        ?ModelRouterInterface $modelRouter = null,
+    ): Platform {
+        return new Platform(
+            [self::createProvider($name, $command, $workingDirectory, $environment, $onStatus, $logger, $modelCatalog, $contract, $eventDispatcher)],
+            $modelRouter ?? new CatalogBasedModelRouter(),
+            $eventDispatcher,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Acp/Factory.php
+++ b/src/platform/src/Bridge/Acp/Factory.php
@@ -39,7 +39,6 @@ class Factory
         ?string $command = null,
         ?string $workingDirectory = null,
         array $environment = [],
-        ?callable $onStatus = null,
         ?LoggerInterface $logger = null,
         ModelCatalogInterface $modelCatalog = new ModelCatalog(),
         ?Contract $contract = null,
@@ -67,7 +66,6 @@ class Factory
             command: $command ?? '',
             workingDirectory: $workingDirectory,
             environment: $environment,
-            onStatus: $onStatus,
             logger: $logger,
             transport: $transportInstance,
         );
@@ -91,7 +89,6 @@ class Factory
         ?string $command = null,
         ?string $workingDirectory = null,
         array $environment = [],
-        ?callable $onStatus = null,
         ?LoggerInterface $logger = null,
         ModelCatalogInterface $modelCatalog = new ModelCatalog(),
         ?Contract $contract = null,
@@ -102,7 +99,7 @@ class Factory
         ?int $port = null,
     ): Platform {
         return new Platform(
-            [self::createProvider($name, $command, $workingDirectory, $environment, $onStatus, $logger, $modelCatalog, $contract, $eventDispatcher, $transport, $host, $port)],
+            [self::createProvider($name, $command, $workingDirectory, $environment, $logger, $modelCatalog, $contract, $eventDispatcher, $transport, $host, $port)],
             $modelRouter ?? new CatalogBasedModelRouter(),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Acp/LICENSE
+++ b/src/platform/src/Bridge/Acp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Symfony Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/platform/src/Bridge/Acp/LICENSE
+++ b/src/platform/src/Bridge/Acp/LICENSE
@@ -1,13 +1,11 @@
-MIT License
-
-Copyright (c) Symfony Community
+Copyright (c) 2026-present Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
@@ -17,5 +15,5 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/platform/src/Bridge/Acp/ModelCatalog.php
+++ b/src/platform/src/Bridge/Acp/ModelCatalog.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp;
+
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\AbstractModelCatalog;
+
+/**
+ * Model catalog for ACP models.
+ */
+final class ModelCatalog extends AbstractModelCatalog
+{
+    /**
+     * @var array<string, array{class: class-string, capabilities: list<Capability>, clientCapabilities?: array<string, mixed>, requiredAgentCapabilities?: list<string>, protocolVersion?: int}>
+     */
+    protected array $models = [
+        'acp-v1' => [
+            'class' => Acp::class,
+            'capabilities' => [
+                Capability::INPUT_TEXT,
+                Capability::INPUT_MESSAGES,
+                Capability::OUTPUT_TEXT,
+            ],
+            'clientCapabilities' => [],
+            'requiredAgentCapabilities' => [],
+            'protocolVersion' => 1,
+        ],
+        'acp-v2' => [
+            'class' => Acp::class,
+            'capabilities' => [
+                Capability::INPUT_TEXT,
+                Capability::INPUT_MESSAGES,
+                Capability::OUTPUT_TEXT,
+            ],
+            'clientCapabilities' => [],
+            'requiredAgentCapabilities' => [],
+            'protocolVersion' => 2,
+        ],
+    ];
+
+    public function getModel(string $modelName): Model
+    {
+        $model = parent::getModel($modelName);
+
+        if ($model instanceof Acp) {
+            $parsed = $this->parseModelName($modelName);
+            $config = $this->models[$parsed['catalogKey']] ?? [];
+            $model->clientCapabilities = $config['clientCapabilities'] ?? [];
+            $model->requiredAgentCapabilities = $config['requiredAgentCapabilities'] ?? [];
+            $model->protocolVersion = $config['protocolVersion'] ?? 1;
+        }
+
+        return $model;
+    }
+}

--- a/src/platform/src/Bridge/Acp/ModelClient.php
+++ b/src/platform/src/Bridge/Acp/ModelClient.php
@@ -224,11 +224,30 @@ final class ModelClient implements ModelClientInterface
     {
         while (true) {
             $message = $this->readNextMessage();
-            if (($message['id'] ?? null) !== $requestId) {
+            $messageId = $message['id'] ?? null;
+
+            if (null === $messageId) {
+                if (isset($message['method'])) {
+                    $this->handleNotification($message);
+                }
                 continue;
             }
 
+            if ($messageId !== $requestId) {
+                throw new ProtocolException(\sprintf('Unexpected response ID "%s", expected "%s".', $messageId, $requestId));
+            }
+
             return $message;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    private function handleNotification(array $message): void
+    {
+        if (null !== $this->onStatus && 'status' === ($message['method'] ?? null)) {
+            ($this->onStatus)($message['params']['status'] ?? 'unknown');
         }
     }
 

--- a/src/platform/src/Bridge/Acp/ModelClient.php
+++ b/src/platform/src/Bridge/Acp/ModelClient.php
@@ -42,15 +42,12 @@ final class ModelClient implements ModelClientInterface
     private array $agentInfo = [];
 
     /**
-     * @param array<string, string>       $environment
-     * @param callable(string): void|null $onStatus
+     * @param array<string, string> $environment
      */
     public function __construct(
         private readonly string $command,
         private readonly ?string $workingDirectory = null,
         private readonly array $environment = [],
-        /** @var callable(string): void|null */
-        private $onStatus = null,
         private readonly LoggerInterface $logger = new NullLogger(),
         ?TransportInterface $transport = null,
     ) {
@@ -148,9 +145,7 @@ final class ModelClient implements ModelClientInterface
      */
     private function performHandshake(Acp $model, array $options): void
     {
-        if (null !== $this->onStatus) {
-            ($this->onStatus)('initializing');
-        }
+        $this->logger->info('ACP handshake initializing');
 
         $requestId = $this->nextId++;
         $this->transport->send([
@@ -212,9 +207,7 @@ final class ModelClient implements ModelClientInterface
         $this->sessionId = $sessionId;
         $this->handshakeDone = true;
 
-        if (null !== $this->onStatus) {
-            ($this->onStatus)('handshake_complete');
-        }
+        $this->logger->info('ACP handshake complete', ['sessionId' => $sessionId]);
     }
 
     /**
@@ -246,8 +239,8 @@ final class ModelClient implements ModelClientInterface
      */
     private function handleNotification(array $message): void
     {
-        if (null !== $this->onStatus && 'status' === ($message['method'] ?? null)) {
-            ($this->onStatus)($message['params']['status'] ?? 'unknown');
+        if ('status' === ($message['method'] ?? null)) {
+            $this->logger->info('ACP agent status', ['status' => $message['params']['status'] ?? 'unknown']);
         }
     }
 

--- a/src/platform/src/Bridge/Acp/ModelClient.php
+++ b/src/platform/src/Bridge/Acp/ModelClient.php
@@ -176,7 +176,7 @@ final class ModelClient implements ModelClientInterface
 
         $missingCapabilities = array_diff($model->requiredAgentCapabilities, array_keys(array_filter($this->agentCapabilities)));
         if ([] !== $missingCapabilities) {
-            throw new ProtocolException(\sprintf('ACP agent is missing required capabilities: %s.', implode(', ', $missingCapabilities)));
+            throw new ProtocolException(\sprintf('ACP agent is missing required capabilities: "%s".', implode(', ', $missingCapabilities)));
         }
 
         $sessionRequestId = $this->nextId++;

--- a/src/platform/src/Bridge/Acp/ModelClient.php
+++ b/src/platform/src/Bridge/Acp/ModelClient.php
@@ -1,0 +1,387 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\AI\Platform\Bridge\Acp\Exception\ProtocolException;
+use Symfony\AI\Platform\Bridge\Acp\Exception\TransportException;
+use Symfony\AI\Platform\Bridge\Acp\Transport\ProcessTransport;
+use Symfony\AI\Platform\Bridge\Acp\Transport\TransportInterface;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\RawResultInterface;
+
+/**
+ * ACP model client using transport abstraction.
+ */
+final class ModelClient implements ModelClientInterface
+{
+    private TransportInterface $transport;
+    private ?string $sessionId = null;
+    private int $nextId = 0;
+    private bool $handshakeDone = false;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $agentCapabilities = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $agentInfo = [];
+
+    /**
+     * @param array<string, string>       $environment
+     * @param callable(string): void|null $onStatus
+     */
+    public function __construct(
+        private readonly string $command,
+        private readonly ?string $workingDirectory = null,
+        private readonly array $environment = [],
+        /** @var callable(string): void|null */
+        private $onStatus = null,
+        private readonly LoggerInterface $logger = new NullLogger(),
+        ?TransportInterface $transport = null,
+    ) {
+        $this->transport = $transport ?? new ProcessTransport(
+            $command,
+            $workingDirectory,
+            $environment,
+            $logger,
+        );
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Acp;
+    }
+
+    public function request(Model $model, array|string $payload, array $options = []): RawResultInterface
+    {
+        if (!$model instanceof Acp) {
+            throw new ProtocolException(\sprintf('Unsupported model "%s".', $model::class));
+        }
+
+        $this->transport->start();
+
+        if (!$this->handshakeDone) {
+            $this->performHandshake($model, $options);
+        }
+
+        $prompt = $this->normalizePrompt($payload);
+        $requestId = $this->nextId++;
+
+        $this->transport->send([
+            'jsonrpc' => '2.0',
+            'id' => $requestId,
+            'method' => 'session/prompt',
+            'params' => [
+                'sessionId' => $this->sessionId,
+                'prompt' => $prompt,
+            ],
+        ]);
+
+        return new RawProcessResult($this, $requestId);
+    }
+
+    public function close(): void
+    {
+        if (!$this->transport->isRunning()) {
+            return;
+        }
+
+        if (null !== $this->sessionId && ($this->agentCapabilities['sessionCapabilities']['close'] ?? null) !== null) {
+            $requestId = $this->nextId++;
+            $this->transport->send([
+                'jsonrpc' => '2.0',
+                'id' => $requestId,
+                'method' => 'session/close',
+                'params' => ['sessionId' => $this->sessionId],
+            ]);
+            $this->readUntilResponse($requestId);
+        }
+
+        $this->transport->close();
+        $this->sessionId = null;
+        $this->handshakeDone = false;
+        $this->agentCapabilities = [];
+        $this->agentInfo = [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function readNextMessage(): array
+    {
+        return $this->transport->readNextMessage();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getAgentCapabilities(): array
+    {
+        return $this->agentCapabilities;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getAgentInfo(): array
+    {
+        return $this->agentInfo;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function performHandshake(Acp $model, array $options): void
+    {
+        if (null !== $this->onStatus) {
+            ($this->onStatus)('initializing');
+        }
+
+        $requestId = $this->nextId++;
+        $this->transport->send([
+            'jsonrpc' => '2.0',
+            'id' => $requestId,
+            'method' => 'initialize',
+            'params' => [
+                'protocolVersion' => $model->protocolVersion,
+                'clientCapabilities' => (object) $model->clientCapabilities,
+                'clientInfo' => [
+                    'name' => 'symfony-ai',
+                    'title' => 'Symfony AI',
+                    'version' => '0.1.0',
+                ],
+            ],
+        ]);
+
+        $response = $this->readUntilResponse($requestId);
+        $result = $this->extractResult($response);
+        $protocolVersion = $result['protocolVersion'] ?? null;
+        if (!\is_int($protocolVersion) || $protocolVersion < 1) {
+            throw new ProtocolException('ACP returned an unsupported protocol version.');
+        }
+
+        $model->protocolVersion = min($model->protocolVersion, $protocolVersion);
+        $this->agentCapabilities = \is_array($result['agentCapabilities'] ?? null) ? $result['agentCapabilities'] : [];
+        $this->agentInfo = \is_array($result['agentInfo'] ?? null) ? $result['agentInfo'] : [];
+
+        $missingCapabilities = array_diff($model->requiredAgentCapabilities, array_keys(array_filter($this->agentCapabilities)));
+        if ([] !== $missingCapabilities) {
+            throw new ProtocolException(\sprintf('ACP agent is missing required capabilities: %s.', implode(', ', $missingCapabilities)));
+        }
+
+        $sessionRequestId = $this->nextId++;
+        $params = [
+            'cwd' => $this->resolveWorkingDirectory($options),
+            'mcpServers' => [],
+        ];
+
+        if (isset($options['additionalDirectories']) && [] !== $options['additionalDirectories']) {
+            $params['additionalDirectories'] = $options['additionalDirectories'];
+        }
+
+        $this->transport->send([
+            'jsonrpc' => '2.0',
+            'id' => $sessionRequestId,
+            'method' => 'session/new',
+            'params' => $params,
+        ]);
+
+        $sessionResponse = $this->readUntilResponse($sessionRequestId);
+        $sessionResult = $this->extractResult($sessionResponse);
+        $sessionId = $sessionResult['sessionId'] ?? null;
+
+        if (!\is_string($sessionId) || '' === $sessionId) {
+            throw new ProtocolException('ACP did not return a sessionId.');
+        }
+
+        $this->sessionId = $sessionId;
+        $this->handshakeDone = true;
+
+        if (null !== $this->onStatus) {
+            ($this->onStatus)('handshake_complete');
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readUntilResponse(int $requestId): array
+    {
+        while (true) {
+            $message = $this->readNextMessage();
+            if (($message['id'] ?? null) !== $requestId) {
+                continue;
+            }
+
+            return $message;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     *
+     * @return array<string, mixed>
+     */
+    private function extractResult(array $message): array
+    {
+        if (isset($message['error'])) {
+            $error = $message['error'];
+            $messageText = \is_array($error) ? (string) ($error['message'] ?? 'Unknown ACP error') : 'Unknown ACP error';
+            throw new ProtocolException($messageText);
+        }
+
+        return \is_array($message['result'] ?? null) ? $message['result'] : [];
+    }
+
+    /**
+     * @param array<string, mixed>|string $payload
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function normalizePrompt(array|string $payload): array
+    {
+        if (\is_string($payload)) {
+            return [['type' => 'text', 'text' => $payload]];
+        }
+
+        $prompt = $payload['prompt'] ?? null;
+        if (\is_array($prompt)) {
+            return $this->normalizePromptEntries($prompt, $payload);
+        }
+
+        $messages = $payload['messages'] ?? null;
+        if (\is_array($messages)) {
+            return $this->normalizeMessages($messages, $payload);
+        }
+
+        return [['type' => 'text', 'text' => json_encode($payload, \JSON_THROW_ON_ERROR)]];
+    }
+
+    /**
+     * @param list<mixed>  $prompt
+     * @param array<mixed> $fallbackPayload
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function normalizePromptEntries(array $prompt, array $fallbackPayload): array
+    {
+        $normalized = [];
+        foreach ($prompt as $entry) {
+            if (\is_string($entry)) {
+                $normalized[] = ['type' => 'text', 'text' => $entry];
+                continue;
+            }
+
+            if (!\is_array($entry)) {
+                continue;
+            }
+
+            $type = $entry['type'] ?? 'text';
+            if ('text' === $type && isset($entry['text']) && \is_string($entry['text'])) {
+                $normalized[] = ['type' => 'text', 'text' => $entry['text']];
+                continue;
+            }
+
+            $normalized[] = $entry;
+        }
+
+        if ([] !== $normalized) {
+            return $normalized;
+        }
+
+        return [['type' => 'text', 'text' => json_encode($fallbackPayload, \JSON_THROW_ON_ERROR)]];
+    }
+
+    /**
+     * @param list<mixed>  $messages
+     * @param array<mixed> $fallbackPayload
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeMessages(array $messages, array $fallbackPayload): array
+    {
+        $parts = [];
+
+        foreach ($messages as $message) {
+            if (!\is_array($message)) {
+                continue;
+            }
+
+            $text = $this->normalizeMessageContent($message['content'] ?? null);
+            if (null === $text) {
+                continue;
+            }
+
+            $role = $message['role'] ?? 'user';
+            $parts[] = ['type' => 'text', 'text' => \sprintf('[%s] %s', $role, $text)];
+        }
+
+        if ([] !== $parts) {
+            return $parts;
+        }
+
+        return [['type' => 'text', 'text' => json_encode($fallbackPayload, \JSON_THROW_ON_ERROR)]];
+    }
+
+    private function normalizeMessageContent(mixed $content): ?string
+    {
+        if (\is_string($content)) {
+            return $content;
+        }
+
+        if (!\is_array($content)) {
+            return null;
+        }
+
+        $parts = [];
+        foreach ($content as $part) {
+            if (\is_string($part)) {
+                $parts[] = $part;
+                continue;
+            }
+
+            if (!\is_array($part)) {
+                continue;
+            }
+
+            if (($part['type'] ?? null) === 'text' && \is_string($part['text'] ?? null)) {
+                $parts[] = $part['text'];
+            }
+        }
+
+        if ([] === $parts) {
+            return null;
+        }
+
+        return implode("\n", $parts);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function resolveWorkingDirectory(array $options): string
+    {
+        $cwd = $options['cwd'] ?? $this->workingDirectory ?? getcwd();
+
+        if (!\is_string($cwd) || '' === $cwd) {
+            throw new TransportException('ACP working directory must be a non-empty string.');
+        }
+
+        return $cwd;
+    }
+}

--- a/src/platform/src/Bridge/Acp/README.md
+++ b/src/platform/src/Bridge/Acp/README.md
@@ -1,0 +1,50 @@
+# ACP Platform Bridge
+
+This bridge integrates the [Agent Client Protocol (ACP)](https://agentclientprotocol.com) into the Symfony AI Platform.
+
+## Installation
+
+```bash
+composer require symfony/ai-acp-platform
+```
+
+## Usage
+
+```php
+use Symfony\AI\Platform\Bridge\Acp\Factory;
+use Symfony\AI\Platform\Message\Message;
+
+$platform = Factory::createPlatform(
+    name: 'my-acp-agent',
+    command: $_ENV['ACP_BINARY'] ?? 'opencode acp',
+    onStatus: fn(string $status) => echo "[acp] $status\n",
+);
+
+$result = $platform->invoke('acp-default', Message::ofUser('List files'), ['stream' => true]);
+
+foreach ($result->asStream() as $delta) {
+    // Handle TextDelta, ThinkingDelta, ToolCallStart, ToolInputDelta, ToolCallComplete
+}
+```
+
+## Configuration
+
+- **`ACP_BINARY`** (env var): Path to the ACP CLI binary (default: `opencode acp`)
+- **`ACP_ARGS`** (env var): Additional arguments for the ACP CLI
+- **`workingDirectory`**: Working directory for the ACP process
+- **`environment`**: Environment variables for the ACP process
+- **`protocolVersion`**: ACP protocol version (default: 1)
+
+## Features
+
+- ✅ Text and thinking streaming
+- ✅ Tool call support (start, input, complete)
+- ✅ Multi-version protocol support (v1, v2 ready)
+- ✅ Configurable binary path
+- ✅ Session management
+
+## Notes
+
+- ACP v2 is still in draft. This bridge supports v1 and prepares for v2, but v2-specific features are not yet implemented.
+- Token usage extraction is not supported in v1 (waiting for stable spec).
+- Advanced content types (image, audio, diffs, terminal) are preserved in raw results but not converted to deltas yet.

--- a/src/platform/src/Bridge/Acp/README.md
+++ b/src/platform/src/Bridge/Acp/README.md
@@ -20,6 +20,14 @@ $platform = Factory::createPlatform(
     onStatus: fn(string $status) => echo "[acp] $status\n",
 );
 
+$socketPlatform = Factory::createPlatform(
+    name: 'copilot-acp',
+    transport: 'socket',
+    host: '127.0.0.1',
+    port: 3000,
+    onStatus: fn(string $status) => echo "[acp] $status\n",
+);
+
 $result = $platform->invoke('acp-default', Message::ofUser('List files'), ['stream' => true]);
 
 foreach ($result->asStream() as $delta) {
@@ -29,9 +37,11 @@ foreach ($result->asStream() as $delta) {
 
 ## Configuration
 
+- **`transport`**: ACP transport (`process` or `socket`, default: `process`)
 - **`ACP_BINARY`** (env var): Path to the ACP CLI binary (default: `opencode acp`)
 - **`ACP_ARGS`** (env var): Additional arguments for the ACP CLI
-- **`workingDirectory`**: Working directory for the ACP process
+- **`host` / `port`**: TCP socket endpoint for ACP servers such as Copilot
+- **`workingDirectory`**: Working directory for the ACP process and default session cwd
 - **`environment`**: Environment variables for the ACP process
 - **`protocolVersion`**: ACP protocol version (default: 1)
 

--- a/src/platform/src/Bridge/Acp/README.md
+++ b/src/platform/src/Bridge/Acp/README.md
@@ -1,60 +1,17 @@
-# ACP Platform Bridge
+ACP Platform
+============
 
-This bridge integrates the [Agent Client Protocol (ACP)](https://agentclientprotocol.com) into the Symfony AI Platform.
+Agent Client Protocol (ACP) platform bridge for Symfony AI.
 
-## Installation
+ACP Documentation
+-----------------
 
-```bash
-composer require symfony/ai-acp-platform
-```
+* [Agent Client Protocol](https://agentclientprotocol.com)
 
-## Usage
+Resources
+---------
 
-```php
-use Symfony\AI\Platform\Bridge\Acp\Factory;
-use Symfony\AI\Platform\Message\Message;
-
-$platform = Factory::createPlatform(
-    name: 'my-acp-agent',
-    command: $_ENV['ACP_BINARY'] ?? 'opencode acp',
-    onStatus: fn(string $status) => echo "[acp] $status\n",
-);
-
-$socketPlatform = Factory::createPlatform(
-    name: 'copilot-acp',
-    transport: 'socket',
-    host: '127.0.0.1',
-    port: 3000,
-    onStatus: fn(string $status) => echo "[acp] $status\n",
-);
-
-$result = $platform->invoke('acp-default', Message::ofUser('List files'), ['stream' => true]);
-
-foreach ($result->asStream() as $delta) {
-    // Handle TextDelta, ThinkingDelta, ToolCallStart, ToolInputDelta, ToolCallComplete
-}
-```
-
-## Configuration
-
-- **`transport`**: ACP transport (`process` or `socket`, default: `process`)
-- **`ACP_BINARY`** (env var): Path to the ACP CLI binary (default: `opencode acp`)
-- **`ACP_ARGS`** (env var): Additional arguments for the ACP CLI
-- **`host` / `port`**: TCP socket endpoint for ACP servers such as Copilot
-- **`workingDirectory`**: Working directory for the ACP process and default session cwd
-- **`environment`**: Environment variables for the ACP process
-- **`protocolVersion`**: ACP protocol version (default: 1)
-
-## Features
-
-- ✅ Text and thinking streaming
-- ✅ Tool call support (start, input, complete)
-- ✅ Multi-version protocol support (v1, v2 ready)
-- ✅ Configurable binary path
-- ✅ Session management
-
-## Notes
-
-- ACP v2 is still in draft. This bridge supports v1 and prepares for v2, but v2-specific features are not yet implemented.
-- Token usage extraction is not supported in v1 (waiting for stable spec).
-- Advanced content types (image, audio, diffs, terminal) are preserved in raw results but not converted to deltas yet.
+* [Contributing](https://symfony.com/doc/current/contributing/index.html)
+* [Report issues](https://github.com/symfony/ai/issues) and
+  [send Pull Requests](https://github.com/symfony/ai/pulls)
+  in the [main Symfony AI repository](https://github.com/symfony/ai)

--- a/src/platform/src/Bridge/Acp/RawProcessResult.php
+++ b/src/platform/src/Bridge/Acp/RawProcessResult.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp;
+
+use Symfony\AI\Platform\Bridge\Acp\Exception\ProtocolException;
+use Symfony\AI\Platform\Bridge\Acp\Exception\TransportException;
+use Symfony\AI\Platform\Result\RawResultInterface;
+
+/**
+ * Wraps ACP process output as a raw result.
+ */
+final class RawProcessResult implements RawResultInterface
+{
+    /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $data = null;
+
+    /**
+     * @var list<array<string, mixed>>
+     */
+    private array $lines = [];
+
+    private bool $drained = false;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $response = null;
+
+    public function __construct(
+        private readonly ModelClient $client,
+        private readonly int $requestId,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getData(): array
+    {
+        if (!$this->drained) {
+            $this->drain();
+        }
+
+        return $this->data ?? [];
+    }
+
+    /**
+     * @return \Generator<int, array<string, mixed>>
+     */
+    public function getDataStream(): \Generator
+    {
+        if ($this->drained) {
+            foreach ($this->lines as $line) {
+                yield $line;
+            }
+
+            return;
+        }
+
+        yield from $this->streamLines();
+    }
+
+    /**
+     * Reads pending notifications after response.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function drainPending(): array
+    {
+        $late = [];
+
+        while (true) {
+            try {
+                $message = $this->client->readNextMessage();
+
+                if (isset($message['id'])) {
+                    if ($message['id'] === $this->requestId) {
+                        $this->response = $message;
+                        $this->processResponse();
+
+                        break;
+                    }
+                } else {
+                    $this->lines[] = $message;
+                    $late[] = $message;
+                }
+            } catch (TransportException) {
+                break;
+            }
+        }
+
+        return $late;
+    }
+
+    public function getObject(): object
+    {
+        if (!$this->drained) {
+            $this->drain();
+        }
+
+        if (null === $this->response) {
+            return new \stdClass();
+        }
+
+        $json = json_encode($this->response, \JSON_THROW_ON_ERROR);
+
+        return json_decode($json, false, 512, \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getResponse(): ?array
+    {
+        if (!$this->drained) {
+            $this->drain();
+        }
+
+        return $this->response;
+    }
+
+    private function drain(): void
+    {
+        foreach ($this->streamLines() as $_) {
+        }
+    }
+
+    /**
+     * @return \Generator<int, array<string, mixed>>
+     */
+    private function streamLines(): \Generator
+    {
+        while (true) {
+            $message = $this->client->readNextMessage();
+
+            if (isset($message['id'])) {
+                if ($message['id'] === $this->requestId) {
+                    $this->response = $message;
+                    $this->processResponse();
+                    $this->drained = true;
+
+                    break;
+                }
+
+                continue;
+            }
+
+            $this->lines[] = $message;
+            yield $message;
+        }
+    }
+
+    private function processResponse(): void
+    {
+        if (null === $this->response) {
+            return;
+        }
+
+        if (isset($this->response['error'])) {
+            $error = $this->response['error'];
+            $message = \is_array($error) ? (string) ($error['message'] ?? 'Unknown ACP error') : 'Unknown ACP error';
+            throw new ProtocolException($message);
+        }
+
+        $this->data = \is_array($this->response['result'] ?? null) ? $this->response['result'] : [];
+    }
+}

--- a/src/platform/src/Bridge/Acp/RawProcessResult.php
+++ b/src/platform/src/Bridge/Acp/RawProcessResult.php
@@ -153,7 +153,7 @@ final class RawProcessResult implements RawResultInterface
                     break;
                 }
 
-                continue;
+                throw new ProtocolException(\sprintf('Unexpected response ID "%s", expected "%s".', $message['id'], $this->requestId));
             }
 
             $this->lines[] = $message;

--- a/src/platform/src/Bridge/Acp/ResultConverter.php
+++ b/src/platform/src/Bridge/Acp/ResultConverter.php
@@ -24,6 +24,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
@@ -52,12 +53,25 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         $text = '';
+        $thinking = '';
         $toolCalls = [];
 
         foreach ($result->getDataStream() as $message) {
             $delta = $this->messageToDelta($message);
-            if (null !== $delta) {
-                $this->accumulateDelta($delta, $text, $toolCalls);
+            if (null === $delta) {
+                continue;
+            }
+
+            if ($delta instanceof TextDelta) {
+                $text .= $delta->getText();
+            }
+            if ($delta instanceof ThinkingDelta) {
+                $thinking .= $delta->getThinking();
+            }
+            if ($delta instanceof ToolCallComplete) {
+                foreach ($delta->getToolCalls() as $toolCall) {
+                    $toolCalls[$toolCall->getId()] = $toolCall;
+                }
             }
         }
 
@@ -68,6 +82,10 @@ final class ResultConverter implements ResultConverterInterface
 
         if ('' !== $text) {
             $results[] = new TextResult($text);
+        }
+
+        if ('' !== $thinking) {
+            $results[] = new ThinkingResult($thinking);
         }
 
         if ([] === $results) {
@@ -212,21 +230,5 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         return null;
-    }
-
-    /**
-     * @param array<ToolCall> $toolCalls
-     */
-    private function accumulateDelta(DeltaInterface $delta, string &$text, array &$toolCalls): void
-    {
-        if ($delta instanceof TextDelta) {
-            $text .= $delta->getText();
-        } elseif ($delta instanceof ThinkingDelta) {
-            $text .= $delta->getThinking();
-        } elseif ($delta instanceof ToolCallComplete) {
-            foreach ($delta->getToolCalls() as $toolCall) {
-                $toolCalls[] = $toolCall;
-            }
-        }
     }
 }

--- a/src/platform/src/Bridge/Acp/ResultConverter.php
+++ b/src/platform/src/Bridge/Acp/ResultConverter.php
@@ -1,0 +1,232 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp;
+
+use Symfony\AI\Platform\Bridge\Acp\Exception\ProtocolException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+
+/**
+ * Converts ACP stream output to Platform result objects.
+ */
+final class ResultConverter implements ResultConverterInterface
+{
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Acp;
+    }
+
+    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    {
+        if ($options['stream'] ?? false) {
+            return new StreamResult($this->convertStream($result));
+        }
+
+        $data = $result->getData();
+
+        if ([] === $data) {
+            throw new ProtocolException('ACP did not return any result.');
+        }
+
+        $text = '';
+        $toolCalls = [];
+
+        foreach ($result->getDataStream() as $message) {
+            $delta = $this->messageToDelta($message);
+            if (null !== $delta) {
+                $this->accumulateDelta($delta, $text, $toolCalls);
+            }
+        }
+
+        $results = [];
+        foreach ($toolCalls as $toolCall) {
+            $results[] = new ToolCallResult([$toolCall]);
+        }
+
+        if ('' !== $text) {
+            $results[] = new TextResult($text);
+        }
+
+        if ([] === $results) {
+            throw new ProtocolException('ACP result does not contain any supported content.');
+        }
+
+        if (1 === \count($results)) {
+            return $results[0];
+        }
+
+        return new MultiPartResult($results);
+    }
+
+    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    {
+        return null;
+    }
+
+    /**
+     * @return \Generator<int, DeltaInterface>
+     */
+    private function convertStream(RawResultInterface $result): \Generator
+    {
+        foreach ($result->getDataStream() as $message) {
+            $delta = $this->messageToDelta($message);
+            if (null !== $delta) {
+                yield $delta;
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    private function messageToDelta(array $message): ?DeltaInterface
+    {
+        $method = $message['method'] ?? '';
+
+        if ('agent/messageStream' === $method) {
+            return $this->parseMessageStream($message);
+        }
+
+        if ('session/update' === $method) {
+            return $this->parseSessionUpdate($message);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    private function parseMessageStream(array $message): ?DeltaInterface
+    {
+        $content = $message['params']['content'] ?? [];
+        $type = $content['type'] ?? 'text';
+        $text = $content['text'] ?? '';
+
+        return match ($type) {
+            'text' => new TextDelta($text),
+            'thought' => new ThinkingDelta($text),
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    private function parseSessionUpdate(array $message): ?DeltaInterface
+    {
+        $update = $message['params']['update'] ?? [];
+        $type = $update['sessionUpdate'] ?? '';
+
+        if ('agent_thought_chunk' === $type) {
+            $content = $update['content'] ?? [];
+            $text = \is_array($content) ? (string) ($content['text'] ?? '') : '';
+
+            return new ThinkingDelta($text);
+        }
+
+        if ('tool_call' === $type) {
+            $id = $update['toolCallId'] ?? null;
+            $title = $update['title'] ?? '';
+
+            return \is_string($id) ? new ToolCallStart($id, $title) : null;
+        }
+
+        if ('tool_call_update' === $type) {
+            return $this->parseToolCallUpdate($update);
+        }
+
+        if (\in_array($type, ['agent_message_chunk', 'agent_message'], true)) {
+            $content = $update['content'] ?? [];
+            $contentType = \is_array($content) ? ($content['type'] ?? 'text') : 'text';
+            $text = \is_array($content) ? (string) ($content['text'] ?? '') : '';
+
+            return match ($contentType) {
+                'text' => new TextDelta($text),
+                'thought' => new ThinkingDelta($text),
+                default => null,
+            };
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $update
+     */
+    private function parseToolCallUpdate(array $update): ?DeltaInterface
+    {
+        $id = $update['toolCallId'] ?? null;
+        $title = $update['title'] ?? '';
+        $status = $update['status'] ?? '';
+
+        if (!\is_string($id)) {
+            return null;
+        }
+
+        if ('in_progress' === $status) {
+            $rawInput = $update['rawInput'] ?? [];
+            $json = \is_array($rawInput) ? json_encode($rawInput, \JSON_THROW_ON_ERROR) : (string) $rawInput;
+
+            return new ToolInputDelta($id, $title, $json);
+        }
+
+        if ('completed' === $status || 'failed' === $status) {
+            $arguments = [];
+            $rawOutput = $update['rawOutput'] ?? [];
+
+            if (\is_array($rawOutput) && isset($rawOutput['output'])) {
+                if (\is_array($rawOutput['output'])) {
+                    $arguments = $rawOutput['output'];
+                } else {
+                    $arguments = ['output' => $rawOutput['output']];
+                }
+            }
+
+            $toolCall = new ToolCall($id, $title, $arguments);
+
+            return new ToolCallComplete([$toolCall]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<ToolCall> $toolCalls
+     */
+    private function accumulateDelta(DeltaInterface $delta, string &$text, array &$toolCalls): void
+    {
+        if ($delta instanceof TextDelta) {
+            $text .= $delta->getText();
+        } elseif ($delta instanceof ThinkingDelta) {
+            $text .= $delta->getThinking();
+        } elseif ($delta instanceof ToolCallComplete) {
+            foreach ($delta->getToolCalls() as $toolCall) {
+                $toolCalls[] = $toolCall;
+            }
+        }
+    }
+}

--- a/src/platform/src/Bridge/Acp/ResultConverter.php
+++ b/src/platform/src/Bridge/Acp/ResultConverter.php
@@ -81,7 +81,7 @@ final class ResultConverter implements ResultConverterInterface
         return new MultiPartResult($results);
     }
 
-    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    public function getTokenUsageExtractor(): TokenUsageExtractorInterface
     {
         return new TokenUsageExtractor();
     }

--- a/src/platform/src/Bridge/Acp/ResultConverter.php
+++ b/src/platform/src/Bridge/Acp/ResultConverter.php
@@ -83,7 +83,7 @@ final class ResultConverter implements ResultConverterInterface
 
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
     {
-        return null;
+        return new TokenUsageExtractor();
     }
 
     /**

--- a/src/platform/src/Bridge/Acp/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/ModelCatalogTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Acp\Acp;
+use Symfony\AI\Platform\Bridge\Acp\ModelCatalog;
+use Symfony\AI\Platform\Capability;
+
+/**
+ * @covers \Symfony\AI\Platform\Bridge\Acp\ModelCatalog
+ */
+final class ModelCatalogTest extends TestCase
+{
+    public function testGetModelReturnsAcpModelWithCorrectCapabilities(): void
+    {
+        $catalog = new ModelCatalog();
+
+        $model = $catalog->getModel('acp-v1');
+
+        $this->assertInstanceOf(Acp::class, $model);
+        $this->assertTrue($model->supports(Capability::INPUT_TEXT));
+        $this->assertTrue($model->supports(Capability::INPUT_MESSAGES));
+        $this->assertTrue($model->supports(Capability::OUTPUT_TEXT));
+        $this->assertFalse($model->supports(Capability::INPUT_IMAGE));
+        $this->assertSame([], $model->clientCapabilities);
+        $this->assertSame([], $model->requiredAgentCapabilities);
+        $this->assertSame(1, $model->protocolVersion);
+    }
+
+    public function testGetModelAcpV2SetsProtocolVersion(): void
+    {
+        $catalog = new ModelCatalog();
+
+        $model = $catalog->getModel('acp-v2');
+
+        $this->assertInstanceOf(Acp::class, $model);
+        $this->assertSame(2, $model->protocolVersion);
+    }
+
+    public function testGetModelSetsClientCapabilitiesFromCatalog(): void
+    {
+        $catalog = new ModelCatalog();
+
+        $model = $catalog->getModel('acp-v1');
+
+        $this->assertInstanceOf(Acp::class, $model);
+        $this->assertSame([], $model->clientCapabilities);
+        $this->assertSame([], $model->requiredAgentCapabilities);
+    }
+}

--- a/src/platform/src/Bridge/Acp/Tests/ModelCatalogTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/ModelCatalogTest.php
@@ -21,7 +21,7 @@ use Symfony\AI\Platform\Capability;
  */
 final class ModelCatalogTest extends TestCase
 {
-    public function testGetModelReturnsAcpModelWithCorrectCapabilities(): void
+    public function testGetModelReturnsAcpModelWithCorrectCapabilities()
     {
         $catalog = new ModelCatalog();
 
@@ -37,7 +37,7 @@ final class ModelCatalogTest extends TestCase
         $this->assertSame(1, $model->protocolVersion);
     }
 
-    public function testGetModelAcpV2SetsProtocolVersion(): void
+    public function testGetModelAcpV2SetsProtocolVersion()
     {
         $catalog = new ModelCatalog();
 
@@ -47,7 +47,7 @@ final class ModelCatalogTest extends TestCase
         $this->assertSame(2, $model->protocolVersion);
     }
 
-    public function testGetModelSetsClientCapabilitiesFromCatalog(): void
+    public function testGetModelSetsClientCapabilitiesFromCatalog()
     {
         $catalog = new ModelCatalog();
 

--- a/src/platform/src/Bridge/Acp/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/ModelClientTest.php
@@ -28,21 +28,21 @@ use Symfony\AI\Platform\Model;
  */
 final class ModelClientTest extends TestCase
 {
-    public function testSupportsAcpModel(): void
+    public function testSupportsAcpModel()
     {
         $client = new ModelClient('dummy', null, [], null, new NullLogger(), new FakeTransport());
 
         $this->assertTrue($client->supports(new Acp('acp-v1')));
     }
 
-    public function testDoesNotSupportOtherModels(): void
+    public function testDoesNotSupportOtherModels()
     {
         $client = new ModelClient('dummy', null, [], null, new NullLogger(), new FakeTransport());
 
         $this->assertFalse($client->supports(new Model('other')));
     }
 
-    public function testThrowsExceptionWhenCliNotFound(): void
+    public function testThrowsExceptionWhenCliNotFound()
     {
         $this->expectException(CliNotFoundException::class);
         $this->expectExceptionMessage('ACP binary "" was not found.');
@@ -51,7 +51,7 @@ final class ModelClientTest extends TestCase
         $client->request(new Acp('acp-v1'), 'Hello');
     }
 
-    public function testRequestReturnsRawProcessResult(): void
+    public function testRequestReturnsRawProcessResult()
     {
         $transport = new FakeTransport([
             ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
@@ -64,7 +64,7 @@ final class ModelClientTest extends TestCase
         $this->assertInstanceOf(RawProcessResult::class, $result);
     }
 
-    public function testRequestSendsNormalizedStringPrompt(): void
+    public function testRequestSendsNormalizedStringPrompt()
     {
         $transport = new FakeTransport([
             ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
@@ -80,7 +80,7 @@ final class ModelClientTest extends TestCase
         $this->assertSame([['type' => 'text', 'text' => 'Hello']], $messages[2]['params']['prompt']);
     }
 
-    public function testRequestSendsPromptArrayFromPayload(): void
+    public function testRequestSendsPromptArrayFromPayload()
     {
         $transport = new FakeTransport([
             ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
@@ -94,7 +94,7 @@ final class ModelClientTest extends TestCase
         $this->assertSame([['type' => 'text', 'text' => 'What is PHP?']], $messages[2]['params']['prompt']);
     }
 
-    public function testRequestNormalizesMessageBagPayload(): void
+    public function testRequestNormalizesMessageBagPayload()
     {
         $transport = new FakeTransport([
             ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
@@ -115,7 +115,7 @@ final class ModelClientTest extends TestCase
         ], $messages[2]['params']['prompt']);
     }
 
-    public function testCloseClosesTransport(): void
+    public function testCloseClosesTransport()
     {
         $transport = new FakeTransport();
         $transport->start();

--- a/src/platform/src/Bridge/Acp/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/ModelClientTest.php
@@ -30,14 +30,14 @@ final class ModelClientTest extends TestCase
 {
     public function testSupportsAcpModel()
     {
-        $client = new ModelClient('dummy', null, [], null, new NullLogger(), new FakeTransport());
+        $client = new ModelClient('dummy', null, [], new NullLogger(), new FakeTransport());
 
         $this->assertTrue($client->supports(new Acp('acp-v1')));
     }
 
     public function testDoesNotSupportOtherModels()
     {
-        $client = new ModelClient('dummy', null, [], null, new NullLogger(), new FakeTransport());
+        $client = new ModelClient('dummy', null, [], new NullLogger(), new FakeTransport());
 
         $this->assertFalse($client->supports(new Model('other')));
     }
@@ -47,7 +47,7 @@ final class ModelClientTest extends TestCase
         $this->expectException(CliNotFoundException::class);
         $this->expectExceptionMessage('ACP binary "" was not found.');
 
-        $client = new ModelClient('');
+        $client = new ModelClient('', null, [], new NullLogger());
         $client->request(new Acp('acp-v1'), 'Hello');
     }
 
@@ -57,7 +57,7 @@ final class ModelClientTest extends TestCase
             ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
             ['jsonrpc' => '2.0', 'id' => 1, 'result' => ['sessionId' => 'session-1']],
         ]);
-        $client = new ModelClient('dummy', null, [], null, new NullLogger(), $transport);
+        $client = new ModelClient('dummy', null, [], new NullLogger(), $transport);
 
         $result = $client->request(new Acp('acp-v1'), 'Hello');
 
@@ -70,7 +70,7 @@ final class ModelClientTest extends TestCase
             ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
             ['jsonrpc' => '2.0', 'id' => 1, 'result' => ['sessionId' => 'session-1']],
         ]);
-        $client = new ModelClient('dummy', null, [], null, new NullLogger(), $transport);
+        $client = new ModelClient('dummy', null, [], new NullLogger(), $transport);
 
         $client->request(new Acp('acp-v1'), 'Hello');
 
@@ -86,7 +86,7 @@ final class ModelClientTest extends TestCase
             ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
             ['jsonrpc' => '2.0', 'id' => 1, 'result' => ['sessionId' => 'session-1']],
         ]);
-        $client = new ModelClient('dummy', null, [], null, new NullLogger(), $transport);
+        $client = new ModelClient('dummy', null, [], new NullLogger(), $transport);
 
         $client->request(new Acp('acp-v1'), ['prompt' => ['What is PHP?']]);
 
@@ -100,7 +100,7 @@ final class ModelClientTest extends TestCase
             ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
             ['jsonrpc' => '2.0', 'id' => 1, 'result' => ['sessionId' => 'session-1']],
         ]);
-        $client = new ModelClient('dummy', null, [], null, new NullLogger(), $transport);
+        $client = new ModelClient('dummy', null, [], new NullLogger(), $transport);
         $payload = Contract::create()->createRequestPayload(new Acp('acp-v1'), new MessageBag(
             Message::forSystem('You are helpful.'),
             Message::ofUser('What is Symfony?'),
@@ -119,7 +119,7 @@ final class ModelClientTest extends TestCase
     {
         $transport = new FakeTransport();
         $transport->start();
-        $client = new ModelClient('dummy', null, [], null, new NullLogger(), $transport);
+        $client = new ModelClient('dummy', null, [], new NullLogger(), $transport);
 
         $client->close();
 

--- a/src/platform/src/Bridge/Acp/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/ModelClientTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\Platform\Bridge\Acp\Acp;
+use Symfony\AI\Platform\Bridge\Acp\Exception\CliNotFoundException;
+use Symfony\AI\Platform\Bridge\Acp\ModelClient;
+use Symfony\AI\Platform\Bridge\Acp\RawProcessResult;
+use Symfony\AI\Platform\Bridge\Acp\Transport\TransportInterface;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Model;
+
+/**
+ * @covers \Symfony\AI\Platform\Bridge\Acp\ModelClient
+ */
+final class ModelClientTest extends TestCase
+{
+    public function testSupportsAcpModel(): void
+    {
+        $client = new ModelClient('dummy', null, [], null, new NullLogger(), new FakeTransport());
+
+        $this->assertTrue($client->supports(new Acp('acp-v1')));
+    }
+
+    public function testDoesNotSupportOtherModels(): void
+    {
+        $client = new ModelClient('dummy', null, [], null, new NullLogger(), new FakeTransport());
+
+        $this->assertFalse($client->supports(new Model('other')));
+    }
+
+    public function testThrowsExceptionWhenCliNotFound(): void
+    {
+        $this->expectException(CliNotFoundException::class);
+        $this->expectExceptionMessage('ACP binary "" was not found.');
+
+        $client = new ModelClient('');
+        $client->request(new Acp('acp-v1'), 'Hello');
+    }
+
+    public function testRequestReturnsRawProcessResult(): void
+    {
+        $transport = new FakeTransport([
+            ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
+            ['jsonrpc' => '2.0', 'id' => 1, 'result' => ['sessionId' => 'session-1']],
+        ]);
+        $client = new ModelClient('dummy', null, [], null, new NullLogger(), $transport);
+
+        $result = $client->request(new Acp('acp-v1'), 'Hello');
+
+        $this->assertInstanceOf(RawProcessResult::class, $result);
+    }
+
+    public function testRequestSendsNormalizedStringPrompt(): void
+    {
+        $transport = new FakeTransport([
+            ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
+            ['jsonrpc' => '2.0', 'id' => 1, 'result' => ['sessionId' => 'session-1']],
+        ]);
+        $client = new ModelClient('dummy', null, [], null, new NullLogger(), $transport);
+
+        $client->request(new Acp('acp-v1'), 'Hello');
+
+        $messages = $transport->messages;
+        $this->assertCount(3, $messages);
+        $this->assertSame('session/prompt', $messages[2]['method']);
+        $this->assertSame([['type' => 'text', 'text' => 'Hello']], $messages[2]['params']['prompt']);
+    }
+
+    public function testRequestSendsPromptArrayFromPayload(): void
+    {
+        $transport = new FakeTransport([
+            ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
+            ['jsonrpc' => '2.0', 'id' => 1, 'result' => ['sessionId' => 'session-1']],
+        ]);
+        $client = new ModelClient('dummy', null, [], null, new NullLogger(), $transport);
+
+        $client->request(new Acp('acp-v1'), ['prompt' => ['What is PHP?']]);
+
+        $messages = $transport->messages;
+        $this->assertSame([['type' => 'text', 'text' => 'What is PHP?']], $messages[2]['params']['prompt']);
+    }
+
+    public function testRequestNormalizesMessageBagPayload(): void
+    {
+        $transport = new FakeTransport([
+            ['jsonrpc' => '2.0', 'id' => 0, 'result' => ['protocolVersion' => 1, 'agentCapabilities' => [], 'agentInfo' => []]],
+            ['jsonrpc' => '2.0', 'id' => 1, 'result' => ['sessionId' => 'session-1']],
+        ]);
+        $client = new ModelClient('dummy', null, [], null, new NullLogger(), $transport);
+        $payload = Contract::create()->createRequestPayload(new Acp('acp-v1'), new MessageBag(
+            Message::forSystem('You are helpful.'),
+            Message::ofUser('What is Symfony?'),
+        ));
+
+        $client->request(new Acp('acp-v1'), $payload);
+
+        $messages = $transport->messages;
+        $this->assertSame([
+            ['type' => 'text', 'text' => '[system] You are helpful.'],
+            ['type' => 'text', 'text' => '[user] What is Symfony?'],
+        ], $messages[2]['params']['prompt']);
+    }
+
+    public function testCloseClosesTransport(): void
+    {
+        $transport = new FakeTransport();
+        $transport->start();
+        $client = new ModelClient('dummy', null, [], null, new NullLogger(), $transport);
+
+        $client->close();
+
+        $this->assertFalse($transport->isRunning());
+    }
+}
+
+final class FakeTransport implements TransportInterface
+{
+    /**
+     * @var list<array<string, mixed>>
+     */
+    public array $messages = [];
+
+    /**
+     * @var list<array<string, mixed>>
+     */
+    private array $responses;
+
+    private bool $running = false;
+
+    /**
+     * @param list<array<string, mixed>> $responses
+     */
+    public function __construct(array $responses = [])
+    {
+        $this->responses = $responses;
+    }
+
+    public function start(): void
+    {
+        $this->running = true;
+    }
+
+    public function send(array $message): void
+    {
+        $this->messages[] = $message;
+    }
+
+    public function readNextMessage(): array
+    {
+        if ([] === $this->responses) {
+            throw new CliNotFoundException('ACP command cannot be empty.');
+        }
+
+        return array_shift($this->responses);
+    }
+
+    public function close(): void
+    {
+        $this->running = false;
+    }
+
+    public function isRunning(): bool
+    {
+        return $this->running;
+    }
+}

--- a/src/platform/src/Bridge/Acp/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/ResultConverterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Acp\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Acp\Acp;
 use Symfony\AI\Platform\Bridge\Acp\ResultConverter;
+use Symfony\AI\Platform\Bridge\Acp\TokenUsageExtractor;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
@@ -289,10 +290,10 @@ final class ResultConverterTest extends TestCase
         $converter->convert($rawResult);
     }
 
-    public function testGetTokenUsageExtractorReturnsNull(): void
+    public function testGetTokenUsageExtractorReturnsExtractor(): void
     {
         $converter = new ResultConverter();
 
-        $this->assertNull($converter->getTokenUsageExtractor());
+        $this->assertInstanceOf(TokenUsageExtractor::class, $converter->getTokenUsageExtractor());
     }
 }

--- a/src/platform/src/Bridge/Acp/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/ResultConverterTest.php
@@ -289,7 +289,7 @@ final class ResultConverterTest extends TestCase
         $converter->convert($rawResult);
     }
 
-    public function testGetTokenUsageExtractorReturnsExtractor(): void
+    public function testGetTokenUsageExtractorReturnsExtractor()
     {
         $converter = new ResultConverter();
 

--- a/src/platform/src/Bridge/Acp/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/ResultConverterTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Acp\Acp;
 use Symfony\AI\Platform\Bridge\Acp\ResultConverter;
 use Symfony\AI\Platform\Bridge\Acp\TokenUsageExtractor;
-use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
@@ -32,21 +31,21 @@ use Symfony\AI\Platform\Result\ToolCallResult;
  */
 final class ResultConverterTest extends TestCase
 {
-    public function testSupportsAcpModel(): void
+    public function testSupportsAcpModel()
     {
         $converter = new ResultConverter();
 
         $this->assertTrue($converter->supports(new Acp('acp-v1')));
     }
 
-    public function testDoesNotSupportOtherModels(): void
+    public function testDoesNotSupportOtherModels()
     {
         $converter = new ResultConverter();
 
         $this->assertFalse($converter->supports(new \Symfony\AI\Platform\Model('other')));
     }
 
-    public function testConvertStreamingTextDelta(): void
+    public function testConvertStreamingTextDelta()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult(
@@ -73,7 +72,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame(', World!', $chunks[1]->getText());
     }
 
-    public function testConvertStreamingThinkingDelta(): void
+    public function testConvertStreamingThinkingDelta()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult(
@@ -95,7 +94,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('Let me think...', $chunks[0]->getThinking());
     }
 
-    public function testConvertStreamingToolCallStart(): void
+    public function testConvertStreamingToolCallStart()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult(
@@ -118,7 +117,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('read_file', $chunks[0]->getName());
     }
 
-    public function testConvertStreamingToolInputDelta(): void
+    public function testConvertStreamingToolInputDelta()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult(
@@ -142,7 +141,7 @@ final class ResultConverterTest extends TestCase
         $this->assertJson($chunks[0]->getPartialJson());
     }
 
-    public function testConvertStreamingToolCallComplete(): void
+    public function testConvertStreamingToolCallComplete()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult(
@@ -168,7 +167,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame(['content' => 'file content'], $toolCalls[0]->getArguments());
     }
 
-    public function testConvertStreamingToolCallCompleteWithScalarOutput(): void
+    public function testConvertStreamingToolCallCompleteWithScalarOutput()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult(
@@ -192,7 +191,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame(['output' => 'file content'], $toolCalls[0]->getArguments());
     }
 
-    public function testConvertStreamingAgentMessageChunk(): void
+    public function testConvertStreamingAgentMessageChunk()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult(
@@ -217,7 +216,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('thinking', $chunks[1]->getThinking());
     }
 
-    public function testConvertNonStreamingTextResult(): void
+    public function testConvertNonStreamingTextResult()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult(
@@ -233,7 +232,7 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('Hello, World!', $result->getContent());
     }
 
-    public function testConvertNonStreamingWithToolCalls(): void
+    public function testConvertNonStreamingWithToolCalls()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult(
@@ -263,18 +262,18 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('Done', $parts[1]->getContent());
     }
 
-    public function testConvertThrowsOnEmptyData(): void
+    public function testConvertThrowsOnEmptyData()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult([]);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(\Symfony\AI\Platform\Bridge\Acp\Exception\ProtocolException::class);
         $this->expectExceptionMessage('ACP did not return any result.');
 
         $converter->convert($rawResult);
     }
 
-    public function testConvertThrowsOnNoSupportedContent(): void
+    public function testConvertThrowsOnNoSupportedContent()
     {
         $converter = new ResultConverter();
         $rawResult = new InMemoryRawResult(

--- a/src/platform/src/Bridge/Acp/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/ResultConverterTest.php
@@ -1,0 +1,298 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Acp\Acp;
+use Symfony\AI\Platform\Bridge\Acp\ResultConverter;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCallResult;
+
+/**
+ * @covers \Symfony\AI\Platform\Bridge\Acp\ResultConverter
+ */
+final class ResultConverterTest extends TestCase
+{
+    public function testSupportsAcpModel(): void
+    {
+        $converter = new ResultConverter();
+
+        $this->assertTrue($converter->supports(new Acp('acp-v1')));
+    }
+
+    public function testDoesNotSupportOtherModels(): void
+    {
+        $converter = new ResultConverter();
+
+        $this->assertFalse($converter->supports(new \Symfony\AI\Platform\Model('other')));
+    }
+
+    public function testConvertStreamingTextDelta(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['jsonrpc' => '2.0', 'method' => 'agent/messageStream', 'params' => ['content' => ['type' => 'text', 'text' => 'Hello']]],
+                ['jsonrpc' => '2.0', 'method' => 'agent/messageStream', 'params' => ['content' => ['type' => 'text', 'text' => ', World!']]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(2, $chunks);
+        $this->assertInstanceOf(TextDelta::class, $chunks[0]);
+        $this->assertSame('Hello', $chunks[0]->getText());
+        $this->assertInstanceOf(TextDelta::class, $chunks[1]);
+        $this->assertSame(', World!', $chunks[1]->getText());
+    }
+
+    public function testConvertStreamingThinkingDelta(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['jsonrpc' => '2.0', 'method' => 'agent/messageStream', 'params' => ['content' => ['type' => 'thought', 'text' => 'Let me think...']]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(1, $chunks);
+        $this->assertInstanceOf(ThinkingDelta::class, $chunks[0]);
+        $this->assertSame('Let me think...', $chunks[0]->getThinking());
+    }
+
+    public function testConvertStreamingToolCallStart(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['jsonrpc' => '2.0', 'method' => 'session/update', 'params' => ['update' => ['sessionUpdate' => 'tool_call', 'toolCallId' => 'call-1', 'title' => 'read_file']]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(1, $chunks);
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertSame('call-1', $chunks[0]->getId());
+        $this->assertSame('read_file', $chunks[0]->getName());
+    }
+
+    public function testConvertStreamingToolInputDelta(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['jsonrpc' => '2.0', 'method' => 'session/update', 'params' => ['update' => ['sessionUpdate' => 'tool_call_update', 'toolCallId' => 'call-1', 'title' => 'read_file', 'status' => 'in_progress', 'rawInput' => ['path' => '/tmp/test.txt']]]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(1, $chunks);
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[0]);
+        $this->assertSame('call-1', $chunks[0]->getId());
+        $this->assertSame('read_file', $chunks[0]->getName());
+        $this->assertJson($chunks[0]->getPartialJson());
+    }
+
+    public function testConvertStreamingToolCallComplete(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['jsonrpc' => '2.0', 'method' => 'session/update', 'params' => ['update' => ['sessionUpdate' => 'tool_call_update', 'toolCallId' => 'call-1', 'title' => 'read_file', 'status' => 'completed', 'rawOutput' => ['output' => ['content' => 'file content']]]]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(1, $chunks);
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $toolCalls = $chunks[0]->getToolCalls();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call-1', $toolCalls[0]->getId());
+        $this->assertSame('read_file', $toolCalls[0]->getName());
+        $this->assertSame(['content' => 'file content'], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertStreamingToolCallCompleteWithScalarOutput(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['jsonrpc' => '2.0', 'method' => 'session/update', 'params' => ['update' => ['sessionUpdate' => 'tool_call_update', 'toolCallId' => 'call-1', 'title' => 'read_file', 'status' => 'completed', 'rawOutput' => ['output' => 'file content']]]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(1, $chunks);
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $toolCalls = $chunks[0]->getToolCalls();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame(['output' => 'file content'], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertStreamingAgentMessageChunk(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['jsonrpc' => '2.0', 'method' => 'session/update', 'params' => ['update' => ['sessionUpdate' => 'agent_message_chunk', 'content' => ['type' => 'text', 'text' => 'Hello']]]],
+                ['jsonrpc' => '2.0', 'method' => 'session/update', 'params' => ['update' => ['sessionUpdate' => 'agent_message_chunk', 'content' => ['type' => 'thought', 'text' => 'thinking']]]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $chunks = [];
+        foreach ($result->getContent() as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $this->assertCount(2, $chunks);
+        $this->assertInstanceOf(TextDelta::class, $chunks[0]);
+        $this->assertSame('Hello', $chunks[0]->getText());
+        $this->assertInstanceOf(ThinkingDelta::class, $chunks[1]);
+        $this->assertSame('thinking', $chunks[1]->getThinking());
+    }
+
+    public function testConvertNonStreamingTextResult(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            ['done' => true],
+            [
+                ['jsonrpc' => '2.0', 'method' => 'agent/messageStream', 'params' => ['content' => ['type' => 'text', 'text' => 'Hello, World!']]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello, World!', $result->getContent());
+    }
+
+    public function testConvertNonStreamingWithToolCalls(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            ['done' => true],
+            [
+                ['jsonrpc' => '2.0', 'method' => 'session/update', 'params' => ['update' => ['sessionUpdate' => 'tool_call', 'toolCallId' => 'call-1', 'title' => 'read_file']]],
+                ['jsonrpc' => '2.0', 'method' => 'session/update', 'params' => ['update' => ['sessionUpdate' => 'tool_call_update', 'toolCallId' => 'call-1', 'title' => 'read_file', 'status' => 'in_progress', 'rawInput' => ['path' => '/tmp/test.txt']]]],
+                ['jsonrpc' => '2.0', 'method' => 'session/update', 'params' => ['update' => ['sessionUpdate' => 'tool_call_update', 'toolCallId' => 'call-1', 'title' => 'read_file', 'status' => 'completed', 'rawOutput' => ['output' => ['content' => 'file content']]]]],
+                ['jsonrpc' => '2.0', 'method' => 'agent/messageStream', 'params' => ['content' => ['type' => 'text', 'text' => 'Done']]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+
+        $this->assertInstanceOf(ToolCallResult::class, $parts[0]);
+        $toolCalls = $parts[0]->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('call-1', $toolCalls[0]->getId());
+        $this->assertSame('read_file', $toolCalls[0]->getName());
+        $this->assertSame(['content' => 'file content'], $toolCalls[0]->getArguments());
+
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('Done', $parts[1]->getContent());
+    }
+
+    public function testConvertThrowsOnEmptyData(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult([]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('ACP did not return any result.');
+
+        $converter->convert($rawResult);
+    }
+
+    public function testConvertThrowsOnNoSupportedContent(): void
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            ['done' => true],
+            [
+                ['jsonrpc' => '2.0', 'method' => 'session/update', 'params' => ['update' => ['sessionUpdate' => 'plan', 'content' => 'some plan']]],
+            ],
+        );
+
+        $this->expectException(\Symfony\AI\Platform\Bridge\Acp\Exception\ProtocolException::class);
+        $this->expectExceptionMessage('ACP result does not contain any supported content.');
+
+        $converter->convert($rawResult);
+    }
+
+    public function testGetTokenUsageExtractorReturnsNull(): void
+    {
+        $converter = new ResultConverter();
+
+        $this->assertNull($converter->getTokenUsageExtractor());
+    }
+}

--- a/src/platform/src/Bridge/Acp/Tests/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/TokenUsageExtractorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Acp\TokenUsageExtractor;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+final class TokenUsageExtractorTest extends TestCase
+{
+    public function testItReturnsNullWhenUsageIsMissing(): void
+    {
+        $extractor = new TokenUsageExtractor();
+        $rawResult = new FakeRawResult([]);
+
+        $this->assertNull($extractor->extract($rawResult));
+    }
+
+    public function testItReturnsNullForStreamOption(): void
+    {
+        $extractor = new TokenUsageExtractor();
+        $rawResult = new FakeRawResult([
+            'usage' => [
+                'inputTokens' => 10,
+                'outputTokens' => 5,
+                'thoughtTokens' => 2,
+                'totalTokens' => 17,
+            ],
+        ]);
+
+        $this->assertNull($extractor->extract($rawResult, ['stream' => true]));
+    }
+
+    public function testItExtractsTokenUsage(): void
+    {
+        $extractor = new TokenUsageExtractor();
+        $rawResult = new FakeRawResult([
+            'usage' => [
+                'inputTokens' => 12901,
+                'outputTokens' => 53,
+                'thoughtTokens' => 78,
+                'totalTokens' => 13032,
+            ],
+        ]);
+
+        $tokenUsage = $extractor->extract($rawResult);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(12901, $tokenUsage->getPromptTokens());
+        $this->assertSame(53, $tokenUsage->getCompletionTokens());
+        $this->assertSame(78, $tokenUsage->getThinkingTokens());
+        $this->assertSame(13032, $tokenUsage->getTotalTokens());
+    }
+}
+
+final class FakeRawResult implements RawResultInterface
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(
+        private readonly array $data,
+    ) {
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getDataStream(): iterable
+    {
+        return [];
+    }
+
+    public function getObject(): object
+    {
+        return new \stdClass();
+    }
+}

--- a/src/platform/src/Bridge/Acp/Tests/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/Acp/Tests/TokenUsageExtractorTest.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\TokenUsage\TokenUsage;
 
 final class TokenUsageExtractorTest extends TestCase
 {
-    public function testItReturnsNullWhenUsageIsMissing(): void
+    public function testItReturnsNullWhenUsageIsMissing()
     {
         $extractor = new TokenUsageExtractor();
         $rawResult = new FakeRawResult([]);
@@ -26,7 +26,7 @@ final class TokenUsageExtractorTest extends TestCase
         $this->assertNull($extractor->extract($rawResult));
     }
 
-    public function testItReturnsNullForStreamOption(): void
+    public function testItReturnsNullForStreamOption()
     {
         $extractor = new TokenUsageExtractor();
         $rawResult = new FakeRawResult([
@@ -41,7 +41,7 @@ final class TokenUsageExtractorTest extends TestCase
         $this->assertNull($extractor->extract($rawResult, ['stream' => true]));
     }
 
-    public function testItExtractsTokenUsage(): void
+    public function testItExtractsTokenUsage()
     {
         $extractor = new TokenUsageExtractor();
         $rawResult = new FakeRawResult([

--- a/src/platform/src/Bridge/Acp/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/Acp/TokenUsageExtractor.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp;
+
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
+
+final class TokenUsageExtractor implements TokenUsageExtractorInterface
+{
+    public function extract(RawResultInterface $rawResult, array $options = []): ?TokenUsageInterface
+    {
+        if ($options['stream'] ?? false) {
+            return null;
+        }
+
+        $content = $rawResult->getData();
+        $usage = $content['usage'] ?? null;
+
+        if (!\is_array($usage)) {
+            return null;
+        }
+
+        return new TokenUsage(
+            promptTokens: $usage['inputTokens'] ?? null,
+            completionTokens: $usage['outputTokens'] ?? null,
+            thinkingTokens: $usage['thoughtTokens'] ?? null,
+            totalTokens: $usage['totalTokens'] ?? null,
+        );
+    }
+}

--- a/src/platform/src/Bridge/Acp/Transport/ProcessTransport.php
+++ b/src/platform/src/Bridge/Acp/Transport/ProcessTransport.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Transport;
+
+use Amp\ByteStream\ReadableResourceStream;
+use Amp\ByteStream\WritableResourceStream;
+use Amp\Process\Process;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\AI\Platform\Bridge\Acp\Exception\CliNotFoundException;
+use Symfony\AI\Platform\Bridge\Acp\Exception\TransportException;
+use Symfony\Component\Process\ExecutableFinder;
+
+/**
+ * ACP stdio transport using Amp\Process.
+ */
+final class ProcessTransport implements TransportInterface
+{
+    private ?Process $process = null;
+    private ?WritableResourceStream $stdin = null;
+    private ?ReadableResourceStream $stdout = null;
+    private string $stdoutBuffer = '';
+    private bool $running = false;
+
+    /**
+     * @param array<string, string> $environment
+     */
+    public function __construct(
+        private readonly string $command,
+        private readonly ?string $workingDirectory = null,
+        private readonly array $environment = [],
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function start(): void
+    {
+        if ($this->running) {
+            return;
+        }
+
+        $command = $this->buildCommand();
+        $this->logger->info('Starting ACP process.', ['command' => $command]);
+
+        $this->process = Process::start($command, $this->workingDirectory, $this->environment);
+        $this->stdin = $this->process->getStdin();
+        $this->stdout = $this->process->getStdout();
+        $this->running = true;
+    }
+
+    public function send(array $message): void
+    {
+        if (!$this->running || null === $this->stdin) {
+            throw new TransportException('ACP process stdin is not available.');
+        }
+
+        try {
+            $payload = json_encode($message, \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR)."\n";
+            $this->stdin->write($payload);
+            $this->logger->debug('ACP request sent.', ['payload' => $message]);
+        } catch (\Throwable $e) {
+            throw new TransportException('Failed to write to ACP process.', 0, $e);
+        }
+    }
+
+    public function readNextMessage(): array
+    {
+        if (!$this->running || null === $this->stdout) {
+            throw new TransportException('ACP process stdout is not available.');
+        }
+
+        while (true) {
+            if (str_contains($this->stdoutBuffer, "\n")) {
+                $parts = explode("\n", $this->stdoutBuffer, 2);
+                $line = trim($parts[0]);
+                $this->stdoutBuffer = $parts[1];
+
+                if ('' === $line) {
+                    continue;
+                }
+
+                $decoded = json_decode($line, true);
+                if (!\is_array($decoded)) {
+                    throw new TransportException('ACP returned malformed JSON.');
+                }
+
+                $this->logger->debug('ACP response received.', ['payload' => $decoded]);
+
+                return $decoded;
+            }
+
+            $chunk = $this->stdout->read();
+            if (null === $chunk) {
+                throw new TransportException('ACP process closed stdout unexpectedly.');
+            }
+
+            $this->stdoutBuffer .= $chunk;
+        }
+    }
+
+    public function close(): void
+    {
+        if (!$this->running) {
+            return;
+        }
+
+        $this->process->kill();
+        $this->process = null;
+        $this->stdin = null;
+        $this->stdout = null;
+        $this->stdoutBuffer = '';
+        $this->running = false;
+    }
+
+    public function isRunning(): bool
+    {
+        return $this->running;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildCommand(): array
+    {
+        $parts = preg_split('/\s+/', trim($this->command)) ?: [];
+        if ([] === $parts) {
+            throw new CliNotFoundException('ACP command cannot be empty.');
+        }
+
+        $binary = (new ExecutableFinder())->find($parts[0]);
+        if (null === $binary) {
+            throw new CliNotFoundException(\sprintf('ACP binary "%s" was not found.', $parts[0]));
+        }
+
+        $parts[0] = $binary;
+
+        return $parts;
+    }
+}

--- a/src/platform/src/Bridge/Acp/Transport/SocketTransport.php
+++ b/src/platform/src/Bridge/Acp/Transport/SocketTransport.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Transport;
+
+use Amp\Socket\Socket;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\AI\Platform\Bridge\Acp\Exception\TransportException;
+
+final class SocketTransport implements TransportInterface
+{
+    private ?Socket $socket = null;
+    private string $buffer = '';
+    private bool $running = false;
+
+    public function __construct(
+        private readonly string $address,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function start(): void
+    {
+        if ($this->running) {
+            return;
+        }
+
+        $this->logger->info('Connecting to ACP socket.', ['address' => $this->address]);
+
+        try {
+            $this->socket = \Amp\Socket\connect($this->address);
+        } catch (\Throwable $e) {
+            throw new TransportException(\sprintf('Failed to connect to ACP socket "%s".', $this->address), 0, $e);
+        }
+
+        $this->running = true;
+    }
+
+    public function send(array $message): void
+    {
+        if (!$this->running || null === $this->socket) {
+            throw new TransportException('ACP socket is not connected.');
+        }
+
+        try {
+            $payload = json_encode($message, \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR)."\n";
+            $this->socket->write($payload);
+            $this->logger->debug('ACP request sent.', ['payload' => $message]);
+        } catch (\Throwable $e) {
+            throw new TransportException('Failed to write to ACP socket.', 0, $e);
+        }
+    }
+
+    public function readNextMessage(): array
+    {
+        if (!$this->running || null === $this->socket) {
+            throw new TransportException('ACP socket is not connected.');
+        }
+
+        while (true) {
+            if (str_contains($this->buffer, "\n")) {
+                $parts = explode("\n", $this->buffer, 2);
+                $line = trim($parts[0]);
+                $this->buffer = $parts[1];
+
+                if ('' === $line) {
+                    continue;
+                }
+
+                $decoded = json_decode($line, true);
+                if (!\is_array($decoded)) {
+                    throw new TransportException('ACP returned malformed JSON.');
+                }
+
+                $this->logger->debug('ACP response received.', ['payload' => $decoded]);
+
+                return $decoded;
+            }
+
+            $chunk = $this->socket->read();
+            if (null === $chunk) {
+                throw new TransportException('ACP socket closed unexpectedly.');
+            }
+
+            $this->buffer .= $chunk;
+        }
+    }
+
+    public function close(): void
+    {
+        if (!$this->running) {
+            return;
+        }
+
+        $this->socket?->close();
+        $this->socket = null;
+        $this->buffer = '';
+        $this->running = false;
+    }
+
+    public function isRunning(): bool
+    {
+        return $this->running;
+    }
+}

--- a/src/platform/src/Bridge/Acp/Transport/TransportInterface.php
+++ b/src/platform/src/Bridge/Acp/Transport/TransportInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Acp\Transport;
+
+/**
+ * Transport interface for ACP communication.
+ */
+interface TransportInterface
+{
+    /**
+     * Starts the transport connection.
+     */
+    public function start(): void;
+
+    /**
+     * Sends a message through the transport.
+     *
+     * @param array<string, mixed> $message
+     */
+    public function send(array $message): void;
+
+    /**
+     * Reads the next message from the transport.
+     *
+     * @return array<string, mixed>
+     */
+    public function readNextMessage(): array;
+
+    /**
+     * Closes the transport connection.
+     */
+    public function close(): void;
+
+    /**
+     * Checks if the transport is currently running.
+     */
+    public function isRunning(): bool;
+}

--- a/src/platform/src/Bridge/Acp/composer.json
+++ b/src/platform/src/Bridge/Acp/composer.json
@@ -20,7 +20,8 @@
         "php": ">=8.2",
         "symfony/ai-platform": "^0.10",
         "revolt/event-loop": "^1.0",
-        "amphp/process": "^2.0"
+        "amphp/process": "^2.0",
+        "amphp/socket": "^2.3"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",

--- a/src/platform/src/Bridge/Acp/composer.json
+++ b/src/platform/src/Bridge/Acp/composer.json
@@ -18,10 +18,11 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/ai-platform": "^0.10",
-        "revolt/event-loop": "^1.0",
         "amphp/process": "^2.0",
-        "amphp/socket": "^2.3"
+        "amphp/socket": "^2.3",
+        "revolt/event-loop": "^1.0",
+        "symfony/ai-platform": "^0.11",
+        "symfony/process": "^7.3|^8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",

--- a/src/platform/src/Bridge/Acp/composer.json
+++ b/src/platform/src/Bridge/Acp/composer.json
@@ -1,0 +1,46 @@
+{
+    "name": "symfony/ai-acp-platform",
+    "description": "Agent Client Protocol (ACP) platform bridge for Symfony AI",
+    "license": "MIT",
+    "type": "symfony-ai-platform",
+    "keywords": [
+        "ai",
+        "bridge",
+        "acp",
+        "agent-client-protocol",
+        "platform"
+    ],
+    "authors": [
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "symfony/ai-platform": "^0.10",
+        "revolt/event-loop": "^1.0",
+        "amphp/process": "^2.0"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.5.53"
+    },
+    "minimum-stability": "dev",
+    "autoload": {
+        "psr-4": {
+            "Symfony\\AI\\Platform\\Bridge\\Acp\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\AI\\PHPStan\\": "../../../../../.phpstan/",
+            "Symfony\\AI\\Platform\\Bridge\\Acp\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/src/platform/src/Bridge/Acp/composer.json
+++ b/src/platform/src/Bridge/Acp/composer.json
@@ -21,7 +21,7 @@
         "amphp/process": "^2.0",
         "amphp/socket": "^2.3",
         "revolt/event-loop": "^1.0",
-        "symfony/ai-platform": "^0.11",
+        "symfony/ai-platform": "^0.12",
         "symfony/process": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/platform/src/Bridge/Acp/phpstan.dist.neon
+++ b/src/platform/src/Bridge/Acp/phpstan.dist.neon
@@ -1,5 +1,5 @@
 includes:
-    - ../../../vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/extension.neon
     - ../../../../../.phpstan/extension.neon
 
 parameters:
@@ -8,7 +8,7 @@ parameters:
         - .
         - Tests/
     excludePaths:
-        - vendor/ (?)
+        - vendor/
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/platform/src/Bridge/Acp/phpstan.dist.neon
+++ b/src/platform/src/Bridge/Acp/phpstan.dist.neon
@@ -1,0 +1,29 @@
+includes:
+    - ../../../vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../../../../../.phpstan/extension.neon
+
+parameters:
+    level: 6
+    paths:
+        - .
+        - Tests/
+    excludePaths:
+        - vendor/ (?)
+    treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        -
+            message: "#^Method .*::test.*\\(\\) has no return type specified\\.$#"
+            reportUnmatched: false
+        -
+            message: '#^Call to( static)? method PHPUnit\\Framework\\Assert::.* will always evaluate to true\.$#'
+            reportUnmatched: false
+        -
+            identifier: 'symfonyAi.forbidNativeException'
+            path: Tests/*
+            reportUnmatched: false
+
+services:
+    - # Conditionally enabled by bleeding edge in phpstan/phpstan-phpunit 2.x
+        class: PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension
+        tags:
+            - phpstan.ignoreErrorExtension

--- a/src/platform/src/Bridge/Acp/phpstan.dist.neon
+++ b/src/platform/src/Bridge/Acp/phpstan.dist.neon
@@ -9,6 +9,7 @@ parameters:
         - Tests/
     excludePaths:
         - vendor/
+        - Transport
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -

--- a/src/platform/src/Bridge/Acp/phpunit.xml.dist
+++ b/src/platform/src/Bridge/Acp/phpunit.xml.dist
@@ -1,18 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="../../../../../vendor/autoload.php"
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
          colors="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         cacheDirectory=".phpunit.cache"
-         executionOrder="default"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
          failOnRisky="true"
          failOnWarning="true"
-         requireCoverageMetadata="false"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         executionOrder="random"
 >
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
     <testsuites>
-        <testsuite name="ACP Bridge Test Suite">
-            <directory>Tests</directory>
+        <testsuite name="Symfony AI ACP Platform Test Suite">
+            <directory>./Tests/</directory>
         </testsuite>
     </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
 </phpunit>

--- a/src/platform/src/Bridge/Acp/phpunit.xml.dist
+++ b/src/platform/src/Bridge/Acp/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../../../../../vendor/autoload.php"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="default"
+         failOnRisky="true"
+         failOnWarning="true"
+         requireCoverageMetadata="false"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+>
+    <testsuites>
+        <testsuite name="ACP Bridge Test Suite">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no - **TODO** <!-- required for new features -->
| Issues        | 
| License       | MIT

Hello :wave: 

This PR introduces the **Agent Client Protocol (ACP)** platform bridge (`symfony/ai-acp-platform`), enabling Symfony AI to communicate with any ACP-compatible agent (GitHub Copilot, Claude Code, JetBrains Junie, OpenCode, Google Gemini CLI, etc.).

[ACP](https://agentclientprotocol.com/) is an open standard designed to facilitate communication between AI coding agents and code editors/IDEs (created by Zed and JetBrains). 

This bridge allows Symfony AI to connect to any ACP-compatible agent.

For example, if you have a subscription to [Junie](https://junie.jetbrains.com/) , you don't have any API_KEY to call a model, but you can launch ```junie --acp true``` that let's you call the agent through stdio, and the agent can perform tasks on the folder. 

Some agents allow to use a socket to communicate with like `copilot` 

```
$ copilot --acp --port 3000
```

The platform can start the stdio process, or attach to the tcp socket to communicate. 

Beside, depending the agent, it can use terminal, some tools. There is, AFAIK, not yet the possibility to change the model used by the agent, but it can be changed when we start the process. 

**Example**

```
$platform = Factory::createPlatform(
    command: 'opencode acp', // or "junie --acp true", "gemini --acp" ...
);

$messages = new MessageBag(
    Message::ofUser('Explain the architecture of this project in 3 sentences.'),
);

$result = $platform->invoke('acp-v1', $messages);

echo $result->asText().\PHP_EOL;
```

**Configuration (ai-bundle)**
```
# config/packages/ai.yaml
ai:
    platform:
        acp:
            transport: 'process' # 'process' | 'socket'
            command: 'opencode acp' # required for process
            # host: 'localhost' # required for socket
            # port: 3000 # required for socket
```

I tried (me and opencode) as much as possible to stick with others bridge, but I may miss some things. 

Tell me if there is any interest to get this into symfony/ai :slightly_smiling_face: 
  

