### PR TITLE
[Platform][VertexAi] Normalize nullable fields in structured output schema

### DIFF
--- a/src/platform/src/Bridge/VertexAi/Contract/ToolNormalizer.php
+++ b/src/platform/src/Bridge/VertexAi/Contract/ToolNormalizer.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\VertexAi\Contract;
 
 use Symfony\AI\Platform\Bridge\VertexAi\Gemini\Model;
+use Symfony\AI\Platform\Bridge\VertexAi\SchemaNormalizer;
 use Symfony\AI\Platform\Contract\JsonSchema\Factory;
 use Symfony\AI\Platform\Contract\Normalizer\ModelContractNormalizer;
 use Symfony\AI\Platform\Model as BaseModel;
@@ -35,7 +36,7 @@ final class ToolNormalizer extends ModelContractNormalizer
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        $parameters = $data->getParameters() ? $this->normalizeSchema($data->getParameters()) : null;
+        $parameters = $data->getParameters() ? SchemaNormalizer::normalize($data->getParameters()) : null;
 
         return [
             'name' => $data->getName(),
@@ -52,45 +53,5 @@ final class ToolNormalizer extends ModelContractNormalizer
     protected function supportsModel(BaseModel $model): bool
     {
         return $model instanceof Model;
-    }
-
-    /**
-     * Normalizes a JSON Schema for VertexAI compatibility.
-     *
-     * - Removes 'additionalProperties' (not supported by VertexAI)
-     * - Converts array-style nullable types ['string', 'null'] to ['type' => 'string', 'nullable' => true]
-     *
-     * @template T of array
-     *
-     * @phpstan-param T $data
-     *
-     * @phpstan-return T
-     */
-    private function normalizeSchema(array $data): array
-    {
-        unset($data['additionalProperties']);
-
-        // Convert array-style nullable types to VertexAI format
-        if (isset($data['type']) && \is_array($data['type'])) {
-            $nullIndex = array_search('null', $data['type'], true);
-            if (false !== $nullIndex) {
-                $types = $data['type'];
-                unset($types[$nullIndex]);
-                $types = array_values($types);
-
-                if (1 === \count($types)) {
-                    $data['type'] = $types[0];
-                    $data['nullable'] = true;
-                }
-            }
-        }
-
-        foreach ($data as &$value) {
-            if (\is_array($value)) {
-                $value = $this->normalizeSchema($value);
-            }
-        }
-
-        return $data;
     }
 }

--- a/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
@@ -64,9 +64,10 @@ final class ModelClient implements ModelClientInterface
             $query['alt'] = 'sse';
         }
 
