### PR TITLE
[Platform] Announce streamed tool calls across bridges

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,26 @@ AI Bundle
 Platform
 --------
 
+ * The Gemini and VertexAI bridges now yield a single `ToolCallComplete` delta at the end of a stream,
+   carrying all function calls of the response, instead of one `ToolCallComplete` per streamed
+   `functionCall` part. Consumers collecting tool calls across several deltas can rely on the single
+   batch instead:
+
+   ```diff
+   -$toolCalls = [];
+    foreach ($result->asStream() as $delta) {
+        if ($delta instanceof ToolCallComplete) {
+   -        $toolCalls = array_merge($toolCalls, $delta->getToolCalls());
+   +        $toolCalls = $delta->getToolCalls();
+        }
+    }
+   ```
+
+   Multi-candidate responses (`candidateCount` > 1) are the exception and keep their previous shape: their
+   deltas are wrapped in a `ChoiceDelta`, carrying one `ToolCallComplete` per function call, without
+   `ToolCallStart` and without a terminal batch. A consumer walking `ChoiceDelta::getDeltas()` still has to
+   merge those.
+
  * `Result\Stream\ListenerInterface` gained an `onError()` method, dispatched with the new
    `Result\Stream\ErrorEvent`. Listeners not extending
    `AbstractStreamListener` must add the method:

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -609,6 +609,23 @@ The following delta types are available:
 * :class:`Symfony\\AI\\Platform\\Result\\Stream\\Delta\\ChoiceDelta` -- a choice delta (e.g. multiple completions)
 * :class:`Symfony\\AI\\Platform\\Result\\Stream\\Delta\\BinaryDelta` -- a chunk of binary data
 
+Tool calls follow a fixed shape across bridges: every call is announced with a
+``ToolCallStart`` at the position it appears in the response, its arguments follow as
+``ToolInputDelta`` chunks if the provider streams them, and one final ``ToolCallComplete``
+carries all calls of the response ready for execution. The position of a ``ToolCallStart``
+relative to the surrounding text and thinking deltas is what the provider generated, which
+matters when the assistant message is sent back on a later turn.
+
+.. note::
+
+    A provider that does not identify its tool calls before they are complete only emits
+    ``ToolCallComplete``. Consumers should therefore treat ``ToolCallStart`` and
+    ``ToolInputDelta`` as optional, and ``ToolCallComplete`` as the authoritative one.
+
+    Multi-candidate responses are the exception to the single terminal ``ToolCallComplete``: the
+    Gemini and VertexAI bridges wrap each chunk's candidates in a ``ChoiceDelta`` that carries one
+    ``ToolCallComplete`` per function call, without ``ToolCallStart``.
+
 Finish Reason
 ~~~~~~~~~~~~~
 

--- a/examples/gemini/toolcall-stream.php
+++ b/examples/gemini/toolcall-stream.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Bridge\Clock\Clock;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Fixtures\EuropeanCapitalsTool;
+use Symfony\AI\Platform\Bridge\Gemini\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('GEMINI_API_KEY'), http_client());
+
+// The platform is invoked directly instead of via an Agent: the Agent's StreamListener consumes the
+// terminal ToolCallComplete to execute the tools, so the raw stream is what shows the deltas.
+$toolbox = new Toolbox([new Clock(), new EuropeanCapitalsTool()], logger: logger());
+
+$messages = new MessageBag(Message::ofUser(<<<TXT
+        What time is it right now, and which European capitals do you know about via your tools?
+        Please tell me before you call tools.
+    TXT));
+$result = $platform->invoke('gemini-3.1-pro-preview', $messages, [
+    'stream' => true, // enable streaming of response text
+    'tools' => $toolbox->getTools(),
+]);
+
+foreach ($result->asStream() as $delta) {
+    if ($delta instanceof TextDelta) {
+        echo $delta;
+        continue;
+    }
+    if ($delta instanceof ToolCallStart) {
+        // Announced at the position the functionCall part appears in - Gemini delivers each call as one
+        // complete part, so there are no ToolInputDelta chunks in between: the arguments arrive at once.
+        output()->writeln(\PHP_EOL.'<info>[tool-call started: '.$delta->getName().']</info>');
+        continue;
+    }
+    if ($delta instanceof ToolCallComplete) {
+        // A single terminal completion carries all calls of the stream, including parallel ones.
+        output()->writeln(\PHP_EOL.'<info>[tool-calls ready: '.count($delta->getToolCalls()).']</info>');
+    }
+}
+
+echo \PHP_EOL;

--- a/src/platform/src/Bridge/Cohere/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cohere/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Add `ToolCallStart` and `ToolInputDelta` deltas to streaming responses
+
 0.12
 ----
 

--- a/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Cohere/Llm/ResultConverter.php
@@ -25,6 +25,8 @@ use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -115,13 +117,19 @@ final class ResultConverter implements ResultConverterInterface
             if ('tool-call-start' === $type) {
                 $toolCall = $data['delta']['message']['tool_calls'] ?? null;
                 if (null !== $toolCall) {
+                    $id = $toolCall['id'] ?? '';
+                    $name = $toolCall['function']['name'] ?? '';
                     $toolCalls[] = [
-                        'id' => $toolCall['id'] ?? '',
+                        'id' => $id,
                         'function' => [
-                            'name' => $toolCall['function']['name'] ?? '',
+                            'name' => $name,
                             'arguments' => $toolCall['function']['arguments'] ?? '',
                         ],
                     ];
+
+                    if ('' !== $id) {
+                        yield new ToolCallStart($id, $name);
+                    }
                 }
                 continue;
             }
