### PR TITLE
[Agent] Preserve assistant content during tool calls

### DIFF
--- a/src/agent/src/Execution/Runner.php
+++ b/src/agent/src/Execution/Runner.php
@@ -79,7 +79,7 @@ final class Runner
 
         if ($result instanceof StreamResult) {
             $result->addListener(new StreamListener(
-                fn (ToolCallResult $toolCallResult, ?AssistantMessage $streamedAssistantResponse = null): ResultInterface => $this->handleToolCalls($agent, $messages, $options, $toolCallResult, $streamedAssistantResponse),
+                fn (ToolCallResult $toolCallResult, ?AssistantMessage $assistantResponse = null): ResultInterface => $this->handleToolCalls($agent, $messages, $options, $toolCallResult, $assistantResponse),
             ));
 
             return $result;
@@ -91,7 +91,8 @@ final class Runner
             return $result;
         }
 
-        return $this->handleToolCalls($agent, $messages, $options, $toolCallResult);
+        // Pass the full mixed result so thinking and text survive the tool round-trip
+        return $this->handleToolCalls($agent, $messages, $options, $toolCallResult, Message::ofAssistant($result));
     }
 
     /**
@@ -131,16 +132,12 @@ final class Runner
     /**
      * @param array<string, mixed> $options
      */
