### PR TITLE
[Mate] Support multi-kernel (APP_ID) cache and log directories via context maps

### DIFF
--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -274,13 +274,27 @@ Container Introspection
 **MCP Tools:**
 
 * ``symfony-services`` - List Symfony services from the compiled container and optionally filter by service ID or class name using the ``query`` parameter
+* ``symfony-service-detail`` - Get full details of a single service by its exact ID
 
 **Configuration:**
 
-Configure the cache directory::
+Single cache directory (default)::
 
     $container->parameters()
         ->set('ai_mate_symfony.cache_dir', '%mate.root_dir%/var/cache');
+
+Multiple directories with contexts (e.g., for `multi-kernel applications`_ that split their
+cache per ``APP_ID``)::
+
+    $container->parameters()
+        ->set('ai_mate_symfony.cache_dir', [
+            'website' => '%mate.root_dir%/var/cache/website',
+            'admin' => '%mate.root_dir%/var/cache/admin',
+        ]);
+
+When using multiple directories, ``symfony-services`` returns the services grouped by context and
+``symfony-service-detail`` includes the ``context`` a service was found in. Both tools accept an
+optional ``context`` parameter to narrow the lookup to a single kernel.
 
 **Troubleshooting:**
 
@@ -328,7 +342,7 @@ Single profiler directory (default)::
     $container->parameters()
         ->set('ai_mate_symfony.profiler_dir', '%mate.root_dir%/var/cache/dev/profiler');
 
-Multiple directories with contexts (e.g., for multi-kernel applications)::
+Multiple directories with contexts (e.g., for `multi-kernel applications`_)::
 
     $container->parameters()
         ->set('ai_mate_symfony.profiler_dir', [
@@ -407,10 +421,24 @@ The Monolog bridge (``symfony/ai-monolog-mate-extension``) provides log search a
 * ``monolog-list-files`` - List available log files
 * ``monolog-list-channels`` - List all log channels
 
-Configure the log directory::
+Single log directory (default)::
 
     $container->parameters()
         ->set('ai_mate_monolog.log_dir', '%mate.root_dir%/var/log');
+
+Multiple directories with contexts (e.g., for `multi-kernel applications`_ that split their
+logs per ``APP_ID``)::
+
+    $container->parameters()
+        ->set('ai_mate_monolog.log_dir', [
+            'website' => '%mate.root_dir%/var/log/website',
+            'admin' => '%mate.root_dir%/var/log/admin',
+        ]);
+
+When using multiple directories, log entries and files carry a ``kernel_context`` field, and all
+Monolog tools accept an optional ``kernelContext`` parameter to restrict the lookup to a single
+kernel. The field is named ``kernel_context`` rather than ``context`` to keep it apart from the
+Monolog context of a log record.
 
 **Troubleshooting**
 
@@ -753,3 +781,4 @@ Further Reading
     mate/troubleshooting
 
 .. _`MCP SDK documentation`: https://github.com/modelcontextprotocol/php-sdk
+.. _`multi-kernel applications`: https://symfony.com/doc/current/configuration/multiple_kernels.html

--- a/src/mate/src/Bridge/Monolog/CHANGELOG.md
+++ b/src/mate/src/Bridge/Monolog/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Allow `ai_mate_monolog.log_dir` to be a map of context name to log directory. Log entries and files then carry a `kernel_context` field, and `monolog-search`, `monolog-context-search`, `monolog-tail`, `monolog-list-files` and `monolog-list-channels` accept an optional `kernelContext` filter parameter
+
 0.7
 ---
 

--- a/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
+++ b/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
@@ -29,16 +29,17 @@ final class LogSearchTool
     }
 
     /**
-     * @param string      $term        Text to search for in log messages, or a regex pattern when $regex is true
-     * @param bool        $regex       When true, treat $term as a regular expression pattern
-     * @param string|null $level       Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
-     * @param string|null $channel     Filter by Monolog channel name (e.g. app, security, doctrine)
-     * @param string|null $environment Filter by Symfony environment (e.g. dev, prod, test)
-     * @param string|null $from        Start date filter, any PHP-parseable date string (e.g. 2024-01-01, -1 hour, yesterday)
-     * @param string|null $to          End date filter, any PHP-parseable date string
-     * @param int         $limit       Maximum number of entries to return
+     * @param string      $term          Text to search for in log messages, or a regex pattern when $regex is true
+     * @param bool        $regex         When true, treat $term as a regular expression pattern
+     * @param string|null $level         Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
+     * @param string|null $channel       Filter by Monolog channel name (e.g. app, security, doctrine)
+     * @param string|null $environment   Filter by Symfony environment (e.g. dev, prod, test)
+     * @param string|null $from          Start date filter, any PHP-parseable date string (e.g. 2024-01-01, -1 hour, yesterday)
+     * @param string|null $to            End date filter, any PHP-parseable date string
+     * @param int         $limit         Maximum number of entries to return
+     * @param string|null $kernelContext Filter by kernel context (e.g. the APP_ID of a multi-kernel application), only relevant when multiple log directories are configured
      */
-    #[McpTool(name: 'monolog-search', title: 'Log Search', description: 'Search log entries by text or regex pattern. Supports filtering by log level, channel, environment, and date range. Use empty string for term to match all entries when using filters only.')]
+    #[McpTool(name: 'monolog-search', title: 'Log Search', description: 'Search log entries by text or regex pattern. Supports filtering by log level, channel, environment, and date range. Use empty string for term to match all entries when using filters only. When multiple kernel contexts are configured, entries carry a kernel_context field and can be narrowed with the kernelContext parameter.')]
     public function search(
         string $term,
         bool $regex = false,
@@ -48,6 +49,7 @@ final class LogSearchTool
         ?string $from = null,
         ?string $to = null,
         int $limit = 100,
+        ?string $kernelContext = null,
     ): string {
         if ($regex) {
             $pattern = $term;
@@ -74,15 +76,16 @@ final class LogSearchTool
             );
         }
 
-        return ResponseEncoder::encode(['entries' => $this->collectResults($criteria, $environment)]);
+        return ResponseEncoder::encode(['entries' => $this->collectResults($criteria, $environment, $kernelContext)]);
     }
 
     /**
-     * @param string      $key         The context field name to search for (e.g. user_id, exception, order_id)
-     * @param string      $value       The value to match in the context field
-     * @param string|null $level       Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
-     * @param string|null $environment Filter by Symfony environment (e.g. dev, prod, test)
-     * @param int         $limit       Maximum number of entries to return
+     * @param string      $key           The context field name to search for (e.g. user_id, exception, order_id)
+     * @param string      $value         The value to match in the context field
+     * @param string|null $level         Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
+     * @param string|null $environment   Filter by Symfony environment (e.g. dev, prod, test)
+     * @param int         $limit         Maximum number of entries to return
+     * @param string|null $kernelContext Filter by kernel context (e.g. the APP_ID of a multi-kernel application), only relevant when multiple log directories are configured
      */
     #[McpTool(name: 'monolog-context-search', title: 'Log Context Search', description: 'Search log entries by structured context data. Finds entries where a specific context key contains the given value.')]
     public function searchContext(
@@ -91,6 +94,7 @@ final class LogSearchTool
         ?string $level = null,
         ?string $environment = null,
         int $limit = 100,
+        ?string $kernelContext = null,
     ): string {
         $criteria = new SearchCriteria(
             level: $level,
@@ -99,62 +103,74 @@ final class LogSearchTool
             limit: $limit,
         );
 
-        return ResponseEncoder::encode(['entries' => $this->collectResults($criteria, $environment)]);
+        return ResponseEncoder::encode(['entries' => $this->collectResults($criteria, $environment, $kernelContext)]);
     }
 
     /**
-     * @param int         $lines       Number of most recent log entries to return
-     * @param string|null $level       Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
-     * @param string|null $environment Filter by Symfony environment (e.g. dev, prod, test)
-     * @param string|null $channel     Filter by Monolog channel name (e.g. app, security, doctrine)
+     * @param int         $lines         Number of most recent log entries to return
+     * @param string|null $level         Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
+     * @param string|null $environment   Filter by Symfony environment (e.g. dev, prod, test)
+     * @param string|null $channel       Filter by Monolog channel name (e.g. app, security, doctrine)
+     * @param string|null $kernelContext Filter by kernel context (e.g. the APP_ID of a multi-kernel application), only relevant when multiple log directories are configured
      */