@@ -129,7 +137,12 @@ final class ResultConverter implements ResultConverterInterface
             if ('tool-call-delta' === $type) {
                 if ([] !== $toolCalls) {
                     $lastIndex = \count($toolCalls) - 1;
-                    $toolCalls[$lastIndex]['function']['arguments'] .= $data['delta']['message']['tool_calls']['function']['arguments'] ?? '';
+                    $partialJson = $data['delta']['message']['tool_calls']['function']['arguments'] ?? '';
+                    $toolCalls[$lastIndex]['function']['arguments'] .= $partialJson;
+
+                    if ('' !== $partialJson && '' !== $toolCalls[$lastIndex]['id']) {
+                        yield new ToolInputDelta($toolCalls[$lastIndex]['id'], $toolCalls[$lastIndex]['function']['name'], $partialJson);
+                    }
                 }
                 continue;
             }

--- a/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Cohere/Tests/Llm/ResultConverterTest.php
@@ -23,6 +23,8 @@ use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
@@ -202,9 +204,22 @@ final class ResultConverterTest extends TestCase
         );
 
         $chunks = iterator_to_array($result->getContent(), false);
-        $this->assertCount(1, $chunks);
-        $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
-        $toolCalls = $chunks[0]->getToolCalls();
+        $this->assertCount(4, $chunks);
+
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertSame('call_1', $chunks[0]->getId());
+        $this->assertSame('get_time', $chunks[0]->getName());
+
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[1]);
+        $this->assertSame('call_1', $chunks[1]->getId());
+        $this->assertSame('get_time', $chunks[1]->getName());
+        $this->assertSame('{"tz":', $chunks[1]->getPartialJson());
+
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[2]);
+        $this->assertSame('"UTC"}', $chunks[2]->getPartialJson());
+
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[3]);
+        $toolCalls = $chunks[3]->getToolCalls();
         $this->assertSame('call_1', $toolCalls[0]->getId());
         $this->assertSame('get_time', $toolCalls[0]->getName());
         $this->assertSame(['tz' => 'UTC'], $toolCalls[0]->getArguments());
@@ -255,12 +270,71 @@ final class ResultConverterTest extends TestCase
         );
 
         $chunks = iterator_to_array($result->getContent(), false);
-        $this->assertCount(1, $chunks);
-        $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
-        $toolCalls = $chunks[0]->getToolCalls();
+        $this->assertCount(2, $chunks);
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertSame('call_1', $chunks[0]->getId());
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[1]);
+        $toolCalls = $chunks[1]->getToolCalls();
         $this->assertSame('call_1', $toolCalls[0]->getId());
         $this->assertSame('get_time', $toolCalls[0]->getName());
         $this->assertSame([], $toolCalls[0]->getArguments());
+    }
+
+    public function testItDoesNotAnnounceStreamedToolCallWithoutId()
+    {
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(
+            new InMemoryRawResult([], [
+                ['type' => 'tool-call-start', 'delta' => ['message' => ['tool_calls' => ['function' => ['name' => 'get_time', 'arguments' => '']]]]],
+                ['type' => 'tool-call-delta', 'delta' => ['message' => ['tool_calls' => ['function' => ['arguments' => '{"tz":']]]]],
+                ['type' => 'tool-call-delta', 'delta' => ['message' => ['tool_calls' => ['function' => ['arguments' => '"UTC"}']]]]],
+                ['type' => 'message-end', 'delta' => []],
+            ], $httpResponse),
+            ['stream' => true],
+        );
+
+        $chunks = iterator_to_array($result->getContent(), false);
+        $this->assertCount(1, $chunks);
+
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
+        $toolCalls = $chunks[0]->getToolCalls();
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame('', $toolCalls[0]->getId());
+        $this->assertSame('get_time', $toolCalls[0]->getName());
+        $this->assertSame(['tz' => 'UTC'], $toolCalls[0]->getArguments());
+    }
+
+    public function testItSkipsToolInputDeltaWithoutPartialJson()
+    {
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(
+            new InMemoryRawResult([], [
+                ['type' => 'tool-call-start', 'delta' => ['message' => ['tool_calls' => ['id' => 'call_1', 'function' => ['name' => 'get_time', 'arguments' => '']]]]],
+                ['type' => 'tool-call-delta', 'delta' => ['message' => ['tool_calls' => ['function' => []]]]],
+                ['type' => 'tool-call-delta', 'delta' => ['message' => ['tool_calls' => ['function' => ['arguments' => '{"tz":"UTC"}']]]]],
+                ['type' => 'message-end', 'delta' => []],
+            ], $httpResponse),
+            ['stream' => true],
+        );
+
+        $chunks = iterator_to_array($result->getContent(), false);
+        $this->assertCount(3, $chunks);
+
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertSame('call_1', $chunks[0]->getId());
+
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[1]);
+        $this->assertSame('{"tz":"UTC"}', $chunks[1]->getPartialJson());
+
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[2]);
+        $toolCalls = $chunks[2]->getToolCalls();
+        $this->assertSame(['tz' => 'UTC'], $toolCalls[0]->getArguments());
     }
 
     public function testItThrowsIncompleteStreamWhenMessageEndIsMissing()

