### PR TITLE
[Store] Forward platform options from Retriever to the vectorizer

### DIFF
--- a/docs/components/store.rst
+++ b/docs/components/store.rst
@@ -86,6 +86,18 @@ The retriever accepts optional parameters to customize the retrieval:
 
 * ``$options``: An array of options to pass to the underlying store query (e.g., limit, filters)
 
+The ``platform_options`` key is the one exception: it is not passed to the store, but to the
+vectorizer, and from there to the platform that embeds the query. Some embedding models treat a
+stored document and a search query differently, and expect to be told which of the two they are
+looking at::
+
+    use Symfony\AI\Platform\Bridge\Cohere\InputType;
+
+    $documents = $retriever->retrieve('What is the capital of France?', [
+        'maxItems' => 5,
+        'platform_options' => ['input_type' => InputType::SearchQuery],
+    ]);
+
 Example Usage
 ~~~~~~~~~~~~~
 

--- a/docs/components/store.rst
+++ b/docs/components/store.rst
@@ -86,6 +86,21 @@ The retriever accepts optional parameters to customize the retrieval:
 
 * ``$options``: An array of options to pass to the underlying store query (e.g., limit, filters)
 
+The ``platform_options`` key is the one exception: it is not passed to the store, but to the
+vectorizer, and from there to the platform that embeds the query. Some embedding models treat a
+stored document and a search query differently, and expect to be told which of the two they are
+looking at::
+
+    use Symfony\AI\Platform\Bridge\Cohere\InputType;
+
+    $documents = $retriever->retrieve('What is the capital of France?', [
+        'maxItems' => 5,
+        'platform_options' => ['input_type' => InputType::SearchQuery],
+    ]);
+
+This mirrors the ``platform_options`` key of :class:`Symfony\\AI\\Store\\Indexer\\DocumentProcessor`,
+which does the same for the indexing side.
+
 Example Usage
 ~~~~~~~~~~~~~
 

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Add `platform_options` to `Retriever::retrieve()` options, forwarded to the vectorizer instead of the store, e.g. to embed the query with a provider's query mode (`['platform_options' => ['input_type' => InputType::SearchQuery]]` for Cohere)
+
 0.11
 ----
 

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.14
+----
+
+ * Add `platform_options` to `Retriever::retrieve()` options, forwarded to the vectorizer instead of the store, e.g. to embed the query with a provider's query mode (`['platform_options' => ['input_type' => InputType::SearchQuery]]` for Cohere)
+
 0.11
 ----
 

--- a/src/store/src/Retriever.php
+++ b/src/store/src/Retriever.php
@@ -37,7 +37,7 @@ final class Retriever implements RetrieverInterface
     }
 
     /**
-     * @param array<string, mixed> $options
+     * @param array{semanticRatio?: float, platform_options?: array<string, mixed>}&array<string, mixed> $options Store options; `platform_options` is forwarded to the vectorizer instead
      *
      * @return iterable<VectorDocument>
      */
@@ -49,7 +49,12 @@ final class Retriever implements RetrieverInterface
             [$query, $options] = $this->dispatchPreQuery($query, $options);
         }
 
-        $queryObject = $this->createQuery($query, $options);
+        // Configures the query embedding, not the store query, so it must not reach the store:
+        // bridges like MongoDB merge the options they get straight into their query payload.
+        $platformOptions = $options['platform_options'] ?? [];
+        unset($options['platform_options']);
+
+        $queryObject = $this->createQuery($query, $options, $platformOptions);
 
         $this->logger->debug('Searching store', ['query_type' => $queryObject::class]);
 
@@ -106,9 +111,10 @@ final class Retriever implements RetrieverInterface
     }
 
     /**
-     * @param array<string, mixed> $options
+     * @param array{semanticRatio?: float}&array<string, mixed> $options
+     * @param array<string, mixed>                              $platformOptions Options for the platform that embeds the query
      */