-    #[McpTool(name: 'monolog-tail', title: 'Log Tail', description: 'Get the most recent log entries. Reads from the end of log files, optionally filtered by level, environment, and channel.')]
-    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null, ?string $channel = null): string
+    #[McpTool(name: 'monolog-tail', title: 'Log Tail', description: 'Get the most recent log entries. Reads from the end of log files, optionally filtered by level, environment, and channel. When multiple kernel contexts are configured, the most recent entries of every context are merged.')]
+    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null, ?string $channel = null, ?string $kernelContext = null): string
     {
-        $entries = $this->reader->tail($lines, $level, $environment, $channel);
+        $entries = $this->reader->tail($lines, $level, $environment, $channel, $kernelContext);
 
         return ResponseEncoder::encode(['entries' => array_values(array_map(static fn ($entry) => $entry->toArray(), $entries))]);
     }
 
     /**
-     * @param string|null $environment Filter log files by Symfony environment (e.g. dev, prod, test)
+     * @param string|null $environment   Filter log files by Symfony environment (e.g. dev, prod, test)
+     * @param string|null $kernelContext Filter by kernel context (e.g. the APP_ID of a multi-kernel application), only relevant when multiple log directories are configured
      */
-    #[McpTool(name: 'monolog-list-files', title: 'List Log Files', description: 'List available log files with metadata (name, path, size, last modified). Use to discover which logs exist before searching.')]
-    public function listFiles(?string $environment = null): string
+    #[McpTool(name: 'monolog-list-files', title: 'List Log Files', description: 'List available log files with metadata (name, path, size, last modified). Use to discover which logs exist before searching. When multiple kernel contexts are configured, files carry a kernel_context field.')]
+    public function listFiles(?string $environment = null, ?string $kernelContext = null): string
     {
         $files = null !== $environment
-            ? $this->reader->getLogFilesForEnvironment($environment)
-            : $this->reader->getLogFiles();
+            ? $this->reader->getLogFilesForEnvironment($environment, $kernelContext)
+            : $this->reader->getLogFiles($kernelContext);
         $result = [];
 
         foreach ($files as $file) {
-            $result[] = [
+            $entry = [
                 'name' => basename($file),
                 'path' => $file,
                 'size' => filesize($file) ?: 0,
                 'modified' => date(\DateTimeInterface::ATOM, filemtime($file) ?: 0),
             ];
+
+            $context = $this->reader->getKernelContext($file);
+            if (null !== $context) {
+                $entry['kernel_context'] = $context;
+            }
+
+            $result[] = $entry;
         }
 
         return ResponseEncoder::encode(['files' => $result]);
     }
 
+    /**
+     * @param string|null $kernelContext Filter by kernel context (e.g. the APP_ID of a multi-kernel application), only relevant when multiple log directories are configured
+     */
     #[McpTool(name: 'monolog-list-channels', title: 'List Log Channels', description: 'List all unique Monolog channel names found across log files (e.g. app, security, doctrine).')]
-    public function listChannels(): string
+    public function listChannels(?string $kernelContext = null): string
     {
-        return ResponseEncoder::encode(['channels' => $this->reader->getUniqueChannels()]);
+        return ResponseEncoder::encode(['channels' => $this->reader->getUniqueChannels($kernelContext)]);
     }
 
     /**
      * @return list<array<string, mixed>>
      */
-    private function collectResults(SearchCriteria $criteria, ?string $environment = null): array
+    private function collectResults(SearchCriteria $criteria, ?string $environment = null, ?string $kernelContext = null): array
     {
         $results = [];
 
         $generator = null !== $environment
-            ? $this->reader->readForEnvironment($environment, $criteria)
-            : $this->reader->readAll($criteria);
+            ? $this->reader->readForEnvironment($environment, $criteria, $kernelContext)
+            : $this->reader->readAll($criteria, $kernelContext);
 
         foreach ($generator as $entry) {
             $results[] = $entry->toArray();

--- a/src/mate/src/Bridge/Monolog/INSTRUCTIONS.md
+++ b/src/mate/src/Bridge/Monolog/INSTRUCTIONS.md
@@ -13,3 +13,9 @@ Use MCP tools instead of CLI for log analysis:
 - Structured output with parsed log entries
 - Multi-file search across all logs at once
 - Filter by environment, level, or channel
+
+### Multi-kernel applications
+
+When several log directories are configured (one per kernel context, e.g. per `APP_ID`), every
+entry and file carries a `kernel_context` field, and all tools accept a `kernelContext` parameter
+to restrict the lookup to a single kernel.

--- a/src/mate/src/Bridge/Monolog/Model/LogEntry.php
+++ b/src/mate/src/Bridge/Monolog/Model/LogEntry.php
@@ -22,7 +22,8 @@ namespace Symfony\AI\Mate\Bridge\Monolog\Model;
  *     context: array<string, mixed>,
  *     extra: array<string, mixed>,
  *     source_file: string|null,
- *     line_number: int|null
+ *     line_number: int|null,
+ *     kernel_context?: string
  * }
  *
  * @author Johannes Wachter <johannes@sulu.io>
@@ -83,6 +84,7 @@ final class LogEntry
         private readonly array $extra = [],
         private readonly ?string $sourceFile = null,
         private readonly ?int $lineNumber = null,
+        private readonly ?string $kernelContext = null,
     ) {
     }
 
@@ -133,11 +135,20 @@ final class LogEntry
     }
 
     /**
+     * The kernel context this entry was read from, e.g. the APP_ID of a multi-kernel
+     * application. Named `kernelContext` to avoid confusion with the Monolog context.
+     */
+    public function getKernelContext(): ?string
+    {
+        return $this->kernelContext;
+    }
+
+    /**
      * @phpstan-return LogEntryArray
      */
     public function toArray(): array
     {
-        return [
+        $data = [
             'datetime' => $this->datetime->format(\DateTimeInterface::ATOM),
             'channel' => $this->channel,
             'level' => $this->level,
@@ -147,6 +158,12 @@ final class LogEntry
             'source_file' => $this->sourceFile,
             'line_number' => $this->lineNumber,
         ];
+
+        if (null !== $this->kernelContext) {
+            $data['kernel_context'] = $this->kernelContext;
+        }
+
+        return $data;
     }
 
     public function matchesTerm(string $term): bool

--- a/src/mate/src/Bridge/Monolog/Service/LogParser.php
+++ b/src/mate/src/Bridge/Monolog/Service/LogParser.php
@@ -27,7 +27,7 @@ final class LogParser
      */
     private const LINE_PATTERN = '/^\[(?<datetime>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[+-]\d{2}:?\d{2}|Z)?)\]\s+(?<channel>[\w.-]+)\.(?<level>\w+):\s+(?<rest>.+)$/';
 
-    public function parse(string $line, ?string $sourceFile = null, ?int $lineNumber = null): ?LogEntry
+    public function parse(string $line, ?string $sourceFile = null, ?int $lineNumber = null, ?string $kernelContext = null): ?LogEntry
     {
         $line = trim($line);
 
@@ -35,11 +35,11 @@ final class LogParser
             return null;
         }
 
-        return $this->tryParseJson($line, $sourceFile, $lineNumber)
-            ?? $this->tryParseText($line, $sourceFile, $lineNumber);
+        return $this->tryParseJson($line, $sourceFile, $lineNumber, $kernelContext)
+            ?? $this->tryParseText($line, $sourceFile, $lineNumber, $kernelContext);
     }
 
