### PR TITLE
[AI Bundle][Agent][Platform] Allow attaching metadata to tools

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,18 @@
 UPGRADE FROM 0.10 to 0.11
 =========================
 
+Agent
+-----
+
+ * Rename of `getMetadata()` of tool call events to `getDefinition()` affecting
+   `ToolCallRequested`, `ToolCallArgumentsResolved`, `ToolCallSucceeded` and `ToolCallFailed`.
+   Update custom listeners:
+
+   ```diff
+   -$event->getMetadata()->getName();
+   +$event->getDefinition()->getName();
+   ```
+
 Platform
 --------
 

--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -134,6 +134,58 @@ You can configure the method to be called by the LLM with the :class:`Symfony\\A
         }
     }
 
+Tool Metadata
+~~~~~~~~~~~~~
+
+Tools can carry arbitrary, application-defined data via the ``metadata`` argument. It is not
+interpreted by Symfony AI itself - it is yours to act on::
+
+    use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+
+    #[AsTool('search_products', 'Search the product catalog', metadata: ['needs_confirmation' => false])]
+    #[AsTool('delete_product', 'Delete a product', method: 'delete', metadata: ['needs_confirmation' => true])]
+    final class ProductTool
+    {
+        // ...
+    }
+
+The metadata is carried to the :class:`Symfony\\AI\\Platform\\Tool\\Tool` definition, so you can read it
+with ``getMetadata()`` or ``getMetadataValue()``.
+
+This enables two things a deny-listing listener cannot. First, you can shape the toolset *before* it is
+offered to the model, so a tool the model must not use is never advertised in the first place::
+
+    $readOnlyTools = array_filter(
+        iterator_to_array($toolbox->getTools()),
+        static fn (Tool $tool): bool => false === $tool->getMetadataValue('needs_confirmation', true),
+    );
+
+Second, you can act on it just before a tool is invoked, by listening to
+:class:`Symfony\\AI\\Agent\\Toolbox\\Event\\ToolCallRequested` and denying the call::
+
+    use Symfony\AI\Agent\Toolbox\Event\ToolCallRequested;
+
+    final class HumanInTheLoopListener
+    {
+        public function __invoke(ToolCallRequested $event): void
+        {
+            // default to requiring confirmation, so a tool added without metadata is not silently exempt
+            if (false === $event->getDefinition()->getMetadataValue('needs_confirmation', true)) {
+                return;
+            }
+
+            if (!$this->approvals->isApproved($event->getToolCall())) {
+                $event->deny('Awaiting human confirmation.');
+            }
+        }
+    }
+
+.. note::
+
+    Metadata only describes a tool, it does not enforce anything. Marking a tool as ``needs_confirmation``
+    does not prevent it from being called - a listener like the one above has to do that. Prefer failing
+    closed, as shown, so tools added later without metadata are not silently exempt.
+
 Tool Parameters
 ~~~~~~~~~~~~~~~
 

--- a/examples/rag/agentic-search.php
+++ b/examples/rag/agentic-search.php
@@ -119,7 +119,7 @@ $tools = new AgenticSearchTools($corpus);
 
 $dispatcher = new EventDispatcher();
 $dispatcher->addListener(ToolCallSucceeded::class, static function (ToolCallSucceeded $event): void {
-    $name = $event->getMetadata()->getName();
+    $name = $event->getDefinition()->getName();
     $args = $event->getArguments();
     $resultPreview = $event->getResult()->getResult();
 

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.11
+----
+
+ * Add `metadata` support for tools to allow attaching custom data
+ * [BC BREAK] Rename `getMetadata()` to `getDefinition()` on the tool call events (`ToolCallRequested`, `ToolCallArgumentsResolved`, `ToolCallSucceeded`, `ToolCallFailed`), since it returns the tool definition and the "metadata" name is now used for the tool's classification
+
 0.10
 ----
 

--- a/src/agent/src/Toolbox/Attribute/AsTool.php
+++ b/src/agent/src/Toolbox/Attribute/AsTool.php
@@ -17,10 +17,15 @@ namespace Symfony\AI\Agent\Toolbox\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class AsTool
 {
+    /**
+     * @param array<string, mixed> $metadata Arbitrary custom data attached to the tool, carried to
+     *                                       {@see \Symfony\AI\Platform\Tool\Tool::getMetadata()}
+     */
     public function __construct(
         public readonly string $name,
         public readonly string $description,
         public readonly string $method = '__invoke',
+        public readonly array $metadata = [],
     ) {
     }
 }

--- a/src/agent/src/Toolbox/Event/ToolCallArgumentsResolved.php
+++ b/src/agent/src/Toolbox/Event/ToolCallArgumentsResolved.php
@@ -25,7 +25,7 @@ final class ToolCallArgumentsResolved
      */
     public function __construct(
         private readonly object $tool,
-        private readonly Tool $metadata,
+        private readonly Tool $definition,
         private readonly array $arguments,
     ) {
     }
@@ -35,9 +35,9 @@ final class ToolCallArgumentsResolved
         return $this->tool;
     }
 
-    public function getMetadata(): Tool
+    public function getDefinition(): Tool
     {
-        return $this->metadata;
+        return $this->definition;
     }
 
     /**

--- a/src/agent/src/Toolbox/Event/ToolCallFailed.php
+++ b/src/agent/src/Toolbox/Event/ToolCallFailed.php
@@ -23,7 +23,7 @@ final class ToolCallFailed
      */
     public function __construct(
         private readonly object $tool,
-        private readonly Tool $metadata,
+        private readonly Tool $definition,
         private readonly array $arguments,
         private readonly \Throwable $exception,
     ) {
@@ -34,9 +34,9 @@ final class ToolCallFailed
         return $this->tool;
     }
 
-    public function getMetadata(): Tool
+    public function getDefinition(): Tool
     {
-        return $this->metadata;
+        return $this->definition;
     }
 
     /**

--- a/src/agent/src/Toolbox/Event/ToolCallRequested.php
+++ b/src/agent/src/Toolbox/Event/ToolCallRequested.php
@@ -27,7 +27,7 @@ final class ToolCallRequested implements StoppableEventInterface
 
     public function __construct(
         private readonly ToolCall $toolCall,
-        private readonly Tool $metadata,
+        private readonly Tool $definition,
     ) {
     }
 
@@ -36,9 +36,9 @@ final class ToolCallRequested implements StoppableEventInterface
         return $this->toolCall;
     }
 
-    public function getMetadata(): Tool
+    public function getDefinition(): Tool
     {
-        return $this->metadata;
+        return $this->definition;
     }
 
     /**

--- a/src/agent/src/Toolbox/Event/ToolCallSucceeded.php
+++ b/src/agent/src/Toolbox/Event/ToolCallSucceeded.php
@@ -24,7 +24,7 @@ final class ToolCallSucceeded
      */
     public function __construct(
         private readonly object $tool,
-        private readonly Tool $metadata,
+        private readonly Tool $definition,
         private readonly array $arguments,
         private readonly ToolResult $result,
     ) {
@@ -35,9 +35,9 @@ final class ToolCallSucceeded
         return $this->tool;
     }
 
-    public function getMetadata(): Tool
+    public function getDefinition(): Tool
     {
-        return $this->metadata;
+        return $this->definition;
     }
 
     /**

--- a/src/agent/src/Toolbox/EventListener/ValidateToolCallArgumentsListener.php
+++ b/src/agent/src/Toolbox/EventListener/ValidateToolCallArgumentsListener.php
@@ -37,7 +37,7 @@ final class ValidateToolCallArgumentsListener
         }
 
         if (\count($violations = $validator->getViolations())) {
-            throw new InvalidToolCallArgumentsException(\sprintf('Invalid arguments provided for "%s" tool.', $event->getMetadata()->getName()), 0, null, $violations);
+            throw new InvalidToolCallArgumentsException(\sprintf('Invalid arguments provided for "%s" tool.', $event->getDefinition()->getName()), 0, null, $violations);
         }
     }
 }

--- a/src/agent/src/Toolbox/ToolFactory/MemoryToolFactory.php
+++ b/src/agent/src/Toolbox/ToolFactory/MemoryToolFactory.php
@@ -33,7 +33,10 @@ final class MemoryToolFactory implements ToolFactoryInterface
     ) {
     }
 
-    public function addTool(string|object $class, string $name, string $description, string $method = '__invoke'): self
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function addTool(string|object $class, string $name, string $description, string $method = '__invoke', array $metadata = []): self
     {
         $className = \is_object($class) ? $class::class : $class;
         $key = \is_object($class) ? (string) spl_object_id($class) : $className;
@@ -44,6 +47,7 @@ final class MemoryToolFactory implements ToolFactoryInterface
                 $name,
                 $description,
                 $this->factory->buildParameters($className, $method),
+                $metadata,
             );
         } catch (\ReflectionException $e) {
             throw ToolConfigurationException::invalidMethod($className, $method, $e);

--- a/src/agent/src/Toolbox/ToolFactory/ReflectionToolFactory.php
+++ b/src/agent/src/Toolbox/ToolFactory/ReflectionToolFactory.php
@@ -55,6 +55,7 @@ final class ReflectionToolFactory implements ToolFactoryInterface
                     $asTool->name,
                     $asTool->description,
                     $this->factory->buildParameters($className, $asTool->method),
+                    $asTool->metadata,
                 );
             } catch (\ReflectionException $e) {
                 throw ToolConfigurationException::invalidMethod($className, $asTool->method, $e);

--- a/src/agent/tests/Fixtures/Tool/ToolWithMetadata.php
+++ b/src/agent/tests/Fixtures/Tool/ToolWithMetadata.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+
+#[AsTool('tool_with_metadata', 'A tool carrying metadata', metadata: ['needs_confirmation' => true, 'category' => 'admin'])]
+final class ToolWithMetadata
+{
+    public function __invoke(): string
+    {
+        return 'Hello world!';
+    }
+}

--- a/src/agent/tests/Toolbox/Event/ToolCallRequestedTest.php
+++ b/src/agent/tests/Toolbox/Event/ToolCallRequestedTest.php
@@ -36,11 +36,11 @@ final class ToolCallRequestedTest extends TestCase
         $this->assertSame($this->toolCall, $event->getToolCall());
     }
 
-    public function testGetMetadata()
+    public function testGetDefinition()
     {
         $event = new ToolCallRequested($this->toolCall, $this->metadata);
 
-        $this->assertSame($this->metadata, $event->getMetadata());
+        $this->assertSame($this->metadata, $event->getDefinition());
     }
 
     public function testInitialStateIsNotDenied()

--- a/src/agent/tests/Toolbox/ToolFactory/ReflectionToolFactoryTest.php
+++ b/src/agent/tests/Toolbox/ToolFactory/ReflectionToolFactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Toolbox\ToolFactory;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolNoParams;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithMetadata;
+use Symfony\AI\Agent\Toolbox\ToolFactory\ReflectionToolFactory;
+use Symfony\AI\Platform\Tool\Tool;
+
+final class ReflectionToolFactoryTest extends TestCase
+{
+    public function testMetadataFromAttributeIsCarriedToTheTool()
+    {
+        $tool = $this->firstTool(ToolWithMetadata::class);
+
+        $this->assertSame(['needs_confirmation' => true, 'category' => 'admin'], $tool->getMetadata());
+        $this->assertTrue($tool->getMetadataValue('needs_confirmation'));
+        $this->assertSame('admin', $tool->getMetadataValue('category'));
+    }
+
+    public function testMetadataDefaultsToEmpty()
+    {
+        $tool = $this->firstTool(ToolNoParams::class);
+
+        $this->assertSame([], $tool->getMetadata());
+        $this->assertNull($tool->getMetadataValue('needs_confirmation'));
+        $this->assertTrue($tool->getMetadataValue('needs_confirmation', true));
+    }
+
+    private function firstTool(string $className): Tool
+    {
+        $tools = iterator_to_array((new ReflectionToolFactory())->getTool($className));
+
+        return $tools[0];
+    }
+}

--- a/src/ai-bundle/src/Security/EventListener/IsGrantedToolAttributeListener.php
+++ b/src/ai-bundle/src/Security/EventListener/IsGrantedToolAttributeListener.php
@@ -37,7 +37,7 @@ class IsGrantedToolAttributeListener
     {
         $tool = $event->getTool();
         $class = new \ReflectionClass($tool);
-        $method = $class->getMethod($event->getMetadata()->getReference()->getMethod());
+        $method = $class->getMethod($event->getDefinition()->getReference()->getMethod());
         $classAttributes = $class->getAttributes(IsGrantedTool::class);
         $methodAttributes = $method->getAttributes(IsGrantedTool::class);
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Add optional `$context` argument to `Contract\JsonSchema\Factory` build methods to limit schema to subset of properties
+ * Add `Tool::getMetadata()` and `Tool::getMetadataValue()` to carry arbitrary custom data attached to a tool
  * Add `MessageBag::isLastMessageFrom()` to check whether the last message has a given role
  * Add `MaxOutputTokensException` for completed responses truncated by output token limits
  * Convert OpenAI Responses built-in tool output items (`web_search_call`, `file_search_call`, `code_interpreter_call`, `image_generation_call`, `mcp_call`, `mcp_list_tools`, `mcp_approval_request`, `computer_call`, `local_shell_call`) into typed results instead of skipping them. Adds `Result\WebSearchResult`, `Result\FileSearchResult`, `Result\McpCallResult`, `Result\McpListToolsResult`, `Result\McpApprovalRequestResult`, `Result\ComputerCallResult`, and `Result\LocalShellCallResult` (code interpreter reuses `ExecutableCodeResult`/`CodeExecutionResult`, image generation reuses `BinaryResult`), plus the matching `Message\Content` classes so the results round-trip through `Message::ofAssistant()`. Benefits the OpenAI, Azure OpenAI, and Scaleway bridges.

--- a/src/platform/src/Tool/Tool.php
+++ b/src/platform/src/Tool/Tool.php
@@ -21,13 +21,15 @@ use Symfony\AI\Platform\Contract\JsonSchema\Factory;
 final class Tool
 {
     /**
-     * @param JsonSchema|null $parameters
+     * @param JsonSchema|null      $parameters
+     * @param array<string, mixed> $metadata   Arbitrary custom data attached to the tool
      */
     public function __construct(
         private readonly ExecutionReference $reference,
         private readonly string $name,
         private readonly string $description,
         private readonly ?array $parameters = null,
+        private readonly array $metadata = [],
     ) {
     }
 
@@ -52,5 +54,18 @@ final class Tool
     public function getParameters(): ?array
     {
         return $this->parameters;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+
+    public function getMetadataValue(string $key, mixed $default = null): mixed
+    {
+        return $this->metadata[$key] ?? $default;
     }
 }

--- a/src/platform/tests/Tool/ToolTest.php
+++ b/src/platform/tests/Tool/ToolTest.php
@@ -67,4 +67,23 @@ final class ToolTest extends TestCase
 
         $this->assertNull($tool->getParameters());
     }
+
+    public function testReturnsMetadata()
+    {
+        $reference = new ExecutionReference('MyClass');
+        $tool = new Tool($reference, 'tool_name', 'tool description', null, ['hitl' => true]);
+
+        $this->assertSame(['hitl' => true], $tool->getMetadata());
+        $this->assertTrue($tool->getMetadataValue('hitl'));
+    }
+
+    public function testReturnsEmptyMetadataByDefault()
+    {
+        $reference = new ExecutionReference('MyClass');
+        $tool = new Tool($reference, 'tool_name', 'tool description');
+
+        $this->assertSame([], $tool->getMetadata());
+        $this->assertNull($tool->getMetadataValue('hitl'));
+        $this->assertSame('fallback', $tool->getMetadataValue('hitl', 'fallback'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

## Problem

Tools can only be classified by **name**. Any horizontal concern — *"does this need a human in the loop?"*, risk tier, approval queue, cost bucket — has to be re-derived by every consumer as a hard-coded allow/deny list. `#[IsGrantedTool]` is read reflectively at call time, so the classification is invisible to anything inspecting the `Tool` definition: it can only deny a call, never shape the toolset.

