### PR TITLE
[AI Bundle] Fix orphan ai.command.clear_store definition without store

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -253,6 +253,7 @@ final class AiBundle extends AbstractBundle
         if ([] === $stores) {
             $builder->removeDefinition('ai.command.setup_store');
             $builder->removeDefinition('ai.command.drop_store');
+            $builder->removeDefinition('ai.command.clear_store');
         }
 
         if ([] !== ($config['message_store'] ?? [])) {
@@ -396,6 +397,7 @@ final class AiBundle extends AbstractBundle
         if (!ContainerBuilder::willBeAvailable('symfony/ai-store', StoreInterface::class, ['symfony/ai-bundle'])) {
             $builder->removeDefinition('ai.command.setup_store');
             $builder->removeDefinition('ai.command.drop_store');
+            $builder->removeDefinition('ai.command.clear_store');
             $builder->removeDefinition('ai.command.index');
             $builder->removeDefinition('ai.command.retrieve');
         }

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -197,9 +197,11 @@ class AiBundleTest extends TestCase
 
         $this->assertFalse($container->hasDefinition('ai.command.setup_store'));
         $this->assertFalse($container->hasDefinition('ai.command.drop_store'));
+        $this->assertFalse($container->hasDefinition('ai.command.clear_store'));
         $removedIds = $container->getRemovedIds();
         $this->assertArrayHasKey('ai.command.setup_store', $removedIds);
         $this->assertArrayHasKey('ai.command.drop_store', $removedIds);
+        $this->assertArrayHasKey('ai.command.clear_store', $removedIds);
         $this->assertArrayHasKey('ai.command.setup_message_store', $removedIds);
         $this->assertArrayHasKey('ai.command.drop_message_store', $removedIds);
     }
@@ -245,6 +247,12 @@ class AiBundleTest extends TestCase
         $dropStoreCommandDefinition = $container->getDefinition('ai.command.drop_store');
         $this->assertCount(1, $dropStoreCommandDefinition->getArguments());
         $this->assertArrayHasKey('console.command', $dropStoreCommandDefinition->getTags());
+
+        $this->assertTrue($container->hasDefinition('ai.command.clear_store'));
+
+        $clearStoreCommandDefinition = $container->getDefinition('ai.command.clear_store');
+        $this->assertCount(1, $clearStoreCommandDefinition->getArguments());
+        $this->assertArrayHasKey('console.command', $clearStoreCommandDefinition->getTags());
     }
 
     public function testMessageStoreCommandsAreDefined()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2337
| License       | MIT

`ai.command.clear_store` was registered in `config/services.php` but never removed
when `symfony/ai-store` is absent or no store is configured, so the container kept a
definition pointing at a missing class and failed to compile.

Adds the missing `removeDefinition()` to both branches, matching `setup_store` /
`drop_store`.
