### PR TITLE
[Platform][OpenResponses] Add `CustomToolCallResult` for `custom_tool_call` items

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -685,6 +685,35 @@ from the visible deltas::
     when streamed. Wrap the consumption loop in a ``try``/``catch`` when you need to handle truncation
     of a streamed response.
 
+Custom Tool Calls (Provider Extensions)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some providers report sub-calls of their own built-in tools as a ``custom_tool_call`` output
+item -- not part of the official OpenAI Responses specification, but an extension some
+providers use for tools they resolve entirely server-side (e.g. xAI's ``x_search`` reporting
+the searches it ran as ``x_keyword_search``/``x_semantic_search`` calls). Since the provider
+has already executed the call by the time it is reported, the OpenResponses bridge converts it
+into a :class:`Symfony\\AI\\Platform\\Result\\CustomToolCallResult` rather than a ``ToolCall`` --
+the application is not expected to answer it::
+
+    use Symfony\AI\Platform\Result\CustomToolCallResult;
+    use Symfony\AI\Platform\Result\MultiPartResult;
+
+    $result = $platform->invoke($model, $messages);
+
+    if ($result instanceof MultiPartResult) {
+        foreach ($result->getContent() as $part) {
+            if ($part instanceof CustomToolCallResult) {
+                // $part->getName(), $part->getInput(), $part->getStatus()
+            }
+        }
+    }
+
+.. note::
+
+    Like the other built-in server-side tool results, ``custom_tool_call`` items are only
+    available on non-streamed responses.
+
 Streaming in a Symfony Controller
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/examples/.env
+++ b/examples/.env
@@ -225,3 +225,6 @@ SYMFONY_DOCS_MAX_DEPTH=2
 
 # MiniMax (platform)
 MINI_MAX_API_KEY=
+
+# For using xAI's Grok via the Open Responses bridge
+XAI_API_KEY=

--- a/examples/openresponses/custom-tool-call.php
+++ b/examples/openresponses/custom-tool-call.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\OpenResponses\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\CustomToolCallResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform('https://api.x.ai', env('XAI_API_KEY'), http_client());
+
+$messages = new MessageBag(Message::ofUser('What is the current sentiment on X about the Symfony framework?'));
+$result = $platform->invoke('grok-4-fast', $messages, [
+    'tools' => [['type' => 'x_search']],
+]);
+
+$converted = $result->getResult();
+$parts = $converted instanceof MultiPartResult ? $converted->getContent() : [$converted];
+
+foreach ($parts as $part) {
+    if ($part instanceof CustomToolCallResult) {
+        echo sprintf('%s(%s) [%s]', $part->getName(), $part->getInput(), $part->getStatus() ?? 'unknown').\PHP_EOL;
+    }
+}
+
+echo \PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * [BC BREAK] Add `ListenerInterface::onError()` and `Result\Stream\ErrorEvent`, dispatched when draining a `StreamResult` throws, so a listener can finalize on a failed stream where `onComplete()` never fires; `AbstractStreamListener` provides a no-op default
  * Add `Test\Replay\CassetteHttpClient` and `Test\Replay\HttpCassette` to record real HTTP responses (when the cassette file is missing) and replay them offline through the real bridge pipeline (Contract, `ModelClient`, `ResultConverter`) in tests, including raw Server-Sent Event streams
  * Add `Test\Recording\RecordingProvider` (with `Cassette`/`ResultSerializer`) to record a real provider's result once (when the cassette file is missing) and replay it offline in tests
