### PR TITLE
[Docs] Fix outdated references and sync documentation metadata

### DIFF
--- a/ai.symfony.com/public/llms.txt
+++ b/ai.symfony.com/public/llms.txt
@@ -42,6 +42,7 @@ An MCP server for AI-assisted development. Gives AI assistants like Claude Code,
 
 - [Getting Started](https://symfony.com/doc/current/ai/index.html): Official documentation index
 - [Platform Component](https://symfony.com/doc/current/ai/components/platform.html): Unified interface to AI platforms (OpenAI, Anthropic, Azure, Gemini, VertexAI, Ollama, Mistral, Bedrock, and more)
+- [OpenAI Server Tools](https://symfony.com/doc/current/ai/components/platform/openai-server-tools.html): OpenAI built-in server-side tools (web search, file search, and more) hosted via the Responses API used by the OpenAI, Azure OpenAI, and Scaleway bridges
 - [Anthropic Server Tools](https://symfony.com/doc/current/ai/components/platform/anthropic-server-tools.html): Anthropic built-in server-side tools for code execution and file editing in a sandboxed environment
 - [Vertex AI](https://symfony.com/doc/current/ai/components/platform/vertexai.html): Google Vertex AI platform setup and usage
 - [Vertex AI Server Tools](https://symfony.com/doc/current/ai/components/platform/vertexai-server-tools.html): Server-side tool calling with Vertex AI
@@ -49,6 +50,7 @@ An MCP server for AI-assisted development. Gives AI assistants like Claude Code,
 - [Models.dev Platform](https://symfony.com/doc/current/ai/components/platform/models-dev.html): Using Models.dev as an AI platform
 - [Model Catalogs](https://symfony.com/doc/current/ai/components/platform/model-catalogs.html): How platforms resolve model names into Model objects with capabilities, and how to extend catalogs for new or local models
 - [Voyage AI](https://symfony.com/doc/current/ai/components/platform/voyage.html): Voyage AI embedding platform
+- [Deepgram](https://symfony.com/doc/current/ai/components/platform/deepgram.html): Deepgram speech-to-text (STT) and text-to-speech (TTS) bridge over the Deepgram REST endpoints
 - [Agent Component](https://symfony.com/doc/current/ai/components/agent.html): Framework for building AI agents with tool calling, memory, and multi-step reasoning
 - [Store Component](https://symfony.com/doc/current/ai/components/store.html): Vector database abstraction for RAG with 20+ store backends
 - [Local Stores](https://symfony.com/doc/current/ai/components/store/local.html): InMemory and PSR-6 Cache store backends
@@ -69,6 +71,7 @@ An MCP server for AI-assisted development. Gives AI assistants like Claude Code,
 - [AI Bundle Fast Track](https://symfony.com/doc/current/ai/cookbook/ai-bundle-fast-track.html): Wire platforms, agents, tools, and a vector store in a Symfony app with YAML
 - [Tool Calling with Agents](https://symfony.com/doc/current/ai/cookbook/tool-calling-with-agents.html): Let AI agents call your PHP functions to fetch data or trigger actions
 - [Dynamic Tools](https://symfony.com/doc/current/ai/cookbook/dynamic-tools.html): Build a dynamic Toolbox for flexible tool management at runtime
+- [Runtime-driven Tool Parameters](https://symfony.com/doc/current/ai/cookbook/runtime-driven-tool-parameters.html): Constrain tool parameters and structured output with values from env, a database, or services
 - [Human in the Loop](https://symfony.com/doc/current/ai/cookbook/human-in-the-loop.html): Implement human-in-the-loop confirmation for tool execution
 - [Multi-Agent Orchestration](https://symfony.com/doc/current/ai/cookbook/multi-agent-orchestration.html): Route questions to specialist agents with a central orchestrator
 - [Chatbot with Memory](https://symfony.com/doc/current/ai/cookbook/chatbot-with-memory.html): Build a chatbot with persistent conversation memory
@@ -107,7 +110,7 @@ Symfony integration for the official MCP SDK. Install with `composer require sym
 
 ## Supported AI Platforms
 
-OpenAI, Anthropic, Google Gemini, Google VertexAI, Azure OpenAI, AWS Bedrock, Ollama, Mistral, Cohere, Meta Llama, DeepSeek, Perplexity, HuggingFace, Replicate, OpenRouter, ElevenLabs, Cartesia, Cerebras, Claude Code, Codex, Decart, LM Studio, Docker Model Runner, OpenResponses, Voyage, Scaleway, OVH, AmazeeAi, Albert, AiMlApi, ModelsDev, TransformersPHP, and more.
+OpenAI, Anthropic, Google Gemini, Google VertexAI, Azure OpenAI, AWS Bedrock, Ollama, Mistral, Cohere, Meta Llama, DeepSeek, Perplexity, HuggingFace, Replicate, OpenRouter, ElevenLabs, Cartesia, Cerebras, Claude Code, Codex, Decart, Deepgram, MiniMax, LM Studio, Docker Model Runner, OpenResponses, Voyage, Scaleway, OVH, AmazeeAi, Albert, AiMlApi, ModelsDev, TransformersPHP, and more.
 
 ## Supported Vector Stores
 

--- a/ai.symfony.com/templates/cookbook/content/human-in-the-loop.html
+++ b/ai.symfony.com/templates/cookbook/content/human-in-the-loop.html
@@ -288,9 +288,9 @@ response through an HTTP endpoint or WebSocket.</p>
     <p class="admonition-title">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path></svg>
                 <span>Tip</span>
-    </p><p>The event also exposes the tool's metadata via <code translate="no" class="notranslate">$event-&gt;getMetadata()</code>, which includes the
-tool's description and parameter schema. Use it to show the user more context before they
-decide.</p>
+    </p><p>The event also exposes the tool's definition via <code translate="no" class="notranslate">$event-&gt;getDefinition()</code>, which returns a
+<code translate="no" class="notranslate">Tool</code> object whose <code translate="no" class="notranslate">getDescription()</code> and <code translate="no" class="notranslate">getParameters()</code> methods expose the tool's
+description and parameter schema. Use it to show the user more context before they decide.</p>
 </div>
 </div>
 <div class="section">

--- a/docs/cookbook/human-in-the-loop.rst
+++ b/docs/cookbook/human-in-the-loop.rst
@@ -129,9 +129,9 @@ response through an HTTP endpoint or WebSocket.
 
 .. tip::
 
-    The event also exposes the tool's metadata via ``$event->getMetadata()``, which includes the
-    tool's description and parameter schema. Use it to show the user more context before they
-    decide.
+    The event also exposes the tool's definition via ``$event->getDefinition()``, which returns a
+    ``Tool`` object whose ``getDescription()`` and ``getParameters()`` methods expose the tool's
+    description and parameter schema. Use it to show the user more context before they decide.
 
 Step 5: Wire the Policy and Handler Together
 --------------------------------------------

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -23,7 +23,7 @@ CHANGELOG
  * Add OpenAI image editing via the `images/edits` endpoint: pass the source image as a `Content\Image` through the `image` option of `Platform::invoke()`
  * [BC BREAK] Rename the OpenAI `DallE` bridge to `Image` (`Bridge\OpenAi\DallE` → `Bridge\OpenAi\Image`, and the `Bridge\OpenAi\DallE\*` namespace → `Bridge\OpenAi\Image\*`) and remove the `dall-e-2`/`dall-e-3` catalog entries retired by OpenAI
  * [BC BREAK] Replace the bridge-specific `ImageResult`, `Base64Image`, and `UrlImage` classes of the OpenAI image bridge with the generic `Result\BinaryResult` (single image) and `Result\MultiPartResult` (multiple images), matching the other multi-modal bridges
- * Add an exception is the `response_format` option looks like a class, but is not
+ * Throw an exception if the `response_format` option looks like a class, but is not
  * Add the `finish_reason` result metadata, exposing why a model stopped generating as a `FinishReason\FinishReason` object that normalizes the provider value (`length`, `max_tokens`, `MAX_TOKENS`, ...) into a `FinishReason\FinishReasonCase` while keeping the raw value. Set for buffered and streamed results by the OpenAI, Anthropic, Gemini, VertexAI, Amazon Bedrock, Azure, Ollama, Cohere, Mistral, DeepSeek, Cerebras, Scaleway, Docker Model Runner, Perplexity, MiniMax, amazee.ai and Generic bridges
 
 0.10

--- a/src/platform/README.md
+++ b/src/platform/README.md
@@ -32,6 +32,7 @@ To use a specific AI platform, install the corresponding bridge package:
 | Codex               | `symfony/ai-codex-platform`               |
 | Cohere              | `symfony/ai-cohere-platform`              |
 | Decart              | `symfony/ai-decart-platform`              |
+| Deepgram            | `symfony/ai-deepgram-platform`            |
 | DeepSeek            | `symfony/ai-deep-seek-platform`           |
 | Docker Model Runner | `symfony/ai-docker-model-runner-platform` |
 | ElevenLabs          | `symfony/ai-eleven-labs-platform`         |
@@ -41,6 +42,7 @@ To use a specific AI platform, install the corresponding bridge package:
 | Hugging Face        | `symfony/ai-hugging-face-platform`        |
 | LM Studio           | `symfony/ai-lm-studio-platform`           |
 | Meta Llama          | `symfony/ai-meta-platform`                |
+| MiniMax             | `symfony/ai-mini-max-platform`            |
 | Mistral             | `symfony/ai-mistral-platform`             |
 | Models.dev          | `symfony/ai-models-dev-platform`          |
 | Ollama              | `symfony/ai-ollama-platform`              |

--- a/src/store/src/Bridge/ManticoreSearch/CHANGELOG.md
+++ b/src/store/src/Bridge/ManticoreSearch/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Normalize the `endpoint` URL and tolerate a trailing slash
  * [BC BREAK] Rename the `$host` constructor argument to `$endpoint`
+ * [BC BREAK] Create the `uuid` column as a `STRING` attribute instead of a `TEXT` field so documents can be removed by id; existing tables must be recreated (`drop()` + `setup()`)
 
 0.1
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

Documentation housekeeping: scanned the RST and Markdown docs for code references that no longer match the codebase, and synced a few pieces of documentation metadata that had drifted.

- **Cookbook** — `human-in-the-loop.rst` referenced a non-existent `$event->getMetadata()` on `ToolCallRequested`. The event exposes the tool through `getDefinition()`, which returns a `Tool` whose `getDescription()` / `getParameters()` provide the description and parameter schema. Regenerated the cookbook website fragment accordingly.
- **llms.txt** — added the `Deepgram` and `MiniMax` platforms, the `OpenAI Server Tools` and `Deepgram` documentation pages, and the `Runtime-driven Tool Parameters` cookbook entry, all of which existed in the repo but were missing from the file.
- **Platform README** — added the missing `Deepgram` and `MiniMax` rows to the bridge table.
- **Platform CHANGELOG** — fixed a garbled `0.11` entry ("Add an exception is the `response_format`…" → "Throw an exception if the `response_format`…").
- **ManticoreSearch CHANGELOG** — documented the `uuid` `STRING` column BC break that was only present in `UPGRADE.md`.
