### PR TITLE
[Platform] Make Gemini and VertexAI tolerant of empty tool-call roundtrips

### DIFF
--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -95,6 +95,16 @@ final class ResultConverter implements ResultConverterInterface
                 throw new RuntimeException(\sprintf('Error "%s" - "%s": "%s".', $data['error']['code'], $data['error']['status'], $data['error']['message']));
             }
 
+            // Gemini can return a well-formed completion with a terminal finish reason but no
+            // content parts (e.g. an empty message after a tool result). Treat it as empty text
+            // instead of crashing on an otherwise valid response.
+            if (isset($data['candidates'][0]['finishReason'])) {
+                return $this->withFinishReason(
+                    new TextResult(''),
+                    FinishReasonMapper::map($data['candidates'][0]['finishReason']),
+                );
+            }
+
             throw new RuntimeException('Response does not contain any content.');
         }
 
@@ -208,6 +218,30 @@ final class ResultConverter implements ResultConverterInterface
      */
     private function convertToolCall(array $toolCall, ?string $signature = null): ToolCall
     {
-        return new ToolCall($toolCall['id'] ?? '', $toolCall['name'], $toolCall['args'], $signature);
+        return new ToolCall($toolCall['id'] ?? '', $toolCall['name'], $this->normalizeArguments($toolCall['args']), $signature);
+    }
+
+    /**
+     * Gemini emits empty strings for optional object properties it has no value for, whereas other
+     * providers omit them or send null. Coerce those empty strings to null (recursing into nested
+     * structures) so downstream denormalization — e.g. of nullable DateTime properties — behaves
+     * consistently across bridges. List elements (integer-keyed) are left untouched, as an empty
+     * string can be a legitimate value inside a list argument.
+     *
+     * @param mixed[] $arguments
+     *
+     * @return mixed[]
+     */
+    private function normalizeArguments(array $arguments): array
+    {
+        foreach ($arguments as $key => $value) {
+            if (\is_array($value)) {
+                $arguments[$key] = $this->normalizeArguments($value);
+            } elseif ('' === $value && !\is_int($key)) {
+                $arguments[$key] = null;
+            }
+        }
+
+        return $arguments;
     }
 }

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -284,6 +284,74 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('sig_call', $toolCalls[0]->getSignature());
     }
 
