### PR TITLE
[Store][ChromaDb] Only support TextQuery when an embedding function is configured

### DIFF
--- a/src/store/src/Bridge/ChromaDb/CHANGELOG.md
+++ b/src/store/src/Bridge/ChromaDb/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Add an optional `EmbeddingFunction` argument to `Store` and `StoreFactory::create()` so a `TextQuery` can be embedded client-side; `supports(TextQuery::class)` now only returns `true` when one is configured
+
 0.8
 ---
 

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Store\Bridge\ChromaDb;
 
 use Codewithkyrian\ChromaDB\Client;
+use Codewithkyrian\ChromaDB\Embeddings\EmbeddingFunction;
 use Codewithkyrian\ChromaDB\Exceptions\ChromaException;
 use Codewithkyrian\ChromaDB\Responses\QueryItemsResponse;
 use Symfony\AI\Platform\Vector\Vector;
@@ -36,6 +37,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     public function __construct(
         private readonly Client $client,
         private readonly string $collectionName,
+        private readonly ?EmbeddingFunction $embeddingFunction = null,
     ) {
     }
 
@@ -119,10 +121,17 @@ final class Store implements ManagedStoreInterface, StoreInterface
 
     public function supports(string $queryClass): bool
     {
-        return \in_array($queryClass, [
-            VectorQuery::class,
-            TextQuery::class,
-        ], true);
+        if (VectorQuery::class === $queryClass) {
+            return true;
+        }
+
+        // A TextQuery is embedded client-side by the collection's embedding function; without one the
+        // ChromaDB client fatals on a null embedding function before a request is ever sent.
+        if (TextQuery::class === $queryClass) {
+            return null !== $this->embeddingFunction;
+        }
+
+        return false;
     }
 
     /**
@@ -189,7 +198,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     {
         $include = $this->buildInclude($options);
 
-        $collection = $this->client->getOrCreateCollection($this->collectionName);
+        $collection = $this->client->getOrCreateCollection($this->collectionName, embeddingFunction: $this->embeddingFunction);
         $queryResponse = $collection->query(
             queryTexts: $query->getTexts(),
             nResults: $options['limit'] ?? 4,

--- a/src/store/src/Bridge/ChromaDb/StoreFactory.php
+++ b/src/store/src/Bridge/ChromaDb/StoreFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Store\Bridge\ChromaDb;
 
 use Codewithkyrian\ChromaDB\Client;
+use Codewithkyrian\ChromaDB\Embeddings\EmbeddingFunction;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\StoreInterface;
 
@@ -23,7 +24,8 @@ final class StoreFactory
     public static function create(
         Client $client,
         string $collectionName,
+        ?EmbeddingFunction $embeddingFunction = null,
     ): ManagedStoreInterface&StoreInterface {
-        return new Store($client, $collectionName);
+        return new Store($client, $collectionName, $embeddingFunction);
     }
 }

--- a/src/store/src/Bridge/ChromaDb/Tests/IntegrationTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/IntegrationTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Store\Bridge\ChromaDb\Tests;
 
 use Codewithkyrian\ChromaDB\ChromaDB;
-use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\AI\Store\Bridge\ChromaDb\StoreFactory;
 use Symfony\AI\Store\StoreInterface;
@@ -24,15 +23,6 @@ use Symfony\AI\Store\Test\AbstractStoreIntegrationTestCase;
 #[Group('integration')]
 final class IntegrationTest extends AbstractStoreIntegrationTestCase
 {
-    #[Depends('testAddDocuments')]
-    public function testQueryDocumentsWithTextQuery()
-    {
-        // ChromaDb TextQuery requires an embedding function to be configured, but this test must not
-        // be skipped, since the tests depending on it would be skipped as well, and the store would
-        // never get to the point of being removed from, cleared or dropped
-        $this->addToAssertionCount(1);
-    }
-
     /**
      * @return array<string, mixed>
      */

--- a/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Store\Bridge\ChromaDb\Tests;
 
 use Codewithkyrian\ChromaDB\Client;
+use Codewithkyrian\ChromaDB\Embeddings\EmbeddingFunction;
 use Codewithkyrian\ChromaDB\Models\Collection;
 use Codewithkyrian\ChromaDB\Responses\GetItemsResponse;
 use Codewithkyrian\ChromaDB\Responses\QueryItemsResponse;
@@ -22,6 +23,7 @@ use Symfony\AI\Store\Bridge\ChromaDb\StoreFactory;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
+use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\TextQuery;
 use Symfony\AI\Store\Query\VectorQuery;
@@ -828,10 +830,11 @@ final class StoreTest extends TestCase
 
         $collection = $this->createMock(Collection::class);
         $client = $this->createMock(Client::class);
+        $embeddingFunction = $this->createMock(EmbeddingFunction::class);
 
         $client->expects($this->once())
             ->method('getOrCreateCollection')
