### PR TITLE
[Platform][Cache] Key MessageBag inputs on their message content

### DIFF
--- a/src/platform/src/Bridge/Cache/CachePlatform.php
+++ b/src/platform/src/Bridge/Cache/CachePlatform.php
@@ -81,6 +81,10 @@ final class CachePlatform implements PlatformInterface
             default => $this->generateInputCacheKey($input),
         };
 
+        if (isset($options['template_vars'])) {
+            $normalizedInput = hash('xxh128', $normalizedInput.serialize([$options['template_vars'], $options['template_options'] ?? []]));
+        }
+
         $cacheKey = (new UnicodeString())->join([
             $options['prompt_cache_key'] ?? $this->cacheKey,
             (new UnicodeString($modelName))->camel(),

--- a/src/platform/src/Bridge/Cache/MessageBagCacheKeyGenerator.php
+++ b/src/platform/src/Bridge/Cache/MessageBagCacheKeyGenerator.php
@@ -12,9 +12,18 @@
 namespace Symfony\AI\Platform\Bridge\Cache;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\File;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\MessageInterface;
 
 /**
+ * Keys a {@see MessageBag} on the content of its messages, in order.
+ *
+ * The identifiers and the metadata of the bag and of its messages describe the instance,
+ * not the conversation, and are left out of the hash. Identifiers a provider assigns to a
+ * content part, such as a tool call id, are kept, since they are sent along with it.
+ * Binary content is keyed on a hash of its bytes, as {@see FileCacheKeyGenerator} does.
+ *
  * @author Tac Tacelosky <tacman@gmail.com>
  */
 final class MessageBagCacheKeyGenerator implements CacheKeyGenerator
@@ -30,6 +39,43 @@ final class MessageBagCacheKeyGenerator implements CacheKeyGenerator
             throw new InvalidArgumentException(\sprintf('"%s" only supports "%s" inputs, "%s" given.', self::class, MessageBag::class, get_debug_type($input)));
         }
 
-        return $input->getId()->toString();
+        return hash('xxh128', serialize($this->normalize($input->getMessages())));
+    }
+
+    private function normalize(mixed $value): mixed
+    {
+        if ($value instanceof File) {
+            return [$value::class, $value->getFormat(), hash('xxh128', $value->asBinary())];
+        }
+
+        if (\is_array($value)) {
+            return array_map($this->normalize(...), $value);
+        }
+
+        if (!\is_object($value)) {
+            return $value;
+        }
+
+        if ($value instanceof \BackedEnum) {
+            return [$value::class, $value->value];
+        }
+
+        if ($value instanceof \UnitEnum) {
+            return [$value::class, $value->name];
+        }
+
+        $normalized = ['class' => $value::class];
+
+        foreach (get_mangled_object_vars($value) as $name => $property) {
+            $name = substr((string) strrchr("\0".$name, "\0"), 1);
+
+            if ($value instanceof MessageInterface && \in_array($name, ['id', 'metadata'], true)) {
+                continue;
+            }
+
+            $normalized[$name] = $this->normalize($property);
+        }
+
+        return $normalized;
     }
 }

--- a/src/platform/src/Bridge/Cache/Tests/CachePlatformTest.php
+++ b/src/platform/src/Bridge/Cache/Tests/CachePlatformTest.php
@@ -14,10 +14,12 @@ namespace Symfony\AI\Platform\Bridge\Cache\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Bridge\Cache\CacheKeyGenerator;
 use Symfony\AI\Platform\Bridge\Cache\CachePlatform;
+use Symfony\AI\Platform\Bridge\Cache\MessageBagCacheKeyGenerator;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Message\Content\DocumentUrl;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\Template;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -81,7 +83,7 @@ final class CachePlatformTest extends TestCase
         ]);
 
         $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
+        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', (new MessageBagCacheKeyGenerator())->generate($messageBag)), $adapter->getValues());
         $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
         $this->assertSame('test content', $deferredResult->getResult()->getContent());
 
@@ -90,7 +92,7 @@ final class CachePlatformTest extends TestCase
         ]);
 
         $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
+        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', (new MessageBagCacheKeyGenerator())->generate($messageBag)), $adapter->getValues());
         $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
         $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
         $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
