### PR TITLE
[Platform] Allow scoping generated JSON Schema to serializer groups

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -981,6 +981,50 @@ serialization groups::
         'response_format' => $product,
     ]);
 
+Scoping the Schema to Serializer Groups
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Structured output and tools are often built on top of existing domain objects, where only a subset of the properties
+should be exposed to the model. The :class:`Symfony\\AI\\Platform\\Contract\\JsonSchema\\Factory` accepts an optional
+context on both ``buildProperties()`` and ``buildParameters()``. Its ``serializer_groups`` key scopes the generated
+schema to the given Symfony Serializer groups::
+
+    use Symfony\Component\Serializer\Attribute\Groups;
+
+    final class Product
+    {
+        #[Groups(['read', 'write'])]
+        public string $name = '';
+
+        #[Groups(['write'])]
+        public ?int $price = null;
+
+        #[Groups(['read'])]
+        public string $slug = '';
+
+        public string $internalNote = '';
+    }
+
+Without a context, all properties are described, which is the default behavior::
+
+    use Symfony\AI\Platform\Contract\JsonSchema\Factory;
+
+    $factory = new Factory();
+
+    $factory->buildProperties(Product::class);
+    // properties: name, price, slug, internalNote
+
+Passing ``serializer_groups`` limits the schema to the properties tagged with one of the given groups::
+
+    $factory->buildProperties(Product::class, ['serializer_groups' => ['write']]);
+    // properties: name, price
+
+    $factory->buildProperties(Product::class, ['serializer_groups' => ['read', 'write']]);
+    // properties: name, price, slug
+
+The same context is accepted by ``buildParameters()`` for tool method arguments, and it is propagated into nested
+schemas, so discriminated sub-schemas (``anyOf``) are scoped the same way.
+
 Validating Structured Output
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Add optional `$context` argument to `Contract\JsonSchema\Factory` build methods to limit schema to subset of properties
  * Add `MessageBag::isLastMessageFrom()` to check whether the last message has a given role
  * Add `MaxOutputTokensException` for completed responses truncated by output token limits
  * Convert OpenAI Responses built-in tool output items (`web_search_call`, `file_search_call`, `code_interpreter_call`, `image_generation_call`, `mcp_call`, `mcp_list_tools`, `mcp_approval_request`, `computer_call`, `local_shell_call`) into typed results instead of skipping them. Adds `Result\WebSearchResult`, `Result\FileSearchResult`, `Result\McpCallResult`, `Result\McpListToolsResult`, `Result\McpApprovalRequestResult`, `Result\ComputerCallResult`, and `Result\LocalShellCallResult` (code interpreter reuses `ExecutableCodeResult`/`CodeExecutionResult`, image generation reuses `BinaryResult`), plus the matching `Message\Content` classes so the results round-trip through `Message::ofAssistant()`. Benefits the OpenAI, Azure OpenAI, and Scaleway bridges.

--- a/src/platform/src/Contract/JsonSchema/Describer/PropertyInfoDescriber.php
+++ b/src/platform/src/Contract/JsonSchema/Describer/PropertyInfoDescriber.php
@@ -59,7 +59,12 @@ final class PropertyInfoDescriber implements ObjectDescriberInterface, PropertyD
         }
 
         $class = $subject->getReflector()->name;
-        foreach ($this->propertyListExtractor->getProperties($class, ['serializer_groups' => $this->serializerGroups]) ?? [] as $propertyName) {
+
+        // A per-call `serializer_groups` context narrows the schema to the given groups,
+        // falling back to the groups this describer was configured with.
+        $serializerGroups = $subject->getContext()['serializer_groups'] ?? $this->serializerGroups;
+
+        foreach ($this->propertyListExtractor->getProperties($class, ['serializer_groups' => $serializerGroups]) ?? [] as $propertyName) {
             if (!$this->propertyInfo->isWritable($class, $propertyName) && !$this->propertyInfo->isInitializable($class, $propertyName)) {
                 continue;
             }

--- a/src/platform/src/Contract/JsonSchema/Describer/SerializerDescriber.php
+++ b/src/platform/src/Contract/JsonSchema/Describer/SerializerDescriber.php
@@ -61,7 +61,8 @@ final class SerializerDescriber implements ObjectDescriberInterface, ObjectDescr
             $typeProperty = $discriminatorMapping->getTypeProperty();
             foreach ($discriminatorMapping->getTypesMapping() as $discriminatorValue => $discriminatorClass) {
                 $subSchema = &$schema['anyOf'][];
-                $this->describer->describeObject(new ObjectSubject($discriminatorClass, new \ReflectionClass($discriminatorClass)), $subSchema);
+                // Keep nested schemas scoped to the same context, e.g. `serializer_groups`.
+                $this->describer->describeObject(new ObjectSubject($discriminatorClass, new \ReflectionClass($discriminatorClass), $subject->getContext()), $subSchema);
                 $subSchema['properties'][$typeProperty]['enum'] = [$discriminatorValue];
             }
         }

--- a/src/platform/src/Contract/JsonSchema/Factory.php
+++ b/src/platform/src/Contract/JsonSchema/Factory.php
@@ -57,23 +57,27 @@ final class Factory
     }
 
     /**
+     * @param array<string, mixed> $context Describer context, e.g. `['serializer_groups' => ['write']]`
+     *
      * @return JsonSchema|null
      */
