### PR TITLE
[MCP Bundle] Add debug:mcp command listing registered capabilities

### DIFF
--- a/docs/bundles/mcp-bundle.rst
+++ b/docs/bundles/mcp-bundle.rst
@@ -557,6 +557,20 @@ You can customize the logging level and destination according to your needs:
                 channels: ['mcp']
                 webhook_url: '%env(SLACK_WEBHOOK)%'
 
+Debug Command
+-------------
+
+The ``debug:mcp`` command lists all MCP capabilities registered with the server — useful to verify
+that an attributed class was actually picked up (only registered, autoconfigured services are):
+
+.. code-block:: terminal
+
+    # list all tools, prompts, resources, and resource templates with their handlers
+    $ php bin/console debug:mcp
+
+    # show the details of a single element, including the tool's input schema
+    $ php bin/console debug:mcp current-time
+
 Profiler
 --------
 

--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Register tools, prompts, resources, and resource templates via container instead of the SDK's file-based discovery
+ * Add `debug:mcp` command listing the registered MCP capabilities with their handlers
 
 0.11
 ----

--- a/src/mcp-bundle/src/Command/DebugCommand.php
+++ b/src/mcp-bundle/src/Command/DebugCommand.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Command;
+
+use Mcp\Capability\RegistryInterface;
+use Mcp\Schema\Prompt;
+use Mcp\Schema\ResourceDefinition;
+use Mcp\Schema\ResourceTemplate;
+use Mcp\Schema\Tool;
+use Mcp\Server\Builder;
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Lists the MCP capabilities (tools, prompts, resources, resource templates) registered with the server.
+ *
+ * Useful to verify that an attributed class was actually picked up: elements are registered from
+ * container services, so a class that is not a registered (autoconfigured) service will not show up.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+#[AsCommand('debug:mcp', 'Display the MCP capabilities registered with the server')]
+final class DebugCommand
+{
+    public function __construct(
+        private readonly Builder $builder,
+        private readonly RegistryInterface $registry,
+    ) {
+    }
+
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Argument(description: 'A tool/prompt name, resource URI, or resource template to show details for')]
+        ?string $name = null,
+    ): int {
+        // The registry is populated by the loaders when the server is built.
+        $this->builder->build();
+
+        if (null !== $name) {
+            return $this->describeElement($io, $name);
+        }
+
+        $tools = iterator_to_array($this->registry->getTools());
+        $prompts = iterator_to_array($this->registry->getPrompts());
+        $resources = iterator_to_array($this->registry->getResources());
+        $resourceTemplates = iterator_to_array($this->registry->getResourceTemplates());
+
+        if ([] === $tools && [] === $prompts && [] === $resources && [] === $resourceTemplates) {
+            $io->warning('No MCP capabilities are registered.');
+            $io->text([
+                'Capabilities are registered from container services carrying one of the MCP attributes',
+                '(#[McpTool], #[McpPrompt], #[McpResource], #[McpResourceTemplate]).',
+                'Make sure the classes are registered as services with autoconfiguration enabled',
+                'and not excluded from service registration in config/services.yaml.',
+            ]);
+
+            return Command::SUCCESS;
+        }
+
+        if ([] !== $tools) {
+            $io->section(\sprintf('Tools (%d)', \count($tools)));
+            $io->table(['Name', 'Handler', 'Description'], array_map(fn (Tool $tool): array => [
+                $tool->name,
+                $this->formatHandler($this->registry->getTool($tool->name)->handler),
+                $this->truncate($tool->description),
+            ], $tools));
+        }
+
+        if ([] !== $prompts) {
+            $io->section(\sprintf('Prompts (%d)', \count($prompts)));
+            $io->table(['Name', 'Handler', 'Description'], array_map(fn (Prompt $prompt): array => [
+                $prompt->name,
+                $this->formatHandler($this->registry->getPrompt($prompt->name)->handler),
+                $this->truncate($prompt->description),
+            ], $prompts));
+        }
+
+        if ([] !== $resources) {
+            $io->section(\sprintf('Resources (%d)', \count($resources)));
+            $io->table(['URI', 'Name', 'Handler', 'MIME Type'], array_map(fn (ResourceDefinition $resource): array => [
+                $resource->uri,
+                $resource->name,
+                $this->formatHandler($this->registry->getResource($resource->uri, false)->handler),
+                $resource->mimeType ?? '',
+            ], $resources));
+        }
+
+        if ([] !== $resourceTemplates) {
+            $io->section(\sprintf('Resource Templates (%d)', \count($resourceTemplates)));
+            $io->table(['URI Template', 'Name', 'Handler', 'MIME Type'], array_map(fn (ResourceTemplate $template): array => [
+                $template->uriTemplate,
+                $template->name,
+                $this->formatHandler($this->registry->getResourceTemplate($template->uriTemplate)->handler),
+                $template->mimeType ?? '',
+            ], $resourceTemplates));
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function describeElement(SymfonyStyle $io, string $name): int
+    {
+        foreach ($this->registry->getTools() as $tool) {
+            if ($tool->name === $name) {
+                $io->title(\sprintf('Tool "%s"', $name));
+                $io->definitionList(
+                    ['Name' => $tool->name],
+                    ['Title' => $tool->title ?? '-'],
+                    ['Description' => $tool->description ?? '-'],
+                    ['Handler' => $this->formatHandler($this->registry->getTool($name)->handler)],
+                );
+                $io->section('Input Schema');
+                $io->writeln(json_encode($tool->inputSchema, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+                if (null !== $tool->outputSchema) {
+                    $io->section('Output Schema');
+                    $io->writeln(json_encode($tool->outputSchema, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+                }
+
+                return Command::SUCCESS;
+            }
+        }
+
+        foreach ($this->registry->getPrompts() as $prompt) {
+            if ($prompt->name === $name) {
+                $io->title(\sprintf('Prompt "%s"', $name));
+                $io->definitionList(
+                    ['Name' => $prompt->name],
+                    ['Title' => $prompt->title ?? '-'],
+                    ['Description' => $prompt->description ?? '-'],
+                    ['Handler' => $this->formatHandler($this->registry->getPrompt($name)->handler)],
+                    ['Arguments' => implode(', ', array_map(
+                        static fn ($argument): string => $argument->name.($argument->required ? '' : '?'),
+                        $prompt->arguments ?? [],
+                    )) ?: '-'],
+                );
+
+                return Command::SUCCESS;
+            }
+        }
+
+        foreach ($this->registry->getResources() as $resource) {
+            if ($resource->uri === $name || $resource->name === $name) {
+                $io->title(\sprintf('Resource "%s"', $resource->uri));
+                $io->definitionList(
+                    ['URI' => $resource->uri],
+                    ['Name' => $resource->name],
+                    ['Description' => $resource->description ?? '-'],
+                    ['MIME Type' => $resource->mimeType ?? '-'],
+                    ['Handler' => $this->formatHandler($this->registry->getResource($resource->uri, false)->handler)],
+                );
+
+                return Command::SUCCESS;
+            }
+        }
+
+        foreach ($this->registry->getResourceTemplates() as $template) {
+            if ($template->uriTemplate === $name || $template->name === $name) {
+                $io->title(\sprintf('Resource Template "%s"', $template->uriTemplate));
+                $io->definitionList(
+                    ['URI Template' => $template->uriTemplate],
+                    ['Name' => $template->name],
+                    ['Description' => $template->description ?? '-'],
+                    ['MIME Type' => $template->mimeType ?? '-'],
+                    ['Handler' => $this->formatHandler($this->registry->getResourceTemplate($template->uriTemplate)->handler)],
+                );
+
+                return Command::SUCCESS;
+            }
+        }
+
+        $io->error(\sprintf('No MCP capability named "%s" is registered. Run "debug:mcp" without arguments to list all.', $name));
+
+        return Command::FAILURE;
+    }
+
+    /**
+     * @param \Closure|array{0: object|string, 1: string}|string $handler
+     */
+    private function formatHandler(\Closure|array|string $handler): string
+    {
+        if ($handler instanceof \Closure) {
+            return 'Closure';
+        }
+
+        if (\is_array($handler)) {
+            return \sprintf('%s::%s()', \is_object($handler[0]) ? $handler[0]::class : $handler[0], $handler[1]);
+        }
+
+        return class_exists($handler) ? $handler.'::__invoke()' : $handler.'()';
+    }
+
+    private function truncate(?string $text, int $length = 80): string
+    {
+        if (null === $text) {
+            return '';
+        }
+
+        $text = trim(preg_replace('/\s+/', ' ', $text) ?? $text);
+
+        return mb_strlen($text) > $length ? mb_substr($text, 0, $length - 1).'…' : $text;
+    }
+}

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -24,6 +24,7 @@ use Mcp\Server\Session\InMemorySessionStore;
 use Mcp\Server\Session\Psr16SessionStore;
 use Symfony\AI\McpBundle\App\McpAppRenderer;
 use Symfony\AI\McpBundle\Attribute\AsMcpApp;
+use Symfony\AI\McpBundle\Command\DebugCommand;
 use Symfony\AI\McpBundle\Command\McpCommand;
 use Symfony\AI\McpBundle\Controller\McpController;
 use Symfony\AI\McpBundle\DependencyInjection\McpAppPass;
@@ -183,6 +184,13 @@ final class McpBundle extends AbstractBundle
 
         // Configure session store based on HTTP config
         $this->configureSessionStore($httpConfig['session'], $container);
+
+        $container->register('mcp.server.debug_command', DebugCommand::class)
+            ->setArguments([
+                new Reference('mcp.server.builder'),
+                new Reference('mcp.registry'),
+            ])
+            ->addTag('console.command');
 
         if ($transports['stdio']) {
             $container->register('mcp.server.command', McpCommand::class)

--- a/src/mcp-bundle/tests/Command/DebugCommandTest.php
+++ b/src/mcp-bundle/tests/Command/DebugCommandTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\Command;
+
+use Mcp\Capability\Registry;
+use Mcp\Schema\Prompt;
+use Mcp\Schema\PromptArgument;
+use Mcp\Schema\ResourceDefinition;
+use Mcp\Schema\ResourceTemplate;
+use Mcp\Schema\Tool;
+use Mcp\Server;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\Command\DebugCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DebugCommandTest extends TestCase
+{
+    public function testListsRegisteredCapabilities()
+    {
+        $tester = $this->createTester($this->createPopulatedRegistry());
+
+        $exitCode = $tester->execute([]);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Tools (1)', $display);
+        $this->assertStringContainsString('current-time', $display);
+        $this->assertStringContainsString('App\TimeTool::getCurrentTime()', $display);
+        $this->assertStringContainsString('Prompts (1)', $display);
+        $this->assertStringContainsString('greeting', $display);
+        $this->assertStringContainsString('Resources (1)', $display);
+        $this->assertStringContainsString('config://app', $display);
+        $this->assertStringContainsString('Resource Templates (1)', $display);
+        $this->assertStringContainsString('user://{id}', $display);
+    }
+
+    public function testWarnsWithHintWhenNothingIsRegistered()
+    {
+        $tester = $this->createTester(new Registry());
+
+        $exitCode = $tester->execute([]);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('No MCP capabilities are registered.', $display);
+        $this->assertStringContainsString('registered as services with autoconfiguration enabled', $display);
+    }
+
+    public function testDescribesToolWithInputSchema()
+    {
+        $tester = $this->createTester($this->createPopulatedRegistry());
+
+        $exitCode = $tester->execute(['name' => 'current-time']);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Tool "current-time"', $display);
+        $this->assertStringContainsString('App\TimeTool::getCurrentTime()', $display);
+        $this->assertStringContainsString('Input Schema', $display);
+        $this->assertStringContainsString('"format"', $display);
+    }
+
+    public function testDescribesResourceByUri()
+    {
+        $tester = $this->createTester($this->createPopulatedRegistry());
+
+        $exitCode = $tester->execute(['name' => 'config://app']);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Resource "config://app"', $display);
+        $this->assertStringContainsString('application/json', $display);
+    }
+
+    public function testFailsForUnknownName()
+    {
+        $tester = $this->createTester($this->createPopulatedRegistry());
+
+        $exitCode = $tester->execute(['name' => 'unknown-element']);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+        $this->assertStringContainsString('No MCP capability named "unknown-element" is registered.', $tester->getDisplay());
+    }
+
+    private function createTester(Registry $registry): CommandTester
+    {
+        $command = new Command('debug:mcp');
+        $command->setCode(new DebugCommand(Server::builder()->setRegistry($registry), $registry));
+
+        return new CommandTester($command);
+    }
+
+    private function createPopulatedRegistry(): Registry
+    {
+        $registry = new Registry();
+
+        $registry->registerTool(new Tool(
+            name: 'current-time',
+            title: 'Current Time',
+            inputSchema: ['type' => 'object', 'properties' => ['format' => ['type' => 'string']], 'required' => ['format']],
+            description: 'Returns the current time',
+            annotations: null,
+        ), ['App\TimeTool', 'getCurrentTime']);
+
+        $registry->registerPrompt(new Prompt(
+            name: 'greeting',
+            description: 'A greeting prompt',
+            arguments: [new PromptArgument('name', 'The name to greet', true)],
+        ), ['App\GreetingPrompt', 'greeting']);
+
+        $registry->registerResource(new ResourceDefinition(
+            uri: 'config://app',
+            name: 'app-config',
+            mimeType: 'application/json',
+        ), ['App\ConfigResource', 'read']);
+
+        $registry->registerResourceTemplate(new ResourceTemplate(
+            uriTemplate: 'user://{id}',
+            name: 'user',
+        ), ['App\UserTemplate', 'read']);
+
+        return $registry;
+    }
+}

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -125,6 +125,7 @@ class McpBundleTest extends TestCase
                 'mcp.server.command' => false,
                 'mcp.server.controller' => false,
                 'mcp.server.route_loader' => false,
+                'mcp.server.debug_command' => false,
             ],
         ];
 
@@ -137,6 +138,7 @@ class McpBundleTest extends TestCase
                 'mcp.server.command' => true,
                 'mcp.server.controller' => false,
                 'mcp.server.route_loader' => true,
+                'mcp.server.debug_command' => true,
             ],
         ];
 
@@ -149,6 +151,7 @@ class McpBundleTest extends TestCase
                 'mcp.server.command' => false,
                 'mcp.server.controller' => true,
                 'mcp.server.route_loader' => true,
+                'mcp.server.debug_command' => true,
             ],
         ];
 
@@ -161,6 +164,7 @@ class McpBundleTest extends TestCase
                 'mcp.server.command' => true,
                 'mcp.server.controller' => true,
                 'mcp.server.route_loader' => true,
+                'mcp.server.debug_command' => true,
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        |
| License       | MIT

Follow-up to #2349 (based on that branch; only the last commit is new).

Adds a `debug:mcp` console command as the introspection counterpart to the container-based registration — the quick way to verify an attributed class was actually picked up as a service:

* `debug:mcp` lists all registered tools, prompts, resources, and resource templates with their handlers in tables.
* `debug:mcp <name>` shows the details of one element, including a tool's input/output schema; resources match by URI or name.
* When nothing is registered, it prints a hint pointing at service registration/autoconfiguration (the main pitfall after moving away from filesystem discovery).
* Registered whenever at least one client transport is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)