### PR TITLE
[Agent] Validate scalar tool parameters against #[Schema] constraints

### DIFF
--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -215,7 +215,7 @@ To leverage JSON Schema validation rules, configure the :class:`Symfony\\AI\\Pla
          * @param array<string> $categories List of valid categories
          */
         public function __invoke(
-            #[Schema(pattern: '/([a-z0-1]){5}/')]
+            #[Schema(pattern: '^[a-z0-1]{5}$')]
             string $name,
             #[Schema(minimum: 0, maximum: 10)]
             int $number,
@@ -230,7 +230,12 @@ See attribute class :class:`Symfony\\AI\\Platform\\Contract\\JsonSchema\\Attribu
 
 .. note::
 
-    Please be aware, that this is only converted in a JSON Schema for the LLM to respect, but not validated by Symfony AI itself.
+    ``pattern`` follows the JSON Schema convention: a plain regular expression without PCRE delimiters
+    (e.g. ``'^[a-z0-9]{5}$'``).
+
+By itself, ``#[Schema]`` is only converted into a JSON Schema for the LLM to respect, it is not enforced by Symfony AI.
+To reject tool calls whose arguments don't actually satisfy these constraints, register the
+:class:`Symfony\\AI\\Agent\\Toolbox\\EventListener\\ValidateToolCallArgumentsListener`, see `Tool Call Argument Validation`_.
 
 Defining Schema from File
 .........................
