### PR TITLE
[Platform] Notify stream listeners on a mid-stream error via onError()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,6 +21,30 @@ AI Bundle
 
    The default (`false`, tool messages are preserved) is unchanged.
 
+Platform
+--------
+
+ * `Result\Stream\ListenerInterface` gained an `onError()` method, dispatched with the new
+   `Result\Stream\ErrorEvent`. Listeners not extending
+   `AbstractStreamListener` must add the method:
+
+   ```diff
+   +use Symfony\AI\Platform\Result\Stream\ErrorEvent;
+
+    final class MyStreamListener implements ListenerInterface
+    {
+        public function onComplete(CompleteEvent $event): void
+        {
+            // ...
+        }
+   +
+   +    public function onError(ErrorEvent $event): void
+   +    {
+   +        // ...
+   +    }
+    }
+   ```
+
 UPGRADE FROM 0.11 to 0.12
 =========================
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * [BC BREAK] Add `ListenerInterface::onError()` and `Result\Stream\ErrorEvent`, dispatched when draining a `StreamResult` throws, so a listener can finalize on a failed stream where `onComplete()` never fires; `AbstractStreamListener` provides a no-op default
+
 0.12
 ----
 

--- a/src/platform/src/Result/Stream/AbstractStreamListener.php
+++ b/src/platform/src/Result/Stream/AbstractStreamListener.php
@@ -27,4 +27,8 @@ abstract class AbstractStreamListener implements ListenerInterface
     public function onComplete(CompleteEvent $event): void
     {
     }
+
+    public function onError(ErrorEvent $event): void
+    {
+    }
 }

--- a/src/platform/src/Result/Stream/ErrorEvent.php
+++ b/src/platform/src/Result/Stream/ErrorEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Stream;
+
+use Symfony\AI\Platform\Result\StreamResult;
+
+/**
+ * @author Ghislain Flandin <ghislain.flandin@gmail.com>
+ */
+final class ErrorEvent extends Event
+{
+    public function __construct(StreamResult $result, private readonly \Throwable $error)
+    {
+        parent::__construct($result);
+    }
+
+    public function getError(): \Throwable
+    {
+        return $this->error;
+    }
+}

--- a/src/platform/src/Result/Stream/ListenerInterface.php
+++ b/src/platform/src/Result/Stream/ListenerInterface.php
@@ -16,9 +16,31 @@ namespace Symfony\AI\Platform\Result\Stream;
  */
 interface ListenerInterface
 {
+    /**
+     * Dispatched once, before the first delta is consumed.
+     */
     public function onStart(StartEvent $event): void;
 
+    /**
+     * Dispatched for every delta, before it is yielded to the consumer.
+     *
+     * The listener can rewrite or skip the delta through the event.
+     */
     public function onDelta(DeltaEvent $event): void;
 
+    /**
+     * Dispatched once the stream drained without error.
+     *
+     * Terminal, and mutually exclusive with onError().
+     */
     public function onComplete(CompleteEvent $event): void;
+
+    /**
+     * Dispatched when draining the stream throws, right before the exception is rethrown to the caller.
+     *
+     * Terminal, and mutually exclusive with onComplete(): a stream that reported its token usage on a
+     * delta and then failed reaches this one only, so a listener with a finalizing side effect (cost
+     * accounting, quota debit, audit) has to act on both. A stream the consumer abandons reaches neither.
+     */
+    public function onError(ErrorEvent $event): void;
 }

--- a/src/platform/src/Result/StreamResult.php
+++ b/src/platform/src/Result/StreamResult.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Platform\Result;
 use Symfony\AI\Platform\Result\Stream\CompleteEvent;
 use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
 use Symfony\AI\Platform\Result\Stream\DeltaEvent;
+use Symfony\AI\Platform\Result\Stream\ErrorEvent;
 use Symfony\AI\Platform\Result\Stream\ListenerInterface;
 use Symfony\AI\Platform\Result\Stream\StartEvent;
 
@@ -56,24 +57,36 @@ final class StreamResult extends BaseResult
         }
         $this->getMetadata()->merge($event->getMetadata());
 