-            ->with('test-collection')
+            ->with('test-collection', null, $embeddingFunction)
             ->willReturn($collection);
 
         $collection->expects($this->once())
@@ -846,7 +849,7 @@ final class StoreTest extends TestCase
             )
             ->willReturn($queryResponse);
 
-        $store = StoreFactory::create($client, 'test-collection');
+        $store = StoreFactory::create($client, 'test-collection', $embeddingFunction);
         $documents = iterator_to_array($store->query(new TextQuery('search for this text')));
 
         $this->assertCount(1, $documents);
@@ -866,9 +869,29 @@ final class StoreTest extends TestCase
     public function testStoreSupportsTextQuery()
     {
         $client = $this->createMock(Client::class);
-        $store = StoreFactory::create($client, 'test-collection');
+        $store = StoreFactory::create($client, 'test-collection', $this->createMock(EmbeddingFunction::class));
 
         $this->assertTrue($store->supports(TextQuery::class));
+    }
+
+    public function testStoreDoesNotSupportTextQueryWithoutEmbeddingFunction()
+    {
+        $client = $this->createMock(Client::class);
+        $store = StoreFactory::create($client, 'test-collection');
+
+        $this->assertFalse($store->supports(TextQuery::class));
+    }
+
+    public function testQueryWithTextQueryThrowsWithoutEmbeddingFunction()
+    {
+        $client = $this->createMock(Client::class);
+        $client->expects($this->never())->method('getOrCreateCollection');
+
+        $store = StoreFactory::create($client, 'test-collection');
+
+        $this->expectException(UnsupportedQueryTypeException::class);
+
+        $store->query(new TextQuery('search for this text'));
     }
 
     public function testStoreNotSupportsHybridQuery()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #1601
| License       | MIT

### Problem

`Store::supports(TextQuery::class)` returned `true` unconditionally, but running a text query then failed at runtime:

```
Error: Call to a member function generate() on null
```

ChromaDB embeds a text query client-side, in `prepareEmbeddings()`, through the collection's embedding function. The bridge never configured one, and `getOrCreateCollection()` returns a fresh collection whose embedding function is `null`, so every `TextQuery` fataled before a request was ever sent — while `supports()` claimed it was fine.

### Fix

- Accept an optional `?EmbeddingFunction $embeddingFunction` on `Store` (and `StoreFactory::create`), a backward-compatible trailing nullable argument.
- Forward it to `getOrCreateCollection()` on the text-query path so the query text can actually be embedded.
- `supports(TextQuery::class)` now returns `true` only when an embedding function is configured, so it no longer advertises a capability the store cannot fulfil. `VectorQuery` is unaffected (it carries its own vector).

The embedding function is only passed on the text-query path; `add`/`remove`/`clear`/vector queries provide their own ids/vectors and never call `generate()`, so they are intentionally left untouched.

Marked as a feature as well as a bug fix per review: the new public `$embeddingFunction` parameter makes `TextQuery` usable on this bridge for the first time, hence the `CHANGELOG.md` entry. Exposing it through the bundle's `config/store/chromadb.php` is tracked separately in #2418.

### Test verification (RED → GREEN)

New unit tests assert both the flag and its consequence: `supports(TextQuery::class)` is `false` without an embedding function, and `query(new TextQuery(...))` throws `UnsupportedQueryTypeException` without ever reaching `getOrCreateCollection()`.

On the unmodified base branch, with only the test files of this PR applied (RED):

```
1) ...ChromaDb\Tests\StoreTest::testStoreDoesNotSupportTextQueryWithoutEmbeddingFunction
Failed asserting that true is false.

2) ...ChromaDb\Tests\StoreTest::testQueryWithTextQuery
Expectation failed for method name is "getOrCreateCollection" when invoked 1 time
Parameter 2 for invocation Client::getOrCreateCollection('test-collection', null, null): Collection does not match expected value.
null does not match expected type "object".

3) ...ChromaDb\Tests\StoreTest::testQueryWithTextQueryThrowsWithoutEmbeddingFunction
Failed asserting that exception of type "...\UnsupportedQueryTypeException" is thrown.

FAILURES! Tests: 35, Assertions: 220, Failures: 3.
```

With the fix (GREEN), the full ChromaDb bridge unit suite:

```
OK (35 tests, 233 assertions)
```

The `IntegrationTest::testQueryDocumentsWithTextQuery()` override was dropped: `AbstractStoreIntegrationTestCase` now carries the same "do not skip, dependents would be skipped too" guard, keyed on `supports(TextQuery::class)`, so the bridge no longer needs its own copy. The ChromaDb integration suite was run against a real `chromadb/chroma:0.6.3` container to confirm the removal keeps the dependency chain intact.

PHPStan and PHP-CS-Fixer are clean on the changed files.