@@ -373,6 +378,25 @@ to the event dispatcher that is passed to :class:`Symfony\\AI\\Agent\\Toolbox\\T
 
 This makes the toolbox throw :class:`Symfony\\AI\\Agent\\Toolbox\\Exception\\InvalidToolCallArgumentsException` before the tool is invoked if any of the
 arguments did not pass validation. When using the AI Bundle, the event listener is registered automatically and validation happens out-of-the-box.
+
+The listener validates both kinds of parameters:
+
+* Object parameters (like ``Person`` above), using the Symfony Validator constraints declared on their properties;
+* Scalar and array parameters carrying a ``#[Schema]`` attribute, using its runtime-enforceable keywords (``pattern``, ``minLength``/``maxLength``,
+  ``minimum``/``maximum``/``exclusiveMinimum``/``exclusiveMaximum``, ``multipleOf``, ``minItems``/``maxItems``, ``uniqueItems``, ``enum`` and ``const``).
+  This closes the gap described in the note above: a tool call whose ``reference`` argument doesn't match its ``#[Schema(pattern: ...)]`` is rejected
+  instead of silently reaching the tool::
+
+      #[AsTool('get_order', 'Get the status of an order by its reference')]
+      final class GetOrderTool
+      {
+          public function __invoke(
+              #[Schema(pattern: '^ORD-\d{4}-\d{4}$')]
+              string $reference,
+          ): string {
+              // Only ever reached with a well-formed reference, e.g. "ORD-2026-0042"
+          }
+      }
 
 See `Tool Call Argument Validation`_ for a complete example.
 

--- a/examples/toolbox/validation.php
+++ b/examples/toolbox/validation.php
@@ -14,8 +14,10 @@ use Symfony\AI\Agent\Toolbox\AgentProcessor;
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 use Symfony\AI\Agent\Toolbox\Event\ToolCallArgumentsResolved;
 use Symfony\AI\Agent\Toolbox\EventListener\ValidateToolCallArgumentsListener;
+use Symfony\AI\Agent\Toolbox\FaultTolerantToolbox;
 use Symfony\AI\Agent\Toolbox\Toolbox;
 use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -23,18 +25,26 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 require_once dirname(__DIR__).'/bootstrap.php';
 
-#[AsTool('get_country_info', 'Get information about a country by its ISO 3166-1 alpha-2 code')]
-final class GetCountryInfo
+// ValidateToolCallArgumentsListener validates both kinds of tool parameters in the same call:
+// - $reference is a scalar, validated through its #[Schema] constraint;
+// - $destination is an object, validated through the Symfony Validator constraints on its properties.
+#[AsTool('get_order', 'Get the status of an order by its reference and shipping destination')]
+final class GetOrder
 {
-    public function __invoke(CountryQuery $query): string
-    {
-        return sprintf('The country with code "%s" is a beautiful place!', $query->countryCode);
+    public function __invoke(
+        #[Schema(pattern: '^ORD-\d{4}-\d{4}$', description: 'Order reference, e.g. "ORD-2026-0042"')]
+        string $reference,
+        ShippingAddress $destination,
+    ): string {
+        return sprintf('Order "%s" is being shipped to %s, %s.', $reference, $destination->city, $destination->countryCode);
     }
 }
 
-final class CountryQuery
+final class ShippingAddress
 {
     public function __construct(
+        #[Assert\Length(max: 255)]
+        public string $city,
         #[Assert\Regex(pattern: '/^[A-Z]{2}$/', message: 'Must be a valid ISO 3166-1 alpha-2 country code (e.g. "DE", "US", "FR").')]
         public string $countryCode,
     ) {
@@ -46,11 +56,21 @@ $platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
 $eventDispatcher = new EventDispatcher();
 $eventDispatcher->addListener(ToolCallArgumentsResolved::class, new ValidateToolCallArgumentsListener());
 
-$toolbox = new Toolbox([new GetCountryInfo()], logger: logger(), eventDispatcher: $eventDispatcher);
+// FaultTolerantToolbox turns the InvalidToolCallArgumentsException thrown for a rejected call into a
+// readable error message returned to the LLM, instead of an uncaught exception.
+$toolbox = new FaultTolerantToolbox(
+    new Toolbox([new GetOrder()], logger: logger(), eventDispatcher: $eventDispatcher),
+);
 $processor = new AgentProcessor($toolbox, eventDispatcher: $eventDispatcher);
 $agent = new Agent($platform, 'gpt-5-mini', [$processor], [$processor]);
 
-$messages = new MessageBag(Message::ofUser('Use the tool to get info about Finland.'));
+$messages = new MessageBag(Message::ofUser('Look up the order with reference "ORD-2026-0042", shipping to Berlin, DE.'));
+$result = $agent->call($messages);
+
+echo $result->getContent().\PHP_EOL;
+
+// The LLM is instructed to use a malformed reference on purpose, to show the #[Schema] pattern being enforced.
+$messages = new MessageBag(Message::ofUser('Look up the order using exactly this reference, unmodified: "not-a-valid-reference", shipping to Berlin, DE.'));
 $result = $agent->call($messages);
 
 echo $result->getContent().\PHP_EOL;

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * `ValidateToolCallArgumentsListener` now also validates scalar and array tool parameters carrying a `#[Schema]` attribute (`pattern`, `minLength`/`maxLength`, `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`, `multipleOf`, `minItems`/`maxItems`, `uniqueItems`, `enum`, `const`), not only object parameters validated through Symfony Validator constraints
+
 0.12
 ----
 