--- a/src/platform/src/Bridge/Gemini/CHANGELOG.md
+++ b/src/platform/src/Bridge/Gemini/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * [BC BREAK] Streamed tool calls are completed once at the end of the stream, instead of one `ToolCallComplete` delta per `functionCall` part
+ * Add `ToolCallStart` deltas to streaming responses for function calls the API identifies
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/Gemini/Gemini/ResultConverter.php
@@ -34,6 +34,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
@@ -131,6 +132,9 @@ final class ResultConverter implements ResultConverterInterface
         // over several chunks) before the answer, so a thinking block may span multiple iterations.
         $thinking = null;
         $thinkingSignature = null;
+        // Tool calls are collected across the whole stream and completed once at its end, so that
+        // calls split over several parts or chunks arrive as a single batch.
+        $toolCalls = [];
 
         foreach ($result->getDataStream() as $data) {
             // Gemini repeats the reason on every candidate of the terminal chunk; the leading one wins,
@@ -189,6 +193,22 @@ final class ResultConverter implements ResultConverterInterface
                     $thinkingSignature = null;
                 }
 
+                // Gemini delivers each function call as a complete part, so a call is announced at the
+                // position its part appears in and batched into the terminal ToolCallComplete.
+                if ($leaf instanceof ToolCallResult) {
+                    foreach ($leaf->getContent() as $toolCall) {
+                        $toolCalls[] = $toolCall;
+
+                        // Gemini < 3.0 leaves the function call id empty; without one there is nothing
+                        // to correlate the announcement with, so the call is only batched.
+                        if ('' !== $toolCall->getId()) {
+                            yield new ToolCallStart($toolCall->getId(), $toolCall->getName());
+                        }
+                    }
+
+                    continue;
+                }
+
                 yield from $this->resultToDeltas($leaf);
             }
         }
@@ -196,6 +216,10 @@ final class ResultConverter implements ResultConverterInterface
         // A thinking block still open at the end of the stream is completed before the terminal metadata.
         if (null !== $thinking) {
             yield new ThinkingComplete($thinking, $thinkingSignature);
+        }
+
+        if ([] !== $toolCalls) {
+            yield new ToolCallComplete($toolCalls);
         }
 
         // Emitted last: the terminal chunk carries both the finish reason and its content parts.
@@ -255,6 +279,8 @@ final class ResultConverter implements ResultConverterInterface
 
                 return;
             case $result instanceof ToolCallResult:
+                // Only reached through the multi-candidate path: the single-candidate stream batches
+                // tool calls into one terminal ToolCallComplete instead.
                 yield new ToolCallComplete($result->getContent());
 
                 return;

--- a/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Gemini/Tests/Gemini/ResultConverterTest.php
@@ -32,6 +32,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
@@ -501,6 +502,64 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('search', $items[1]->getToolCalls()[0]->getName());
     }
 
