### PR TITLE
[Platform] Report OpenResponses output limit truncation

### DIFF
--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MaxOutputTokensException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
@@ -647,17 +648,24 @@ class ResultConverterTest extends TestCase
                 ],
             ],
         ], 'Error "server_error"-- (-): "The model failed to generate a response".'];
+    }
 
-        yield 'response incomplete' => [[
-            [
-                'type' => 'response.incomplete',
-                'response' => [
-                    'incomplete_details' => [
-                        'reason' => 'max_output_tokens',
-                    ],
-                ],
-            ],
-        ], 'Responses API stream ended incomplete (max_output_tokens).'];
+    public function testStreamThrowsWhenTruncatedAtMaxOutputTokens()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], [[
+            'type' => 'response.incomplete',
+            'response' => ['incomplete_details' => ['reason' => 'max_output_tokens']],
+        ]], $httpResponse), ['stream' => true]);
+
+        $this->expectException(MaxOutputTokensException::class);
+        $this->expectExceptionMessage('OpenResponses truncated the response after reaching the output token limit.');
+
+        iterator_to_array($streamResult->getContent());
     }
 
     public function testStreamThrowsRateLimitExceptionOnRateLimitEvent()

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Throw `MaxOutputTokensException` when a response reaches its output token limit
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MaxOutputTokensException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
@@ -460,7 +461,11 @@ class ResultConverter implements ResultConverterInterface
                     $reason = 'unknown';
                 }
 
-                throw new RuntimeException(\sprintf('Responses API stream ended incomplete (%s).', $reason));
+                if ('max_output_tokens' === $reason) {
+                    throw new MaxOutputTokensException('OpenResponses truncated the response after reaching the output token limit. Raise the output token budget (max_output_tokens) or reduce the request scope.');
+                }
+
+                throw new RuntimeException(\sprintf('Responses API response is incomplete (%s).', $reason));
             }
 
             if (isset($event['response']['usage'])) {

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MaxOutputTokensException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
@@ -1168,7 +1169,25 @@ final class ResultConverterTest extends TestCase
                     ],
                 ],
             ],
-        ], 'Responses API stream ended incomplete (max_tokens).'];
+        ], 'Responses API response is incomplete (max_tokens).'];
+    }
+
+    public function testStreamThrowsWhenTruncatedAtMaxOutputTokens()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], [[
+            'type' => 'response.incomplete',
+            'response' => ['incomplete_details' => ['reason' => 'max_output_tokens']],
+        ]], $httpResponse), ['stream' => true]);
+
+        $this->expectException(MaxOutputTokensException::class);
+        $this->expectExceptionMessage('OpenResponses truncated the response after reaching the output token limit.');
+
+        iterator_to_array($streamResult->getContent());
     }
 
     public function testStreamThrowsRateLimitExceptionOnRateLimitEvent()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

Throw `MaxOutputTokensException` when OpenResponses reaches its output limit, reserving `IncompleteStreamException` for unexpectedly truncated streams.