--- a/src/agent/src/Toolbox/EventListener/ValidateToolCallArgumentsListener.php
+++ b/src/agent/src/Toolbox/EventListener/ValidateToolCallArgumentsListener.php
@@ -13,6 +13,9 @@ namespace Symfony\AI\Agent\Toolbox\EventListener;
 
 use Symfony\AI\Agent\Toolbox\Event\ToolCallArgumentsResolved;
 use Symfony\AI\Agent\Toolbox\Exception\InvalidToolCallArgumentsException;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -27,17 +30,100 @@ final class ValidateToolCallArgumentsListener
 
     public function __invoke(ToolCallArgumentsResolved $event): void
     {
+        $method = new \ReflectionMethod($event->getDefinition()->getReference()->getClass(), $event->getDefinition()->getReference()->getMethod());
+
+        /** @var array<string, \ReflectionParameter> $parameters */
+        $parameters = array_column($method->getParameters(), null, 'name');
+
         $validator = $this->validator->startContext();
         foreach ($event->getArguments() as $name => $argument) {
-            if (!\is_object($argument)) {
+            if (\is_object($argument)) {
+                $validator->atPath($name)->validate($argument);
                 continue;
             }
 
-            $validator->atPath($name)->validate($argument);
+            if (!isset($parameters[$name])) {
+                continue;
+            }
+
+            $constraints = $this->schemaConstraints($parameters[$name]);
+            if ([] !== $constraints) {
+                $validator->atPath($name)->validate($argument, $constraints);
+            }
         }
 
         if (\count($violations = $validator->getViolations())) {
             throw new InvalidToolCallArgumentsException(\sprintf('Invalid arguments provided for "%s" tool.', $event->getDefinition()->getName()), 0, null, $violations);
         }
+    }
+
+    /**
+     * Translates the runtime-enforceable keywords of a #[Schema] attribute into Symfony Validator
+     * constraints, so scalar and array tool parameters get validated the same way object parameters do.
+     *
+     * @return list<Constraint>
+     */
+    private function schemaConstraints(\ReflectionParameter $parameter): array
+    {
+        $attributes = $parameter->getAttributes(Schema::class);
+        if ([] === $attributes) {
+            return [];
+        }
+
+        $schema = $attributes[0]->newInstance();
+
+        if (null !== $schema->ref || null !== $schema->provider) {
+            // Externally defined or runtime-computed schemas are not validated locally.
+            return [];
+        }
+
+        $constraints = [];
+
+        if (null !== $schema->pattern) {
+            // #[Schema]'s pattern follows the JSON Schema convention (no PCRE delimiters), so it needs wrapping before preg_match() can use it.
+            $constraints[] = new Assert\Regex('#'.str_replace('#', '\#', $schema->pattern).'#');
+        }
+
+        if (null !== $schema->minLength || null !== $schema->maxLength) {
+            $constraints[] = new Assert\Length(min: $schema->minLength, max: $schema->maxLength);
+        }
+
+        if (null !== $schema->minimum) {
+            $constraints[] = new Assert\GreaterThanOrEqual($schema->minimum);
+        }
+
+        if (null !== $schema->maximum) {
+            $constraints[] = new Assert\LessThanOrEqual($schema->maximum);
+        }
+
+        if (null !== $schema->exclusiveMinimum) {
+            $constraints[] = new Assert\GreaterThan($schema->exclusiveMinimum);
+        }
+
+        if (null !== $schema->exclusiveMaximum) {
+            $constraints[] = new Assert\LessThan($schema->exclusiveMaximum);
+        }
+
+        if (null !== $schema->multipleOf) {
+            $constraints[] = new Assert\DivisibleBy($schema->multipleOf);
+        }
+
+        if (null !== $schema->minItems || null !== $schema->maxItems) {
+            $constraints[] = new Assert\Count(min: $schema->minItems, max: $schema->maxItems);
+        }
+
+        if (true === $schema->uniqueItems) {
+            $constraints[] = new Assert\Unique();
+        }
+
+        if (null !== $schema->enum) {
+            $constraints[] = new Assert\Choice(choices: $schema->enum);
+        }
+
+        if (null !== $schema->const) {
+            $constraints[] = new Assert\EqualTo($schema->const);
+        }
+
+        return $constraints;
     }
 }

--- a/src/agent/tests/Fixtures/Tool/ToolWithScalarConstraints.php
+++ b/src/agent/tests/Fixtures/Tool/ToolWithScalarConstraints.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+#[AsTool('tool_with_scalar_constraints', 'A tool with #[Schema] constraints on scalar parameters')]
+final class ToolWithScalarConstraints
+{
+    /**
+     * @param string     $reference The order reference, e.g. "ORD-2026-0042"
+     * @param int        $quantity  The number of items, between 1 and 10
+     * @param array<int> $ratings   Individual ratings, at most 3, without duplicates
+     */
+    public function __invoke(
+        #[Schema(pattern: '^ORD-\d{4}-\d{4}$')]
+        string $reference,
+        #[Schema(minimum: 1, maximum: 10)]
+        int $quantity,
+        #[Schema(maxItems: 3, uniqueItems: true)]
+        array $ratings,
+    ): string {
+        return \sprintf('Order "%s": %d item(s).', $reference, $quantity);
+    }
+}

