### PR TITLE
[Platform] Let the model router select the model, not just the provider

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,6 +32,42 @@ MCP Bundle
 Platform
 --------
 
+ * `ModelRouterInterface::resolve()` now returns a `ModelRouter\RoutingDecision` instead of a
+   `ProviderInterface`, and accepts a `Model` instance next to a model name. This lets a router
+   select the model itself (based on the input, a rule set, or cost) instead of only dispatching a
+   pre-decided model to a provider. Custom routers must wrap their provider in a `RoutingDecision`:
+
+   ```diff
+   -use Symfony\AI\Platform\ProviderInterface;
+   +use Symfony\AI\Platform\Model;
+   +use Symfony\AI\Platform\ModelRouter\RoutingDecision;
+
+    final class MyModelRouter implements ModelRouterInterface
+    {
+   -    public function resolve(string $model, iterable $providers, array|string|object $input, array $options = []): ProviderInterface
+   +    public function resolve(string|Model $model, iterable $providers, array|string|object $input, array $options = []): RoutingDecision
+        {
+   -        return $this->pickProvider($model, $providers);
+   +        return new RoutingDecision($this->pickProvider($model, $providers));
+        }
+    }
+   ```
+
+   Passing a model or options to the `RoutingDecision` constructor replaces the requested model or
+   options for that invocation; leaving them out keeps the requested values. Calling
+   `Platform::invoke()` is unchanged.
+
+   As a consequence, `Model` instances passed to `Platform::invoke()` are no longer resolved on a
+   separate path: they now go through the `ModelRoutingEvent` and the model router like model names
+   do. Listeners of `ModelRoutingEvent` therefore have to expect `getModel()` to return either a
+   `non-empty-string` or a `Model`.
+
+ * A provider without a `ModelClient` registered for the invoked model now throws
+   `Exception\ModelNotFoundException` instead of `Exception\RuntimeException`, so that a routing
+   decision naming a provider that cannot serve the model fails the same way as an unknown model
+   name. Both implement `Exception\ExceptionInterface`, but note that `ModelNotFoundException`
+   extends `\InvalidArgumentException`, not `\RuntimeException`.
+
  * The Albert bridge now follows the same `base_url` convention as the Generic bridge:
    the API version must **not** be included in `baseUrl`, it is part of the path instead.
    Remove the version segment from your configured URL:

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -228,17 +228,83 @@ connection per region)::
     OpenAiFactory::createProvider(apiKey: env('OPENAI_EU_KEY'), name: 'openai-eu');
     OpenAiFactory::createProvider(apiKey: env('OPENAI_US_KEY'), name: 'openai-us');
 
