### PR TITLE
[Platform][Mistral] Drop stale conversion overrides rejecting truncated responses

### DIFF
--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Platform\Bridge\Mistral\Llm;
 
 use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
-use Symfony\AI\Platform\Bridge\Generic\Completions\FinishReasonMapper;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -23,9 +22,6 @@ use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
-use Symfony\AI\Platform\Result\TextResult;
-use Symfony\AI\Platform\Result\ToolCall;
-use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 
 /**
@@ -82,55 +78,5 @@ final class ResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): TokenUsageExtractor
     {
         return new TokenUsageExtractor();
-    }
-
-    /**
-     * @param array{
-     *     index: int,
-     *     message: array{
-     *         role: 'assistant',
-     *         content: ?string,
-     *         tool_calls: array{
-     *             id: string,
-     *             type: 'function',
-     *             function: array{
-     *                 name: string,
-     *                 arguments: string
-     *             },
-     *         },
-     *         refusal: ?mixed
-     *     },
-     *     logprobs: string,
-     *     finish_reason: 'stop'|'length'|'tool_calls'|'content_filter',
-     * } $choice
-     */
-    protected function convertChoice(array $choice): ToolCallResult|TextResult
-    {
-        if ('tool_calls' === $choice['finish_reason']) {
-            return $this->withFinishReason(new ToolCallResult(array_map([$this, 'convertToolCall'], $choice['message']['tool_calls'])), FinishReasonMapper::map($choice['finish_reason']));
-        }
-
-        if ('stop' === $choice['finish_reason']) {
-            return $this->withFinishReason(new TextResult($choice['message']['content']), FinishReasonMapper::map($choice['finish_reason']));
-        }
-
-        throw new RuntimeException(\sprintf('Unsupported finish reason "%s".', $choice['finish_reason']));
-    }
-
-    /**
-     * @param array{
-     *     id: string,
-     *     type: 'function',
-     *     function: array{
-     *         name: string,
-     *         arguments: string
-     *     }
-     * } $toolCall
-     */
-    protected function convertToolCall(array $toolCall): ToolCall
-    {
-        $arguments = json_decode((string) $toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
-
-        return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }
 }

--- a/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -53,6 +54,31 @@ final class ResultConverterTest extends TestCase
 
         $this->assertInstanceOf(TextResult::class, $result);
         $this->assertSame('Hello world', $result->getContent());
+    }
+
+    public function testConvertTruncatedTextResult()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse([
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Truncated answ',
+                    ],
+                    'finish_reason' => 'length',
+                ],
+            ],
+        ]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions');
+        $converter = new ResultConverter();
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Truncated answ', $result->getContent());
+        $this->assertTrue($result->getMetadata()->get('finish_reason')->is(FinishReasonCase::LENGTH));
     }
 
     public function testConvertThrowsExceedContextSizeExceptionOnContextOverflow()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Any Mistral chat completion truncated by `max_tokens` currently throws instead of returning the truncated text:

```
Symfony\AI\Platform\Exception\RuntimeException: Unsupported finish reason "length".
```

Root cause: the Mistral `ResultConverter` uses `CompletionsConversionTrait` but still carries local copies of `convertChoice()` and `convertToolCall()` from before the trait extraction (f08cca25). The local `convertChoice()` only accepts `stop` and `tool_calls`, while its own phpdoc documents `finish_reason: 'stop'|'length'|'tool_calls'|'content_filter'`.

Removing the stale overrides lets the trait handle the conversion, exactly like the Generic bridge already behaves:

- `length` → `TextResult` with the truncated content and the `LENGTH` finish reason (verified against the live Mistral API: a `max_tokens: 30` request now returns the truncated text with `finish_reason.raw = "length"` instead of throwing)
- empty tool-call `arguments` → empty array instead of a `JsonException` (the trait guards, the local copy force-decoded)

Net diff: +26/−54.