### PR TITLE
[MCP Bundle][Mate] Support mcp/sdk 0.7

### DIFF
--- a/src/mate/composer.json
+++ b/src/mate/composer.json
@@ -31,12 +31,12 @@
     ],
     "require": {
         "php": ">=8.2",
-        "mcp/sdk": "^0.6",
+        "mcp/sdk": "^0.6|^0.7",
         "psr/log": "^2.0|^3.0",
+        "symfony/ai-mate-composer-plugin": "^0.10",
         "symfony/config": "^5.4|^6.4|^7.3|^8.0",
         "symfony/console": "^5.4|^6.4|^7.3|^8.0",
         "symfony/dependency-injection": "^5.4|^6.4|^7.3|^8.0",
-        "symfony/ai-mate-composer-plugin": "^0.10",
         "symfony/finder": "^5.4|^6.4|^7.3|^8.0"
     },
     "require-dev": {

--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "mcp/sdk": "^0.6",
+        "mcp/sdk": "^0.6|^0.7",
         "php-http/discovery": "^1.20",
         "symfony/config": "^7.3|^8.0",
         "symfony/console": "^7.3|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Widen the `mcp/sdk` constraint to `^0.6 || ^0.7` in the MCP Bundle and Mate. v0.7's changes are additive for both consumers (the new `Registry` `$loader` constructor arg is optional; mate loads eagerly via `$loader->load()` and the bundle uses `setRegistry()`, so the lazy-loading BC break doesn't reach them). PHPStan and the full test suites pass on both 0.6 and 0.7.

cc @wachterjohannes 