### PR TITLE
[Mate] Redact email bodies, recipients and link tokens in mailer collector

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/MailerCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/MailerCollectorFormatter.php
@@ -16,13 +16,14 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\Mailer\DataCollector\MessageDataCollector;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
-use Symfony\Component\String\UnicodeString;
 
 /**
  * Formats Mailer collector data for AI consumption.
  *
- * Extracts email message details including recipients, subject,
- * body preview, attachments, and transport information.
+ * Extracts email message metadata (subject, masked recipients, attachments,
+ * transport). Email bodies are omitted and links are stripped of their query
+ * string and fragment, since reset/verify/magic-login URLs and the body itself
+ * routinely carry one-time tokens and personal data that must not reach the AI.
  *
  * @author Johannes Wachter <johannes@sulu.io>
  *
@@ -32,8 +33,6 @@ use Symfony\Component\String\UnicodeString;
  */
 final class MailerCollectorFormatter implements CollectorFormatterInterface
 {
-    private const MAX_BODY_LENGTH = 500;
-
     public function getName(): string
     {
         return 'mailer';
@@ -93,8 +92,6 @@ final class MailerCollectorFormatter implements CollectorFormatterInterface
      */
     private function formatEmail(Email $email): array
     {
-        $textBody = $email->getTextBody();
-
         return [
             'subject' => $email->getSubject(),
             'from' => $this->formatAddresses($email->getFrom()),
@@ -102,14 +99,16 @@ final class MailerCollectorFormatter implements CollectorFormatterInterface
             'cc' => $this->formatAddresses($email->getCc()),
             'bcc' => $this->formatAddresses($email->getBcc()),
             'reply_to' => $this->formatAddresses($email->getReplyTo()),
-            'text_body' => null !== $textBody ? $this->truncateBody($textBody) : null,
-            'links' => $this->extractLinks($textBody, $email->getHtmlBody()),
+            'has_text_body' => null !== $email->getTextBody(),
             'has_html_body' => null !== $email->getHtmlBody(),
+            'links' => $this->extractLinks($email->getTextBody(), $email->getHtmlBody()),
             'attachments' => $this->formatAttachments($email),
         ];
     }
 
     /**
+     * Mask recipient PII (local part replaced with `***`, display name dropped).
+     *
      * @param Address[] $addresses
      *
      * @return string[]
@@ -117,11 +116,19 @@ final class MailerCollectorFormatter implements CollectorFormatterInterface
     private function formatAddresses(array $addresses): array
     {
         return array_map(
-            static fn (Address $address): string => '' !== $address->getName()
-                ? \sprintf('%s <%s>', $address->getName(), $address->getAddress())
-                : $address->getAddress(),
+            fn (Address $address): string => $this->maskAddress($address->getAddress()),
             $addresses
         );
+    }
+
+    private function maskAddress(string $address): string
+    {
+        $atPosition = strrpos($address, '@');
+        if (false === $atPosition) {
+            return '***';
+        }
+
+        return '***'.substr($address, $atPosition);
     }
 
     /**
@@ -141,18 +148,61 @@ final class MailerCollectorFormatter implements CollectorFormatterInterface
             $links = array_merge($links, $matches[1]);
         }
 
-        return array_values(array_unique($links));
-    }
-
-    private function truncateBody(string $body): string
-    {
-        $unicode = new UnicodeString($body);
-
-        if ($unicode->length() <= self::MAX_BODY_LENGTH) {
-            return $body;
+        $sanitized = [];
+        foreach ($links as $link) {
+            $clean = $this->stripUrlSecrets($link);
+            if (null !== $clean) {
+                $sanitized[] = $clean;
+            }
         }
 
-        return $unicode->slice(0, self::MAX_BODY_LENGTH)->toString().'...';
+        return array_values(array_unique($sanitized));
+    }
+
+    /**
+     * Keep scheme, host and the descriptive path so the AI sees which endpoint
+     * was linked, but drop userinfo, query string and fragment, and mask any
+     * high-entropy path segment — reset/verify/magic-login flows put the
+     * one-time token in the path (e.g. `/reset-password/reset/{token}`), not
+     * only the query string.
+     */
+    private function stripUrlSecrets(string $url): ?string
+    {
+        $parts = parse_url($url);
+        if (false === $parts || !isset($parts['host'])) {
+            return null;
+        }
+
+        $scheme = isset($parts['scheme']) ? $parts['scheme'].'://' : '';
+        $port = isset($parts['port']) ? ':'.$parts['port'] : '';
+
+        return $scheme.$parts['host'].$port.$this->maskPathTokens($parts['path'] ?? '');
+    }
+
+    private function maskPathTokens(string $path): string
+    {
+        $segments = explode('/', $path);
+        foreach ($segments as $index => $segment) {
+            if ($this->looksLikeToken($segment)) {
+                $segments[$index] = '***';
+            }
+        }
+
+        return implode('/', $segments);
+    }
+
+    private function looksLikeToken(string $segment): bool
+    {
+        // Short segments are ids or descriptive words; keep them.
+        if (\strlen($segment) < 16) {
+            return false;
+        }
+
+        // A descriptive slug — lowercase words separated by single hyphens or
+        // underscores, each starting with a letter — is kept so the AI still
+        // sees the endpoint. Anything else of length >= 16 (hex/base64 blobs,
+        // UUIDs, mixed-case or digit-bearing opaque strings) is a likely token.
+        return 1 !== preg_match('/^[a-z][a-z0-9]*(?:[_-][a-z][a-z0-9]*)+$/', $segment);
     }
 
     /**

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/MailerCollectorFormatterTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/MailerCollectorFormatterTest.php
@@ -70,12 +70,12 @@ final class MailerCollectorFormatterTest extends TestCase
         $this->assertSame('smtp', $message['transport']);
         $this->assertFalse($message['is_queued']);
         $this->assertSame('Test Subject', $message['subject']);
-        $this->assertSame(['John Sender <sender@example.com>'], $message['from']);
-        $this->assertSame(['Jane Recipient <recipient@example.com>'], $message['to']);
+        $this->assertSame(['***@example.com'], $message['from']);
+        $this->assertSame(['***@example.com'], $message['to']);
         $this->assertSame([], $message['cc']);
         $this->assertSame([], $message['bcc']);
         $this->assertSame([], $message['reply_to']);
-        $this->assertSame('This is the body text.', $message['text_body']);
+        $this->assertTrue($message['has_text_body']);
         $this->assertFalse($message['has_html_body']);
         $this->assertSame([], $message['attachments']);
     }
@@ -111,7 +111,7 @@ final class MailerCollectorFormatterTest extends TestCase
 
         $result = $this->formatter->format($collector);
 
-        $this->assertNull($result['messages'][0]['text_body']);
+        $this->assertFalse($result['messages'][0]['has_text_body']);
         $this->assertTrue($result['messages'][0]['has_html_body']);
     }
 
@@ -132,21 +132,20 @@ final class MailerCollectorFormatterTest extends TestCase
         $result = $this->formatter->format($collector);
 
         $message = $result['messages'][0];
-        $this->assertSame(['sender@example.com'], $message['from']);
-        $this->assertSame(['to@example.com'], $message['to']);
-        $this->assertSame(['cc@example.com'], $message['cc']);
-        $this->assertSame(['bcc@example.com'], $message['bcc']);
-        $this->assertSame(['reply@example.com'], $message['reply_to']);
+        $this->assertSame(['***@example.com'], $message['from']);
+        $this->assertSame(['***@example.com'], $message['to']);
+        $this->assertSame(['***@example.com'], $message['cc']);
+        $this->assertSame(['***@example.com'], $message['bcc']);
+        $this->assertSame(['***@example.com'], $message['reply_to']);
     }
 
-    public function testFormatTruncatesLongBody()
+    public function testFormatOmitsEmailBody()
     {
-        $longBody = str_repeat('a', 600);
         $email = (new Email())
             ->from('sender@example.com')
             ->to('recipient@example.com')
-            ->subject('Long Body')
-            ->text($longBody);
+            ->subject('Sensitive')
+            ->text('Your one-time code is 123456 and your SSN is 000-00-0000.');
 
         $collector = $this->createCollectorWithMessages([
             $this->createMessageEvent($email, 'smtp', false),
@@ -154,8 +153,86 @@ final class MailerCollectorFormatterTest extends TestCase
 
         $result = $this->formatter->format($collector);
 
-        $this->assertSame(503, mb_strlen($result['messages'][0]['text_body']));
-        $this->assertStringEndsWith('...', $result['messages'][0]['text_body']);
+        $message = $result['messages'][0];
+        $this->assertArrayNotHasKey('text_body', $message);
+        $this->assertTrue($message['has_text_body']);
+        $this->assertStringNotContainsString('123456', json_encode($message));
+        $this->assertStringNotContainsString('000-00-0000', json_encode($message));
+    }
+
+    public function testFormatStripsTokensFromLinks()
+    {
+        $email = (new Email())
+            ->from('sender@example.com')
+            ->to('recipient@example.com')
+            ->subject('Reset your password')
+            ->text('Reset here: https://app.example.com/reset?token=SECRET-TOKEN&id=5#frag')
+            ->html('<a href="https://app.example.com/verify/path?code=ANOTHER-SECRET">verify</a>');
+
+        $collector = $this->createCollectorWithMessages([
+            $this->createMessageEvent($email, 'smtp', false),
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $this->assertSame(
+            ['https://app.example.com/reset', 'https://app.example.com/verify/path'],
+            $result['messages'][0]['links']
+        );
+
+        $serialized = json_encode($result);
+        $this->assertStringNotContainsString('SECRET-TOKEN', $serialized);
+        $this->assertStringNotContainsString('ANOTHER-SECRET', $serialized);
+    }
+
+    public function testFormatMasksPathEmbeddedTokens()
+    {
+        // Canonical SymfonyCasts reset flow puts the token in the path, not the query.
+        $resetToken = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
+        $email = (new Email())
+            ->from('sender@example.com')
+            ->to('recipient@example.com')
+            ->subject('Reset your password')
+            ->text('Reset: https://app.example.com/reset-password/reset/'.$resetToken);
+
+        $collector = $this->createCollectorWithMessages([
+            $this->createMessageEvent($email, 'smtp', false),
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $links = $result['messages'][0]['links'];
+        // The descriptive part of the path is kept; the token segment is masked.
+        $this->assertSame(['https://app.example.com/reset-password/reset/***'], $links);
+        $this->assertStringNotContainsString($resetToken, json_encode($result));
+    }
+
+    public function testFormatMasksShortHexAndUuidPathTokensButKeepsSlugs()
+    {
+        $email = (new Email())
+            ->from('sender@example.com')
+            ->to('recipient@example.com')
+            ->subject('links')
+            ->text(implode(' ', [
+                'https://app.test/verify/0123456789abcdef',                  // 16-char hex token
+                'https://app.test/u/550e8400-e29b-41d4-a716-446655440000',   // uuid token
+                'https://app.test/blog/how-to-configure-the-symfony-mailer', // descriptive slug
+            ]));
+
+        $collector = $this->createCollectorWithMessages([
+            $this->createMessageEvent($email, 'smtp', false),
+        ]);
+
+        $links = $this->formatter->format($collector)['messages'][0]['links'];
+
+        $this->assertContains('https://app.test/verify/***', $links);
+        $this->assertContains('https://app.test/u/***', $links);
+        // A long descriptive slug is preserved so the endpoint stays visible.
+        $this->assertContains('https://app.test/blog/how-to-configure-the-symfony-mailer', $links);
+
+        $serialized = json_encode($links);
+        $this->assertStringNotContainsString('0123456789abcdef', $serialized);
+        $this->assertStringNotContainsString('550e8400', $serialized);
     }
 
     public function testFormatWithAttachments()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT


The Mailer profiler collector handed the AI recipient addresses, up to 500 chars
of the raw text body, and — most dangerously — `extractLinks()` scraped every
URL out of the bodies, so password-reset / verification / magic-login links were
returned **with their one-time tokens**, handing the model working credentials.

- Omit the email body entirely (keep a `has_text_body` flag for triage).
- For links: drop userinfo, query string and fragment, and mask high-entropy
  path segments — the canonical reset flow `/reset-password/reset/{token}`
  carries the token in the **path** — while keeping descriptive slugs so the
  endpoint stays visible.
- Mask the local part of recipient addresses and drop display names (keep the
  domain).

Subjects are kept (diagnostic value outweighs the residual risk).

