### PR TITLE
[Platform][OpenResponses] Replay reasoning items across turns of store: false conversations

### DIFF
--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Throw `ServerException` when an OpenAI response reports that the server is overloaded
+ * Preserve reasoning items as thinking signatures and replay them on subsequent requests
 
 0.12
 ----

--- a/src/platform/src/Bridge/OpenResponses/Contract/Message/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/OpenResponses/Contract/Message/AssistantMessageNormalizer.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Bridge\OpenResponses\ResponsesModel;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Model;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
@@ -29,16 +30,17 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
     /**
      * @param AssistantMessage $data
      *
-     * @return array{
-     *     role: 'assistant',
-     *     type: 'message',
-     *     content: ?string
-     * }
+     * @return list<array<string, mixed>>
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
+        $reasoningItems = $this->extractReasoningItems($data);
+
         if ($data->hasToolCalls()) {
-            return $this->normalizer->normalize($data->getToolCalls(), $format, $context);
+            /** @var list<array<string, mixed>> $toolCalls */
+            $toolCalls = $this->normalizer->normalize($data->getToolCalls(), $format, $context);
+
+            return array_merge($reasoningItems, $toolCalls);
         }
 
         $text = '';
@@ -49,9 +51,12 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
         }
 
         return [
-            'role' => $data->getRole()->value,
-            'type' => 'message',
-            'content' => '' === $text ? null : $text,
+            ...$reasoningItems,
+            [
+                'role' => $data->getRole()->value,
+                'type' => 'message',
+                'content' => '' === $text ? null : $text,
+            ],
         ];
     }
 
@@ -63,5 +68,32 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
     protected function supportsModel(Model $model): bool
     {
         return $model instanceof ResponsesModel;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function extractReasoningItems(AssistantMessage $data): array
+    {
+        $items = [];
+
+        foreach ($data->getContent() as $part) {
+            if (!$part instanceof Thinking || null === $part->getSignature()) {
+                continue;
+            }
+
+            try {
+                $item = json_decode($part->getSignature(), true, flags: \JSON_THROW_ON_ERROR);
+            } catch (\JsonException) {
+                // Signatures from other providers may be opaque strings
+                continue;
+            }
+
+            if (\is_array($item) && 'reasoning' === ($item['type'] ?? null)) {
+                $items[] = $item;
+            }
+        }
+
+        return $items;
     }
 }

--- a/src/platform/src/Bridge/OpenResponses/Contract/Message/MessageBagNormalizer.php
+++ b/src/platform/src/Bridge/OpenResponses/Contract/Message/MessageBagNormalizer.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Bridge\OpenResponses\ResponsesModel;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\Template;
 use Symfony\AI\Platform\Model;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
@@ -31,8 +32,8 @@ final class MessageBagNormalizer extends ModelContractNormalizer implements Norm
      * @param MessageBag $data
      *
      * @return array{
-     *     input: array<string, mixed>,
-     *     instructions?: string,
+     *     input: list<mixed>,
+     *     instructions?: string|Template,
      * }
      *
      * @throws ExceptionInterface
