### PR TITLE
[CI] Restrict model catalog update to symfony/ai

### DIFF
--- a/.github/workflows/update-model-catalogs.yaml
+++ b/.github/workflows/update-model-catalogs.yaml
@@ -20,6 +20,7 @@ jobs:
     update:
         name: Refresh catalogs and open PR
         runs-on: ubuntu-latest
+        if: github.repository == 'symfony/ai'
         permissions:
             contents: write
             pull-requests: write


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The `Update Model Catalogs` workflow currently runs on forks too — it has been firing weekly on `chr-hertel/ai` since mid-June and opening automated PRs there.

Neither of GitHub's built-in protections helps: the "scheduled workflows are disabled when a public repo is forked" default only applies at fork creation, and the 60-day inactivity disable never triggers on an actively used fork.

Adds a job-level `if: github.repository == 'symfony/ai'` guard.