## Solution

Attach an arbitrary, application-defined metadata map to tools, carried onto the `Tool` definition:

```php
#[AsTool('delete_product', 'Delete a product', metadata: ['hitl' => true])]
```

Readable via `Tool::getMetadata()` / `getMetadataValue()`. Symfony AI does not interpret it — it just carries it (same as `symfony/workflow` metadata on places/transitions). Also added to `MemoryToolFactory::addTool()`.

Because it lives on the definition, it can both **shape the toolset before the model sees it** (filter `getTools()` on a metadata value) and **gate the call** (tool call events already carry the definition). Metadata *classifies*, it does not *enforce* — a listener still has to act on it; the docs recommend failing closed.

## BC break

Tool call events (`ToolCallRequested`, `ToolCallArgumentsResolved`, `ToolCallSucceeded`, `ToolCallFailed`) now expose the tool definition as **`getDefinition()`** instead of `getMetadata()` — the old name returned the `Tool` definition, not metadata, and would otherwise read as `getMetadata()->getMetadata()`. Documented in `UPGRADE.md`.

## Docs & Tests

`docs/components/agent.rst` gains a *Tool Metadata* section (`doctor-rst` passes). New `ReflectionToolFactoryTest` and `ToolTest` accessor cases. Green locally: Platform 743, Agent 262, AI Bundle 403.