@@ -44,7 +45,7 @@ final class MessageBagNormalizer extends ModelContractNormalizer implements Norm
         foreach ($data->withoutSystemMessage()->getMessages() as $message) {
             $normalized = $this->normalizer->normalize($message, $format, $context);
 
-            if ($message instanceof AssistantMessage && $message->hasToolCalls()) {
+            if ($message instanceof AssistantMessage) {
                 $messages['input'] = array_merge($messages['input'], $normalized);
                 continue;
             }

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -39,6 +39,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingSignature;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -57,7 +58,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * @phpstan-type OutputText array{type: 'output_text', text: string}
  * @phpstan-type Refusal array{type: 'refusal', refusal: string}
  * @phpstan-type FunctionCall array{id?: string|null, arguments: string, call_id?: string|null, name: string, type: 'function_call'}
- * @phpstan-type Thinking array{summary: list<array{type: string, text?: string}>, id: string}
+ * @phpstan-type Thinking array{summary: list<array{type: string, text?: string}>, id: string, encrypted_content?: string|null}
  * @phpstan-type Error array{code?: string|null, type?: string|null, param?: string|null, message?: string|null}
  * @phpstan-type WebSearchCall array{type: 'web_search_call', id?: string, status?: string, action?: array{type?: string, query?: string, queries?: list<string>}}
  * @phpstan-type FileSearchCall array{type: 'file_search_call', id?: string, status?: string, queries?: list<string>, results?: list<array<string, mixed>>|null}
@@ -136,7 +137,7 @@ class ResultConverter implements ResultConverterInterface
 
         $results = $this->convertOutputArray($data[self::KEY_OUTPUT]);
 
-        if ([] === $results) {
+        if (!$this->containsContent($results)) {
             if ('incomplete' === ($data['status'] ?? null)) {
                 $reason = $data['incomplete_details']['reason'] ?? 'unknown';
                 if (!\is_string($reason) || '' === $reason) {
@@ -210,6 +211,20 @@ class ResultConverter implements ResultConverterInterface
 
         foreach ($result->getContent() as $part) {
             if ($part instanceof ToolCallResult) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ResultInterface[] $results
+     */
+    private function containsContent(array $results): bool
+    {
+        foreach ($results as $result) {
+            if (!$result instanceof ThinkingResult || null !== $result->getContent()) {
                 return true;
             }
         }
@@ -502,6 +517,14 @@ class ResultConverter implements ResultConverterInterface
                 $toolCalls[$toolCall->getId()] = $toolCall;
             }
 
+            // The full reasoning item (including encrypted_content when requested
+            // via include: ["reasoning.encrypted_content"]) is emitted as the
+            // thinking signature so that requests using "store" => false can
+            // replay it on subsequent turns.
+            if ('response.output_item.done' === $type && \is_array($event['item'] ?? null) && 'reasoning' === ($event['item']['type'] ?? null)) {
+                yield new ThinkingSignature(json_encode($event['item'], \JSON_THROW_ON_ERROR));
+            }
+
             if ('response.completed' !== $type) {
                 continue;
             }
@@ -603,10 +626,21 @@ class ResultConverter implements ResultConverterInterface
      */
     private function convertReasoning(array $item): \Generator
     {
+        // The serialized reasoning item doubles as the thinking signature so
+        // that requests using "store" => false can replay it on subsequent
+        // turns. It is attached to the first emitted result to avoid replay
+        // duplication.
+        $signature = json_encode($item, \JSON_THROW_ON_ERROR);
+
         foreach ($item['summary'] ?? [] as $entry) {
             if ('' !== ($entry['text'] ?? '')) {
-                yield new ThinkingResult($entry['text']);
+                yield new ThinkingResult($entry['text'], $signature);
+                $signature = null;
             }
+        }
+
+        if (null !== $signature && isset($item['encrypted_content'])) {
+            yield new ThinkingResult(null, $signature);
         }
     }
 

--- a/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/AssistantMessageNormalizerTest.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\Bridge\OpenResponses\Contract\ToolCallNormalizer;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -27,7 +28,7 @@ use Symfony\Component\Serializer\Serializer;
 class AssistantMessageNormalizerTest extends TestCase
 {
     /**
-     * @param array{role: 'assistant', type: 'message', content: ?string} $expected
+     * @param list<array<string, mixed>> $expected
      */
     #[DataProvider('normalizeProvider')]
     public function testNormalize(AssistantMessage $message, array $expected)
@@ -44,11 +45,11 @@ class AssistantMessageNormalizerTest extends TestCase
         $message = Message::ofAssistant('Foo');
         yield 'without tool calls' => [
             $message,
-            [
+            [[
                 'role' => 'assistant',
                 'type' => 'message',
                 'content' => 'Foo',
-            ],
+            ]],
         ];
 
         $toolCall = new ToolCall('some-id', 'roll-die', ['sides' => 24]);
@@ -62,6 +63,55 @@ class AssistantMessageNormalizerTest extends TestCase
                     'type' => 'function_call',
                 ],
             ],
+        ];
+
+        $reasoningItem = [
+            'type' => 'reasoning',
+            'id' => 'rs_1',
+            'summary' => [['type' => 'summary_text', 'text' => 'Pondering.']],
+            'encrypted_content' => 'gAAAAA-encrypted',
+        ];
+        yield 'reasoning items are replayed before tool calls' => [
+            Message::ofAssistant(new Thinking('Pondering.', json_encode($reasoningItem)), $toolCall),
+            [
+                $reasoningItem,
+                [
+                    'arguments' => json_encode($toolCall->getArguments()),
+                    'call_id' => $toolCall->getId(),
+                    'name' => $toolCall->getName(),
+                    'type' => 'function_call',
+                ],
+            ],
+        ];
+
+        yield 'reasoning items are replayed before the message' => [
+            Message::ofAssistant(new Thinking('Pondering.', json_encode($reasoningItem)), new Text('Foo')),
+            [
+                $reasoningItem,
+                [
+                    'role' => 'assistant',
+                    'type' => 'message',
+                    'content' => 'Foo',
+                ],
+            ],
+        ];
+
+        yield 'thinking without signature is not replayed' => [
+            Message::ofAssistant(new Thinking('Pondering.'), new Text('Foo')),
+            [[
+                'role' => 'assistant',
+                'type' => 'message',
+                'content' => 'Foo',
+            ]],
+        ];
+
+        yield 'non-reasoning signature is ignored' => [
+            Message::ofAssistant(new Thinking('Pondering.', 'anthropic-opaque-signature'), new Text('Foo')),
+            [[
+                'role' => 'assistant',
+                'type' => 'message',
+                'content' => 'Foo',
+            ]],
         ];
     }
 

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -43,6 +43,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingSignature;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -258,6 +259,76 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('Then I divide by 8.', $parts[1]->getContent());
         $this->assertInstanceOf(TextResult::class, $parts[2]);
         $this->assertSame('x = -3.75', $parts[2]->getContent());
+    }
+
+    public function testConvertReasoningAttachesSerializedItemAsSignature()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $reasoningItem = [
+            'type' => 'reasoning',
+            'id' => 'rs_1',
+            'summary' => [
+                ['type' => 'summary_text', 'text' => 'Thinking it through.'],
+            ],
+            'encrypted_content' => 'gAAAAA-encrypted',
+        ];
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                $reasoningItem,
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'final',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertInstanceOf(ThinkingResult::class, $parts[0]);
+        $this->assertSame('Thinking it through.', $parts[0]->getContent());
+        $this->assertSame($reasoningItem, json_decode($parts[0]->getSignature(), true));
+    }
+
+    public function testConvertReasoningWithEncryptedContentButNoSummaryKeepsSignature()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $reasoningItem = [
+            'type' => 'reasoning',
+            'id' => 'rs_1',
+            'summary' => [],
+            'encrypted_content' => 'gAAAAA-encrypted',
+        ];
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                $reasoningItem,
+                [
+                    'type' => 'message',
+                    'id' => 'msg_1',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'final',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertInstanceOf(ThinkingResult::class, $parts[0]);
+        $this->assertNull($parts[0]->getContent());
+        $this->assertSame($reasoningItem, json_decode($parts[0]->getSignature(), true));
     }
 
     public function testConvertReasoningWithoutSummaryIsDropped()
@@ -691,6 +762,7 @@ final class ResultConverterTest extends TestCase
                     'type' => 'reasoning',
                     'id' => 'rs_1',
                     'summary' => [],
+                    'encrypted_content' => 'gAAAAA-encrypted',
                 ],
             ],
         ]);
