### PR TITLE
[Platform] Preserve forward slashes in JSON request bodies

### DIFF
--- a/src/platform/src/Bridge/Deepgram/Tests/DeepgramClientTest.php
+++ b/src/platform/src/Bridge/Deepgram/Tests/DeepgramClientTest.php
@@ -189,7 +189,7 @@ final class DeepgramClientTest extends TestCase
 
         $this->assertSame('POST', $capturedMethod);
         $this->assertSame('/v1/listen', parse_url($capturedUrl, \PHP_URL_PATH));
-        $this->assertSame('{"url":"https:\/\/example.com\/audio.mp3"}', $capturedBody);
+        $this->assertSame('{"url":"https://example.com/audio.mp3"}', $capturedBody);
     }
 
     public function testSpeechToTextRejectsDataUrlScheme()

--- a/src/platform/src/Bridge/Generic/Embeddings/ModelClient.php
+++ b/src/platform/src/Bridge/Generic/Embeddings/ModelClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\Generic\Embeddings;
 
 use Symfony\AI\Platform\Bridge\Generic\EmbeddingsModel;
+use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelClientInterface;
 use Symfony\AI\Platform\Result\RawHttpResult;
@@ -25,6 +26,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class ModelClient implements ModelClientInterface
 {
+    use JsonBodyEncodingTrait;
+
     private readonly string $baseUrl;
 
     /**
@@ -49,10 +52,10 @@ class ModelClient implements ModelClientInterface
         return new RawHttpResult($this->httpClient->request('POST', $this->baseUrl.$this->path, [
             'auth_bearer' => $this->apiKey,
             'headers' => ['Content-Type' => 'application/json'],
-            'json' => array_merge($options, [
+            'body' => $this->encodeJsonBody(array_merge($options, [
                 'model' => $model->getName(),
                 'input' => $payload,
-            ]),
+            ])),
         ]));
     }
 }

--- a/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Completions/ModelClientTest.php
@@ -72,6 +72,19 @@ final class ModelClientTest extends TestCase
         $modelClient->request(new CompletionsModel('gpt-4o'), ['model' => 'gpt-4o', 'messages' => [['role' => 'user', 'content' => 'Hello']]], ['temperature' => 0.7]);
     }
 
+    public function testItDoesNotEscapeForwardSlashesInNamespacedModelNames()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
+            self::assertSame('{"model":"qwen/qwen3.5-4b","messages":[{"role":"user","content":"Hello"}]}', $options['body']);
+            self::assertStringNotContainsString('qwen\/qwen3.5-4b', $options['body']);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'http://localhost:8000', 'sk-valid-api-key');
+        $modelClient->request(new CompletionsModel('qwen/qwen3.5-4b'), ['model' => 'qwen/qwen3.5-4b', 'messages' => [['role' => 'user', 'content' => 'Hello']]]);
+    }
+
     public function testItRequestsUsageForStreamedResponses()
     {
         $resultCallback = function (string $method, string $url, array $options): HttpResponse {

--- a/src/platform/src/Bridge/Generic/Tests/Embeddings/ModelClientTest.php
+++ b/src/platform/src/Bridge/Generic/Tests/Embeddings/ModelClientTest.php
@@ -54,6 +54,19 @@ final class ModelClientTest extends TestCase
         $modelClient->request(new EmbeddingsModel('text-embedding-3-small'), 'test text');
     }
 
+    public function testItDoesNotEscapeForwardSlashesInNamespacedModelNames()
+    {
+        $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
+            self::assertSame('{"model":"qwen/qwen3-embedding","input":"test text"}', $options['body']);
+            self::assertStringNotContainsString('qwen\/qwen3-embedding', $options['body']);
+
+            return new MockResponse();
+        };
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'http://localhost:8000', 'sk-api-key');
+        $modelClient->request(new EmbeddingsModel('qwen/qwen3-embedding'), 'test text');
+    }
+
     public function testItIsExecutingTheCorrectRequestWithCustomOptions()
     {
         $resultCallback = static function (string $method, string $url, array $options): HttpResponse {

--- a/src/platform/src/JsonBodyEncodingTrait.php
+++ b/src/platform/src/JsonBodyEncodingTrait.php
@@ -20,6 +20,11 @@ namespace Symfony\AI\Platform;
  * invalid sequences with U+FFFD so the request can still be sent; the
  * other flags mirror what the "json" option would have used.
  *
+ * JSON_UNESCAPED_SLASHES is added on top: the "json" option escapes forward
+ * slashes ("qwen/qwen3" becomes "qwen\/qwen3"), which several OpenAI-compatible
+ * backends (vLLM, LM Studio) fail to match when they do a raw string comparison
+ * on namespaced model names, returning a "model not found" error.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 trait JsonBodyEncodingTrait
@@ -29,6 +34,6 @@ trait JsonBodyEncodingTrait
      */
     private function encodeJsonBody(array $payload): string
     {
-        return json_encode($payload, \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_PRESERVE_ZERO_FRACTION | \JSON_INVALID_UTF8_SUBSTITUTE | \JSON_THROW_ON_ERROR);
+        return json_encode($payload, \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_PRESERVE_ZERO_FRACTION | \JSON_INVALID_UTF8_SUBSTITUTE | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1973
| License       | MIT

### Problem

`JsonBodyEncodingTrait::encodeJsonBody()` (used by every OpenAI-compatible bridge) and the Generic `Embeddings\ModelClient` (which still used HttpClient's `json` option) both encode without `JSON_UNESCAPED_SLASHES`. A namespaced model name such as `qwen/qwen3.5-4b` therefore goes on the wire as:

```json
{"model":"qwen\/qwen3.5-4b", ...}
```

That is valid JSON, but several OpenAI-compatible backends (observed with vLLM and LM Studio) do a raw string comparison of the model key during routing/lookup and fail to match the escaped form, returning a "model not found" error for any `org/model` name containing `/`.

### Fix

- Add `JSON_UNESCAPED_SLASHES` to `encodeJsonBody()` so the shared encoder emits the natural, semantically identical form. This benefits every bridge that routes JSON bodies through the trait, not just Generic.
- Route the Generic `Embeddings\ModelClient` through the same shared encoder (it was the last client still using the `json` option), so namespaced embedding model names work too.

The change is a pure serialization tweak: `/` and `\/` decode to the exact same string in every JSON parser. The one existing test asserting the escaped byte form (`DeepgramClientTest`, an unrelated URL payload) is updated to the unescaped output.

### Test verification (RED → GREEN)

New tests assert the model name is sent unescaped. On the unmodified branch (RED):

```
1) ...Generic\Tests\Completions\ModelClientTest::testItDoesNotEscapeForwardSlashesInNamespacedModelNames
-'{"model":"qwen/qwen3.5-4b","messages":[{"role":"user","content":"Hello"}]}'
+'{"model":"qwen\/qwen3.5-4b","messages":[{"role":"user","content":"Hello"}]}'
2) ...Generic\Tests\Embeddings\ModelClientTest::testItDoesNotEscapeForwardSlashesInNamespacedModelNames
-'{"model":"qwen/qwen3-embedding","input":"test text"}'
+'{"model":"qwen\/qwen3-embedding","input":"test text"}'
FAILURES! Tests: 2, Assertions: 2, Failures: 2.
```

With the fix (GREEN), Generic + Deepgram bridge suites:

```
OK (205 tests, 530 assertions)
```

No regression: the full `src/platform` bridge run is iso-baseline (same 85 pre-existing errors / 3 pre-existing failures from unrelated bridges lacking optional deps in the local env), plus the 2 new passing tests. PHPStan and PHP-CS-Fixer are clean on the changed files.
