### PR TITLE
[Agent] Count tool calling iterations across nested agent calls

### DIFF
--- a/src/agent/src/Execution/Runner.php
+++ b/src/agent/src/Execution/Runner.php
@@ -51,6 +51,13 @@ final class Runner
      */
     private int $nestingLevel = 0;
 
+    /**
+     * Counts the tool calling iterations of the outermost agent call, which the agent nests into
+     * one level per iteration. Reset together with the nesting level, so that the limit applies
+     * per conversation and does not leak into the next one in a long-running process.
+     */
+    private int $iterations = 0;
+
     public function __construct(
         private readonly PlatformInterface $platform,
         private readonly ?ToolboxInterface $toolbox = null,
@@ -143,9 +150,8 @@ final class Runner
         }
 
         try {
-            $iterations = 0;
             do {
-                if (null !== $this->maxToolCalls && ++$iterations > $this->maxToolCalls) {
+                if (null !== $this->maxToolCalls && ++$this->iterations > $this->maxToolCalls) {
                     throw new MaxIterationsExceededException($this->maxToolCalls);
                 }
 
@@ -172,6 +178,10 @@ final class Runner
             } while ($result instanceof ToolCallResult);
         } finally {
             --$this->nestingLevel;
+
+            if (0 === $this->nestingLevel) {
+                $this->iterations = 0;
+            }
 
             if ($this->includeSources && 0 === $this->nestingLevel && $result instanceof ToolCallResult) {
                 $this->sources = new SourceCollection();

--- a/src/agent/tests/Execution/RunnerTest.php
+++ b/src/agent/tests/Execution/RunnerTest.php
@@ -468,6 +468,32 @@ final class RunnerTest extends TestCase
         $runner->run($agent, 'gpt-4', new MessageBag(), []);
     }
 
+    public function testThrowsExceptionWhenMaxIterationsExceededAcrossNestedAgentCalls()
+    {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Test response'));
+
+        // A real agent re-enters the runner for every tool call instead of looping in place,
+        // so the limit has to be counted across the whole conversation, not per entry.
+        $platform = $this->platform(
+            new ToolCallResult([$toolCall]),
+            new ToolCallResult([$toolCall]),
+            new ToolCallResult([$toolCall]),
+            new ToolCallResult([$toolCall]),
+            new TextResult('Never reached, the limit stops the loop before this.'),
+        );
+
+        $agent = new Agent($platform, 'foo-bar', toolbox: $toolbox, maxToolCalls: 3);
+
+        $this->expectException(MaxIterationsExceededException::class);
+        $this->expectExceptionMessage('Maximum number of tool calling iterations (3) exceeded.');
+
+        $agent->call(new MessageBag());
+    }
+
     public function testCustomMaxIterationsLimitAllowsConfiguredIterations()
     {
         $toolCall1 = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2393
| License       | MIT

`maxToolCalls` is checked against a counter that is local to a single entry into
`Runner::handleToolCalls()`:

```php
$iterations = 0;
do {
    if (null !== $this->maxToolCalls && ++$iterations > $this->maxToolCalls) {
        throw new MaxIterationsExceededException($this->maxToolCalls);
    }
    // ...
    $result = $event->hasResult() ? $event->getResult() : $agent->call($messages, $options);
} while ($result instanceof ToolCallResult);
```

The loop reads as if tool calling were flat, but `$agent->call()` is a full agent
invocation: it goes back through `Runner::run()`, which sees another
`ToolCallResult` and calls `handleToolCalls()` again — with a fresh
`$iterations = 0`. The nested entry returns something that is no longer a
`ToolCallResult`, so the parent's `while` is false on its first check.

Every level therefore runs exactly one iteration and `$iterations` never gets
past 1, so the limit is unreachable and the tool calling loop is bounded only by
the PHP stack. The check can only fire for `maxToolCalls <= 0`.

The class already tracks the recursion for the sources it collects, so this
counts iterations on the instance the same way and resets it when the outermost
call finishes. Resetting on nesting level 0 also keeps the limit from leaking
between conversations, which matters because the runner is long-lived in a
worker (Messenger, RoadRunner, FrankenPHP).

The existing coverage passes both before and after, because the stub agents
return a `ToolCallResult` directly and so keep the loop flat — which is the one
shape the real wiring never produces. The added test drives a real `Agent`, so
it nests the way production does: it fails on `main` (the conversation runs all
the way to the final `TextResult` with no exception) and passes here.

Reported and diagnosed by @b1rdex in #2393.
