### PR TITLE
[Mate] Redact sensitive keys in the profiler raw-data fallback

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/ProfilerDataProvider.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/ProfilerDataProvider.php
@@ -36,6 +36,47 @@ use Symfony\Component\VarDumper\Cloner\Data;
 final class ProfilerDataProvider
 {
     /**
+     * Key-name substrings (case-insensitive) used to redact values in the raw
+     * fallback dump of collectors that have no dedicated formatter. Best-effort:
+     * a secret stored under a non-sensitive key name is only caught when it is
+     * embedded in a URL or in a header-like `Name: value` pair (see
+     * scrubStringValue). Bare `AUTH` is excluded to avoid redacting diagnostic
+     * keys like `authenticated`/`author`, while the `AUTH_` prefix form catches
+     * the `auth_basic`/`auth_bearer`/`auth_ntlm` HttpClient request options.
+     *
+     * @var array<string>
+     */
+    private const SENSITIVE_RAW_KEY_PATTERNS = [
+        'PASSWORD',
+        'PASSWD',
+        'PASSPHRASE',
+        'PWD',
+        'SECRET',
+        'TOKEN',
+        'JWT',
+        'API_KEY',
+        'APIKEY',
+        'ACCESS_KEY',
+        'SIGNING_KEY',
+        'ENCRYPTION_KEY',
+        'OAUTH',
+        'AUTH_',
+        'AUTHORIZATION',
+        'AUTHENTICATION',
+        'CREDENTIAL',
+        'PRIVATE',
+        'BEARER',
+        'CSRF',
+        'XSRF',
+        'SESSION',
+        'SESSID',
+        'SIGNATURE',
+        'SALT',
+        'COOKIE',
+        'OTP',
+    ];
+
+    /**
      * @var array<string|int, FileProfilerStorage>
      */
     private readonly array $storages;
@@ -177,9 +218,13 @@ final class ProfilerDataProvider
         $formatter = $this->collectorRegistry->get($collectorName);
 
         if (null === $formatter) {
+            // No dedicated formatter: the raw collector internals are dumped
+            // verbatim, so apply best-effort key-based redaction to avoid
+            // leaking secrets from collectors such as security, form or
+            // http_client that nobody has distilled yet.
             return [
                 'name' => $collectorName,
-                'data' => ['raw' => $this->extractRawData($collectorData)],
+                'data' => ['raw' => $this->redactRawData($this->extractRawData($collectorData))],
                 'summary' => [],
             ];
         }
@@ -241,6 +286,102 @@ final class ProfilerDataProvider
         }
 
         return [];