-    private function createQuery(string $query, array $options): QueryInterface
+    private function createQuery(string $query, array $options, array $platformOptions): QueryInterface
     {
         if (null === $this->vectorizer) {
             $this->logger->debug('No vectorizer configured, using TextQuery if supported');
@@ -125,11 +131,11 @@ final class Retriever implements RetrieverInterface
         if ($this->store->supports(HybridQuery::class)) {
             $this->logger->debug('Store supports hybrid queries, using HybridQuery with semantic ratio', ['semanticRatio' => $options['semanticRatio'] ?? 0.5]);
 
-            return new HybridQuery($this->vectorizer->vectorize($query), explode(' ', $query), $options['semanticRatio'] ?? 0.5);
+            return new HybridQuery($this->vectorizer->vectorize($query, $platformOptions), explode(' ', $query), $options['semanticRatio'] ?? 0.5);
         }
 
         $this->logger->debug('Store supports vector queries, using VectorQuery');
 
-        return new VectorQuery($this->vectorizer->vectorize($query));
+        return new VectorQuery($this->vectorizer->vectorize($query, $platformOptions));
     }
 }

--- a/src/store/src/RetrieverInterface.php
+++ b/src/store/src/RetrieverInterface.php
@@ -26,8 +26,8 @@ interface RetrieverInterface
     /**
      * Retrieve documents from the store that are similar to the given query.
      *
-     * @param string               $query   The search query to vectorize and use for similarity search
-     * @param array<string, mixed> $options Options to pass to the store query (e.g., limit, filters)
+     * @param string                                                              $query   The search query to vectorize and use for similarity search
+     * @param array{platform_options?: array<string, mixed>}&array<string, mixed> $options Options to pass to the store query (e.g., limit, filters), except `platform_options`, which is passed to the vectorizer
      *
      * @return iterable<VectorDocument> The retrieved documents with similarity scores
      */

--- a/src/store/tests/RetrieverTest.php
+++ b/src/store/tests/RetrieverTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Document\Vectorizer;
+use Symfony\AI\Store\Document\VectorizerInterface;
 use Symfony\AI\Store\Event\PostQueryEvent;
 use Symfony\AI\Store\Event\PreQueryEvent;
 use Symfony\AI\Store\Query\HybridQuery;
@@ -283,6 +284,187 @@ final class RetrieverTest extends TestCase
 
         $retriever = new Retriever($store, $vectorizer);
         $results = iterator_to_array($retriever->retrieve('test query', ['semanticRatio' => 0.7]));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrievePassesPlatformOptionsToVectorizer()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $vectorizer = $this->createMock(VectorizerInterface::class);