-    public function buildParameters(string $className, string $methodName): ?array
+    public function buildParameters(string $className, string $methodName, array $context = []): ?array
     {
         $schema = null;
-        $this->objectDescriber->describeObject(new ObjectSubject($className.'::'.$methodName, new \ReflectionMethod($className, $methodName)), $schema);
+        $this->objectDescriber->describeObject(new ObjectSubject($className.'::'.$methodName, new \ReflectionMethod($className, $methodName), $context), $schema);
 
         return $schema;
     }
 
     /**
+     * @param array<string, mixed> $context Describer context, e.g. `['serializer_groups' => ['write']]`
+     *
      * @return JsonSchema|null
      */
-    public function buildProperties(string $className): ?array
+    public function buildProperties(string $className, array $context = []): ?array
     {
         $schema = null;
-        $this->objectDescriber->describeObject(new ObjectSubject($className, new \ReflectionClass($className)), $schema);
+        $this->objectDescriber->describeObject(new ObjectSubject($className, new \ReflectionClass($className), $context), $schema);
 
         return $schema;
     }

--- a/src/platform/src/Contract/JsonSchema/Subject/ObjectSubject.php
+++ b/src/platform/src/Contract/JsonSchema/Subject/ObjectSubject.php
@@ -16,14 +16,26 @@ final class ObjectSubject
     /**
      * @param class-string|string                                  $name
      * @param \ReflectionClass<covariant object>|\ReflectionMethod $reflector
+     * @param array<string, mixed>                                 $context   Describer context, e.g. `serializer_groups`
      */
-    public function __construct(private string $name, private \ReflectionClass|\ReflectionMethod $reflector)
-    {
+    public function __construct(
+        private string $name,
+        private \ReflectionClass|\ReflectionMethod $reflector,
+        private array $context = [],
+    ) {
     }
 
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContext(): array
+    {
+        return $this->context;
     }
 
     /**

--- a/src/platform/tests/Contract/JsonSchema/FactoryTest.php
+++ b/src/platform/tests/Contract/JsonSchema/FactoryTest.php
@@ -20,6 +20,7 @@ use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithObjectAccessors;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithToolParameterAttribute;
 use Symfony\AI\Platform\Contract\JsonSchema\Factory;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\ExampleDto;
+use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\GroupedDto;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\MathReasoning;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\PolymorphicType\ListOfPolymorphicTypesDto;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\SchemaAttributeValuesDto;
@@ -455,5 +456,48 @@ final class FactoryTest extends TestCase
         ];
 
         $this->assertSame($expected, $actual);
+    }
+
+    public function testBuildPropertiesWithoutSerializerGroupsIncludesAllProperties()
+    {
+        $expected = [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'age' => ['type' => ['integer', 'null']],
+                'slug' => ['type' => 'string'],
+                'internal' => ['type' => 'string'],
+            ],
+            'required' => ['name', 'age', 'slug', 'internal'],
+            'additionalProperties' => false,
+        ];
+
+        $actual = $this->factory->buildProperties(GroupedDto::class);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testBuildPropertiesScopedToSerializerGroups()
+    {
+        $expected = [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'age' => ['type' => ['integer', 'null']],
+            ],
+            'required' => ['name', 'age'],
+            'additionalProperties' => false,
+        ];
+
+        $actual = $this->factory->buildProperties(GroupedDto::class, ['serializer_groups' => ['write']]);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testBuildPropertiesScopedToMultipleSerializerGroups()
+    {
+        $actual = $this->factory->buildProperties(GroupedDto::class, ['serializer_groups' => ['read', 'write']]);
+
+        $this->assertSame(['name', 'age', 'slug'], array_keys($actual['properties']));
     }
 }

--- a/src/platform/tests/Fixtures/StructuredOutput/GroupedDto.php
+++ b/src/platform/tests/Fixtures/StructuredOutput/GroupedDto.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Fixtures\StructuredOutput;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+
+final class GroupedDto
+{
+    #[Groups(['read', 'write'])]
+    public string $name = '';
+
+    #[Groups(['write'])]
+    public ?int $age = null;
+
+    #[Groups(['read'])]
+    public string $slug = '';
+
+    public string $internal = '';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

`PropertyInfoDescriber` already supports serializer-group filtering, but only via its constructor — there was no way to pass groups per call.

This threads an optional `$context` from `Factory` down to the describers:

* `Factory::buildProperties()` / `buildParameters()` accept `array $context = []`
* `ObjectSubject` carries it and exposes `getContext()`
* `PropertyInfoDescriber` prefers a per-call `serializer_groups` context over its constructed groups
* `SerializerDescriber` propagates the context into discriminator `anyOf` sub-schemas

```php
$factory->buildProperties(GroupedDto::class, ['serializer_groups' => ['write']]);
// => only the properties in the "write" group
```

Fully backward compatible: the new arguments default to `[]` / `['*']`, so existing callers and emitted schemas are unchanged.