+    }
+
+    /**
+     * Recursively redact values whose key matches a sensitive pattern, and scrub
+     * secrets embedded in string values (e.g. the request URL the http_client
+     * collector stores under a non-sensitive `url` key, or the `curlCommand` it
+     * builds from every request header).
+     *
+     * @param array<array-key, mixed> $data
+     *
+     * @return array<array-key, mixed>
+     */
+    private function redactRawData(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (\is_string($key) && $this->isSensitiveRawKey($key)) {
+                $data[$key] = '***REDACTED***';
+                continue;
+            }
+
+            if (\is_array($value)) {
+                $data[$key] = $this->redactRawData($value);
+            } elseif (\is_string($value)) {
+                $data[$key] = $this->scrubStringValue($value);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Scrub secrets embedded anywhere in a string value, in three passes: the
+     * value of every header-like `Name: value` pair whose name is sensitive,
+     * every absolute URL the string contains, and the query string of every
+     * bare request target. The http_client collector stores a ready-to-run
+     * `curlCommand` plus the raw curl transcript under `info.debug`, both of
+     * which carry the credentials of the whole exchange - request headers, the
+     * request line, a `Location:` redirect target, `Set-Cookie:` - without a key
+     * name or a value shape that gives them away. Everything else is kept so the
+     * exchange stays readable.
+     */
+    private function scrubStringValue(string $value): string
+    {
+        $value = preg_replace_callback(
+            '~(?P<name>[A-Za-z][A-Za-z0-9_-]*)(?P<separator>:[ \t]*)[^\r\n\']+~',
+            function (array $match): string {
+                if (!$this->isSensitiveRawKey($match['name'])) {
+                    return $match[0];
+                }
+
+                return $match['name'].$match['separator'].'***REDACTED***';
+            },
+            $value,
+        ) ?? $value;
+
+        $value = preg_replace_callback(
+            '~[a-z][a-z0-9+.\-]*://[^\s\'"]+~i',
+            fn (array $match): string => $this->scrubUrlValue($match[0]),
+            $value,
+        ) ?? $value;
+
+        // A request line such as `> GET /v1/me?access_token=... HTTP/1.1` carries
+        // its credentials in a bare target that no scheme introduces. Only a
+        // token that both starts a word and starts with a slash qualifies, so
+        // prose that merely ends in a question mark is left alone, and the path
+        // itself is kept next to the method and the protocol version.
+        return preg_replace('~(?<![^\s\'"])(/[^\s\'"?]*)\?[^\s\'"]*~', '$1?***REDACTED***', $value) ?? $value;
+    }
+
+    /**
+     * Drop userinfo and redact the query string / fragment of a URL value, where
+     * credentials and tokens commonly live, keeping scheme, host and path.
+     */
+    private function scrubUrlValue(string $value): string
+    {
+        // Drop the whole userinfo segment (both `user:pass@` and a bare
+        // `token@` credential-as-username form).
+        $value = preg_replace('~(://)[^/@\s]*@~', '$1', $value) ?? $value;
+        $value = preg_replace('~\?[^#\s]*~', '?***REDACTED***', $value) ?? $value;
+        $value = preg_replace('~#[^\s]*~', '', $value) ?? $value;
+
+        return $value;
+    }
+
+    private function isSensitiveRawKey(string $key): bool
+    {
+        // Normalise hyphens to underscores so `api-key` / `x-api-key` match the
+        // underscore-style patterns too.
+        $upperKey = str_replace('-', '_', strtoupper($key));
+        foreach (self::SENSITIVE_RAW_KEY_PATTERNS as $pattern) {
+            if (str_contains($upperKey, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/ProfilerDataProviderTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/ProfilerDataProviderTest.php
@@ -16,6 +16,15 @@ use Symfony\AI\Mate\Bridge\Symfony\Profiler\Exception\InvalidCollectorException;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Exception\ProfileNotFoundException;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorRegistry;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
+use Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\TestCollector;
+use Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\TraceableHttpClient;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
 /**
@@ -157,6 +166,184 @@ final class ProfilerDataProviderTest extends TestCase
         $this->assertSame('/api/users', $data['data']['raw']['path']);
     }
 
+    public function testGetCollectorDataRedactsSensitiveKeysInRawFallback()
+    {
+        $dir = sys_get_temp_dir().'/mate_raw_redaction_'.uniqid();
+        mkdir($dir);
+
+        try {
+            $collector = new TestCollector('http_client', [
+                'method' => 'GET',
+                'api_key' => 'leaked-key',
+                'x-api-key' => 'leaked-hyphen-key',
+                'jwt' => 'leaked-jwt',
+                'url' => 'https://api.example.com/v1/resource?access_token=URLTOKEN&id=5',
+                'callback_url' => 'https://ghp_USERINFOTOKEN@github.com/owner/repo',
+                'request' => [
+                    'authorization' => 'Bearer leaked-token',
+                    'note' => 'visible',
+                ],
+            ]);
+
+            $profile = new Profile('rawtoken');
+            $profile->setMethod('GET');
+            $profile->setUrl('http://localhost/test');
+            $profile->setIp('127.0.0.1');
+            $profile->setStatusCode(200);
+            $profile->setCollectors([$collector]);
+
+            $storage = new FileProfilerStorage('file:'.$dir);
+            $storage->write($profile);
+
+            $provider = new ProfilerDataProvider($dir, new CollectorRegistry([]));
+            $data = $provider->getCollectorData('rawtoken', 'http_client');
+
+            $raw = $data['data']['raw'];
+            // Non-sensitive keys remain visible, nested or not.
+            $this->assertSame('GET', $raw['method']);
+            $this->assertSame('visible', $raw['request']['note']);
+            // Sensitive keys are redacted, including nested and hyphenated ones.
+            $this->assertSame('***REDACTED***', $raw['api_key']);
+            $this->assertSame('***REDACTED***', $raw['x-api-key']);
+            $this->assertSame('***REDACTED***', $raw['jwt']);
+            $this->assertSame('***REDACTED***', $raw['request']['authorization']);
+            // URL-shaped values under a non-sensitive key get their query and
+            // userinfo (incl. a bare token-as-username) stripped.
+            $this->assertSame('https://api.example.com/v1/resource?***REDACTED***', $raw['url']);
+            $this->assertSame('https://github.com/owner/repo', $raw['callback_url']);
+
+            $serialized = json_encode($data);
+            $this->assertStringNotContainsString('leaked-key', $serialized);
+            $this->assertStringNotContainsString('leaked-hyphen-key', $serialized);
+            $this->assertStringNotContainsString('leaked-jwt', $serialized);
+            $this->assertStringNotContainsString('leaked-token', $serialized);
+            $this->assertStringNotContainsString('URLTOKEN', $serialized);
+            $this->assertStringNotContainsString('USERINFOTOKEN', $serialized);
+        } finally {
+            $this->removeDirectory($dir);
+        }
+    }
+
+    public function testGetCollectorDataRedactsCurlCommandInRawFallback()
+    {
+        $curlCommand = <<<'CURL'
+            curl --compressed \
+              --request GET \
+              --url 'https://api.example.com/v1/models?access_token=CURLURLTOKEN&id=5' \
+              --header 'Accept: application/json' \
+              --header 'Authorization: Bearer CURLHEADERTOKEN' \
+              --header 'X-Api-Key: CURLAPIKEY' \
+              --header 'Cookie: PHPSESSID=CURLSESSION'
+            CURL;
+
+        $data = $this->collectRawHttpClientTrace('curltoken', [
+            'method' => 'GET',
+            'curlCommand' => $curlCommand,
+        ]);
+
+        $redactedCommand = $data['data']['raw']['clients']['default']['traces'][0]['curlCommand'];
+
+        // The command keeps its shape, but loses every credential it inlines -
+        // none of which the `curlCommand` key name reveals on its own.
+        $this->assertStringContainsString('--request GET', $redactedCommand);
+        $this->assertStringContainsString("--header 'Accept: application/json'", $redactedCommand);
+        $this->assertStringContainsString("--url 'https://api.example.com/v1/models?***REDACTED***'", $redactedCommand);
+        $this->assertStringContainsString("--header 'Authorization: ***REDACTED***'", $redactedCommand);
+        $this->assertStringContainsString("--header 'X-Api-Key: ***REDACTED***'", $redactedCommand);
+        $this->assertStringContainsString("--header 'Cookie: ***REDACTED***'", $redactedCommand);
+
+        $serialized = json_encode($data);
+        $this->assertStringNotContainsString('CURLURLTOKEN', $serialized);
+        $this->assertStringNotContainsString('CURLHEADERTOKEN', $serialized);
+        $this->assertStringNotContainsString('CURLAPIKEY', $serialized);
+        $this->assertStringNotContainsString('CURLSESSION', $serialized);
+    }
+
+    public function testGetCollectorDataRedactsHttpClientAuthOptionsInRawFallback()
+    {
+        $data = $this->collectRawHttpClientTrace('authoptionstoken', [
+            'options' => [
+                'auth_bearer' => 'AUTHBEARERSECRET',
+                'auth_basic' => 'user:AUTHBASICSECRET',
+                'auth_ntlm' => 'user:AUTHNTLMSECRET',
+                'max_redirects' => 20,
+            ],
+        ]);
+
+        $options = $data['data']['raw']['clients']['default']['traces'][0]['options'];
+
+        // HttpClient keys its credential options `auth_*`, which bare `AUTH` must
+        // not match (it would swallow `author`/`authenticated`) - but the prefix does.
+        $this->assertSame('***REDACTED***', $options['auth_bearer']);
+        $this->assertSame('***REDACTED***', $options['auth_basic']);
+        $this->assertSame('***REDACTED***', $options['auth_ntlm']);
+        $this->assertSame(20, $options['max_redirects']);
+
+        $serialized = json_encode($data);
+        $this->assertStringNotContainsString('AUTHBEARERSECRET', $serialized);
+        $this->assertStringNotContainsString('AUTHBASICSECRET', $serialized);
+        $this->assertStringNotContainsString('AUTHNTLMSECRET', $serialized);
+    }
+
+    public function testGetCollectorDataRedactsSecretsGatheredByTheRealHttpClientCollector()
+    {
+        // Shaped like a curl transcript: CRLF line endings, the request line, the
+        // request headers, then the response half. HttpClientDataCollector keeps
+        // it verbatim under `info.debug` and derives `curlCommand` from it.
+        $debug = implode("\r\n", [
+            '*   Trying 127.0.0.1:443...',
+            '> GET /v1/me?access_token=QUERYSECRET HTTP/1.1',
+            'Host: api.example.com',
+            'Authorization: Bearer HEADERSECRET',
+            'X-Api-Key: APIKEYSECRET',
+            'Accept: application/json',
+            '',
+            '< HTTP/1.1 302 Found',
+            '< Location: https://api.example.com/v1/me?access_token=LOCATIONSECRET',
+            '< Set-Cookie: PHPSESSID=COOKIESECRET; Path=/; HttpOnly',
+            '',
+        ]);
+
+        $client = new TraceableHttpClient(new MockHttpClient(new MockResponse('{"ok":true}', [
+            'http_code' => 200,
+            'debug' => $debug,
+        ])));
+        $client->request('GET', 'https://api.example.com/v1/me?access_token=QUERYSECRET', [
+            'auth_bearer' => 'BEARERSECRET',
+            'headers' => ['X-Api-Key' => 'APIKEYSECRET'],
+        ])->getContent();
+
+        $collector = new HttpClientDataCollector();
+        $collector->registerClient('default', $client);
+        $collector->collect(new Request(), new Response());
+        $collector->lateCollect();
+
+        $data = $this->collectRaw('realhttpclient', $collector);
+        $trace = $data['data']['raw']['clients']['default']['traces'][0];
+
+        $transcript = $trace['info']['info']['debug'];
+        // The request line names its credentials in a bare target that no scheme
+        // introduces, while method, path and protocol version stay readable.
+        $this->assertStringContainsString('> GET /v1/me?***REDACTED*** HTTP/1.1', $transcript);
+        $this->assertStringContainsString('Host: api.example.com', $transcript);
+        $this->assertStringContainsString('Accept: application/json', $transcript);
+        $this->assertStringContainsString('Authorization: ***REDACTED***', $transcript);
+        $this->assertStringContainsString('X-Api-Key: ***REDACTED***', $transcript);
+        // The response half leaks just as readily as the request half.
+        $this->assertStringContainsString('< HTTP/1.1 302 Found', $transcript);
+        $this->assertStringContainsString('< Location: https://api.example.com/v1/me?***REDACTED***', $transcript);
+        $this->assertStringContainsString('< Set-Cookie: ***REDACTED***', $transcript);
+
+        $this->assertStringContainsString("--url 'https://api.example.com/v1/me?***REDACTED***'", $trace['curlCommand']);
+        $this->assertStringContainsString("--header 'Authorization: ***REDACTED***'", $trace['curlCommand']);
+        $this->assertSame('***REDACTED***', $trace['options']['auth_bearer']);
+
+        $serialized = json_encode($data);
+        foreach (['QUERYSECRET', 'HEADERSECRET', 'APIKEYSECRET', 'BEARERSECRET', 'LOCATIONSECRET', 'COOKIESECRET'] as $secret) {
+            $this->assertStringNotContainsString($secret, $serialized);
+        }
+    }
+
     public function testListAvailableCollectorsThrowsExceptionForNonExistentProfile()
     {
         $this->expectException(ProfileNotFoundException::class);
@@ -233,5 +420,72 @@ final class ProfilerDataProviderTest extends TestCase
 
         $this->assertCount(3, $profiles);
         $this->assertSame('context1', $profiles[0]->getContext());
+    }
+
+    /**
+     * Store a single http_client-shaped trace in a throwaway profiler dir and read
+     * it back through the formatter-less raw fallback.
+     *
+     * @param array<string, mixed> $trace
+     *
+     * @return array{name: string, data: array<string, mixed>, summary: array<string, mixed>}
+     */
+    private function collectRawHttpClientTrace(string $token, array $trace): array
+    {
+        return $this->collectRaw($token, new TestCollector('http_client', [
+            'clients' => ['default' => ['traces' => [$trace]]],
+        ]));
+    }
+
+    /**
+     * Store a collector in a throwaway profiler dir and read it back through the
+     * formatter-less raw fallback.
+     *
+     * @return array{name: string, data: array<string, mixed>, summary: array<string, mixed>}
+     */
+    private function collectRaw(string $token, DataCollectorInterface $collector): array
+    {
+        $dir = sys_get_temp_dir().'/mate_raw_redaction_'.uniqid();
+        mkdir($dir);
+
+        try {
+            $profile = new Profile($token);
+            $profile->setMethod('GET');
+            $profile->setUrl('http://localhost/test');
+            $profile->setIp('127.0.0.1');
+            $profile->setStatusCode(200);
+            $profile->setCollectors([$collector]);
+
+            $storage = new FileProfilerStorage('file:'.$dir);
+            $storage->write($profile);
+
+            $provider = new ProfilerDataProvider($dir, new CollectorRegistry([]));
+
+            return $provider->getCollectorData($token, $collector->getName());
+        } finally {
+            $this->removeDirectory($dir);
+        }
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($dir);
     }
 }

--- a/src/mate/src/Bridge/Symfony/composer.json
+++ b/src/mate/src/Bridge/Symfony/composer.json
@@ -38,6 +38,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5.53",
+        "symfony/http-client": "^7.3|^8.0",
         "symfony/http-kernel": "^7.3|^8.0",
         "symfony/mailer": "^7.3|^8.0",
         "symfony/stopwatch": "^7.3|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT


Follow-up to the profiler request/doctrine redaction PRs (a verification pass
surfaced more leak surfaces in the same component).

When a profiler collector has **no dedicated formatter**, `ProfilerDataProvider`
reflected the protected `DataCollector::$data` and returned the entire collector
internals verbatim. Only eight collectors have formatters (request, db, logger,
exception, mailer, time, translation, memory), so any other — security, form,
**http_client**, dump, config, … — handed its raw internals to the AI
unredacted, reachable via `symfony-profiler://profile/{token}/{collector}`.

- Recursively redact values whose key matches a sensitive pattern (hyphenated
  keys like `x-api-key` are normalised, bare `AUTH` excluded to avoid masking
  `authenticated`/`author`).
- Scrub URL-shaped string values (the request URL `http_client` stores under a
  non-sensitive `url` key): drop the whole userinfo segment (incl. a bare
  `token@host` form) and redact the query string and fragment.

Best-effort by design — a secret under a non-sensitive, non-URL key is not
detected; registering a dedicated formatter remains the way to expose a
collector precisely.

