### PR TITLE
[Platform] Fix Gemini and VertexAI streaming crash on thinking and multi-part parts

### DIFF
--- a/examples/gemini/stream-thinking.php
+++ b/examples/gemini/stream-thinking.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Gemini\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('GEMINI_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant that reasons step by step.'),
+    Message::ofUser('If a train travels 60 km in 45 minutes, what is its average speed in km/h?'),
+);
+
+// Enabling thought summaries makes Gemini stream "thought" parts before the answer; the streaming
+// converter frames them with ThinkingStart / ThinkingComplete boundaries around the ThinkingDelta
+// instances and turns the answer into TextDelta instances.
+$result = $platform->invoke('gemini-2.5-flash', $messages, [
+    'stream' => true,
+    'thinkingConfig' => [
+        'includeThoughts' => true,
+    ],
+]);
+
+foreach ($result->asStream() as $delta) {
+    if ($delta instanceof ThinkingStart) {
+        output()->writeln('<info><thinking></info>');
+    }
+    if ($delta instanceof ThinkingDelta) {
+        output()->write('<fg=#999999>'.$delta->getThinking().'</>');
+    }
+    if ($delta instanceof ThinkingComplete) {
+        output()->writeln(\PHP_EOL.'<info></thinking></info>');
+    }
+    if ($delta instanceof TextDelta) {
+        echo $delta;
+    }
+}
+echo \PHP_EOL;

--- a/src/platform/src/Bridge/Gemini/CHANGELOG.md
+++ b/src/platform/src/Bridge/Gemini/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Add a `baseUrl` argument to the model clients and the factory to target Gemini-compatible endpoints
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+ * Stream thinking as `ThinkingStart`/`ThinkingDelta`/`ThinkingComplete` deltas for `thought` parts and expand multi-part streamed candidates
 
 0.10
 ----

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -30,6 +30,9 @@ use Symfony\AI\Platform\Result\Stream\Delta\ChoiceDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -124,6 +127,10 @@ final class ResultConverter implements ResultConverterInterface
     private function convertStream(RawResultInterface $result): \Generator
     {
         $finishReason = null;
+        // Thinking boundary state, carried across chunks: Gemini streams thought parts (often split
+        // over several chunks) before the answer, so a thinking block may span multiple iterations.
+        $thinking = null;
+        $thinkingSignature = null;
 
         foreach ($result->getDataStream() as $data) {
             // Gemini repeats the reason on every candidate of the terminal chunk; the leading one wins,
@@ -138,12 +145,57 @@ final class ResultConverter implements ResultConverterInterface
                 continue;
             }
 
+            // The multi-candidate path is exotic for Gemini; preserve its bare-delta behavior.
             if (1 !== \count($choices)) {
-                yield new ChoiceDelta(array_map($this->resultToDelta(...), $choices));
+                $deltas = [];
+                foreach ($choices as $choice) {
+                    $deltas = array_merge($deltas, iterator_to_array($this->resultToDeltas($choice), false));
+                }
+
+                if ([] !== $deltas) {
+                    yield new ChoiceDelta($deltas);
+                }
+
                 continue;
             }
 
-            yield $this->resultToDelta($choices[0]);
+            // A single candidate may carry multiple parts (e.g. a thought part plus text, or a tool
+            // call plus text) that convertChoice() returns as a MultiPartResult; flatten to leaves so
+            // thought and non-thought parts are framed identically whether combined in one chunk or
+            // split across chunks.
+            foreach ($this->flattenResult($choices[0]) as $leaf) {
+                if ($leaf instanceof ThinkingResult) {
+                    if (null === $thinking) {
+                        yield new ThinkingStart();
+                        $thinking = '';
+                    }
+
+                    $content = $leaf->getContent() ?? '';
+                    $thinking .= $content;
+
+                    if (null !== $leaf->getSignature()) {
+                        $thinkingSignature = $leaf->getSignature();
+                    }
+
+                    yield new ThinkingDelta($content);
+
+                    continue;
+                }
+
+                // The first non-thinking part closes an open thinking block.
+                if (null !== $thinking) {
+                    yield new ThinkingComplete($thinking, $thinkingSignature);
+                    $thinking = null;
+                    $thinkingSignature = null;
+                }
+
+                yield from $this->resultToDeltas($leaf);
+            }
+        }
+
+        // A thinking block still open at the end of the stream is completed before the terminal metadata.
+        if (null !== $thinking) {
+            yield new ThinkingComplete($thinking, $thinkingSignature);
         }
 
         // Emitted last: the terminal chunk carries both the finish reason and its content parts.
