### PR TITLE
[MCP Bundle] Fix FrameworkSessionStore destroy without open()

### DIFF
--- a/src/mcp-bundle/src/Session/FrameworkSessionStore.php
+++ b/src/mcp-bundle/src/Session/FrameworkSessionStore.php
@@ -61,6 +61,8 @@ final class FrameworkSessionStore implements SessionStoreInterface
 
     public function destroy(Uuid $id): bool
     {
+        $this->handler->open('', 'mcp');
+
         return $this->handler->destroy($this->getKey($id));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| License       | MIT

`FrameworkSessionStore::destroy()` calls `SessionHandlerInterface::destroy()` without calling `open()` first.

With Symfony's `AbstractSessionHandler` (e.g. `RedisSessionHandler`), it throws on HTTP DELETE /_mcp:
```
LogicException: Session name cannot be empty, did you forget to call "parent::open()" in "Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler"?
  at AbstractSessionHandler.php:101
     Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler::destroy()
  at FrameworkSessionStore.php:64
     Symfony\AI\McpBundle\Session\FrameworkSessionStore::destroy()
  at SessionManager.php:61
     Mcp\Server\Session\SessionManager::destroy()
  at Protocol.php:671
     Mcp\Server\Protocol::destroySession()
  at BaseTransport.php:161
     Mcp\Server\Transport\BaseTransport::handleSessionEnd()
  at StreamableHttpTransport.php:154
     Mcp\Server\Transport\StreamableHttpTransport::handleDeleteRequest()
  at StreamableHttpTransport.php:365
     Mcp\Server\Transport\StreamableHttpTransport::handleRequest()
     'DELETE' => $this->handleDeleteRequest()
  at McpController.php:48
     Symfony\AI\McpBundle\Controller\McpController::handle()
```

This breaks MCP Streamable HTTP session termination (`DELETE` on the MCP endpoint) when `http.session.store` is `framework`.

### Fix
Call `$this->handler->open()` before `destroy()`, as required by the `SessionHandlerInterface` lifecycle.
