### PR TITLE
[Platform][OpenResponses] Retry overloaded requests

### DIFF
--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Throw `ServerException` when an OpenAI response reports that the server is overloaded
+
 0.12
 ----
 

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -632,8 +632,8 @@ class ResultConverter implements ResultConverterInterface
      */
     private function isServerError(array $error): bool
     {
-        return \in_array($error['code'], ['server_error', 'internal_error'], true)
-            || \in_array($error['type'], ['server_error', 'internal_error'], true);
+        return \in_array($error['code'], ['server_error', 'internal_error', 'server_is_overloaded'], true)
+            || \in_array($error['type'], ['server_error', 'internal_error', 'service_unavailable_error'], true);
     }
 
     /**

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -1310,6 +1310,42 @@ final class ResultConverterTest extends TestCase
         iterator_to_array($streamResult->getContent());
     }
 
+    /**
+     * @param array{code?: string, type?: string, message: string} $error
+     */
+    #[DataProvider('provideOverloadedResponses')]
+    public function testStreamThrowsServerExceptionOnOverloadedResponse(array $error)
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], [[
+            'type' => 'response.failed',
+            'response' => ['error' => $error],
+        ]], $httpResponse), ['stream' => true]);
+
+        $this->expectException(ServerException::class);
+
+        iterator_to_array($streamResult->getContent());
+    }
+
+    /**
+     * @return iterable<string, array{array{code?: string, type?: string, message: string}}>
+     */
+    public static function provideOverloadedResponses(): iterable
+    {
+        yield 'overloaded code' => [[
+            'code' => 'server_is_overloaded',
+            'message' => 'Our servers are currently overloaded. Please try again later.',
+        ]];
+        yield 'service unavailable type' => [[
+            'type' => 'service_unavailable_error',
+            'message' => 'Service unavailable.',
+        ]];
+    }
+
     public function testStreamThrowsExceptionOnErrorEvent()
     {
         $converter = new ResultConverter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

OpenAI can report temporary server overloads through a successful HTTP response containing a `response.failed` event with the `server_is_overloaded` code or `service_unavailable_error` type. These errors were previously treated as generic runtime failures, causing agents to stop instead of retrying. This change classifies them as transient server errors, allowing existing retry mechanisms to retry the request with exponential backoff.