@@ -711,6 +783,7 @@ final class ResultConverterTest extends TestCase
                     'type' => 'reasoning',
                     'id' => 'rs_1',
                     'summary' => [],
+                    'encrypted_content' => 'gAAAAA-encrypted',
                 ],
             ],
         ]);
@@ -1427,6 +1500,52 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('Let me think about this...', $chunks[3]->getThinking());
         $this->assertInstanceOf(TextDelta::class, $chunks[4]);
         $this->assertSame('The answer is 42.', $chunks[4]->getText());
+    }
+
+    public function testStreamEmitsThinkingSignatureForReasoningItems()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $reasoningItem = [
+            'type' => 'reasoning',
+            'id' => 'rs_1',
+            'summary' => [
+                ['type' => 'summary_text', 'text' => 'Reasoning about it.'],
+            ],
+            'encrypted_content' => 'gAAAAA-encrypted',
+        ];
+
+        $events = [
+            [
+                'type' => 'response.output_item.done',
+                'item' => $reasoningItem,
+            ],
+            [
+                'type' => 'response.output_text.delta',
+                'delta' => 'The answer is 42.',
+            ],
+            [
+                'type' => 'response.completed',
+                'response' => [
+                    'output' => [],
+                ],
+            ],
+        ];
+
+        $raw = new InMemoryRawResult([], $events, $httpResponse);
+
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $streamResult);
+
+        $chunks = iterator_to_array($streamResult->getContent());
+
+        $this->assertInstanceOf(ThinkingSignature::class, $chunks[0]);
+        $this->assertSame($reasoningItem, json_decode($chunks[0]->getSignature(), true));
+        $this->assertInstanceOf(TextDelta::class, $chunks[1]);
     }
 
     public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

When using OpenResponses with `store: false`, the provider does not keep the reasoning state. But it also means that encrypted reasoning items must be sent back with the next request, especially after a tool call.

We currently discard those items during result conversion. The next request then loses the context the model just produced. This PR keeps them as thinking signatures so Symfony AI can replay them from the conversation history.