+Custom Routing Strategies
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Custom routing strategies (load balancing, model-pattern matching, input-based
-selection) are implemented as additional
-:class:`Symfony\\AI\\Platform\\ModelRouterInterface` implementations passed as the
-second ``Platform`` constructor argument.
+selection) are implemented as :class:`Symfony\\AI\\Platform\\ModelRouterInterface`
+implementations passed as the second ``Platform`` constructor argument.
+
+A router receives the requested model, the available providers, and the invocation
+input and options. It answers with a
+:class:`Symfony\\AI\\Platform\\ModelRouter\\RoutingDecision`, which names the provider
+serving the request and — optionally — a model and options replacing the requested
+ones. Leaving the model or options at ``null`` keeps the requested values, so a router
+that only dispatches between providers never has to think about either::
+
+    use Symfony\AI\Platform\ModelRouter\RoutingDecision;
+    use Symfony\AI\Platform\ModelRouterInterface;
+
+    final class VisionModelRouter implements ModelRouterInterface
+    {
+        public function __construct(
+            private readonly ModelRouterInterface $fallback = new CatalogBasedModelRouter(),
+        ) {
+        }
+
+        public function resolve(string|Model $model, iterable $providers, array|string|object $input, array $options = []): RoutingDecision
+        {
+            if (!$input instanceof MessageBag || !$input->containsImage()) {
+                return $this->fallback->resolve($model, $providers, $input, $options);
+            }
+
+            $decision = $this->fallback->resolve('claude-sonnet-4-5', $providers, $input, $options);
+
+            return new RoutingDecision($decision->getProvider(), 'claude-sonnet-4-5', reason: 'image detected');
+        }
+    }
+
+Because :class:`Symfony\\AI\\Platform\\ModelRouter\\CatalogBasedModelRouter` never
+replaces the model, it works as the terminal resolver that model-selecting routers
+delegate to: they decide *which* model, and hand the "who serves it" question back to
+the default router instead of reimplementing catalog lookup.
+
+The selected model may be a name or a fully defined
+:class:`Symfony\\AI\\Platform\\Model`. A name is resolved through the chosen provider's
+model catalog; a ``Model`` instance bypasses the catalog and carries its own options,
+which lets a router tune options per routing decision::
+
+    return new RoutingDecision(
+        $decision->getProvider(),
+        new Model('gpt-4o', options: ['temperature' => 0.2]),
+        reason: 'deterministic answer requested',
+    );
+
+Because providers and models differ in the options they understand, a decision that
+redirects a request may also have to rewrite the invocation options — renaming an
+option for the selected provider, or dropping one the selected model does not
+support::
+
+    unset($options['seed']); // not supported by the selected provider
+
+    return new RoutingDecision($decision->getProvider(), 'claude-sonnet-4-5', $options, 'image detected');
+
+Routing runs for every invocation, including those made with a ``Model`` instance, so a
+custom router sees all traffic through the platform.
+
+.. note::
+
+    A router that names a provider unable to serve the selected model causes a
+    :class:`Symfony\\AI\\Platform\\Exception\\ModelNotFoundException` at invocation time.
+    Delegating to the default router (as above) resolves the provider from the model and
+    avoids constructing such a decision by hand.
 
 Routing Events
 ~~~~~~~~~~~~~~
 
 Before resolving a model to a provider, ``Platform`` dispatches a
 :class:`Symfony\\AI\\Platform\\Event\\ModelRoutingEvent`. Listeners can modify the
-model name, input, or options, or short-circuit routing entirely by setting a
+model, input, or options, or short-circuit routing entirely by setting a
 provider directly::
 
     use Symfony\AI\Platform\Event\ModelRoutingEvent;
@@ -248,6 +314,20 @@ provider directly::
             $event->setProvider($customProvider);  // skip router, use this provider
         }
     });
+
+``getModel()`` returns the requested model name, or a :class:`Symfony\\AI\\Platform\\Model`
+instance when the caller passed one to ``invoke()``. Listeners that match on the model
+name should account for both.
+
+Listeners and routers overlap in power — both can change the model, the options,
+or the provider — so use them for different jobs: a listener observes or adjusts
+an invocation *before* routing (pinning a provider behind a feature flag,
+rewriting input, overriding in tests), while the router *is* the routing strategy
+that answers which provider and model serve every request. As a rule of thumb:
+logic that decides between providers or models belongs in a
+:class:`Symfony\\AI\\Platform\\ModelRouterInterface` implementation; logic that
+tweaks a request on its way there belongs in a listener. If a listener starts
+iterating providers, it wants to be a router.
 
 Provider-level events (:class:`Symfony\\AI\\Platform\\Event\\InvocationEvent` and
 :class:`Symfony\\AI\\Platform\\Event\\ResultEvent`) still fire inside the selected

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * [BC BREAK] Widen `ModelRouterInterface::resolve()` to accept `non-empty-string|Model` and return the new `ModelRouter\RoutingDecision` instead of a `ProviderInterface`, so a router can select the model - by input, rule set, or cost - and rewrite the invocation options for the selected provider, not only pick the provider serving the request. `Platform` now routes `Model` instances through the router and `ModelRoutingEvent` as well, instead of resolving them on a separate path
+ * [BC BREAK] Throw `ModelNotFoundException` instead of `RuntimeException` when a provider has no `ModelClient` registered for a model, so a routing decision naming a provider that cannot serve the model fails consistently with an unknown model name
+
 0.11
 ----
 

--- a/src/platform/src/Event/ModelRoutingEvent.php
+++ b/src/platform/src/Event/ModelRoutingEvent.php
@@ -11,13 +11,14 @@
 
 namespace Symfony\AI\Platform\Event;
 
