### PR TITLE
[Chat][Platform] Notify stream listeners about deltas yielded from an injected generator

### DIFF
--- a/src/chat/tests/ChatStreamListenerTest.php
+++ b/src/chat/tests/ChatStreamListenerTest.php
@@ -17,9 +17,13 @@ use Symfony\AI\Chat\InMemory\Store as InMemoryStore;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\AbstractStreamListener;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\DeltaEvent;
 use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\ToolCall;
 
 final class ChatStreamListenerTest extends TestCase
 {
@@ -47,6 +51,36 @@ final class ChatStreamListenerTest extends TestCase
         $assistantMessage = $stored->getMessages()[1];
         $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
         $this->assertSame('I am doing well!', $assistantMessage->asText());
+    }
+
+    public function testItAccumulatesChunksOfAToolCallFollowUp()
+    {
+        $store = new InMemoryStore();
+        $messages = new MessageBag();
+        $messages->add(Message::ofUser('Hello'));
+
+        $generator = (static function () {
+            yield new ToolCallComplete([new ToolCall('id', 'some_tool')]);
+        })();
+
+        $stream = new StreamResult($generator);
+        $stream->addListener(new class extends AbstractStreamListener {
+            public function onDelta(DeltaEvent $event): void
+            {
+                $event->setDelta((static function (): \Generator {
+                    yield new TextDelta('The ');
+                    yield new TextDelta('answer.');
+                })());
+            }
+        });
+        $stream->addListener(new ChatStreamListener($messages, $store));
+
+        iterator_to_array($stream->getContent());
+
+        $stored = $store->load();
+        $assistantMessage = $stored->getMessages()[1];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame('The answer.', $assistantMessage->asText());
     }
 
     public function testItIgnoresNonStringChunks()

--- a/src/platform/src/Result/StreamResult.php
+++ b/src/platform/src/Result/StreamResult.php
@@ -59,22 +59,8 @@ final class StreamResult extends BaseResult
 
         try {
             foreach ($this->generator as $delta) {
-                $event = new DeltaEvent($this, $delta);
-                foreach ($this->listeners as $listener) {
-                    $listener->onDelta($event);
-                }
-                $this->getMetadata()->merge($event->getMetadata());
-
-                if ($event->isDeltaSkipped()) {
-                    continue;
-                }
-
-                $delta = $event->getDelta();
-
-                if ($delta instanceof DeltaInterface) {
-                    yield $delta;
-                } else {
-                    yield from $delta;
+                foreach ($this->dispatchDelta($delta, $this->listeners) as $dispatchedDelta) {
+                    yield $dispatchedDelta;
                 }
             }
         } catch (\Throwable $e) {
@@ -94,5 +80,46 @@ final class StreamResult extends BaseResult
             $listener->onComplete($event);
         }
         $this->getMetadata()->merge($event->getMetadata());
+    }
+
+    /**
+     * @param ListenerInterface[] $listeners
+     *
+     * @return \Generator<DeltaInterface>
+     */
+    private function dispatchDelta(DeltaInterface $delta, array $listeners): \Generator
+    {
+        $event = new DeltaEvent($this, $delta);
+        $nestedListeners = $listeners;
+
+        foreach ($listeners as $listener) {
+            $previousDelta = $event->getDelta();
+            $listener->onDelta($event);
+
+            // A listener that replaced the delta with a generator produced that content itself, so
+            // it is left out of the nested dispatch and does not reprocess its own output.
+            if ($event->getDelta() !== $previousDelta && $event->getDelta() instanceof \Generator) {
+                $nestedListeners = array_filter($nestedListeners, static fn ($nested) => $nested !== $listener);
+            }
+        }
+        $this->getMetadata()->merge($event->getMetadata());
+
+        if ($event->isDeltaSkipped()) {
+            return;
+        }
+
+        $delta = $event->getDelta();
+
+        if ($delta instanceof DeltaInterface) {
+            yield $delta;
+
+            return;
+        }
+
+        foreach ($delta as $nestedDelta) {
+            foreach ($this->dispatchDelta($nestedDelta, $nestedListeners) as $dispatchedDelta) {
+                yield $dispatchedDelta;
+            }
+        }
     }
 }

--- a/src/platform/tests/Result/StreamResultTest.php
+++ b/src/platform/tests/Result/StreamResultTest.php
@@ -70,6 +70,53 @@ final class StreamResultTest extends TestCase
         $this->assertSame('chunk2', $capturedDeltas[1]->getText());
     }
 
+    public function testListenersAreNotifiedAboutDeltasYieldedFromAnInjectedGenerator()
+    {
+        $result = new StreamResult((static function () {
+            yield new TextDelta('chunk1');
+        })());
+
+        $observer = new class extends AbstractStreamListener {
+            /** @var list<string> */
+            public array $texts = [];
+
+            public function onDelta(DeltaEvent $event): void
+            {
+                $delta = $event->getDelta();
+                if ($delta instanceof TextDelta) {
+                    $this->texts[] = $delta->getText();
+                }
+            }
+        };
+
+        $injector = new class extends AbstractStreamListener {
+            public int $calls = 0;
+
+            public function onDelta(DeltaEvent $event): void
+            {
+                ++$this->calls;
+
+                $event->setDelta((static function (): \Generator {
+                    yield new TextDelta('nested1');
+                    yield new TextDelta('nested2');
+                })());
+            }
+        };
+
+        $result->addListener($observer);
+        $result->addListener($injector);
+
+        $content = iterator_to_array($result->getContent());
+
+        $this->assertSame(['chunk1', 'nested1', 'nested2'], $observer->texts);
+        $this->assertSame(1, $injector->calls);
+        $this->assertCount(2, $content);
+        $this->assertInstanceOf(TextDelta::class, $content[0]);
+        $this->assertSame('nested1', $content[0]->getText());
+        $this->assertInstanceOf(TextDelta::class, $content[1]);
+        $this->assertSame('nested2', $content[1]->getText());
+    }
+
     public function testListenerCanAddMetadataDuringStreaming()
     {
         $result = new StreamResult((static function () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2330
| License       | MIT

When a stream listener replaces a delta with a generator, `StreamResult::getContent()` forwarded it with `yield from`. PHP does not re-enter the outer generator for the values of a delegated one, so the deltas coming out of that generator were never sent to `onDelta()`. The toolbox `StreamListener` injects the tool-call follow-up exactly that way, which is why `ChatStreamListener` saw nothing after a tool call and stored an empty assistant message, while the frontend received the text.

The delta dispatch now recurses into an injected generator and notifies the listeners about each delta it yields. The listener that injected the generator is left out of that nested round, so it does not reprocess its own output: `PartialObjectStreamListener` would otherwise buffer the same text twice and re-inject forever, and the toolbox `StreamListener` would drop the follow-up it just produced. The order and the number of yielded deltas stay the same.

The forwarding also went through `yield from`, which keeps the inner generator's keys, so the outer stream repeated key `0` and `iterator_to_array()` on it silently lost deltas. Yielding one by one gives the whole stream sequential keys again.
