### PR TITLE
[Examples] Fix Perplexity examples crashing on empty search metadata

### DIFF
--- a/examples/perplexity/academic-search.php
+++ b/examples/perplexity/academic-search.php
@@ -27,5 +27,5 @@ $result = $platform->invoke('sonar', $messages, [
 echo $result->asText().\PHP_EOL;
 echo \PHP_EOL;
 
-print_search_results($result->getMetadata()->get('search_results'));
-print_citations($result->getMetadata()->get('citations'));
+print_search_results($result->getMetadata()->get('search_results', []));
+print_citations($result->getMetadata()->get('citations', []));

--- a/examples/perplexity/image-input-url.php
+++ b/examples/perplexity/image-input-url.php
@@ -29,5 +29,5 @@ $result = $platform->invoke('sonar', $messages);
 
 echo $result->asText().\PHP_EOL;
 
-print_search_results($result->getMetadata()->get('search_results'));
-print_citations($result->getMetadata()->get('citations'));
+print_search_results($result->getMetadata()->get('search_results', []));
+print_citations($result->getMetadata()->get('citations', []));

--- a/examples/perplexity/pdf-input-url.php
+++ b/examples/perplexity/pdf-input-url.php
@@ -28,5 +28,5 @@ $result = $platform->invoke('sonar', $messages);
 
 echo $result->asText().\PHP_EOL;
 
-print_search_results($result->getMetadata()->get('search_results'));
-print_citations($result->getMetadata()->get('citations'));
+print_search_results($result->getMetadata()->get('search_results', []));
+print_citations($result->getMetadata()->get('citations', []));

--- a/examples/perplexity/stream.php
+++ b/examples/perplexity/stream.php
@@ -30,5 +30,5 @@ foreach ($result->asTextStream() as $delta) {
 }
 echo \PHP_EOL;
 
-print_search_results($result->getResult()->getMetadata()->get('search_results'));
-print_citations($result->getResult()->getMetadata()->get('citations'));
+print_search_results($result->getResult()->getMetadata()->get('search_results', []));
+print_citations($result->getResult()->getMetadata()->get('citations', []));

--- a/examples/perplexity/web-search.php
+++ b/examples/perplexity/web-search.php
@@ -20,15 +20,16 @@ $platform = Factory::createPlatform(env('PERPLEXITY_API_KEY'), http_client());
 $messages = new MessageBag(Message::ofUser('What is the best French cheese?'));
 $result = $platform->invoke('sonar', $messages, [
     'search_domain_filter' => [
-        'https://en.wikipedia.org/wiki/Cheese',
+        // Perplexity expects bare domains here, not full URLs with a path.
+        'wikipedia.org',
     ],
     'search_mode' => 'web',
     'enable_search_classifier' => true,
-    'search_recency_filter' => 'week',
+    'search_recency_filter' => 'month',
 ]);
 
 echo $result->asText().\PHP_EOL;
 echo \PHP_EOL;
 
-print_search_results($result->getMetadata()->get('search_results'));
-print_citations($result->getMetadata()->get('citations'));
+print_search_results($result->getMetadata()->get('search_results', []));
+print_citations($result->getMetadata()->get('citations', []));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The Perplexity examples threw a `TypeError` (`print_search_results(): Argument #1 must be of type array, null given`) whenever the API returned no `search_results`/`citations`.

- `web-search.php` never demonstrated anything: `search_domain_filter` used a full URL (`https://en.wikipedia.org/wiki/Cheese`) where Perplexity expects a bare domain, and `search_recency_filter => week` narrowed it to zero. Switched to `wikipedia.org` + `month` so it returns real Wikipedia-filtered results.
- The image/PDF (and other) examples legitimately get no search results when analyzing supplied media — defaulted the metadata lookups to `[]` so they print "No search results" instead of crashing.