### PR TITLE
[Platform] Add Mistral audio normalizer for chat/audio understanding

### DIFF
--- a/examples/mistral/audio-understanding.php
+++ b/examples/mistral/audio-understanding.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Mistral\Factory;
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('MISTRAL_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant that answers questions about audio recordings.'),
+    Message::ofUser(
+        'What is said in this audio? Answer in one sentence.',
+        Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3'),
+    ),
+);
+$result = $platform->invoke('voxtral-small-latest', $messages);
+
+echo $result->asText().\PHP_EOL;

--- a/src/platform/src/Bridge/Mistral/CHANGELOG.md
+++ b/src/platform/src/Bridge/Mistral/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Add a Mistral audio normalizer so `Content\Audio` can be used as a chat message part (audio understanding) with Voxtral models such as `voxtral-small-latest`
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/Mistral/Contract/AudioNormalizer.php
+++ b/src/platform/src/Bridge/Mistral/Contract/AudioNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Contract;
+
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\AI\Platform\Model;
+
+/**
+ * Serializes an audio message part for the Mistral chat/completions endpoint, e.g. for the
+ * Voxtral models. Mistral expects the base64-encoded audio directly as the `input_audio` value,
+ * unlike the OpenAI-style object handled by the generic normalizer.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class AudioNormalizer extends ModelContractNormalizer
+{
+    /**
+     * @param Audio $data
+     *
+     * @return array{type: 'input_audio', input_audio: string}
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        return [
+            'type' => 'input_audio',
+            'input_audio' => $data->asBase64(),
+        ];
+    }
+
+    protected function supportedDataClass(): string
+    {
+        return Audio::class;
+    }
+
+    protected function supportsModel(Model $model): bool
+    {
+        return $model instanceof Mistral;
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Factory.php
+++ b/src/platform/src/Bridge/Mistral/Factory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Mistral;
 
+use Symfony\AI\Platform\Bridge\Mistral\Contract\AudioNormalizer;
 use Symfony\AI\Platform\Bridge\Mistral\Contract\DocumentNormalizer;
 use Symfony\AI\Platform\Bridge\Mistral\Contract\DocumentUrlNormalizer;
 use Symfony\AI\Platform\Bridge\Mistral\Contract\ImageUrlNormalizer;
@@ -55,6 +56,7 @@ final class Factory
                 new DocumentNormalizer(),
                 new DocumentUrlNormalizer(),
                 new ImageUrlNormalizer(),
+                new AudioNormalizer(),
             ]),
             $eventDispatcher,
         );

--- a/src/platform/src/Bridge/Mistral/Tests/Contract/AudioNormalizerTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Contract/AudioNormalizerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\Contract;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Contract\AudioNormalizer;
+use Symfony\AI\Platform\Bridge\Mistral\Mistral;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\AI\Platform\Message\Content\Text;
+
+final class AudioNormalizerTest extends TestCase
+{
+    public function testSupportsNormalizationForMistralModel()
+    {
+        $normalizer = new AudioNormalizer();
+
+        $this->assertTrue($normalizer->supportsNormalization(new Audio('audio-data', 'audio/mpeg'), context: [
+            Contract::CONTEXT_MODEL => new Mistral('voxtral-small-latest'),
+        ]));
+    }
+
+    public function testDoesNotSupportNormalizationWithoutModel()
+    {
+        $normalizer = new AudioNormalizer();
+
+        $this->assertFalse($normalizer->supportsNormalization(new Audio('audio-data', 'audio/mpeg')));
+    }
+
+    public function testDoesNotSupportNormalizationForOtherContent()
+    {
+        $normalizer = new AudioNormalizer();
+
+        $this->assertFalse($normalizer->supportsNormalization(new Text('not audio'), context: [
+            Contract::CONTEXT_MODEL => new Mistral('voxtral-small-latest'),
+        ]));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $normalizer = new AudioNormalizer();
+
+        $this->assertSame([Audio::class => true], $normalizer->getSupportedTypes(null));
+    }
+
+    public function testNormalize()
+    {
+        $normalizer = new AudioNormalizer();
+
+        $normalized = $normalizer->normalize(new Audio('audio-data', 'audio/mpeg'));
+
+        $this->assertSame([
+            'type' => 'input_audio',
+            'input_audio' => base64_encode('audio-data'),
+        ], $normalized);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Adds a Mistral-specific **audio message-part normalizer** so `Message\Content\Audio` can be
used inside a chat conversation with the Voxtral models (audio understanding), e.g.
`voxtral-small-latest` — a single chat call can transcribe, clean and reason over a
recording, including with structured output.

Mistral's chat API expects the base64-encoded audio **directly** as the `input_audio` value
(`{"type": "input_audio", "input_audio": "<base64>"}`), unlike the OpenAI-style
`{"data": ..., "format": ...}` object emitted by the generic
`Contract\Normalizer\Message\Content\AudioNormalizer`. Without this bridge-specific
normalizer, audio-in-chat requests to Mistral are serialized in the wrong shape.

`Contract\AudioNormalizer` (extends `ModelContractNormalizer`, gated on the chat `Mistral`
model) is registered ahead of the generic normalizer in the Mistral contract, so it wins
for Mistral models.

### Usage

```php
use Symfony\AI\Platform\Message\Content\Audio;
use Symfony\AI\Platform\Message\Message;
use Symfony\AI\Platform\Message\MessageBag;

$messages = new MessageBag(
    Message::forSystem('You are a helpful assistant that answers questions about audio recordings.'),
    Message::ofUser('What is said in this audio?', Audio::fromFile('note.mp3')),
);
echo $platform->invoke('voxtral-small-latest', $messages)->asText();
```

### Notes

- No BC break: `voxtral-small-latest` stays a chat `Mistral` model and already advertises
  `INPUT_AUDIO`; this only fixes the wire format.
- Complements the dedicated speech-to-text bridge (`/v1/audio/transcriptions`,
  `voxtral-mini`) in symfony/ai#2331. The two surfaces are disjoint by model class and can
  be merged independently.