--- a/src/agent/tests/Toolbox/EventListener/ValidateToolCallArgumentsListenerTest.php
+++ b/src/agent/tests/Toolbox/EventListener/ValidateToolCallArgumentsListenerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\Recipe;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithConstraints;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithScalarConstraints;
 use Symfony\AI\Agent\Toolbox\Event\ToolCallArgumentsResolved;
 use Symfony\AI\Agent\Toolbox\EventListener\ValidateToolCallArgumentsListener;
 use Symfony\AI\Agent\Toolbox\Exception\InvalidToolCallArgumentsException;
@@ -56,6 +57,92 @@ class ValidateToolCallArgumentsListenerTest extends TestCase
 
         $this->expectException(InvalidToolCallArgumentsException::class);
         $this->expectExceptionMessage('Invalid arguments provided for "get_recipe" tool.');
+        $listener($event);
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testPassesValidationForScalarSchemaConstraints()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolWithScalarConstraints();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'tool_with_scalar_constraints', 'A tool with #[Schema] constraints on scalar parameters'),
+            ['reference' => 'ORD-2026-0042', 'quantity' => 5, 'ratings' => [1, 2, 3]],
+        );
+
+        $listener($event);
+    }
+
+    public function testFailsValidationForInvalidPattern()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolWithScalarConstraints();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'tool_with_scalar_constraints', 'A tool with #[Schema] constraints on scalar parameters'),
+            ['reference' => 'not-a-valid-reference', 'quantity' => 5, 'ratings' => [1, 2, 3]],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $this->expectExceptionMessage('Invalid arguments provided for "tool_with_scalar_constraints" tool.');
+        $listener($event);
+    }
+
+    public function testFailsValidationForOutOfRangeNumber()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolWithScalarConstraints();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'tool_with_scalar_constraints', 'A tool with #[Schema] constraints on scalar parameters'),
+            ['reference' => 'ORD-2026-0042', 'quantity' => 42, 'ratings' => [1, 2, 3]],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $listener($event);
+    }
+
+    public function testFailsValidationForTooManyItems()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolWithScalarConstraints();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'tool_with_scalar_constraints', 'A tool with #[Schema] constraints on scalar parameters'),
+            ['reference' => 'ORD-2026-0042', 'quantity' => 5, 'ratings' => [1, 2, 3, 4]],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $listener($event);
+    }
+
+    public function testFailsValidationForDuplicateItems()
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $listener = new ValidateToolCallArgumentsListener($validator);
+
+        $tool = new ToolWithScalarConstraints();
+
+        $event = new ToolCallArgumentsResolved(
+            $tool,
+            new Tool(new ExecutionReference($tool::class), 'tool_with_scalar_constraints', 'A tool with #[Schema] constraints on scalar parameters'),
+            ['reference' => 'ORD-2026-0042', 'quantity' => 5, 'ratings' => [1, 1, 2]],
+        );
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
         $listener($event);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        |
| License       | MIT

ValidateToolCallArgumentsListener only validated object-typed tool
parameters via Symfony Validator, silently skipping scalar and array
parameters carrying a #[Schema] attribute (pattern, min/max, enum,
etc.). Those constraints only shaped the JSON Schema sent to the LLM
without ever being enforced, so a malformed tool call could still
reach the tool.

The listener now also translates the runtime-enforceable #[Schema]
keywords into Symfony Validator constraints for scalar/array
parameters, rejecting the call the same way it already does for
object parameters and backed enums.