+    public function testConvertReturnsEmptyTextResultForCandidateWithoutContentParts()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        // Gemini occasionally returns a valid completion with a terminal finish reason but no
+        // content parts, e.g. an empty message after a tool result.
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => ['role' => 'model'],
+                    'finishReason' => 'STOP',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('', $result->getContent());
+        $this->assertTrue($result->getMetadata()->get('finish_reason')->is(FinishReasonCase::STOP));
+    }
+
+    public function testConvertThrowsWhenResponseContainsNoCandidates()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Response does not contain any content.');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testConvertCoercesEmptyStringToolCallArgumentsToNull()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+        // Gemini emits empty strings for optional object properties it has no value for; empty
+        // strings inside list arguments are legitimate values and must be preserved.
+        $httpResponse->method('toArray')->willReturn([
+            'candidates' => [
+                ['content' => ['parts' => [
+                    ['functionCall' => ['name' => 'search', 'args' => [
+                        'query' => 'Symfony',
+                        'departureDate' => '',
+                        'nested' => ['since' => ''],
+                        'tags' => ['a', '', 'b'],
+                    ]]],
+                ]]],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $arguments = $result->getContent()[0]->getArguments();
+        $this->assertSame('Symfony', $arguments['query']);
+        $this->assertNull($arguments['departureDate']);
+        $this->assertNull($arguments['nested']['since']);
+        $this->assertSame(['a', '', 'b'], $arguments['tags']);
+    }
+
     public function testStreamSkipsCandidatesWithoutContentParts()
     {
         $converter = new ResultConverter();

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -105,6 +105,16 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         if (!isset($data['candidates'][0]['content']['parts'][0])) {
+            // Gemini can return a well-formed completion with a terminal finish reason but no
+            // content parts (e.g. an empty message after a tool result). Treat it as empty text
+            // instead of crashing on an otherwise valid response.
+            if (isset($data['candidates'][0]['finishReason'])) {
+                return $this->withFinishReason(
+                    new TextResult(''),
+                    FinishReasonMapper::map($data['candidates'][0]['finishReason']),
+                );
+            }
+
             throw new RuntimeException('Response does not contain any content.');
         }
 
@@ -226,6 +236,30 @@ final class ResultConverter implements ResultConverterInterface
      */
     private function convertToolCall(array $toolCall, ?string $signature = null): ToolCall
     {
-        return new ToolCall($toolCall['id'] ?? '', $toolCall['name'], $toolCall['args'], $signature);
+        return new ToolCall($toolCall['id'] ?? '', $toolCall['name'], $this->normalizeArguments($toolCall['args']), $signature);
+    }
+
+    /**
+     * Gemini emits empty strings for optional object properties it has no value for, whereas other
+     * providers omit them or send null. Coerce those empty strings to null (recursing into nested
+     * structures) so downstream denormalization — e.g. of nullable DateTime properties — behaves
+     * consistently across bridges. List elements (integer-keyed) are left untouched, as an empty
+     * string can be a legitimate value inside a list argument.
+     *
+     * @param mixed[] $arguments
+     *
+     * @return mixed[]
+     */
+    private function normalizeArguments(array $arguments): array
+    {
+        foreach ($arguments as $key => $value) {
+            if (\is_array($value)) {
+                $arguments[$key] = $this->normalizeArguments($value);
+            } elseif ('' === $value && !\is_int($key)) {
+                $arguments[$key] = null;
+            }
+        }
+
+        return $arguments;
     }
 }

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
@@ -15,7 +15,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\ResultConverter;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
+use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
@@ -256,6 +258,68 @@ final class ResultConverterTest extends TestCase
         $toolCalls = $result->getContent();
         $this->assertCount(1, $toolCalls);
         $this->assertSame('sig_call', $toolCalls[0]->getSignature());
+    }
+
+    public function testConvertReturnsEmptyTextResultForCandidateWithoutContentParts()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        // Gemini occasionally returns a valid completion with a terminal finish reason but no
+        // content parts, e.g. an empty message after a tool result.
+        $response->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => ['role' => 'model'],
+                    'finishReason' => 'STOP',
+                ],
+            ],
+        ]);
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('', $result->getContent());
+        $this->assertTrue($result->getMetadata()->get('finish_reason')->is(FinishReasonCase::STOP));
+    }
+
+    public function testConvertThrowsWhenResponseContainsNoCandidates()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'candidates' => [],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Response does not contain any content.');
+
+        (new ResultConverter())->convert(new RawHttpResult($response));
+    }
+
+    public function testConvertCoercesEmptyStringToolCallArgumentsToNull()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        // Gemini emits empty strings for optional object properties it has no value for; empty
+        // strings inside list arguments are legitimate values and must be preserved.
+        $response->method('toArray')->willReturn([
+            'candidates' => [
+                ['content' => ['parts' => [
+                    ['functionCall' => ['name' => 'search', 'args' => [
+                        'query' => 'Symfony',
+                        'departureDate' => '',
+                        'nested' => ['since' => ''],
+                        'tags' => ['a', '', 'b'],
+                    ]]],
+                ]]],
+            ],
+        ]);
+
+        $result = (new ResultConverter())->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(ToolCallResult::class, $result);
+        $arguments = $result->getContent()[0]->getArguments();
+        $this->assertSame('Symfony', $arguments['query']);
+        $this->assertNull($arguments['departureDate']);
+        $this->assertNull($arguments['nested']['since']);
+        $this->assertSame(['a', '', 'b'], $arguments['tags']);
     }
 
     public function testConvertsInlineDataToBinaryResult()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Surfaced while running the examples. Two robustness gaps in the Gemini and VertexAI result converters, both around tool-call roundtrips:

- Gemini can return a valid HTTP 200 completion with a terminal finish reason but no `content.parts` (e.g. an empty message after a tool result). The converters threw `Response does not contain any content.` on this valid response. They now return an empty text result carrying the finish reason, and only throw when no candidate is present at all. Fixes `gemini/toolcall-roundtrip`, `vertexai/toolcall`, `rag/mariadb-gemini`.
- Gemini emits an empty string for optional tool-call arguments it has no value for, whereas OpenAI/Anthropic send `null`. That empty string broke denormalization of nullable properties such as `DateTime`. Arguments are now normalized so `""` becomes `null`, consistent across bridges. Fixes `agent/toolcall-polymorphic-interface` on Gemini.

Tests added for both behaviors in each bridge.
