### PR TITLE
[Platform][OpenResponses] Add citations metadata from `url_citation` annotations

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -714,6 +714,28 @@ the application is not expected to answer it::
     Like the other built-in server-side tool results, ``custom_tool_call`` items are only
     available on non-streamed responses.
 
+Citations
+~~~~~~~~~
+
+Bridges whose provider grounds an answer in web sources expose the URLs as ``citations``
+result metadata, a deduplicated list of strings::
+
+    $result = $platform->invoke($model, $messages);
+
+    foreach ($result->getMetadata()->get('citations') ?? [] as $url) {
+        // ...
+    }
+
+.. note::
+
+    The metadata is only set when the provider reports citations for the response, so
+    guard against ``null``.
+
+The Perplexity bridge always reports its own ``citations`` response field this way. The
+OpenResponses bridge reports it too, extracted from ``url_citation`` annotations on the
+assistant message -- for example when a model uses a citation-grounded built-in tool such
+as xAI's ``x_search``.
+
 Streaming in a Symfony Controller
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/examples/openresponses/citations.php
+++ b/examples/openresponses/citations.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenResponses\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\TextResult;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform('https://api.x.ai', env('XAI_API_KEY'), http_client());
+
+$messages = new MessageBag(Message::ofUser('What is xAI?'));
+$result = $platform->invoke('grok-4-fast', $messages, [
+    'tools' => [['type' => 'web_search']],
+]);
+
+echo $result->asText().\PHP_EOL;
+echo \PHP_EOL;
+
+$converted = $result->getResult();
+$parts = $converted instanceof MultiPartResult ? $converted->getContent() : [$converted];
+
+$citations = [];
+foreach ($parts as $part) {
+    if ($part instanceof TextResult) {
+        $citations = $part->getMetadata()->get('citations') ?? [];
+    }
+}
+
+echo 'Citations:'.\PHP_EOL;
+if ([] === $citations) {
+    echo 'No citations.'.\PHP_EOL;
+} else {
+    foreach ($citations as $citation) {
+        echo ' '.$citation.\PHP_EOL;
+    }
+}

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Preserve reasoning items as thinking signatures and replay them on subsequent requests
  * Add `ToolCallStart` and `ToolInputDelta` deltas to streaming responses
  * Add `CustomToolCallResult` for `custom_tool_call` output items, produced by remote tools like `x_search` in xAI
+ * Add `citations` metadata entry to `TextResult`, extracted from `url_citation` annotations on `output_text` content
 
 0.12
 ----

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -58,7 +58,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * @author Christopher Hertel <mail@christopher-hertel.de>
  *
  * @phpstan-type OutputMessage array{content: array<Refusal|OutputText>, id: string, role: string, type: 'message'}
- * @phpstan-type OutputText array{type: 'output_text', text: string}
+ * @phpstan-type OutputText array{type: 'output_text', text: string, annotations?: Annotation[]}
+ * @phpstan-type Annotation UrlCitation|array{type: string}
+ * @phpstan-type UrlCitation array{type: 'url_citation', url: string, title?: string, start_index?: int, end_index?: int}
  * @phpstan-type Refusal array{type: 'refusal', refusal: string}
  * @phpstan-type FunctionCall array{id?: string|null, arguments: string, call_id?: string|null, name: string, type: 'function_call'}
  * @phpstan-type Thinking array{summary: list<array{type: string, text?: string}>, id: string, encrypted_content?: string|null}
@@ -645,7 +647,31 @@ class ResultConverter implements ResultConverterInterface
             return;
         }
 
-        yield new TextResult($content['text']);
+        $result = new TextResult($content['text']);
+
+        $citations = $this->extractCitations($content['annotations'] ?? []);
+        if ([] !== $citations) {
+            $result->getMetadata()->add('citations', $citations);
+        }
+
+        yield $result;
+    }
+
+    /**
+     * @param Annotation[] $annotations
+     *
+     * @return list<string>
+     */
+    private function extractCitations(array $annotations): array
+    {
+        $urls = [];
+        foreach ($annotations as $annotation) {
+            if ('url_citation' === ($annotation['type'] ?? null)) {
+                $urls[$annotation['url']] = true;
+            }
+        }
+
+        return array_keys($urls);
     }
 
     /**

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -83,6 +83,79 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('Hello world', $result->getContent());
     }
 
+    public function testConvertTextResultWithUrlCitations()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'Sentiment is bearish.',
+                        'annotations' => [
+                            [
+                                'type' => 'url_citation',
+                                'url' => 'https://x.com/i/status/1',
+                                'title' => 'https://x.com/i/status/1',
+                                'start_index' => 0,
+                                'end_index' => 0,
+                            ],
+                            [
+                                'type' => 'url_citation',
+                                'url' => 'https://x.com/i/status/2',
+                                'title' => 'https://x.com/i/status/2',
+                                'start_index' => 0,
+                                'end_index' => 0,
+                            ],
+                            [
+                                'type' => 'url_citation',
+                                'url' => 'https://x.com/i/status/1',
+                                'title' => 'https://x.com/i/status/1',
+                                'start_index' => 0,
+                                'end_index' => 0,
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Sentiment is bearish.', $result->getContent());
+        $this->assertSame(
+            ['https://x.com/i/status/1', 'https://x.com/i/status/2'],
+            $result->getMetadata()->get('citations')
+        );
+    }
+
+    public function testConvertTextResultWithoutAnnotationsHasNoCitationsMetadata()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'Hello world',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertFalse($result->getMetadata()->has('citations'));
+    }
+
     public function testConvertToolCallResult()
     {
         $converter = new ResultConverter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| License       | MIT

`output_text` content's `annotations` field (part of the [OpenResponses spec](https://www.openresponses.org/reference#object-OutputTextContent-title)) was previously dropped entirely. Extract `url_citation` entries into a deduplicated citations metadata entry, matching the existing Perplexity bridge convention.