-    private function handleToolCalls(AgentInterface $agent, MessageBag $messages, array $options, ToolCallResult $result, ?AssistantMessage $streamedAssistantResponse = null): ResultInterface
+    private function handleToolCalls(AgentInterface $agent, MessageBag $messages, array $options, ToolCallResult $result, ?AssistantMessage $assistantResponse = null): ResultInterface
     {
         \assert($this->toolExecutor instanceof ToolExecutorInterface);
 
         ++$this->nestingLevel;
         $messages = $this->excludeToolMessages ? clone $messages : $messages;
-
-        if (null !== $streamedAssistantResponse && [] !== $streamedAssistantResponse->getContent()) {
-            $messages->add($streamedAssistantResponse);
-        }
 
         try {
             $iterations = 0;
@@ -152,7 +149,16 @@ final class Runner
                 $toolCalls = array_values($result->getContent());
                 $toolResults = $this->toolExecutor->execute($toolCalls);
 
-                $messages->add(Message::ofAssistant(...$toolCalls));
+                // Preserve the provider's original content on the first iteration; later
+                // tool-only iterations synthesize the assistant tool-call message as before
+                if (null === $assistantResponse) {
+                    $assistantResponse = Message::ofAssistant(...$toolCalls);
+                } elseif (!$assistantResponse->hasToolCalls()) {
+                    $assistantResponse = new AssistantMessage(...$assistantResponse->getContent(), ...$toolCalls);
+                }
+                $messages->add($assistantResponse);
+                $assistantResponse = null;
+
                 foreach ($toolResults as $i => $toolResult) {
                     $messages->add(Message::ofToolCall($toolCalls[$i], $this->resultConverter->convert($toolResult)));
                 }

--- a/src/agent/src/Toolbox/StreamListener.php
+++ b/src/agent/src/Toolbox/StreamListener.php
@@ -11,12 +11,20 @@
 
 namespace Symfony\AI\Agent\Toolbox;
 
-use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\ContentInterface;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\AbstractStreamListener;
 use Symfony\AI\Platform\Result\Stream\CompleteEvent;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingSignature;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\Stream\DeltaEvent;
 use Symfony\AI\Platform\Result\Stream\StartEvent;
 use Symfony\AI\Platform\Result\ToolCallResult;
@@ -27,7 +35,18 @@ use Symfony\AI\Platform\Result\ToolCallResult;
  */
 final class StreamListener extends AbstractStreamListener
 {
-    private string $buffer = '';
+    /**
+     * Content is collected in provider order; strings reserve the positions announced by ToolCallStart.
+     *
+     * @var list<ContentInterface|string>
+     */
+    private array $assistantContent = [];
+
+    // Index of the thinking block currently receiving streamed chunks
+    private ?int $currentThinkingIndex = null;
+
+    // Last thinking block, for providers that emit its signature after completion
+    private ?int $lastThinkingIndex = null;
     private ?ResultInterface $result = null;
     private bool $toolHandled = false;
 
@@ -38,14 +57,15 @@ final class StreamListener extends AbstractStreamListener
 
     public function onStart(StartEvent $event): void
     {
-        $this->buffer = '';
+        $this->assistantContent = [];
+        $this->currentThinkingIndex = null;
+        $this->lastThinkingIndex = null;
         $this->result = null;
         $this->toolHandled = false;
     }
 
     public function onDelta(DeltaEvent $event): void
     {
-        // Skip further processing if a tool call has already been handled
         if ($this->toolHandled) {
             $event->skipDelta();
 
@@ -54,17 +74,97 @@ final class StreamListener extends AbstractStreamListener
 
         $delta = $event->getDelta();
 
-        // Build up assistant message for tool call response.
+        // Empty deltas carry no replay state, and some providers reject empty content blocks
+        if ($delta instanceof TextDelta && '' === $delta->getText()) {
+            $event->skipDelta();
+
+            return;
+        }
+
+        // Build the assistant message that will be replayed with the tool results
         if ($delta instanceof TextDelta) {
-            $this->buffer .= $delta->getText();
+            $index = array_key_last($this->assistantContent);
+            $text = null === $index ? null : $this->assistantContent[$index];
+            if ($text instanceof Text) {
+                $this->assistantContent[$index] = new Text($text->getText().$delta->getText(), $text->getSignature());
+            } else {
+                $this->assistantContent[] = new Text($delta->getText());
+            }
+            $this->currentThinkingIndex = null;
+        } elseif ($delta instanceof ThinkingStart) {
+            $this->startThinking();
+        } elseif ($delta instanceof ThinkingDelta) {
+            $index = $this->currentThinkingIndex ?? $this->startThinking();
+            /** @var Thinking $thinking */
+            $thinking = $this->assistantContent[$index];
+            $this->assistantContent[$index] = new Thinking($thinking->getContent().$delta->getThinking(), $thinking->getSignature());
+        } elseif ($delta instanceof ThinkingSignature) {
+            $index = $this->currentThinkingIndex;
+            if (null === $index) {
+                $index = $this->lastThinkingIndex;
+                $thinking = null === $index ? null : $this->assistantContent[$index];
+                if (!$thinking instanceof Thinking || null !== $thinking->getSignature()) {
+                    $index = $this->startThinking();
+                    // A signature without an open thinking block is a complete
+                    // provider-state item, not a chunk of the next one
+                    $this->currentThinkingIndex = null;
+                }
+            }
+
+            /** @var Thinking $thinking */
+            $thinking = $this->assistantContent[$index];
+            $this->assistantContent[$index] = new Thinking($thinking->getContent(), ($thinking->getSignature() ?? '').$delta->getSignature());
+            $this->lastThinkingIndex = $index;
+        } elseif ($delta instanceof ThinkingComplete) {
+            $index = $this->currentThinkingIndex ?? $this->startThinking();
+            /** @var Thinking $thinking */
+            $thinking = $this->assistantContent[$index];
+            $this->assistantContent[$index] = new Thinking($delta->getThinking(), $delta->getSignature() ?? $thinking->getSignature());
+            $this->currentThinkingIndex = null;
+            $this->lastThinkingIndex = $index;
+        } elseif ($delta instanceof ToolCallStart) {
+            $this->assistantContent[] = $delta->getId();
+            $this->currentThinkingIndex = null;
         }
 
         if (!$delta instanceof ToolCallComplete) {
             return;
         }
 
-        $streamedMessage = '' === $this->buffer ? null : Message::ofAssistant($this->buffer);
-        $this->result = ($this->handleToolCallsCallback)(new ToolCallResult($delta->getToolCalls()), $streamedMessage);
+        // Replace ToolCallStart placeholders with completed calls while retaining their
+        // positions relative to text and thinking blocks
+        $toolCalls = [];
+        foreach ($delta->getToolCalls() as $toolCall) {
+            $toolCalls[$toolCall->getId()] = $toolCall;
+        }
+
+        $content = [];
+        $placedToolCalls = [];
+        foreach ($this->assistantContent as $part) {
+            // A frame without content or a signature is structural only and must not be replayed
+            if ($part instanceof Thinking && '' === $part->getContent() && null === $part->getSignature()) {
+                continue;
+            }
+
+            if ($part instanceof ContentInterface) {
+                $content[] = $part;
+            } elseif (isset($toolCalls[$part])) {
+                $content[] = $toolCalls[$part];
+                $placedToolCalls[$part] = true;
+            }
+        }
+
+        // Bridges that do not emit ToolCallStart still need all completed calls replayed
+        foreach ($delta->getToolCalls() as $toolCall) {
+            if (!isset($placedToolCalls[$toolCall->getId()])) {
+                $content[] = $toolCall;
+            }
+        }
+
+        $this->result = ($this->handleToolCallsCallback)(
+            new ToolCallResult($delta->getToolCalls()),
+            new AssistantMessage(...$content),
+        );
 
         $content = $this->result->getContent();
         $event->setDelta(\is_string($content) ? new TextDelta($content) : $content);
@@ -74,11 +174,20 @@ final class StreamListener extends AbstractStreamListener
 
     public function onComplete(CompleteEvent $event): void
     {
-        $this->buffer = '';
+        $this->assistantContent = [];
+        $this->currentThinkingIndex = null;
+        $this->lastThinkingIndex = null;
         $this->toolHandled = false;
 
         if (null !== $this->result) {
             $event->getMetadata()->merge($this->result->getMetadata());
         }
+    }
+
+    private function startThinking(): int
+    {
+        $this->assistantContent[] = new Thinking('');
+
+        return $this->currentThinkingIndex = $this->lastThinkingIndex = array_key_last($this->assistantContent);
     }
 }

--- a/src/agent/tests/Execution/RunnerTest.php
+++ b/src/agent/tests/Execution/RunnerTest.php
@@ -22,15 +22,22 @@ use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
 use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\ToolCallMessage;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingSignature;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\Test\InMemoryPlatform;
@@ -133,6 +140,36 @@ final class RunnerTest extends TestCase
 
         $this->assertInstanceOf(TextResult::class, $actual);
         $this->assertSame('Final response', $actual->getContent());
+    }
+
+    public function testThinkingIsPreservedInAssistantToolCallMessage()
+    {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Test response'));
+
+        $result = new MultiPartResult([
+            new ThinkingResult('I should use a tool.', 'sig_123'),
+            new ToolCallResult([$toolCall]),
+        ]);
+        $agent = $this->createStub(AgentInterface::class);
+        $agent->method('call')->willReturn(new TextResult('Final response'));
+        $messages = new MessageBag();
+
+        $runner = $this->createRunner($this->platform($result), $toolbox);
+        $runner->run($agent, 'claude', $messages, []);
+
+        $assistantMessage = $messages->getMessages()[0];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $content = $assistantMessage->getContent();
+        $this->assertCount(2, $content);
+        $this->assertInstanceOf(Thinking::class, $content[0]);
+        $this->assertSame('I should use a tool.', $content[0]->getContent());
+        $this->assertSame('sig_123', $content[0]->getSignature());
+        $this->assertSame($toolCall, $content[1]);
     }
 
     public function testMultiPartResultWithSeveralToolCallPartsExecutesAllOfThem()
@@ -402,13 +439,67 @@ final class RunnerTest extends TestCase
         $result = $runner->run($agent, 'gpt-4', new MessageBag(), []);
         iterator_to_array($result->getContent());
 
-        $this->assertNotNull($capturedMessages);
-        $textMessages = array_filter(
+        $this->assertInstanceOf(MessageBag::class, $capturedMessages);
+        $assistantMessages = array_values(array_filter(
             $capturedMessages->getMessages(),
-            static fn ($message): bool => $message instanceof AssistantMessage && !$message->hasToolCalls(),
-        );
-        $this->assertCount(1, $textMessages);
-        $this->assertSame('Let me check that.', reset($textMessages)->asText());
+            static fn ($message): bool => $message instanceof AssistantMessage,
+        ));
+        $this->assertCount(1, $assistantMessages);
+        $this->assertTrue($assistantMessages[0]->hasToolCalls());
+        $this->assertSame('Let me check that.', $assistantMessages[0]->asText());
+    }
+
+    public function testStreamedThinkingIsPreservedInAssistantToolCallMessage()
+    {
+        $toolCall1 = new ToolCall('call_1', 'tool_1');
+        $toolCall2 = new ToolCall('call_2', 'tool_2');
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->expects($this->exactly(2))
+            ->method('execute')
+            ->willReturnCallback(static fn (ToolCall $toolCall): ToolResult => new ToolResult($toolCall, 'Test response'));
+
+        $stream = new StreamResult((static function () use ($toolCall1, $toolCall2) {
+            yield new ThinkingStart();
+            yield new ThinkingSignature('opaque_sig');
+            yield new ThinkingComplete('', 'opaque_sig');
+            yield new ToolCallStart($toolCall1->getId(), $toolCall1->getName());
+            yield new ThinkingStart();
+            yield new ThinkingDelta('A visible summary.');
+            yield new ThinkingSignature('summary_sig');
+            yield new ThinkingComplete('A visible summary.', 'summary_sig');
+            yield new ToolCallStart($toolCall2->getId(), $toolCall2->getName());
+            yield new ToolCallComplete([$toolCall1, $toolCall2]);
+        })());
+
+        $capturedMessages = null;
+        $agent = $this->createMock(AgentInterface::class);
+        $agent
+            ->expects($this->once())
+            ->method('call')
+            ->willReturnCallback(static function (MessageBag $messages) use (&$capturedMessages): TextResult {
+                $capturedMessages = $messages;
+
+                return new TextResult('Final response');
+            });
+
+        $runner = $this->createRunner($this->platform($stream), $toolbox);
+        $result = $runner->run($agent, 'claude', new MessageBag(), []);
+        iterator_to_array($result->getContent());
+
+        $this->assertInstanceOf(MessageBag::class, $capturedMessages);
+        $assistantMessage = $capturedMessages->getMessages()[0];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $content = $assistantMessage->getContent();
+        $this->assertCount(4, $content);
+        $this->assertInstanceOf(Thinking::class, $content[0]);
+        $this->assertSame('', $content[0]->getContent());
+        $this->assertSame('opaque_sig', $content[0]->getSignature());
+        $this->assertSame($toolCall1, $content[1]);
+        $this->assertInstanceOf(Thinking::class, $content[2]);
+        $this->assertSame('A visible summary.', $content[2]->getContent());
+        $this->assertSame('summary_sig', $content[2]->getSignature());
+        $this->assertSame($toolCall2, $content[3]);
     }
 
     public function testUsageMetadataGetsPropagatedInStreaming()

--- a/src/agent/tests/Toolbox/StreamListenerTest.php
+++ b/src/agent/tests/Toolbox/StreamListenerTest.php
@@ -14,8 +14,11 @@ namespace Symfony\AI\Agent\Tests\Toolbox;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Agent\Toolbox\StreamListener;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Result\Stream\AbstractStreamListener;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingSignature;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\Stream\DeltaEvent;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -106,7 +109,83 @@ final class StreamListenerTest extends TestCase
         $this->assertInstanceOf(TextDelta::class, $result[0]);
         $this->assertSame('Immediate tool response', $result[0]->getText());
         $this->assertTrue($callbackCalled);
-        $this->assertNull($capturedAssistantMessage);
+        $this->assertInstanceOf(AssistantMessage::class, $capturedAssistantMessage);
+        $this->assertTrue($capturedAssistantMessage->hasToolCalls());
+        $this->assertNull($capturedAssistantMessage->asText());
+    }
+
+    public function testEmptyTextAndStartOnlyThinkingAreNotReplayed()
+    {
+        $toolCall = new ToolCall('test-id', 'test_tool');
+        $streamResult = new StreamResult((static function () use ($toolCall): \Generator {
+            yield new TextDelta('');
+            yield new ThinkingStart();
+            yield new ToolCallComplete([$toolCall]);
+        })());
+
+        $capturedAssistantMessage = null;
+        $streamResult->addListener(new StreamListener(static function (ToolCallResult $result, AssistantMessage $message) use (&$capturedAssistantMessage): TextResult {
+            $capturedAssistantMessage = $message;
+
+            return new TextResult('Tool response');
+        }));
+        iterator_to_array($streamResult->getContent());
+
+        $this->assertInstanceOf(AssistantMessage::class, $capturedAssistantMessage);
+        $this->assertSame([$toolCall], $capturedAssistantMessage->getContent());
+    }
+
+    public function testConsecutiveSignatureOnlyThinkingBlocksRemainSeparate()
+    {
+        $toolCall = new ToolCall('test-id', 'test_tool');
+        $streamResult = new StreamResult((static function () use ($toolCall): \Generator {
+            yield new ThinkingSignature('first-signature');
+            yield new ThinkingSignature('second-signature');
+            yield new ToolCallComplete([$toolCall]);
+        })());
+
+        $capturedAssistantMessage = null;
+        $streamResult->addListener(new StreamListener(static function (ToolCallResult $result, AssistantMessage $message) use (&$capturedAssistantMessage): TextResult {
+            $capturedAssistantMessage = $message;
+
+            return new TextResult('Tool response');
+        }));
+        iterator_to_array($streamResult->getContent());
+
+        $this->assertInstanceOf(AssistantMessage::class, $capturedAssistantMessage);
+        $content = $capturedAssistantMessage->getContent();
+        $this->assertCount(3, $content);
+        $this->assertInstanceOf(Thinking::class, $content[0]);
+        $this->assertSame('first-signature', $content[0]->getSignature());
+        $this->assertInstanceOf(Thinking::class, $content[1]);
+        $this->assertSame('second-signature', $content[1]->getSignature());
+        $this->assertSame($toolCall, $content[2]);
+    }
+
+    public function testSignatureChunksForOpenThinkingAreCombined()
+    {
+        $toolCall = new ToolCall('test-id', 'test_tool');
+        $streamResult = new StreamResult((static function () use ($toolCall): \Generator {
+            yield new ThinkingStart();
+            yield new ThinkingSignature('first-');
+            yield new ThinkingSignature('second');
+            yield new ToolCallComplete([$toolCall]);
+        })());
+
+        $capturedAssistantMessage = null;
+        $streamResult->addListener(new StreamListener(static function (ToolCallResult $result, AssistantMessage $message) use (&$capturedAssistantMessage): TextResult {
+            $capturedAssistantMessage = $message;
+
+            return new TextResult('Tool response');
+        }));
+        iterator_to_array($streamResult->getContent());
+
+        $this->assertInstanceOf(AssistantMessage::class, $capturedAssistantMessage);
+        $content = $capturedAssistantMessage->getContent();
+        $this->assertCount(2, $content);
+        $this->assertInstanceOf(Thinking::class, $content[0]);
+        $this->assertSame('first-second', $content[0]->getSignature());
+        $this->assertSame($toolCall, $content[1]);
     }
 
     public function testGetContentWithToolCallCompleteReturningGenerator()

--- a/src/platform/src/Bridge/OpenResponses/Contract/Message/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/OpenResponses/Contract/Message/AssistantMessageNormalizer.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 
@@ -34,30 +35,80 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        $reasoningItems = $this->extractReasoningItems($data);
-
-        if ($data->hasToolCalls()) {
-            /** @var list<array<string, mixed>> $toolCalls */
-            $toolCalls = $this->normalizer->normalize($data->getToolCalls(), $format, $context);
-
-            return array_merge($reasoningItems, $toolCalls);
-        }
-
+        $items = [];
         $text = '';
+
+        // Responses input is a flat list of output items. Text is buffered until
+        // a reasoning item or tool call establishes the next position in that list
         foreach ($data->getContent() as $part) {
             if ($part instanceof Text) {
                 $text .= $part->getText();
+                continue;
+            }
+
+            if ($part instanceof Thinking) {
+                // With store=false, the signature carries the original reasoning output item
+                $signature = $part->getSignature();
+                if (null === $signature) {
+                    continue;
+                }
+
+                try {
+                    $item = json_decode($signature, true, flags: \JSON_THROW_ON_ERROR);
+                } catch (\JsonException) {
+                    // Signatures from other providers may be opaque strings
+                    continue;
+                }
+
+                if (!\is_array($item) || 'reasoning' !== ($item['type'] ?? null)) {
+                    continue;
+                }
+
+                if ('' !== $text) {
+                    $items[] = [
+                        'role' => $data->getRole()->value,
+                        'type' => 'message',
+                        'content' => $text,
+                    ];
+                    $text = '';
+                }
+                $items[] = $item;
+                continue;
+            }
+
+            if ($part instanceof ToolCall) {
+                if ('' !== $text) {
+                    $items[] = [
+                        'role' => $data->getRole()->value,
+                        'type' => 'message',
+                        'content' => $text,
+                    ];
+                    $text = '';
+                }
+                /** @var array<string, mixed> $toolCall */
+                $toolCall = $this->normalizer->normalize($part, $format, $context);
+                $items[] = $toolCall;
             }
         }
 
-        return [
-            ...$reasoningItems,
-            [
+        if ('' !== $text) {
+            $items[] = [
                 'role' => $data->getRole()->value,
                 'type' => 'message',
-                'content' => '' === $text ? null : $text,
-            ],
-        ];
+                'content' => $text,
+            ];
+        }
+
+        // Keep the existing empty-assistant representation when nothing is replayable
+        if ([] === $items) {
+            $items[] = [
+                'role' => $data->getRole()->value,
+                'type' => 'message',
+                'content' => null,
+            ];
+        }
+
+        return $items;
     }
 
     protected function supportedDataClass(): string
