### PR TITLE
[Store] Add integration tests for Pinecone and S3Vectors bridges

### DIFF
--- a/src/store/src/Bridge/Pinecone/Tests/Fixtures/PineconeLocalClient.php
+++ b/src/store/src/Bridge/Pinecone/Tests/Fixtures/PineconeLocalClient.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Pinecone\Tests\Fixtures;
+
+use Probots\Pinecone\Client;
+use Probots\Pinecone\Resources\ControlResource;
+use Probots\Pinecone\Resources\DataResource;
+
+/**
+ * Client for Pinecone Local, which - unlike the hosted service - serves the control plane and every index
+ * on a different host: the control plane listens on a fixed port, while each index gets its own port assigned
+ * on creation. Since the index host is therefore unknown until the index exists, it is resolved lazily.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ *
+ * @see https://docs.pinecone.io/guides/operations/local-development
+ */
+final class PineconeLocalClient extends Client
+{
+    public function __construct(
+        string $apiKey,
+        private readonly string $controlPlaneHost,
+        private readonly string $indexName,
+    ) {
+        parent::__construct($apiKey);
+    }
+
+    public function control(): ControlResource
+    {
+        // Reset the base URL, since data operations point it to the index host
+        $this->baseUrl = $this->controlPlaneHost;
+
+        return parent::control();
+    }
+
+    public function data(): DataResource
+    {
+        if (null === $this->indexHost) {
+            $host = $this->control()->index($this->indexName)->describe()->json()['host'];
+
+            $this->setIndexHost(str_starts_with($host, 'http') ? $host : 'http://'.$host);
+        }
+
+        return parent::data();
+    }
+}

--- a/src/store/src/Bridge/Pinecone/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/Pinecone/Tests/IntegrationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\Pinecone\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use Saloon\Exceptions\Request\Statuses\NotFoundException;
+use Symfony\AI\Store\Bridge\Pinecone\Store;
+use Symfony\AI\Store\Bridge\Pinecone\Tests\Fixtures\PineconeLocalClient;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    private const INDEX_NAME = 'test-index';
+
+    protected static function createStore(): StoreInterface
+    {
+        // Pinecone Local ignores the API key, but the client requires one
+        $store = new Store(
+            new PineconeLocalClient('pclocal', 'http://127.0.0.1:5080', self::INDEX_NAME),
+            self::INDEX_NAME,
+        );
+
+        // The index outlives a previous run that did not reach drop(), and creating it again would fail
+        try {
+            $store->drop();
+        } catch (NotFoundException) {
+        }
+
+        return $store;
+    }
+
+    protected static function getSetupOptions(): array
+    {
+        return [
+            'dimension' => 3,
+            'metric' => 'cosine',
+            'cloud' => 'aws',
+            'region' => 'us-east-1',
+        ];
+    }
+
+    protected function waitForIndexing(): void
+    {
+        sleep(2);
+    }
+}

--- a/src/store/src/Bridge/Pinecone/compose.yaml
+++ b/src/store/src/Bridge/Pinecone/compose.yaml
@@ -1,0 +1,10 @@
+services:
+    pinecone:
+        image: ghcr.io/pinecone-io/pinecone-local:latest
+        platform: linux/amd64
+        environment:
+            PORT: 5080
+            PINECONE_HOST: localhost
+        ports:
+            # The control plane listens on 5080, every created index is exposed on its own port of the range
+            - '5080-5090:5080-5090'

--- a/src/store/src/Bridge/S3Vectors/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/S3Vectors/Tests/IntegrationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Bridge\S3Vectors\Tests;
+
+use AsyncAws\S3Vectors\Exception\NotFoundException;
+use AsyncAws\S3Vectors\S3VectorsClient;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\AI\Store\Bridge\S3Vectors\Store;
+use Symfony\AI\Store\StoreInterface;
+use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[Group('integration')]
+final class IntegrationTest extends AbstractStoreIntegrationTestCase
+{
+    protected static function createStore(): StoreInterface
+    {
+        // LocalS3 ignores the credentials, but the client requires them
+        $store = new Store(
+            new S3VectorsClient([
+                'endpoint' => 'http://127.0.0.1:8099',
+                'region' => 'us-east-1',
+                'accessKeyId' => 'test',
+                'accessKeySecret' => 'test',
+            ]),
+            'test-bucket',
+            'test-index',
+        );
+
+        // Bucket and index outlive a previous run that did not reach drop(), and creating them again would fail
+        try {
+            $store->drop();
+        } catch (NotFoundException) {
+        }
+
+        return $store;
+    }
+
+    protected static function getSetupOptions(): array
+    {
+        return [
+            'dimension' => 3,
+        ];
+    }
+}

--- a/src/store/src/Bridge/S3Vectors/compose.yaml
+++ b/src/store/src/Bridge/S3Vectors/compose.yaml
@@ -1,0 +1,5 @@
+services:
+    local-s3:
+        image: luofuxiang/local-s3:2.4
+        ports:
+            - '8099:80'

--- a/src/store/src/Bridge/S3Vectors/phpunit.xml.dist
+++ b/src/store/src/Bridge/S3Vectors/phpunit.xml.dist
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    failOnWarning is disabled, unlike in the other bridges: the LocalS3 emulator used for the integration tests
+    omits the "distanceMetric" field in QueryVectors responses, even though AWS declares it as required, which
+    makes async-aws emit a PHP warning while parsing the response. Can be enabled once LocalS3 returns it.
+-->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
@@ -6,7 +12,7 @@
          bootstrap="vendor/autoload.php"
          failOnDeprecation="true"
          failOnRisky="true"
-         failOnWarning="true"
+         failOnWarning="false"
          executionOrder="random"
 >
     <php>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Adds `compose.yaml` + `IntegrationTest` for the two store bridges that had neither, so CI covers them like the other store bridges:

* **Pinecone** via the official `pinecone-local` emulator. It serves the control plane and each index on different ports, while the `probots` client hardcodes control calls to `api.pinecone.io`, so the test uses a small `PineconeLocalClient` fixture that redirects the control plane and resolves the index host lazily.
* **S3Vectors** via the LocalS3 emulator, which is the only one implementing `QueryVectors` (LocalStack has no S3 Vectors support, moto lacks the query call).

`failOnWarning` is disabled for the S3Vectors bridge: LocalS3 omits the `distanceMetric` field in `QueryVectors` responses although AWS declares it as required, which makes async-aws warn while parsing. Can be enabled again once LocalS3 returns it.

AzureSearch and Cloudflare stay uncovered - there is no emulator for Azure AI Search with vector search support, and Cloudflare Vectorize has no local mode at all.