### PR TITLE
[Chat] Fix TypeError in Chat::submit() on non-text results

### DIFF
--- a/src/chat/src/Chat.php
+++ b/src/chat/src/Chat.php
@@ -17,7 +17,6 @@ use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Result\StreamResult;
-use Symfony\AI\Platform\Result\TextResult;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -43,9 +42,7 @@ final class Chat implements ChatInterface
         $messages->add($message);
         $result = $this->agent->call($messages);
 
-        \assert($result instanceof TextResult);
-
-        $assistantMessage = Message::ofAssistant($result->getContent());
+        $assistantMessage = Message::ofAssistant($result);
         $assistantMessage->getMetadata()->merge($result->getMetadata());
         $messages->add($assistantMessage);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2146
| License       | MIT

`Chat::submit()` assumed the agent always returns a `TextResult`:

```php
\assert($result instanceof TextResult);
$assistantMessage = Message::ofAssistant($result->getContent());
```

The `\assert()` is a no-op in production (`zend.assertions=-1`), so it never guarded
anything. When the agent returns a `MultiPartResult` — for example a reasoning/thinking
part plus the answer text, as OpenAI Responses reasoning models produce — `getContent()`
returns an array, and the variadic `Message::ofAssistant()` rejects it:

```
Message::ofAssistant(): Argument #1 must be of type
ContentInterface|ResultInterface|string, array given
```

This surfaced as an intermittent `TypeError`, only on turns where the model emitted a
multi-part response.

### Fix

`Message::ofAssistant()` already accepts a `ResultInterface` and maps every result type
recursively via `Message::toContent()` — `TextResult`, `ThinkingResult`, `ToolCallResult`,
`MultiPartResult`, etc. So the fix is to pass the result object straight through and drop
the `TextResult`-only assumption:

```diff
-        \assert($result instanceof TextResult);
-
-        $assistantMessage = Message::ofAssistant($result->getContent());
+        $assistantMessage = Message::ofAssistant($result);
```

The now-unused `TextResult` import is removed. The metadata merge on the next line is
unaffected (`ResultInterface extends MetadataAwareInterface`), and the existing
`TextResult` path is preserved by `toContent()`.

No test changes: multi-part unwrapping is `Message::toContent()`'s responsibility (covered
in the Platform component), not `Chat`'s — `Chat` contains no multi-part logic. The
existing `ChatTest` coverage of `submit()`'s contract continues to pass.