+use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ProviderInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event dispatched by Platform before resolving a model to a provider.
  *
- * Allows listeners to observe or modify the model name, input, and options
+ * Allows listeners to observe or modify the model, input, and options
  * before routing takes place. Setting a provider on the event skips the
  * model router entirely.
  *
@@ -28,29 +29,29 @@ final class ModelRoutingEvent extends Event
     private ?ProviderInterface $provider = null;
 
     /**
-     * @param non-empty-string           $model
+     * @param non-empty-string|Model     $model
      * @param array<mixed>|string|object $input
      * @param array<string, mixed>       $options
      */
     public function __construct(
-        private string $model,
+        private string|Model $model,
         private array|string|object $input,
         private array $options = [],
     ) {
     }
 
     /**
-     * @return non-empty-string
+     * @return non-empty-string|Model
      */
-    public function getModel(): string
+    public function getModel(): string|Model
     {
         return $this->model;
     }
 
     /**
-     * @param non-empty-string $model
+     * @param non-empty-string|Model $model
      */
-    public function setModel(string $model): void
+    public function setModel(string|Model $model): void
     {
         $this->model = $model;
     }

--- a/src/platform/src/ModelRouter/CatalogBasedModelRouter.php
+++ b/src/platform/src/ModelRouter/CatalogBasedModelRouter.php
@@ -12,27 +12,31 @@
 namespace Symfony\AI\Platform\ModelRouter;
 
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
+use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelRouterInterface;
-use Symfony\AI\Platform\ProviderInterface;
 
 /**
- * Routes to the first provider whose model catalog contains the requested model.
+ * Routes to the first provider supporting the requested model.
  *
  * This is the default, zero-configuration router. It iterates through all
- * registered providers and returns the first one that supports the model name.
+ * registered providers and returns the first one that supports the model, either
+ * via its model catalog (model name) or its model clients (fully defined model).
+ *
+ * It never replaces the requested model, which makes it the terminal resolver
+ * that model-selecting routers delegate to.
  *
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
 final class CatalogBasedModelRouter implements ModelRouterInterface
 {
-    public function resolve(string $model, iterable $providers, array|string|object $input, array $options = []): ProviderInterface
+    public function resolve(string|Model $model, iterable $providers, array|string|object $input, array $options = []): RoutingDecision
     {
         foreach ($providers as $provider) {
             if ($provider->supports($model)) {
-                return $provider;
+                return new RoutingDecision($provider);
             }
         }
 
-        throw new ModelNotFoundException(\sprintf('No provider found for model "%s".', $model));
+        throw new ModelNotFoundException(\sprintf('No provider found for model "%s".', $model instanceof Model ? $model->getName() : $model));
     }
 }

--- a/src/platform/src/ModelRouter/RoutingDecision.php
+++ b/src/platform/src/ModelRouter/RoutingDecision.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\ModelRouter;
+
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ProviderInterface;
+
+/**
+ * The outcome of a routing decision: the provider serving the request, and
+ * optionally the model and options replacing the requested ones.
+ *
+ * A router that only dispatches to a provider leaves the model and options at
+ * null, which keeps the requested ones. A router that selects a model - based
+ * on the input, a rule set, or cost - returns it alongside the provider that
+ * serves it, and may rewrite the options to fit the selected provider or model.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class RoutingDecision
+{
+    /**
+     * @param non-empty-string|Model|null $model   Replaces the requested model, or null to keep it
+     * @param array<string, mixed>|null   $options Replaces the invocation options, or null to keep them
+     * @param string                      $reason  Human-readable explanation, surfaced in debugging and profiling
+     */
+    public function __construct(
+        private readonly ProviderInterface $provider,
+        private readonly string|Model|null $model = null,
+        private readonly ?array $options = null,
+        private readonly string $reason = '',
+    ) {
+    }
+
+    public function getProvider(): ProviderInterface
+    {
+        return $this->provider;
+    }
+
+    /**
+     * @return non-empty-string|Model|null
+     */
+    public function getModel(): string|Model|null
+    {
+        return $this->model;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getOptions(): ?array
+    {
+        return $this->options;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+}

--- a/src/platform/src/ModelRouterInterface.php
+++ b/src/platform/src/ModelRouterInterface.php
@@ -11,18 +11,23 @@
 
 namespace Symfony\AI\Platform;
 
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
+use Symfony\AI\Platform\ModelRouter\RoutingDecision;
+
 /**
- * Resolves which provider should handle a given model invocation.
+ * Resolves which provider handles a given model invocation, and optionally which model.
  *
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
 interface ModelRouterInterface
 {
     /**
-     * @param non-empty-string            $model     The model name to resolve
+     * @param non-empty-string|Model      $model     The requested model name to resolve via the catalog, or a fully defined model
      * @param iterable<ProviderInterface> $providers The available providers
      * @param array<mixed>|string|object  $input     The input data
      * @param array<string, mixed>        $options   The invocation options
+     *
+     * @throws ModelNotFoundException When no provider can serve the model
      */
-    public function resolve(string $model, iterable $providers, array|string|object $input, array $options = []): ProviderInterface;
+    public function resolve(string|Model $model, iterable $providers, array|string|object $input, array $options = []): RoutingDecision;
 }