-    private function tryParseJson(string $line, ?string $sourceFile, ?int $lineNumber): ?LogEntry
+    private function tryParseJson(string $line, ?string $sourceFile, ?int $lineNumber, ?string $kernelContext): ?LogEntry
     {
         if (!str_starts_with($line, '{')) {
             return null;
@@ -91,10 +91,11 @@ final class LogParser
             extra: $extra,
             sourceFile: $sourceFile,
             lineNumber: $lineNumber,
+            kernelContext: $kernelContext,
         );
     }
 
-    private function tryParseText(string $line, ?string $sourceFile, ?int $lineNumber): ?LogEntry
+    private function tryParseText(string $line, ?string $sourceFile, ?int $lineNumber, ?string $kernelContext): ?LogEntry
     {
         if (!preg_match(self::LINE_PATTERN, $line, $matches)) {
             return null;
@@ -116,6 +117,7 @@ final class LogParser
             extra: $extra,
             sourceFile: $sourceFile,
             lineNumber: $lineNumber,
+            kernelContext: $kernelContext,
         );
     }
 

--- a/src/mate/src/Bridge/Monolog/Service/LogReader.php
+++ b/src/mate/src/Bridge/Monolog/Service/LogReader.php
@@ -22,53 +22,44 @@ use Symfony\AI\Mate\Bridge\Monolog\Model\SearchCriteria;
  */
 final class LogReader
 {
+    /**
+     * @var array<string|int, string>
+     */
+    private readonly array $logDirs;
+
+    /**
+     * @param string|array<string, string> $logDir A single log directory, or a map of context name to log
+     *                                             directory for multi-kernel (APP_ID) applications
+     */
     public function __construct(
         private LogParser $parser,
-        private string $logDir,
+        string|array $logDir,
     ) {
+        $this->logDirs = \is_string($logDir) ? [0 => $logDir] : $logDir;
     }
 
     /**
      * @return string[]
      */
-    public function getLogFiles(): array
+    public function getLogFiles(?string $kernelContext = null): array
     {
-        if (!is_dir($this->logDir)) {
-            return [];
-        }
-
-        $files = glob($this->logDir.'/*.log');
-        if (false === $files) {
-            return [];
-        }
-
-        usort($files, static fn (string $a, string $b) => filemtime($b) <=> filemtime($a));
-
-        return $files;
+        return $this->collectLogFiles($this->resolveLogDirs($kernelContext));
     }
 
     /**
      * @return string[]
      */
-    public function getLogFilesForEnvironment(string $environment): array
+    public function getLogFilesForEnvironment(string $environment, ?string $kernelContext = null): array
     {
-        $files = $this->getLogFiles();
-
-        return array_filter($files, static function (string $file) use ($environment) {
-            $filename = basename($file);
-
-            // Match files like dev.log, prod.log, test.log
-            // Or files containing the environment name like app_dev.log
-            return str_contains($filename, $environment);
-        });
+        return $this->filterForEnvironment($this->getLogFiles($kernelContext), $environment);
     }
 
     /**
      * @return \Generator<LogEntry>
      */
-    public function readAll(?SearchCriteria $criteria = null): \Generator
+    public function readAll(?SearchCriteria $criteria = null, ?string $kernelContext = null): \Generator
     {
-        $files = $this->getLogFiles();
+        $files = $this->getLogFiles($kernelContext);
 
         yield from $this->readFiles($files, $criteria);
     }
@@ -76,9 +67,9 @@ final class LogReader
     /**
      * @return \Generator<LogEntry>
      */
-    public function readForEnvironment(string $environment, ?SearchCriteria $criteria = null): \Generator
+    public function readForEnvironment(string $environment, ?SearchCriteria $criteria = null, ?string $kernelContext = null): \Generator
     {
-        $files = $this->getLogFilesForEnvironment($environment);
+        $files = $this->getLogFilesForEnvironment($environment, $kernelContext);
 
         yield from $this->readFiles($files, $criteria);
     }
@@ -124,11 +115,12 @@ final class LogReader
             try {
                 $lineNumber = 0;
                 $relativePath = $this->getRelativePath($file);
+                $fileContext = $this->getKernelContext($file);
 
                 while (false !== ($line = fgets($handle))) {
                     ++$lineNumber;
 
-                    $entry = $this->parser->parse($line, $relativePath, $lineNumber);
+                    $entry = $this->parser->parse($line, $relativePath, $lineNumber, $fileContext);
                     if (null === $entry) {
                         continue;
                     }
@@ -156,38 +148,71 @@ final class LogReader
     }
 
     /**
+     * Returns the most recent entries of the newest log file of every configured context.
+     *
      * @return LogEntry[]
      */
-    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null, ?string $channel = null): array
+    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null, ?string $channel = null, ?string $kernelContext = null): array
     {
-        $files = null !== $environment
-            ? $this->getLogFilesForEnvironment($environment)
-            : $this->getLogFiles();
+        $entriesPerContext = [];
 
-        if ([] === $files) {
+        foreach ($this->resolveLogDirs($kernelContext) as $context => $dir) {
+            $files = $this->collectLogFiles([$context => $dir]);
+            if (null !== $environment) {
+                $files = $this->filterForEnvironment($files, $environment);
+            }
+
+            if ([] === $files) {
+                continue;
+            }
+
+            $file = $files[0];
+            if (!file_exists($file) || !is_readable($file)) {
+                continue;
+            }
+
+            $entriesPerContext[] = $this->tailFromFile($file, $lines, $level, $channel);
+        }
+
+        if ([] === $entriesPerContext) {
             return [];
         }
 
-        $file = $files[0];
-        if (!file_exists($file) || !is_readable($file)) {
-            return [];
+        if (1 === \count($entriesPerContext)) {
+            return $entriesPerContext[0];
         }
 
-        return $this->tailFromFile($file, $lines, $level, $channel);
+        $entries = array_merge(...$entriesPerContext);
+        usort($entries, static fn (LogEntry $a, LogEntry $b) => $a->getDatetime() <=> $b->getDatetime());
+
+        return \array_slice($entries, -$lines);
     }
 
     /**
      * @return string[]
      */
-    public function getUniqueChannels(): array
+    public function getUniqueChannels(?string $kernelContext = null): array
     {
         $channels = [];
 
-        foreach ($this->readAll() as $entry) {
+        foreach ($this->readAll(null, $kernelContext) as $entry) {
             $channels[$entry->getChannel()] = true;
         }
 
         return array_keys($channels);
+    }
+
+    /**
+     * The context a log file belongs to, or null when a single log directory is configured.
+     */
+    public function getKernelContext(string $filePath): ?string
+    {
+        $logDir = $this->findLogDir($filePath);
+        if (null === $logDir) {
+            return null;
+        }
+
+        return \is_string($logDir[0]) ? $logDir[0] : null;
     }
 
     /**
@@ -204,6 +229,7 @@ final class LogReader
             $buffer = [];
             $lineNumber = 0;
             $relativePath = $this->getRelativePath($file);
+            $fileContext = $this->getKernelContext($file);
 
             while (false !== ($line = fgets($handle))) {
                 ++$lineNumber;
@@ -217,7 +243,7 @@ final class LogReader
 
             $entries = [];
             for ($i = \count($buffer) - 1; $i >= 0 && \count($entries) < $lines; --$i) {
-                $entry = $this->parser->parse($buffer[$i]['line'], $relativePath, $buffer[$i]['number']);
+                $entry = $this->parser->parse($buffer[$i]['line'], $relativePath, $buffer[$i]['number'], $fileContext);
                 if (null === $entry) {
                     continue;
                 }
@@ -241,10 +267,109 @@ final class LogReader
 
     private function getRelativePath(string $filePath): string
     {
-        if (str_starts_with($filePath, $this->logDir)) {
-            return ltrim(substr($filePath, \strlen($this->logDir)), '/\\');
+        $logDir = $this->findLogDir($filePath);
+        if (null === $logDir) {
+            return basename($filePath);
         }
 
-        return basename($filePath);
+        return ltrim(substr($filePath, \strlen($logDir[1])), '/\\');
+    }
+
+    /**
+     * Returns the configured directory a file belongs to, the longest match wins so nested
+     * context directories are resolved to the most specific one.
+     *
+     * Directories are compared with a trailing separator boundary so a configured directory
+     * like "/var/log/web" does not also match a sibling directory like "/var/log/website".
+     *
+     * @return array{0: string|int, 1: string}|null
+     */
+    private function findLogDir(string $filePath): ?array
+    {
+        $matchedContext = null;
+        $matchedDir = null;
+
+        foreach ($this->logDirs as $context => $dir) {
+            $normalizedDir = rtrim($dir, '/\\');
+
+            if ($filePath !== $normalizedDir && !str_starts_with($filePath, $normalizedDir.'/') && !str_starts_with($filePath, $normalizedDir.'\\')) {
+                continue;
+            }
+
+            if (null === $matchedDir || \strlen($normalizedDir) > \strlen($matchedDir)) {
+                $matchedContext = $context;
+                $matchedDir = $normalizedDir;
+            }
+        }
+
+        if (null === $matchedDir || null === $matchedContext) {
+            return null;
+        }
+
+        return [$matchedContext, $matchedDir];
+    }
+
+    /**
+     * @param string[] $files
+     *
+     * @return string[]
+     */
+    private function filterForEnvironment(array $files, string $environment): array
+    {
+        return array_values(array_filter($files, static function (string $file) use ($environment) {
+            $filename = basename($file);
+
+            // Match files like dev.log, prod.log, test.log
+            // Or files containing the environment name like app_dev.log
+            return str_contains($filename, $environment);
+        }));
+    }
+
+    /**
+     * @param array<string|int, string> $logDirs
+     *
+     * @return string[]
+     */
+    private function collectLogFiles(array $logDirs): array
+    {
+        $allFiles = [];
+
+        foreach ($logDirs as $dir) {
+            if (!is_dir($dir)) {
+                continue;
+            }
+
+            $files = glob($dir.'/*.log');
+            if (false === $files) {
+                continue;
+            }
+
+            foreach ($files as $file) {
+                $allFiles[] = $file;
+            }
+        }
+
+        usort($allFiles, static fn (string $a, string $b) => filemtime($b) <=> filemtime($a));
+
+        return $allFiles;
+    }
+
+    /**
+     * @return array<string|int, string>
+     */
+    private function resolveLogDirs(?string $kernelContext): array
+    {
+        if (null === $kernelContext || '' === $kernelContext) {
+            return $this->logDirs;
+        }
+
+        $logDirs = [];
+        foreach ($this->logDirs as $context => $dir) {
+            if ($context === $kernelContext) {
+                $logDirs[$context] = $dir;
+            }
+        }
+
+        return $logDirs;
     }
 }

--- a/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
@@ -231,4 +231,86 @@ final class LogSearchToolTest extends TestCase
         $this->assertArrayHasKey('source_file', $entry);
         $this->assertArrayHasKey('line_number', $entry);
     }
+
+    public function testSearchOmitsKernelContextForSingleLogDirectory()
+    {
+        $result = Toon::decode($this->tool->search('logged'));
+
+        $this->assertArrayNotHasKey('kernel_context', $result['entries'][0]);
+    }
+
+    public function testSearchStampsKernelContextForMultipleLogDirectories()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $result = Toon::decode($tool->search('logged'));
+
+        $this->assertNotEmpty($result['entries']);
+        $this->assertSame('website', $result['entries'][0]['kernel_context']);
+    }
+
+    public function testSearchFiltersByKernelContext()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $result = Toon::decode($tool->search('', level: 'ERROR', kernelContext: 'admin'));
+
+        $this->assertCount(1, $result['entries']);
+        $this->assertSame('admin', $result['entries'][0]['kernel_context']);
+        $this->assertStringContainsString('Critical system error', $result['entries'][0]['message']);
+    }
+
+    public function testSearchContextFiltersByKernelContext()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $result = Toon::decode($tool->searchContext('test', 'UserControllerTest', kernelContext: 'admin'));
+
+        $this->assertCount(2, $result['entries']);
+        foreach ($result['entries'] as $entry) {
+            $this->assertSame('admin', $entry['kernel_context']);
+        }
+    }
+
+    public function testListFilesIncludesKernelContextForMultipleLogDirectories()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $result = Toon::decode($tool->listFiles(kernelContext: 'admin'));
+
+        $this->assertCount(2, $result['files']);
+        foreach ($result['files'] as $file) {
+            $this->assertSame('admin', $file['kernel_context']);
+        }
+    }
+
+    public function testListChannelsFiltersByKernelContext()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $result = Toon::decode($tool->listChannels('admin'));
+
+        $this->assertContains('test', $result['channels']);
+        $this->assertNotContains('security', $result['channels']);
+    }
+
+    public function testTailFiltersByKernelContext()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $result = Toon::decode($tool->tail(10, kernelContext: 'admin'));
+
+        $this->assertCount(2, $result['entries']);
+        foreach ($result['entries'] as $entry) {
+            $this->assertSame('admin', $entry['kernel_context']);
+        }
+    }
+
+    private function createMultiKernelTool(): LogSearchTool
+    {
+        return new LogSearchTool(new LogReader(new LogParser(), [
+            'website' => $this->fixturesDir,
+            'admin' => $this->fixturesDir.'/logs',
+        ]));
+    }
 }

