### PR TITLE
[Agent] Surface tool-argument resolution failures to the LLM

### DIFF
--- a/src/agent/src/Toolbox/ToolCallArgumentResolver.php
+++ b/src/agent/src/Toolbox/ToolCallArgumentResolver.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\AI\Agent\Toolbox;
 
-use Symfony\AI\Agent\Toolbox\Exception\ToolException;
+use Symfony\AI\Agent\Toolbox\Exception\InvalidToolCallArgumentsException;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tool\Tool;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Exception\ExceptionInterface as SerializerExceptionInterface;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
@@ -63,7 +64,7 @@ final class ToolCallArgumentResolver implements ToolCallArgumentResolverInterfac
     /**
      * @return array<string, mixed>
      *
-     * @throws ToolException When a mandatory tool parameter is missing from the tool call arguments
+     * @throws InvalidToolCallArgumentsException When a mandatory tool parameter is missing from the tool call arguments or an argument cannot be denormalized to the expected parameter type
      */
     public function resolveArguments(Tool $metadata, ToolCall $toolCall): array
     {
@@ -76,7 +77,7 @@ final class ToolCallArgumentResolver implements ToolCallArgumentResolverInterfac
         foreach ($parameters as $name => $reflectionParameter) {
             if (!\array_key_exists($name, $toolCall->getArguments())) {
                 if (!$reflectionParameter->isOptional()) {
-                    throw new ToolException(\sprintf('Parameter "%s" is mandatory for tool "%s".', $name, $toolCall->getName()));
+                    throw new InvalidToolCallArgumentsException(\sprintf('Parameter "%s" is mandatory for tool "%s".', $name, $toolCall->getName()));
                 }
                 continue;
             }
@@ -102,7 +103,11 @@ final class ToolCallArgumentResolver implements ToolCallArgumentResolverInterfac
             $parameterType .= $dimensions;
 
             if ($this->denormalizer->supportsDenormalization($value, $parameterType, 'json')) {
-                $value = $this->denormalizer->denormalize($value, $parameterType, 'json');
+                try {
+                    $value = $this->denormalizer->denormalize($value, $parameterType, 'json');
+                } catch (SerializerExceptionInterface $e) {
+                    throw new InvalidToolCallArgumentsException(\sprintf('Invalid value for parameter "%s" of tool "%s": %s', $name, $toolCall->getName(), $e->getMessage()), previous: $e);
+                }
             }
 
             $arguments[$name] = $value;

--- a/src/agent/src/Toolbox/ToolCallArgumentResolver.php
+++ b/src/agent/src/Toolbox/ToolCallArgumentResolver.php
@@ -106,7 +106,7 @@ final class ToolCallArgumentResolver implements ToolCallArgumentResolverInterfac
                 try {
                     $value = $this->denormalizer->denormalize($value, $parameterType, 'json');
                 } catch (SerializerExceptionInterface $e) {
-                    throw new InvalidToolCallArgumentsException(\sprintf('Invalid value for parameter "%s" of tool "%s": %s', $name, $toolCall->getName(), $e->getMessage()), previous: $e);
+                    throw new InvalidToolCallArgumentsException(\sprintf('Invalid value for parameter "%s" of tool "%s": "%s"', $name, $toolCall->getName(), $e->getMessage()), previous: $e);
                 }
             }
 

--- a/src/agent/src/Toolbox/ToolCallArgumentResolverInterface.php
+++ b/src/agent/src/Toolbox/ToolCallArgumentResolverInterface.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Agent\Toolbox;
 
-use Symfony\AI\Agent\Toolbox\Exception\ToolException;
+use Symfony\AI\Agent\Toolbox\Exception\InvalidToolCallArgumentsException;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tool\Tool;
 
@@ -23,7 +23,7 @@ interface ToolCallArgumentResolverInterface
     /**
      * @return array<string, mixed>
      *
-     * @throws ToolException When it is not possible to resolve the tool arguments
+     * @throws InvalidToolCallArgumentsException When it is not possible to resolve the tool arguments
      */
     public function resolveArguments(Tool $metadata, ToolCall $toolCall): array;
 }

--- a/src/agent/src/Toolbox/Toolbox.php
+++ b/src/agent/src/Toolbox/Toolbox.php
@@ -93,6 +93,7 @@ final class Toolbox implements ToolboxInterface
         }
 
         $tool = $this->getExecutable($metadata);