--- a/src/platform/src/Platform.php
+++ b/src/platform/src/Platform.php
@@ -13,10 +13,10 @@ namespace Symfony\AI\Platform;
 
 use Symfony\AI\Platform\Event\ModelRoutingEvent;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
-use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\ModelCatalog\CompositeModelCatalog;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
 use Symfony\AI\Platform\ModelRouter\CatalogBasedModelRouter;
+use Symfony\AI\Platform\ModelRouter\RoutingDecision;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -47,17 +47,18 @@ final class Platform implements PlatformInterface
 
     public function invoke(string|Model $model, array|string|object $input, array $options = []): DeferredResult
     {
-        if ($model instanceof Model) {
-            return $this->resolveProviderForModel($model)->invoke($model, $input, $options);
-        }
-
         $event = new ModelRoutingEvent($model, $input, $options);
         $this->eventDispatcher?->dispatch($event);
 
-        $provider = $event->getProvider()
-            ?? $this->modelRouter->resolve($event->getModel(), $this->providers, $event->getInput(), $event->getOptions());
+        $decision = null !== $event->getProvider()
+            ? new RoutingDecision($event->getProvider())
+            : $this->modelRouter->resolve($event->getModel(), $this->providers, $event->getInput(), $event->getOptions());
 
-        return $provider->invoke($event->getModel(), $event->getInput(), $event->getOptions());
+        return $decision->getProvider()->invoke(
+            $decision->getModel() ?? $event->getModel(),
+            $event->getInput(),
+            $decision->getOptions() ?? $event->getOptions(),
+        );
     }
 
     public function getModelCatalog(): ModelCatalogInterface
@@ -68,19 +69,5 @@ final class Platform implements PlatformInterface
                 $this->providers,
             ),
         );
-    }
-
-    /**
-     * Routes a fully defined model to the first provider whose model clients accept it.
-     */
-    private function resolveProviderForModel(Model $model): ProviderInterface
-    {
-        foreach ($this->providers as $provider) {
-            if ($provider->supports($model)) {
-                return $provider;
-            }
-        }
-
-        throw new ModelNotFoundException(\sprintf('No provider found for model "%s" (%s).', $model->getName(), $model::class));
     }
 }

--- a/src/platform/src/Provider.php
+++ b/src/platform/src/Provider.php
@@ -148,7 +148,7 @@ final class Provider implements ProviderInterface
             }
         }
 
