### PR TITLE
[Chat] Fix SurrealDB message store corrupting the message UUID

### DIFF
--- a/src/chat/src/Bridge/SurrealDb/MessageStore.php
+++ b/src/chat/src/Bridge/SurrealDb/MessageStore.php
@@ -66,7 +66,12 @@ final class MessageStore implements ManagedStoreInterface, MessageStoreInterface
     public function save(MessageBag $messages): void
     {
         foreach ($messages->getMessages() as $message) {
-            $this->request('POST', \sprintf('key/%s', $this->table), $this->serializer->normalize($message));
+            // SurrealDB treats the "id" field as the reserved record identifier and rewrites it into
+            // a table-prefixed record id ("table:⟨uuid⟩") on read-back, which is no longer a valid
+            // UUID. Store the message UUID under a dedicated field so it round-trips untouched.
+            $this->request('POST', \sprintf('key/%s', $this->table), $this->serializer->normalize($message, context: [
+                'identifier' => 'messageId',
+            ]));
         }
     }
 
@@ -75,7 +80,9 @@ final class MessageStore implements ManagedStoreInterface, MessageStoreInterface
         $messages = $this->request('GET', \sprintf('key/%s', $this->table), []);
 
         return new MessageBag(...array_map(
-            fn (array $message): MessageInterface => $this->serializer->denormalize($message, MessageInterface::class),
+            fn (array $message): MessageInterface => $this->serializer->denormalize($message, MessageInterface::class, context: [
+                'identifier' => 'messageId',
+            ]),
             $messages[0]['result'],
         ));
     }

--- a/src/chat/src/Bridge/SurrealDb/Tests/MessageStoreTest.php
+++ b/src/chat/src/Bridge/SurrealDb/Tests/MessageStoreTest.php
@@ -188,8 +188,13 @@ final class MessageStoreTest extends TestCase
             ]),
             new JsonMockResponse([
                 [
+                    // SurrealDB rewrites the reserved "id" field into a table-prefixed record id on
+                    // read-back; the message UUID is preserved under the dedicated "messageId" field.
                     'result' => [
-                        $serializer->normalize(Message::ofUser('Hello World')),
+                        [
+                            'id' => 'test:⟨0197f6a2-1c8f-7b3e-9d4a-1234567890ab⟩',
+                            ...$serializer->normalize(Message::ofUser('Hello World'), context: ['identifier' => 'messageId']),
+                        ],
                     ],
                     'status' => 'OK',
                     'time' => '263.208µs',
@@ -208,5 +213,37 @@ final class MessageStoreTest extends TestCase
 
         $message = $messages->getUserMessage();
         $this->assertSame('Hello World', $message->asText());
+    }
+
+    public function testStoreSavesMessageUuidOutsideReservedIdField()
+    {
+        $capturedBody = null;
+
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedBody): JsonMockResponse {
+            if (str_ends_with($url, '/signin')) {
+                return new JsonMockResponse([
+                    'code' => 200,
+                    'details' => 'Authentication succeeded.',
+                    'token' => 'bar',
+                ], ['http_code' => 200]);
+            }
+
+            $capturedBody = json_decode($options['body'], true);
+
+            return new JsonMockResponse([[
+                'result' => [],
+                'status' => 'OK',
+                'time' => '263.208µs',
+            ]], ['http_code' => 200]);
+        }, 'http://127.0.0.1:8000');
+
+        $store = new MessageStore($httpClient, 'http://127.0.0.1:8000', 'test', 'test', 'test', 'test', table: 'test');
+
+        $store->save(new MessageBag(Message::ofUser('Hello world')));
+
+        // The UUID must not land in SurrealDB's reserved "id" field, otherwise it is corrupted on load.
+        $this->assertIsArray($capturedBody);
+        $this->assertArrayNotHasKey('id', $capturedBody);
+        $this->assertArrayHasKey('messageId', $capturedBody);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Surfaced while running the examples: `chat/persistent-chat-surrealdb` failed with `Invalid UUID.` on load.

SurrealDB treats the `id` field as the reserved record identifier and rewrites it into a table-prefixed record id (`table:⟨uuid⟩`) on read-back, so the stored message UUID was no longer parseable by `Uuid::fromString()`. The store now writes the UUID under a dedicated `messageId` field via the serializer's `identifier` context — mirroring the MongoDB bridge — so it round-trips untouched.

Adds a save test asserting the UUID stays out of the reserved `id` field and updates the load test to reflect SurrealDB's real record-id rewriting.
