### PR TITLE
[Mate] Redact request/query parameters, raw body and headers in profiler request collector

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/RequestCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/RequestCollectorFormatter.php
@@ -22,7 +22,9 @@ use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector;
  * - Session cookies and tokens
  * - API keys and secrets in environment variables
  * - Authorization headers
- * - Password and authentication data
+ * - Password and authentication data submitted as request/query parameters
+ * - The raw request body (which may carry credentials, e.g. a JSON login payload)
+ * - The reconstructed curl command (re-embeds body, URL query string and headers)
  *
  * @author Johannes Wachter <johannes@sulu.io>
  *
@@ -44,17 +46,71 @@ final class RequestCollectorFormatter implements CollectorFormatterInterface
         'AUTH',
         'CREDENTIAL',
         'PRIVATE',
+        'COOKIE',
     ];
 
     /**
+     * Server-bag keys whose values embed sensitive request data (the raw query
+     * string, in particular) under a non-sensitive key name, so key-based
+     * matching would otherwise miss them.
+     *
      * @var array<string>
      */
-    private const SENSITIVE_HEADERS = [
+    private const SENSITIVE_SERVER_KEYS = [
+        'REQUEST_URI',
+        'QUERY_STRING',
+    ];
+
+    /**
+     * Substrings that mark a header as sensitive (case-insensitive). Matching by
+     * substring rather than an exact name list so variants and vendor-specific
+     * headers (e.g. `proxy-authorization`, `www-authenticate`, `x-csrf-token`,
+     * `x-amz-security-token`) are covered without enumerating every spelling.
+     *
+     * @var array<string>
+     */
+    private const SENSITIVE_HEADER_PATTERNS = [
         'authorization',
         'cookie',
-        'set-cookie',
-        'x-api-key',
-        'x-auth-token',
+        'auth',
+        'token',
+        'secret',
+        'credential',
+        'csrf',
+        'xsrf',
+        'api-key',
+        'apikey',
+        'session',
+        'x-amz-security',
+    ];
+
+    /**
+     * Parameter names whose values are redacted wherever they appear in request,
+     * query, or attribute data (case-insensitive substring match). Symfony's own
+     * collector only masks `_password`; any other field name (e.g. `password`,
+     * `api_key`) and the whole query string otherwise reach us in clear text.
+     *
+     * @var array<string>
+     */
+    private const SENSITIVE_PARAM_PATTERNS = [
+        'PASSWORD',
+        'PASSWD',
+        'PASSPHRASE',
+        'PWD',
+        'SECRET',
+        'TOKEN',
+        'API_KEY',
+        'APIKEY',
+        'ACCESS_KEY',
+        'SIGNING_KEY',
+        'ENCRYPTION_KEY',
+        'OAUTH',
+        'CREDENTIAL',
+        'PRIVATE',
+        'BEARER',
+        'CSRF',
+        'XSRF',
+        'OTP',
     ];
 
     public function getName(): string
@@ -116,7 +172,7 @@ final class RequestCollectorFormatter implements CollectorFormatterInterface
 
         // Sanitize server variables (environment)
         if (isset($data['request_server']) && \is_array($data['request_server'])) {
-            $data['request_server'] = $this->sanitizeEnvironment($data['request_server']);
+            $data['request_server'] = $this->sanitizeServer($data['request_server']);
         }
 
         // Sanitize dotenv vars
@@ -127,6 +183,30 @@ final class RequestCollectorFormatter implements CollectorFormatterInterface
         // Sanitize session data
         if (isset($data['session_attributes']) && \is_array($data['session_attributes'])) {
             $data['session_attributes'] = $this->redactArray($data['session_attributes']);
+        }
+
+        // Redact sensitive values submitted as request/query parameters or stored
+        // as request attributes (e.g. passwords, API keys, CSRF tokens). Symfony
+        // only masks `_password`; other field names and the query string would
+        // otherwise be exposed verbatim.
+        foreach (['request_request', 'request_query', 'request_attributes'] as $key) {
+            if (isset($data[$key]) && \is_array($data[$key])) {
+                $data[$key] = $this->redactSensitiveParams($data[$key]);
+            }
+        }
+
+        // The raw request body can carry credentials (e.g. a JSON login payload)
+        // that cannot be reliably field-redacted; omit it. Parsed, sanitized
+        // parameters remain available under request_request / request_query.
+        if (isset($data['content']) && \is_string($data['content']) && '' !== $data['content']) {
+            $data['content'] = '***REDACTED*** (raw request body omitted; see request_request / request_query)';
+        }
+
+        // The reconstructed curl command re-embeds the raw body (--data-raw), the
+        // full URL including the query string, and request headers (Authorization
+        // included), so it would re-expose everything the redactions above remove.
+        if (isset($data['curlCommand']) && \is_string($data['curlCommand'])) {
+            $data['curlCommand'] = '***REDACTED*** (curl command omitted; reconstructs the raw body, URL query string and request headers)';
         }
 
         return $data;
@@ -140,13 +220,24 @@ final class RequestCollectorFormatter implements CollectorFormatterInterface
     private function sanitizeHeaders(array $headers): array
     {
         foreach ($headers as $key => $value) {
-            $lowerKey = strtolower($key);
-            if (\in_array($lowerKey, self::SENSITIVE_HEADERS, true)) {
+            if ($this->isSensitiveHeader($key)) {
                 $headers[$key] = '***REDACTED***';
             }
         }
 
         return $headers;
+    }
+
+    private function isSensitiveHeader(string $name): bool
+    {
+        $lowerName = strtolower($name);
+        foreach (self::SENSITIVE_HEADER_PATTERNS as $pattern) {
+            if (str_contains($lowerName, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -170,6 +261,24 @@ final class RequestCollectorFormatter implements CollectorFormatterInterface
     }
 
     /**
+     * @param array<string, mixed> $server
+     *
+     * @return array<string, mixed>
+     */
+    private function sanitizeServer(array $server): array
+    {
+        $server = $this->sanitizeEnvironment($server);
+
+        foreach (self::SENSITIVE_SERVER_KEYS as $key) {
+            if (isset($server[$key]) && '' !== $server[$key]) {
+                $server[$key] = '***REDACTED***';
+            }
+        }
+
+        return $server;
+    }
+
+    /**
      * @param array<string, mixed> $data
      *
      * @return array<string, mixed>
@@ -181,5 +290,42 @@ final class RequestCollectorFormatter implements CollectorFormatterInterface
         }
 
         return $data;
+    }
+
+    /**
+     * Recursively redact values whose key matches a sensitive parameter pattern,
+     * leaving non-sensitive keys (and the overall structure) intact so the AI can
+     * still see which parameters were submitted.
+     *
+     * @param array<array-key, mixed> $data
+     *
+     * @return array<array-key, mixed>
+     */
+    private function redactSensitiveParams(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (\is_string($key) && $this->isSensitiveParam($key)) {
+                $data[$key] = '***REDACTED***';
+                continue;
+            }
+
+            if (\is_array($value)) {
+                $data[$key] = $this->redactSensitiveParams($value);
+            }
+        }
+
+        return $data;
+    }
+
+    private function isSensitiveParam(string $key): bool
+    {
+        $upperKey = strtoupper($key);
+        foreach (self::SENSITIVE_PARAM_PATTERNS as $pattern) {
+            if (str_contains($upperKey, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/RequestCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/RequestCollectorFormatterTest.php
@@ -1,0 +1,217 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Profiler\Service\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\RequestCollectorFormatter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RequestCollectorFormatterTest extends TestCase
+{
+    private RequestCollectorFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new RequestCollectorFormatter();
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('request', $this->formatter->getName());
+    }
+
+    public function testFormatRedactsSensitivePostParameters()
+    {
+        $data = $this->format($this->collect(Request::create('/login', 'POST', [
+            'username' => 'alice',
+            'password' => 'hunter2',
+            'pwd' => 'hunter2',
+            '_csrf_token' => 'csrf-value',
+            'api_key' => 'sk-12345',
+            'remember' => '1',
+        ])));
+
+        $this->assertSame('***REDACTED***', $data['request_request']['password']);
+        $this->assertSame('***REDACTED***', $data['request_request']['pwd']);
+        $this->assertSame('***REDACTED***', $data['request_request']['_csrf_token']);
+        $this->assertSame('***REDACTED***', $data['request_request']['api_key']);
+
+        // Non-sensitive fields stay visible so the AI can still reason over them.
+        $this->assertSame('alice', $data['request_request']['username']);
+        $this->assertSame('1', $data['request_request']['remember']);
+    }
+
+    public function testFormatRedactsSensitiveQueryParameters()
+    {
+        $data = $this->format($this->collect(Request::create('/search?q=cats&api_key=topsecret&access_token=abc&page=2')));
+
+        $this->assertSame('***REDACTED***', $data['request_query']['api_key']);
+        $this->assertSame('***REDACTED***', $data['request_query']['access_token']);
+        $this->assertSame('cats', $data['request_query']['q']);
+        $this->assertSame('2', $data['request_query']['page']);
+    }
+
+    public function testFormatRedactsNestedSensitiveParameters()
+    {
+        $data = $this->format($this->collect(Request::create('/api', 'POST', [
+            'user' => [
+                'name' => 'bob',
+                'password' => 'nested-secret',
+            ],
+        ])));
+
+        $this->assertSame('bob', $data['request_request']['user']['name']);
+        $this->assertSame('***REDACTED***', $data['request_request']['user']['password']);
+    }
+
+    public function testFormatOmitsRawRequestBody()
+    {
+        $request = Request::create('/api/login', 'POST', [], [], [], [], '{"username":"alice","password":"hunter2"}');
+        $request->headers->set('Content-Type', 'application/json');
+
+        $data = $this->format($this->collect($request));
+
+        $this->assertIsString($data['content']);
+        $this->assertStringContainsString('REDACTED', $data['content']);
+        // The secret must not survive anywhere in the formatted output (e.g. via
+        // the reconstructed curl command, which re-embeds the raw body).
+        $this->assertStringNotContainsString('hunter2', json_encode($data));
+    }
+
+    public function testFormatDoesNotLeakSecretsViaReconstructedCurlCommand()
+    {
+        $request = Request::create('/login?api_key=topsecret', 'POST', [], [], [], [], '{"password":"hunter2"}');
+        $request->headers->set('Content-Type', 'application/json');
+        $request->headers->set('Authorization', 'Bearer leak-me');
+
+        $data = $this->format($this->collect($request));
+
+        // The reconstructed curl command re-embeds the raw body, query string and
+        // auth header. Whether Symfony's RequestDataCollector emits it depends on
+        // the installed version, so assert its redaction only when it is present.
+        if (isset($data['curlCommand'])) {
+            $this->assertIsString($data['curlCommand']);
+            $this->assertStringContainsString('REDACTED', $data['curlCommand']);
+        }
+
+        // No secret from the body, query string or auth header may survive in the
+        // full serialized output through any field, curlCommand included.
+        $serialized = json_encode($data);
+        $this->assertStringNotContainsString('hunter2', $serialized);
+        $this->assertStringNotContainsString('topsecret', $serialized);
+        $this->assertStringNotContainsString('leak-me', $serialized);
+    }
+
+    public function testFormatRedactsRawQueryStringInServerBag()
+    {
+        $data = $this->format($this->collect(Request::create('/page?api_key=topsecret&p=2')));
+
+        // REQUEST_URI / QUERY_STRING embed the raw query string under
+        // non-sensitive key names, so they are redacted wholesale.
+        $this->assertSame('***REDACTED***', $data['request_server']['REQUEST_URI']);
+        $this->assertSame('***REDACTED***', $data['request_server']['QUERY_STRING']);
+        $this->assertStringNotContainsString('topsecret', json_encode($data));
+    }
+
+    public function testFormatRedactsCloudAccessKeyParameters()
+    {
+        $data = $this->format($this->collect(Request::create('/api', 'POST', [
+            'aws_access_key_id' => 'AKIA-example',
+            'signing_key' => 'sign-me',
+            'encryption_key' => 'enc-me',
+            'oauth_verifier' => 'verify-me',
+            'limit' => '20',
+        ])));
+
+        $this->assertSame('***REDACTED***', $data['request_request']['aws_access_key_id']);
+        $this->assertSame('***REDACTED***', $data['request_request']['signing_key']);
+        $this->assertSame('***REDACTED***', $data['request_request']['encryption_key']);
+        $this->assertSame('***REDACTED***', $data['request_request']['oauth_verifier']);
+        $this->assertSame('20', $data['request_request']['limit']);
+    }
+
+    public function testFormatRedactsSensitiveHeadersCookiesAndEnvironment()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Authorization', 'Bearer super-secret-token');
+        $request->cookies->set('PHPSESSID', 'session-value');
+        $request->server->set('APP_SECRET', 'the-app-secret');
+        $request->server->set('DATABASE_PASSWORD', 'db-pass');
+
+        $data = $this->format($this->collect($request));
+
+        $this->assertSame('***REDACTED***', $data['request_headers']['authorization']);
+        $this->assertSame('***REDACTED***', $data['request_cookies']['PHPSESSID']);
+        $this->assertSame('***REDACTED***', $data['request_server']['APP_SECRET']);
+        $this->assertSame('***REDACTED***', $data['request_server']['DATABASE_PASSWORD']);
+    }
+
+    public function testFormatRedactsBroadSetOfSensitiveHeaders()
+    {
+        $request = Request::create('/');
+        $request->headers->set('Proxy-Authorization', 'Basic abc');
+        $request->headers->set('Www-Authenticate', 'Bearer realm="x"');
+        $request->headers->set('X-Csrf-Token', 'csrf-123');
+        $request->headers->set('X-Xsrf-Token', 'xsrf-123');
+        $request->headers->set('X-Api-Key', 'key-123');
+        $request->headers->set('X-Amz-Security-Token', 'amz-123');
+        $request->headers->set('X-Custom-Auth', 'auth-123');
+        $request->headers->set('Accept', 'application/json');
+
+        $data = $this->format($this->collect($request));
+
+        $this->assertSame('***REDACTED***', $data['request_headers']['proxy-authorization']);
+        $this->assertSame('***REDACTED***', $data['request_headers']['www-authenticate']);
+        $this->assertSame('***REDACTED***', $data['request_headers']['x-csrf-token']);
+        $this->assertSame('***REDACTED***', $data['request_headers']['x-xsrf-token']);
+        $this->assertSame('***REDACTED***', $data['request_headers']['x-api-key']);
+        $this->assertSame('***REDACTED***', $data['request_headers']['x-amz-security-token']);
+        $this->assertSame('***REDACTED***', $data['request_headers']['x-custom-auth']);
+
+        // Non-sensitive headers stay untouched.
+        $this->assertNotSame('***REDACTED***', $data['request_headers']['accept']);
+    }
+
+    public function testGetSummaryExposesOnlyNonSensitiveMetadata()
+    {
+        $summary = $this->formatter->getSummary($this->collect(Request::create('/login', 'POST', ['password' => 'hunter2'])));
+
+        $this->assertSame('POST', $summary['method']);
+        $this->assertSame('/login', $summary['path']);
+        $this->assertArrayHasKey('status_code', $summary);
+        $this->assertArrayNotHasKey('request_request', $summary);
+    }
+
+    private function collect(Request $request): RequestDataCollector
+    {
+        $collector = new RequestDataCollector();
+        $collector->collect($request, new Response());
+        // Mirror the profiler lifecycle: data is cloned into a VarDumper Data
+        // object during lateCollect(), which is what the formatter reads back.
+        $collector->lateCollect();
+
+        return $collector;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function format(RequestDataCollector $collector): array
+    {
+        return $this->formatter->format($collector);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

The Symfony profiler `request` collector is exposed to the AI via the
`symfony-profiler-*` tools and resources. It shipped with only cookies,
response/request headers, server/dotenv vars and session attributes redacted —
while the data that actually carries user secrets was passed through verbatim.
This bundles the two request-collector fixes together, since the header change
builds directly on the parameter/body redaction (fork PRs wachterjohannes#36 +
wachterjohannes#39).

### Redact request/query parameters and raw body

Symfony's own collector masks only `request_request['_password']`, so any other
field name (`password`, `pwd`, `api_key`, …), every query-string value and the
whole raw body (e.g. a JSON login payload) reached the model in clear text.

- Redacts values whose key matches a sensitive parameter pattern across
  `request_request` / `request_query` / `request_attributes`, recursively,
  while keeping non-sensitive keys so the AI can still reason over the request.
- Omits the raw request body (`content`), which cannot be reliably
  field-redacted; the parsed, sanitized parameters remain available.
- Closes two re-exposure vectors that re-embed the same data under
  non-sensitive key names:
  - `curlCommand` — reconstructs the request with `--data-raw <body>`, the full
    URL (query string included) and request headers (Authorization included).
  - `REQUEST_URI` / `QUERY_STRING` server vars carry the raw query string;
    `HTTP_COOKIE` is now covered by the env patterns too.

The added test asserts the secret values are absent from the entire formatted
output (not just the one field under test — which is how the `curlCommand` /
server-var re-exposure was found).

### Match request headers by substring

`sanitizeHeaders()` only redacted five hard-coded header names via an exact
`in_array()` match, so common sensitive headers such as `proxy-authorization`,
`www-authenticate`, `x-csrf-token`, `x-xsrf-token` and `x-amz-security-token`
were forwarded unredacted. Replaces the exact-match denylist with
case-insensitive substring matching against a broader pattern set, mirroring the
approach already used for environment variables. A denylist is the wrong
polarity for secrets: over-redacting an occasional benign header is preferable
to leaking one.

Note: detection is key-based, so a secret placed under an innocuous key (e.g. a
JWT in `?q=`) is not caught; this is a deliberate, documented limitation.