+        $arguments = [];
 
         try {
             $this->logger->debug(\sprintf('Executing tool "%s".', $toolCall->getName()), $toolCall->getArguments());
@@ -113,11 +114,11 @@ final class Toolbox implements ToolboxInterface
 
             $this->eventDispatcher?->dispatch(new ToolCallSucceeded($tool, $metadata, $arguments, $result));
         } catch (ToolExecutionExceptionInterface $e) {
-            $this->eventDispatcher?->dispatch(new ToolCallFailed($tool, $metadata, $arguments ?? [], $e));
+            $this->eventDispatcher?->dispatch(new ToolCallFailed($tool, $metadata, $arguments, $e));
             throw $e;
         } catch (\Throwable $e) {
             $this->logger->warning(\sprintf('Failed to execute tool "%s".', $toolCall->getName()), ['exception' => $e]);
-            $this->eventDispatcher?->dispatch(new ToolCallFailed($tool, $metadata, $arguments ?? [], $e));
+            $this->eventDispatcher?->dispatch(new ToolCallFailed($tool, $metadata, $arguments, $e));
             throw ToolExecutionException::executionFailed($toolCall, $e);
         }
 

--- a/src/agent/tests/Toolbox/FaultTolerantToolboxTest.php
+++ b/src/agent/tests/Toolbox/FaultTolerantToolboxTest.php
@@ -14,11 +14,14 @@ namespace Symfony\AI\Agent\Tests\Toolbox;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolNoParams;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolRequiredParams;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithBackedEnums;
 use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionException;
 use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
 use Symfony\AI\Agent\Toolbox\Exception\ToolNotFoundException;
 use Symfony\AI\Agent\Toolbox\FaultTolerantToolbox;
+use Symfony\AI\Agent\Toolbox\Toolbox;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
+use Symfony\AI\Agent\Toolbox\ToolFactory\MemoryToolFactory;
 use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tool\ExecutionReference;
@@ -77,6 +80,33 @@ final class FaultTolerantToolboxTest extends TestCase
         $actual = $faultTolerantToolbox->execute($toolCall);
 
         $this->assertSame($expected, $actual->getResult());
+    }
+
+    public function testMissingMandatoryParameterIsSurfacedToTheLlm()
+    {
+        $faultTolerantToolbox = new FaultTolerantToolbox(new Toolbox([new ToolRequiredParams()]));
+
+        $toolCall = new ToolCall('123456789', 'tool_required_params', ['text' => 'Hello']);
+        $actual = $faultTolerantToolbox->execute($toolCall);
+
+        $this->assertSame('Parameter "number" is mandatory for tool "tool_required_params".', $actual->getResult());
+    }
+
+    public function testUndeserializableArgumentIsSurfacedToTheLlm()
+    {
+        $toolFactory = (new MemoryToolFactory())
+            ->addTool(ToolWithBackedEnums::class, 'tool_with_backed_enums', 'A tool with backed enum parameters');
+        $faultTolerantToolbox = new FaultTolerantToolbox(new Toolbox([new ToolWithBackedEnums()], $toolFactory));
+
+        $toolCall = new ToolCall('123456789', 'tool_with_backed_enums', [
+            'searchTerms' => ['symfony'],
+            'mode' => 'not_a_mode',
+            'priority' => 'high',
+        ]);
+        $actual = $faultTolerantToolbox->execute($toolCall);
+
+        $this->assertIsString($actual->getResult());
+        $this->assertStringStartsWith('Invalid value for parameter "mode" of tool "tool_with_backed_enums":', $actual->getResult());
     }
 
     private function createFaultyToolbox(\Closure $exceptionFactory): ToolboxInterface