+        $vectorizer->expects($this->once())
+            ->method('vectorize')
+            ->with('test query', ['input_type' => 'search_query'])
+            ->willReturn(new Vector([0.2, 0.3, 0.4]));
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, false],
+                [HybridQuery::class, false],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->with($this->isInstanceOf(VectorQuery::class), ['maxItems' => 5])
+            ->willReturn([$document]);
+
+        $retriever = new Retriever($store, $vectorizer);
+        $results = iterator_to_array($retriever->retrieve('test query', [
+            'maxItems' => 5,
+            'platform_options' => ['input_type' => 'search_query'],
+        ]));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrievePassesPlatformOptionsToVectorizerForHybridQuery()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $vectorizer = $this->createMock(VectorizerInterface::class);
+        $vectorizer->expects($this->once())
+            ->method('vectorize')
+            ->with('test query', ['input_type' => 'search_query'])
+            ->willReturn(new Vector([0.2, 0.3, 0.4]));
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, true],
+                [HybridQuery::class, true],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->with($this->isInstanceOf(HybridQuery::class), ['semanticRatio' => 0.5])
+            ->willReturn([$document]);
+
+        $retriever = new Retriever($store, $vectorizer);
+        $results = iterator_to_array($retriever->retrieve('test query', [
+            'semanticRatio' => 0.5,
+            'platform_options' => ['input_type' => 'search_query'],
+        ]));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrieveDoesNotPassStoreOptionsToVectorizer()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $vectorizer = $this->createMock(VectorizerInterface::class);
+        $vectorizer->expects($this->once())
+            ->method('vectorize')
+            ->with('test query', [])
+            ->willReturn(new Vector([0.2, 0.3, 0.4]));
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, false],
+                [HybridQuery::class, false],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->willReturn([$document]);
+
+        $retriever = new Retriever($store, $vectorizer);
+        $results = iterator_to_array($retriever->retrieve('test query', ['maxItems' => 5]));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrieveWithPreQueryEventCanSetPlatformOptions()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $vectorizer = $this->createMock(VectorizerInterface::class);
+        $vectorizer->expects($this->once())
+            ->method('vectorize')
+            ->with('test query', ['input_type' => 'search_query'])
+            ->willReturn(new Vector([0.2, 0.3, 0.4]));
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, false],
+                [HybridQuery::class, false],
+            ]);
+
+        $store->expects($this->once())
+            ->method('query')
+            ->willReturn([$document]);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')
+            ->willReturnCallback(static function (object $event) {
+                if ($event instanceof PreQueryEvent) {
+                    $event->setOptions(['platform_options' => ['input_type' => 'search_query']]);
+                }
+
+                return $event;
+            });
+
+        $retriever = new Retriever($store, $vectorizer, $eventDispatcher);
+        $results = iterator_to_array($retriever->retrieve('test query'));
+
+        $this->assertCount(1, $results);
+    }
+
+    public function testRetrieveDoesNotPassPlatformOptionsToStore()
+    {
+        $document = new VectorDocument(
+            Uuid::v4(),
+            new Vector([0.1, 0.2, 0.3]),
+            new Metadata(['title' => 'Test Document']),
+        );
+
+        $vectorizer = $this->createMock(VectorizerInterface::class);
+        $vectorizer->method('vectorize')
+            ->willReturn(new Vector([0.2, 0.3, 0.4]));
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('supports')
+            ->willReturnMap([
+                [VectorQuery::class, true],
+                [TextQuery::class, false],
+                [HybridQuery::class, false],
+            ]);
+
+        // Stores merging their options into the query payload (e.g. the MongoDB bridge)
+        // would send `platform_options` to the vector database.
+        $store->expects($this->once())
+            ->method('query')
+            ->with($this->isInstanceOf(VectorQuery::class), [])
+            ->willReturn([$document]);
+
+        $retriever = new Retriever($store, $vectorizer);
+        $results = iterator_to_array($retriever->retrieve('test query', [
+            'platform_options' => ['input_type' => 'search_query'],
+        ]));
 
         $this->assertCount(1, $results);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

`Retriever::createQuery()` calls `$this->vectorizer->vectorize($query)` with no options, so nothing on the query side can reach the platform that does the embedding.

That is a problem for embedding models with asymmetric input modes. Cohere embeds a stored document and a search query differently, so that a short question lands next to the longer passage that answers it, and expects to be told which of the two it is looking at. Its default is `search_document`, which is right for indexing and wrong for retrieval. Today a `Retriever` embeds the query as if it were a document, and there is no option to change that. The results still look plausible, which is what makes it easy to miss: the two sides are simply misaligned.

The indexing side already has the answer. `DocumentProcessor::process()` reads a `platform_options` key out of its options and forwards it to the vectorizer. This does the same for the query side, so both halves of a RAG pipeline are configured the same way:

```php
use Symfony\AI\Platform\Bridge\Cohere\InputType;

$documents = $retriever->retrieve('send email', [
    'maxItems' => 5,
    'platform_options' => ['input_type' => InputType::SearchQuery],
]);
```

Notes:

- `platform_options` is consumed by the `Retriever` and stripped from the options handed to the store, since it configures the embedding and not the store query. That matters: the MongoDB bridge merges the options it receives straight into its `$vectorSearch` stage, so leaving the key in would send an unknown field to the vector database. Every other option is passed to the store unchanged.
- Blanket-forwarding all options to the vectorizer was not an option either, since bridges like OpenAI's embeddings client merge their options straight into the request body.
- A `PreQueryEvent` listener can set `platform_options` as well, since listeners can already rewrite the options.
- No BC break: without the key, `vectorize()` is called with an empty array, exactly as before.

Tests cover the vector and hybrid paths, the listener case, that plain store options do not leak into the vectorizer, and that `platform_options` does not leak into the store. `src/store`: 422 tests green, PHPStan clean, CS fixer run.
