### PR TITLE
[AI Bundle] Add AiAssertionsTrait to assert on AI usage in functional tests

### DIFF
--- a/demo/tests/AiAssertionsTest.php
+++ b/demo/tests/AiAssertionsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Symfony\AI\AiBundle\Test\AiAssertionsTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * The assertions of the AI bundle against the profiler of a real request - the home page calls no
+ * platform, which keeps this test free of an API key, and part of the default suite.
+ *
+ * The use cases themselves are driven by the browser tests in tests/E2E, which do call the models.
+ */
+#[CoversNothing]
+final class AiAssertionsTest extends WebTestCase
+{
+    use AiAssertionsTrait;
+
+    public function testTheHomePageCallsNoPlatform()
+    {
+        $client = static::createClient();
+        $client->enableProfiler();
+
+        $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        self::assertPlatformCallCount(0);
+        self::assertToolCallCount(0);
+    }
+
+    public function testTheToolsOfTheAgentsAreRegistered()
+    {
+        $client = static::createClient();
+        $client->enableProfiler();
+
+        $client->request('GET', '/');
+
+        // The collector gathers the tools of every toolbox of the application, so they are all
+        // registered - even on a request that called no agent at all.
+        self::assertToolRegistered('similarity_search');
+        self::assertToolRegistered('movie_search');
+        self::assertToolRegistered('symfony_blog');
+    }
+}

--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -1245,6 +1245,77 @@ The profiler panel provides insights into the agent's execution:
 .. image:: images/profiler-ai.png
    :alt: Profiler Panel
 
+Testing agents
+~~~~~~~~~~~~~~
+
+Answers of a model are not deterministic, which makes them a poor thing to assert on. What an agent
+*did* is deterministic enough: that it called the model, that it reached for a tool, that it did not
+call the platform twice when once is expected.
+
+The profiler collects exactly that, and ``AiAssertionsTrait`` turns it into assertions for
+functional tests. Enable the profiler on the client before the request, and assert afterwards::
+
+    use Symfony\AI\AiBundle\Test\AiAssertionsTrait;
+    use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+    final class AgentTest extends WebTestCase
+    {
+        use AiAssertionsTrait;
+
+        public function testTheAgentSearchesTheBlog()
+        {
+            $client = static::createClient();
+            $client->enableProfiler();
+
+            $client->request('POST', '/chat', ['message' => 'What happened last week?']);
+
+            // Once to decide on the tool, once with its result.
+            self::assertPlatformCallCount(2);
+            self::assertModelCalled('gpt-4.1');
+            self::assertToolCalled('similarity_search');
+        }
+    }
+
+The trait provides:
+
+``assertPlatformCallCount(int $expectedCount)``
+    The number of calls made to a platform while handling the request, across all agents.
+
+``assertModelCalled(string $model)``
+    That the given model was called at least once.
+
+``assertToolCalled(string $tool)`` and ``assertToolCallCount(int $expectedCount)``
+    The tools the model actually invoked.
+
+``assertToolRegistered(string $tool)``
+    That a tool is configured and therefore available to be called. Careful: the tools are collected
+    from *every* toolbox of the application, not only from the agent that handled the request - so
+    this says that a tool exists, not that this request used it. ``assertToolCalled()`` is what
+    answers the latter.
+
+Reading the collected data
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For anything the assertions do not cover, ``getAiDataCollector()`` hands back the collector itself.
+Its data is collected as objects, so the ``input`` of a platform call is the ``MessageBag`` that was
+sent, and the ``metadata`` is a ``Metadata`` instance carrying the token usage the platform
+reported - there is nothing to parse::
+
+    $call = self::getAiDataCollector()->getPlatformCalls()[0];
+
+    $this->assertNotNull($call['input']->getSystemMessage());
+    $this->assertGreaterThan(0, $call['metadata']->get('token_usage')->getPromptTokens());
+
+Next to ``getPlatformCalls()``, ``getToolCalls()`` and ``getTools()``, the collector exposes the
+agents, chats, message stores and stores that took part in the request.
+
+.. note::
+
+    The data collector only exists when the profiler is enabled, so the profiler needs to be
+    available in the ``test`` environment. Browser-based tests that drive the application in a
+    separate web server - Panther, for instance - cannot reach the collector through the container,
+    and are not covered by the trait.
+
 Message stores
 --------------
 

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Add `AiAssertionsTrait` for functional tests based on Profiler data
  * Add `minimax` platform configuration for the MiniMax bridge
  * Autoconfigure `SchemaProviderInterface` implementations so they can be referenced from `#[Schema(provider: ...)]`, and validate those references on tools at container build time
  * Add support for `ScopingHttpClient` usage in `Typesense` store via `http_client` option