+    public function testStreamBatchesParallelToolCallsIntoASingleCompletion()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createMock(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($httpResponse);
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['functionCall' => ['id' => 'call_1', 'name' => 'search', 'args' => ['q' => 'x']]],
+                        ['text' => 'and now the weather', 'thought' => true, 'thoughtSignature' => 'sig'],
+                        ['functionCall' => ['id' => 'call_2', 'name' => 'weather', 'args' => ['city' => 'Berlin']]],
+                    ]]],
+                ],
+            ];
+        })());
+
+        $items = iterator_to_array($converter->convert($rawResult, ['stream' => true])->getContent());
+
+        $this->assertInstanceOf(ToolCallStart::class, $items[0]);
+        $this->assertSame('call_1', $items[0]->getId());
+        $this->assertInstanceOf(ThinkingStart::class, $items[1]);
+        $this->assertInstanceOf(ThinkingDelta::class, $items[2]);
+        $this->assertInstanceOf(ThinkingComplete::class, $items[3]);
+        $this->assertInstanceOf(ToolCallStart::class, $items[4]);
+        $this->assertSame('call_2', $items[4]->getId());
+
+        // Both calls arrive as one batch, instead of one completion per functionCall part
+        $this->assertInstanceOf(ToolCallComplete::class, $items[5]);
+        $toolCalls = $items[5]->getToolCalls();
+        $this->assertCount(2, $toolCalls);
+        $this->assertSame('call_1', $toolCalls[0]->getId());
+        $this->assertSame('call_2', $toolCalls[1]->getId());
+        $this->assertCount(6, $items);
+    }
+
+    public function testStreamOmitsToolCallStartForUnidentifiedCalls()
+    {
+        $converter = new ResultConverter();
+        $httpResponse = $this->createMock(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createMock(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($httpResponse);
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield ['candidates' => [['content' => ['parts' => [['functionCall' => ['name' => 'search', 'args' => []]]]]]]];
+        })());
+
+        $items = iterator_to_array($converter->convert($rawResult, ['stream' => true])->getContent());
+
+        $this->assertCount(1, $items);
+        $this->assertInstanceOf(ToolCallComplete::class, $items[0]);
+        $this->assertSame('', $items[0]->getToolCalls()[0]->getId());
+    }
+
     public function testStreamSkipsCandidatesWithoutContentParts()
     {
         $converter = new ResultConverter();
@@ -575,6 +634,19 @@ final class ResultConverterTest extends TestCase
         $result = $converter->convert($rawResult, ['stream' => true]);
         $items = iterator_to_array($result->getContent());
 
+        // An identified tool call is announced at its position and completed at the end of the stream.
+        if (ToolCallComplete::class === $expectedClass) {
+            $this->assertCount(2, $items);
+            $this->assertInstanceOf(ToolCallStart::class, $items[0]);
+            $this->assertSame($expectedPayload['id'], $items[0]->getId());
+            $this->assertSame($expectedPayload['name'], $items[0]->getName());
+            $this->assertInstanceOf(ToolCallComplete::class, $items[1]);
+            $this->assertSame($expectedPayload['id'], $items[1]->getToolCalls()[0]->getId());
+            $this->assertSame($expectedPayload['name'], $items[1]->getToolCalls()[0]->getName());
+
+            return;
+        }
+
         $this->assertCount(1, $items);
         $this->assertInstanceOf($expectedClass, $items[0]);
 
@@ -587,13 +659,6 @@ final class ResultConverterTest extends TestCase
         if (BinaryDelta::class === $expectedClass) {
             $this->assertSame($expectedPayload['data'], $items[0]->getData());
             $this->assertSame($expectedPayload['mimeType'], $items[0]->getMimeType());
-
-            return;
-        }
-
-        if (ToolCallComplete::class === $expectedClass) {
-            $this->assertSame($expectedPayload['id'], $items[0]->getToolCalls()[0]->getId());
-            $this->assertSame($expectedPayload['name'], $items[0]->getToolCalls()[0]->getName());
 
             return;
         }

--- a/src/platform/src/Bridge/Ollama/CHANGELOG.md
+++ b/src/platform/src/Bridge/Ollama/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Add `ToolCallStart` deltas to streaming responses
+
 0.10
 ----
 

--- a/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
+++ b/src/platform/src/Bridge/Ollama/OllamaResultConverter.php
@@ -21,6 +21,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -127,16 +128,25 @@ final class OllamaResultConverter implements ResultConverterInterface
                 }
             }
 
