### PR TITLE
[Agent] Fix max tool calls never capping the tool calling loop

### DIFF
--- a/examples/agent/toolcall-limit.php
+++ b/examples/agent/toolcall-limit.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Exception\MaxIterationsExceededException;
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+#[AsTool('process_next_message', 'Processes the next message of the queue and reports the remaining ones')]
+final class QueueProcessor
+{
+    private int $processed = 0;
+
+    public function __invoke(): string
+    {
+        ++$this->processed;
+
+        return sprintf('Message %d processed, 100 messages left in the queue.', $this->processed);
+    }
+}
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+$toolbox = new Toolbox([new QueueProcessor()], logger: logger());
+$agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox, maxToolCalls: 3);
+
+$messages = new MessageBag(
+    Message::forSystem('You work off message queues. Keep processing messages until the queue is empty.'),
+    Message::ofUser('Please empty the message queue.'),
+);
+
+try {
+    $result = $agent->call($messages);
+} catch (MaxIterationsExceededException $e) {
+    echo $e->getMessage().\PHP_EOL;
+
+    exit(0);
+}
+
+output()->writeln('<error>Expected the tool call limit to stop the agent, but it returned a result.</error>');
+echo $result->getContent().\PHP_EOL;
+
+exit(1);

--- a/src/agent/src/Execution/Runner.php
+++ b/src/agent/src/Execution/Runner.php
@@ -51,6 +51,11 @@ final class Runner
      */
     private int $nestingLevel = 0;
 
