### PR TITLE
[AI Bundle] Remove stale logger argument from agent definition

### DIFF
--- a/src/ai-bundle/src/AiBundle.php
+++ b/src/ai-bundle/src/AiBundle.php
@@ -1383,7 +1383,6 @@ final class AiBundle extends AbstractBundle
             ->setArgument(2, []) // placeholder until ProcessorCompilerPass process.
             ->setArgument(3, []) // placeholder until ProcessorCompilerPass process.
             ->setArgument(4, $name)
-            ->setArgument(5, new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE))
         ;
 
         $container->setDefinition($agentId, $agentDefinition);

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 use Probots\Pinecone\Client as PineconeClient;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Agent\Memory\MemoryInputProcessor;
 use Symfony\AI\Agent\Memory\StaticMemoryProvider;
@@ -4503,6 +4504,28 @@ class AiBundleTest extends TestCase
 
         $this->assertTrue($definition->hasTag('proxy'));
         $this->assertSame([['interface' => PlatformInterface::class]], $definition->getTag('proxy'));
+    }
+
+    #[TestDox('Agent definition arguments match the Agent constructor signature')]
+    public function testAgentDefinitionHasNoSurplusArguments()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'test_agent' => [
+                        'model' => 'gpt-4',
+                    ],
+                ],
+            ],
+        ]);
+
+        $arguments = $container->getDefinition('ai.agent.test_agent')->getArguments();
+
+        $this->assertCount(
+            (new \ReflectionMethod(Agent::class, '__construct'))->getNumberOfParameters(),
+            $arguments,
+        );
+        $this->assertSame('test_agent', $arguments[4]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

`Agent::__construct()` takes five parameters, but the bundle still sets a sixth one:

```php
->setArgument(4, $name)
->setArgument(5, new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE))
```

The logger parameter was dropped from `Agent` a while ago and the bundle was not updated. PHP ignores surplus arguments to a userland constructor, so nothing breaks today — but every agent definition carries a pointless `logger` reference, and the moment `Agent` gains a sixth parameter it would silently receive a logger.

Removed the argument and pinned the definition to the constructor arity via reflection, so the two cannot drift apart again.
