### PR TITLE
[AI Bundle][Platform] Preserve periods in model option names

### DIFF
--- a/src/ai-bundle/config/options.php
+++ b/src/ai-bundle/config/options.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Config\Definition\Configurator;
 use Symfony\AI\AiBundle\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelOptionsParser;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Store\Document\VectorizerInterface;
 use Symfony\AI\Store\StoreInterface;
@@ -158,8 +159,7 @@ return static function (DefinitionConfigurator $configurator): void {
                                             if ([] !== $options) {
                                                 throw new InvalidConfigurationException('Cannot use both query parameters in model name and options array.');
                                             }
-                                            parse_str($parsed['query'], $existingOptions);
-                                            $options = $existingOptions;
+                                            $options = ModelOptionsParser::parse($parsed['query']);
                                         }
                                     }
 
@@ -510,8 +510,7 @@ return static function (DefinitionConfigurator $configurator): void {
                                             if ([] !== $options) {
                                                 throw new InvalidConfigurationException('Cannot use both query parameters in model name and options array.');
                                             }
-                                            parse_str($parsed['query'], $existingOptions);
-                                            $options = $existingOptions;
+                                            $options = ModelOptionsParser::parse($parsed['query']);
                                         }
                                     }
 

--- a/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
+++ b/src/ai-bundle/tests/DependencyInjection/AiBundleTest.php
@@ -6144,6 +6144,45 @@ class AiBundleTest extends TestCase
         $this->assertSame('gpt-4o-mini?temperature=0.7&max_tokens=1500', $agentDefinition->getArgument('$model'));
     }
 