@@ -68,32 +119,5 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
     protected function supportsModel(Model $model): bool
     {
         return $model instanceof ResponsesModel;
-    }
-
-    /**
-     * @return list<array<string, mixed>>
-     */
-    private function extractReasoningItems(AssistantMessage $data): array
-    {
-        $items = [];
-
-        foreach ($data->getContent() as $part) {
-            if (!$part instanceof Thinking || null === $part->getSignature()) {
-                continue;
-            }
-
-            try {
-                $item = json_decode($part->getSignature(), true, flags: \JSON_THROW_ON_ERROR);
-            } catch (\JsonException) {
-                // Signatures from other providers may be opaque strings
-                continue;
-            }
-
-            if (\is_array($item) && 'reasoning' === ($item['type'] ?? null)) {
-                $items[] = $item;
-            }
-        }
-
-        return $items;
     }
 }

--- a/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/AssistantMessageNormalizerTest.php
@@ -65,6 +65,20 @@ class AssistantMessageNormalizerTest extends TestCase
             ],
         ];
 
+        yield 'text is preserved around tool calls' => [
+            Message::ofAssistant(new Text('Before'), $toolCall, new Text('After')),
+            [
+                ['role' => 'assistant', 'type' => 'message', 'content' => 'Before'],
+                [
+                    'arguments' => json_encode($toolCall->getArguments()),
+                    'call_id' => $toolCall->getId(),
+                    'name' => $toolCall->getName(),
+                    'type' => 'function_call',
+                ],
+                ['role' => 'assistant', 'type' => 'message', 'content' => 'After'],
+            ],
+        ];
+
         $reasoningItem = [
             'type' => 'reasoning',
             'id' => 'rs_1',
@@ -81,6 +95,30 @@ class AssistantMessageNormalizerTest extends TestCase
                     'name' => $toolCall->getName(),
                     'type' => 'function_call',
                 ],
+            ],
+        ];
+
+        $secondReasoningItem = [
+            'type' => 'reasoning',
+            'id' => 'rs_2',
+            'summary' => [['type' => 'summary_text', 'text' => 'More pondering.']],
+            'encrypted_content' => 'gAAAAA-more-encrypted',
+        ];
+        yield 'reasoning items keep their order around tool calls' => [
+            Message::ofAssistant(
+                new Thinking('Pondering.', json_encode($reasoningItem)),
+                $toolCall,
+                new Thinking('More pondering.', json_encode($secondReasoningItem)),
+            ),
+            [
+                $reasoningItem,
+                [
+                    'arguments' => json_encode($toolCall->getArguments()),
+                    'call_id' => $toolCall->getId(),
+                    'name' => $toolCall->getName(),
+                    'type' => 'function_call',
+                ],
+                $secondReasoningItem,
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | no <!-- required for new features -->
| Issues        | n/a
| License       | MIT

Preserves the assistant’s complete response (text, thinking/signatures, and tool calls) when an agent enters the tool loop. Content order is retained for streaming and buffered responses, including OpenResponses, while empty replay blocks are discarded.