--- a/src/mate/src/Bridge/Monolog/Tests/Service/LogReaderTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Service/LogReaderTest.php
@@ -127,4 +127,155 @@ final class LogReaderTest extends TestCase
 
         $this->assertSame([], $files);
     }
+
+    public function testSingleLogDirectoryDoesNotStampKernelContext()
+    {
+        $entries = iterator_to_array($this->reader->readAll());
+
+        foreach ($entries as $entry) {
+            $this->assertNull($entry->getKernelContext());
+        }
+    }
+
+    public function testSupportsMultipleLogDirectories()
+    {
+        $reader = $this->createMultiKernelReader();
+
+        $files = $reader->getLogFiles();
+
+        // 2 files in the fixtures directory + 2 files in the nested logs directory
+        $this->assertCount(4, $files);
+        $this->assertContains($this->fixturesDir.'/sample.log', $files);
+        $this->assertContains($this->fixturesDir.'/logs/prod.log', $files);
+    }
+
+    public function testGetLogFilesFiltersByKernelContext()
+    {
+        $reader = $this->createMultiKernelReader();
+
+        $files = $reader->getLogFiles('admin');
+
+        $this->assertCount(2, $files);
+        $this->assertContains($this->fixturesDir.'/logs/prod.log', $files);
+        $this->assertContains($this->fixturesDir.'/logs/app_test.log', $files);
+    }
+
+    public function testGetKernelContextResolvesTheMostSpecificDirectory()
+    {
+        $reader = $this->createMultiKernelReader();
+
+        $this->assertSame('website', $reader->getKernelContext($this->fixturesDir.'/sample.log'));
+        $this->assertSame('admin', $reader->getKernelContext($this->fixturesDir.'/logs/prod.log'));
+        $this->assertNull($reader->getKernelContext('/somewhere/else/dev.log'));
+    }
+
+    public function testReadAllStampsKernelContextOnEntries()
+    {
+        $reader = $this->createMultiKernelReader();
+
+        $entries = iterator_to_array($reader->readAll());
+
+        // 11 entries in the fixtures directory + 4 entries in the nested logs directory
+        $this->assertCount(15, $entries);
+
+        $contexts = [];
+        foreach ($entries as $entry) {
+            $contexts[$entry->getKernelContext()] = true;
+        }
+
+        $this->assertArrayHasKey('website', $contexts);
+        $this->assertArrayHasKey('admin', $contexts);
+        $this->assertCount(2, $contexts);
+    }
+
+    public function testReadAllFiltersByKernelContext()
+    {
+        $reader = $this->createMultiKernelReader();
+
+        $entries = iterator_to_array($reader->readAll(null, 'admin'));
+
+        $this->assertCount(4, $entries);
+        foreach ($entries as $entry) {
+            $this->assertSame('admin', $entry->getKernelContext());
+        }
+    }
+
+    public function testGetUniqueChannelsFiltersByKernelContext()
+    {
+        $reader = $this->createMultiKernelReader();
+
+        $channels = $reader->getUniqueChannels('admin');
+
+        $this->assertContains('test', $channels);
+        $this->assertNotContains('security', $channels);
+    }
+
+    public function testTailMergesTheNewestFileOfEveryKernelContext()
+    {
+        $reader = $this->createMultiKernelReader();
+
+        $entries = $reader->tail(3);
+
+        // Both contexts are tailed, merged and sorted by time: the admin fixtures are the most recent ones
+        $this->assertCount(3, $entries);
+        $this->assertSame('website', $entries[0]->getKernelContext());
+        $this->assertSame('admin', $entries[1]->getKernelContext());
+        $this->assertSame('admin', $entries[2]->getKernelContext());
+    }
+
+    public function testTailFiltersByKernelContext()
+    {
+        $reader = $this->createMultiKernelReader();
+
+        $entries = $reader->tail(10, kernelContext: 'admin');
+
+        $this->assertCount(2, $entries);
+        foreach ($entries as $entry) {
+            $this->assertSame('admin', $entry->getKernelContext());
+        }
+    }
+
+    public function testGetKernelContextDoesNotMatchSiblingDirectoryWithSharedPrefix()
+    {
+        $tempDir = sys_get_temp_dir().'/mate-log-reader-test-'.uniqid();
+        mkdir($tempDir.'/web', 0755, true);
+        mkdir($tempDir.'/website', 0755, true);
+        file_put_contents($tempDir.'/website/dev.log', "[2024-01-01T00:00:00+00:00] app.INFO: Test message [] []\n");
+
+        try {
+            $reader = new LogReader(new LogParser(), ['web' => $tempDir.'/web']);
+
+            $this->assertNull($reader->getKernelContext($tempDir.'/website/dev.log'));
+
+            $entries = iterator_to_array($reader->readFile($tempDir.'/website/dev.log'));
+
+            $this->assertCount(1, $entries);
+            $this->assertNull($entries[0]->getKernelContext());
+            $this->assertSame('dev.log', $entries[0]->getSourceFile());
+        } finally {
+            $this->removeDirectory($tempDir);
+        }
+    }
+
+    private function createMultiKernelReader(): LogReader
+    {
+        return new LogReader(new LogParser(), [
+            'website' => $this->fixturesDir,
+            'admin' => $this->fixturesDir.'/logs',
+        ]);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir.'/'.$file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
 }