@@ -99,7 +101,7 @@ final class CachePlatformTest extends TestCase
     public function testPlatformCanReturnCachedResultWhenCalledTwiceWithSeparateMessageBag()
     {
         $platform = $this->createMock(PlatformInterface::class);
-        $platform->expects($this->exactly(2))->method('invoke')->willReturn(new DeferredResult(
+        $platform->expects($this->once())->method('invoke')->willReturn(new DeferredResult(
             new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
         ));
 
@@ -119,42 +121,50 @@ final class CachePlatformTest extends TestCase
         ]);
 
         $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
+        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', (new MessageBagCacheKeyGenerator())->generate($messageBag)), $adapter->getValues());
         $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
         $this->assertSame('test content', $deferredResult->getResult()->getContent());
-
-        $secondDeferredResult = $cachedPlatform->invoke('foo', $messageBag, [
-            'prompt_cache_key' => 'symfony',
-        ]);
-
-        $this->assertCount(3, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $messageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
-        $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
-        $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
 
         $secondMessageBag = new MessageBag(
             Message::ofUser('Hello there'),
         );
 
-        $deferredResult = $cachedPlatform->invoke('foo', $secondMessageBag, [
-            'prompt_cache_key' => 'symfony',
-        ]);
-
-        $this->assertCount(5, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $secondMessageBag->getId()->toRfc4122()), $adapter->getValues());
-        $this->assertTrue($deferredResult->getMetadata()->has('cached_at'));
-        $this->assertSame('test content', $deferredResult->getResult()->getContent());
-
         $secondDeferredResult = $cachedPlatform->invoke('foo', $secondMessageBag, [
             'prompt_cache_key' => 'symfony',
         ]);
 
-        $this->assertCount(5, $adapter->getValues());
-        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', $secondMessageBag->getId()->toRfc4122()), $adapter->getValues());
+        $this->assertCount(3, $adapter->getValues());
+        $this->assertArrayHasKey(\sprintf('symfonyfoo%s', (new MessageBagCacheKeyGenerator())->generate($secondMessageBag)), $adapter->getValues());
         $this->assertSame('test content', $secondDeferredResult->getResult()->getContent());
         $this->assertTrue($secondDeferredResult->getMetadata()->has('cached_at'));
         $this->assertSame($deferredResult->getMetadata()->get('cached_at'), $secondDeferredResult->getMetadata()->get('cached_at'));
+    }
+
+    public function testPlatformDoesNotShareCacheBetweenDifferentMessageBags()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+
+        $cachedPlatform->invoke('foo', new MessageBag(Message::ofUser('Hello there')), ['prompt_cache_key' => 'symfony']);
+        $cachedPlatform->invoke('foo', new MessageBag(Message::ofUser('Hello again')), ['prompt_cache_key' => 'symfony']);
+    }
+
+    public function testPlatformDoesNotShareCacheBetweenDifferentTemplateVars()
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects($this->exactly(2))->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter(new TextResult('test content')), new InMemoryRawResult(),
+        ));
+
+        $cachedPlatform = new CachePlatform($platform, cache: new TagAwareAdapter(new ArrayAdapter()));
+        $messageBag = new MessageBag(Message::ofUser(Template::string('Hello {{ name }}')));
+
+        $cachedPlatform->invoke('foo', $messageBag, ['prompt_cache_key' => 'symfony', 'template_vars' => ['name' => 'Ada']]);
+        $cachedPlatform->invoke('foo', $messageBag, ['prompt_cache_key' => 'symfony', 'template_vars' => ['name' => 'Grace']]);
     }
 
     public function testPlatformCachesContentObjectInput()