+ * Add `Result\CustomToolCallResult` for `custom_tool_call` output items reported by provider-specific server-side tools (e.g. xAI's `x_search`), converted the same way as the other built-in tool call results instead of being surfaced as a `ToolCall` the application is expected to execute
 
 0.12
 ----

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Throw `ServerException` when an OpenAI response reports that the server is overloaded
  * Preserve reasoning items as thinking signatures and replay them on subsequent requests
  * Add `ToolCallStart` and `ToolInputDelta` deltas to streaming responses
+ * Add `CustomToolCallResult` for `custom_tool_call` output items, produced by remote tools like `x_search` in xAI
 
 0.12
 ----

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -25,6 +25,7 @@ use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ComputerCallResult;
+use Symfony\AI\Platform\Result\CustomToolCallResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
 use Symfony\AI\Platform\Result\FileSearchResult;
 use Symfony\AI\Platform\Result\LocalShellCallResult;
@@ -71,7 +72,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * @phpstan-type McpApprovalRequest array{type: 'mcp_approval_request', id?: string, server_label?: string, name?: string, arguments?: string}
  * @phpstan-type ComputerCall array{type: 'computer_call', id?: string, status?: string, call_id?: string, action?: array<string, mixed>, pending_safety_checks?: list<array{id: string, code?: string|null, message?: string|null}>}
  * @phpstan-type LocalShellCall array{type: 'local_shell_call', id?: string, status?: string, call_id?: string, action?: array{type?: string, command?: list<string>}}
- * @phpstan-type OutputItem OutputMessage|FunctionCall|Thinking|WebSearchCall|FileSearchCall|CodeInterpreterCall|ImageGenerationCall|McpCall|McpListTools|McpApprovalRequest|ComputerCall|LocalShellCall
+ * @phpstan-type CustomToolCall array{type: 'custom_tool_call', id?: string, status?: string, name: string, input: string}
+ * @phpstan-type OutputItem OutputMessage|FunctionCall|Thinking|WebSearchCall|FileSearchCall|CodeInterpreterCall|ImageGenerationCall|McpCall|McpListTools|McpApprovalRequest|ComputerCall|LocalShellCall|CustomToolCall
  */
 class ResultConverter implements ResultConverterInterface
 {
@@ -266,8 +268,9 @@ class ResultConverter implements ResultConverterInterface
         $type = $item['type'] ?? null;
 
         // Built-in server-side tool calls (web search, file search, code
-        // interpreter, image generation, computer use, local shell, hosted MCP)
-        // are reported as their own output items next to the assistant message.
+        // interpreter, image generation, computer use, local shell, hosted MCP,
+        // provider-specific custom tools) are reported as their own output items
+        // next to the assistant message, already resolved by the provider.
         // Convert them into typed results so consumers can introspect what the
         // model did, while the message item is still converted as usual.
         return match ($type) {
@@ -282,6 +285,7 @@ class ResultConverter implements ResultConverterInterface
             'mcp_call' => $this->convertMcpCall($item),
             'mcp_list_tools' => $this->convertMcpListTools($item),
             'mcp_approval_request' => $this->convertMcpApprovalRequest($item),
+            'custom_tool_call' => $this->convertCustomToolCall($item),
             default => throw new RuntimeException(\sprintf('Unsupported output type "%s".', $type)),
         };
     }
@@ -430,6 +434,21 @@ class ResultConverter implements ResultConverterInterface
             $item['name'] ?? '',
             $item['arguments'] ?? null,
             $item['id'] ?? null,
+        )];
+    }
+
+    /**
+     * @param CustomToolCall $item
+     *
+     * @return list<CustomToolCallResult>
+     */
+    private function convertCustomToolCall(array $item): array
+    {
+        return [new CustomToolCallResult(
+            $item['name'],
+            $item['input'],
+            $item['id'] ?? null,
+            $item['status'] ?? null,
         )];
     }
 

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -29,6 +29,7 @@ use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ComputerCallResult;
+use Symfony\AI\Platform\Result\CustomToolCallResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
 use Symfony\AI\Platform\Result\FileSearchResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
@@ -152,6 +153,150 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('call_789', $toolCalls[0]->getId());
         $this->assertSame('test_function', $toolCalls[0]->getName());
         $this->assertSame(['arg1' => 'value1'], $toolCalls[0]->getArguments());