--- a/src/agent/tests/Toolbox/ToolCallArgumentResolverTest.php
+++ b/src/agent/tests/Toolbox/ToolCallArgumentResolverTest.php
@@ -18,12 +18,16 @@ use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolArrayMultidimensional;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolDate;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolNoParams;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolObjectFloat;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolRequiredParams;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithBackedEnums;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithNullableClass;
+use Symfony\AI\Agent\Toolbox\Exception\InvalidToolCallArgumentsException;
 use Symfony\AI\Agent\Toolbox\ToolCallArgumentResolver;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Tests\Fixtures\StructuredOutput\SomeStructure;
 use Symfony\AI\Platform\Tool\ExecutionReference;
 use Symfony\AI\Platform\Tool\Tool;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 
 class ToolCallArgumentResolverTest extends TestCase
 {
@@ -115,5 +119,38 @@ class ToolCallArgumentResolverTest extends TestCase
         $toolCall = new ToolCall('invocation', 'tool_with_nullable_class', $toolParams);
 
         $this->assertEquals($expected, $resolver->resolveArguments($metadata, $toolCall));
+    }
+
+    public function testResolveArgumentsThrowsWhenMandatoryParameterIsMissing()
+    {
+        $resolver = new ToolCallArgumentResolver();
+
+        $metadata = new Tool(new ExecutionReference(ToolRequiredParams::class, 'bar'), 'tool_required_params', 'A tool with required parameters');
+        $toolCall = new ToolCall('invocation', 'tool_required_params', ['text' => 'Hello']);
+
+        $this->expectException(InvalidToolCallArgumentsException::class);
+        $this->expectExceptionMessage('Parameter "number" is mandatory for tool "tool_required_params".');
+
+        $resolver->resolveArguments($metadata, $toolCall);
+    }
+
+    public function testResolveArgumentsThrowsWhenValueCannotBeDenormalized()
+    {
+        $resolver = new ToolCallArgumentResolver();
+
+        $metadata = new Tool(new ExecutionReference(ToolWithBackedEnums::class, '__invoke'), 'tool_with_backed_enums', 'A tool with backed enum parameters');
+        $toolCall = new ToolCall('invocation', 'tool_with_backed_enums', [
+            'searchTerms' => ['symfony'],
+            'mode' => 'not_a_mode',
+            'priority' => 'high',
+        ]);
+
+        try {
+            $resolver->resolveArguments($metadata, $toolCall);
+            $this->fail(\sprintf('Expected exception of type "%s" to be thrown.', InvalidToolCallArgumentsException::class));
+        } catch (InvalidToolCallArgumentsException $e) {
+            $this->assertStringStartsWith('Invalid value for parameter "mode" of tool "tool_with_backed_enums":', $e->getMessage());
+            $this->assertInstanceOf(NotNormalizableValueException::class, $e->getPrevious());
+        }
     }
 }


### PR DESCRIPTION
| Q            | A           |
| ------------ | ----------- |
| Bug fix?     | yes         |
| New feature? | no          |
| Docs?        | no          |
| Issues       | Fixes #2137 |
| License      | MIT         |

## Problem

When `ToolCallArgumentResolver::resolveArguments()` fails because of invalid LLM-generated tool-call input—such as a missing mandatory parameter or a value that cannot be denormalized (for example, an invalid backed-enum value)—the exception is caught by the generic `\Throwable` arm in `Toolbox::execute()`.

It is then wrapped in a `ToolExecutionException`, whose `getToolCallResult()` only returns:

> An error occurred while executing tool "X".

As a result, `FaultTolerantToolbox` relays no actionable feedback to the model. The model cannot self-correct and typically repeats the same invalid call.

## Solution

This PR treats argument-resolution failures as agent-correctable errors by reusing the existing `InvalidToolCallArgumentsException`.

This exception implements `ToolExecutionExceptionInterface`, allowing its message to reach the LLM as the tool result. This is the same mechanism already used by `ValidateToolCallArgumentsListener`.

- A missing mandatory parameter now throws `InvalidToolCallArgumentsException` with the existing message:

  ```text
  Parameter "number" is mandatory for tool "tool_required_params".
  ```

- A denormalization failure is caught and rethrown as `InvalidToolCallArgumentsException`:

  ```text
  Invalid value for parameter "mode" of tool "tool_with_backed_enums": The data must belong to a backed enumeration of type ...
  ```

  The original Serializer exception is preserved as the previous exception for debugging and logging purposes, but is not exposed directly to the LLM.

These messages are derived from the model's input and the tool's argument metadata. Exceptions raised during tool execution remain hidden and continue to produce the generic error message.

## Compatibility

Code catching the component's `ExceptionInterface` remains unaffected, since both the old and new exceptions implement it.

Consumers catching the concrete `ToolExecutionException` may need to handle `InvalidToolCallArgumentsException` as well.

## Technical Note

`Toolbox::execute()` now initializes `$arguments` before entering the `try` block, ensuring that it is safely available to the catch arms, as reported by PHPStan.

## Tests

This behavior is covered by:

- Unit tests for the argument resolver.
- End-to-end tests through `Toolbox` and `FaultTolerantToolbox`.
- Assertions on the exact error message received by the LLM.
