### PR TITLE
[Platform][Mistral] Add Voxtral speech-to-text (opt-in transcription endpoint)

### DIFF
--- a/examples/mistral/audio-transcript.php
+++ b/examples/mistral/audio-transcript.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Mistral\Factory;
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+use Symfony\AI\Platform\Message\Content\Audio;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('MISTRAL_API_KEY'), http_client());
+
+// "voxtral-mini-latest" is a chat model by default; wrap it in the SpeechToText model to
+// opt into the dedicated /v1/audio/transcriptions endpoint (transcription only, no chat).
+$result = $platform->invoke(new SpeechToText('voxtral-mini-latest'), Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3'), [
+    'language' => 'en',
+]);
+
+echo $result->asText().\PHP_EOL;

--- a/src/platform/src/Bridge/Mistral/CHANGELOG.md
+++ b/src/platform/src/Bridge/Mistral/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Add a Mistral audio normalizer so `Content\Audio` can be used as a chat message part (audio understanding) with Voxtral models such as `voxtral-small-latest`
+ * Add Voxtral speech-to-text support through the dedicated `/v1/audio/transcriptions` endpoint, exposing a `SpeechToText` model, model client, result converter and audio normalizer (opt-in via `new SpeechToText('voxtral-mini-latest')`)
 
 0.11
 ----

