### PR TITLE
[AI Bundle] Show configured components and their calls in the profiler panel

### DIFF
--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -1247,7 +1247,8 @@ The profiler panel provides insights into the agent's execution:
 
 Next to the platform calls, the registered tools and the tool calls, the panel lists the calls
 collected for agents, chats, message stores and stores, as well as every configured component
-with the service id it was registered under.
+with the service id it was registered under. Components without a configured instance are
+omitted from both the toolbar and the panel.
 
 Testing agents
 ~~~~~~~~~~~~~~

--- a/docs/bundles/ai-bundle.rst
+++ b/docs/bundles/ai-bundle.rst
@@ -1245,6 +1245,10 @@ The profiler panel provides insights into the agent's execution:
 .. image:: images/profiler-ai.png
    :alt: Profiler Panel
 
+Next to the platform calls, the registered tools and the tool calls, the panel lists the calls
+collected for agents, chats, message stores and stores, as well as every configured component
+with the service id it was registered under.
+
 Testing agents
 ~~~~~~~~~~~~~~
 

--- a/src/ai-bundle/CHANGELOG.md
+++ b/src/ai-bundle/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Show the calls collected for agents, chats, message stores and stores in the profiler panel
+ * Show the configured platforms, toolboxes, agents, chats, message stores and stores with their service ids in the profiler panel
+
 0.11
 ----
 

--- a/src/ai-bundle/config/services.php
+++ b/src/ai-bundle/config/services.php
@@ -274,12 +274,12 @@ return static function (ContainerConfigurator $container): void {
         // profiler
         ->set('ai.data_collector', DataCollector::class)
             ->args([
-                tagged_iterator('ai.traceable_platform'),
-                tagged_iterator('ai.traceable_toolbox'),
-                tagged_iterator('ai.traceable_message_store'),
-                tagged_iterator('ai.traceable_chat'),
-                tagged_iterator('ai.traceable_agent'),
-                tagged_iterator('ai.traceable_store'),
+                tagged_iterator('ai.traceable_platform', 'name'),
+                tagged_iterator('ai.traceable_toolbox', 'name'),
+                tagged_iterator('ai.traceable_message_store', 'name'),
+                tagged_iterator('ai.traceable_chat', 'name'),
+                tagged_iterator('ai.traceable_agent', 'name'),
+                tagged_iterator('ai.traceable_store', 'name'),
             ])
             ->tag('data_collector', ['id' => 'ai'])
 

--- a/src/ai-bundle/src/DependencyInjection/DebugCompilerPass.php
+++ b/src/ai-bundle/src/DependencyInjection/DebugCompilerPass.php
@@ -37,7 +37,7 @@ final class DebugCompilerPass implements CompilerPassInterface
             $traceablePlatformDefinition = (new Definition(TraceablePlatform::class))
                 ->setDecoratedService($platform, priority: -1024)
                 ->setArguments([new Reference('.inner')])
-                ->addTag('ai.traceable_platform')
+                ->addTag('ai.traceable_platform', ['name' => $platform])
                 ->addTag('kernel.reset', ['method' => 'reset']);
             $suffix = u($platform)->after('ai.platform.')->toString();
             $container->setDefinition('ai.traceable_platform.'.$suffix, $traceablePlatformDefinition);
@@ -50,7 +50,7 @@ final class DebugCompilerPass implements CompilerPassInterface
                     new Reference('.inner'),
                     new Reference(ClockInterface::class),
                 ])
-                ->addTag('ai.traceable_message_store')
+                ->addTag('ai.traceable_message_store', ['name' => $messageStore])
                 ->addTag('kernel.reset', ['method' => 'reset']);
             $suffix = u($messageStore)->afterLast('.')->toString();
             $container->setDefinition('ai.traceable_message_store.'.$suffix, $traceableMessageStoreDefinition);
@@ -63,7 +63,7 @@ final class DebugCompilerPass implements CompilerPassInterface
                     new Reference('.inner'),
                     new Reference(ClockInterface::class),
                 ])
-                ->addTag('ai.traceable_chat')
+                ->addTag('ai.traceable_chat', ['name' => $chat])
                 ->addTag('kernel.reset', ['method' => 'reset']);
             $suffix = u($chat)->afterLast('.')->toString();
             $container->setDefinition('ai.traceable_chat.'.$suffix, $traceableChatDefinition);
@@ -73,7 +73,7 @@ final class DebugCompilerPass implements CompilerPassInterface
             $traceableToolboxDefinition = (new Definition(TraceableToolbox::class))
                 ->setDecoratedService($toolbox, priority: -1024)
                 ->setArguments([new Reference('.inner')])
-                ->addTag('ai.traceable_toolbox')
+                ->addTag('ai.traceable_toolbox', ['name' => $toolbox])
                 ->addTag('kernel.reset', ['method' => 'reset']);
             $suffix = u($toolbox)->afterLast('.')->toString();
             $container->setDefinition('ai.traceable_toolbox.'.$suffix, $traceableToolboxDefinition);
@@ -83,7 +83,7 @@ final class DebugCompilerPass implements CompilerPassInterface
             $traceableAgentDefinition = (new Definition(TraceableAgent::class))
                 ->setDecoratedService($agent, priority: -1024)
                 ->setArguments([new Reference('.inner')])
-                ->addTag('ai.traceable_agent')
+                ->addTag('ai.traceable_agent', ['name' => $agent])
                 ->addTag('kernel.reset', ['method' => 'reset']);
             $suffix = u($agent)->afterLast('.')->toString();
             $container->setDefinition('ai.traceable_agent.'.$suffix, $traceableAgentDefinition);
@@ -93,7 +93,7 @@ final class DebugCompilerPass implements CompilerPassInterface
             $traceableStoreDefinition = (new Definition(TraceableStore::class))
                 ->setDecoratedService($store, priority: -1024)
                 ->setArguments([new Reference('.inner')])
-                ->addTag('ai.traceable_store')
+                ->addTag('ai.traceable_store', ['name' => $store])
                 ->addTag('kernel.reset', ['method' => 'reset']);
             $suffix = u($store)->afterLast('.')->toString();
             $container->setDefinition('ai.traceable_store.'.$suffix, $traceableStoreDefinition);

--- a/src/ai-bundle/src/Profiler/DataCollector.php
+++ b/src/ai-bundle/src/Profiler/DataCollector.php
@@ -45,6 +45,7 @@ use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
  *     metadata: Metadata,
  *     error?: array{class: class-string, message: string},
  * }
