### PR TITLE
[Agent][Rework #1] Accept string and UserMessage as agent input

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,29 @@
 UPGRADE FROM 0.11 to 0.12
 =========================
 
+Agent
+-----
+
+ * `AgentInterface::call()` now accepts a `string` or a single `UserMessage` next to a `MessageBag`, and its
+   first parameter has been renamed from `$messages` to `$input`. Calls with a `MessageBag` keep working
+   unchanged, but custom implementations of `AgentInterface` have to widen their signature:
+
+   ```diff
+   -public function call(MessageBag $messages, array $options = []): ResultInterface
+   +public function call(string|MessageBag|UserMessage $input, array $options = []): ResultInterface
+    {
+   +    $messages = InputNormalizer::toMessageBag($input);
+        // ...
+    }
+   ```
+
+   `TraceableAgent::getCalls()` reports the untouched input under the `input` key instead of `messages`:
+
+   ```diff
+   -$call['messages'];
+   +$call['input'];
+   ```
+
 MCP Bundle
 ----------
 

--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -47,6 +47,11 @@ array of options::
 
 The structure of the input message bag is flexible, see `Platform Component`_ for more details on how to use it.
 
+For a one-off question without any conversation history, a plain string or a single
+:class:`Symfony\\AI\\Platform\\Message\\UserMessage` is accepted as well and normalized into a message bag::
+
+    $result = $agent->call('Hello, how are you?');
+
 Options
 ~~~~~~~
 

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * [BC BREAK] Change `AgentInterface::call()` to accept `string|MessageBag|UserMessage` and rename its first parameter from `$messages` to `$input`
+ * [BC BREAK] Change the `input` key of `TraceableAgent::getCalls()` entries, which was previously named `messages`, to carry the untouched input
+ * Add `Agent::call()` support for plain strings and single `UserMessage` objects, e.g. `$agent->call('Hello world')`
+
 0.11
 ----
 

--- a/src/agent/src/Agent.php
+++ b/src/agent/src/Agent.php
@@ -15,6 +15,7 @@ use Symfony\AI\Agent\Exception\InvalidArgumentException;
 use Symfony\AI\Agent\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ExceptionInterface;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 
@@ -54,9 +55,9 @@ final class Agent implements AgentInterface
      * @throws RuntimeException         When the platform returns a server error (5xx) or network failure occurs
      * @throws ExceptionInterface       When the platform converter throws an exception
      */
-    public function call(MessageBag $messages, array $options = []): ResultInterface
+    public function call(string|MessageBag|UserMessage $input, array $options = []): ResultInterface
     {
-        $input = new Input($this->getModel(), $messages, $options);
+        $input = new Input($this->getModel(), InputNormalizer::toMessageBag($input), $options);
         foreach ($this->inputProcessors as $inputProcessor) {
             if (!$inputProcessor instanceof InputProcessorInterface) {
                 throw new InvalidArgumentException(\sprintf('Input processor "%s" must implement "%s".', $inputProcessor::class, InputProcessorInterface::class));

--- a/src/agent/src/AgentInterface.php
+++ b/src/agent/src/AgentInterface.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Agent;
 
 use Symfony\AI\Agent\Exception\ExceptionInterface;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Result\ResultInterface;
 
 /**
@@ -21,11 +22,13 @@ use Symfony\AI\Platform\Result\ResultInterface;
 interface AgentInterface
 {
     /**
+     * A plain string and a single {@see UserMessage} are normalized into a {@see MessageBag}.
+     *
      * @param array<string, mixed> $options
      *
      * @throws ExceptionInterface When the agent encounters an error (e.g., unsupported model capabilities, invalid arguments, network failures, or processor errors)
      */
-    public function call(MessageBag $messages, array $options = []): ResultInterface;
+    public function call(string|MessageBag|UserMessage $input, array $options = []): ResultInterface;
 
     /**
      * Get the agent's name, which can be used for debugging or multi-agent configuration.

--- a/src/agent/src/InputNormalizer.php
+++ b/src/agent/src/InputNormalizer.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent;
+
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\UserMessage;
+
+/**
+ * Normalizes the different input shapes accepted by {@see AgentInterface::call()}.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ *
+ * @internal
+ */
+final class InputNormalizer
+{
+    public static function toMessageBag(string|MessageBag|UserMessage $input): MessageBag
+    {
+        if ($input instanceof MessageBag) {
+            return $input;
+        }
+
+        if ($input instanceof UserMessage) {
+            return new MessageBag($input);
+        }
+
+        return new MessageBag(Message::ofUser($input));
+    }
+}

--- a/src/agent/src/MockAgent.php
+++ b/src/agent/src/MockAgent.php
@@ -57,18 +57,10 @@ final class MockAgent implements AgentInterface
     /**
      * @param array<string, mixed> $options
      */
-    public function call(MessageBag $messages, array $options = []): ResultInterface
+    public function call(string|MessageBag|UserMessage $input, array $options = []): ResultInterface
     {
-        $lastMessage = $messages->getMessages()[\count($messages->getMessages()) - 1];
-        $content = '';
-
-        if ($lastMessage instanceof UserMessage) {
-            foreach ($lastMessage->getContent() as $messageContent) {
-                if ($messageContent instanceof Text) {
-                    $content .= $messageContent->getText();
-                }
-            }
-        }
+        $messages = InputNormalizer::toMessageBag($input);
+        $content = $this->extractText($messages);
 
         if (!isset($this->responses[$content])) {
             throw new RuntimeException(\sprintf('No response configured for input "%s".', $content));
@@ -250,5 +242,22 @@ final class MockAgent implements AgentInterface
     public function getName(): string
     {
         return $this->name;
+    }
+
+    private function extractText(MessageBag $messages): string
+    {
+        $lastMessage = $messages->getMessages()[\count($messages->getMessages()) - 1];
+        if (!$lastMessage instanceof UserMessage) {
+            return '';
+        }
+
+        $content = '';
+        foreach ($lastMessage->getContent() as $messageContent) {
+            if ($messageContent instanceof Text) {
+                $content .= $messageContent->getText();
+            }
+        }
+
+        return $content;
     }
 }

--- a/src/agent/src/MultiAgent/MultiAgent.php
+++ b/src/agent/src/MultiAgent/MultiAgent.php
@@ -17,9 +17,11 @@ use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Agent\Exception\ExceptionInterface;
 use Symfony\AI\Agent\Exception\InvalidArgumentException;
 use Symfony\AI\Agent\Exception\RuntimeException;
+use Symfony\AI\Agent\InputNormalizer;
 use Symfony\AI\Agent\MultiAgent\Handoff\Decision;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Result\ResultInterface;
 
 /**
@@ -62,8 +64,9 @@ final class MultiAgent implements AgentInterface
     /**
      * @throws ExceptionInterface When the agent encounters an error during orchestration or handoffs
      */
-    public function call(MessageBag $messages, array $options = []): ResultInterface
+    public function call(string|MessageBag|UserMessage $input, array $options = []): ResultInterface
     {
+        $messages = InputNormalizer::toMessageBag($input);
         $userMessages = $messages->withoutSystemMessage();
 
         $userMessage = $userMessages->getUserMessage();

--- a/src/agent/src/SpeechAgent.php
+++ b/src/agent/src/SpeechAgent.php
@@ -34,8 +34,10 @@ final class SpeechAgent implements AgentInterface
     ) {
     }
 
-    public function call(MessageBag $messages, array $options = []): ResultInterface
+    public function call(string|MessageBag|UserMessage $input, array $options = []): ResultInterface
     {
+        $messages = InputNormalizer::toMessageBag($input);
+
         if ($this->configuration->supportsSpeechToText() && $this->speechToTextPlatform instanceof PlatformInterface) {
             $messages = $this->transcribe($messages, $options);
         }

--- a/src/agent/src/Toolbox/Tool/Subagent.php
+++ b/src/agent/src/Toolbox/Tool/Subagent.php
@@ -14,8 +14,6 @@ namespace Symfony\AI\Agent\Toolbox\Tool;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Agent\Toolbox\Source\HasSourcesInterface;
 use Symfony\AI\Agent\Toolbox\Source\HasSourcesTrait;
-use Symfony\AI\Platform\Message\Message;
-use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Result\TextResult;
 
 /**
@@ -31,11 +29,11 @@ final class Subagent implements HasSourcesInterface
     }
 
     /**
-     * @param string $message the message to pass to the chain
+     * @param string $message the message to pass to the subagent
      */
     public function __invoke(string $message): string
     {
-        $result = $this->agent->call(new MessageBag(Message::ofUser($message)));
+        $result = $this->agent->call($message);
 
         \assert($result instanceof TextResult);
 

--- a/src/agent/src/TraceableAgent.php
+++ b/src/agent/src/TraceableAgent.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Agent;
 
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Clock\MonotonicClock;
@@ -21,7 +22,7 @@ use Symfony\Contracts\Service\ResetInterface;
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
  *
  * @phpstan-type AgentData array{
- *     messages: MessageBag,
+ *     input: string|MessageBag|UserMessage,
  *     options: array<string, mixed>,
  *     called_at: \DateTimeImmutable,
  * }
@@ -39,15 +40,15 @@ final class TraceableAgent implements AgentInterface, ResetInterface
     ) {
     }
 
-    public function call(MessageBag $messages, array $options = []): ResultInterface
+    public function call(string|MessageBag|UserMessage $input, array $options = []): ResultInterface
     {
         $this->calls[] = [
-            'messages' => $messages,
+            'input' => $input,
             'options' => $options,
             'called_at' => $this->clock->now(),
         ];
 
-        return $this->agent->call($messages, $options);
+        return $this->agent->call($input, $options);
     }
 
     public function getName(): string

--- a/src/agent/tests/AgentTest.php
+++ b/src/agent/tests/AgentTest.php
@@ -20,9 +20,11 @@ use Symfony\AI\Agent\Input;
 use Symfony\AI\Agent\InputProcessorInterface;
 use Symfony\AI\Agent\Output;
 use Symfony\AI\Agent\OutputProcessorInterface;
+use Symfony\AI\Agent\Tests\Fixtures\MessageBagCapturingProcessor;
 use Symfony\AI\Platform\Message\Content\Audio;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\PlainConverter;
@@ -61,6 +63,43 @@ final class AgentTest extends TestCase
         $agent = new Agent($platform, 'gpt-4o');
 
         $this->assertSame('gpt-4o', $agent->getModel());
+    }
+
+    public function testCallNormalizesStringInputIntoUserMessage()
+    {
+        $processor = new MessageBagCapturingProcessor();
+
+        $agent = new Agent(new InMemoryPlatform('Hi'), 'gpt-4o', [$processor]);
+        $agent->call('Hello there');
+
+        $this->assertInstanceOf(MessageBag::class, $processor->messageBag);
+        $messages = $processor->messageBag->getMessages();
+        $this->assertCount(1, $messages);
+        $this->assertInstanceOf(UserMessage::class, $messages[0]);
+        $this->assertSame('Hello there', $messages[0]->asText());
+    }
+
+    public function testCallNormalizesUserMessageIntoMessageBag()
+    {
+        $processor = new MessageBagCapturingProcessor();
+        $userMessage = Message::ofUser('Hello there');
+
+        $agent = new Agent(new InMemoryPlatform('Hi'), 'gpt-4o', [$processor]);
+        $agent->call($userMessage);
+
+        $this->assertInstanceOf(MessageBag::class, $processor->messageBag);
+        $this->assertSame([$userMessage], $processor->messageBag->getMessages());
+    }
+
+    public function testCallKeepsAGivenMessageBagAsIs()
+    {
+        $processor = new MessageBagCapturingProcessor();
+        $messageBag = new MessageBag(Message::ofUser('Hello there'));
+
+        $agent = new Agent(new InMemoryPlatform('Hi'), 'gpt-4o', [$processor]);
+        $agent->call($messageBag);
+
+        $this->assertSame($messageBag, $processor->messageBag);
     }
 
     public function testSetsAgentOnAgentAwareProcessors()

--- a/src/agent/tests/Fixtures/MessageBagCapturingProcessor.php
+++ b/src/agent/tests/Fixtures/MessageBagCapturingProcessor.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures;
+
+use Symfony\AI\Agent\Input;
+use Symfony\AI\Agent\InputProcessorInterface;
+use Symfony\AI\Platform\Message\MessageBag;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class MessageBagCapturingProcessor implements InputProcessorInterface
+{
+    public ?MessageBag $messageBag = null;
+
+    public function processInput(Input $input): void
+    {
+        $this->messageBag = $input->getMessageBag();
+    }
+}

--- a/src/agent/tests/TraceableAgentTest.php
+++ b/src/agent/tests/TraceableAgentTest.php
@@ -37,7 +37,7 @@ final class TraceableAgentTest extends TestCase
         $this->assertCount(1, $traceableAgent->getCalls());
         $this->assertEquals([
             [
-                'messages' => $messageBag,
+                'input' => $messageBag,
                 'options' => [],
                 'called_at' => $clock->now(),
             ],

--- a/src/ai-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/ai-bundle/tests/Profiler/DataCollectorTest.php
@@ -334,7 +334,7 @@ class DataCollectorTest extends TestCase
         $this->assertCount(1, $dataCollector->getAgents());
         $this->assertCount(1, $traceableAgent->getCalls());
         $this->assertEquals([
-            'messages' => $messageBag,
+            'input' => $messageBag,
             'options' => [],
             'called_at' => $clock->now(),
         ], $dataCollector->getAgents()[0]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

First slice of the Agent interface rework (replaces the monolithic chr-hertel/ai#10).

* `AgentInterface::call()` accepts `string|MessageBag|UserMessage`, normalized via the new `@internal` `InputNormalizer`.
* `Subagent` no longer wraps its message by hand.
* `TraceableAgent::getCalls()` records the untouched input under `input` instead of `messages`.

BC break for custom `AgentInterface` implementations (signature widening) — documented in `UPGRADE.md`.