@@ -152,13 +204,61 @@ final class ResultConverter implements ResultConverterInterface
         }
     }
 
-    private function resultToDelta(ToolCallResult|TextResult|BinaryResult $result): DeltaInterface
+    /**
+     * Flattens a single choice into its leaf results so the streaming thinking-boundary logic can walk
+     * thought and non-thought parts uniformly, whether they arrive combined in one MultiPartResult
+     * chunk or split across chunks.
+     *
+     * @return list<ResultInterface>
+     */
+    private function flattenResult(ResultInterface $result): array
     {
-        return match (true) {
-            $result instanceof TextResult => new TextDelta($result->getContent()),
-            $result instanceof BinaryResult => new BinaryDelta($result->getContent(), $result->getMimeType()),
-            $result instanceof ToolCallResult => new ToolCallComplete($result->getContent()),
-        };
+        if (!$result instanceof MultiPartResult) {
+            return [$result];
+        }
+
+        $leaves = [];
+        foreach ($result->getContent() as $part) {
+            foreach ($this->flattenResult($part) as $leaf) {
+                $leaves[] = $leaf;
+            }
+        }
+
+        return $leaves;
+    }
+
+    /**
+     * ExecutableCodeResult and CodeExecutionResult have no streaming delta representation and are
+     * only exposed through the buffered result; they are skipped here instead of crashing.
+     *
+     * @return \Generator<DeltaInterface>
+     */
+    private function resultToDeltas(ResultInterface $result): \Generator
+    {
+        switch (true) {
+            case $result instanceof MultiPartResult:
+                foreach ($result->getContent() as $part) {
+                    yield from $this->resultToDeltas($part);
+                }
+
+                return;
+            case $result instanceof ThinkingResult:
+                yield new ThinkingDelta($result->getContent() ?? '');
+
+                return;
+            case $result instanceof TextResult:
+                yield new TextDelta($result->getContent());
+
+                return;
+            case $result instanceof BinaryResult:
+                yield new BinaryDelta($result->getContent(), $result->getMimeType());
+
+                return;
+            case $result instanceof ToolCallResult:
+                yield new ToolCallComplete($result->getContent());
+
+                return;
+        }
     }
 
     /**
@@ -169,7 +269,7 @@ final class ResultConverter implements ResultConverterInterface
      *     }
      * } $choice
      */
