### PR TITLE
[Mate] Keep param shape when redacting Doctrine params from stored profiles

### DIFF
--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/DoctrineCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/DoctrineCollectorFormatter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
 use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * Formats Doctrine collector data.
@@ -113,9 +114,18 @@ final class DoctrineCollectorFormatter implements CollectorFormatterInterface
      * reset tokens, ...) and there is no key name to decide which are sensitive,
      * so every leaf value is redacted. The array shape and parameter count are
      * preserved so the AI can still see that the query was parameterized.
+     *
+     * A stored profile hands the parameters over as a VarDumper {@see Data}
+     * object rather than a plain array, so it is unwrapped first; otherwise the
+     * whole parameter list would collapse into a single redacted scalar and the
+     * count/shape would be lost.
      */
     private function redactParams(mixed $params): mixed
     {
+        if ($params instanceof Data) {
+            $params = $params->getValue(true);
+        }
+
         if (\is_array($params)) {
             return array_map(fn (mixed $param): mixed => $this->redactParams($param), $params);
         }

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/LoggerCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/LoggerCollectorFormatter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * Formats logger collector data.
@@ -114,12 +115,12 @@ final class LoggerCollectorFormatter implements CollectorFormatterInterface
         $formatted = [];
         foreach ($logs as $log) {
             $message = $log['message'] ?? null;
-            if (\is_object($message) && method_exists($message, 'getValue')) {
+            if ($message instanceof Data) {
                 $message = $message->getValue();
             }
 
             $context = $log['context'] ?? null;
-            if (\is_object($context) && method_exists($context, 'getValue')) {
+            if ($context instanceof Data) {
                 $context = $context->getValue(true);
             }
 

--- a/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/TranslationCollectorFormatter.php
+++ b/src/mate/src/Bridge/Symfony/Profiler/Service/Formatter/TranslationCollectorFormatter.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\CollectorFormatterInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\Translation\DataCollector\TranslationDataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * Formats translation collector data.
@@ -68,7 +69,7 @@ final class TranslationCollectorFormatter implements CollectorFormatterInterface
             return $data;
         }
 
-        if (\is_object($data) && method_exists($data, 'getValue')) {
+        if ($data instanceof Data) {
             return (array) $data->getValue(true);
         }
 

--- a/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterIntegrationTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Profiler/Service/Formatter/DoctrineCollectorFormatterIntegrationTest.php
@@ -116,6 +116,32 @@ final class DoctrineCollectorFormatterIntegrationTest extends TestCase
         $this->assertCount(2, $result['queries']);
     }
 
+    public function testFormatRedactsSampleParamsFromRealCollectorPreservingShape()
+    {
+        // A stored profile hands parameters over as a VarDumper Data object, not
+        // a plain array. Each bound value must be redacted while the parameter
+        // count/shape stays visible, and a param-less query must stay empty
+        // rather than collapse into a single misleading "***REDACTED***".
+        $collector = $this->createRealCollector([
+            'default' => [
+                ['sql' => 'SELECT * FROM users WHERE email = ? AND password_hash = ?', 'params' => [1 => 'alice@example.com', 2 => 's3cr3t-hash']],
+                ['sql' => 'SELECT 1', 'params' => []],
+            ],
+        ]);
+
+        $result = $this->formatter->format($collector);
+
+        $bySql = [];
+        foreach ($result['queries'] as $query) {
+            $bySql[$query['sql']] = $query['sample_params'];
+        }
+
+        $this->assertSame(['***REDACTED***', '***REDACTED***'], array_values($bySql['SELECT * FROM users WHERE email = ? AND password_hash = ?']));
+        $this->assertSame([], $bySql['SELECT 1']);
+        $this->assertStringNotContainsString('alice@example.com', json_encode($result));
+        $this->assertStringNotContainsString('s3cr3t-hash', json_encode($result));
+    }
+
     /**
      * @param array<string, list<array{sql: string, params: array<int, mixed>}>> $queriesByConnection
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | n/a
| License       | MIT

Follow-up to #2307. That change redacts the profiler `db` collector's bound
parameter values, and its unit tests pass — but they feed `redactParams()` a
plain PHP array, which a **stored** profile never produces.

A stored profile hands the query parameters over as a
`Symfony\Component\VarDumper\Cloner\Data` object. That is neither an `array`
nor `null`, so `redactParams()` skipped both branches and hit the catch-all —
collapsing the **entire** parameter list into a single `"***REDACTED***"`
scalar. Two consequences on real data (the only case Mate actually sees):

- the parameter count/shape #2307 intended to preserve is lost;
- a parameter-**less** query (e.g. `bin/console dbal:run-sql "…" --profile`)
  shows `sample_params: "***REDACTED***"` — implying redacted secrets where
  there were no parameters at all.

### Fix

Unwrap the `Data` object first, then redact each leaf. Bound values are still
fully redacted, but the array shape and count survive and a param-less query
stays an empty array:

```
before (stored profile):  "sample_params": "***REDACTED***"     // 0 or N params, indistinguishable
after  (N bound params):  "sample_params": ["***REDACTED***", "***REDACTED***"]
after  (0 params):        "sample_params": []
```

Adds an integration test that goes through a real `DoctrineDataCollector`
(which produces the `Data` object), asserting the shape is preserved, the
param-less query stays empty, and no bound value leaks — the gap the
plain-array unit tests could not catch.