-            if ($this->streamIsToolCall($data)) {
-                $toolCalls = $this->convertStreamToToolCalls($toolCalls, $data);
-            }
-
             if ($this->hasThinkingDelta($data)) {
                 yield new ThinkingDelta($data['message']['thinking']);
             }
 
             if ($this->hasTextDelta($data)) {
                 yield new TextDelta($data['message']['content']);
+            }
+
+            // Ollama streams tool calls as complete objects in intermediate chunks; announcing them
+            // here keeps their position relative to the surrounding thinking and content
+            if ($this->streamIsToolCall($data)) {
+                foreach ($data['message']['tool_calls'] as $toolCall) {
+                    // Ollama does not identify its tool calls, and the ids are never sent back to it,
+                    // so the position in the stream serves as a stream-wide unique handle
+                    $id = (string) \count($toolCalls);
+                    $toolCalls[] = new ToolCall($id, $toolCall['function']['name'], $toolCall['function']['arguments']);
+
+                    yield new ToolCallStart($id, $toolCall['function']['name']);
+                }
             }
 
             if ([] !== $toolCalls && $this->isToolCallsStreamFinished($data)) {
@@ -158,25 +168,6 @@ final class OllamaResultConverter implements ResultConverterInterface
         if (null !== $finishReason) {
             yield new MetadataDelta('finish_reason', $finishReason);
         }
-    }
-
-    /**
-     * @param array<string, mixed> $toolCalls
-     * @param array<string, mixed> $data
-     *
-     * @return array<ToolCall>
-     */
-    private function convertStreamToToolCalls(array $toolCalls, array $data): array
-    {
-        if (!isset($data['message']['tool_calls'])) {
-            return $toolCalls;
-        }
-
-        foreach ($data['message']['tool_calls'] ?? [] as $id => $toolCall) {
-            $toolCalls[] = new ToolCall($id, $toolCall['function']['name'], $toolCall['function']['arguments']);
-        }
-
-        return $toolCalls;
     }
 
     /**

--- a/src/platform/src/Bridge/Ollama/Tests/OllamaResultConverterTest.php
+++ b/src/platform/src/Bridge/Ollama/Tests/OllamaResultConverterTest.php
@@ -25,6 +25,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
@@ -248,17 +249,45 @@ final class OllamaResultConverterTest extends TestCase
 
         $chunks = iterator_to_array($result->getContent());
 
-        $this->assertCount(3, $chunks);
-        $this->assertInstanceOf(ToolCallComplete::class, $chunks[0]);
-        $toolCalls = $chunks[0]->getToolCalls();
+        $this->assertCount(4, $chunks);
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertSame('0', $chunks[0]->getId());
+        $this->assertSame('clock', $chunks[0]->getName());
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[1]);
+        $toolCalls = $chunks[1]->getToolCalls();
         $this->assertCount(1, $toolCalls);
         $this->assertSame('clock', $toolCalls[0]->getName());
         $this->assertSame(['timezone' => 'UTC'], $toolCalls[0]->getArguments());
-        $this->assertInstanceOf(TokenUsageInterface::class, $chunks[1]);
-        $this->assertSame(11, $chunks[1]->getPromptTokens());
-        $this->assertSame(4, $chunks[1]->getCompletionTokens());
-        $this->assertInstanceOf(MetadataDelta::class, $chunks[2]);
-        $this->assertTrue($chunks[2]->getValue()->is(FinishReasonCase::STOP));
+        $this->assertInstanceOf(TokenUsageInterface::class, $chunks[2]);
+        $this->assertSame(11, $chunks[2]->getPromptTokens());
+        $this->assertSame(4, $chunks[2]->getCompletionTokens());
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[3]);
+        $this->assertTrue($chunks[3]->getValue()->is(FinishReasonCase::STOP));
+    }
+
+    public function testConvertStreamingToolCallsArrivingInSeparateChunksKeepDistinctIds()
+    {
+        $converter = new OllamaResultConverter();
+        $rawResult = new InMemoryRawResult(dataStream: (static function (): iterable {
+            yield ['model' => 'llama3.2', 'message' => ['role' => 'assistant', 'content' => '', 'tool_calls' => [['function' => ['name' => 'clock', 'arguments' => ['timezone' => 'UTC']]]]], 'done' => false];
+            yield ['model' => 'llama3.2', 'message' => ['role' => 'assistant', 'content' => '', 'tool_calls' => [['function' => ['name' => 'weather', 'arguments' => ['city' => 'Berlin']]]]], 'done' => false];
+            yield ['model' => 'llama3.2', 'message' => ['role' => 'assistant', 'content' => ''], 'done' => true, 'done_reason' => 'stop'];
+        })());
+
+        $chunks = iterator_to_array($converter->convert($rawResult, options: ['stream' => true])->getContent());
+
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertSame('0', $chunks[0]->getId());
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[1]);
+        $this->assertSame('1', $chunks[1]->getId());
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[2]);
+
+        $toolCalls = $chunks[2]->getToolCalls();
+        $this->assertCount(2, $toolCalls);
+        $this->assertSame('0', $toolCalls[0]->getId());
+        $this->assertSame('clock', $toolCalls[0]->getName());
+        $this->assertSame('1', $toolCalls[1]->getId());
+        $this->assertSame('weather', $toolCalls[1]->getName());
     }
 
     public function testConvertStreamingThrowsWhenDoneIsMissing()

--- a/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenResponses/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Throw `ServerException` when an OpenAI response reports that the server is overloaded
  * Preserve reasoning items as thinking signatures and replay them on subsequent requests
+ * Add `ToolCallStart` and `ToolInputDelta` deltas to streaming responses
 
 0.12
 ----

--- a/src/platform/src/Bridge/OpenResponses/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenResponses/ResultConverter.php
@@ -42,6 +42,8 @@ use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingSignature;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
@@ -436,6 +438,10 @@ class ResultConverter implements ResultConverterInterface
         $currentThinking = null;
         /** @var array<string, ToolCall> $toolCalls */
         $toolCalls = [];
+        // Announced function calls, keyed by output item id, so the argument deltas of an item
+        // can be attributed to the call id that ToolCallStart was emitted with
+        /** @var array<string, array{id: string, name: string}> $announcedToolCalls */
+        $announcedToolCalls = [];
         $sawResponseEvent = false;
         $sawResponseCompleted = false;
         $sawToolCallComplete = false;