--- a/src/platform/src/Bridge/Cache/Tests/MessageBagCacheKeyGeneratorTest.php
+++ b/src/platform/src/Bridge/Cache/Tests/MessageBagCacheKeyGeneratorTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cache\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cache\MessageBagCacheKeyGenerator;
+use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\Message\Content\Image;
+use Symfony\AI\Platform\Message\Content\ImageUrl;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\ToolCall;
+
+final class MessageBagCacheKeyGeneratorTest extends TestCase
+{
+    private MessageBagCacheKeyGenerator $generator;
+
+    protected function setUp(): void
+    {
+        $this->generator = new MessageBagCacheKeyGenerator();
+    }
+
+    public function testGeneratorSupportsMessageBag()
+    {
+        $this->assertTrue($this->generator->supports(new MessageBag()));
+        $this->assertFalse($this->generator->supports(new \stdClass()));
+    }
+
+    public function testGeneratorThrowsOnUnsupportedInput()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('"%s" only supports "%s" inputs, "stdClass" given.', MessageBagCacheKeyGenerator::class, MessageBag::class));
+
+        $this->generator->generate(new \stdClass());
+    }
+
+    public function testGeneratorReturnsSameKeyForSameMessageBag()
+    {
+        $messageBag = new MessageBag(
+            Message::forSystem('You are a helpful assistant'),
+            Message::ofUser('Hello there'),
+        );
+
+        $this->assertSame($this->generator->generate($messageBag), $this->generator->generate($messageBag));
+    }
+
+    public function testGeneratorReturnsSameKeyForSeparateMessageBagsWithSameContent()
+    {
+        $messageBag = new MessageBag(
+            Message::forSystem('You are a helpful assistant'),
+            Message::ofUser('Hello there'),
+            Message::ofAssistant('General Kenobi'),
+        );
+
+        $secondMessageBag = new MessageBag(
+            Message::forSystem('You are a helpful assistant'),
+            Message::ofUser('Hello there'),
+            Message::ofAssistant('General Kenobi'),
+        );
+
+        $this->assertSame($this->generator->generate($messageBag), $this->generator->generate($secondMessageBag));
+    }
+
+    public function testGeneratorReturnsDifferentKeyForDifferentContent()
+    {
+        $messageBag = new MessageBag(Message::ofUser('Hello there'));
+        $secondMessageBag = new MessageBag(Message::ofUser('Hello again'));
+
+        $this->assertNotSame($this->generator->generate($messageBag), $this->generator->generate($secondMessageBag));
+    }
+
+    public function testGeneratorReturnsDifferentKeyForDifferentMessageOrder()
+    {
+        $messageBag = new MessageBag(Message::ofUser('Hello there'), Message::ofUser('Hello again'));
+        $secondMessageBag = new MessageBag(Message::ofUser('Hello again'), Message::ofUser('Hello there'));
+
+        $this->assertNotSame($this->generator->generate($messageBag), $this->generator->generate($secondMessageBag));
+    }
+
+    public function testGeneratorReturnsDifferentKeyForDifferentRole()
+    {
+        $messageBag = new MessageBag(Message::ofUser('Hello there'));
+        $secondMessageBag = new MessageBag(Message::ofAssistant('Hello there'));
+
+        $this->assertNotSame($this->generator->generate($messageBag), $this->generator->generate($secondMessageBag));
+    }
+
+    public function testGeneratorKeysImageUrlContent()
+    {
+        $messageBag = new MessageBag(Message::ofUser(new Text('What is on it?'), new ImageUrl('https://example.com/first.png')));
+        $sameMessageBag = new MessageBag(Message::ofUser(new Text('What is on it?'), new ImageUrl('https://example.com/first.png')));
+        $otherMessageBag = new MessageBag(Message::ofUser(new Text('What is on it?'), new ImageUrl('https://example.com/second.png')));
+
+        $this->assertSame($this->generator->generate($messageBag), $this->generator->generate($sameMessageBag));
+        $this->assertNotSame($this->generator->generate($messageBag), $this->generator->generate($otherMessageBag));
+    }
+
+    public function testGeneratorKeysBinaryContentOnItsBytes()
+    {
+        $messageBag = new MessageBag(Message::ofUser(new Image(static fn (): string => 'first-image', 'image/png')));
+        $sameMessageBag = new MessageBag(Message::ofUser(new Image('first-image', 'image/png')));
+        $otherMessageBag = new MessageBag(Message::ofUser(new Image('second-image', 'image/png')));
+
+        $this->assertSame($this->generator->generate($messageBag), $this->generator->generate($sameMessageBag));
+        $this->assertNotSame($this->generator->generate($messageBag), $this->generator->generate($otherMessageBag));
+    }
+
+    public function testGeneratorKeysToolCallAndThinkingContent()
+    {
+        $messageBag = new MessageBag(Message::ofAssistant(new Thinking('Let me check'), new ToolCall('call_1', 'weather', ['city' => 'Paris'])));
+        $sameMessageBag = new MessageBag(Message::ofAssistant(new Thinking('Let me check'), new ToolCall('call_1', 'weather', ['city' => 'Paris'])));
+        $otherMessageBag = new MessageBag(Message::ofAssistant(new Thinking('Let me check'), new ToolCall('call_1', 'weather', ['city' => 'Berlin'])));
+
+        $this->assertSame($this->generator->generate($messageBag), $this->generator->generate($sameMessageBag));
+        $this->assertNotSame($this->generator->generate($messageBag), $this->generator->generate($otherMessageBag));
+    }
+
+    public function testGeneratorIgnoresMessageMetadata()
+    {
+        $messageBag = new MessageBag(Message::ofUser('Hello there'));
+
+        $key = $this->generator->generate($messageBag);
+        $messageBag->getMetadata()->set(['request_id' => 'abc']);
+        $messageBag->getMessages()[0]->getMetadata()->set(['request_id' => 'abc']);
+
+        $this->assertSame($key, $this->generator->generate($messageBag));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2192
| License       | MIT

`MessageBagCacheKeyGenerator` returned `$input->getId()->toString()`, and `MessageBag` generates a fresh `Uuid::v7()` in its constructor. Every request builds a new bag, so every request produced a new cache key and `CachePlatform` never returned a cached result for a conversation.

The generator now hashes the messages themselves: their class, their content and their order. The identifiers and the metadata of the bag and of its messages stay out of the hash, since they describe the instance rather than the conversation. Identifiers a provider assigns to a content part, a tool call id for instance, are kept, because they are sent along with it. Binary content is keyed on a hash of its bytes, the way `FileCacheKeyGenerator` already does, so a lazily read file does not leak its closure into the key.

`template_vars` now goes into the key as well. Templates are rendered inside the inner platform, after `CachePlatform` has built the key, so without that a bag of templates would serve the first render to every later set of variables.

The existing test for two separate bags with the same messages asserted the current behaviour (two calls to the inner platform), so it now asserts the cache hit, and further tests cover two bags with different messages and two calls with different template variables.
