### PR TITLE
[Examples] Update Hugging Face text-to-image example to a warm model

### DIFF
--- a/examples/huggingface/text-to-image.php
+++ b/examples/huggingface/text-to-image.php
@@ -16,7 +16,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = Factory::createPlatform(env('HUGGINGFACE_KEY'), httpClient: http_client());
 
-$result = $platform->invoke('stabilityai/stable-diffusion-xl-base-1.0', 'Astronaut riding a horse', [
+$result = $platform->invoke('black-forest-labs/FLUX.1-schnell', 'Astronaut riding a horse', [
     'task' => Task::TEXT_TO_IMAGE,
 ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Surfaced while running the examples: `huggingface/text-to-image` failed with HTTP 410 "The requested model is deprecated and no longer supported by provider hf-inference".

`stabilityai/stable-diffusion-xl-base-1.0` is no longer served by the `hf-inference` provider. Switched to `black-forest-labs/FLUX.1-schnell`, which is currently warm on `hf-inference`. Verified the example produces an image again.