-        foreach ($this->generator as $delta) {
-            $event = new DeltaEvent($this, $delta);
+        try {
+            foreach ($this->generator as $delta) {
+                $event = new DeltaEvent($this, $delta);
+                foreach ($this->listeners as $listener) {
+                    $listener->onDelta($event);
+                }
+                $this->getMetadata()->merge($event->getMetadata());
+
+                if ($event->isDeltaSkipped()) {
+                    continue;
+                }
+
+                $delta = $event->getDelta();
+
+                if ($delta instanceof DeltaInterface) {
+                    yield $delta;
+                } else {
+                    yield from $delta;
+                }
+            }
+        } catch (\Throwable $e) {
+            // Notify listeners before rethrowing (see ErrorEvent); an abandoned stream breaks out
+            // and tears the generator down without entering this catch, so it stays unbilled.
+            $event = new ErrorEvent($this, $e);
             foreach ($this->listeners as $listener) {
-                $listener->onDelta($event);
+                $listener->onError($event);
             }
             $this->getMetadata()->merge($event->getMetadata());
 
-            if ($event->isDeltaSkipped()) {
-                continue;
-            }
-
-            $delta = $event->getDelta();
-
-            if ($delta instanceof DeltaInterface) {
-                yield $delta;
-            } else {
-                yield from $delta;
-            }
+            throw $e;
         }
 
         $event = new CompleteEvent($this);

--- a/src/platform/tests/Result/StreamResultTest.php
+++ b/src/platform/tests/Result/StreamResultTest.php
@@ -13,9 +13,11 @@ namespace Symfony\AI\Platform\Tests\Result;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Result\Stream\AbstractStreamListener;
+use Symfony\AI\Platform\Result\Stream\CompleteEvent;
 use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\DeltaEvent;
+use Symfony\AI\Platform\Result\Stream\ErrorEvent;
 use Symfony\AI\Platform\Result\StreamResult;
 
 final class StreamResultTest extends TestCase
@@ -93,5 +95,76 @@ final class StreamResultTest extends TestCase
 
         // After consumption, metadata is populated
         $this->assertTrue($result->getMetadata()->has('seen_chunk2'));
+    }
+
+    public function testListenerIsNotifiedOnErrorNotOnCompleteWhenStreamThrows()
+    {
+        $exception = new \RuntimeException('stream failed mid-flight');
+
+        $result = new StreamResult((static function () use ($exception): \Generator {
+            yield new TextDelta('chunk1');
+
+            throw $exception;
+        })());
+
+        $listener = new class extends AbstractStreamListener {
+            public ?\Throwable $error = null;
+            public bool $completed = false;
+
+            public function onComplete(CompleteEvent $event): void
+            {
+                $this->completed = true;
+            }
+
+            public function onError(ErrorEvent $event): void
+            {
+                $this->error = $event->getError();
+            }
+        };
+        $result->addListener($listener);
+
+        $caught = null;
+        try {
+            iterator_to_array($result->getContent());
+        } catch (\RuntimeException $e) {
+            $caught = $e;
+        }
+
+        $this->assertSame($exception, $caught);
+        $this->assertSame($exception, $listener->error);
+        $this->assertFalse($listener->completed);
+    }
+
+    public function testErrorListenerReadsMetadataMergedBeforeTheThrow()
+    {
+        $result = new StreamResult((static function (): \Generator {
+            yield new TextDelta('chunk1');
+
+            throw new \RuntimeException('truncated at the output token ceiling');
+        })());
+
+        $result->addListener(new class extends AbstractStreamListener {
+            public function onDelta(DeltaEvent $event): void
+            {
+                $event->getResult()->getMetadata()->add('token_usage', true);
+            }
+        });
+
+        $listener = new class extends AbstractStreamListener {
+            public bool $sawUsageAtError = false;
+
+            public function onError(ErrorEvent $event): void
+            {
+                $this->sawUsageAtError = $event->getResult()->getMetadata()->has('token_usage');
+            }
+        };
+        $result->addListener($listener);
+
+        try {
+            iterator_to_array($result->getContent());
+        } catch (\RuntimeException) {
+        }
+
+        $this->assertTrue($listener->sawUsageAtError);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #2360
| License       | MIT

Follow-up to #2360, which @chr-hertel greenlit there.

`StreamResult::getContent()` dispatches `CompleteEvent` only after the generator drains normally.
A stream that reports its usage on a delta and *then* throws, e.g. `MaxOutputTokensException` on a
response completed at the output-token ceiling, therefore never notifies a listener that finalizes
on `onComplete()`. The usage is sitting on the result metadata, but any accounting side effect
(cost, audit row, quota debit) is silently skipped: the provider billed the round and the
application ends up with no record of it.

This keeps the upcast to an exception, semantically "this is not a clean success" and adds a
terminal event for the failure path instead of blurring `CompleteEvent`:

 * new `Result\Stream\ErrorEvent`, carrying the `\Throwable`;
 * `ListenerInterface::onError()`, with a no-op default on `AbstractStreamListener`;
 * `StreamResult` wraps the drain loop in `try`/`catch`, dispatches `ErrorEvent` to every listener,
   then rethrows.

`onComplete()` and `onError()` are mutually exclusive terminal events, mirroring the
`ResultConvertedEvent` / `ResultErrorEvent` pair added one layer up in 0.11.

Usage: a listener that meters on either terminal event:

```php
final class MyAccountingListener extends AbstractStreamListener
{
    public function onComplete(CompleteEvent $event): void
    {
        $this->meter($event->getResult());
    }

    public function onError(ErrorEvent $event): void
    {
        $this->meter($event->getResult());
    }
}
```

Worth flagging for review: **abandoning** a stream (breaking out of the consuming loop) tears the
generator down *without* entering the `catch`. PHP runs `finally`, not `catch`, on generator
destruction, so an abandoned stream still fires neither event and stays unmetered, exactly as
before. That is precisely why this uses `catch` + rethrow rather than a `finally`.

**BC break:** adding a method to `ListenerInterface` breaks direct implementers (anything extending
`AbstractStreamListener` is covered by the no-op default). Tagged `[BC BREAK]` in
`src/platform/CHANGELOG.md`, with a matching entry in the root `UPGRADE.md`