+ * @phpstan-type ConfiguredInstances array{count: int, names: string[]}
  */
 final class DataCollector extends AbstractDataCollector implements LateDataCollectorInterface
 {
@@ -110,13 +111,21 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
     public function lateCollect(): void
     {
         $this->data = [
+            'instances' => [
+                'platform' => $this->describeInstances($this->platforms),
+                'toolbox' => $this->describeInstances($this->toolboxes),
+                'message_store' => $this->describeInstances($this->messageStores),
+                'chat' => $this->describeInstances($this->chats),
+                'agent' => $this->describeInstances($this->agents),
+                'store' => $this->describeInstances($this->stores),
+            ],
             'tools' => $this->getAllTools(),
-            'platform_calls' => array_merge(...array_map($this->awaitCallResults(...), $this->platforms)),
-            'tool_calls' => array_merge(...array_map(static fn (TraceableToolbox $toolbox) => $toolbox->getCalls(), $this->toolboxes)),
-            'messages' => array_merge(...array_map(static fn (TraceableMessageStore $messageStore): array => $messageStore->getCalls(), $this->messageStores)),
-            'chats' => array_merge(...array_map(static fn (TraceableChat $chat): array => $chat->getCalls(), $this->chats)),
-            'agents' => array_merge(...array_map(static fn (TraceableAgent $agent): array => $agent->getCalls(), $this->agents)),
-            'stores' => array_merge(...array_map(static fn (TraceableStore $store): array => $store->getCalls(), $this->stores)),
+            'platform_calls' => array_merge(...array_values(array_map($this->awaitCallResults(...), $this->platforms))),
+            'tool_calls' => array_merge(...array_values(array_map(static fn (TraceableToolbox $toolbox) => $toolbox->getCalls(), $this->toolboxes))),
+            'messages' => array_merge(...array_values(array_map(static fn (TraceableMessageStore $messageStore): array => $messageStore->getCalls(), $this->messageStores))),
+            'chats' => array_merge(...array_values(array_map(static fn (TraceableChat $chat): array => $chat->getCalls(), $this->chats))),
+            'agents' => array_merge(...array_values(array_map(static fn (TraceableAgent $agent): array => $agent->getCalls(), $this->agents))),
+            'stores' => array_merge(...array_values(array_map(static fn (TraceableStore $store): array => $store->getCalls(), $this->stores))),
         ];
     }
 
@@ -136,6 +145,67 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
     public function getPlatformCalls(): array
     {
         return $this->data['platform_calls'] ?? [];
+    }
+
+    /**
+     * Sum of every call recorded across all traced components, used as headline number of the toolbar.
+     */
+    public function getTotalCalls(): int
+    {
+        return \count($this->getPlatformCalls())
+            + \count($this->getToolCalls())
+            + \count($this->getAgents())
+            + \count($this->getChats())
+            + \count($this->getStores())
+            + \count($this->getMessages());
+    }
+
+    /**
+     * @return ConfiguredInstances
+     */
+    public function getConfiguredPlatforms(): array
+    {
+        return $this->data['instances']['platform'] ?? ['count' => 0, 'names' => []];
+    }
+
+    /**
+     * @return ConfiguredInstances
+     */
+    public function getConfiguredToolboxes(): array
+    {
+        return $this->data['instances']['toolbox'] ?? ['count' => 0, 'names' => []];
+    }
+
+    /**
+     * @return ConfiguredInstances
+     */
+    public function getConfiguredMessageStores(): array
+    {
+        return $this->data['instances']['message_store'] ?? ['count' => 0, 'names' => []];
+    }
+
+    /**
+     * @return ConfiguredInstances
+     */
+    public function getConfiguredChats(): array
+    {
+        return $this->data['instances']['chat'] ?? ['count' => 0, 'names' => []];
+    }
+
+    /**
+     * @return ConfiguredInstances
+     */
+    public function getConfiguredAgents(): array
+    {
+        return $this->data['instances']['agent'] ?? ['count' => 0, 'names' => []];
+    }
+
+    /**
+     * @return ConfiguredInstances
+     */
+    public function getConfiguredStores(): array
+    {
+        return $this->data['instances']['store'] ?? ['count' => 0, 'names' => []];
     }
 
     /**
@@ -184,6 +254,22 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
     public function getStores(): array
     {
         return $this->data['stores'] ?? [];
+    }
+
+    /**
+     * The traceable services are collected through indexed tagged iterators, so their keys carry
+     * the service id of the decorated instance. Plain lists stay supported and only expose a count.
+     *
+     * @param array<array-key, object> $instances
+     *
+     * @return ConfiguredInstances
+     */
+    private function describeInstances(array $instances): array
+    {
+        return [
+            'count' => \count($instances),
+            'names' => array_values(array_filter(array_keys($instances), \is_string(...))),
+        ];
     }
 
     /**

--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -1,10 +1,10 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
-    {% if collector.platformCalls|length > 0 %}
+    {% if collector.totalCalls > 0 %}
         {% set icon %}
             {{ include('@Ai/icon.svg') }}
-            <span class="sf-toolbar-value">{{ collector.platformCalls|length }}</span>
+            <span class="sf-toolbar-value">{{ collector.totalCalls }}</span>
             <span class="sf-toolbar-info-piece-additional-detail">
                 <span class="sf-toolbar-label">calls</span>
             </span>
@@ -14,7 +14,7 @@
             <div class="sf-toolbar-info-piece">
                 <div class="sf-toolbar-info-piece">
                     <b class="label">Configured Platforms</b>
-                    <span class="sf-toolbar-status">1</span>
+                    <span class="sf-toolbar-status">{{ collector.configuredPlatforms.count }}</span>
                 </div>
                 <div class="sf-toolbar-info-piece">
                     <b class="label">Platform Calls</b>
@@ -25,20 +25,40 @@
                     <span class="sf-toolbar-status">{{ collector.tools|length }}</span>
                 </div>
                 <div class="sf-toolbar-info-piece">
-                    <b class="label">Messages stored</b>
-                    <span class="sf-toolbar-status">{{ collector.messages|length }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
                     <b class="label">Tool Calls</b>
                     <span class="sf-toolbar-status">{{ collector.toolCalls|length }}</span>
                 </div>
                 <div class="sf-toolbar-info-piece">
-                    <b class="label">Chats sent</b>
+                    <b class="label">Configured Agents</b>
+                    <span class="sf-toolbar-status">{{ collector.configuredAgents.count }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Agent Calls</b>
+                    <span class="sf-toolbar-status">{{ collector.agents|length }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Configured Chats</b>
+                    <span class="sf-toolbar-status">{{ collector.configuredChats.count }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Chat Calls</b>
                     <span class="sf-toolbar-status">{{ collector.chats|length }}</span>
                 </div>
                 <div class="sf-toolbar-info-piece">
-                    <b class="label">Stores used</b>
+                    <b class="label">Configured Stores</b>
+                    <span class="sf-toolbar-status">{{ collector.configuredStores.count }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Store Calls</b>
                     <span class="sf-toolbar-status">{{ collector.stores|length }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Configured Message Stores</b>
+                    <span class="sf-toolbar-status">{{ collector.configuredMessageStores.count }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Messages stored</b>
+                    <span class="sf-toolbar-status">{{ collector.messages|length }}</span>
                 </div>
             </div>
         {% endset %}
@@ -51,9 +71,73 @@
     <span class="label">
         <span class="icon">{{ include('@Ai/icon.svg') }}</span>
         <strong>Symfony AI</strong>
-        <span class="count">{{ collector.platformCalls|length }}</span>
+        <span class="count">{{ collector.totalCalls }}</span>
     </span>
 {% endblock %}
+
+{% macro message_bag(input) %}
+    {% if input.content is defined and input.messages is not defined %}{# expect UserMessage #}
+        {% for item in input.content %}
+            {% if item.text is defined %}
+                {{ item.text|nl2br }}
+            {% else %}
+                {{ dump(item) }}
+            {% endif %}
+        {% endfor %}
+    {% elseif input.messages is defined %}{# expect MessageBag #}
+        <ol>
+            {% for message in input.messages %}
+                <li>
+                    <strong>{{ message.role.value|title }}:</strong>
+                    {% if 'assistant' == message.role.value %}
+                        {% for part in message.content %}
+                            {% if part.text is defined %}{# Text #}
+                                {{ part.text|nl2br }}
+                            {% elseif part.code is defined %}{# ExecutableCode #}
+                                <pre><code>{{ part.code }}</code></pre>
+                            {% elseif part.output is defined %}{# CodeExecution #}
+                                <pre>{{ part.output }}</pre>
+                            {% elseif part.arguments is defined %}{# ToolCall #}
+                                <strong>{{ part.name }}({{ part.arguments|map((value, key) => "#{key}: #{value|json_encode}")|join(', ') }})</strong>
+                                <i>(ID: {{ part.id }})</i>
+                            {% elseif part.content is defined %}{# Thinking #}
+                                <details><summary><i>Thinking</i></summary>{{ part.content|nl2br }}</details>
+                            {% endif %}
+                        {% endfor %}
+                    {% elseif 'tool' == message.role.value %}
+                        <i>Result of tool call with ID {{ message.toolCall.id }}</i><br />
+                        {% for item in message.content %}
+                            {% if item.text is defined %}
+                                {{ item.text|nl2br }}
+                            {% else %}
+                                {{ item }}
+                            {% endif %}
+                        {% endfor %}
+                    {% elseif 'user' == message.role.value %}
+                        {% for item in message.content %}
+                            {% if item.text is defined %}
+                                {{ item.text|nl2br }}
+                            {% elseif item.format is defined and item.format starts with 'image/'  %}
+                                <img src="{{ item.asDataUrl }}" style="max-width: 100%;"/>
+                            {% elseif item.asDataUrl is defined %}
+                                <a href="{{ item.asDataUrl }}" download="{{ item.filename ?? 'View File' }}">{{ item.filename ?? 'View File' }}</a>
+                            {% elseif item.url is defined %}{# ImageUrl, DocumentUrl #}
+                                <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.url }}</a>
+                            {% endif %}
+                        {% endfor %}
+                    {% elseif message.content.template is defined %}{# SystemMessage holding a Template #}
+                        {{ message.content.template|nl2br }}
+                        <small><i>(template type: {{ message.content.type }})</i></small>
+                    {% else %}
+                        {{ message.content|nl2br }}
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ol>
+    {% else %}
+        {{ dump(input) }}
+    {% endif %}
+{% endmacro %}
 
 {% macro tool_calls(toolCalls) %}
     Tool call{{ toolCalls|length > 1 ? 's' }}:
@@ -76,7 +160,7 @@
     <section class="metrics">
         <div class="metric-group">
             <div class="metric">
-                <span class="value">1</span>
+                <span class="value">{{ collector.configuredPlatforms.count }}</span>
                 <span class="label">Platforms</span>
             </div>
             <div class="metric">
@@ -93,6 +177,50 @@
             <div class="metric">
                 <span class="value">{{ collector.toolCalls|length }}</span>
                 <span class="label">Tool Calls</span>
+            </div>
+        </div>
+        <div class="metric-divider"></div>
+        <div class="metric-group">
+            <div class="metric">
+                <span class="value">{{ collector.configuredAgents.count }}</span>
+                <span class="label">Agents</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ collector.agents|length }}</span>
+                <span class="label">Agent Calls</span>
+            </div>
+        </div>
+        <div class="metric-divider"></div>
+        <div class="metric-group">
+            <div class="metric">
+                <span class="value">{{ collector.configuredChats.count }}</span>
+                <span class="label">Chats</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ collector.chats|length }}</span>
+                <span class="label">Chat Calls</span>
+            </div>
+        </div>
+        <div class="metric-divider"></div>
+        <div class="metric-group">
+            <div class="metric">
+                <span class="value">{{ collector.configuredStores.count }}</span>
+                <span class="label">Stores</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ collector.stores|length }}</span>
+                <span class="label">Store Calls</span>
+            </div>
+        </div>
+        <div class="metric-divider"></div>
+        <div class="metric-group">
+            <div class="metric">
+                <span class="value">{{ collector.configuredMessageStores.count }}</span>
+                <span class="label">Message Stores</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ collector.messages|length }}</span>
+                <span class="label">Messages Stored</span>
             </div>
         </div>
     </section>
@@ -117,59 +245,7 @@
                                 <tr>
                                     <th>Input</th>
                                     <td>
-                                        {% if call.input.messages is defined %}{# expect MessageBag #}
-                                            <ol>
-                                                {% for message in call.input.messages %}
-                                                    <li>
-                                                        <strong>{{ message.role.value|title }}:</strong>
-                                                        {% if 'assistant' == message.role.value %}
-                                                            {% for part in message.content %}
-                                                                {% if part.text is defined %}{# Text #}
-                                                                    {{ part.text|nl2br }}
-                                                                {% elseif part.code is defined %}{# ExecutableCode #}
-                                                                    <pre><code>{{ part.code }}</code></pre>
-                                                                {% elseif part.output is defined %}{# CodeExecution #}
-                                                                    <pre>{{ part.output }}</pre>
-                                                                {% elseif part.arguments is defined %}{# ToolCall #}
-                                                                    <strong>{{ part.name }}({{ part.arguments|map((value, key) => "#{key}: #{value|json_encode}")|join(', ') }})</strong>
-                                                                    <i>(ID: {{ part.id }})</i>
-                                                                {% elseif part.content is defined %}{# Thinking #}
-                                                                    <details><summary><i>Thinking</i></summary>{{ part.content|nl2br }}</details>
-                                                                {% endif %}
-                                                            {% endfor %}
-                                                        {% elseif 'tool' == message.role.value %}
-                                                            <i>Result of tool call with ID {{ message.toolCall.id }}</i><br />
-                                                            {% for item in message.content %}
-                                                                {% if item.text is defined %}
-                                                                    {{ item.text|nl2br }}
-                                                                {% else %}
-                                                                    {{ item }}
-                                                                {% endif %}
-                                                            {% endfor %}
-                                                        {% elseif 'user' == message.role.value %}
-                                                            {% for item in message.content %}
-                                                                {% if item.text is defined %}
-                                                                    {{ item.text|nl2br }}
-                                                                {% elseif item.format is defined and item.format starts with 'image/'  %}
-                                                                    <img src="{{ item.asDataUrl }}" style="max-width: 100%;"/>
-                                                                {% elseif item.asDataUrl is defined %}
-                                                                    <a href="{{ item.asDataUrl }}" download="{{ item.filename ?? 'View File' }}">{{ item.filename ?? 'View File' }}</a>
-                                                                {% elseif item.url is defined %}{# ImageUrl, DocumentUrl #}
-                                                                    <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.url }}</a>
-                                                                {% endif %}
-                                                            {% endfor %}
-                                                        {% elseif message.content.template is defined %}{# SystemMessage holding a Template #}
-                                                            {{ message.content.template|nl2br }}
-                                                            <small><i>(template type: {{ message.content.type }})</i></small>
-                                                        {% else %}
-                                                            {{ message.content|nl2br }}
-                                                        {% endif %}
-                                                    </li>
-                                                {% endfor %}
-                                            </ol>
-                                        {% else %}
-                                            {{ dump(call.input) }}
-                                        {% endif %}
+                                        {{ _self.message_bag(call.input) }}
                                     </td>
                                 </tr>
                                 <tr>
@@ -316,4 +392,190 @@
             <p>No tool calls were made.</p>
         </div>
     {% endif %}
+
+    <h3>Agent Calls</h3>
+    {% if collector.agents|length %}
+        {% for call in collector.agents %}
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th colspan="2">Call {{ loop.index }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <th>Input</th>
+                        <td>
+                            {% if call.input.messages is defined or call.input.content is defined %}
+                                {{ _self.message_bag(call.input) }}
+                            {% else %}
+                                {{ call.input }}
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Options</th>
+                        <td>{{ [] == call.options ? '<i>none</i>'|raw : dump(call.options) }}</td>
+                    </tr>
+                    <tr>
+                        <th>Called at</th>
+                        <td>{{ call.called_at|date('H:i:s.v') }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        {% endfor %}
+    {% else %}
+        <div class="empty">
+            <p>No agent calls were made.</p>
+        </div>
+    {% endif %}
+
+    <h3>Chat Calls</h3>
+    {% if collector.chats|length %}
+        {% for call in collector.chats %}
+            {% set called_at = call.submitted_at ?? call.streamed_at ?? call.initiated_at ?? null %}
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th colspan="2">{{ call.action }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <th>Message{{ call.bag is defined ? 's' }}</th>
+                        <td>{{ _self.message_bag(call.bag ?? call.message) }}</td>
+                    </tr>
+                    {% if called_at is not null %}
+                        <tr>
+                            <th>Called at</th>
+                            <td>{{ called_at|date('H:i:s.v') }}</td>
+                        </tr>
+                    {% endif %}
+                </tbody>
+            </table>
+        {% endfor %}
+    {% else %}
+        <div class="empty">
+            <p>No chat calls were made.</p>
+        </div>
+    {% endif %}
+
+    <h3>Message Store Calls</h3>
+    {% if collector.messages|length %}
+        {% for call in collector.messages %}
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th colspan="2">Save {{ loop.index }} <span class="badge">{{ call.bag.messages|length }} message{{ call.bag.messages|length > 1 ? 's' }}</span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <th>Messages</th>
+                        <td>{{ _self.message_bag(call.bag) }}</td>
+                    </tr>
+                    <tr>
+                        <th>Saved at</th>
+                        <td>{{ call.saved_at|date('H:i:s.v') }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        {% endfor %}
+    {% else %}
+        <div class="empty">
+            <p>No messages were stored.</p>
+        </div>
+    {% endif %}
+
+    <h3>Store Calls</h3>
+    {% if collector.stores|length %}
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Method</th>
+                    <th>Payload</th>
+                    <th>Options</th>
+                    <th>Called at</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for call in collector.stores %}
+                    <tr>
+                        <th>{{ call.method }}</th>
+                        <td>
+                            {% if call.documents is defined %}
+                                {% set documents = call.documents.id is defined ? [call.documents] : call.documents %}
+                                {{ documents|length }} document{{ documents|length > 1 ? 's' }}
+                                <ol>
+                                    {% for document in documents %}
+                                        <li>
+                                            <code>{{ document.id }}</code>
+                                            {% if document.vector is defined %}
+                                                &mdash; vector with <strong>{{ document.vector.dimensions }}</strong> dimensions
+                                            {% endif %}
+                                        </li>
+                                    {% endfor %}
+                                </ol>
+                            {% elseif call.query is defined %}
+                                {% if call.query.text is defined %}
+                                    {{ call.query.text }}
+                                {% endif %}
+                                {% if call.query.vector is defined %}
+                                    Vector with <strong>{{ call.query.vector.dimensions }}</strong> dimensions
+                                {% endif %}
+                                {% if call.query.text is not defined and call.query.vector is not defined %}
+                                    {{ dump(call.query) }}
+                                {% endif %}
+                            {% elseif call.ids is defined %}
+                                {{ dump(call.ids) }}
+                            {% else %}
+                                <i>none</i>
+                            {% endif %}
+                        </td>
+                        <td>{{ [] == call.options|default([]) ? '<i>none</i>'|raw : dump(call.options) }}</td>
+                        <td>{{ call.called_at|date('H:i:s.v') }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <div class="empty">
+            <p>No store calls were made.</p>
+        </div>
+    {% endif %}
+
+    <h3>Configured Components</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Component</th>
+                <th>Configured</th>
+                <th>Services</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for label, instances in {
+                'Platforms': collector.configuredPlatforms,
+                'Toolboxes': collector.configuredToolboxes,
+                'Agents': collector.configuredAgents,
+                'Chats': collector.configuredChats,
+                'Message Stores': collector.configuredMessageStores,
+                'Stores': collector.configuredStores,
+            } %}
+                <tr>
+                    <th>{{ label }}</th>
+                    <td>{{ instances.count }}</td>
+                    <td>
+                        {% if instances.names|length %}
+                            {% for name in instances.names %}
+                                <code>{{ name }}</code>{{ not loop.last ? ', ' }}
+                            {% endfor %}
+                        {% else %}
+                            <i>none</i>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 {% endblock %}

--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -23,54 +23,52 @@
 
         {% set text %}
             <div class="sf-toolbar-info-piece">
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Configured Platforms</b>
-                    <span class="sf-toolbar-status">{{ collector.configuredPlatforms.count }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Platform Calls</b>
-                    <span class="sf-toolbar-status">{{ collector.platformCalls|length }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Registered Tools</b>
-                    <span class="sf-toolbar-status">{{ collector.tools|length }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Tool Calls</b>
-                    <span class="sf-toolbar-status">{{ collector.toolCalls|length }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Configured Agents</b>
-                    <span class="sf-toolbar-status">{{ collector.configuredAgents.count }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Agent Calls</b>
-                    <span class="sf-toolbar-status">{{ collector.agents|length }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Configured Chats</b>
-                    <span class="sf-toolbar-status">{{ collector.configuredChats.count }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Chat Calls</b>
-                    <span class="sf-toolbar-status">{{ collector.chats|length }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Configured Stores</b>
-                    <span class="sf-toolbar-status">{{ collector.configuredStores.count }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Store Calls</b>
-                    <span class="sf-toolbar-status">{{ collector.stores|length }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Configured Message Stores</b>
-                    <span class="sf-toolbar-status">{{ collector.configuredMessageStores.count }}</span>
-                </div>
-                <div class="sf-toolbar-info-piece">
-                    <b class="label">Messages stored</b>
-                    <span class="sf-toolbar-status">{{ collector.messages|length }}</span>
-                </div>
+                <b class="label">Configured Platforms</b>
+                <span class="sf-toolbar-status">{{ collector.configuredPlatforms.count }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Platform Calls</b>
+                <span class="sf-toolbar-status">{{ collector.platformCalls|length }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Registered Tools</b>
+                <span class="sf-toolbar-status">{{ collector.tools|length }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Tool Calls</b>
+                <span class="sf-toolbar-status">{{ collector.toolCalls|length }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Configured Agents</b>
+                <span class="sf-toolbar-status">{{ collector.configuredAgents.count }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Agent Calls</b>
+                <span class="sf-toolbar-status">{{ collector.agents|length }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Configured Chats</b>
+                <span class="sf-toolbar-status">{{ collector.configuredChats.count }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Chat Calls</b>
+                <span class="sf-toolbar-status">{{ collector.chats|length }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Configured Stores</b>
+                <span class="sf-toolbar-status">{{ collector.configuredStores.count }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Store Calls</b>
+                <span class="sf-toolbar-status">{{ collector.stores|length }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Configured Message Stores</b>
+                <span class="sf-toolbar-status">{{ collector.configuredMessageStores.count }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b class="label">Messages Stored</b>
+                <span class="sf-toolbar-status">{{ collector.messages|length }}</span>
             </div>
         {% endset %}
 

--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -1,5 +1,16 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
+{% block stylesheets %}
+    {{ parent() }}
+
+    <style>
+        {# the metric groups wrap into multiple rows, which the profiler CSS does not space out vertically #}
+        .ai-metrics {
+            row-gap: 1em;
+        }
+    </style>
+{% endblock %}
+
 {% block toolbar %}
     {% if collector.totalCalls > 0 %}
         {% set icon %}
@@ -157,7 +168,7 @@
 
 {% block panel %}
     <h2>Symfony AI</h2>
-    <section class="metrics">
+    <section class="metrics ai-metrics">
         <div class="metric-group">
             <div class="metric">
                 <span class="value">{{ collector.configuredPlatforms.count }}</span>

--- a/src/ai-bundle/templates/data_collector.html.twig
+++ b/src/ai-bundle/templates/data_collector.html.twig
@@ -22,54 +22,66 @@
         {% endset %}
 
         {% set text %}
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Configured Platforms</b>
-                <span class="sf-toolbar-status">{{ collector.configuredPlatforms.count }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Platform Calls</b>
-                <span class="sf-toolbar-status">{{ collector.platformCalls|length }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Registered Tools</b>
-                <span class="sf-toolbar-status">{{ collector.tools|length }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Tool Calls</b>
-                <span class="sf-toolbar-status">{{ collector.toolCalls|length }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Configured Agents</b>
-                <span class="sf-toolbar-status">{{ collector.configuredAgents.count }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Agent Calls</b>
-                <span class="sf-toolbar-status">{{ collector.agents|length }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Configured Chats</b>
-                <span class="sf-toolbar-status">{{ collector.configuredChats.count }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Chat Calls</b>
-                <span class="sf-toolbar-status">{{ collector.chats|length }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Configured Stores</b>
-                <span class="sf-toolbar-status">{{ collector.configuredStores.count }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Store Calls</b>
-                <span class="sf-toolbar-status">{{ collector.stores|length }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Configured Message Stores</b>
-                <span class="sf-toolbar-status">{{ collector.configuredMessageStores.count }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Messages Stored</b>
-                <span class="sf-toolbar-status">{{ collector.messages|length }}</span>
-            </div>
+            {% if collector.configuredPlatforms.count > 0 %}
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Configured Platforms</b>
+                    <span class="sf-toolbar-status">{{ collector.configuredPlatforms.count }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Platform Calls</b>
+                    <span class="sf-toolbar-status">{{ collector.platformCalls|length }}</span>
+                </div>
+            {% endif %}
+            {% if collector.configuredToolboxes.count > 0 %}
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Registered Tools</b>
+                    <span class="sf-toolbar-status">{{ collector.tools|length }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Tool Calls</b>
+                    <span class="sf-toolbar-status">{{ collector.toolCalls|length }}</span>
+                </div>
+            {% endif %}
+            {% if collector.configuredAgents.count > 0 %}
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Configured Agents</b>
+                    <span class="sf-toolbar-status">{{ collector.configuredAgents.count }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Agent Calls</b>
+                    <span class="sf-toolbar-status">{{ collector.agents|length }}</span>
+                </div>
+            {% endif %}
+            {% if collector.configuredChats.count > 0 %}
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Configured Chats</b>
+                    <span class="sf-toolbar-status">{{ collector.configuredChats.count }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Chat Calls</b>
+                    <span class="sf-toolbar-status">{{ collector.chats|length }}</span>
+                </div>
+            {% endif %}
+            {% if collector.configuredStores.count > 0 %}
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Configured Stores</b>
+                    <span class="sf-toolbar-status">{{ collector.configuredStores.count }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Store Calls</b>
+                    <span class="sf-toolbar-status">{{ collector.stores|length }}</span>
+                </div>
+            {% endif %}
+            {% if collector.configuredMessageStores.count > 0 %}
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Configured Message Stores</b>
+                    <span class="sf-toolbar-status">{{ collector.configuredMessageStores.count }}</span>
+                </div>
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">Messages Stored</b>
+                    <span class="sf-toolbar-status">{{ collector.messages|length }}</span>
+                </div>
+            {% endif %}
         {% endset %}
 
         {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { 'link': true }) }}
@@ -165,426 +177,441 @@
 {% endmacro %}
 
 {% block panel %}
+    {% set ai_components = [
+        {
+            label: 'Platforms',
+            count: collector.configuredPlatforms.count,
+            calls_label: 'Platform Calls',
+            calls: collector.platformCalls|length,
+            services_label: 'Platforms',
+            instances: collector.configuredPlatforms,
+        },
+        {
+            label: 'Tools',
+            count: collector.tools|length,
+            calls_label: 'Tool Calls',
+            calls: collector.toolCalls|length,
+            services_label: 'Toolboxes',
+            instances: collector.configuredToolboxes,
+        },
+        {
+            label: 'Agents',
+            count: collector.configuredAgents.count,
+            calls_label: 'Agent Calls',
+            calls: collector.agents|length,
+            services_label: 'Agents',
+            instances: collector.configuredAgents,
+        },
+        {
+            label: 'Chats',
+            count: collector.configuredChats.count,
+            calls_label: 'Chat Calls',
+            calls: collector.chats|length,
+            services_label: 'Chats',
+            instances: collector.configuredChats,
+        },
+        {
+            label: 'Stores',
+            count: collector.configuredStores.count,
+            calls_label: 'Store Calls',
+            calls: collector.stores|length,
+            services_label: 'Stores',
+            instances: collector.configuredStores,
+        },
+        {
+            label: 'Message Stores',
+            count: collector.configuredMessageStores.count,
+            calls_label: 'Messages Stored',
+            calls: collector.messages|length,
+            services_label: 'Message Stores',
+            instances: collector.configuredMessageStores,
+        },
+    ]|filter(component => component.instances.count > 0) %}
+
     <h2>Symfony AI</h2>
-    <section class="metrics ai-metrics">
-        <div class="metric-group">
-            <div class="metric">
-                <span class="value">{{ collector.configuredPlatforms.count }}</span>
-                <span class="label">Platforms</span>
-            </div>
-            <div class="metric">
-                <span class="value">{{ collector.platformCalls|length }}</span>
-                <span class="label">Platform Calls</span>
-            </div>
+    {% if ai_components is empty %}
+        <div class="empty">
+            <p>No AI components are configured.</p>
         </div>
-        <div class="metric-divider"></div>
-        <div class="metric-group">
-            <div class="metric">
-                <span class="value">{{ collector.tools|length }}</span>
-                <span class="label">Tools</span>
-            </div>
-            <div class="metric">
-                <span class="value">{{ collector.toolCalls|length }}</span>
-                <span class="label">Tool Calls</span>
-            </div>
-        </div>
-        <div class="metric-divider"></div>
-        <div class="metric-group">
-            <div class="metric">
-                <span class="value">{{ collector.configuredAgents.count }}</span>
-                <span class="label">Agents</span>
-            </div>
-            <div class="metric">
-                <span class="value">{{ collector.agents|length }}</span>
-                <span class="label">Agent Calls</span>
-            </div>
-        </div>
-        <div class="metric-divider"></div>
-        <div class="metric-group">
-            <div class="metric">
-                <span class="value">{{ collector.configuredChats.count }}</span>
-                <span class="label">Chats</span>
-            </div>
-            <div class="metric">
-                <span class="value">{{ collector.chats|length }}</span>
-                <span class="label">Chat Calls</span>
-            </div>
-        </div>
-        <div class="metric-divider"></div>
-        <div class="metric-group">
-            <div class="metric">
-                <span class="value">{{ collector.configuredStores.count }}</span>
-                <span class="label">Stores</span>
-            </div>
-            <div class="metric">
-                <span class="value">{{ collector.stores|length }}</span>
-                <span class="label">Store Calls</span>
-            </div>
-        </div>
-        <div class="metric-divider"></div>
-        <div class="metric-group">
-            <div class="metric">
-                <span class="value">{{ collector.configuredMessageStores.count }}</span>
-                <span class="label">Message Stores</span>
-            </div>
-            <div class="metric">
-                <span class="value">{{ collector.messages|length }}</span>
-                <span class="label">Messages Stored</span>
-            </div>
-        </div>
-    </section>
-    <h3>Platform Calls</h3>
-    {% if collector.platformCalls|length %}
-        <div class="sf-tabs">
-            <div class="tab {{ collector.platformCalls|length == 0 ? 'disabled' }}">
-                <h3 class="tab-title">Platform Calls <span class="badge">{{ collector.platformCalls|length }}</span></h3>
-                <div class="tab-content">
-                    {% for call in collector.platformCalls %}
-                        <table class="table">
-                            <thead>
-                                <tr>
-                                    <th colspan="2">Call {{ loop.index }}</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <th>Model</th>
-                                    <td><strong>{{ call.model }}</strong></td>
-                                </tr>
-                                <tr>
-                                    <th>Input</th>
-                                    <td>
-                                        {{ _self.message_bag(call.input) }}
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>Options</th>
-                                    <td>
-                                        <ul>
-                                            {% for key, value in call.options %}
-                                                {% if key == 'tools' %}
-                                                    <li>{{ key }}:
-                                                        <ul>
-                                                            {% for tool in value %}
-                                                                <li>
-                                                                    <strong>{{ tool.name }}</strong>
-                                                                    {% if tool.parameters %}
-                                                                        <button class="btn btn-sm hidden" data-clipboard-text="{{ tool.parameters|json_encode|e('html_attr') }}">Copy JSON Schema</button>
-                                                                        {{ dump(tool.parameters) }}
-                                                                    {% endif %}
-                                                                </li>
-                                                            {% endfor %}
-                                                        </ul>
-                                                    </li>
-                                                {% else %}
-                                                    <li>{{ key }}: {{ dump(value) }}</li>
-                                                {% endif %}
-                                            {% endfor %}
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>Result</th>
-                                    <td>
-                                        {% if call.result_type == 'tool_calls' %}
-                                            {{ _self.tool_calls(call.result) }}
-                                        {% elseif call.result_type == 'vectors' %}
-                                            <ol>
-                                                {% for vector in call.result %}
-                                                    <li>Vector with <strong>{{ vector.dimensions }}</strong> dimensions</li>
-                                                {% endfor %}
-                                            </ol>
-                                        {% elseif call.result_type == 'error' %}
-                                            <strong class="status-error">Failed:</strong>
-                                            <code>{{ call.error.class }}</code>: {{ call.error.message }}
-                                        {% else %}
-                                            {{ dump(call.result) }}
-                                        {% endif %}
-                                        {% if call.metadata|length > 0 %}
-                                            <br />
-                                            <strong>Metadata</strong>
+    {% else %}
+        <section class="metrics ai-metrics">
+            {% for component in ai_components %}
+                {% if not loop.first %}
+                    <div class="metric-divider"></div>
+                {% endif %}
+                <div class="metric-group">
+                    <div class="metric">
+                        <span class="value">{{ component.count }}</span>
+                        <span class="label">{{ component.label }}</span>
+                    </div>
+                    <div class="metric">
+                        <span class="value">{{ component.calls }}</span>
+                        <span class="label">{{ component.calls_label }}</span>
+                    </div>
+                </div>
+            {% endfor %}
+        </section>
+    {% endif %}
+
+    {% if collector.configuredPlatforms.count > 0 %}
+        <h3>Platform Calls</h3>
+        {% if collector.platformCalls|length %}
+            <div class="sf-tabs">
+                <div class="tab {{ collector.platformCalls|length == 0 ? 'disabled' }}">
+                    <h3 class="tab-title">Platform Calls <span class="badge">{{ collector.platformCalls|length }}</span></h3>
+                    <div class="tab-content">
+                        {% for call in collector.platformCalls %}
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th colspan="2">Call {{ loop.index }}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th>Model</th>
+                                        <td><strong>{{ call.model }}</strong></td>
+                                    </tr>
+                                    <tr>
+                                        <th>Input</th>
+                                        <td>
+                                            {{ _self.message_bag(call.input) }}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th>Options</th>
+                                        <td>
                                             <ul>
-                                                {% for key, value in call.metadata.all %}
-                                                    <li>{{ key }}:<br />{{ dump(value) }}</li>
+                                                {% for key, value in call.options %}
+                                                    {% if key == 'tools' %}
+                                                        <li>{{ key }}:
+                                                            <ul>
+                                                                {% for tool in value %}
+                                                                    <li>
+                                                                        <strong>{{ tool.name }}</strong>
+                                                                        {% if tool.parameters %}
+                                                                            <button class="btn btn-sm hidden" data-clipboard-text="{{ tool.parameters|json_encode|e('html_attr') }}">Copy JSON Schema</button>
+                                                                            {{ dump(tool.parameters) }}
+                                                                        {% endif %}
+                                                                    </li>
+                                                                {% endfor %}
+                                                            </ul>
+                                                        </li>
+                                                    {% else %}
+                                                        <li>{{ key }}: {{ dump(value) }}</li>
+                                                    {% endif %}
                                                 {% endfor %}
                                             </ul>
-                                        {% endif %}
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    {% endfor %}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th>Result</th>
+                                        <td>
+                                            {% if call.result_type == 'tool_calls' %}
+                                                {{ _self.tool_calls(call.result) }}
+                                            {% elseif call.result_type == 'vectors' %}
+                                                <ol>
+                                                    {% for vector in call.result %}
+                                                        <li>Vector with <strong>{{ vector.dimensions }}</strong> dimensions</li>
+                                                    {% endfor %}
+                                                </ol>
+                                            {% elseif call.result_type == 'error' %}
+                                                <strong class="status-error">Failed:</strong>
+                                                <code>{{ call.error.class }}</code>: {{ call.error.message }}
+                                            {% else %}
+                                                {{ dump(call.result) }}
+                                            {% endif %}
+                                            {% if call.metadata|length > 0 %}
+                                                <br />
+                                                <strong>Metadata</strong>
+                                                <ul>
+                                                    {% for key, value in call.metadata.all %}
+                                                        <li>{{ key }}:<br />{{ dump(value) }}</li>
+                                                    {% endfor %}
+                                                </ul>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        {% endfor %}
+                    </div>
                 </div>
             </div>
-        </div>
-    {% else %}
-        <div class="empty">
-            <p>No platform calls were made.</p>
-        </div>
+        {% else %}
+            <div class="empty">
+                <p>No platform calls were made.</p>
+            </div>
+        {% endif %}
     {% endif %}
 
-    <h3>Tools</h3>
-    {% if collector.tools|length %}
-        <table class="table">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Description</th>
-                    <th>Class & Method</th>
-                    <th>Parameters</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for tool in collector.tools %}
-                    <tr>
-                        <th>{{ tool.name }}</th>
-                        <td>{{ tool.description }}</td>
-                        <td>{{ tool.reference.class }}::{{ tool.reference.method }}</td>
-                        <td>
-                            {% if tool.parameters %}
-                                <ul>
-                                    {% for name, parameter in tool.parameters.properties %}
-                                        {% set parameterType %}
-                                            {%- if parameter.type is defined -%}
-                                                {{ parameter.type is iterable ? parameter.type|join(', ') : parameter.type }}
-                                            {%- elseif parameter.anyOf is defined -%}
-                                                {{ parameter.anyOf|map(p => p.type)|join(', ') }}
-                                            {%- endif -%}
-                                        {% endset %}
-                                        <li>
-                                            <strong>{{ name }} ({{ parameterType }})</strong><br />
-                                            <i>{{ parameter.description|default() }}</i>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                            {% else %}
-                                <i>none</i>
-                            {% endif %}
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% else %}
-        <div class="empty">
-            <p>No tools were registered.</p>
-        </div>
-    {% endif %}
-
-    <h3>Tool Calls</h3>
-    {% if collector.toolCalls|length %}
-        {% for toolResult in collector.toolCalls %}
+    {% if collector.configuredToolboxes.count > 0 %}
+        <h3>Tools</h3>
+        {% if collector.tools|length %}
             <table class="table">
                 <thead>
                     <tr>
-                        <th colspan="2">{{ toolResult.toolCall.name }}</th>
+                        <th>Name</th>
+                        <th>Description</th>
+                        <th>Class & Method</th>
+                        <th>Parameters</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <th>ID</th>
-                        <td>{{ toolResult.toolCall.id }}</td>
-                    </tr>
-                    <tr>
-                        <th>Arguments</th>
-                        <td>{{ dump(toolResult.toolCall.arguments) }}</td>
-                    </tr>
-                    <tr>
-                        <th>Result</th>
-                        <td>{{ dump(toolResult.result) }}</td>
-                    </tr>
+                    {% for tool in collector.tools %}
+                        <tr>
+                            <th>{{ tool.name }}</th>
+                            <td>{{ tool.description }}</td>
+                            <td>{{ tool.reference.class }}::{{ tool.reference.method }}</td>
+                            <td>
+                                {% if tool.parameters %}
+                                    <ul>
+                                        {% for name, parameter in tool.parameters.properties %}
+                                            {% set parameterType %}
+                                                {%- if parameter.type is defined -%}
+                                                    {{ parameter.type is iterable ? parameter.type|join(', ') : parameter.type }}
+                                                {%- elseif parameter.anyOf is defined -%}
+                                                    {{ parameter.anyOf|map(p => p.type)|join(', ') }}
+                                                {%- endif -%}
+                                            {% endset %}
+                                            <li>
+                                                <strong>{{ name }} ({{ parameterType }})</strong><br />
+                                                <i>{{ parameter.description|default() }}</i>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                {% else %}
+                                    <i>none</i>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
                 </tbody>
             </table>
-        {% endfor %}
-    {% else %}
-        <div class="empty">
-            <p>No tool calls were made.</p>
-        </div>
+        {% else %}
+            <div class="empty">
+                <p>No tools were registered.</p>
+            </div>
+        {% endif %}
+
+        <h3>Tool Calls</h3>
+        {% if collector.toolCalls|length %}
+            {% for toolResult in collector.toolCalls %}
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th colspan="2">{{ toolResult.toolCall.name }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th>ID</th>
+                            <td>{{ toolResult.toolCall.id }}</td>
+                        </tr>
+                        <tr>
+                            <th>Arguments</th>
+                            <td>{{ dump(toolResult.toolCall.arguments) }}</td>
+                        </tr>
+                        <tr>
+                            <th>Result</th>
+                            <td>{{ dump(toolResult.result) }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            {% endfor %}
+        {% else %}
+            <div class="empty">
+                <p>No tool calls were made.</p>
+            </div>
+        {% endif %}
     {% endif %}
 
-    <h3>Agent Calls</h3>
-    {% if collector.agents|length %}
-        {% for call in collector.agents %}
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th colspan="2">Call {{ loop.index }}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <th>Input</th>
-                        <td>
-                            {% if call.input.messages is defined or call.input.content is defined %}
-                                {{ _self.message_bag(call.input) }}
-                            {% else %}
-                                {{ call.input }}
-                            {% endif %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>Options</th>
-                        <td>{{ [] == call.options ? '<i>none</i>'|raw : dump(call.options) }}</td>
-                    </tr>
-                    <tr>
-                        <th>Called at</th>
-                        <td>{{ call.called_at|date('H:i:s.v') }}</td>
-                    </tr>
-                </tbody>
-            </table>
-        {% endfor %}
-    {% else %}
-        <div class="empty">
-            <p>No agent calls were made.</p>
-        </div>
-    {% endif %}
-
-    <h3>Chat Calls</h3>
-    {% if collector.chats|length %}
-        {% for call in collector.chats %}
-            {% set called_at = call.submitted_at ?? call.streamed_at ?? call.initiated_at ?? null %}
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th colspan="2">{{ call.action }}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <th>Message{{ call.bag is defined ? 's' }}</th>
-                        <td>{{ _self.message_bag(call.bag ?? call.message) }}</td>
-                    </tr>
-                    {% if called_at is not null %}
+    {% if collector.configuredAgents.count > 0 %}
+        <h3>Agent Calls</h3>
+        {% if collector.agents|length %}
+            {% for call in collector.agents %}
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th colspan="2">Call {{ loop.index }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th>Input</th>
+                            <td>
+                                {% if call.input.messages is defined or call.input.content is defined %}
+                                    {{ _self.message_bag(call.input) }}
+                                {% else %}
+                                    {{ call.input }}
+                                {% endif %}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Options</th>
+                            <td>{{ [] == call.options ? '<i>none</i>'|raw : dump(call.options) }}</td>
+                        </tr>
                         <tr>
                             <th>Called at</th>
-                            <td>{{ called_at|date('H:i:s.v') }}</td>
+                            <td>{{ call.called_at|date('H:i:s.v') }}</td>
                         </tr>
-                    {% endif %}
-                </tbody>
-            </table>
-        {% endfor %}
-    {% else %}
-        <div class="empty">
-            <p>No chat calls were made.</p>
-        </div>
+                    </tbody>
+                </table>
+            {% endfor %}
+        {% else %}
+            <div class="empty">
+                <p>No agent calls were made.</p>
+            </div>
+        {% endif %}
     {% endif %}
 
-    <h3>Message Store Calls</h3>
-    {% if collector.messages|length %}
-        {% for call in collector.messages %}
+    {% if collector.configuredChats.count > 0 %}
+        <h3>Chat Calls</h3>
+        {% if collector.chats|length %}
+            {% for call in collector.chats %}
+                {% set called_at = call.submitted_at ?? call.streamed_at ?? call.initiated_at ?? null %}
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th colspan="2">{{ call.action }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th>Message{{ call.bag is defined ? 's' }}</th>
+                            <td>{{ _self.message_bag(call.bag ?? call.message) }}</td>
+                        </tr>
+                        {% if called_at is not null %}
+                            <tr>
+                                <th>Called at</th>
+                                <td>{{ called_at|date('H:i:s.v') }}</td>
+                            </tr>
+                        {% endif %}
+                    </tbody>
+                </table>
+            {% endfor %}
+        {% else %}
+            <div class="empty">
+                <p>No chat calls were made.</p>
+            </div>
+        {% endif %}
+    {% endif %}
+
+    {% if collector.configuredMessageStores.count > 0 %}
+        <h3>Message Store Calls</h3>
+        {% if collector.messages|length %}
+            {% for call in collector.messages %}
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th colspan="2">Save {{ loop.index }} <span class="badge">{{ call.bag.messages|length }} message{{ call.bag.messages|length > 1 ? 's' }}</span></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th>Messages</th>
+                            <td>{{ _self.message_bag(call.bag) }}</td>
+                        </tr>
+                        <tr>
+                            <th>Saved at</th>
+                            <td>{{ call.saved_at|date('H:i:s.v') }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            {% endfor %}
+        {% else %}
+            <div class="empty">
+                <p>No messages were stored.</p>
+            </div>
+        {% endif %}
+    {% endif %}
+
+    {% if collector.configuredStores.count > 0 %}
+        <h3>Store Calls</h3>
+        {% if collector.stores|length %}
             <table class="table">
                 <thead>
                     <tr>
-                        <th colspan="2">Save {{ loop.index }} <span class="badge">{{ call.bag.messages|length }} message{{ call.bag.messages|length > 1 ? 's' }}</span></th>
+                        <th>Method</th>
+                        <th>Payload</th>
+                        <th>Options</th>
+                        <th>Called at</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <th>Messages</th>
-                        <td>{{ _self.message_bag(call.bag) }}</td>
-                    </tr>
-                    <tr>
-                        <th>Saved at</th>
-                        <td>{{ call.saved_at|date('H:i:s.v') }}</td>
-                    </tr>
+                    {% for call in collector.stores %}
+                        <tr>
+                            <th>{{ call.method }}</th>
+                            <td>
+                                {% if call.documents is defined %}
+                                    {% set documents = call.documents.id is defined ? [call.documents] : call.documents %}
+                                    {{ documents|length }} document{{ documents|length > 1 ? 's' }}
+                                    <ol>
+                                        {% for document in documents %}
+                                            <li>
+                                                <code>{{ document.id }}</code>
+                                                {% if document.vector is defined %}
+                                                    &mdash; vector with <strong>{{ document.vector.dimensions }}</strong> dimensions
+                                                {% endif %}
+                                            </li>
+                                        {% endfor %}
+                                    </ol>
+                                {% elseif call.query is defined %}
+                                    {% if call.query.text is defined %}
+                                        {{ call.query.text }}
+                                    {% endif %}
+                                    {% if call.query.vector is defined %}
+                                        Vector with <strong>{{ call.query.vector.dimensions }}</strong> dimensions
+                                    {% endif %}
+                                    {% if call.query.text is not defined and call.query.vector is not defined %}
+                                        {{ dump(call.query) }}
+                                    {% endif %}
+                                {% elseif call.ids is defined %}
+                                    {{ dump(call.ids) }}
+                                {% else %}
+                                    <i>none</i>
+                                {% endif %}
+                            </td>
+                            <td>{{ [] == call.options|default([]) ? '<i>none</i>'|raw : dump(call.options) }}</td>
+                            <td>{{ call.called_at|date('H:i:s.v') }}</td>
+                        </tr>
+                    {% endfor %}
                 </tbody>
             </table>
-        {% endfor %}
-    {% else %}
-        <div class="empty">
-            <p>No messages were stored.</p>
-        </div>
+        {% else %}
+            <div class="empty">
+                <p>No store calls were made.</p>
+            </div>
+        {% endif %}
     {% endif %}
 
-    <h3>Store Calls</h3>
-    {% if collector.stores|length %}
+    {% if ai_components is not empty %}
+        <h3>Configured Components</h3>
         <table class="table">
             <thead>
                 <tr>
-                    <th>Method</th>
-                    <th>Payload</th>
-                    <th>Options</th>
-                    <th>Called at</th>
+                    <th>Component</th>
+                    <th>Configured</th>
+                    <th>Services</th>
                 </tr>
             </thead>
             <tbody>
-                {% for call in collector.stores %}
+                {% for component in ai_components %}
                     <tr>
-                        <th>{{ call.method }}</th>
+                        <th>{{ component.services_label }}</th>
+                        <td>{{ component.instances.count }}</td>
                         <td>
-                            {% if call.documents is defined %}
-                                {% set documents = call.documents.id is defined ? [call.documents] : call.documents %}
-                                {{ documents|length }} document{{ documents|length > 1 ? 's' }}
-                                <ol>
-                                    {% for document in documents %}
-                                        <li>
-                                            <code>{{ document.id }}</code>
-                                            {% if document.vector is defined %}
-                                                &mdash; vector with <strong>{{ document.vector.dimensions }}</strong> dimensions
-                                            {% endif %}
-                                        </li>
-                                    {% endfor %}
-                                </ol>
-                            {% elseif call.query is defined %}
-                                {% if call.query.text is defined %}
-                                    {{ call.query.text }}
-                                {% endif %}
-                                {% if call.query.vector is defined %}
-                                    Vector with <strong>{{ call.query.vector.dimensions }}</strong> dimensions
-                                {% endif %}
-                                {% if call.query.text is not defined and call.query.vector is not defined %}
-                                    {{ dump(call.query) }}
-                                {% endif %}
-                            {% elseif call.ids is defined %}
-                                {{ dump(call.ids) }}
+                            {% if component.instances.names|length %}
+                                {% for name in component.instances.names %}
+                                    <code>{{ name }}</code>{{ not loop.last ? ', ' }}
+                                {% endfor %}
                             {% else %}
                                 <i>none</i>
                             {% endif %}
                         </td>
-                        <td>{{ [] == call.options|default([]) ? '<i>none</i>'|raw : dump(call.options) }}</td>
-                        <td>{{ call.called_at|date('H:i:s.v') }}</td>
                     </tr>
                 {% endfor %}
             </tbody>
         </table>
-    {% else %}
-        <div class="empty">
-            <p>No store calls were made.</p>
-        </div>
     {% endif %}
-
-    <h3>Configured Components</h3>
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Component</th>
-                <th>Configured</th>
-                <th>Services</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for label, instances in {
-                'Platforms': collector.configuredPlatforms,
-                'Toolboxes': collector.configuredToolboxes,
-                'Agents': collector.configuredAgents,
-                'Chats': collector.configuredChats,
-                'Message Stores': collector.configuredMessageStores,
-                'Stores': collector.configuredStores,
-            } %}
-                <tr>
-                    <th>{{ label }}</th>
-                    <td>{{ instances.count }}</td>
-                    <td>
-                        {% if instances.names|length %}
-                            {% for name in instances.names %}
-                                <code>{{ name }}</code>{{ not loop.last ? ', ' }}
-                            {% endfor %}
-                        {% else %}
-                            <i>none</i>
-                        {% endif %}
-                    </td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
 {% endblock %}

--- a/src/ai-bundle/tests/DependencyInjection/DebugCompilerPassTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/DebugCompilerPassTest.php
@@ -82,6 +82,28 @@ final class DebugCompilerPassTest extends TestCase
         $this->assertSame([['method' => 'reset']], $traceableStore->getTag('kernel.reset'));
     }
 
+    public function testTraceableDefinitionsCarryTheDecoratedServiceIdAsTagName()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', true);
+
+        $container->register('ai.platform.azure.eu', \stdClass::class)->addTag('ai.platform');
+        $container->register('ai.message_store.memory.main', \stdClass::class)->addTag('ai.message_store');
+        $container->register('ai.chat.main', \stdClass::class)->addTag('ai.chat');
+        $container->register('ai.toolbox.my_agent', \stdClass::class)->addTag('ai.toolbox');
+        $container->register('ai.agent.my_agent', \stdClass::class)->addTag('ai.agent');
+        $container->register('ai.store.store', \stdClass::class)->addTag('ai.store');
+
+        (new DebugCompilerPass())->process($container);
+
+        $this->assertSame([['name' => 'ai.platform.azure.eu']], $container->getDefinition('ai.traceable_platform.azure.eu')->getTag('ai.traceable_platform'));
+        $this->assertSame([['name' => 'ai.message_store.memory.main']], $container->getDefinition('ai.traceable_message_store.main')->getTag('ai.traceable_message_store'));
+        $this->assertSame([['name' => 'ai.chat.main']], $container->getDefinition('ai.traceable_chat.main')->getTag('ai.traceable_chat'));
+        $this->assertSame([['name' => 'ai.toolbox.my_agent']], $container->getDefinition('ai.traceable_toolbox.my_agent')->getTag('ai.traceable_toolbox'));
+        $this->assertSame([['name' => 'ai.agent.my_agent']], $container->getDefinition('ai.traceable_agent.my_agent')->getTag('ai.traceable_agent'));
+        $this->assertSame([['name' => 'ai.store.store']], $container->getDefinition('ai.traceable_store.store')->getTag('ai.traceable_store'));
+    }
+
     public function testProcessSkipsWhenDebugDisabled()
     {
         $container = new ContainerBuilder();

--- a/src/ai-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/ai-bundle/tests/Profiler/DataCollectorTest.php
@@ -422,4 +422,68 @@ class DataCollectorTest extends TestCase
         $this->assertSame('research_agent', $tools[0]->getName());
         $this->assertSame('writer_agent', $tools[1]->getName());
     }
+
+    public function testItCollectsConfiguredInstancesWithTheirServiceIds()
+    {
+        $toolbox = $this->createStub(ToolboxInterface::class);
+        $toolbox->method('getTools')->willReturn([]);
+
+        $dataCollector = new DataCollector(
+            ['ai.platform.openai' => new TraceablePlatform($this->createStub(PlatformInterface::class))],
+            ['ai.toolbox.default' => new TraceableToolbox($toolbox)],
+            ['ai.message_store.default' => new TraceableMessageStore(new InMemoryStore(), new MockClock())],
+            ['ai.chat.default' => new TraceableChat(new Chat(new MockAgent(), new InMemoryStore()), new MockClock())],
+            ['ai.agent.blog' => new TraceableAgent(new MockAgent()), 'ai.agent.movies' => new TraceableAgent(new MockAgent())],
+            ['ai.store.memory.main' => new TraceableStore(new Store())],
+        );
+        $dataCollector->lateCollect();
+
+        $this->assertSame(['count' => 1, 'names' => ['ai.platform.openai']], $dataCollector->getConfiguredPlatforms());
+        $this->assertSame(['count' => 1, 'names' => ['ai.toolbox.default']], $dataCollector->getConfiguredToolboxes());
+        $this->assertSame(['count' => 1, 'names' => ['ai.message_store.default']], $dataCollector->getConfiguredMessageStores());
+        $this->assertSame(['count' => 1, 'names' => ['ai.chat.default']], $dataCollector->getConfiguredChats());
+        $this->assertSame(['count' => 2, 'names' => ['ai.agent.blog', 'ai.agent.movies']], $dataCollector->getConfiguredAgents());
+        $this->assertSame(['count' => 1, 'names' => ['ai.store.memory.main']], $dataCollector->getConfiguredStores());
+    }
+
+    public function testItCollectsConfiguredInstancesWithoutServiceIds()
+    {
+        $dataCollector = new DataCollector([new TraceablePlatform($this->createStub(PlatformInterface::class))], [], [], [], [], []);
+        $dataCollector->lateCollect();
+
+        $this->assertSame(['count' => 1, 'names' => []], $dataCollector->getConfiguredPlatforms());
+        $this->assertSame(['count' => 0, 'names' => []], $dataCollector->getConfiguredAgents());
+    }
+
+    public function testConfiguredInstancesAreEmptyBeforeCollecting()
+    {
+        $dataCollector = new DataCollector([new TraceablePlatform($this->createStub(PlatformInterface::class))], [], [], [], [], []);
+
+        $this->assertSame(['count' => 0, 'names' => []], $dataCollector->getConfiguredPlatforms());
+        $this->assertSame(0, $dataCollector->getTotalCalls());
+    }
+
+    public function testItSumsUpCallsOfEveryTracedComponent()
+    {
+        $clock = new MockClock('2020-01-01 10:00:00');
+
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->method('invoke')->willReturn(new DeferredResult(new PlainConverter(new TextResult('Assistant response')), $this->createStub(RawResultInterface::class)));
+        $traceablePlatform = new TraceablePlatform($platform);
+        $traceablePlatform->invoke('gpt-4o', new MessageBag(Message::ofUser(new Text('Hello'))));
+
+        $traceableAgent = new TraceableAgent(new MockAgent(['Hello there' => 'General Kenobi']), $clock);
+        $traceableAgent->call(new MessageBag(Message::ofUser('Hello there')));
+
+        $traceableMessageStore = new TraceableMessageStore(new InMemoryStore(), $clock);
+        $traceableMessageStore->save(new MessageBag(Message::ofUser('Hello there')));
+
+        $traceableStore = new TraceableStore(new Store(), $clock);
+        $traceableStore->add(new VectorDocument(Uuid::v4(), new PlatformVector([0.1, 0.2, 0.3])));
+
+        $dataCollector = new DataCollector([$traceablePlatform], [], [$traceableMessageStore], [], [$traceableAgent], [$traceableStore]);
+        $dataCollector->lateCollect();
+
+        $this->assertSame(4, $dataCollector->getTotalCalls());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #525
| License       | MIT

The profiler panel previously showed only platform calls, tools and tool calls, with the "Configured Platforms" metric hardcoded to `1`, while the collector already gathered agent, chat, message store and store calls without rendering them.

As proposed in [the issue discussion](https://github.com/symfony/ai/issues/525#issuecomment-5084631012), this PR surfaces everything that is already collected - scoped to `src/ai-bundle` only:

- panel sections for Agent Calls, Chat Calls, Message Store Calls and Store Calls (reusing a shared `message_bag` macro extracted from the platform calls section);
- real per-component metrics (configured instances + calls) instead of the hardcoded platform count, and a "Configured Components" table listing each component with the service ids it was registered under (via indexed tagged iterators);
- the toolbar now reflects all component slices and counts every collected call.

A follow-up PR will add `TraceableIndexer` to `symfony/ai-store` and wire it into the collector.

Screenshots (before / after / narrow viewport):

<img width="1600" height="1600" alt="ai-panel-before-top" src="https://github.com/user-attachments/assets/127ee6f5-94d9-4cf2-9f65-44caf5c9a911" />
<img width="1600" height="1600" alt="ai-panel-after-top" src="https://github.com/user-attachments/assets/ae0c1eb9-4603-47d6-b584-49b56c8e62f8" />
<img width="1600" height="1600" alt="ai-panel-after-configured" src="https://github.com/user-attachments/assets/851e34aa-3613-4306-a22c-b51e61d4ee91" />
<img width="1100" height="900" alt="ai-panel-narrow" src="https://github.com/user-attachments/assets/136caea4-ffb0-4957-9749-ec58b39f4629" />

