### PR TITLE
[Platform] Throw MaxOutputTokensException for non-streamed OpenResponses truncation

### DIFF
--- a/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Gpt/ResultConverterTest.php
@@ -663,7 +663,7 @@ class ResultConverterTest extends TestCase
         ]], $httpResponse), ['stream' => true]);
 
         $this->expectException(MaxOutputTokensException::class);
-        $this->expectExceptionMessage('OpenResponses truncated the response after reaching the output token limit.');
+        $this->expectExceptionMessage('Responses API truncated the response after reaching the output token limit.');
 
         iterator_to_array($streamResult->getContent());
     }

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -142,6 +142,10 @@ class ResultConverter implements ResultConverterInterface
                     $reason = 'unknown';
                 }
 
+                if ('max_output_tokens' === $reason) {
+                    throw new MaxOutputTokensException('Responses API truncated the response after reaching the output token limit. Raise the output token budget (max_output_tokens) or reduce the request scope.');
+                }
+
                 throw new RuntimeException(\sprintf('Responses API response is incomplete (%s) and contains no content.', $reason));
             }
 
@@ -462,7 +466,7 @@ class ResultConverter implements ResultConverterInterface
                 }
 
                 if ('max_output_tokens' === $reason) {
-                    throw new MaxOutputTokensException('OpenResponses truncated the response after reaching the output token limit. Raise the output token budget (max_output_tokens) or reduce the request scope.');
+                    throw new MaxOutputTokensException('Responses API truncated the response after reaching the output token limit. Raise the output token budget (max_output_tokens) or reduce the request scope.');
                 }
 
                 throw new RuntimeException(\sprintf('Responses API response is incomplete (%s).', $reason));

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -641,7 +641,7 @@ final class ResultConverterTest extends TestCase
         $httpResponse = $this->createMock(ResponseInterface::class);
         $httpResponse->method('toArray')->willReturn([
             'status' => 'incomplete',
-            'incomplete_details' => ['reason' => 'max_output_tokens'],
+            'incomplete_details' => ['reason' => 'content_filter'],
             'output' => [
                 [
                     'type' => 'reasoning',
@@ -652,7 +652,29 @@ final class ResultConverterTest extends TestCase
         ]);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Responses API response is incomplete (max_output_tokens) and contains no content.');
+        $this->expectExceptionMessage('Responses API response is incomplete (content_filter) and contains no content.');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
+    public function testThrowsMaxOutputTokensExceptionWhenIncompleteResponseHasNoContent()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'status' => 'incomplete',
+            'incomplete_details' => ['reason' => 'max_output_tokens'],
+            'output' => [
+                [
+                    'type' => 'reasoning',
+                    'id' => 'rs_1',
+                    'summary' => [],
+                ],
+            ],
+        ]);
+
+        $this->expectException(MaxOutputTokensException::class);
+        $this->expectExceptionMessage('Responses API truncated the response after reaching the output token limit.');
 
         $converter->convert(new RawHttpResult($httpResponse));
     }
@@ -1185,7 +1207,7 @@ final class ResultConverterTest extends TestCase
         ]], $httpResponse), ['stream' => true]);
 
         $this->expectException(MaxOutputTokensException::class);
-        $this->expectExceptionMessage('OpenResponses truncated the response after reaching the output token limit.');
+        $this->expectExceptionMessage('Responses API truncated the response after reaching the output token limit.');
 
         iterator_to_array($streamResult->getContent());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

Follow-up to #2335. That PR reports output-limit truncation for streamed OpenResponses results; this extends the same handling to the non-streaming path and aligns the exception message.

- Non-streaming responses that come back `incomplete` with `reason: max_output_tokens` and no content now throw `MaxOutputTokensException` instead of a generic `RuntimeException`, so consumers can catch a single exception type for both stream and non-stream. `MaxOutputTokensException extends RuntimeException`, so this is backward compatible.
- Uses "Responses API" instead of the internal "OpenResponses" name in the message, matching the other messages in the converter (the base class is extended by the OpenAI GPT bridge, where the internal name leaked into surfaced errors).

No CHANGELOG entry: the `0.12` line added in #2335 already covers this and is now accurate for both modes.