-    private function convertChoice(array $choice): ToolCallResult|TextResult|BinaryResult|ExecutableCodeResult|CodeExecutionResult|MultiPartResult|null
+    private function convertChoice(array $choice): ToolCallResult|TextResult|ThinkingResult|BinaryResult|ExecutableCodeResult|CodeExecutionResult|MultiPartResult|null
     {
         if (!isset($choice['content']['parts'])) {
             return null;

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -28,6 +28,9 @@ use Symfony\AI\Platform\Result\Stream\Delta\BinaryDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ChoiceDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -350,6 +353,152 @@ final class ResultConverterTest extends TestCase
         $this->assertNull($arguments['departureDate']);
         $this->assertNull($arguments['nested']['since']);
         $this->assertSame(['a', '', 'b'], $arguments['tags']);
+    }
+
+    public function testStreamConvertsSingleThoughtPartToThinkingDelta()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createMock(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($httpResponse);
+        // A thinking-enabled model streams thought parts, which convertChoice() turns into a
+        // ThinkingResult; the stream frames it with ThinkingStart and ThinkingComplete boundaries.
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'Let me think.', 'thought' => true, 'thoughtSignature' => 'sig_1'],
+                    ]]],
+                ],
+            ];
+        })());
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+        $items = iterator_to_array($result->getContent());
+
+        $this->assertCount(3, $items);
+        $this->assertInstanceOf(ThinkingStart::class, $items[0]);
+        $this->assertInstanceOf(ThinkingDelta::class, $items[1]);
+        $this->assertSame('Let me think.', $items[1]->getThinking());
+        $this->assertInstanceOf(ThinkingComplete::class, $items[2]);
+        $this->assertSame('Let me think.', $items[2]->getThinking());
+        $this->assertSame('sig_1', $items[2]->getSignature());
+    }
+
+    public function testStreamExpandsMultiPartCandidateIntoDeltas()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createMock(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($httpResponse);
+        // A candidate with several parts (thought + text) is a MultiPartResult; the thought is framed
+        // with ThinkingStart / ThinkingComplete and the text follows as a TextDelta.
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'Reasoning.', 'thought' => true],
+                        ['text' => 'Final answer.'],
+                    ]]],
+                ],
+            ];
+        })());
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+        $items = iterator_to_array($result->getContent());
+
+        $this->assertCount(4, $items);
+        $this->assertInstanceOf(ThinkingStart::class, $items[0]);
+        $this->assertInstanceOf(ThinkingDelta::class, $items[1]);
+        $this->assertSame('Reasoning.', $items[1]->getThinking());
+        $this->assertInstanceOf(ThinkingComplete::class, $items[2]);
+        $this->assertSame('Reasoning.', $items[2]->getThinking());
+        $this->assertInstanceOf(TextDelta::class, $items[3]);
+        $this->assertSame('Final answer.', $items[3]->getText());
+    }
+
+    public function testStreamFramesThoughtPartsSplitAcrossChunksWithSingleBoundaryPair()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createMock(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($httpResponse);
+        // Gemini splits a thinking block across several chunks before the answer; the boundary logic
+        // must emit a single ThinkingStart, one ThinkingDelta per chunk, and one ThinkingComplete
+        // whose accumulated text is the concatenation, then the answer as a TextDelta.
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'First thought. ', 'thought' => true],
+                    ]]],
+                ],
+            ];
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'Second thought.', 'thought' => true, 'thoughtSignature' => 'sig_final'],
+                    ]]],
+                ],
+            ];
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'The answer.'],
+                    ]]],
+                ],
+            ];
+        })());
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+        $items = iterator_to_array($result->getContent());
+
+        $this->assertCount(5, $items);
+        $this->assertInstanceOf(ThinkingStart::class, $items[0]);
+        $this->assertInstanceOf(ThinkingDelta::class, $items[1]);
+        $this->assertSame('First thought. ', $items[1]->getThinking());
+        $this->assertInstanceOf(ThinkingDelta::class, $items[2]);
+        $this->assertSame('Second thought.', $items[2]->getThinking());
+        $this->assertInstanceOf(ThinkingComplete::class, $items[3]);
+        $this->assertSame('First thought. Second thought.', $items[3]->getThinking());
+        $this->assertSame('sig_final', $items[3]->getSignature());
+        $this->assertInstanceOf(TextDelta::class, $items[4]);
+        $this->assertSame('The answer.', $items[4]->getText());
+    }
+
+    public function testStreamExpandsToolCallWithTextIntoDeltas()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createMock(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($httpResponse);
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'Calling tool.'],
+                        ['functionCall' => ['name' => 'search', 'args' => ['q' => 'x']]],
+                    ]]],
+                ],
+            ];
+        })());
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+        $items = iterator_to_array($result->getContent());
+
+        $this->assertCount(2, $items);
+        $this->assertInstanceOf(TextDelta::class, $items[0]);
+        $this->assertSame('Calling tool.', $items[0]->getText());
+        $this->assertInstanceOf(ToolCallComplete::class, $items[1]);
+        $this->assertSame('search', $items[1]->getToolCalls()[0]->getName());
     }
 
     public function testStreamSkipsCandidatesWithoutContentParts()