@@ -508,6 +514,33 @@ class ResultConverter implements ResultConverterInterface
             if ('response.reasoning_summary_text.done' === $type) {
                 yield new ThinkingComplete($currentThinking ?? '');
                 $currentThinking = null;
+            }
+
+            // A function call is announced before its arguments stream, which pins its position
+            // relative to the reasoning items and message content around it
+            if ('response.output_item.added' === $type && \is_array($event['item'] ?? null) && 'function_call' === ($event['item']['type'] ?? null)) {
+                /** @var FunctionCall $item */
+                $item = $event['item'];
+                $id = $item['call_id'] ?? $item['id'] ?? null;
+                $name = $item['name'] ?? null;
+
+                if (null !== $id && '' !== $id && null !== $name) {
+                    if (isset($item['id']) && '' !== $item['id']) {
+                        $announcedToolCalls[$item['id']] = ['id' => $id, 'name' => $name];
+                    }
+
+                    yield new ToolCallStart($id, $name);
+                }
+            }
+
+            // Argument deltas address the output item, not the call, so they are mapped back
+            // onto the announced call id; unannounced items stay silent until output_item.done
+            if ('response.function_call_arguments.delta' === $type && \is_string($event['delta'] ?? null)) {
+                $announced = $announcedToolCalls[$event['item_id'] ?? ''] ?? null;
+
+                if (null !== $announced) {
+                    yield new ToolInputDelta($announced['id'], $announced['name'], $event['delta']);
+                }
             }
 
             if ('response.output_item.done' === $type && \is_array($event['item'] ?? null) && 'function_call' === ($event['item']['type'] ?? null)) {

--- a/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/ResultConverterTest.php
@@ -46,6 +46,8 @@ use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingSignature;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
@@ -1165,6 +1167,216 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('call_456', $toolCalls[0]->getId());
         $this->assertSame('get_weather', $toolCalls[0]->getName());
         $this->assertSame(['city' => 'Berlin'], $toolCalls[0]->getArguments());
+    }
+
+    public function testStreamAnnouncesToolCallsAndStreamsTheirArguments()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $events = [
+            [
+                'type' => 'response.output_item.added',
+                'item' => [
+                    'type' => 'function_call',
+                    'id' => 'fc_1',
+                    'call_id' => 'call_1',
+                    'name' => 'get_weather',
+                    'arguments' => '',
+                ],
+            ],
+            ['type' => 'response.function_call_arguments.delta', 'item_id' => 'fc_1', 'delta' => '{"city":'],
+            ['type' => 'response.function_call_arguments.delta', 'item_id' => 'fc_1', 'delta' => '"Berlin"}'],
+            [
+                'type' => 'response.output_item.done',
+                'item' => [
+                    'type' => 'function_call',
+                    'id' => 'fc_1',
+                    'call_id' => 'call_1',
+                    'name' => 'get_weather',
+                    'arguments' => '{"city": "Berlin"}',
+                ],
+            ],
+            ['type' => 'response.completed', 'response' => ['output' => []]],
+        ];
+
+        $chunks = iterator_to_array($converter->convert(new InMemoryRawResult([], $events, $httpResponse), ['stream' => true])->getContent());
+
+        $this->assertCount(5, $chunks);
+
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertSame('call_1', $chunks[0]->getId());
+        $this->assertSame('get_weather', $chunks[0]->getName());
+
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[1]);
+        $this->assertSame('call_1', $chunks[1]->getId());
+        $this->assertSame('get_weather', $chunks[1]->getName());
+        $this->assertSame('{"city":', $chunks[1]->getPartialJson());
+
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[2]);
+        $this->assertSame('"Berlin"}', $chunks[2]->getPartialJson());
+
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[3]);
+        $this->assertSame('call_1', $chunks[3]->getToolCalls()[0]->getId());
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[4]);
+    }
+
+    public function testStreamAnnouncesToolCallsWithoutCallIdAndStreamsTheirArguments()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $events = [
+            [
+                'type' => 'response.output_item.added',
+                'item' => [
+                    'type' => 'function_call',
+                    'id' => 'fc_1',
+                    'name' => 'get_weather',
+                    'arguments' => '',
+                ],
+            ],
+            ['type' => 'response.function_call_arguments.delta', 'item_id' => 'fc_1', 'delta' => '{"city":'],
+            ['type' => 'response.function_call_arguments.delta', 'item_id' => 'fc_1', 'delta' => '"Berlin"}'],
+            [
+                'type' => 'response.output_item.done',
+                'item' => [
+                    'type' => 'function_call',
+                    'id' => 'fc_1',
+                    'name' => 'get_weather',
+                    'arguments' => '{"city": "Berlin"}',
+                ],
+            ],
+            ['type' => 'response.completed', 'response' => ['output' => []]],
+        ];
+
+        $chunks = iterator_to_array($converter->convert(new InMemoryRawResult([], $events, $httpResponse), ['stream' => true])->getContent());
+
+        $this->assertCount(5, $chunks);
+
+        // Without a "call_id" the output item id addresses the call, so it is used all the way through
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertSame('fc_1', $chunks[0]->getId());
+        $this->assertSame('get_weather', $chunks[0]->getName());
+
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[1]);
+        $this->assertSame('fc_1', $chunks[1]->getId());
+        $this->assertSame('{"city":', $chunks[1]->getPartialJson());
+
+        $this->assertInstanceOf(ToolInputDelta::class, $chunks[2]);
+        $this->assertSame('"Berlin"}', $chunks[2]->getPartialJson());
+
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[3]);
+        $this->assertSame('fc_1', $chunks[3]->getToolCalls()[0]->getId());
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[4]);
+    }
+
+    public function testStreamAnnouncesCallIdOnlyToolCallsWithoutStreamingTheirArguments()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        // Providers that only send "call_id" leave the output item without an id, so the argument
+        // deltas keep addressing an item id that was never announced and cannot be mapped back
+        $events = [
+            [
+                'type' => 'response.output_item.added',
+                'item' => [
+                    'type' => 'function_call',
+                    'id' => null,
+                    'call_id' => 'call_789',
+                    'name' => 'get_weather',
+                    'arguments' => '',
+                ],
+            ],
+            ['type' => 'response.function_call_arguments.delta', 'item_id' => 'fc_1', 'delta' => '{"city":'],
+            ['type' => 'response.function_call_arguments.delta', 'item_id' => 'fc_1', 'delta' => '"Berlin"}'],
+            [
+                'type' => 'response.output_item.done',
+                'item' => [
+                    'type' => 'function_call',
+                    'id' => null,
+                    'call_id' => 'call_789',
+                    'name' => 'get_weather',
+                    'arguments' => '{"city": "Berlin"}',
+                ],
+            ],
+            ['type' => 'response.completed', 'response' => ['output' => []]],
+        ];
+
+        $chunks = iterator_to_array($converter->convert(new InMemoryRawResult([], $events, $httpResponse), ['stream' => true])->getContent());
+
+        // The call is still announced and completed under its call id, only the arguments stay silent
+        $this->assertCount(3, $chunks);
+
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[0]);
+        $this->assertSame('call_789', $chunks[0]->getId());
+        $this->assertSame('get_weather', $chunks[0]->getName());
+
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[1]);
+        $this->assertSame('call_789', $chunks[1]->getToolCalls()[0]->getId());
+        $this->assertSame(['city' => 'Berlin'], $chunks[1]->getToolCalls()[0]->getArguments());
+
+        $this->assertInstanceOf(MetadataDelta::class, $chunks[2]);
+        $this->assertTrue($chunks[2]->getValue()->is(FinishReasonCase::TOOL_CALL));
+    }
+
+    public function testStreamKeepsReasoningItemsAndToolCallsInOrder()
+    {
+        $converter = new ResultConverter();
+
+        $httpResponse = $this->createStub(ResponseInterface::class);
+        $httpResponse->method('getStatusCode')->willReturn(200);
+
+        $firstReasoning = ['type' => 'reasoning', 'id' => 'rs_1', 'summary' => [], 'encrypted_content' => 'enc_1'];
+        $secondReasoning = ['type' => 'reasoning', 'id' => 'rs_2', 'summary' => [], 'encrypted_content' => 'enc_2'];
+
+        $events = [
+            ['type' => 'response.output_item.done', 'item' => $firstReasoning],
+            [
+                'type' => 'response.output_item.added',
+                'item' => ['type' => 'function_call', 'id' => 'fc_1', 'call_id' => 'call_1', 'name' => 'get_weather', 'arguments' => ''],
+            ],
+            [
+                'type' => 'response.output_item.done',
+                'item' => ['type' => 'function_call', 'id' => 'fc_1', 'call_id' => 'call_1', 'name' => 'get_weather', 'arguments' => '{}'],
+            ],
+            ['type' => 'response.output_item.done', 'item' => $secondReasoning],
+            [
+                'type' => 'response.output_item.added',
+                'item' => ['type' => 'function_call', 'id' => 'fc_2', 'call_id' => 'call_2', 'name' => 'get_time', 'arguments' => ''],
+            ],
+            [
+                'type' => 'response.output_item.done',
+                'item' => ['type' => 'function_call', 'id' => 'fc_2', 'call_id' => 'call_2', 'name' => 'get_time', 'arguments' => '{}'],
+            ],
+            ['type' => 'response.completed', 'response' => ['output' => []]],
+        ];
+
+        $chunks = iterator_to_array($converter->convert(new InMemoryRawResult([], $events, $httpResponse), ['stream' => true])->getContent());
+
+        // The reasoning item belonging to a call is replayable in front of it, which the
+        // Responses API requires when the reasoning is sent back with "store" => false
+        $this->assertInstanceOf(ThinkingSignature::class, $chunks[0]);
+        $this->assertSame(json_encode($firstReasoning), $chunks[0]->getSignature());
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[1]);
+        $this->assertSame('call_1', $chunks[1]->getId());
+        $this->assertInstanceOf(ThinkingSignature::class, $chunks[2]);
+        $this->assertSame(json_encode($secondReasoning), $chunks[2]->getSignature());
+        $this->assertInstanceOf(ToolCallStart::class, $chunks[3]);
+        $this->assertSame('call_2', $chunks[3]->getId());
+
+        $this->assertInstanceOf(ToolCallComplete::class, $chunks[4]);
+        $toolCalls = $chunks[4]->getToolCalls();
+        $this->assertCount(2, $toolCalls);
+        $this->assertSame('call_1', $toolCalls[0]->getId());
+        $this->assertSame('call_2', $toolCalls[1]->getId());
     }
 
     public function testStreamThrowsClearExceptionForMalformedToolCallArguments()

