### PR TITLE
[Agent] Fix maxToolCalls never being reached across nested agent calls

### DIFF
--- a/src/agent/src/Execution/Runner.php
+++ b/src/agent/src/Execution/Runner.php
@@ -51,6 +51,12 @@ final class Runner
      */
     private int $nestingLevel = 0;
 
+    /**
+     * Tool calling iterations get counted on class level to also cover the nested agent calls.
+     * They get reset when the outermost agent call is finished via nesting level.
+     */
+    private int $iterations = 0;
+
     public function __construct(
         private readonly PlatformInterface $platform,
         private readonly ?ToolboxInterface $toolbox = null,
@@ -143,9 +149,8 @@ final class Runner
         }
 
         try {
-            $iterations = 0;
             do {
-                if (null !== $this->maxToolCalls && ++$iterations > $this->maxToolCalls) {
+                if (null !== $this->maxToolCalls && ++$this->iterations > $this->maxToolCalls) {
                     throw new MaxIterationsExceededException($this->maxToolCalls);
                 }
 
@@ -172,6 +177,10 @@ final class Runner
             } while ($result instanceof ToolCallResult);
         } finally {
             --$this->nestingLevel;
+
+            if (0 === $this->nestingLevel) {
+                $this->iterations = 0;
+            }
 
             if ($this->includeSources && 0 === $this->nestingLevel && $result instanceof ToolCallResult) {
                 $this->sources = new SourceCollection();

--- a/src/agent/tests/Execution/RunnerTest.php
+++ b/src/agent/tests/Execution/RunnerTest.php
@@ -468,6 +468,35 @@ final class RunnerTest extends TestCase
         $runner->run($agent, 'gpt-4', new MessageBag(), []);
     }
 
+    public function testThrowsExceptionWhenMaxIterationsExceededAcrossNestedAgentCalls()
+    {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Test response'));
+
+        $platform = $this->platform(
+            new ToolCallResult([$toolCall]),
+            new ToolCallResult([$toolCall]),
+            new ToolCallResult([$toolCall]),
+            new ToolCallResult([$toolCall]),
+            new ToolCallResult([$toolCall]),
+            new TextResult('Final response'),
+        );
+        $runner = $this->createRunner($platform, $toolbox, maxToolCalls: 3);
+
+        $agent = $this->createMock(AgentInterface::class);
+        $agent
+            ->method('call')
+            ->willReturnCallback(static fn (MessageBag $messages, array $options): ResultInterface => $runner->run($agent, 'gpt-4', $messages, $options));
+
+        $this->expectException(MaxIterationsExceededException::class);
+        $this->expectExceptionMessage('Maximum number of tool calling iterations (3) exceeded.');
+
+        $runner->run($agent, 'gpt-4', new MessageBag(), []);
+    }
+
     public function testCustomMaxIterationsLimitAllowsConfiguredIterations()
     {
         $toolCall1 = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2393
| License       | MIT

The iteration counter in `Runner::handleToolCalls()` is a local variable, but every round of tool calling goes through `$agent->call()`, which lands back in the same method one level deeper with a fresh counter. Each level then runs exactly one iteration, so `maxToolCalls` is only ever compared against 1 and never triggers. The loop ends up bounded by the PHP stack rather than by the configured limit.

The counter now lives on the class next to `$nestingLevel` and gets reset once the outermost call finishes, the same way `$sources` already does.

The existing tests pass today because their stub agent returns straight into the same loop. The new test re-enters the runner the way the real `Agent::call()` does.