### PR TITLE
 Fix outdated code references in component docs

### DIFF
--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -789,11 +789,11 @@ Memory integration is handled through the :class:`Symfony\\AI\\Agent\\Memory\\Me
 
     // Platform instantiation
 
-    $personalFacts = new StaticMemoryProvider(
+    $personalFacts = new StaticMemoryProvider([
         'My name is Wilhelm Tell',
         'I wish to be a swiss national hero',
         'I am struggling with hitting apples but want to be professional with the bow and arrow',
-    );
+    ]);
     $memoryProcessor = new MemoryInputProcessor([$personalFacts]);
 
     $agent = new Agent($platform, $model, [$memoryProcessor]);
@@ -813,10 +813,10 @@ information that should be consistently available without being directly added t
 
     use Symfony\AI\Agent\Memory\StaticMemoryProvider;
 
-    $staticMemory = new StaticMemoryProvider(
+    $staticMemory = new StaticMemoryProvider([
         'The user is allergic to nuts',
         'The user prefers brief explanations',
-    );
+    ]);
 
 Embedding Provider
 ..................

--- a/docs/components/store.rst
+++ b/docs/components/store.rst
@@ -79,7 +79,7 @@ search for documents in a store based on a query string. It vectorizes the query
     $documents = $retriever->retrieve('What is the capital of France?');
 
     foreach ($documents as $document) {
-        echo $document->metadata->get('source');
+        echo $document->getMetadata()->getSource();
     }
 
 The retriever accepts optional parameters to customize the retrieval:

--- a/docs/components/store/mongodb.rst
+++ b/docs/components/store/mongodb.rst
@@ -197,7 +197,7 @@ Removing Documents
 
 ::
 
-    $store->remove($document->getId()->toString());
+    $store->remove($document->getId());
 
     // Or remove multiple documents at once:
     $store->remove([$id1, $id2, $id3]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        |
| License       | MIT

Full docs scan against the current codebase; three code examples had drifted:

- `docs/components/agent.rst`: `StaticMemoryProvider` examples passed variadic strings — the constructor takes a single `array<string>` (2 occurrences)
- `docs/components/store.rst`: Retriever example used `$document->metadata->get('source')` — private property and no `Metadata::get()`; now `$document->getMetadata()->getSource()`
- `docs/components/store/mongodb.rst`: remove example called `->toString()` on `VectorDocument::getId()`, which returns `int|string`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