+    }
+
+    public function testConvertCustomToolCallResult()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'custom_tool_call',
+                    'id' => 'ctc_123',
+                    'call_id' => 'call_123',
+                    'name' => 'x_keyword_search',
+                    'input' => '{"query": "BETR stock"}',
+                    'status' => 'completed',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(CustomToolCallResult::class, $result);
+        $this->assertSame('x_keyword_search', $result->getName());
+        $this->assertSame('{"query": "BETR stock"}', $result->getInput());
+        $this->assertSame('{"query": "BETR stock"}', $result->getContent());
+        $this->assertSame('ctc_123', $result->getId());
+        $this->assertSame('completed', $result->getStatus());
+    }
+
+    public function testConvertCustomToolCallResultWithMissingIdAndStatus()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'custom_tool_call',
+                    'name' => 'x_keyword_search',
+                    'input' => '{"query": "BETR stock"}',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(CustomToolCallResult::class, $result);
+        $this->assertNull($result->getId());
+        $this->assertNull($result->getStatus());
+    }
+
+    public function testConvertCustomToolCallResultPreservesFreeformInputVerbatim()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'custom_tool_call',
+                    'id' => 'ctc_456',
+                    'name' => 'run_sql',
+                    'input' => 'SELECT * FROM users',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(CustomToolCallResult::class, $result);
+        $this->assertSame('SELECT * FROM users', $result->getInput());
+    }
+
+    public function testConvertCustomToolCallAlongsideMessageDoesNotBecomeToolCallResult()
+    {
+        // Regression test: xAI's x_search reports its own sub-calls (e.g. "x_keyword_search")
+        // as custom_tool_call items next to the assistant's already-generated answer. They must
+        // NOT be surfaced as a ToolCallResult, since AgentProcessor would then try to execute
+        // "x_keyword_search" against the application's own Toolbox and fail -- the provider has
+        // already resolved the call by the time it is reported.
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'custom_tool_call',
+                    'id' => 'ctc_123',
+                    'call_id' => 'xs_call_123',
+                    'name' => 'x_keyword_search',
+                    'input' => '{"query": "BETR stock"}',
+                    'status' => 'completed',
+                ],
+                [
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'Sentiment is bearish.',
+                    ]],
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertNotInstanceOf(ToolCallResult::class, $result);
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(CustomToolCallResult::class, $parts[0]);
+        $this->assertSame('x_keyword_search', $parts[0]->getName());
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('Sentiment is bearish.', $parts[1]->getContent());
+    }
+
+    public function testConvertFunctionCallAlongsideCustomToolCall()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('toArray')->willReturn([
+            'output' => [
+                [
+                    'type' => 'function_call',
+                    'id' => 'call_123',
+                    'name' => 'test_function',
+                    'arguments' => '{"arg1": "value1"}',
+                ],
+                [
+                    'type' => 'custom_tool_call',
+                    'id' => 'ctc_123',
+                    'name' => 'x_keyword_search',
+                    'input' => '{"query": "BETR stock"}',
+                ],
+            ],
+        ]);
+
+        $result = $converter->convert(new RawHttpResult($httpResponse));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(CustomToolCallResult::class, $parts[0]);
+        $this->assertInstanceOf(ToolCallResult::class, $parts[1]);
+        $toolCalls = $parts[1]->getContent();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('test_function', $toolCalls[0]->getName());
     }
 
     public function testConvertMultipleMessagesIntoMultiPartResult()
@@ -1377,6 +1522,44 @@ final class ResultConverterTest extends TestCase
         $this->assertCount(2, $toolCalls);
         $this->assertSame('call_1', $toolCalls[0]->getId());
         $this->assertSame('call_2', $toolCalls[1]->getId());