--- a/src/platform/src/Bridge/VertexAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/VertexAi/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Derive the API host from the configured `location` to support regional and data-residency endpoints
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream
+ * Stream thinking as `ThinkingStart`/`ThinkingDelta`/`ThinkingComplete` deltas for `thought` parts and expand multi-part streamed candidates
 
 0.10
 ----

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -31,6 +31,9 @@ use Symfony\AI\Platform\Result\Stream\Delta\ChoiceDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -137,6 +140,10 @@ final class ResultConverter implements ResultConverterInterface
     private function convertStream(RawResultInterface $result): \Generator
     {
         $finishReason = null;
+        // Thinking boundary state, carried across chunks: Gemini streams thought parts (often split
+        // over several chunks) before the answer, so a thinking block may span multiple iterations.
+        $thinking = null;
+        $thinkingSignature = null;
 
         foreach ($result->getDataStream() as $data) {
             if (isset($data['usageMetadata']['totalTokenCount']) && 0 < $data['usageMetadata']['totalTokenCount']) {
@@ -155,12 +162,57 @@ final class ResultConverter implements ResultConverterInterface
                 continue;
             }
 
+            // The multi-candidate path is exotic for Gemini; preserve its bare-delta behavior.
             if (1 !== \count($choices)) {
-                yield new ChoiceDelta(array_map($this->resultToDelta(...), $choices));
+                $deltas = [];
+                foreach ($choices as $choice) {
+                    $deltas = array_merge($deltas, iterator_to_array($this->resultToDeltas($choice), false));
+                }
+
+                if ([] !== $deltas) {
+                    yield new ChoiceDelta($deltas);
+                }
+
                 continue;
             }
 
-            yield $this->resultToDelta($choices[0]);
+            // A single candidate may carry multiple parts (e.g. a thought part plus text, or a tool
+            // call plus text) that convertChoice() returns as a MultiPartResult; flatten to leaves so
+            // thought and non-thought parts are framed identically whether combined in one chunk or
+            // split across chunks.
+            foreach ($this->flattenResult($choices[0]) as $leaf) {
+                if ($leaf instanceof ThinkingResult) {
+                    if (null === $thinking) {
+                        yield new ThinkingStart();
+                        $thinking = '';
+                    }
+
+                    $content = $leaf->getContent() ?? '';
+                    $thinking .= $content;
+
+                    if (null !== $leaf->getSignature()) {
+                        $thinkingSignature = $leaf->getSignature();
+                    }
+
+                    yield new ThinkingDelta($content);
+
+                    continue;
+                }
+
+                // The first non-thinking part closes an open thinking block.
+                if (null !== $thinking) {
+                    yield new ThinkingComplete($thinking, $thinkingSignature);
+                    $thinking = null;
+                    $thinkingSignature = null;
+                }
+
+                yield from $this->resultToDeltas($leaf);
+            }
+        }
+
+        // A thinking block still open at the end of the stream is completed before the terminal metadata.
+        if (null !== $thinking) {
+            yield new ThinkingComplete($thinking, $thinkingSignature);
         }
 
         // Emitted last: the terminal chunk carries both the finish reason and its content parts.
@@ -169,13 +221,61 @@ final class ResultConverter implements ResultConverterInterface
         }
     }
 