--- a/src/ai-bundle/src/Test/AiAssertionsTrait.php
+++ b/src/ai-bundle/src/Test/AiAssertionsTrait.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\AiBundle\Test;
+
+use PHPUnit\Framework\Assert;
+use Symfony\AI\Agent\Toolbox\ToolResult;
+use Symfony\AI\AiBundle\Profiler\DataCollector;
+use Symfony\AI\Platform\Tool\Tool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+
+/**
+ * Assertions on what the AI components did while handling a request, based on what the profiler
+ * collected for it - the platforms that were called, the tools that were invoked, the token usage
+ * the platform reported.
+ *
+ * Answers of a model are not deterministic, so asserting on them is of limited use. What an agent
+ * *did* is deterministic enough to assert: that it called the model, that it reached for a tool,
+ * that it did not call the platform twice when once is expected.
+ *
+ * The profiler must be enabled for the request, which `$client->enableProfiler()` does.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ *
+ * @phpstan-require-extends WebTestCase
+ */
+trait AiAssertionsTrait
+{
+    /**
+     * Asserts the number of calls that were made to a platform, across all agents of the request.
+     */
+    public static function assertPlatformCallCount(int $expectedCount, string $message = ''): void
+    {
+        $models = self::getCalledModels();
+
+        Assert::assertCount($expectedCount, $models, $message ?: \sprintf(
+            'Failed asserting that %d platform call(s) were made, got %d: %s.',
+            $expectedCount,
+            \count($models),
+            [] === $models ? 'none' : implode(', ', $models),
+        ));
+    }
+
+    /**
+     * Asserts that the given model was called at least once.
+     */
+    public static function assertModelCalled(string $model, string $message = ''): void
+    {
+        $models = self::getCalledModels();
+
+        Assert::assertContains($model, $models, $message ?: \sprintf(
+            'Failed asserting that model "%s" was called, got: %s.',
+            $model,
+            [] === $models ? 'no platform call at all' : implode(', ', $models),
+        ));
+    }
+
+    /**
+     * Asserts that the model invoked the given tool while handling the request.
+     */
+    public static function assertToolCalled(string $tool, string $message = ''): void
+    {
+        $tools = self::getCalledTools();
+
+        Assert::assertContains($tool, $tools, $message ?: \sprintf(
+            'Failed asserting that tool "%s" was called, got: %s.',
+            $tool,
+            [] === $tools ? 'no tool call at all' : implode(', ', $tools),
+        ));
+    }
+
+    /**
+     * Asserts the number of tool calls the models made while handling the request.
+     */
+    public static function assertToolCallCount(int $expectedCount, string $message = ''): void
+    {
+        $tools = self::getCalledTools();
+
+        Assert::assertCount($expectedCount, $tools, $message ?: \sprintf(
+            'Failed asserting that %d tool call(s) were made, got %d: %s.',
+            $expectedCount,
+            \count($tools),
+            [] === $tools ? 'none' : implode(', ', $tools),
+        ));
+    }
+
+    /**
+     * Asserts that the given tool is registered, and therefore available to be called.
+     *
+     * The tools are collected from every toolbox of the application, not only from the agent that
+     * handled the request - this asserts that a tool is configured, not that it was used. Use
+     * `assertToolCalled()` for the latter.
+     */
+    public static function assertToolRegistered(string $tool, string $message = ''): void
+    {
+        $tools = array_map(
+            static fn (Tool $registered): string => $registered->getName(),
+            self::getAiDataCollector()->getTools(),
+        );
+
+        Assert::assertContains($tool, $tools, $message ?: \sprintf(
+            'Failed asserting that tool "%s" is registered, got: %s.',
+            $tool,
+            [] === $tools ? 'no tool at all' : implode(', ', $tools),
+        ));
+    }
+
+    /**
+     * The data collector of the AI bundle, for the last request the client made.
+     */
+    protected static function getAiDataCollector(): DataCollector
+    {
+        $client = self::getClient();
+
+        if (!$client instanceof KernelBrowser) {
+            Assert::fail('A client is needed to make AI assertions, create one with "self::createClient()".');
+        }
+
+        $profile = $client->getProfile();
+
+        if (!$profile instanceof Profile) {
+            Assert::fail('The profiler is not enabled for the request, call "$client->enableProfiler()" before making it.');
+        }
+
+        if (!$profile->hasCollector('ai')) {
+            Assert::fail('The AI data collector is not available, make sure the profiler is enabled in the "test" environment.');
+        }
+
+        $collector = $profile->getCollector('ai');
+
+        if (!$collector instanceof DataCollector) {
+            Assert::fail(\sprintf('Expected the "ai" collector to be a "%s", got a "%s".', DataCollector::class, get_debug_type($collector)));
+        }
+
+        return $collector;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function getCalledModels(): array
+    {
+        return array_map(
+            static fn (array $call): string => $call['model'],
+            self::getAiDataCollector()->getPlatformCalls(),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function getCalledTools(): array
+    {
+        return array_map(
+            static fn (ToolResult $call): string => $call->getToolCall()->getName(),
+            self::getAiDataCollector()->getToolCalls(),
+        );
+    }
+}

--- a/src/ai-bundle/tests/Test/AiAssertionsTraitTest.php
+++ b/src/ai-bundle/tests/Test/AiAssertionsTraitTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\AiBundle\Tests\Test;
+
+use PHPUnit\Framework\AssertionFailedError;
+use Symfony\AI\Agent\Toolbox\ToolboxInterface;
+use Symfony\AI\Agent\Toolbox\ToolResult;
+use Symfony\AI\Agent\Toolbox\TraceableToolbox;
+use Symfony\AI\AiBundle\Exception\RuntimeException;
+use Symfony\AI\AiBundle\Profiler\DataCollector;
+use Symfony\AI\AiBundle\Test\AiAssertionsTrait;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\PlainConverter;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\ExecutionReference;
+use Symfony\AI\Platform\Tool\Tool;
+use Symfony\AI\Platform\TraceablePlatform;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * The assertions of the trait, against a collector that is built by hand - the wiring to the
+ * profiler of a real request is covered by the functional tests of the demo application.
+ */
+final class AiAssertionsTraitTest extends WebTestCase
+{
+    use AiAssertionsTrait;
+
+    private static ?DataCollector $collector = null;
+
+    protected function tearDown(): void
+    {
+        self::$collector = null;
+    }
+
+    public function testAssertsTheNumberOfPlatformCalls()
+    {
+        self::collect(models: ['gpt-4.1', 'gpt-4.1']);
+
+        self::assertPlatformCallCount(2);
+    }
+
+    public function testFailsWhenTheNumberOfPlatformCallsDiffers()
+    {
+        self::collect(models: ['gpt-4.1']);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that 2 platform call(s) were made, got 1: gpt-4.1.');
+
+        self::assertPlatformCallCount(2);
+    }
+
+    public function testAssertsThatAModelWasCalled()
+    {
+        self::collect(models: ['text-embedding-ada-002', 'gpt-4.1']);
+
+        self::assertModelCalled('gpt-4.1');
+        self::assertModelCalled('text-embedding-ada-002');
+    }
+
+    public function testFailsWhenTheModelWasNotCalled()
+    {
+        self::collect(models: ['gpt-4.1']);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that model "gpt-5-mini" was called, got: gpt-4.1.');
+
+        self::assertModelCalled('gpt-5-mini');
+    }
+
+    public function testFailsWithoutAnyPlatformCall()
+    {
+        self::collect();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that model "gpt-4.1" was called, got: no platform call at all.');
+
+        self::assertModelCalled('gpt-4.1');
+    }
+
+    public function testAssertsTheToolCallsOfTheModel()
+    {
+        self::collect(toolCalls: ['similarity_search']);
+
+        self::assertToolCalled('similarity_search');
+        self::assertToolCallCount(1);
+    }
+
+    public function testFailsWhenTheToolWasNotCalled()
+    {
+        self::collect(tools: ['similarity_search'], toolCalls: []);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that tool "similarity_search" was called, got: no tool call at all.');
+
+        self::assertToolCalled('similarity_search');
+    }
+
+    public function testAssertsThatAToolIsRegistered()
+    {
+        self::collect(tools: ['similarity_search', 'clock']);
+
+        self::assertToolRegistered('clock');
+    }
+
+    /**
+     * A tool being registered says nothing about it being called - the collector gathers the tools
+     * of every toolbox of the application, not only of the agent that handled the request.
+     */
+    public function testARegisteredToolIsNotACalledTool()
+    {
+        self::collect(tools: ['similarity_search'], toolCalls: []);
+
+        self::assertToolRegistered('similarity_search');
+        self::assertToolCallCount(0);
+    }
+
+    public function testFailsWhenTheToolIsNotRegistered()
+    {
+        self::collect(tools: ['clock']);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that tool "movie_search" is registered, got: clock.');
+
+        self::assertToolRegistered('movie_search');
+    }
+
+    protected static function getAiDataCollector(): DataCollector
+    {
+        return self::$collector ?? throw new RuntimeException('Collect data with "self::collect()" first.');
+    }
+
+    /**
+     * @param list<string> $models    the models that were called on a platform
+     * @param list<string> $tools     the tools that are registered on a toolbox
+     * @param list<string> $toolCalls the tools the model invoked
+     */
+    private static function collect(array $models = [], array $tools = [], array $toolCalls = []): void
+    {
+        $platform = self::createStub(PlatformInterface::class);
+        $platform->method('invoke')->willReturn(
+            new DeferredResult(new PlainConverter(new TextResult('Answer')), self::createStub(RawResultInterface::class)),
+        );
+
+        $traceablePlatform = new TraceablePlatform($platform);
+        foreach ($models as $model) {
+            $traceablePlatform->invoke($model, new MessageBag(Message::ofUser('Hello')));
+        }
+
+        $toolbox = self::createStub(ToolboxInterface::class);
+        $toolbox->method('getTools')->willReturn(array_map(
+            static fn (string $tool): Tool => new Tool(new ExecutionReference('App\Tool\\'.$tool, '__invoke'), $tool, 'A tool.'),
+            $tools,
+        ));
+        $toolbox->method('execute')->willReturnCallback(
+            static fn (ToolCall $toolCall): ToolResult => new ToolResult($toolCall, 'Result of '.$toolCall->getName()),
+        );
+
+        $traceableToolbox = new TraceableToolbox($toolbox);
+        foreach ($toolCalls as $index => $tool) {
+            $traceableToolbox->execute(new ToolCall('call_'.$index, $tool));
+        }
+
+        self::$collector = new DataCollector([$traceablePlatform], [$traceableToolbox], [], [], [], []);
+        self::$collector->lateCollect();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Answers of a model are not deterministic, which makes them a poor thing to assert on. What an agent
*did* is deterministic enough: that it called the model, that it reached for a tool, that it did not
call the platform twice when once is expected.

The profiler already collects all of that - `AiAssertionsTrait` turns it into assertions for a
`WebTestCase`:

```php
final class AgentTest extends WebTestCase
{
    use AiAssertionsTrait;

    public function testTheAgentSearchesTheBlog()
    {
        $client = static::createClient();
        $client->enableProfiler();

        $client->request('POST', '/chat', ['message' => 'What happened last week?']);

        self::assertPlatformCallCount(2);   // once to decide on the tool, once with its result
        self::assertModelCalled('gpt-4.1');
        self::assertToolCalled('similarity_search');
    }
}
```

* `assertPlatformCallCount()`, `assertModelCalled()`, `assertToolCalled()`, `assertToolCallCount()`
  and `assertToolRegistered()`.
* `assertToolRegistered()` is named apart from `assertToolCalled()` on purpose: the collector gathers
  the tools of *every* toolbox of the application, not only of the agent that handled the request, so
  it says a tool is configured - not that this request used it.
* `getAiDataCollector()` is the escape hatch for anything the assertions do not cover. The data is
  collected as objects, so the `input` of a platform call is the `MessageBag` that was sent and the
  `metadata` is a `Metadata` carrying the token usage - there is nothing to parse.

The demo uses it in `AiAssertionsTest` on its home page, which calls no platform and therefore needs
no API key, so it runs in CI.

Split out of #2300, which is rebased on top of this and where the trait came up.