-        if (isset($options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema'])) {
+        $responseSchema = $options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema'] ?? null;
+        if (\is_array($responseSchema)) {
             $options['generationConfig']['responseMimeType'] = 'application/json';
-            $options['generationConfig']['responseSchema'] = SchemaNormalizer::normalize($options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema']);
+            $options['generationConfig']['responseSchema'] = SchemaNormalizer::normalize($responseSchema);
 
             unset($options[PlatformSubscriber::RESPONSE_FORMAT]);
         }

--- a/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
+++ b/src/platform/src/Bridge/VertexAi/Gemini/ModelClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Bridge\VertexAi\Gemini;
 
 use Symfony\AI\Platform\Bridge\VertexAi\RegionAwareTrait;
+use Symfony\AI\Platform\Bridge\VertexAi\SchemaNormalizer;
 use Symfony\AI\Platform\JsonBodyEncodingTrait;
 use Symfony\AI\Platform\Model as BaseModel;
 use Symfony\AI\Platform\ModelClientInterface;
@@ -65,7 +66,7 @@ final class ModelClient implements ModelClientInterface
 
         if (isset($options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema'])) {
             $options['generationConfig']['responseMimeType'] = 'application/json';
-            $options['generationConfig']['responseSchema'] = $options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema'];
+            $options['generationConfig']['responseSchema'] = SchemaNormalizer::normalize($options[PlatformSubscriber::RESPONSE_FORMAT]['json_schema']['schema']);
 
             unset($options[PlatformSubscriber::RESPONSE_FORMAT]);
         }

--- a/src/platform/src/Bridge/VertexAi/SchemaNormalizer.php
+++ b/src/platform/src/Bridge/VertexAi/SchemaNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\VertexAi;
+
+/**
+ * Normalizes a JSON Schema for VertexAI compatibility.
+ *
+ * - Removes 'additionalProperties' (not supported by VertexAI).
+ * - Converts array-style nullable types ['string', 'null'] to
+ *   ['type' => 'string', 'nullable' => true], which VertexAI's OpenAPI-flavored
+ *   schema parser requires. Sent as-is, an array type triggers
+ *   "Proto field is not repeating, cannot start list".
+ *
+ * Used both for tool parameter schemas and for structured-output response
+ * schemas so the two stay in sync.
+ *
+ * @author Ben Younes <benyounes.ousama@gmail.com>
+ */
+final class SchemaNormalizer
+{
+    /**
+     * @template T of array
+     *
+     * @param T $schema
+     *
+     * @return T
+     */
+    public static function normalize(array $schema): array
+    {
+        unset($schema['additionalProperties']);
+
+        if (isset($schema['type']) && \is_array($schema['type'])) {
+            $nullIndex = array_search('null', $schema['type'], true);
+            if (false !== $nullIndex) {
+                $types = $schema['type'];
+                unset($types[$nullIndex]);
+                $types = array_values($types);
+
+                if (1 === \count($types)) {
+                    $schema['type'] = $types[0];
+                    $schema['nullable'] = true;
+                }
+            }
+        }
+
+        foreach ($schema as &$value) {
+            if (\is_array($value)) {
+                $value = self::normalize($value);
+            }
+        }
+
+        return $schema;
+    }
+}

--- a/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
+++ b/src/platform/src/Bridge/VertexAi/Tests/Gemini/ModelClientTest.php
@@ -179,6 +179,45 @@ final class ModelClientTest extends TestCase
         $client->request(new Model('gemini-2.0-flash'), $payload, ['server_tools' => ['google_search' => true]]);
     }
 
+    public function testItNormalizesNullableFieldsInStructuredOutputResponseSchema()
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => ['string', 'null'],
+                    'description' => 'A nullable name',
+                ],
+                'tags' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => ['string', 'null'],
+                    ],
+                ],
+            ],
+            'additionalProperties' => false,
+        ];
+
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $body = json_decode($options['body'], true);
+            $responseSchema = $body['generationConfig']['responseSchema'];
+
+            $this->assertSame('application/json', $body['generationConfig']['responseMimeType']);
+            $this->assertSame('string', $responseSchema['properties']['name']['type']);
+            $this->assertTrue($responseSchema['properties']['name']['nullable']);
+            $this->assertSame('string', $responseSchema['properties']['tags']['items']['type']);
+            $this->assertTrue($responseSchema['properties']['tags']['items']['nullable']);
+            $this->assertArrayNotHasKey('additionalProperties', $responseSchema);
+
+            return new JsonMockResponse(['candidates' => []]);
+        });
+
+        $client = new ModelClient($httpClient, 'global', 'test');
+        $client->request(new Model('gemini-2.0-flash'), ['contents' => []], [
+            'response_format' => ['json_schema' => ['schema' => $schema]],
+        ]);
+    }
+
     public function testMalformedUtf8InPayloadDoesNotAbortTheRequest()
     {
         $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1999
| License       | MIT

### Problem

Using structured output with the Vertex/Gemini bridge throws as soon as a DTO property is nullable:

```
Error from Gemini API: "Invalid JSON payload received. Unknown name "type" at
'generation_config.response_schema.properties[0].value.items.properties[5].value':
Proto field is not repeating, cannot start list."
```

The JSON Schema factory represents a nullable field with an array-style type (`"type": ["string", "null"]`). VertexAI's OpenAPI-flavored schema parser does not accept an array there — it requires a single `type` plus `"nullable": true`.

`Contract\ToolNormalizer` already performed this conversion for **tool parameter** schemas, but the **structured-output** `responseSchema` in `Gemini\ModelClient` was assigned straight from the `response_format` payload without any normalization, so nullable fields broke.

### Fix

- Extract the nullable-array → `nullable: true` conversion (and the `additionalProperties` stripping) from `ToolNormalizer` into a shared `SchemaNormalizer`.
- `ToolNormalizer` now delegates to it (identical behavior, no duplicated logic).
- `Gemini\ModelClient` runs the structured-output `responseSchema` through the same normalizer, so tool and response schemas stay in sync.

### Test verification (RED → GREEN)

New test `testItNormalizesNullableFieldsInStructuredOutputResponseSchema` asserts the wire `responseSchema` has a single `type` + `nullable: true` (top-level and nested `items`) and no `additionalProperties`.

On the unmodified branch (RED):

```
1) ...VertexAi\Tests\Gemini\ModelClientTest::testItNormalizesNullableFieldsInStructuredOutputResponseSchema
Failed asserting that Array &0 [
    0 => 'string',
    1 => 'null',
] is identical to 'string'.
FAILURES! Tests: 1, Assertions: 2, Failures: 1.
```

With the fix (GREEN), the whole VertexAi bridge suite (including the existing ToolNormalizer nullable tests, proving behavior parity after the extraction):

```
OK (109 tests, 457 assertions)
```

PHPStan and PHP-CS-Fixer are clean on the changed files.