### PR TITLE
[Platform] Harden VertexAI location handling and deduplicate endpoint building

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -89,6 +89,20 @@ Platform
    +Factory::createPlatform('global', 'my-project'); // keep the global host
    ```
 
+   The same applies to the AI Bundle, which passes its configured `location` to the factory:
+
+   ```diff
+   ai:
+       platform:
+           vertexai:
+   -            location: 'europe-west1' # used aiplatform.googleapis.com
+   +            location: 'global' # keep the global host
+               project_id: 'my-project'
+   ```
+
+   A `location` that is neither `global`, `eu`/`us`, nor a region (e.g. `europe-west1`) is now
+   rejected with an `InvalidArgumentException` instead of being sent to a non-existing host.
+
 Store
 -----
 

--- a/docs/components/platform/vertexai.rst
+++ b/docs/components/platform/vertexai.rst
@@ -165,6 +165,14 @@ The API host is derived from the ``location`` passed to the factory:
 
 See `Vertex AI locations`_ and `Vertex AI data residency`_ for the list of supported values.
 
+The location is case-insensitive, and a value that is neither ``global``, ``eu``/``us``, nor a
+region is rejected with an ``InvalidArgumentException``.
+
+.. note::
+
+    The location is only part of the project-scoped URL, so it only takes effect together with a
+    project ID. The API-key-only setup always uses the global endpoint.
+
 Token Usage Tracking
 --------------------
 

--- a/src/platform/src/Bridge/VertexAi/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/VertexAi/Embeddings/ModelClient.php
@@ -43,25 +43,7 @@ final class ModelClient implements ModelClientInterface
      */
     public function request(BaseModel $model, array|string $payload, array $options = []): RawHttpResult
     {
-        $host = $this->resolveHost($this->location);
-
-        if (null !== $this->location && null !== $this->projectId) {
-            $url = \sprintf(
-                'https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s:%s',
-                $host,
-                $this->projectId,
-                $this->location,
-                $model->getName(),
-                'predict',
-            );
-        } else {
-            $url = \sprintf(
-                'https://%s/v1/publishers/google/models/%s:%s',
-                $host,
-                $model->getName(),
-                'predict',
-            );
-        }
+        $url = self::getEndpoint($this->location, $this->projectId, $model->getName(), 'predict');
 
         $query = [];
         if (null !== $this->apiKey) {

--- a/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
@@ -53,25 +53,7 @@ final class ModelClient implements ModelClientInterface
         $isStream = $options['stream'] ?? false;
         $method = $isStream ? 'streamGenerateContent' : 'generateContent';
 
-        $host = $this->resolveHost($this->location);
-
-        if (null !== $this->location && null !== $this->projectId) {
-            $url = \sprintf(
-                'https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s:%s',
-                $host,
-                $this->projectId,
-                $this->location,
-                $model->getName(),
-                $method,
-            );
-        } else {
-            $url = \sprintf(
-                'https://%s/v1/publishers/google/models/%s:%s',
-                $host,
-                $model->getName(),
-                $method,
-            );
-        }
+        $url = self::getEndpoint($this->location, $this->projectId, $model->getName(), $method);
 
         $query = [];
         if (null !== $this->apiKey) {

--- a/src/platform/src/Bridge/VertexAi/RegionAwareTrait.php
+++ b/src/platform/src/Bridge/VertexAi/RegionAwareTrait.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\AI\Platform\Bridge\VertexAi;
 
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+
 /**
- * Derives the Vertex AI API host from the configured location so that regional
- * and data-residency (jurisdictional) endpoints are used when required.
+ * Builds the Vertex AI endpoint URL, deriving the API host from the configured location so that
+ * regional and data-residency (jurisdictional) endpoints are used when required.
  *
  * @see https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
  * @see https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/data-residency
@@ -22,6 +24,8 @@ namespace Symfony\AI\Platform\Bridge\VertexAi;
  */
 trait RegionAwareTrait
 {
+    private const GLOBAL_HOST = 'aiplatform.googleapis.com';
+
     /**
      * Multi-region data-residency (jurisdictional) endpoints keyed by location.
      */
@@ -30,16 +34,43 @@ trait RegionAwareTrait
         'us' => 'aiplatform.us.rep.googleapis.com',
     ];
 
-    private function resolveHost(?string $location): string
+    /**
+     * Locations are lowercase, e.g. "global", "eu", "us", "europe-west1" or "northamerica-northeast1".
+     */
+    private const LOCATION_PATTERN = '/^[a-z]+(-[a-z]+\d+)?$/';
+
+    /**
+     * The location is only part of the URL for the project-scoped endpoint, so without a project ID
+     * the global endpoint is the only one that can be addressed.
+     */
+    private static function getEndpoint(?string $location, ?string $projectId, string $model, string $method): string
     {
-        if (null === $location || 'global' === $location) {
-            return 'aiplatform.googleapis.com';
+        if (null === $location || null === $projectId) {
+            return \sprintf('https://%s/v1/publishers/google/models/%s:%s', self::GLOBAL_HOST, $model, $method);
         }
 
-        if (isset(self::RESIDENCY_HOSTS[$location])) {
-            return self::RESIDENCY_HOSTS[$location];
+        $location = strtolower($location);
+
+        return \sprintf(
+            'https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s:%s',
+            self::getHost($location),
+            $projectId,
+            $location,
+            $model,
+            $method,
+        );
+    }
+
+    private static function getHost(string $location): string
+    {
+        if (1 !== preg_match(self::LOCATION_PATTERN, $location)) {
+            throw new InvalidArgumentException(\sprintf('Invalid location "%s". Valid options are "global", "eu", "us", or a region like "europe-west1".', $location));
         }
 
-        return \sprintf('%s-aiplatform.googleapis.com', $location);
+        if ('global' === $location) {
+            return self::GLOBAL_HOST;
+        }
+
+        return self::RESIDENCY_HOSTS[$location] ?? \sprintf('%s-aiplatform.googleapis.com', $location);
     }
 }

--- a/src/platform/src/Bridge/VertexAi/Tests/Embeddings/ModelClientTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Embeddings/ModelClientTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\ModelClient;
 use Symfony\AI\Platform\Bridge\VertexAi\Embeddings\TaskType;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 
@@ -36,6 +37,10 @@ final class ModelClientTest extends TestCase
         $result = $client->request($model, 'test payload');
 
         $this->assertSame($expectedResponse, $result->getData());
+        $this->assertSame(
+            'https://aiplatform.googleapis.com/v1/projects/test/locations/global/publishers/google/models/gemini-embedding-001:predict',
+            $result->getObject()->getInfo()['url'],
+        );
     }
 
     public function testItUsesTheRegionalEndpointForARegionalLocation()
@@ -80,6 +85,31 @@ final class ModelClientTest extends TestCase
         });
 
         $client = new ModelClient($httpClient, apiKey: 'test-key');
+        $client->request(new Model('gemini-embedding-001'), 'test payload');
+    }
+
+    public function testItUsesTheGlobalEndpointWhenTheProjectIdIsMissing()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertSame(
+                'https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-embedding-001:predict',
+                $url,
+            );
+
+            return new JsonMockResponse(['predictions' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'europe-west1');
+        $client->request(new Model('gemini-embedding-001'), 'test payload');
+    }
+
+    public function testItThrowsOnAnInvalidLocation()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'evil.com/europe-west1', 'test');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid location "evil.com/europe-west1". Valid options are "global", "eu", "us", or a region like "europe-west1".');
+
         $client->request(new Model('gemini-embedding-001'), 'test payload');
     }
 }

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\VertexAi\Tests\Gemini;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ModelClient;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 
@@ -91,6 +92,46 @@ final class ModelClientTest extends TestCase
         });
 
         $client = new ModelClient($httpClient, apiKey: 'test-key');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => []]);
+    }
+
+    public function testItUsesTheGlobalEndpointWhenTheProjectIdIsMissing()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertSame(
+                'https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.0-flash:generateContent',
+                $url,
+            );
+
+            return new JsonMockResponse(['candidates' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'europe-west1');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => []]);
+    }
+
+    public function testItLowercasesTheLocation()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url) {
+            $this->assertSame(
+                'https://aiplatform.eu.rep.googleapis.com/v1/projects/test/locations/eu/publishers/google/models/gemini-2.0-flash:generateContent',
+                $url,
+            );
+
+            return new JsonMockResponse(['candidates' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'EU', 'test');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => []]);
+    }
+
+    public function testItThrowsOnAnInvalidLocation()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'evil.com/europe-west1', 'test');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid location "evil.com/europe-west1". Valid options are "global", "eu", "us", or a region like "europe-west1".');
+
         $client->request(new Model('gemini-2.0-flash'), ['contents' => []]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

Follow-up to #2284, addressing review findings on the merged change.

- Move the full URL construction into `RegionAwareTrait` — both model clients carried an identical copy of the project-scoped/global branch.
- Resolve the host only when a project ID is present: a location without a project ID produced a regional host glued to a location-less path, i.e. a URL that cannot work (`Factory` forbids that combination, the clients did not).
- Validate and lowercase the location, so `EU` works and a typo fails with an `InvalidArgumentException` instead of a DNS error on a bogus host. Mirrors `OpenAi\RegionAwareTrait::getBaseUrl()`.
- `UPGRADE.md`: cover AI Bundle users too — the bundle passes its configured `location` straight into the factory, so `ai.platform.vertexai.location` is affected by the same BC break.
- Tests for the new cases, plus the previously unasserted global-with-project URL on the embeddings client.