+    /**
+     * Counts the tool calling rounds of one agent call, including the ones happening in nested agent calls.
+     */
+    private int $iterations = 0;
+
     public function __construct(
         private readonly PlatformInterface $platform,
         private readonly ?ToolboxInterface $toolbox = null,
@@ -69,6 +74,11 @@ final class Runner
      */
     public function run(AgentInterface $agent, string $model, MessageBag $messages, array $options): ResultInterface
     {
+        // nested calls continue the tool calling loop of the outermost call and share its budget
+        if (0 === $this->nestingLevel) {
+            $this->iterations = 0;
+        }
+
         $options = $this->exposeTools($options);
 
         $result = $this->platform->invoke($model, $messages, $options)->getResult();
@@ -143,9 +153,8 @@ final class Runner
         }
 
         try {
-            $iterations = 0;
             do {
-                if (null !== $this->maxToolCalls && ++$iterations > $this->maxToolCalls) {
+                if (null !== $this->maxToolCalls && ++$this->iterations > $this->maxToolCalls) {
                     throw new MaxIterationsExceededException($this->maxToolCalls);
                 }
 

--- a/src/agent/tests/AgentTest.php
+++ b/src/agent/tests/AgentTest.php
@@ -16,11 +16,14 @@ use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\AgentAwareInterface;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Agent\Exception\InvalidArgumentException;
+use Symfony\AI\Agent\Exception\MaxIterationsExceededException;
 use Symfony\AI\Agent\Input;
 use Symfony\AI\Agent\InputProcessorInterface;
 use Symfony\AI\Agent\Output;
 use Symfony\AI\Agent\OutputProcessorInterface;
 use Symfony\AI\Agent\Tests\Fixtures\MessageBagCapturingProcessor;
+use Symfony\AI\Agent\Toolbox\ToolboxInterface;
+use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Message\Content\Audio;
 use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Content\Text;
@@ -32,7 +35,11 @@ use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\Test\InMemoryPlatform;
+use Symfony\AI\Platform\Tool\ExecutionReference;
+use Symfony\AI\Platform\Tool\Tool;
 
 final class AgentTest extends TestCase
 {
@@ -269,6 +276,34 @@ final class AgentTest extends TestCase
         $agent = new Agent($platform, 'gpt-4', $inputProcessors, $outputProcessors);
 
         $this->assertInstanceOf(AgentInterface::class, $agent);
+    }
+
+    public function testMaxToolCallsCapsTheToolCallingLoop()
+    {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->method('getTools')
+            ->willReturn([new Tool(new ExecutionReference('ClassTool1', 'method1'), 'tool1', 'description1', null)]);
+        $toolbox
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Test response'));
+
+        $invocations = 0;
+        $platform = new InMemoryPlatform(static function () use (&$invocations, $toolCall): ResultInterface {
+            if (++$invocations > 10) {
+                throw new \LogicException('The tool calling loop was not capped by max tool calls.');
+            }
+
+            return new ToolCallResult([$toolCall]);
+        });
+
+        $agent = new Agent($platform, 'gpt-4', toolbox: $toolbox, maxToolCalls: 3);
+
+        $this->expectException(MaxIterationsExceededException::class);
+        $this->expectExceptionMessage('Maximum number of tool calling iterations (3) exceeded.');
+
+        $agent->call(new MessageBag(), []);
     }
 
     public function testGetNameReturnsDefaultName()

--- a/src/agent/tests/Execution/RunnerTest.php
+++ b/src/agent/tests/Execution/RunnerTest.php
@@ -24,6 +24,7 @@ use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\ToolCallMessage;
+use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -455,17 +456,34 @@ final class RunnerTest extends TestCase
             ->method('execute')
             ->willReturn(new ToolResult($toolCall, 'Test response'));
 
-        $agent = $this->createMock(AgentInterface::class);
-        $agent
-            ->method('call')
-            ->willReturn(new ToolCallResult([$toolCall])); // Always returns tool call, causing infinite loop
-
-        $runner = $this->createRunner($this->platform(new ToolCallResult([$toolCall])), $toolbox, maxToolCalls: 3);
+        // the model keeps asking for tools, the platform provides more rounds than the limit allows
+        $runner = $this->createRunner($this->platform(...array_fill(0, 10, new ToolCallResult([$toolCall]))), $toolbox, maxToolCalls: 3);
 
         $this->expectException(MaxIterationsExceededException::class);
         $this->expectExceptionMessage('Maximum number of tool calling iterations (3) exceeded.');
 
-        $runner->run($agent, 'gpt-4', new MessageBag(), []);
+        $runner->run($this->recursiveAgent($runner), 'gpt-4', new MessageBag(), []);
+    }
+
+    public function testThrowsExceptionWhenMaxIterationsExceededWhileStreaming()
+    {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Test response'));
+
+        $streams = array_map(static fn (): StreamResult => new StreamResult((static function () use ($toolCall) {
+            yield new ToolCallComplete([$toolCall]);
+        })()), range(1, 10));
+
+        $runner = $this->createRunner($this->platform(...$streams), $toolbox, maxToolCalls: 3);
+        $result = $runner->run($this->recursiveAgent($runner), 'gpt-4', new MessageBag(), ['stream' => true]);
+
+        $this->expectException(MaxIterationsExceededException::class);
+        $this->expectExceptionMessage('Maximum number of tool calling iterations (3) exceeded.');
+
+        iterator_to_array($result->getContent());
     }
 
     public function testCustomMaxIterationsLimitAllowsConfiguredIterations()
@@ -474,26 +492,44 @@ final class RunnerTest extends TestCase
         $toolCall2 = new ToolCall('id2', 'tool2', ['arg1' => 'value2']);
         $toolbox = $this->createMock(ToolboxInterface::class);
         $toolbox
+            ->expects($this->exactly(2))
             ->method('execute')
             ->willReturnOnConsecutiveCalls(
                 new ToolResult($toolCall1, 'Response 1'),
                 new ToolResult($toolCall2, 'Response 2'),
             );
 
-        $agent = $this->createMock(AgentInterface::class);
-        $agent
-            ->expects($this->exactly(2))
-            ->method('call')
-            ->willReturnOnConsecutiveCalls(
-                new ToolCallResult([$toolCall2]),
-                new TextResult('Final response after two tool calls.'),
-            );
+        $platform = $this->platform(
+            new ToolCallResult([$toolCall1]),
+            new ToolCallResult([$toolCall2]),
+            new TextResult('Final response after two tool calls.'),
+        );
 
         // Allow up to 5 iterations, we only need 2
-        $runner = $this->createRunner($this->platform(new ToolCallResult([$toolCall1])), $toolbox, maxToolCalls: 5);
-        $result = $runner->run($agent, 'gpt-4', new MessageBag(), []);
+        $runner = $this->createRunner($platform, $toolbox, maxToolCalls: 5);
+        $result = $runner->run($this->recursiveAgent($runner), 'gpt-4', new MessageBag(), []);
 
         $this->assertInstanceOf(TextResult::class, $result);
+    }
+
+    public function testMaxIterationsLimitAppliesPerAgentCall()
+    {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Test response'));
+
+        $platform = $this->platform(
+            new ToolCallResult([$toolCall]),
+            new TextResult('First response'),
+            new ToolCallResult([$toolCall]),
+            new TextResult('Second response'),
+        );
+        $runner = $this->createRunner($platform, $toolbox, maxToolCalls: 1);
+
+        $this->assertSame('First response', $runner->run($this->recursiveAgent($runner), 'gpt-4', new MessageBag(), [])->getContent());
+        $this->assertSame('Second response', $runner->run($this->recursiveAgent($runner), 'gpt-4', new MessageBag(), [])->getContent());
     }
 
     public function testSourcesAreResetAfterMaxIterationsException()
@@ -512,28 +548,19 @@ final class RunnerTest extends TestCase
 
         $platform = $this->platform(
             new ToolCallResult([$failingToolCall]),
+            new ToolCallResult([$failingToolCall]),
             new ToolCallResult([$successfulToolCall]),
+            new TextResult('Final response'),
         );
         $runner = $this->createRunner($platform, $toolbox, maxToolCalls: 1, includeSources: true);
 
-        $failingAgent = $this->createMock(AgentInterface::class);
-        $failingAgent
-            ->method('call')
-            ->willReturn(new ToolCallResult([$failingToolCall]));
-
         try {
-            $runner->run($failingAgent, 'gpt-4', new MessageBag(), []);
+            $runner->run($this->recursiveAgent($runner), 'gpt-4', new MessageBag(), []);
             $this->fail('Expected MaxIterationsExceededException to be thrown.');
         } catch (MaxIterationsExceededException) {
         }
 
-        $successfulAgent = $this->createMock(AgentInterface::class);
-        $successfulAgent
-            ->expects($this->once())
-            ->method('call')
-            ->willReturn(new TextResult('Final response'));
-
-        $result = $runner->run($successfulAgent, 'gpt-4', new MessageBag(), []);
+        $result = $runner->run($this->recursiveAgent($runner), 'gpt-4', new MessageBag(), []);
 
         $metadata = $result->getMetadata();
         $this->assertTrue($metadata->has('sources'));
@@ -558,6 +585,33 @@ final class RunnerTest extends TestCase
         $runner->run($this->createStub(AgentInterface::class), 'gpt-4', new MessageBag(), $options);
 
         return $captured;
+    }
+
+    /**
+     * Mirrors what {@see Agent::call()} does with a tool call result: instead of handing it back to the
+     * runner, it re-enters the runner, which is where the tool calling loop is actually continued.
+     */
+    private function recursiveAgent(Runner $runner, string $model = 'gpt-4'): AgentInterface
+    {
+        return new class($runner, $model) implements AgentInterface {
+            public function __construct(
+                private readonly Runner $runner,
+                private readonly string $model,
+            ) {
+            }
+
+            public function call(string|MessageBag|UserMessage $input, array $options = []): ResultInterface
+            {
+                \assert($input instanceof MessageBag);
+
+                return $this->runner->run($this, $this->model, $input, $options);
+            }
+
+            public function getName(): string
+            {
+                return 'agent';
+            }
+        };
     }
 
     private function createRunner(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2393
| License       | MIT

The iteration counter was local to one entry into the tool calling loop, but every round re-enters it through `Agent::call()`, so it never got past 1 and `maxToolCalls` was unreachable for any value >= 1.

- count the rounds of the whole agent call and reset them when the outermost call starts - that also covers the streaming path, where the nested round runs lazily during consumption, after the parent already returned
- the existing tests mocked `AgentInterface::call()` to return a `ToolCallResult`, which makes the loop flat and hides this; they now drive the runner through the real recursion, buffered and streaming, plus an end-to-end test on `Agent` itself