### PR TITLE
[Platform] Make base URL configurable in OpenRouter ModelApiCatalog

### DIFF
--- a/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenRouter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Add configurable `$baseUrl` constructor parameter to `ModelApiCatalog`
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/OpenRouter/ModelApiCatalog.php
+++ b/src/platform/src/Bridge/OpenRouter/ModelApiCatalog.php
@@ -25,9 +25,14 @@ final class ModelApiCatalog extends AbstractOpenRouterModelCatalog
 {
     protected bool $modelsAreLoaded = false;
 
+    private readonly string $baseUrl;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
+        string $baseUrl = 'https://openrouter.ai/api',
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
+
         parent::__construct();
     }
 
@@ -63,7 +68,7 @@ final class ModelApiCatalog extends AbstractOpenRouterModelCatalog
      */
     protected function fetchRemoteModels(): iterable
     {
-        $responseModels = $this->httpClient->request('GET', 'https://openrouter.ai/api/v1/models');
+        $responseModels = $this->httpClient->request('GET', $this->baseUrl.'/v1/models');
         foreach ($responseModels->toArray()['data'] as $model) {
             $capabilities = [];
 
@@ -128,7 +133,7 @@ final class ModelApiCatalog extends AbstractOpenRouterModelCatalog
      */
     protected function fetchRemoteEmbeddings(): iterable
     {
-        $responseEmbeddings = $this->httpClient->request('GET', 'https://openrouter.ai/api/v1/embeddings/models');
+        $responseEmbeddings = $this->httpClient->request('GET', $this->baseUrl.'/v1/embeddings/models');
         foreach ($responseEmbeddings->toArray()['data'] as $embedding) {
             yield $embedding['id'] => [
                 'class' => EmbeddingsModel::class,

--- a/src/platform/src/Bridge/OpenRouter/Tests/ModelApiCatalogTest.php
+++ b/src/platform/src/Bridge/OpenRouter/Tests/ModelApiCatalogTest.php
@@ -254,6 +254,33 @@ final class ModelApiCatalogTest extends TestCase
         $this->assertSame(Capability::cases(), $model->getCapabilities());
     }
 
+    public function testItUsesTheConfiguredBaseUrl()
+    {
+        $modelsResponse = new JsonMockResponse([
+            'data' => [
+                [
+                    'id' => 'anthropic/claude-3-opus',
+                    'architecture' => [
+                        'input_modalities' => ['text'],
+                        'output_modalities' => ['text'],
+                    ],
+                ],
+            ],
+        ]);
+        $embeddingsResponse = new JsonMockResponse([
+            'data' => [],
+        ]);
+
+        $httpClient = new MockHttpClient([$modelsResponse, $embeddingsResponse]);
+
+        $catalog = new ModelApiCatalog($httpClient, 'https://gateway.internal/api/');
+        $catalog->getModels();
+
+        $this->assertSame(2, $httpClient->getRequestsCount());
+        $this->assertSame('https://gateway.internal/api/v1/models', $modelsResponse->getRequestUrl());
+        $this->assertSame('https://gateway.internal/api/v1/embeddings/models', $embeddingsResponse->getRequestUrl());
+    }
+
     public function testAutoRouterModelStillWorksWithApiCatalog()
     {
         $httpClient = new MockHttpClient([


### PR DESCRIPTION
Make the base URL in `OpenRouter\ModelApiCatalog` configurable via a new `$baseUrl` constructor parameter (defaults to `https://openrouter.ai/api`).

This allows using OpenRouter-compatible APIs hosted on a different domain, e.g. self-hosted proxies or alternative endpoints.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | 
| License       | MIT