### PR TITLE
[Platform] Report malformed tool call arguments across bridges

### DIFF
--- a/src/platform/src/Bridge/Anthropic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Anthropic/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Throw a clear exception for malformed tool call arguments
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/Anthropic/ResultConverter.php
+++ b/src/platform/src/Bridge/Anthropic/ResultConverter.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Exception\AuthenticationException;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MalformedToolCallException;
 use Symfony\AI\Platform\Exception\MaxOutputTokensException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
@@ -291,9 +292,14 @@ class ResultConverter implements ResultConverterInterface
                 }
 
                 if (null !== $currentToolCall) {
-                    $input = '' !== $currentToolCallJson
-                        ? json_decode($currentToolCallJson, true, flags: \JSON_THROW_ON_ERROR)
-                        : [];
+                    $input = [];
+                    if ('' !== $currentToolCallJson) {
+                        try {
+                            $input = json_decode($currentToolCallJson, true, flags: \JSON_THROW_ON_ERROR);
+                        } catch (\JsonException $e) {
+                            throw new MalformedToolCallException(\sprintf('Anthropic returned malformed JSON arguments for the "%s" tool: "%s"', $currentToolCall['name'], $e->getMessage()), 0, $e);
+                        }
+                    }
                     $toolCalls[] = new ToolCall(
                         $currentToolCall['id'],
                         $currentToolCall['name'],

--- a/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ResultConverterTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\Anthropic\ResultConverter;
 use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MalformedToolCallException;
 use Symfony\AI\Platform\Exception\MaxOutputTokensException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
@@ -335,6 +336,28 @@ final class ResultConverterTest extends TestCase
         $this->expectExceptionMessage('reaching the maximum of 16000 output tokens');
 
         iterator_to_array($streamResult->getContent());
+    }
+
+    public function testStreamingThrowsClearExceptionForMalformedToolCallArguments()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $raw = new InMemoryRawResult([], [
+            ['type' => 'message_start', 'message' => ['id' => 'msg_123', 'type' => 'message', 'role' => 'assistant', 'content' => []]],
+            ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_01ABC123', 'name' => 'get_weather']],
+            ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'input_json_delta', 'partial_json' => '{"city":Berlin}']],
+            ['type' => 'content_block_stop', 'index' => 0],
+        ], $httpResponse);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $this->expectException(MalformedToolCallException::class);
+        $this->expectExceptionMessage('Anthropic returned malformed JSON arguments for the "get_weather" tool: "Syntax error"');
+
+        iterator_to_array($streamResult->getContent(), false);
     }
 
     public function testStreamingThrowsBeforeYieldingToolCallWhenTruncatedAtMaxTokens()

--- a/src/platform/src/Bridge/ClaudeCode/CHANGELOG.md
+++ b/src/platform/src/Bridge/ClaudeCode/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Throw a clear exception for malformed tool call arguments
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/ClaudeCode/ResultConverter.php
+++ b/src/platform/src/Bridge/ClaudeCode/ResultConverter.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\ClaudeCode;
 
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MalformedToolCallException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\MultiPartResult;
@@ -140,9 +141,14 @@ final class ResultConverter implements ResultConverterInterface
                 && 'content_block_stop' === $eventType
                 && null !== $currentToolCall
             ) {
-                $input = '' !== $currentToolCallJson
-                    ? json_decode($currentToolCallJson, true, flags: \JSON_THROW_ON_ERROR)
-                    : [];
+                $input = [];
+                if ('' !== $currentToolCallJson) {
+                    try {
+                        $input = json_decode($currentToolCallJson, true, flags: \JSON_THROW_ON_ERROR);
+                    } catch (\JsonException $e) {
+                        throw new MalformedToolCallException(\sprintf('Claude Code returned malformed JSON arguments for the "%s" tool: "%s"', $currentToolCall['name'], $e->getMessage()), 0, $e);
+                    }
+                }
                 $toolCalls[] = new ToolCall(
                     $currentToolCall['id'],
                     $currentToolCall['name'],

--- a/src/platform/src/Bridge/ClaudeCode/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/ClaudeCode/Tests/ResultConverterTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Bridge\ClaudeCode\ClaudeCode;
 use Symfony\AI\Platform\Bridge\ClaudeCode\ResultConverter;
 use Symfony\AI\Platform\Bridge\ClaudeCode\TokenUsageExtractor;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MalformedToolCallException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
@@ -257,6 +258,27 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('toolu_01ABC123', $toolCalls[0]->getId());
         $this->assertSame('get_weather', $toolCalls[0]->getName());
         $this->assertSame(['location' => 'Berlin'], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertStreamingThrowsClearExceptionForMalformedToolCallArguments()
+    {
+        $converter = new ResultConverter();
+        $rawResult = new InMemoryRawResult(
+            [],
+            [
+                ['type' => 'stream_event', 'event' => ['type' => 'message_start']],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'tool_use', 'id' => 'toolu_01ABC123', 'name' => 'get_weather']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'input_json_delta', 'partial_json' => '{"city":Berlin}']]],
+                ['type' => 'stream_event', 'event' => ['type' => 'content_block_stop', 'index' => 0]],
+            ],
+        );
+
+        $result = $converter->convert($rawResult, ['stream' => true]);
+
+        $this->expectException(MalformedToolCallException::class);
+        $this->expectExceptionMessage('Claude Code returned malformed JSON arguments for the "get_weather" tool: "Syntax error"');
+
+        iterator_to_array($result->getContent(), false);
     }
 
     public function testConvertStreamingThrowsWhenMessageStopIsMissing()