--- a/src/platform/src/Bridge/VertexAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/VertexAi/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * [BC BREAK] Streamed tool calls are completed once at the end of the stream, instead of one `ToolCallComplete` delta per `functionCall` part
+ * Add `ToolCallStart` deltas to streaming responses for function calls the API identifies
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ResultConverter.php
@@ -35,6 +35,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
@@ -144,6 +145,9 @@ final class ResultConverter implements ResultConverterInterface
         // over several chunks) before the answer, so a thinking block may span multiple iterations.
         $thinking = null;
         $thinkingSignature = null;
+        // Tool calls are collected across the whole stream and completed once at its end, so that
+        // calls split over several parts or chunks arrive as a single batch.
+        $toolCalls = [];
 
         foreach ($result->getDataStream() as $data) {
             if (isset($data['usageMetadata']['totalTokenCount']) && 0 < $data['usageMetadata']['totalTokenCount']) {
@@ -206,6 +210,22 @@ final class ResultConverter implements ResultConverterInterface
                     $thinkingSignature = null;
                 }
 
+                // Gemini delivers each function call as a complete part, so a call is announced at the
+                // position its part appears in and batched into the terminal ToolCallComplete.
+                if ($leaf instanceof ToolCallResult) {
+                    foreach ($leaf->getContent() as $toolCall) {
+                        $toolCalls[] = $toolCall;
+
+                        // Gemini < 3.0 leaves the function call id empty; without one there is nothing
+                        // to correlate the announcement with, so the call is only batched.
+                        if ('' !== $toolCall->getId()) {
+                            yield new ToolCallStart($toolCall->getId(), $toolCall->getName());
+                        }
+                    }
+
+                    continue;
+                }
+
                 yield from $this->resultToDeltas($leaf);
             }
         }
