### PR TITLE
[Mate] Redact Doctrine query parameter values in profiler db collector

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/DoctrineCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/DoctrineCollectorFormatter.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 final class DoctrineCollectorFormatter implements CollectorFormatterInterface
 {
     private const MAX_QUERIES = 50;
-    private const MAX_PARAM_LENGTH = 100;
+    private const REDACTED = '***REDACTED***';
 
     public function getName(): string
     {
@@ -82,7 +82,7 @@ final class DoctrineCollectorFormatter implements CollectorFormatterInterface
                     $grouped[$sql] = [
                         'count' => 0,
                         'total_time_ms' => 0.0,
-                        'sample_params' => $this->truncateParams($query['params'] ?? null),
+                        'sample_params' => $this->redactParams($query['params'] ?? null),
                     ];
                 }
 
@@ -108,16 +108,22 @@ final class DoctrineCollectorFormatter implements CollectorFormatterInterface
         return $result;
     }
 
-    private function truncateParams(mixed $params): mixed
+    /**
+     * Bound query parameters routinely carry user data (emails, password hashes,
+     * reset tokens, ...) and there is no key name to decide which are sensitive,
+     * so every leaf value is redacted. The array shape and parameter count are
+     * preserved so the AI can still see that the query was parameterized.
+     */
+    private function redactParams(mixed $params): mixed
     {
-        if (\is_string($params) && \strlen($params) > self::MAX_PARAM_LENGTH) {
-            return substr($params, 0, self::MAX_PARAM_LENGTH).'...';
-        }
-
         if (\is_array($params)) {
-            return array_map(fn (mixed $param): mixed => $this->truncateParams($param), $params);
+            return array_map(fn (mixed $param): mixed => $this->redactParams($param), $params);
         }
 
-        return $params;
+        if (null === $params) {
+            return null;
+        }
+
+        return self::REDACTED;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterTest.php
@@ -63,7 +63,8 @@ final class DoctrineCollectorFormatterTest extends TestCase
         $this->assertSame(1, $result['queries'][1]['count']);
         $this->assertSame(0.8, $result['queries'][1]['total_time_ms']);
         $this->assertSame(0.8, $result['queries'][1]['avg_time_ms']);
-        $this->assertSame([1], $result['queries'][1]['sample_params']);
+        // Parameter values are redacted; the shape (one bound parameter) is kept.
+        $this->assertSame(['***REDACTED***'], $result['queries'][1]['sample_params']);
     }
 
     public function testFormatMultipleConnections()
@@ -128,7 +129,7 @@ final class DoctrineCollectorFormatterTest extends TestCase
         $this->assertSame(3, $result['queries'][0]['count']);
         $this->assertSame(6.0, $result['queries'][0]['total_time_ms']);
         $this->assertSame(2.0, $result['queries'][0]['avg_time_ms']);
-        $this->assertSame([1], $result['queries'][0]['sample_params']);
+        $this->assertSame(['***REDACTED***'], $result['queries'][0]['sample_params']);
         $this->assertSame('SELECT * FROM posts', $result['queries'][1]['sql']);
         $this->assertSame(1, $result['queries'][1]['count']);
         $this->assertSame(1.0, $result['queries'][1]['total_time_ms']);
@@ -137,23 +138,44 @@ final class DoctrineCollectorFormatterTest extends TestCase
         $this->assertArrayNotHasKey('duplicate_queries', $result);
     }
 
-    public function testFormatTruncatesLongSampleParams()
+    public function testFormatRedactsSampleParamValues()
     {
-        $longParam = str_repeat('a', 150);
-
         $collector = $this->createCollector(
             ['default' => 'doctrine.default'],
             [
                 'default' => [
-                    ['sql' => 'SELECT * FROM users WHERE bio = ?', 'params' => [$longParam], 'executionMS' => 0.001, 'types' => []],
+                    [
+                        'sql' => 'SELECT * FROM users WHERE email = ? AND password = ?',
+                        'params' => ['alice@example.com', 's3cr3t-hash'],
+                        'executionMS' => 0.001,
+                        'types' => [],
+                    ],
                 ],
             ],
         );
 
         $result = $this->formatter->format($collector);
 
-        $this->assertSame(103, \strlen($result['queries'][0]['sample_params'][0]));
-        $this->assertStringEndsWith('...', $result['queries'][0]['sample_params'][0]);
+        // No raw parameter value survives; the parameter count is still visible.
+        $this->assertSame(['***REDACTED***', '***REDACTED***'], $result['queries'][0]['sample_params']);
+        $this->assertStringNotContainsString('alice@example.com', json_encode($result));
+        $this->assertStringNotContainsString('s3cr3t-hash', json_encode($result));
+    }
+
+    public function testFormatRedactsNestedSampleParamValues()
+    {
+        $collector = $this->createCollector(
+            ['default' => 'doctrine.default'],
+            [
+                'default' => [
+                    ['sql' => 'SELECT * FROM t WHERE id IN (?)', 'params' => [[1, 2, 3]], 'executionMS' => 0.001, 'types' => []],
+                ],
+            ],
+        );
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame([['***REDACTED***', '***REDACTED***', '***REDACTED***']], $result['queries'][0]['sample_params']);
     }
 
     public function testFormatNoQueries()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

The profiler `db` collector exposed `sample_params` — the bound parameter
values of each SQL query — to the AI with only a 100-character truncation. For a
statement like `INSERT INTO users (email, password_hash, reset_token) VALUES
(?, ?, ?)` that means real user PII and credentials were handed to the model
verbatim, against the bridge's "sensitive data stays out" principle.

Bound parameters have no key name to decide which are sensitive, so every leaf
value is redacted while the array shape and parameter count are preserved (so
the AI can still see the query was parameterized). The SQL text, counts and
timings — which carry the diagnostic value — are unchanged.

Note (out of scope): a non-parameterized query that inlines literals into the
SQL string itself (`WHERE email = 'a@b.com'`) is not scrubbed; Doctrine rarely
produces these and it is a separate, harder problem.
