### PR TITLE
[Agent] Fix int to float widening for scalar tool parameters

### DIFF
--- a/src/agent/src/Toolbox/ToolCallArgumentResolver.php
+++ b/src/agent/src/Toolbox/ToolCallArgumentResolver.php
@@ -101,6 +101,10 @@ final class ToolCallArgumentResolver implements ToolCallArgumentResolverInterfac
 
             $parameterType .= $dimensions;
 
+            if ('float' === $parameterType && \is_int($value)) {
+                $value = (float) $value;
+            }
+
             if ($this->denormalizer->supportsDenormalization($value, $parameterType, 'json')) {
                 $value = $this->denormalizer->denormalize($value, $parameterType, 'json');
             }

--- a/src/agent/tests/Fixtures/Tool/ToolScalarFloat.php
+++ b/src/agent/tests/Fixtures/Tool/ToolScalarFloat.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures\Tool;
+
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+
+#[AsTool('tool_scalar_float', 'A tool with float parameters')]
+final class ToolScalarFloat
+{
+    public function __invoke(float $height, ?float $weight = null): string
+    {
+        return \sprintf('Height: %.2fm, Weight: %.2fkg', $height, $weight);
+    }
+}

--- a/src/agent/tests/Toolbox/ToolCallArgumentResolverTest.php
+++ b/src/agent/tests/Toolbox/ToolCallArgumentResolverTest.php
@@ -18,6 +18,7 @@ use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolArrayMultidimensional;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolDate;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolNoParams;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolObjectFloat;
+use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolScalarFloat;
 use Symfony\AI\Agent\Tests\Fixtures\Tool\ToolWithNullableClass;
 use Symfony\AI\Agent\Toolbox\ToolCallArgumentResolver;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -99,6 +100,16 @@ class ToolCallArgumentResolverTest extends TestCase
         $personArgument = $resolver->resolveArguments($metadata, $toolCall)['person'];
         $this->assertInstanceOf(ToolObjectFloat::class, $personArgument);
         $this->assertSame(1.0, $personArgument->height);
+    }
+
+    public function testIntCastToFloatForScalarParameters()
+    {
+        $resolver = new ToolCallArgumentResolver();
+
+        $metadata = new Tool(new ExecutionReference(ToolScalarFloat::class, '__invoke'), 'tool_scalar_float', 'A tool with float parameters');
+        $toolCall = new ToolCall('tool_id_1234', 'tool_scalar_float', ['height' => 1, 'weight' => 80]);
+
+        $this->assertSame(['height' => 1.0, 'weight' => 80.0], $resolver->resolveArguments($metadata, $toolCall));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2136
| License       | MIT

JSON has a single Number type, so `{"amount": 100}` decodes to a PHP `int` and a tool declared as `__invoke(float $amount)` blows up with `Data expected to be of type "float" ("int" given)`.

#2011 passed `'json'` to `denormalize()`, which fixed the same problem for `float` properties of object parameters, because the int to float widening lives in `AbstractObjectNormalizer`. A top-level scalar never reaches that normalizer: `Serializer::denormalize()` handles it in its own scalar branch, which checks `is_float()` and ignores the format entirely.

So the resolver now widens the value itself when the resolved parameter type is `float`, same as the normalizer does for object properties. Nullable `float` parameters go through the same path, since the wrapped type is already unwrapped at that point.

Parameters typed `float[]` reach that same scalar branch one level down through `ArrayDenormalizer` and still throw. I left that out here since the issue is about the top-level case, but I can fold it in if you want both in one go.
