### PR TITLE
[AI Bundle] Pass the serializer to TemplateRendererListener

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -392,6 +392,45 @@ Multiple messages can use the same variable set::
         ],
     ]);
 
+Object Variables
+................
+
+Template variables are not restricted to scalar values - objects can be passed as
+well. They are normalized into an array first, and since the string renderer
+flattens nested arrays into dot-paths, the object's properties are addressable
+with dotted placeholders::
+
+    $messages = new MessageBag(
+        Message::forSystem('You are a product copywriter.'),
+        Message::ofUser(Template::string('Write a teaser for {product.name}, priced at {product.price} EUR.'))
+    );
+
+    $result = $platform->invoke('gpt-4o-mini', $messages, [
+        'template_vars' => ['product' => $product],
+    ]);
+
+By default, every property the normalizer can read ends up in the prompt. To
+control which ones are exposed - for example to keep internal fields out of the
+prompt - pass a normalizer context via the ``template_options`` option, such as
+serialization groups::
+
+    $result = $platform->invoke('gpt-4o-mini', $messages, [
+        'template_vars' => ['product' => $product],
+        'template_options' => [
+            'normalizer_context' => [
+                'groups' => ['prompt'],
+            ],
+        ],
+    ]);
+
+With that context, only properties within the ``prompt`` serialization group are
+normalized, and therefore only those can be referenced in the template.
+
+.. note::
+
+    Object variables require a normalizer, see `Setup`_ below. Objects implementing
+    ``\Stringable`` are an exception: they are used as-is and not normalized.
+
 Expression Templates
 ....................
 
@@ -422,9 +461,17 @@ To use templates, register the ``TemplateRendererListener`` with your platform's
 
     $platform = Factory::createPlatform($apiKey, eventDispatcher: $eventDispatcher);
 
+To use objects as template variables, the listener needs a normalizer as second
+argument - without it, object variables are rejected with an exception::
+
+    use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+    $templateListener = new TemplateRendererListener($rendererRegistry, new ObjectNormalizer());
+
 .. note::
 
-    When using the AI Bundle, template rendering is automatically configured and available without manual setup.
+    When using the AI Bundle, template rendering is automatically configured and available without manual setup,
+    including the ``serializer`` service as normalizer, so object variables work out of the box.
 
 Result Streaming
 ----------------

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Pass the `serializer` to `TemplateRendererListener` so objects can be used as `template_vars`
  * Add `AiAssertionsTrait` for functional tests based on Profiler data
  * Add `minimax` platform configuration for the MiniMax bridge
  * Autoconfigure `SchemaProviderInterface` implementations so they can be referenced from `#[Schema(provider: ...)]`, and validate those references on tools at container build time

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -162,6 +162,7 @@ return static function (ContainerConfigurator $container): void {
         ->set('ai.platform.template_renderer_listener', TemplateRendererListener::class)
             ->args([
                 service('ai.platform.template_renderer_registry'),
+                service('serializer')->nullOnInvalid(),
             ])
             ->tag('kernel.event_subscriber')
         ->set('ai.platform.string_to_message_bag_listener', StringToMessageBagListener::class)

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -167,6 +167,22 @@ class AiBundleTest extends TestCase
         $this->assertSame([['id' => 'ai']], $definition->getTag('data_collector'));
     }
 
+    public function testTemplateRendererListenerReceivesNormalizer()
+    {
+        $container = $this->buildContainer($this->getFullConfig());
+        $definition = $container->getDefinition('ai.platform.template_renderer_listener');
+
+        $this->assertTrue($definition->hasTag('kernel.event_subscriber'));
+
+        $arguments = $definition->getArguments();
+        $this->assertCount(2, $arguments);
+        $this->assertSame('ai.platform.template_renderer_registry', (string) $arguments[0]);
+
+        // Without a normalizer the listener rejects object template vars, which makes
+        // `template_options.normalizer_context` unusable.
+        $this->assertSame('serializer', (string) $arguments[1]);
+    }
+
     public function testStoreCommandsArentDefinedWithoutStore()
     {
         $container = $this->buildContainer([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

## Problem

`TemplateRendererListener` accepts an optional `NormalizerInterface` as its second argument and uses it to normalize **object** template variables, honoring `template_options['normalizer_context']` (e.g. serializer `groups`):

```php
if (\is_object($value) && !$value instanceof \Stringable) {
    if (null === $this->normalizer) {
        throw new InvalidArgumentException(\sprintf('Template variable "%s" is an object but no normalizer is configured. ...', $key));
    }

    $normalized[$key] = $this->normalizer->normalize($value, null, $normalizerContext);
}
```

The bundle registers the listener with **only** the renderer registry:

```php
->set('ai.platform.template_renderer_listener', TemplateRendererListener::class)
    ->args([
        service('ai.platform.template_renderer_registry'),
    ])
    ->tag('kernel.event_subscriber')
```

so `$normalizer` is always `null`. Passing an object as a template variable therefore throws, and the entire object-normalization feature — together with `template_options['normalizer_context']` — is unreachable in a Symfony application. Only scalar template vars work today.

## Solution

Wire the `serializer` service as the second argument (`nullOnInvalid()`, since the argument is optional and the serializer may not be installed).

This makes objects usable as template variables, with the normalizer context applied:

```php
$platform->invoke($model, $messages, [
    'template_vars' => ['star' => $star],
    'template_options' => ['normalizer_context' => ['groups' => ['prompt']]],
]);
```

Combined with `StringTemplateRenderer`'s array flattening, the normalized object is addressable with dotted placeholders — `{star.name}`, `{star.yearOfBirth}` — and serializer groups control exactly which fields reach the prompt.

## BC

None. The argument was already optional; this only supplies it. Behavior for scalar template vars is unchanged.

## Tests

`AiBundleTest::testTemplateRendererListenerReceivesNormalizer()` asserts the listener is registered with both arguments and still tagged `kernel.event_subscriber`.

Full `src/ai-bundle` suite is green (404 tests) and PHPStan reports no errors.