-    private function resultToDelta(ToolCallResult|TextResult|BinaryResult $result): DeltaInterface
+    /**
+     * Flattens a single choice into its leaf results so the streaming thinking-boundary logic can walk
+     * thought and non-thought parts uniformly, whether they arrive combined in one MultiPartResult
+     * chunk or split across chunks.
+     *
+     * @return list<ResultInterface>
+     */
+    private function flattenResult(ResultInterface $result): array
     {
-        return match (true) {
-            $result instanceof TextResult => new TextDelta($result->getContent()),
-            $result instanceof BinaryResult => new BinaryDelta($result->getContent(), $result->getMimeType()),
-            $result instanceof ToolCallResult => new ToolCallComplete($result->getContent()),
-        };
+        if (!$result instanceof MultiPartResult) {
+            return [$result];
+        }
+
+        $leaves = [];
+        foreach ($result->getContent() as $part) {
+            foreach ($this->flattenResult($part) as $leaf) {
+                $leaves[] = $leaf;
+            }
+        }
+
+        return $leaves;
+    }
+
+    /**
+     * ExecutableCodeResult and CodeExecutionResult have no streaming delta representation and are
+     * only exposed through the buffered result; they are skipped here instead of crashing.
+     *
+     * @return \Generator<DeltaInterface>
+     */
+    private function resultToDeltas(ResultInterface $result): \Generator
+    {
+        switch (true) {
+            case $result instanceof MultiPartResult:
+                foreach ($result->getContent() as $part) {
+                    yield from $this->resultToDeltas($part);
+                }
+
+                return;
+            case $result instanceof ThinkingResult:
+                yield new ThinkingDelta($result->getContent() ?? '');
+
+                return;
+            case $result instanceof TextResult:
+                yield new TextDelta($result->getContent());
+
+                return;
+            case $result instanceof BinaryResult:
+                yield new BinaryDelta($result->getContent(), $result->getMimeType());
+
+                return;
+            case $result instanceof ToolCallResult:
+                yield new ToolCallComplete($result->getContent());
+
+                return;
+        }
     }
 
     /**
@@ -187,7 +287,7 @@ final class ResultConverter implements ResultConverterInterface
      *     }
      * } $choice
      */
