### PR TITLE
[Examples] Extend gitignore files in example to cover changes after full example run with report

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,6 +1,7 @@
 .env.local
 .transformers-cache
 composer.lock
+report.md
 vendor
 tmp
 var

--- a/examples/openai/.gitignore
+++ b/examples/openai/.gitignore
@@ -1,2 +1,3 @@
 gpt-image-1-edit.png
 gpt-image-1.png
+openai-image-generation.png


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | 
| License       | MIT

those files are not meant to be committed, but get created with a full example run (or on openai) and with report active, e.g. `./runner --report`