### PR TITLE
[Platform][Mistral] Extract cached tokens from prompt_tokens_details

### DIFF
--- a/src/platform/src/Bridge/Mistral/Llm/TokenUsageExtractor.php
+++ b/src/platform/src/Bridge/Mistral/Llm/TokenUsageExtractor.php
@@ -43,6 +43,7 @@ final class TokenUsageExtractor implements TokenUsageExtractorInterface
         return new TokenUsage(
             promptTokens: $content['usage']['prompt_tokens'] ?? null,
             completionTokens: $content['usage']['completion_tokens'] ?? null,
+            cachedTokens: $content['usage']['prompt_tokens_details']['cached_tokens'] ?? null,
             remainingTokensMinute: null !== $remainingTokensMinute ? (int) $remainingTokensMinute : null,
             remainingTokensMonth: null !== $remainingTokensMonth ? (int) $remainingTokensMonth : null,
             totalTokens: $content['usage']['total_tokens'] ?? null,

--- a/src/platform/src/Bridge/Mistral/Tests/TokenUsageExtractorTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/TokenUsageExtractorTest.php
@@ -53,6 +53,28 @@ final class TokenUsageExtractorTest extends TestCase
         $this->assertSame(10, $tokenUsage->getPromptTokens());
         $this->assertSame(20, $tokenUsage->getCompletionTokens());
         $this->assertSame(30, $tokenUsage->getTotalTokens());
+        $this->assertNull($tokenUsage->getCachedTokens());
+    }
+
+    public function testItExtractsCachedTokens()
+    {
+        $extractor = new TokenUsageExtractor();
+        $result = new InMemoryRawResult([
+            'usage' => [
+                'prompt_tokens' => 128,
+                'completion_tokens' => 20,
+                'total_tokens' => 148,
+                'prompt_tokens_details' => [
+                    'cached_tokens' => 64,
+                ],
+            ],
+        ], object: $this->createResponseObject());
+
+        $tokenUsage = $extractor->extract($result);
+
+        $this->assertInstanceOf(TokenUsage::class, $tokenUsage);
+        $this->assertSame(128, $tokenUsage->getPromptTokens());
+        $this->assertSame(64, $tokenUsage->getCachedTokens());
     }
 
     public function testItHandlesMissingUsageFields()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2236
| License       | MIT

Mistral's chat completions API reports cached prompt tokens under `usage.prompt_tokens_details.cached_tokens` when prompt caching kicks in ([docs](https://docs.mistral.ai/studio-api/conversations/advanced/prompt-caching)), but the Mistral `TokenUsageExtractor` never read that field, so `TokenUsage::getCachedTokens()` was always `null` — cost accounting overestimates the input cost since cached tokens are billed at 10%.

This maps the field the same way the DeepSeek, Gemini and Codex bridges already do for their equivalents.

Verified against the live Mistral API with two requests sharing a `prompt_cache_key`:

```
usage: { "prompt_tokens": 801, "completion_tokens": 2, "prompt_tokens_details": { "cached_tokens": 768 } }
TokenUsage->getCachedTokens(): 768   // was null before the fix
```

(768 is a multiple of 64, matching the documented cache block size.)