@@ -213,6 +233,10 @@ final class ResultConverter implements ResultConverterInterface
         // A thinking block still open at the end of the stream is completed before the terminal metadata.
         if (null !== $thinking) {
             yield new ThinkingComplete($thinking, $thinkingSignature);
+        }
+
+        if ([] !== $toolCalls) {
+            yield new ToolCallComplete($toolCalls);
         }
 
         // Emitted last: the terminal chunk carries both the finish reason and its content parts.
@@ -272,6 +296,8 @@ final class ResultConverter implements ResultConverterInterface
 
                 return;
             case $result instanceof ToolCallResult:
+                // Only reached through the multi-candidate path: the single-candidate stream batches
+                // tool calls into one terminal ToolCallComplete instead.
                 yield new ToolCallComplete($result->getContent());
 
                 return;

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ResultConverterTest.php
@@ -31,6 +31,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
@@ -727,6 +728,62 @@ final class ResultConverterTest extends TestCase
         $this->assertSame('Calling tool.', $items[0]->getText());
         $this->assertInstanceOf(ToolCallComplete::class, $items[1]);
         $this->assertSame('search', $items[1]->getToolCalls()[0]->getName());
+    }
+
+    public function testStreamAnnouncesIdentifiedToolCallsAndBatchesThemIntoASingleCompletion()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createStub(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($response);
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield [
+                'candidates' => [
+                    ['content' => ['parts' => [
+                        ['functionCall' => ['id' => 'call_1', 'name' => 'search', 'args' => ['q' => 'x']]],
+                        ['text' => 'and now the weather', 'thought' => true, 'thoughtSignature' => 'sig'],
+                        ['functionCall' => ['id' => 'call_2', 'name' => 'weather', 'args' => ['city' => 'Berlin']]],
+                    ]]],
+                ],
+            ];
+        })());
+
+        $items = iterator_to_array((new ResultConverter())->convert($rawResult, ['stream' => true])->getContent());
+
+        $this->assertCount(6, $items);
+        $this->assertInstanceOf(ToolCallStart::class, $items[0]);
+        $this->assertSame('call_1', $items[0]->getId());
+        $this->assertInstanceOf(ThinkingStart::class, $items[1]);
+        $this->assertInstanceOf(ThinkingDelta::class, $items[2]);
+        $this->assertInstanceOf(ThinkingComplete::class, $items[3]);
+        $this->assertInstanceOf(ToolCallStart::class, $items[4]);
+        $this->assertSame('call_2', $items[4]->getId());
+
+        // Both calls arrive as one batch, instead of one completion per functionCall part
+        $this->assertInstanceOf(ToolCallComplete::class, $items[5]);
+        $toolCalls = $items[5]->getToolCalls();
+        $this->assertCount(2, $toolCalls);
+        $this->assertSame('call_1', $toolCalls[0]->getId());
+        $this->assertSame('call_2', $toolCalls[1]->getId());
+    }
+
+    public function testStreamOmitsToolCallStartForUnidentifiedCalls()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $rawResult = $this->createStub(RawResultInterface::class);
+        $rawResult->method('getObject')->willReturn($response);
+        $rawResult->method('getDataStream')->willReturn((static function (): \Generator {
+            yield ['candidates' => [['content' => ['parts' => [['functionCall' => ['name' => 'search', 'args' => []]]]]]]];
+        })());
+
+        $items = iterator_to_array((new ResultConverter())->convert($rawResult, ['stream' => true])->getContent());
+
+        $this->assertCount(1, $items);
+        $this->assertInstanceOf(ToolCallComplete::class, $items[0]);
+        $this->assertSame('', $items[0]->getToolCalls()[0]->getId());
     }
 
     public function testThrowsServerExceptionOnServerErrorStatusBeforeStreaming()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | n/a
| License       | MIT

Makes the streaming tool call contract uniform across bridges, so consumers can rely on `ToolCallStart`: every call is announced at the position it appears in, its arguments follow as `ToolInputDelta` chunks when the provider streams them, and one terminal `ToolCallComplete` carries all calls.

* **OpenResponses**: `response.output_item.added` -> `ToolCallStart`, `response.function_call_arguments.delta` -> `ToolInputDelta`. Argument deltas address the output item, so announced items are mapped back onto the `call_id` the call is completed with. Reasoning items and tool calls now stream in the order the model generated them, which the Responses API requires when reasoning is replayed with `store => false`.
* **Cohere**: maps the native `tool-call-start` / `tool-call-delta` events.
* **Ollama**: announces calls at the chunk they arrive in. The per-chunk array index was used as the `ToolCall` id, so calls in separate chunks collided on `"0"` — now a stream-wide counter (the id is never sent back to Ollama).
* **Gemini / VertexAI**: announces calls at their `functionCall` part and batches them into a single terminal `ToolCallComplete` instead of one per part. Previously parallel calls produced several `ToolCallComplete` deltas, of which consumers stopping at the first only saw one. The Agent's own `Toolbox\StreamListener` is such a consumer, so parallel calls from Gemini and VertexAI ended up with only the first one executed. Calls without an id (Gemini < 3.0 leaves it empty) are batched but not announced, as the announcement could not be correlated.