-    private function convertChoice(array $choice): ToolCallResult|TextResult|BinaryResult|ExecutableCodeResult|CodeExecutionResult|MultiPartResult|null
+    private function convertChoice(array $choice): ToolCallResult|TextResult|ThinkingResult|BinaryResult|ExecutableCodeResult|CodeExecutionResult|MultiPartResult|null
     {
         if (!isset($choice['content']['parts'])) {
             return null;

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
@@ -27,6 +27,9 @@ use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\BinaryDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ChoiceDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -582,6 +585,148 @@ final class ResultConverterTest extends TestCase
         $this->assertSame(40, $items[2]->getTotalTokens());
         $this->assertInstanceOf(TextDelta::class, $items[3]);
         $this->assertSame('!', $items[3]->getText());
+    }
+
+    public function testStreamConvertsSingleThoughtPartToThinkingDelta()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createStub(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($response);
+        // A thinking-enabled model streams thought parts, which convertChoice() turns into a
+        // ThinkingResult; the stream frames it with ThinkingStart and ThinkingComplete boundaries.
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'Let me think.', 'thought' => true, 'thoughtSignature' => 'sig_1'],
+                    ]]],
+                ],
+            ];
+        })());
+
+        $result = (new ResultConverter())->convert($rawResult, ['stream' => true]);
+        $items = iterator_to_array($result->getContent());
+
+        $this->assertCount(3, $items);
+        $this->assertInstanceOf(ThinkingStart::class, $items[0]);
+        $this->assertInstanceOf(ThinkingDelta::class, $items[1]);
+        $this->assertSame('Let me think.', $items[1]->getThinking());
+        $this->assertInstanceOf(ThinkingComplete::class, $items[2]);
+        $this->assertSame('Let me think.', $items[2]->getThinking());
+        $this->assertSame('sig_1', $items[2]->getSignature());
+    }
+
+    public function testStreamExpandsMultiPartCandidateIntoDeltas()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createStub(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($response);
+        // A candidate with several parts (thought + text) is a MultiPartResult; the thought is framed
+        // with ThinkingStart / ThinkingComplete and the text follows as a TextDelta.
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'Reasoning.', 'thought' => true],
+                        ['text' => 'Final answer.'],
+                    ]]],
+                ],
+            ];
+        })());
+
+        $result = (new ResultConverter())->convert($rawResult, ['stream' => true]);
+        $items = iterator_to_array($result->getContent());
+
+        $this->assertCount(4, $items);
+        $this->assertInstanceOf(ThinkingStart::class, $items[0]);
+        $this->assertInstanceOf(ThinkingDelta::class, $items[1]);
+        $this->assertSame('Reasoning.', $items[1]->getThinking());
+        $this->assertInstanceOf(ThinkingComplete::class, $items[2]);
+        $this->assertSame('Reasoning.', $items[2]->getThinking());
+        $this->assertInstanceOf(TextDelta::class, $items[3]);
+        $this->assertSame('Final answer.', $items[3]->getText());
+    }
+
+    public function testStreamFramesThoughtPartsSplitAcrossChunksWithSingleBoundaryPair()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createStub(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($response);
+        // Gemini splits a thinking block across several chunks before the answer; the boundary logic
+        // must emit a single ThinkingStart, one ThinkingDelta per chunk, and one ThinkingComplete
+        // whose accumulated text is the concatenation, then the answer as a TextDelta.
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'First thought. ', 'thought' => true],
+                    ]]],
+                ],
+            ];
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'Second thought.', 'thought' => true, 'thoughtSignature' => 'sig_final'],
+                    ]]],
+                ],
+            ];
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'The answer.'],
+                    ]]],
+                ],
+            ];
+        })());
+
+        $result = (new ResultConverter())->convert($rawResult, ['stream' => true]);
+        $items = iterator_to_array($result->getContent());
+
+        $this->assertCount(5, $items);
+        $this->assertInstanceOf(ThinkingStart::class, $items[0]);
+        $this->assertInstanceOf(ThinkingDelta::class, $items[1]);
+        $this->assertSame('First thought. ', $items[1]->getThinking());
+        $this->assertInstanceOf(ThinkingDelta::class, $items[2]);
+        $this->assertSame('Second thought.', $items[2]->getThinking());
+        $this->assertInstanceOf(ThinkingComplete::class, $items[3]);
+        $this->assertSame('First thought. Second thought.', $items[3]->getThinking());
+        $this->assertSame('sig_final', $items[3]->getSignature());
+        $this->assertInstanceOf(TextDelta::class, $items[4]);
+        $this->assertSame('The answer.', $items[4]->getText());
+    }
+
+    public function testStreamExpandsToolCallWithTextIntoDeltas()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createStub(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($response);
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['text' => 'Calling tool.'],
+                        ['functionCall' => ['name' => 'search', 'args' => ['q' => 'x']]],
+                    ]]],
+                ],
+            ];
+        })());
+
+        $result = (new ResultConverter())->convert($rawResult, ['stream' => true]);
+        $items = iterator_to_array($result->getContent());
+
+        $this->assertCount(2, $items);
+        $this->assertInstanceOf(TextDelta::class, $items[0]);
+        $this->assertSame('Calling tool.', $items[0]->getText());
+        $this->assertInstanceOf(ToolCallComplete::class, $items[1]);
+        $this->assertSame('search', $items[1]->getToolCalls()[0]->getName());
     }
 
     public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #2322
| License       | MIT

When streaming a thinking-enabled Gemini model (or any candidate carrying more than one part), the Gemini and VertexAI result converters threw a `TypeError`: the streaming path only accepted `ToolCallResult|TextResult|BinaryResult`, but `convertChoice()` can return a `ThinkingResult` (single thought part) or a `MultiPartResult` (≥2 parts).

Bug fix:
- `convertChoice()` now also returns `ThinkingResult` (it crashed on the buffered path too for a lone thought part).
- `resultToDelta()` is replaced by a recursive `resultToDeltas()` that expands `MultiPartResult` into per-part deltas. `ExecutableCodeResult`/`CodeExecutionResult` have no streaming delta representation and are skipped rather than crashing (still available via the buffered result).

Feature:
- Streaming now frames thinking with `ThinkingStart` … `ThinkingComplete` (carrying the accumulated thought text and signature) around the `ThinkingDelta`s, so consumers get boundary-delimited thinking in streamed responses. CHANGELOG updated for both bridges.

Added a runnable example at `examples/gemini/stream-thinking.php` (streams `gemini-2.5-flash` with `thinkingConfig.includeThoughts`, prints a framed thinking block then the answer), plus deterministic stream tests in both bridges (single thought part, thoughts split across chunks, thought+text, and unchanged tool-call+text).
