### PR TITLE
[Examples] Give the OpenAI token-metadata example room for reasoning tokens

### DIFF
--- a/examples/openai/token-metadata.php
+++ b/examples/openai/token-metadata.php
@@ -24,7 +24,7 @@ $messages = new MessageBag(
     Message::ofUser('What is the Symfony framework?'),
 );
 $result = $agent->call($messages, [
-    'max_output_tokens' => 500, // specific options just for this call
+    'max_output_tokens' => 2000, // specific options just for this call; reasoning models spend part of this budget on reasoning tokens
 ]);
 
 print_token_usage($result->getMetadata()->get('token_usage'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Surfaced while running the examples: `openai/token-metadata` returned no content.

`gpt-5-mini` is a reasoning model and spends part of the output budget on reasoning tokens, so `max_output_tokens: 500` left no room for the answer and the response came back incomplete with no content. Raised to 2000.
