### PR TITLE
[Platform] Fix PSR-4 namespaces in bridge test files

### DIFF
--- a/src/platform/src/Bridge/Anthropic/Tests/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/TokenUsageExtractorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Bridge\Anthropic;
+namespace Symfony\AI\Platform\Bridge\Anthropic\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Anthropic\TokenUsageExtractor;

--- a/src/platform/src/Bridge/Mistral/Tests/Contract/ImageUrlNormalizerTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Contract/ImageUrlNormalizerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Bridge\Mistral\Contract;
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\Contract;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;

--- a/src/platform/src/Bridge/Ovh/Tests/FactoryTest.php
+++ b/src/platform/src/Bridge/Ovh/Tests/FactoryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Bridge\Scaleway;
+namespace Symfony\AI\Platform\Bridge\Ovh\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Scaleway\Factory;

--- a/src/platform/src/Bridge/Perplexity/Tests/ModelClientTest.php
+++ b/src/platform/src/Bridge/Perplexity/Tests/ModelClientTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Bridge\Perplexity;
+namespace Symfony\AI\Platform\Bridge\Perplexity\Tests;
 
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;

--- a/src/platform/src/Bridge/Scaleway/Tests/Embeddings/ModelClientTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Embeddings/ModelClientTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Bridge\Scaleway\Embeddings;
+namespace Symfony\AI\Platform\Bridge\Scaleway\Tests\Embeddings;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Scaleway\Embeddings;

--- a/src/platform/src/Bridge/Scaleway/Tests/Embeddings/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Embeddings/ResultConverterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Bridge\Scaleway\Embeddings;
+namespace Symfony\AI\Platform\Bridge\Scaleway\Tests\Embeddings;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Scaleway\Embeddings\ResultConverter;

--- a/src/platform/src/Bridge/Scaleway/Tests/EmbeddingsTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/EmbeddingsTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Bridge\Scaleway;
+namespace Symfony\AI\Platform\Bridge\Scaleway\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Scaleway\Embeddings;

--- a/src/platform/src/Bridge/Scaleway/Tests/FactoryTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/FactoryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Bridge\Scaleway;
+namespace Symfony\AI\Platform\Bridge\Scaleway\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Scaleway\Factory;

--- a/src/platform/src/Bridge/Scaleway/Tests/Llm/ModelClientTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Llm/ModelClientTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Bridge\Scaleway\Llm;
+namespace Symfony\AI\Platform\Bridge\Scaleway\Tests\Llm;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Scaleway\Llm\ModelClient;

--- a/src/platform/src/Bridge/Scaleway/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Scaleway/Tests/Llm/ResultConverterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Bridge\Scaleway\Llm;
+namespace Symfony\AI\Platform\Bridge\Scaleway\Tests\Llm;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Scaleway\Llm\ResultConverter;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Ten Platform bridge test files declared namespaces that did not match the PSR-4
`autoload-dev` mapping (`Symfony\AI\Platform\Bridge\<Vendor>\Tests\ => Tests/`), instead
using a truncated `Bridge\<Vendor>` form. One of them — `Ovh/Tests/FactoryTest.php` — even
declared the wrong vendor (`namespace Bridge\Scaleway;`).

PHPUnit tolerates the mismatch because it includes test files directly, but the
declarations violate PSR-4 and the project convention. This aligns each file's namespace
with its location:

- `Bridge/Anthropic/Tests/TokenUsageExtractorTest.php`
- `Bridge/Mistral/Tests/Contract/ImageUrlNormalizerTest.php`
- `Bridge/Ovh/Tests/FactoryTest.php`
- `Bridge/Perplexity/Tests/ModelClientTest.php`
- `Bridge/Scaleway/Tests/FactoryTest.php`, `Tests/EmbeddingsTest.php`,
  `Tests/Embeddings/{ModelClient,ResultConverter}Test.php`,
  `Tests/Llm/{ModelClient,ResultConverter}Test.php`

Namespace declarations only; no test logic changed.