--- a/src/mate/src/Bridge/Symfony/CHANGELOG.md
+++ b/src/mate/src/Bridge/Symfony/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Allow `ai_mate_symfony.cache_dir` to be a map of context name to cache directory, so a single Mate server can introspect the containers of multi-kernel (`APP_ID`) applications. `symfony-services` then returns the services grouped per context, `symfony-service-detail` reports the context a service was found in, and both accept an optional `context` filter parameter
+
 0.7
 ---
 

--- a/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
@@ -22,25 +22,116 @@ use Symfony\AI\Mate\Encoding\ResponseEncoder;
  */
 class ServiceTool
 {
+    private const ENVIRONMENTS = ['', '/dev', '/test', '/prod'];
+
+    /**
+     * @var array<string|int, string>
+     */
+    private readonly array $cacheDirs;
+
+    private readonly bool $hasContexts;
+
+    /**
+     * @param string|array<string, string> $cacheDir A single cache directory, or a map of context name to cache
+     *                                               directory for multi-kernel (APP_ID) applications
+     */
     public function __construct(
-        private string $cacheDir,
+        string|array $cacheDir,
         private ContainerProvider $provider,
     ) {
+        $this->hasContexts = \is_array($cacheDir);
+        $this->cacheDirs = \is_string($cacheDir) ? [0 => $cacheDir] : $cacheDir;
     }
 
     /**
-     * @param string|null $query Filter by service ID or class name (case-insensitive partial match)
-     * @param string|null $tag   Filter by DI tag name (e.g. kernel.event_listener, twig.extension)
+     * @param string|null $query   Filter by service ID or class name (case-insensitive partial match)
+     * @param string|null $tag     Filter by DI tag name (e.g. kernel.event_listener, twig.extension)
+     * @param string|null $context Filter by Symfony kernel context, only relevant when multiple cache directories are configured
      */
-    #[McpTool(name: 'symfony-services', title: 'Symfony Services', description: 'Search Symfony dependency injection container services. Optionally filter by service ID, class name, or tag name. Returns a map of service IDs to their class names.')]
-    public function getServices(?string $query = null, ?string $tag = null): string
+    #[McpTool(name: 'symfony-services', title: 'Symfony Services', description: 'Search Symfony dependency injection container services. Optionally filter by service ID, class name, or tag name. Returns a map of service IDs to their class names. When multiple kernel contexts are configured, the map is nested per context and can be narrowed with the context parameter.')]
+    public function getServices(?string $query = null, ?string $tag = null, ?string $context = null): string
     {
-        $container = $this->readContainer();
-        if (null === $container) {
-            return ResponseEncoder::encode([]);
+        $containers = $this->readContainers($context);
+
+        if (!$this->hasContexts) {
+            $container = $containers[0] ?? null;
+            if (null === $container) {
+                return ResponseEncoder::encode([]);
+            }
+
+            return ResponseEncoder::encode($this->collectServices($container, $query, $tag));
         }
 
         $output = [];
+        foreach ($containers as $containerContext => $container) {
+            $output[$containerContext] = $this->collectServices($container, $query, $tag);
+        }
+
+        return ResponseEncoder::encode($output);
+    }
+
+    /**
+     * @param string      $id      The exact service ID to retrieve details for
+     * @param string|null $context Filter by Symfony kernel context, only relevant when multiple cache directories are configured
+     */
+    #[McpTool(name: 'symfony-service-detail', title: 'Symfony Service Detail', description: 'Get full details of a single Symfony DI container service by its exact ID, including class, tags, method calls, and constructor/factory information. When multiple kernel contexts are configured, the containers are searched in order and the result carries the context it was found in.')]
+    public function getServiceDetail(string $id, ?string $context = null): string
+    {
+        $containers = $this->readContainers($context);
+        if ([] === $containers) {
+            throw new ServiceNotFoundException(\sprintf('Service "%s" not found: container could not be loaded.', $id));
+        }
+
+        foreach ($containers as $containerContext => $container) {
+            $services = $container->getServices();
+            if (!isset($services[$id])) {
+                continue;
+            }
+
+            $service = $services[$id];
+
+            $tags = [];
+            foreach ($service->getTags() as $tag) {
+                $entry = ['name' => $tag->getName()];
+                foreach ($tag->getAttributes() as $key => $value) {
+                    $entry[$key] = $value;
+                }
+                $tags[] = $entry;
+            }
+
+            [$factoryClass, $factoryMethod] = $service->getConstructor();
+            $constructor = null;
+            if (null !== $factoryClass) {
+                $constructor = $factoryClass.'::'.$factoryMethod;
+            }
+
+            $output = [
+                'id' => $service->getId(),
+                'class' => $service->getClass(),
+                'tags' => $tags,
+                'calls' => $service->getCalls(),
+            ];
+
+            if (null !== $constructor) {
+                $output['factory'] = $constructor;
+            }
+
+            if (\is_string($containerContext)) {
+                $output['context'] = $containerContext;
+            }
+
+            return ResponseEncoder::encode($output);
+        }
+
+        throw new ServiceNotFoundException(\sprintf('Service "%s" not found in the container.', $id));
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function collectServices(Container $container, ?string $query, ?string $tag): array
+    {
+        $services = [];
         foreach ($container->getServices() as $service) {
             if (null !== $query && '' !== $query) {
                 $matches = str_contains(strtolower($service->getId()), strtolower($query))
@@ -63,64 +154,38 @@ class ServiceTool
                 }
             }
 
-            $output[$service->getId()] = $service->getClass();
+            $services[$service->getId()] = $service->getClass();
         }
 
-        return ResponseEncoder::encode($output);
+        return $services;
     }
 
     /**
-     * @param string $id The exact service ID to retrieve details for
+     * @return array<string|int, Container>
      */
-    #[McpTool(name: 'symfony-service-detail', title: 'Symfony Service Detail', description: 'Get full details of a single Symfony DI container service by its exact ID, including class, tags, method calls, and constructor/factory information.')]
-    public function getServiceDetail(string $id): string
+    private function readContainers(?string $context = null): array
     {
-        $container = $this->readContainer();
-        if (null === $container) {
-            throw new ServiceNotFoundException(\sprintf('Service "%s" not found: container could not be loaded.', $id));
-        }
-
-        $services = $container->getServices();
-        if (!isset($services[$id])) {
-            throw new ServiceNotFoundException(\sprintf('Service "%s" not found in the container.', $id));
-        }
-
-        $service = $services[$id];
-
-        $tags = [];
-        foreach ($service->getTags() as $tag) {
-            $entry = ['name' => $tag->getName()];
-            foreach ($tag->getAttributes() as $key => $value) {
-                $entry[$key] = $value;
+        $containers = [];
+        foreach ($this->cacheDirs as $cacheContext => $cacheDir) {
+            if (null !== $context && '' !== $context && $cacheContext !== $context) {
+                continue;
             }
-            $tags[] = $entry;
+
+            $container = $this->readContainer($cacheDir);
+            if (null === $container) {
+                continue;
+            }
+
+            $containers[$cacheContext] = $container;
         }
 
-        [$factoryClass, $factoryMethod] = $service->getConstructor();
-        $constructor = null;
-        if (null !== $factoryClass) {
-            $constructor = $factoryClass.'::'.$factoryMethod;
-        }
-
-        $output = [
-            'id' => $service->getId(),
-            'class' => $service->getClass(),
-            'tags' => $tags,
-            'calls' => $service->getCalls(),
-        ];
-
-        if (null !== $constructor) {
-            $output['factory'] = $constructor;
-        }
-
-        return ResponseEncoder::encode($output);
+        return $containers;
     }
 
-    private function readContainer(): ?Container
+    private function readContainer(string $cacheDir): ?Container
     {
-        $environments = ['', '/dev', '/test', '/prod'];
-        foreach ($environments as $env) {
-            $dir = $this->cacheDir.$env;
+        foreach (self::ENVIRONMENTS as $env) {
+            $dir = $cacheDir.$env;
             $files = glob($dir.'/*DebugContainer.xml');
             if (false !== $files && [] !== $files) {
                 sort($files);

--- a/src/mate/src/Bridge/Symfony/INSTRUCTIONS.md
+++ b/src/mate/src/Bridge/Symfony/INSTRUCTIONS.md
@@ -9,6 +9,9 @@
 - Direct access to compiled container
 - Environment-aware (auto-detects dev/test/prod)
 - Supports filtering by service ID or class name via query parameter
+- Multi-kernel aware: when several cache directories are configured (one per kernel context, e.g.
+  per `APP_ID`), `symfony-services` groups the services by context, `symfony-service-detail`
+  reports the context a service was found in, and both accept a `context` parameter
 
 ### Profiler Access
 

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Mate\Bridge\Symfony\Capability\ServiceTool;
 use Symfony\AI\Mate\Bridge\Symfony\Exception\ServiceNotFoundException;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 /**
@@ -276,6 +277,90 @@ final class ServiceToolTest extends TestCase
         $tool->getServiceDetail('cache.app');
     }
 
+    public function testSupportsMultipleCacheDirectories()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $services = Toon::decode($tool->getServices());
+
+        $this->assertArrayHasKey('website', $services);
+        $this->assertArrayHasKey('admin', $services);
+        $this->assertArrayHasKey('event_dispatcher', $services['website']);
+        $this->assertArrayHasKey('admin.dashboard', $services['admin']);
+        $this->assertArrayNotHasKey('event_dispatcher', $services['admin']);
+        $this->assertSame('Admin\Controller\DashboardController', $services['admin']['admin.dashboard']);
+    }
+
+    public function testGetServicesFiltersByContext()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $services = Toon::decode($tool->getServices(context: 'admin'));
+
+        $this->assertSame(['admin'], array_keys($services));
+        $this->assertArrayHasKey('admin.dashboard', $services['admin']);
+    }
+
+    public function testGetServicesAppliesFiltersPerContext()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $services = Toon::decode($tool->getServices(tag: 'cache.pool'));
+
+        $this->assertArrayNotHasKey('logger', $services['website']);
+        $this->assertSame(['cache.app'], array_keys($services['admin']));
+        $this->assertSame(FilesystemAdapter::class, $services['website']['cache.app']);
+        $this->assertSame(ArrayAdapter::class, $services['admin']['cache.app']);
+    }
+
+    public function testGetServiceDetailReturnsTheContextItWasFoundIn()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $detail = Toon::decode($tool->getServiceDetail('admin.dashboard'));
+
+        $this->assertSame('admin.dashboard', $detail['id']);
+        $this->assertSame('admin', $detail['context']);
+    }
+
+    public function testGetServiceDetailPrefersTheFirstMatchingContext()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $detail = Toon::decode($tool->getServiceDetail('cache.app'));
+
+        $this->assertSame(FilesystemAdapter::class, $detail['class']);
+        $this->assertSame('website', $detail['context']);
+    }
+
+    public function testGetServiceDetailFiltersByContext()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $detail = Toon::decode($tool->getServiceDetail('cache.app', 'admin'));
+
+        $this->assertSame(ArrayAdapter::class, $detail['class']);
+        $this->assertSame('admin', $detail['context']);
+    }
+
+    public function testGetServiceDetailThrowsForServiceMissingInTheGivenContext()
+    {
+        $tool = $this->createMultiKernelTool();
+
+        $this->expectException(ServiceNotFoundException::class);
+        $tool->getServiceDetail('event_dispatcher', 'admin');
+    }
+
+    public function testGetServiceDetailOmitsContextForSingleCacheDirectory()
+    {
+        $provider = new ContainerProvider();
+        $tool = new ServiceTool($this->fixturesDir, $provider);
+
+        $detail = Toon::decode($tool->getServiceDetail('cache.app'));
+
+        $this->assertArrayNotHasKey('context', $detail);
+    }
+
     public function testGetServicesDetectsCustomKernelClassName()
     {
         $tempDir = sys_get_temp_dir().'/symfony_ai_mate_test_'.uniqid();
@@ -310,5 +395,13 @@ XML;
                 rmdir($tempDir);
             }
         }
+    }
+
+    private function createMultiKernelTool(): ServiceTool
+    {
+        return new ServiceTool([
+            'website' => $this->fixturesDir,
+            'admin' => $this->fixturesDir.'/admin',
+        ], new ContainerProvider());
     }
 }

--- a/src/mate/src/Bridge/Symfony/Tests/Fixtures/admin/Admin_KernelDevDebugContainer.xml
+++ b/src/mate/src/Bridge/Symfony/Tests/Fixtures/admin/Admin_KernelDevDebugContainer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services">
+    <services>
+        <service id="cache.app" class="Symfony\Component\Cache\Adapter\ArrayAdapter">
+            <tag name="cache.pool"/>
+        </service>
+        <service id="admin.dashboard" class="Admin\Controller\DashboardController">
+            <tag name="controller.service_arguments"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #2405
| License       | MIT

Symfony's [multi-kernel layout](https://symfony.com/doc/current/configuration/multiple_kernels.html)
splits cache and logs per `APP_ID` (`var/cache/{APP_ID}/{env}/`, `var/log/{APP_ID}/`). Mate's
`ai_mate_symfony.profiler_dir` already accepts either a single string or a context map, but
`ai_mate_symfony.cache_dir` (consumed by `ServiceTool`) and `ai_mate_monolog.log_dir` (consumed by
`LogReader`) were single-path strings — so one Mate MCP server could not inspect more than one
kernel's container or logs.

Both options now accept the same context map as `profiler_dir`. Passing a string keeps the exact
behaviour of today, passing an array is purely additive.

```php
// mate/config.php
$container->parameters()
    ->set('ai_mate_symfony.cache_dir', [
        'website' => '%mate.root_dir%/var/cache/website',
        'admin' => '%mate.root_dir%/var/cache/admin',
    ])
    ->set('ai_mate_monolog.log_dir', [
        'website' => '%mate.root_dir%/var/log/website',
        'admin' => '%mate.root_dir%/var/log/admin',
    ]);
```

### Symfony bridge

`symfony-services` groups its result per context and `symfony-service-detail` reports the context a
service was found in; both take an optional `context` filter, mirroring `symfony-profiler-list`:

```json
{ "website": { "cache.app": "Symfony\\Component\\Cache\\Adapter\\FilesystemAdapter" },
  "admin":   { "admin.dashboard": "Admin\\Controller\\DashboardController" } }
```

With a plain string the output is the flat service map it has always been, and no `context` field
is emitted — same as profiles carrying no `context` when a single profiler directory is configured.
`symfony-service-detail` searches the contexts in configuration order and returns the first match,
mirroring `ProfilerDataProvider::findProfile()`.

### Monolog bridge

Log entries and files carry the context, and `monolog-search`, `monolog-context-search`,
`monolog-tail`, `monolog-list-files` and `monolog-list-channels` take an optional filter.
`monolog-tail` tails the newest file of *every* configured context and merges the entries by time,
so a second kernel cannot silently disappear from the tail.

### Judgement calls

Two things the issue left open, decided here rather than asking:

* **No `APP_ID` auto-detection.** The issue offers it as an alternative; the explicit map is
  consistent with the existing `profiler_dir` convention and does not guess a layout. Auto-detection
  can still be layered on top later without changing this API.
* **The Monolog field/parameter is called `kernel_context` / `kernelContext`, not `context`.** A log
  entry already exposes `context` — the Monolog context of the record, which `monolog-context-search`
  searches by key. Reusing the name there would be genuinely ambiguous for the model calling the
  tool. The Symfony bridge keeps the plain `context` naming of the profiler tools, where no such
  clash exists.