-        throw new RuntimeException(\sprintf('No ModelClient registered for model "%s" (%s) in provider "%s".', $model->getName(), $model::class, $this->name));
+        throw new ModelNotFoundException(\sprintf('No ModelClient registered for model "%s" (%s) in provider "%s".', $model->getName(), $model::class, $this->name));
     }
 
     /**

--- a/src/platform/tests/Event/ModelRoutingEventTest.php
+++ b/src/platform/tests/Event/ModelRoutingEventTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Tests\Event;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Event\ModelRoutingEvent;
+use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ProviderInterface;
 
 final class ModelRoutingEventTest extends TestCase
@@ -26,6 +27,15 @@ final class ModelRoutingEventTest extends TestCase
         $this->assertSame(['temperature' => 0.7], $event->getOptions());
     }
 
+    public function testGetModelReturnsModelInstance()
+    {
+        $model = new Model('custom-model', []);
+
+        $event = new ModelRoutingEvent($model, 'Hello');
+
+        $this->assertSame($model, $event->getModel());
+    }
+
     public function testSetModel()
     {
         $event = new ModelRoutingEvent('gpt-4o', 'Hello');
@@ -33,6 +43,16 @@ final class ModelRoutingEventTest extends TestCase
         $event->setModel('claude-3-5-sonnet');
 
         $this->assertSame('claude-3-5-sonnet', $event->getModel());
+    }
+
+    public function testSetModelWithModelInstance()
+    {
+        $event = new ModelRoutingEvent('gpt-4o', 'Hello');
+        $model = new Model('custom-model', []);
+
+        $event->setModel($model);
+
+        $this->assertSame($model, $event->getModel());
     }
 
     public function testSetInput()

--- a/src/platform/tests/ModelRouter/CatalogBasedModelRouterTest.php
+++ b/src/platform/tests/ModelRouter/CatalogBasedModelRouterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Platform\Tests\ModelRouter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
+use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelRouter\CatalogBasedModelRouter;
 use Symfony\AI\Platform\ProviderInterface;
 
@@ -29,9 +30,9 @@ final class CatalogBasedModelRouterTest extends TestCase
         $provider2->method('getName')->willReturn('openai');
 
         $router = new CatalogBasedModelRouter();
-        $result = $router->resolve('gpt-4o', [$provider1, $provider2], 'Hello');
+        $decision = $router->resolve('gpt-4o', [$provider1, $provider2], 'Hello');
 
-        $this->assertSame($provider2, $result);
+        $this->assertSame($provider2, $decision->getProvider());
     }
 
     public function testResolvesFirstProviderWhenMultipleSupport()
@@ -45,9 +46,40 @@ final class CatalogBasedModelRouterTest extends TestCase
         $provider2->method('getName')->willReturn('openrouter');
 
         $router = new CatalogBasedModelRouter();
-        $result = $router->resolve('gpt-4o', [$provider1, $provider2], 'Hello');
+        $decision = $router->resolve('gpt-4o', [$provider1, $provider2], 'Hello');
 
-        $this->assertSame($provider1, $result);
+        $this->assertSame($provider1, $decision->getProvider());
+    }
+
+    public function testKeepsRequestedModel()
+    {
+        $provider = $this->createStub(ProviderInterface::class);
+        $provider->method('supports')->willReturn(true);
+
+        $router = new CatalogBasedModelRouter();
+        $decision = $router->resolve('gpt-4o', [$provider], 'Hello');
+
+        $this->assertNull($decision->getModel());
+    }
+
+    public function testResolvesModelInstanceViaSupports()
+    {
+        $model = new Model('custom-model', []);
+
+        $provider1 = $this->createStub(ProviderInterface::class);
+        $provider1->method('supports')->willReturn(false);
+
+        $provider2 = $this->createMock(ProviderInterface::class);
+        $provider2->expects($this->once())
+            ->method('supports')
+            ->with($model)
+            ->willReturn(true);
+
+        $router = new CatalogBasedModelRouter();
+        $decision = $router->resolve($model, [$provider1, $provider2], 'Hello');
+
+        $this->assertSame($provider2, $decision->getProvider());
+        $this->assertNull($decision->getModel());
     }
 
     public function testThrowsWhenNoProviderSupportsModel()
@@ -61,6 +93,19 @@ final class CatalogBasedModelRouterTest extends TestCase
         $this->expectExceptionMessageMatches('/No provider found for model "unknown-model"/');
 
         $router->resolve('unknown-model', [$provider], 'Hello');
+    }
+
+    public function testThrowsWithModelNameWhenNoProviderSupportsModelInstance()
+    {
+        $provider = $this->createStub(ProviderInterface::class);
+        $provider->method('supports')->willReturn(false);
+
+        $router = new CatalogBasedModelRouter();
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessageMatches('/No provider found for model "custom-model"/');
+
+        $router->resolve(new Model('custom-model', []), [$provider], 'Hello');
     }
 
     public function testThrowsWhenNoProvidersGiven()

--- a/src/platform/tests/ModelRouter/RoutingDecisionTest.php
+++ b/src/platform/tests/ModelRouter/RoutingDecisionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\ModelRouter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelRouter\RoutingDecision;
+use Symfony\AI\Platform\ProviderInterface;
+
+final class RoutingDecisionTest extends TestCase
+{
+    public function testProviderOnlyDecisionKeepsRequestedModel()
+    {
+        $provider = $this->createStub(ProviderInterface::class);
+
+        $decision = new RoutingDecision($provider);
+
+        $this->assertSame($provider, $decision->getProvider());
+        $this->assertNull($decision->getModel());
+        $this->assertNull($decision->getOptions());
+        $this->assertSame('', $decision->getReason());
+    }
+
+    public function testDecisionCanSelectModelByName()
+    {
+        $provider = $this->createStub(ProviderInterface::class);
+
+        $decision = new RoutingDecision($provider, 'gpt-4o', reason: 'image detected');
+
+        $this->assertSame('gpt-4o', $decision->getModel());
+        $this->assertSame('image detected', $decision->getReason());
+    }
+
+    public function testDecisionCanReplaceOptions()
+    {
+        $provider = $this->createStub(ProviderInterface::class);
+
+        $decision = new RoutingDecision($provider, 'gpt-4o', ['max_tokens' => 100], 'token limit rewritten');
+
+        $this->assertSame(['max_tokens' => 100], $decision->getOptions());
+        $this->assertSame('token limit rewritten', $decision->getReason());
+    }
+
+    public function testDecisionCanSelectModelInstance()
+    {
+        $provider = $this->createStub(ProviderInterface::class);
+        $model = new Model('gpt-4o', [], ['temperature' => 0.2]);
+
+        $decision = new RoutingDecision($provider, $model);
+
+        $this->assertSame($model, $decision->getModel());
+    }
+}

--- a/src/platform/tests/PlatformTest.php
+++ b/src/platform/tests/PlatformTest.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\CompositeModelCatalog;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\ModelRouter\RoutingDecision;
 use Symfony\AI\Platform\ModelRouterInterface;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\Platform;
@@ -39,7 +40,7 @@ final class PlatformTest extends TestCase
 
     public function testInvokeRoutesToCorrectProvider()
     {
-        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
+        $deferredResult = $this->createDeferredResult();
 
         $provider = $this->createMock(ProviderInterface::class);
         $provider->expects($this->once())
@@ -48,7 +49,7 @@ final class PlatformTest extends TestCase
             ->willReturn($deferredResult);
 
         $router = $this->createStub(ModelRouterInterface::class);
-        $router->method('resolve')->willReturn($provider);
+        $router->method('resolve')->willReturn(new RoutingDecision($provider));
 
         $platform = new Platform([$provider], $router);
 
@@ -57,15 +58,88 @@ final class PlatformTest extends TestCase
         $this->assertSame($deferredResult, $result);
     }
 
+    public function testRouterCanReplaceRequestedModel()
+    {
+        $deferredResult = $this->createDeferredResult();
+
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('invoke')
+            ->with('gpt-4o', 'Hello', [])
+            ->willReturn($deferredResult);
+
+        $router = $this->createStub(ModelRouterInterface::class);
+        $router->method('resolve')->willReturn(new RoutingDecision($provider, 'gpt-4o', reason: 'image detected'));
+
+        $platform = new Platform([$provider], $router);
+
+        $platform->invoke('gpt-4o-mini', 'Hello');
+    }
+
+    public function testRouterCanReplaceRequestedModelWithModelInstance()
+    {
+        $deferredResult = $this->createDeferredResult();
+        $model = new Model('gpt-4o', [], ['temperature' => 0.2]);
+
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('invoke')
+            ->with($model, 'Hello', [])
+            ->willReturn($deferredResult);
+
+        $router = $this->createStub(ModelRouterInterface::class);
+        $router->method('resolve')->willReturn(new RoutingDecision($provider, $model));
+
+        $platform = new Platform([$provider], $router);
+
+        $platform->invoke('gpt-4o-mini', 'Hello');
+    }
+
+    public function testRouterCanReplaceRequestedOptions()
+    {
+        $deferredResult = $this->createDeferredResult();
+
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('invoke')
+            ->with('gpt-4o-mini', 'Hello', ['max_tokens' => 100])
+            ->willReturn($deferredResult);
+
+        $router = $this->createStub(ModelRouterInterface::class);
+        $router->method('resolve')->willReturn(new RoutingDecision($provider, options: ['max_tokens' => 100]));
+
+        $platform = new Platform([$provider], $router);
+
+        $platform->invoke('gpt-4o-mini', 'Hello', ['max_output_tokens' => 100]);
+    }
+
+    public function testRouterWithoutOptionsKeepsRequestedOptions()
+    {
+        $deferredResult = $this->createDeferredResult();
+
+        $provider = $this->createMock(ProviderInterface::class);
+        $provider->expects($this->once())
+            ->method('invoke')
+            ->with('gpt-4o-mini', 'Hello', ['temperature' => 0.7])
+            ->willReturn($deferredResult);
+
+        $router = $this->createStub(ModelRouterInterface::class);
+        $router->method('resolve')->willReturn(new RoutingDecision($provider));
+
+        $platform = new Platform([$provider], $router);
+
+        $platform->invoke('gpt-4o-mini', 'Hello', ['temperature' => 0.7]);
+    }
+
     public function testInvokeDispatchesModelRoutingEvent()
     {
-        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
+        $deferredResult = $this->createDeferredResult();
 
         $provider = $this->createStub(ProviderInterface::class);
         $provider->method('invoke')->willReturn($deferredResult);
 
         $router = $this->createStub(ModelRouterInterface::class);
-        $router->method('resolve')->willReturn($provider);
+        $router->method('resolve')->willReturn(new RoutingDecision($provider));
 
         $dispatchedEvent = null;
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
@@ -89,7 +163,7 @@ final class PlatformTest extends TestCase
 
     public function testModelRoutingEventCanModifyModel()
     {
-        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
+        $deferredResult = $this->createDeferredResult();
 
         $provider = $this->createMock(ProviderInterface::class);
         $provider->expects($this->once())
@@ -101,7 +175,7 @@ final class PlatformTest extends TestCase
         $router->expects($this->once())
             ->method('resolve')
             ->with('claude-3-5-sonnet', $this->anything(), $this->anything(), $this->anything())
-            ->willReturn($provider);
+            ->willReturn(new RoutingDecision($provider));
 
         $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
         $eventDispatcher->method('dispatch')->willReturnCallback(static function (ModelRoutingEvent $event) {
@@ -117,7 +191,7 @@ final class PlatformTest extends TestCase
 
     public function testModelRoutingEventProviderSkipsRouter()
     {
-        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
+        $deferredResult = $this->createDeferredResult();
 
         $overrideProvider = $this->createMock(ProviderInterface::class);
         $overrideProvider->expects($this->once())
@@ -147,7 +221,7 @@ final class PlatformTest extends TestCase
     public function testInvokeWithModelObjectRoutesViaSupports()
     {
         $model = new Model('custom-model', []);
-        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
+        $deferredResult = $this->createDeferredResult();
 
         $provider = $this->createMock(ProviderInterface::class);
         $provider->expects($this->once())
@@ -159,10 +233,7 @@ final class PlatformTest extends TestCase
             ->with($model, 'Hello', [])
             ->willReturn($deferredResult);
 
-        $router = $this->createMock(ModelRouterInterface::class);
-        $router->expects($this->never())->method('resolve');
-
-        $platform = new Platform([$provider], $router);
+        $platform = new Platform([$provider]);
 
         $result = $platform->invoke($model, 'Hello');
 
@@ -172,7 +243,7 @@ final class PlatformTest extends TestCase
     public function testInvokeWithModelObjectPicksFirstSupportingProvider()
     {
         $model = new Model('custom-model', []);
-        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
+        $deferredResult = $this->createDeferredResult();
 
         $firstProvider = $this->createMock(ProviderInterface::class);
         $firstProvider->method('supports')->with($model)->willReturn(false);
@@ -208,21 +279,31 @@ final class PlatformTest extends TestCase
         $platform->invoke($model, 'Hello');
     }
 
-    public function testInvokeWithModelObjectDoesNotDispatchModelRoutingEvent()
+    public function testInvokeWithModelObjectDispatchesModelRoutingEvent()
     {
         $model = new Model('custom-model', []);
-        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
+        $deferredResult = $this->createDeferredResult();
 
         $provider = $this->createStub(ProviderInterface::class);
         $provider->method('supports')->willReturn(true);
         $provider->method('invoke')->willReturn($deferredResult);
 
+        $dispatchedEvent = null;
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $eventDispatcher->expects($this->never())->method('dispatch');
+        $eventDispatcher->expects($this->once())
+            ->method('dispatch')
+            ->willReturnCallback(static function ($event) use (&$dispatchedEvent) {
+                $dispatchedEvent = $event;
+
+                return $event;
+            });
 
         $platform = new Platform([$provider], eventDispatcher: $eventDispatcher);
 
         $platform->invoke($model, 'Hello');
+
+        $this->assertInstanceOf(ModelRoutingEvent::class, $dispatchedEvent);
+        $this->assertSame($model, $dispatchedEvent->getModel());
     }
 
     public function testGetModelCatalogBuildsComposite()
@@ -239,5 +320,10 @@ final class PlatformTest extends TestCase
         $platform = new Platform([$provider1, $provider2]);
 
         $this->assertInstanceOf(CompositeModelCatalog::class, $platform->getModelCatalog());
+    }
+
+    private function createDeferredResult(): DeferredResult
+    {
+        return new DeferredResult(new PlainConverter(new TextResult('Hello')), $this->createStub(RawResultInterface::class));
     }
 }

--- a/src/platform/tests/ProviderTest.php
+++ b/src/platform/tests/ProviderTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Event\InvocationEvent;
 use Symfony\AI\Platform\Event\ResultConvertedEvent;
 use Symfony\AI\Platform\Event\ResultErrorEvent;
 use Symfony\AI\Platform\Event\ResultEvent;
+use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
@@ -56,7 +57,7 @@ final class ProviderTest extends TestCase
     {
         $catalog = $this->createStub(ModelCatalogInterface::class);
         $catalog->method('getModel')->willThrowException(
-            new \Symfony\AI\Platform\Exception\ModelNotFoundException('Model not found'),
+            new ModelNotFoundException('Model not found'),
         );
 
         $provider = new Provider('openai', [], [], $catalog);
@@ -150,7 +151,7 @@ final class ProviderTest extends TestCase
 
         $provider = new Provider('openai', [$modelClient], [], $catalog);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(ModelNotFoundException::class);
         $this->expectExceptionMessageMatches('/No ModelClient registered/');
 
         $provider->invoke('gpt-4o', 'Hello');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Lets the Platform model router decide **which model** serves a request, not only **which provider** — turning the routing layer into a home for input-/rule-/cost-based model selection. This is the idea behind #1090, one layer down so it applies to every Platform consumer, not just `Agent::call()`.

- `ModelRouterInterface::resolve()` accepts `string|Model` and returns a `RoutingDecision` (provider + optional model + optional options + reason) instead of a bare `ProviderInterface`. `null` model/options keep the requested ones; rewriting the options lets a decision fit them to the selected provider or model.
- `CatalogBasedModelRouter` never replaces the model, so it's the terminal resolver that model-selecting routers delegate to for provider lookup.
- `Model` instances now route through `ModelRoutingEvent` + the router like names do (previously bypassed both); `ModelRoutingEvent::getModel()` can return `string|Model`.

**BC breaks** (see `UPGRADE.md`): `resolve()` signature widened — custom routers wrap their provider in `new RoutingDecision(...)`; a provider with no `ModelClient` for a model now throws `ModelNotFoundException` instead of `RuntimeException`.

This is just the routing primitive. Concrete routers (rule-based, cost-based, AI-powered) compose on top as separate `ModelRouterInterface` implementations and can live in user-land or land later. Also out of scope: input **transformation** during routing (better as a `ModelRoutingEvent` listener) and `providers:`/`model_router:` bundle config (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