--- a/src/platform/src/Bridge/Mistral/Factory.php
+++ b/src/platform/src/Bridge/Mistral/Factory.php
@@ -48,8 +48,8 @@ final class Factory
 
         return new Provider(
             $name,
-            [new Embeddings\ModelClient($httpClient, $apiKey, $baseUrl), new Llm\ModelClient($httpClient, $apiKey, $baseUrl), new Ocr\ModelClient($httpClient, $apiKey)],
-            [new Embeddings\ResultConverter(), new Llm\ResultConverter(), new Ocr\ResultConverter()],
+            [new Embeddings\ModelClient($httpClient, $apiKey, $baseUrl), new Llm\ModelClient($httpClient, $apiKey, $baseUrl), new Ocr\ModelClient($httpClient, $apiKey), new SpeechToText\ModelClient($httpClient, $apiKey, $baseUrl)],
+            [new Embeddings\ResultConverter(), new Llm\ResultConverter(), new Ocr\ResultConverter(), new SpeechToText\ResultConverter()],
             $modelCatalog,
             $contract ?? Contract::create([
                 new ToolNormalizer(),
@@ -57,6 +57,7 @@ final class Factory
                 new DocumentUrlNormalizer(),
                 new ImageUrlNormalizer(),
                 new AudioNormalizer(),
+                new SpeechToText\AudioNormalizer(),
             ]),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Mistral/README.md
+++ b/src/platform/src/Bridge/Mistral/README.md
@@ -9,6 +9,7 @@ Mistral Documentation
  * [API reference](https://docs.mistral.ai/api/)
  * [Chat completions](https://docs.mistral.ai/api/endpoint/chat)
  * [OCR](https://docs.mistral.ai/api/endpoint/ocr)
+ * [Speech to Text (Voxtral)](https://docs.mistral.ai/api/endpoint/audio_transcriptions)
 
 
 Test Fixtures

--- a/src/platform/src/Bridge/Mistral/SpeechToText.php
+++ b/src/platform/src/Bridge/Mistral/SpeechToText.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral;
+
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SpeechToText extends Model
+{
+}

--- a/src/platform/src/Bridge/Mistral/SpeechToText/AudioNormalizer.php
+++ b/src/platform/src/Bridge/Mistral/SpeechToText/AudioNormalizer.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class AudioNormalizer extends ModelContractNormalizer
+{
+    /**
+     * @param Audio $data
+     *
+     * @return array{model: string, file: resource}
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        return [
+            'model' => $context[Contract::CONTEXT_MODEL]->getName(),
+            'file' => $data->asResource(),
+        ];
+    }
+
+    protected function supportedDataClass(): string
+    {
+        return Audio::class;
+    }
+
+    protected function supportsModel(Model $model): bool
+    {
+        return $model instanceof SpeechToText;
+    }
+}

--- a/src/platform/src/Bridge/Mistral/SpeechToText/ModelClient.php
+++ b/src/platform/src/Bridge/Mistral/SpeechToText/ModelClient.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ModelClient implements ModelClientInterface
+{
+    private readonly string $baseUrl;
+
+    /**
+     * @param string $baseUrl Base URL of a Mistral-compatible endpoint, with or without a trailing slash
+     */
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        #[\SensitiveParameter] private readonly string $apiKey,
+        string $baseUrl = 'https://api.mistral.ai',
+    ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof SpeechToText;
+    }
+
+    public function request(Model $model, array|string $payload, array $options = []): RawHttpResult
+    {
+        if (\is_string($payload)) {
+            throw new InvalidArgumentException(\sprintf('Payload must be an array, but a string was given to "%s".', self::class));
+        }
+
+        $body = array_merge($options, $payload, ['model' => $model->getName()]);
+
+        return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.'/v1/audio/transcriptions', [
+            'auth_bearer' => $this->apiKey,
+            'headers' => ['Content-Type' => 'multipart/form-data'],
+            'body' => $body,
+        ]));
+    }
+}

--- a/src/platform/src/Bridge/Mistral/SpeechToText/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/SpeechToText/ResultConverter.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ResultConverter implements ResultConverterInterface
+{
+    use HttpStatusErrorHandlingTrait;
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof SpeechToText;
+    }
+
+    public function convert(RawResultInterface $result, array $options = []): TextResult
+    {
+        $httpResponse = $result->getObject();
+
+        $this->throwOnHttpError($httpResponse);
+
+        if (200 !== $httpResponse->getStatusCode()) {
+            throw new RuntimeException(\sprintf('Unexpected response code %d: "%s"', $httpResponse->getStatusCode(), $httpResponse->getContent(false)));
+        }
+
+        $data = $result->getData();
+
+        if (!isset($data['text'])) {
+            throw new RuntimeException('Response does not contain transcription text.');
+        }
+
+        $textResult = new TextResult($data['text']);
+
+        if (isset($data['usage'])) {
+            $textResult->getMetadata()->add('usage', $data['usage']);
+        }
+
+        return $textResult;
+    }
+
+    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    {
+        return null;
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Tests/SpeechToText/AudioNormalizerTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/SpeechToText/AudioNormalizerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\SpeechToText;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText\AudioNormalizer;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\AI\Platform\Message\Content\Text;
+
+final class AudioNormalizerTest extends TestCase
+{
+    public function testSupportsNormalizationForSpeechToTextModel()
+    {
+        $normalizer = new AudioNormalizer();
+
+        $this->assertTrue($normalizer->supportsNormalization(new Audio('audio-data', 'audio/mpeg'), context: [
+            Contract::CONTEXT_MODEL => new SpeechToText('voxtral-mini-latest'),
+        ]));
+    }
+
+    public function testDoesNotSupportNormalizationForOtherModels()
+    {
+        $normalizer = new AudioNormalizer();
+
+        $this->assertFalse($normalizer->supportsNormalization(new Audio('audio-data', 'audio/mpeg'), context: [
+            Contract::CONTEXT_MODEL => new Mistral('mistral-large-latest'),
+        ]));
+    }
+
+    public function testDoesNotSupportNormalizationForOtherContent()
+    {
+        $normalizer = new AudioNormalizer();
+
+        $this->assertFalse($normalizer->supportsNormalization(new Text('not audio'), context: [
+            Contract::CONTEXT_MODEL => new SpeechToText('voxtral-mini-latest'),
+        ]));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $normalizer = new AudioNormalizer();
+
+        $this->assertSame([Audio::class => true], $normalizer->getSupportedTypes(null));
+    }
+
+    public function testNormalize()
+    {
+        $normalizer = new AudioNormalizer();
+
+        $audio = Audio::fromFile(\dirname(__DIR__, 7).'/fixtures/audio.mp3');
+        $normalized = $normalizer->normalize($audio, context: [
+            Contract::CONTEXT_MODEL => new SpeechToText('voxtral-mini-latest'),
+        ]);
+
+        $this->assertSame('voxtral-mini-latest', $normalized['model']);
+        $this->assertIsResource($normalized['file']);
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Tests/SpeechToText/ModelClientTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/SpeechToText/ModelClientTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\SpeechToText;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText\ModelClient;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ModelClientTest extends TestCase
+{
+    public function testItSupportsSpeechToTextModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertTrue($client->supports(new SpeechToText('voxtral-mini-latest')));
+    }
+
+    public function testItDoesNotSupportMistralModel()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->assertFalse($client->supports(new Mistral('mistral-large-latest')));
+    }
+
+    public function testItSendsExpectedRequest()
+    {
+        $httpClient = new MockHttpClient([function (
+            string $method,
+            string $url,
+            array $options,
+        ): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.mistral.ai/v1/audio/transcriptions', $url);
+            $this->assertStringContainsString('Bearer test-key', $options['normalized_headers']['authorization'][0]);
+            $this->assertStringContainsString('multipart/form-data', $options['normalized_headers']['content-type'][0]);
+
+            return new MockResponse('{"text": "Hello world"}');
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key');
+
+        $client->request(new SpeechToText('voxtral-mini-latest'), ['file' => 'audio-data', 'language' => 'en']);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testItHonorsCustomBaseUrl()
+    {
+        $httpClient = new MockHttpClient([function (
+            string $method,
+            string $url,
+        ): MockResponse {
+            $this->assertSame('https://example.com/v1/audio/transcriptions', $url);
+
+            return new MockResponse('{"text": "Hello world"}');
+        }]);
+
+        $client = new ModelClient($httpClient, 'test-key', 'https://example.com/');
+
+        $client->request(new SpeechToText('voxtral-mini-latest'), ['file' => 'audio-data']);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testStringPayloadThrowsException()
+    {
+        $client = new ModelClient(new MockHttpClient(), 'test-key');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Payload must be an array, but a string was given');
+
+        $client->request(new SpeechToText('voxtral-mini-latest'), 'string payload');
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Tests/SpeechToText/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/SpeechToText/ResultConverterTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\SpeechToText;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText\ResultConverter;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ResultConverterTest extends TestCase
+{
+    public function testItSupportsSpeechToTextModel()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertTrue($converter->supports(new SpeechToText('voxtral-mini-latest')));
+    }
+
+    public function testItThrowsExceptionOnServerError()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(500);
+        $response->method('getContent')->willReturn('Internal Server Error');
+
+        $converter = new ResultConverter();
+
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('Server error (HTTP 500');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testItConvertsResponseToTextResult()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'text' => 'Hello, this is a transcription test.',
+        ]);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(new RawHttpResult($response));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello, this is a transcription test.', $result->getContent());
+    }
+
+    public function testItAddsUsageMetadataWhenPresent()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'text' => 'Hello world.',
+            'usage' => ['prompt_audio_seconds' => 12],
+        ]);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(new RawHttpResult($response));
+
+        $this->assertSame(['prompt_audio_seconds' => 12], $result->getMetadata()->get('usage'));
+    }
+
+    public function testItThrowsExceptionWhenResponseDoesNotContainText()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn(['invalid' => 'response']);
+
+        $converter = new ResultConverter();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Response does not contain transcription text.');
+
+        $converter->convert(new RawHttpResult($response));
+    }
+
+    public function testItReturnsNullTokenUsageExtractor()
+    {
+        $converter = new ResultConverter();
+
+        $this->assertNull($converter->getTokenUsageExtractor());
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Tests/SpeechToTextTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/SpeechToTextTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Factory;
+use Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Platform;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * "voxtral-mini-latest" is both a chat and a transcription model at Mistral, and the catalog keeps
+ * it mapped to the chat model. Transcription is opt-in through an explicit {@see SpeechToText}
+ * instance, so these tests pin which endpoint each of the two invocation styles reaches.
+ */
+final class SpeechToTextTest extends TestCase
+{
+    public function testItExtendsModel()
+    {
+        $model = new SpeechToText('voxtral-mini-latest');
+
+        $this->assertInstanceOf(Model::class, $model);
+        $this->assertSame('voxtral-mini-latest', $model->getName());
+    }
+
+    public function testItRoutesAnExplicitSpeechToTextModelToTheTranscriptionEndpoint()
+    {
+        $urls = [];
+        $platform = $this->createPlatform($urls, new JsonMockResponse(['text' => 'Hello from the fixture.']));
+
+        $result = $platform->invoke(
+            new SpeechToText('voxtral-mini-latest'),
+            Audio::fromFile(\dirname(__DIR__, 6).'/fixtures/audio.mp3'),
+            ['language' => 'en'],
+        );
+
+        $this->assertSame('Hello from the fixture.', $result->asText());
+        $this->assertSame(['https://api.mistral.ai/v1/audio/transcriptions'], $urls);
+    }
+
+    public function testItRoutesThePlainModelNameToTheChatEndpoint()
+    {
+        $urls = [];
+        $platform = $this->createPlatform($urls, new JsonMockResponse([
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => 'Hello from chat.'],
+                'finish_reason' => 'stop',
+            ]],
+        ]));
+
+        $result = $platform->invoke(
+            'voxtral-mini-latest',
+            new MessageBag(Message::ofUser(
+                'What is said in this audio?',
+                Audio::fromFile(\dirname(__DIR__, 6).'/fixtures/audio.mp3'),
+            )),
+        );
+
+        $this->assertSame('Hello from chat.', $result->asText());
+        $this->assertSame(['https://api.mistral.ai/v1/chat/completions'], $urls);
+    }
+
+    /**
+     * @param list<string> $urls Receives the URL of every request performed by the returned platform
+     */
+    private function createPlatform(array &$urls, MockResponse $response): Platform
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$urls, $response): MockResponse {
+            $urls[] = $url;
+
+            return $response;
+        });
+
+        return Factory::createPlatform('test-key', $httpClient);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Adds **Voxtral speech-to-text** support to the Mistral bridge (dedicated
`POST /v1/audio/transcriptions` endpoint), mirroring the OpenAI `Whisper` and Cohere
`SpeechToText` bridges: `SpeechToText` model class, `ModelClient`, `ResultConverter` and
`AudioNormalizer`.

### `voxtral-mini-latest` serves multiple purposes

Unlike `whisper-1` or `cohere-transcribe-03-2026` (transcription-only names),
`voxtral-mini-latest` is a fully capable chat model that Mistral *also* exposes on the
transcription endpoint — the same name has two meanings. Since the `ModelCatalog` maps one
name to one class, it stays the chat `Mistral` model (no BC break) and transcription is
opt-in via an explicit `SpeechToText` instance. That is why this example wraps the model
where the OpenAI/Cohere ones pass a plain string.

### Usage

```php
use Symfony\AI\Platform\Bridge\Mistral\SpeechToText;
use Symfony\AI\Platform\Message\Content\Audio;

$result = $platform->invoke(new SpeechToText('voxtral-mini-latest'), Audio::fromFile('note.mp3'), ['language' => 'en']);
echo $result->asText();
```

Chat / audio understanding keeps working with the plain name: `$platform->invoke('voxtral-mini-latest', $messages)`.