+    #[TestDox('Model configuration keeps periods in option names given in the model name')]
+    public function testModelConfigurationKeepsPeriodsInQueryParameters()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'test' => [
+                        'model' => 'gpt-5?reasoning.effort=medium',
+                    ],
+                ],
+            ],
+        ]);
+
+        $agentDefinition = $container->getDefinition('ai.agent.test');
+        $this->assertSame('gpt-5?reasoning.effort=medium', $agentDefinition->getArgument('$model'));
+    }
+
+    #[TestDox('Model configuration keeps periods in option names given in the options array')]
+    public function testModelConfigurationKeepsPeriodsInSeparateOptions()
+    {
+        $container = $this->buildContainer([
+            'ai' => [
+                'agent' => [
+                    'test' => [
+                        'model' => [
+                            'name' => 'gpt-5',
+                            'options' => [
+                                'reasoning.effort' => 'medium',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $agentDefinition = $container->getDefinition('ai.agent.test');
+        $this->assertSame('gpt-5?reasoning.effort=medium', $agentDefinition->getArgument('$model'));
+    }
+
     #[TestDox('Model configuration throws exception when using both query parameters and options array')]
     public function testModelConfigurationConflictThrowsException()
     {

--- a/src/platform/src/ModelCatalog/AbstractModelCatalog.php
+++ b/src/platform/src/ModelCatalog/AbstractModelCatalog.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
 use Symfony\AI\Platform\Exception\ModelNotFoundException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelOptionsParser;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
@@ -84,7 +85,7 @@ abstract class AbstractModelCatalog implements ModelCatalogInterface
                 throw new InvalidArgumentException('Model name cannot be empty.');
             }
 
-            parse_str($queryString, $options);
+            $options = ModelOptionsParser::parse($queryString);
 
             $options = self::convertScalarStrings($options);
         }

--- a/src/platform/src/ModelOptionsParser.php
+++ b/src/platform/src/ModelOptionsParser.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform;
+
+/**
+ * Parses the query string of a model name into options.
+ *
+ * Behaves like parse_str(), except that it keeps periods in option names instead
+ * of turning them into underscores, so that provider options like
+ * "reasoning.effort" survive.
+ *
+ * @author Saiful Islam Feroz <saif012@gmail.com>
+ */
+final class ModelOptionsParser
+{
+    /**
+     * Marks periods while parse_str() runs. U+0001 cannot appear in a decoded
+     * option name that came from a model string, so it never collides.
+     */
+    private const PERIOD_PLACEHOLDER = "\u{1}";
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function parse(string $queryString): array
+    {
+        // parse_str() replaces periods in option names with underscores, and does so
+        // after decoding, so "%2E" is folded as well. Mask them for the duration of
+        // the call: only the name of each pair is touched, values are left alone.
+        $masked = preg_replace_callback(
+            '/(?:^|(?<=&))[^=&]*/',
+            static fn (array $matches): string => str_replace(['.', '%2E', '%2e'], self::PERIOD_PLACEHOLDER, $matches[0]),
+            $queryString,
+        );
+
+        parse_str($masked ?? $queryString, $options);
+
+        return self::restorePeriods($options);
+    }
+
+    /**
+     * @param array<array-key, mixed> $options
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function restorePeriods(array $options): array
+    {
+        $restored = [];
+
+        foreach ($options as $name => $value) {
+            if (\is_string($name)) {
+                $name = str_replace(self::PERIOD_PLACEHOLDER, '.', $name);
+            }
+
+            $restored[$name] = \is_array($value) ? self::restorePeriods($value) : $value;
+        }
+
+        return $restored;
+    }
+}

--- a/src/platform/tests/ModelCatalog/AbstractModelCatalogTest.php
+++ b/src/platform/tests/ModelCatalog/AbstractModelCatalogTest.php
@@ -171,6 +171,15 @@ final class AbstractModelCatalogTest extends TestCase
         $this->assertSame(2.5E3, $options['presence_penalty']);
     }
 
+    public function testGetModelKeepsPeriodsInOptionNames()
+    {
+        $catalog = $this->createTestCatalog();
+        $model = $catalog->getModel('test-model?reasoning.effort=medium');
+
+        $this->assertSame('test-model', $model->getName());
+        $this->assertSame(['reasoning.effort' => 'medium'], $model->getOptions());
+    }
+
     private function createTestCatalog(): AbstractModelCatalog
     {
         return new class extends AbstractModelCatalog {

--- a/src/platform/tests/ModelOptionsParserTest.php
+++ b/src/platform/tests/ModelOptionsParserTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\ModelOptionsParser;
+
+final class ModelOptionsParserTest extends TestCase
+{
+    public function testPeriodsInOptionNamesArePreserved()
+    {
+        $this->assertSame(['reasoning.effort' => 'medium'], ModelOptionsParser::parse('reasoning.effort=medium'));
+    }
+
+    public function testPeriodsArePreservedInNestedOptionNames()
+    {
+        $this->assertSame(['a.b' => ['c.d' => '1']], ModelOptionsParser::parse('a.b[c.d]=1'));
+    }
+
+    public function testEncodedPeriodsInOptionNamesArePreserved()
+    {
+        $this->assertSame(['reasoning.effort' => 'medium'], ModelOptionsParser::parse('reasoning%2Eeffort=medium'));
+    }
+
+    public function testPeriodsInValuesAreUntouched()
+    {
+        $this->assertSame(['temperature' => '0.7'], ModelOptionsParser::parse('temperature=0.7'));
+    }
+
+    /**
+     * Everything without a period in an option name has to keep behaving exactly like parse_str().
+     */
+    #[DataProvider('provideQueryStringsWithoutPeriodsInNames')]
+    public function testBehavesLikeParseStrOtherwise(string $queryString)
+    {
+        parse_str($queryString, $expected);
+
+        $this->assertSame($expected, ModelOptionsParser::parse($queryString));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideQueryStringsWithoutPeriodsInNames(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'flat' => ['think=true&stream=false'];
+        yield 'value without name' => ['flag'];
+        yield 'nested arrays' => ['options[max_tokens]=500&options[metadata][version]=1'];
+        yield 'deeply nested arrays' => ['a[b][c]=123&a[b][d]=text&a[e]=456'];
+        yield 'appended values' => ['x[]=1&x[]=2'];
+        yield 'repeated name' => ['a=1&a=2'];
+        yield 'encoded value' => ['key=val%20ue'];
+        yield 'encoded ampersand in value' => ['e=a%26b'];
+        yield 'period in value' => ['frequency_penalty=1e-5&presence_penalty=2.5E3'];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #1437
| License       | MIT

`parse_str()` replaces periods in parameter *names* with underscores, so an
option like `reasoning.effort` arrives as `reasoning_effort`. A model string is
parsed in two places, and both used it:

* `src/ai-bundle/config/options.php`, when the model name carries a query string
  (twice, once for agents and once for vectorizers);
* `AbstractModelCatalog::parseModelName()`, when the normalized model string is
  turned back into options.

That covers both ways of configuring such an option, which is why neither of the
first two cases in the issue works:

```yaml
# option 1 — mangled by the bundle, then again by the catalog
model: 'gpt-5?reasoning.effort=medium'

# option 2 — survives http_build_query(), then mangled by the catalog
model:
    name: 'gpt-5'
    options:
        reasoning.effort: 'medium'
```

`http_build_query()` is not part of the problem: it emits `reasoning.effort=medium`
unchanged, and only the `parse_str()` on the way back folds the period. So both
paths needed the same single fix rather than a change to how options are encoded.

The new `ModelOptionsParser` masks periods in the name of each pair, runs
`parse_str()`, and restores them. Masking rather than hand-rolling the parse keeps
everything else `parse_str()` does, in particular the nested array notation that
`test-model?options[metadata][version]=1` relies on, and it also covers `%2E`,
which `parse_str()` decodes before folding.

Per the discussion on #1438, this fixes options 1 and 2 only. Option 3 (a nested
`options` array in YAML) is left alone.

Reported by @TomvdPeet in #1437, who also traced both call sites.