+    }
+
+    public function testStreamIgnoresCustomToolCallOutputItemDone()
+    {
+        // Like the other built-in server-side tool calls (web_search_call, mcp_call, ...),
+        // custom_tool_call results are only available on non-streamed responses, so it must not
+        // be surfaced as a ToolCallComplete during streaming.
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $events = [
+            [
+                'type' => 'response.output_item.done',
+                'item' => [
+                    'type' => 'custom_tool_call',
+                    'id' => 'ctc_123',
+                    'name' => 'x_keyword_search',
+                    'input' => '{"query": "BETR stock"}',
+                ],
+            ],
+            [
+                'type' => 'response.completed',
+                'response' => [
+                    'output' => [],
+                ],
+            ],
+        ];
+
+        $raw = new InMemoryRawResult([], $events, $httpResponse);
+        $streamResult = $converter->convert($raw, ['stream' => true]);
+
+        $chunks = iterator_to_array($streamResult->getContent());
+
+        $this->assertCount(1, $chunks);
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[0]);
+        $this->assertTrue($chunks[0]->getValue()->is(FinishReasonCase::STOP));
     }
 
     public function testStreamThrowsClearExceptionForMalformedToolCallArguments()

--- a/src/platform/src/Message/Content/CustomToolCall.php
+++ b/src/platform/src/Message/Content/CustomToolCall.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Message\Content;
+
+/**
+ * @author Valtteri R <valtzu@gmail.com>
+ */
+final class CustomToolCall implements ContentInterface
+{
+    /**
+     * @param string      $name   Name of the custom tool that was invoked
+     * @param string      $input  Freeform text input the tool was called with, as reported by the provider
+     * @param string|null $id     Identifier of the custom tool call output item (e.g. "ctc_...")
+     * @param string|null $status Provider-reported status of the call, e.g. "completed" or "failed"
+     */
+    public function __construct(
+        private readonly string $name,
+        private readonly string $input,
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getInput(): string
+    {
+        return $this->input;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/src/Message/Message.php
+++ b/src/platform/src/Message/Message.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\Content\CodeExecution;
 use Symfony\AI\Platform\Message\Content\ComputerCall;
 use Symfony\AI\Platform\Message\Content\ContentInterface;
+use Symfony\AI\Platform\Message\Content\CustomToolCall;
 use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\AI\Platform\Message\Content\FileSearch;
 use Symfony\AI\Platform\Message\Content\LocalShellCall;
@@ -26,6 +27,7 @@ use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Message\Content\WebSearch;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ComputerCallResult;
+use Symfony\AI\Platform\Result\CustomToolCallResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
 use Symfony\AI\Platform\Result\FileSearchResult;
 use Symfony\AI\Platform\Result\LocalShellCallResult;
@@ -141,6 +143,10 @@ final class Message
 
         if ($part instanceof McpCallResult) {
             return [new McpCall($part->getServerLabel(), $part->getName(), $part->getArguments(), $part->getContent(), $part->getError(), $part->getId(), $part->getStatus())];
+        }
+
+        if ($part instanceof CustomToolCallResult) {
+            return [new CustomToolCall($part->getName(), $part->getInput(), $part->getId(), $part->getStatus())];
         }
 
         if ($part instanceof McpListToolsResult) {

--- a/src/platform/src/Result/CustomToolCallResult.php
+++ b/src/platform/src/Result/CustomToolCallResult.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * Result of a custom tool invoked server-side by the model as part of a built-in tool
+ * (e.g. xAI's `x_search` reporting its own `custom_tool_call` sub-calls). Unlike
+ * {@see ToolCall}, the provider has already resolved the call by the time it is reported,
+ * so it is exposed as an informational result rather than something the application is
+ * expected to execute and answer.
+ *
+ * @author Valtteri R <valtzu@gmail.com>
+ */
+final class CustomToolCallResult extends BaseResult
+{
+    /**
+     * @param string      $name   Name of the custom tool that was invoked
+     * @param string      $input  Freeform text input the tool was called with, as reported by the provider
+     * @param string|null $id     Identifier of the custom tool call output item (e.g. "ctc_...")
+     * @param string|null $status Provider-reported status of the call, e.g. "completed" or "failed"
+     */
+    public function __construct(
+        private readonly string $name,
+        private readonly string $input,
+        private readonly ?string $id = null,
+        private readonly ?string $status = null,
+    ) {
+    }
+
+    public function getContent(): string
+    {
+        return $this->input;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getInput(): string
+    {
+        return $this->input;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+}

--- a/src/platform/tests/Message/MessageTest.php
+++ b/src/platform/tests/Message/MessageTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\Content\CodeExecution;
 use Symfony\AI\Platform\Message\Content\ComputerCall;
 use Symfony\AI\Platform\Message\Content\ContentInterface;
+use Symfony\AI\Platform\Message\Content\CustomToolCall;
 use Symfony\AI\Platform\Message\Content\ExecutableCode;
 use Symfony\AI\Platform\Message\Content\FileSearch;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
@@ -30,6 +31,7 @@ use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ComputerCallResult;
+use Symfony\AI\Platform\Result\CustomToolCallResult;
 use Symfony\AI\Platform\Result\ExecutableCodeResult;
 use Symfony\AI\Platform\Result\FileSearchResult;
 use Symfony\AI\Platform\Result\LocalShellCallResult;
@@ -178,13 +180,14 @@ final class MessageTest extends TestCase
             new McpApprovalRequestResult('deepwiki', 'ask', '{"q":1}', 'mcpr_1'),
             new ComputerCallResult(['type' => 'click'], 'call_1', [], 'cu_1', 'completed'),
             new LocalShellCallResult(['bash', '-lc', 'ls'], 'call_2', 'lsh_1', 'completed'),
+            new CustomToolCallResult('x_search', 'latest AI news', 'ctc_1', 'completed'),
             new TextResult('Visible answer.'),
         ]);
 
         $message = Message::ofAssistant($result);
 
         $parts = $message->getContent();
-        $this->assertCount(8, $parts);
+        $this->assertCount(9, $parts);
 
         $this->assertInstanceOf(WebSearch::class, $parts[0]);
         $this->assertSame('latest AI news', $parts[0]->getQuery());
@@ -211,7 +214,13 @@ final class MessageTest extends TestCase
         $this->assertInstanceOf(LocalShellCall::class, $parts[6]);
         $this->assertSame(['bash', '-lc', 'ls'], $parts[6]->getCommand());
 
-        $this->assertInstanceOf(Text::class, $parts[7]);
+        $this->assertInstanceOf(CustomToolCall::class, $parts[7]);
+        $this->assertSame('x_search', $parts[7]->getName());
+        $this->assertSame('latest AI news', $parts[7]->getInput());
+        $this->assertSame('ctc_1', $parts[7]->getId());
+        $this->assertSame('completed', $parts[7]->getStatus());
+
+        $this->assertInstanceOf(Text::class, $parts[8]);
     }
 
     public function testCreateAssistantMessageFromUnsupportedResultThrows()

--- a/src/platform/tests/Result/CustomToolCallResultTest.php
+++ b/src/platform/tests/Result/CustomToolCallResultTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\CustomToolCallResult;
+
+final class CustomToolCallResultTest extends TestCase
+{
+    public function testGetters()
+    {
+        $result = new CustomToolCallResult('x_keyword_search', '{"query":"BETR stock"}', 'ctc_1', 'completed');
+
+        $this->assertSame('{"query":"BETR stock"}', $result->getContent());
+        $this->assertSame('x_keyword_search', $result->getName());
+        $this->assertSame('{"query":"BETR stock"}', $result->getInput());
+        $this->assertSame('ctc_1', $result->getId());
+        $this->assertSame('completed', $result->getStatus());
+    }
+
+    public function testDefaults()
+    {
+        $result = new CustomToolCallResult('run_sql', 'SELECT * FROM users');
+
+        $this->assertNull($result->getId());
+        $this->assertNull($result->getStatus());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | yes
| License       | MIT

Some providers (e.g. xAI's `x_search`) report their own built-in sub-tool calls as `custom_tool_call` output items, already resolved server-side by the time they're reported. Let's convert them into `CustomToolCallResult`, the same way the other built-in server-side tool calls (`web_search_call`, `mcp_call`, ...) are handled: an informational result alongside the assistant's message, not something the application is expected to execute and answer.

This fixes the usage of `x_search` remote tool since without these changes it throws a `RuntimeException`.