--- a/src/platform/src/Bridge/Cohere/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cohere/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Throw a clear exception for malformed tool call arguments
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Bridge\Cohere\Llm;
 use Symfony\AI\Platform\Bridge\Cohere\Cohere;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MalformedToolCallException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\FinishReason\FinishReasonAwareTrait;
 use Symfony\AI\Platform\Model;
@@ -171,13 +172,20 @@ final class ResultConverter implements ResultConverterInterface
      *         arguments: string
      *     }
      * } $toolCall
+     *
+     * @throws MalformedToolCallException
      */
     private function convertToolCall(array $toolCall): ToolCall
     {
         $argumentsJson = (string) $toolCall['function']['arguments'];
-        $arguments = '' !== $argumentsJson
-            ? json_decode($argumentsJson, true, flags: \JSON_THROW_ON_ERROR)
-            : [];
+        $arguments = [];
+        if ('' !== $argumentsJson) {
+            try {
+                $arguments = json_decode($argumentsJson, true, flags: \JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                throw new MalformedToolCallException(\sprintf('Cohere returned malformed JSON arguments for the "%s" tool: "%s"', $toolCall['function']['name'], $e->getMessage()), 0, $e);
+            }
+        }
 
         return new ToolCall($toolCall['id'], $toolCall['function']['name'], $arguments);
     }

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Bridge\Cohere\Cohere;
 use Symfony\AI\Platform\Bridge\Cohere\Llm\ResultConverter;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MalformedToolCallException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
@@ -115,6 +116,33 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('call_123', $toolCalls[0]->getId());
         $this->assertSame('get_weather', $toolCalls[0]->getName());
         $this->assertSame(['city' => 'Paris'], $toolCalls[0]->getArguments());
+    }
+
+    public function testItThrowsClearExceptionForMalformedToolCallArguments()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn([
+            'finish_reason' => 'TOOL_CALL',
+            'message' => [
+                'tool_calls' => [
+                    [
+                        'id' => 'call_123',
+                        'function' => [
+                            'name' => 'get_weather',
+                            'arguments' => '{"city":Berlin}',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $converter = new ResultConverter();
+
+        $this->expectException(MalformedToolCallException::class);
+        $this->expectExceptionMessage('Cohere returned malformed JSON arguments for the "get_weather" tool: "Syntax error"');
+
+        $converter->convert(new RawHttpResult($response));
     }
 
     public function testItThrowsExceptionOnUnsupportedFinishReason()

--- a/src/platform/src/Bridge/Generic/CHANGELOG.md
+++ b/src/platform/src/Bridge/Generic/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.12
+----
+
+ * Throw a clear exception for malformed tool call arguments
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
+++ b/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Generic\Completions;
 
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MalformedToolCallException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
@@ -249,11 +250,17 @@ trait CompletionsConversionTrait
      *         arguments?: string
      *     }
      * } $toolCall
+     *
+     * @throws MalformedToolCallException
      */
     protected function convertToolCall(array $toolCall): ToolCall
     {
         if (isset($toolCall['function']['arguments']) && '' !== $toolCall['function']['arguments']) {
-            $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
+            try {
+                $arguments = json_decode($toolCall['function']['arguments'], true, flags: \JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                throw new MalformedToolCallException(\sprintf('Model returned malformed JSON arguments for the "%s" tool: "%s"', $toolCall['function']['name'], $e->getMessage()), 0, $e);
+            }
         } else {
             $arguments = [];
         }

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ResultConverterTest.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\Exception\BadRequestException;
 use Symfony\AI\Platform\Exception\ContentFilterException;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\IncompleteStreamException;
+use Symfony\AI\Platform\Exception\MalformedToolCallException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Exception\ServerException;
@@ -100,6 +101,38 @@ class ResultConverterTest extends TestCase
         $this->assertSame('call_123', $toolCalls[0]->getId());
         $this->assertSame('test_function', $toolCalls[0]->getName());
         $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertThrowsClearExceptionForMalformedToolCallArguments()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => null,
+                        'tool_calls' => [
+                            [
+                                'id' => 'call_123',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'get_weather',
+                                    'arguments' => '{"city":Berlin}',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ],
+            ],
+        ]);
+
+        $this->expectException(MalformedToolCallException::class);
+        $this->expectExceptionMessage('Model returned malformed JSON arguments for the "get_weather" tool: "Syntax error"');
+
+        $converter->convert(new RawHttpResult($httpResponse));
     }
 
     public function testConvertToolWithEmptyArgsCallResult()

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -104,6 +104,27 @@ final class ResultConverterTest extends TestCase
         $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->getArguments());
     }
 
+    public function testConvertThrowsClearExceptionForMalformedToolCallArguments()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'function_call',
+                    'id' => 'call_123',
+                    'name' => 'get_weather',
+                    'arguments' => '{"city":Berlin}',
+                ],
+            ],
+        ]);
+
+        $this->expectException(MalformedToolCallException::class);
+        $this->expectExceptionMessage('OpenResponses returned malformed JSON arguments for the "get_weather" tool: "Syntax error"');
+
+        $converter->convert(new RawHttpResult($httpResponse));
+    }
+
     public function testConvertToolCallResultUsesCallIdWhenIdIsMissing()
     {
         $converter = new ResultConverter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | n/a
| License       | MIT

Follow-up to #2336, extending `MalformedToolCallException` to the remaining bridges that decode provider-returned tool call arguments:

- Cohere LLM converter
- Generic Completions trait (covers Generic, Mistral, DeepSeek, Scaleway, Cerebras, DockerModelRunner)
- Anthropic streaming converter
- Claude Code streaming converter

Also adds the missing non-streamed malformed-arguments test for OpenResponses.