### PR TITLE
[MCP Bundle] Support multiple servers and clients

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -38,6 +38,104 @@ AI Bundle
 
    The default (`false`, tool messages are preserved) is unchanged.
 
+MCP Bundle
+----------
+
+ * The bundle now supports several MCP servers per application, so every server-related option moved
+   under a named entry in `mcp.servers`. **Capabilities are no longer exposed automatically**: each
+   server declares what it exposes, and `['*']` is the explicit "everything of that kind" — that is the
+   1:1 migration of the previous behavior:
+
+   ```diff
+    # config/packages/mcp.yaml
+    mcp:
+   -    app: 'my-app'
+   -    version: '1.0.0'
+   -    description: 'My MCP server'
+   -    instructions: 'Use this server for time calculations.'
+   -    pagination_limit: 50
+   -    client_transports:
+   -        stdio: true
+   -        http: true
+   -    http:
+   -        path: /_mcp
+   -        allowed_hosts: ['example.com']
+   -        session:
+   -            store: cache
+   -    apps:
+   -        enabled: true
+   +    servers:
+   +        default:
+   +            name: 'my-app'
+   +            version: '1.0.0'
+   +            description: 'My MCP server'
+   +            instructions: 'Use this server for time calculations.'
+   +            pagination_limit: 50
+   +            transports:
+   +                stdio: true
+   +                http: true
+   +            http:
+   +                path: /_mcp
+   +                allowed_hosts: ['example.com']
+   +            session:
+   +                store: cache
+   +            registry: '*'
+   ```
+
+   Option by option: `app` became `servers.<name>.name` (defaulting to the configuration key),
+   `client_transports` became `servers.<name>.transports` (its `http` option now defaults to `true`),
+   `http.session` moved up to `servers.<name>.session` (it was never HTTP-specific — a STDIO server
+   uses it too), and `apps.enabled` was replaced by the `servers.<name>.registry.apps` list
+   (`enabled: false` → omit it, the auto/`true` modes → `apps: ['*']`).
+
+   `http.path` now defaults to `/mcp/<name>` instead of `/_mcp`. The default is always derived from the
+   server name, so that adding a second server can never move an existing endpoint; set `http.path`
+   explicitly to keep the old URL.
+
+   The required `registry:` option decides what a server exposes. Give it one list to cover every kind
+   of capability, or a map to narrow each kind separately. Entries match a service id, a class name, or
+   a namespace prefix (written with a trailing backslash):
+
+   ```yaml
+   mcp:
+       servers:
+           public:
+               http: { path: /mcp }
+               registry:
+                   tools: ['App\Mcp\Public\']
+                   resources: ['*']
+           editors:
+               http: { path: /mcp/editors }
+               registry: '*'
+           reporting:
+               http: { path: /mcp/reporting }
+               registry: ['App\Mcp\Reporting\']   # every kind, from one namespace
+   ```
+
+   A pattern that matches no service *at all* on its server is a compile-time error — practically
+   always a typo. Matching only some kinds is fine, which is what makes the single-list form usable:
+   few applications carry all five kinds under one namespace. The reverse is allowed on purpose too —
+   a service carrying an MCP attribute that no server lists is simply not exposed, and `debug:mcp`
+   reports those under "Not exposed by any server".
+
+ * The per-server services replace their singleton counterparts: `mcp.registry`, `mcp.server.builder`,
+   `mcp.server`, `mcp.session.store`, `mcp.middleware_factory` and `mcp.server.controller` became
+   `mcp.server.<name>.registry`, `mcp.server.<name>.builder`, `mcp.server.<name>`,
+   `mcp.server.<name>.session.store`, `mcp.server.<name>.middleware_factory` and
+   `mcp.server.<name>.controller`. Autowire a specific server with `Mcp\Server $<name>Server`.
+
+   Session storage is now isolated per server by default (`%kernel.cache_dir%/mcp-sessions/<name>` and
+   the `mcp-<name>-` cache prefix), and two servers resolving to the same storage is rejected at compile
+   time: session ids are not namespaced by server, so a shared store would let a session created on a
+   public server be accepted by a firewalled one.
+
+ * The route name `_mcp_endpoint` became `_mcp_endpoint_<name>`. The `config/routes.yaml` entry
+   (`resource: .`, `type: mcp`) is unchanged.
+
+ * `mcp:server` gained an optional server argument (`bin/console mcp:server editors`), required as soon
+   as more than one server enables the STDIO transport — one process can serve only one of them.
+   `debug:mcp` gained a `--server` option to restrict its output to a single server.
+
 Platform
 --------
 

--- a/ai.symfony.com/templates/cookbook/content/build-an-mcp-server.html
+++ b/ai.symfony.com/templates/cookbook/content/build-an-mcp-server.html
@@ -131,8 +131,9 @@ together.</p>
     Step 4: Configure Transport
     
 </h2>
-<p>Enable STDIO and/or HTTP transport in the bundle configuration. The STDIO transport is used by
-command-line clients; HTTP is used by web-based clients and the MCP Inspector:</p>
+<p>Declare your server and the transports it offers. The STDIO transport is used by command-line clients;
+HTTP is used by web-based clients and the MCP Inspector. A server exposes only what its capability lists
+name, so <code translate="no" class="notranslate">['*']</code> hands it everything you annotate:</p>
 <div translate="no" class="highlight-yaml notranslate">
     <table class="highlighttable">
         <tbody>
@@ -150,23 +151,31 @@ command-line clients; HTTP is used by web-based clients and the MCP Inspector:</
 9
 10
 11
-12</pre>
+12
+13
+14
+15
+16</pre>
                     </div>
                 </td>
                 <td class="code">
                     <div class="highlight">
                         <pre class="hljs yaml"><span class="hljs-comment"># config/packages/mcp.yaml</span>
 <span class="hljs-attr">mcp:</span>
-    <span class="hljs-attr">app:</span> <span class="hljs-string">'my-app'</span>
-    <span class="hljs-attr">version:</span> <span class="hljs-string">'1.0.0'</span>
-    <span class="hljs-attr">description:</span> <span class="hljs-string">'My Symfony MCP server'</span>
+    <span class="hljs-attr">servers:</span>
+        <span class="hljs-attr">default:</span>
+            <span class="hljs-attr">name:</span> <span class="hljs-string">'my-app'</span>
+            <span class="hljs-attr">version:</span> <span class="hljs-string">'1.0.0'</span>
+            <span class="hljs-attr">description:</span> <span class="hljs-string">'My Symfony MCP server'</span>
 
-    <span class="hljs-attr">client_transports:</span>
-        <span class="hljs-attr">stdio:</span> <span class="hljs-literal">true</span>
-        <span class="hljs-attr">http:</span> <span class="hljs-literal">true</span>
+            <span class="hljs-attr">transports:</span>
+                <span class="hljs-attr">stdio:</span> <span class="hljs-literal">true</span>
+                <span class="hljs-attr">http:</span> <span class="hljs-literal">true</span>
 
-    <span class="hljs-attr">http:</span>
-        <span class="hljs-attr">path:</span> <span class="hljs-string">/_mcp</span></pre>
+            <span class="hljs-attr">http:</span>
+                <span class="hljs-attr">path:</span> <span class="hljs-string">/_mcp</span>
+
+            <span class="hljs-attr">registry:</span> <span class="hljs-string">'*'</span></pre>
                     </div>
                 </td>
             </tr>
@@ -355,7 +364,8 @@ client's configuration file pointing at your Symfony console command for STDIO t
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path></svg>
                 <span>Tip</span>
     </p><p>Run <code translate="no" class="notranslate">symfony console mcp:server</code> to start the STDIO server manually. This is useful for
-debugging before connecting a client.</p>
+debugging before connecting a client. With more than one server configured for STDIO, name the
+one to run: <code translate="no" class="notranslate">symfony console mcp:server default</code>.</p>
 </div>
 </div>
 <div class="section">

--- a/demo/config/packages/mcp.yaml
+++ b/demo/config/packages/mcp.yaml
@@ -1,15 +1,20 @@
 mcp:
-    app: demo-app
-    version: 0.0.1
-    pagination_limit: 10
-    instructions: |
-        This demo MCP server provides time management capabilities for developers.
+    servers:
+        demo:
+            name: demo-app
+            version: 0.0.1
+            pagination_limit: 10
+            instructions: |
+                This demo MCP server provides time management capabilities for developers.
 
-        Use this server when you need to work with timestamps, time zones, or time-based calculations.
+                Use this server when you need to work with timestamps, time zones, or time-based calculations.
 
-    client_transports:
-        stdio: true
-        http: true
-    http:
-        session:
-            store: file
+            transports:
+                stdio: true
+                http: true
+            http:
+                path: /_mcp
+            session:
+                store: file
+
+            registry: '*'

--- a/docs/bundles/mcp-bundle.rst
+++ b/docs/bundles/mcp-bundle.rst
@@ -15,8 +15,11 @@ Installation
 Usage
 -----
 
-At first, you need to decide whether your application should act as a MCP server or client. Both can be configured in
-the ``mcp`` section of your ``config/packages/mcp.yaml`` file.
+An application can act as an MCP **server** (exposing tools, prompts and resources to clients), as an MCP
+**client** (consuming remote MCP servers), or as both. The two live side by side in the ``mcp`` section of
+``config/packages/mcp.yaml``: servers under ``servers:``, clients under ``clients:``. Both keys take named
+entries, so an application can expose several servers and use several clients at once.
+
 You also need to add few lines in the routing configuration for this bundle:
 
 .. code-block:: yaml
@@ -30,8 +33,28 @@ You also need to add few lines in the routing configuration for this bundle:
 Act as Server
 ~~~~~~~~~~~~~
 
-To use your application as an MCP server, exposing tools, prompts, resources, and resource templates to clients like `Claude Desktop`_, you need to configure in the
-``client_transports`` section the transports you want to expose to clients. You can use either STDIO or HTTP.
+To use your application as an MCP server, exposing tools, prompts, resources, and resource templates to
+clients like `Claude Desktop`_, declare a server under ``servers:``. Each server names the transports it
+offers (STDIO, HTTP or both) and the capabilities it exposes:
+
+.. code-block:: yaml
+
+    # config/packages/mcp.yaml
+    mcp:
+        servers:
+            default:
+                name: 'my-app'
+                transports:
+                    stdio: true
+                    http: true
+                http:
+                    path: /mcp
+                registry: '*'         # expose every registered capability
+
+A server exposes **only what its** ``registry:`` **lists**. It takes either one list covering every kind
+of capability, or a map narrowing each kind separately. Entries are service ids, class names, namespace
+prefixes (written with a trailing backslash) or the ``*`` wildcard, as described in
+*Exposing capabilities* below.
 
 Creating MCP Capabilities
 .........................
@@ -128,6 +151,108 @@ compiled container. Classes that are not registered as services (for example exc
 ``services.yaml`` or shipped by a third-party package) must be registered as services to be exposed.
 For fully custom registration logic you can implement ``Mcp\Capability\Registry\Loader\LoaderInterface``;
 implementations are autoconfigured with the ``mcp.loader`` tag and run when the server is built.
+
+Exposing capabilities
+.....................
+
+Carrying an attribute makes a class *available*; a server's capability lists decide which of them it
+*exposes*. Each list entry matches one of:
+
+* ``'*'`` — every registered element of that kind;
+* ``App\Mcp\SearchTool`` — that exact class name, or a service id for services registered under one;
+* ``App\Mcp\Editor\`` — every element whose class or service id starts with that namespace.
+
+.. code-block:: yaml
+
+    mcp:
+        servers:
+            default:
+                registry:
+                    tools:
+                        - 'App\Mcp\Tool\'          # a whole namespace
+                        - 'App\Mcp\SearchTool'      # a single class
+                        - 'app.mcp.legacy_lookup'    # a custom service id
+                    prompts: ['*']
+                    # resources, resource_templates and the app list default to [] — nothing exposed
+
+When every kind comes from the same place, give ``registry`` the list directly instead of repeating it
+five times:
+
+.. code-block:: yaml
+
+    # config/packages/mcp.yaml
+    mcp:
+        servers:
+            default:
+                registry: ['App\Mcp\']   # every kind, from this namespace
+            everything:
+                registry: '*'             # every kind, everywhere
+
+.. note::
+
+    In YAML, write namespace prefixes in single quotes (or unquoted). Inside double quotes every
+    backslash has to be doubled.
+
+``registry:`` is required and must end up with at least one non-empty kind, and a pattern that matches no service fails at
+compile time — that is nearly always a typo. The reverse is allowed on purpose: a service carrying an
+MCP attribute that no server lists (a tool shipped by a third-party bundle, say) is simply not exposed.
+Run ``debug:mcp`` to see those listed under *Not exposed by any server*.
+
+Multiple Servers
+................
+
+Because ``servers:`` is a map, one application can expose several MCP servers on different routes, each
+with its own identity and capability set. A common shape is a public server next to a privileged one:
+
+.. code-block:: yaml
+
+    # config/packages/mcp.yaml
+    mcp:
+        servers:
+            public:
+                name: 'acme'
+                transports: { http: true }
+                http:
+                    path: /mcp
+                    allowed_hosts: ['acme.example']
+                registry:
+                    tools: ['App\Mcp\Public\']
+                    resources: ['*']
+
+            editors:
+                name: 'acme-editors'
+                instructions: 'Editorial tooling. Requires an authenticated editor.'
+                transports: { http: true }
+                http:
+                    path: /mcp/editors
+                registry:
+                    tools: ['*']
+                    prompts: ['*']
+
+Access control is plain Symfony security — the routes have distinct, stable paths, so a firewall or an
+``access_control`` rule targets them directly:
+
+.. code-block:: yaml
+
+    # config/packages/security.yaml
+    security:
+        access_control:
+            - { path: ^/mcp/editors, roles: ROLE_EDITOR }
+
+Each server gets its own registry, session store and HTTP route (named ``_mcp_endpoint_<name>``), and its
+own services under ``mcp.server.<name>.*``. Autowire a specific server with ``Mcp\Server $editorsServer``.
+
+.. caution::
+
+    Give every server its own session storage. Session ids are not namespaced by server, so two servers
+    sharing a store would accept each other's sessions — across a firewall boundary that is a privilege
+    escalation. The defaults already isolate them (``%kernel.cache_dir%/mcp-sessions/<name>`` for the file
+    store, the ``mcp-<name>-`` prefix for the cache and framework stores), and a configuration that makes
+    two servers share a store is rejected when the container is compiled.
+
+If ``http.path`` is not set, it defaults to ``/mcp/<name>``. That default is always derived from the
+server's name rather than from how many servers exist, so adding a second server can never silently move
+the first one's endpoint.
 
 Attribute Placement Patterns
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -242,15 +367,20 @@ You can declare CSP and permission requirements for the iframe directly on the a
         geolocation: true,
     )]
 
-The MCP Apps extension is enabled automatically as soon as one ``#[AsMcpApp]`` class exists. Use the
-``apps.enabled`` option to force it on or off:
+The MCP Apps extension is enabled on a server as soon as it exposes at least one ``#[AsMcpApp]`` class,
+which its ``apps:`` list decides like any other capability:
 
 .. code-block:: yaml
 
     # config/packages/mcp.yaml
     mcp:
-        apps:
-            enabled: true # null (default) = auto-enable when an app is registered; true/false forces it
+        servers:
+            default:
+                registry:
+                    apps: ['*']                  # every app; [] (the default) exposes none
+            editors:
+                registry:
+                    apps: ['App\Mcp\App\Editor\'] # only these
 
 Rendering with Twig (HTML-over-the-wire)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -347,10 +477,13 @@ render the result yourself, but the declarative attributes cover the common case
 Transport Types
 ...............
 
-The MCP Bundle supports two transport types for server communication:
+Each server declares its transports under ``transports:``:
 
-- **STDIO Transport** - For command-line clients (e.g., ``symfony console mcp:server``)
-- **HTTP Transport** - For web-based clients and MCP Inspector using streamable HTTP connections
+- **STDIO Transport** (``stdio``, default ``false``) - For command-line clients, served by
+  ``symfony console mcp:server <name>``. A process owns one STDIN/STDOUT pair, so one invocation serves
+  exactly one server; the argument may be omitted when only one server enables STDIO.
+- **HTTP Transport** (``http``, default ``true``) - For web-based clients and MCP Inspector, using
+  streamable HTTP connections on that server's route.
 
 The HTTP transport uses the MCP SDK's ``StreamableHttpTransport`` which supports:
 
@@ -369,8 +502,10 @@ public MCP server, configure the allowed hosts:
 .. code-block:: yaml
 
     mcp:
-        http:
-            allowed_hosts: ['example.com', 'mcp.example.com'] # Replaces the default localhost allowlist
+        servers:
+            default:
+                http:
+                    allowed_hosts: ['example.com', 'mcp.example.com'] # Replaces the default localhost allowlist
 
 Alternatively, disable the protection entirely (for example when the server sits behind a
 reverse proxy that already validates the ``Host`` header) by setting it to ``false``:
@@ -378,46 +513,52 @@ reverse proxy that already validates the ``Host`` header) by setting it to ``fal
 .. code-block:: yaml
 
     mcp:
-        http:
-            allowed_hosts: false
+        servers:
+            default:
+                http:
+                    allowed_hosts: false
 
 Session Storage
 ...............
 
-The MCP Bundle supports four types of session storage for the HTTP transport:
+The MCP Bundle supports four types of session storage, configured per server. Every server needs its own
+storage — see the caution in `Multiple Servers`_.
 
 **File Storage** (default) - Stores sessions on the filesystem:
 
 .. code-block:: yaml
 
     mcp:
-        http:
-            session:
-                store: file
-                directory: '%kernel.cache_dir%/mcp-sessions'
-                ttl: 3600
+        servers:
+            default:
+                session:
+                    store: file
+                    directory: '%kernel.cache_dir%/mcp-sessions/default' # defaults to this
+                    ttl: 3600
 
 **Memory Storage** - Stores sessions in memory (non-persistent):
 
 .. code-block:: yaml
 
     mcp:
-        http:
-            session:
-                store: memory
-                ttl: 3600
+        servers:
+            default:
+                session:
+                    store: memory
+                    ttl: 3600
 
 **PSR-16 Cache Storage** - Stores sessions in any PSR-16 compliant cache (Redis, Doctrine, APCu, etc.):
 
 .. code-block:: yaml
 
     mcp:
-        http:
-            session:
-                store: cache
-                cache_pool: 'cache.mcp.sessions' # Reference to your cache pool service (PSR-16)
-                prefix: 'mcp-' # Optional prefix for cache keys
-                ttl: 3600
+        servers:
+            default:
+                session:
+                    store: cache
+                    cache_pool: 'cache.mcp.sessions' # Reference to your cache pool service (PSR-16)
+                    prefix: 'mcp-default-' # Optional; defaults to "mcp-<name>-"
+                    ttl: 3600
 
 By default, if you don't configure a custom cache pool, the bundle automatically creates ``cache.mcp.sessions`` as a PSR-16 wrapper around Symfony's default ``cache.app`` pool.
 
@@ -444,11 +585,12 @@ See the `Symfony Cache documentation`_ for more details on configuring cache poo
 **Framework Storage** - Uses Symfony's ``SessionHandlerInterface`` for session persistence::
 
     mcp:
-        http:
-            session:
-                store: framework
-                prefix: 'mcp-' # Optional prefix for session keys
-                ttl: 3600
+        servers:
+            default:
+                session:
+                    store: framework
+                    prefix: 'mcp-default-' # Optional; defaults to "mcp-<name>-"
+                    ttl: 3600
 
 This wraps the configured Symfony session handler (e.g. Redis, database, filesystem — whatever
 your application uses for HTTP sessions) with a JSON envelope for application-level TTL.
@@ -457,16 +599,128 @@ Expired sessions are cleaned up lazily on read.
 Act as Client
 ~~~~~~~~~~~~~
 
-.. warning::
+To consume remote MCP servers, declare a client under ``clients:``. A client is a named group of server
+connections: it carries the identity your application advertises during the handshake, and lists the
+remote ``servers`` it talks to over STDIO (a child process) or HTTP:
 
-    Not implemented yet, but planned for the future.
+.. code-block:: yaml
 
-To use your application as an MCP client, integrating other MCP servers, you need to configure the ``servers`` you want
-to connect to. You can use either STDIO or HTTP as transport methods.
+    # config/packages/mcp.yaml
+    mcp:
+        clients:
+            research:
+                client_info:
+                    name: 'acme-research'
+                    version: '1.0.0'
+                servers:
+                    github:
+                        transport: http
+                        url: 'https://api.githubcopilot.com/mcp/'
+                        headers:
+                            Authorization: 'Bearer %env(GITHUB_MCP_TOKEN)%'
+                    filesystem:
+                        transport: stdio
+                        command: ['npx', '-y', '@modelcontextprotocol/server-filesystem', '/tmp']
+
+            simple:
+                servers:
+                    github:
+                        transport: http
+                        url: 'https://api.githubcopilot.com/mcp/'
+
+Several clients can reach the same remote server; each keeps its own connection, since identity,
+timeouts and handlers are per client. Use a YAML anchor to avoid repeating a definition:
+
+.. code-block:: yaml
+
+    mcp:
+        clients:
+            research:
+                servers:
+                    github: &github
+                        transport: http
+                        url: 'https://api.githubcopilot.com/mcp/'
+            simple:
+                servers:
+                    github: *github
 
 You can find a list of example Servers in the `MCP Server List`_.
 
-Tools of those servers are available in your `AI Bundle`_ configuration and usable in your agents.
+Using a Client
+..............
+
+Each client is available as ``Symfony\AI\McpBundle\Client\McpClientInterface``, autowirable by the
+parameter name or with ``#[Target]``. Its connections implement
+``Symfony\AI\McpBundle\Client\ServerConnectionInterface``::
+
+    use Symfony\AI\McpBundle\Client\McpClientInterface;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
+
+    class ResearchService
+    {
+        public function __construct(
+            #[Target('research')] private McpClientInterface $client,
+        ) {
+        }
+
+        public function run(string $path): string
+        {
+            $connection = $this->client->get('filesystem');
+
+            foreach ($connection->getTools() as $tool) {
+                // $tool is an Mcp\Schema\Tool
+            }
+
+            $result = $connection->callTool('read_file', ['path' => $path]);
+
+            return $result->content[0]->text;
+        }
+    }
+
+A client is also iterable, which is handy for fanning a question out over every server it knows::
+
+    foreach ($this->client as $name => $connection) {
+        $tools[$name] = $connection->getTools();
+    }
+
+When exactly one client is configured, a plain ``McpClientInterface`` type hint resolves to it.
+
+Connection Lifecycle
+....................
+
+You never call ``connect()``. A connection opens on its first request and closes on kernel reset, so
+resolving or iterating a client costs nothing until a request is actually made. That matters most for
+the STDIO transport, where connecting spawns a child process: a Messenger worker therefore starts a
+fresh process per message rather than carrying a stale one between them. Call ``disconnect()`` on a
+connection (or on the client, for all of them) to close early; it reconnects transparently afterwards.
+
+Failures surface as bundle exceptions naming the client and server:
+``Symfony\AI\McpBundle\Exception\ConnectionException`` when the handshake fails, and
+``RemoteCallException`` when a request does, both implementing
+``Symfony\AI\McpBundle\Exception\ExceptionInterface``.
+
+The HTTP transport uses the application's PSR-18 client (``psr18.http_client``, provided by
+``symfony/http-client``) unless the ``http_client`` option points at another service.
+
+Sampling and Elicitation
+........................
+
+A remote server can ask the client to run a completion (*sampling*) or to prompt the user
+(*elicitation*). Point the matching option at a service implementing the SDK's callback interface; the
+capability is advertised only when a handler backs it:
+
+.. code-block:: yaml
+
+    mcp:
+        clients:
+            research:
+                sampling: 'App\Mcp\SamplingHandler'      # Mcp\Client\Handler\Request\SamplingCallbackInterface
+                elicitation: 'App\Mcp\ElicitationHandler' # Mcp\Client\Handler\Request\ElicitationCallbackInterface
+                servers:
+                    github: { transport: http, url: 'https://api.githubcopilot.com/mcp/' }
+
+Logging notifications received from remote servers are written to the ``mcp`` logger channel; set
+``forward_server_logs: false`` to drop them.
 
 Configuration
 -------------
@@ -475,55 +729,94 @@ Configuration
 
     # config/packages/mcp.yaml
     mcp:
-        app: 'app' # Application name to be exposed to clients
-        version: '1.0.0' # Application version to be exposed to clients
-        description: 'A sample MCP server for time management.' # Application description to be exposed to clients
-        icons:
-            - src: 'https://example.com/icon.png' # Application icon URL
-              mime_type: 'image/png' # MIME type of the icon
-              sizes: ['64x64'] # Sizes of the icon
-        website_url: 'https://example.com' # Application website URL
-        pagination_limit: 50 # Maximum number of items returned per list request (default: 50)
-        instructions: | # Instructions describing server purpose and usage context (for LLMs)
-            This server provides time management capabilities for developers.
-
-            Use when working with timestamps, time zones, or time-based calculations.
-            All timestamps are in UTC unless specified otherwise.
-
-            Example contexts: logging, debugging, time-sensitive operations.
-
-        # MCP Apps (interactive HTML UI resources, registered with #[AsMcpApp])
-        apps:
-            enabled: ~ # null = auto-enable when at least one app exists; true/false forces it
-
-        client_transports:
-            stdio: true # Enable STDIO via command
-            http: true # Enable HTTP transport via controller
-
-        # HTTP transport configuration (optional)
-        http:
-            path: /_mcp # HTTP endpoint path (default: /_mcp)
-            session:
-                store: file # Session store type: 'file', 'memory', 'cache', or 'framework' (default: file)
-                directory: '%kernel.cache_dir%/mcp-sessions' # Directory for file store (default: cache_dir/mcp-sessions)
-                cache_pool: 'cache.mcp.sessions' # Cache pool service for cache store (default: cache.mcp.sessions)
-                prefix: 'mcp-' # Prefix for cache keys (default: 'mcp-')
-                ttl: 3600 # Session TTL in seconds (default: 3600)
-
-        # Not supported yet
+        # MCP servers this application exposes
         servers:
-            name:
-                transport: 'stdio' # Transport method to use, either 'stdio' or 'http'
-                stdio:
-                    command: 'php /path/bin/console mcp:server' # Command to execute to start the server
-                    arguments: [] # Arguments to pass to the command
+            default:
+                name: 'app' # Name advertised to clients (default: the configuration key)
+                version: '1.0.0' # Version advertised to clients
+                description: 'A sample MCP server for time management.' # Description advertised to clients
+                icons:
+                    - src: 'https://example.com/icon.png' # Icon URL
+                      mime_type: 'image/png' # MIME type of the icon
+                      sizes: ['64x64'] # Sizes of the icon
+                website_url: 'https://example.com' # Website URL advertised to clients
+                pagination_limit: 50 # Maximum number of items returned per list request (default: 50)
+                instructions: | # Instructions describing server purpose and usage context (for LLMs)
+                    This server provides time management capabilities for developers.
+
+                    Use when working with timestamps, time zones, or time-based calculations.
+
+                transports:
+                    stdio: false # Serve over STDIO via "mcp:server <name>" (default: false)
+                    http: true # Serve over HTTP via a controller and route (default: true)
+
                 http:
-                    url: 'http://localhost:8000/_mcp' # URL to HTTP endpoint of MCP server
+                    path: /mcp # HTTP endpoint path (default: /mcp/<name>)
+                    allowed_hosts: ['example.com'] # DNS rebinding allowlist; false disables the protection
+
+                session:
+                    store: file # 'file', 'memory', 'cache' or 'framework' (default: file)
+                    directory: '%kernel.cache_dir%/mcp-sessions/default' # File store (default: cache_dir/mcp-sessions/<name>)
+                    cache_pool: 'cache.mcp.sessions' # Cache pool service for the cache store (PSR-16)
+                    prefix: 'mcp-default-' # Key prefix for the cache/framework stores (default: mcp-<name>-)
+                    ttl: 3600 # Session TTL in seconds (default: 3600)
+
+                # What this server exposes: service ids, class names, namespace prefixes or '*'.
+                # Required. Either one list for every kind (registry: ['App\Mcp\'], registry: '*')
+                # or the map below; each kind defaults to [], and at least one must be non-empty.
+                registry:
+                    tools: ['*']
+                    prompts: ['*']
+                    resources: ['*']
+                    resource_templates: ['*']
+                    apps: ['*'] # MCP Apps (interactive HTML UI resources, registered with #[AsMcpApp])
+
+        # MCP clients this application uses to reach remote MCP servers
+        clients:
+            research:
+                client_info: # Identity advertised during the initialize handshake
+                    name: 'acme-research' # (default: the configuration key)
+                    version: '1.0.0'
+                    description: null
+                protocol_version: null # MCP protocol version to negotiate (default: the SDK default)
+                capabilities:
+                    roots: false # Advertise the "roots" capability
+                    roots_list_changed: false
+                sampling: null # Service id implementing SamplingCallbackInterface; enables the capability
+                elicitation: null # Service id implementing ElicitationCallbackInterface; enables the capability
+                forward_server_logs: true # Write logging notifications to the "mcp" channel
+
+                # Defaults for every server of this client; each may override them
+                init_timeout: 30
+                request_timeout: 120
+                max_retries: 3
+
+                servers:
+                    github:
+                        transport: http # 'stdio' or 'http'
+                        url: 'https://api.githubcopilot.com/mcp/' # Required for the http transport
+                        headers:
+                            Authorization: 'Bearer %env(GITHUB_MCP_TOKEN)%'
+                        http_client: null # Service id of a PSR-18 client (default: psr18.http_client)
+                        max_sse_buffer_bytes: null # Bytes buffered per SSE event (default: the SDK value)
+                        request_timeout: 300 # Overrides the client-level value
+
+                    filesystem:
+                        transport: stdio
+                        # Required for the stdio transport; the first element is the program, not a shell string
+                        command: ['npx', '-y', '@modelcontextprotocol/server-filesystem', '/tmp']
+                        cwd: null # Working directory of the child process
+                        env: # Environment variables for the child process
+                            LOG_LEVEL: 'debug'
+                        inherit_env: true # Merge "env" over the current environment instead of replacing it
+                        max_buffer_size: null # Bytes buffered per line (default: the SDK value)
 
 Logging Configuration
 ---------------------
 
-By default, MCP uses a dedicated logger channel that inherits your application's default logging configuration.
+By default, MCP uses a dedicated logger channel that inherits your application's default logging
+configuration. It carries both the server side and the outbound client traffic, including the logging
+notifications remote servers send back.
 To configure MCP-specific logging, add the following to your ``config/packages/monolog.yaml``:
 
 .. code-block:: yaml
@@ -560,26 +853,49 @@ You can customize the logging level and destination according to your needs:
 Debug Command
 -------------
 
-The ``debug:mcp`` command lists all MCP capabilities registered with the server — useful to verify
-that an attributed class was actually picked up (only registered, autoconfigured services are):
+``debug:mcp`` is the one debug command for the bundle: it covers both the servers this application
+exposes and the clients it uses. Without options it lists the MCP capabilities each configured server
+exposes — useful to verify that an attributed class was actually picked up (it must be a registered,
+autoconfigured service *and* be matched by a server's capability list) — followed by a summary of the
+configured clients:
 
 .. code-block:: terminal
 
-    # list all tools, prompts, resources, and resource templates with their handlers
+    # list every server's tools, prompts, resources, and resource templates with their handlers
     $ php bin/console debug:mcp
+
+    # restrict the output to one server
+    $ php bin/console debug:mcp --server=editors
 
     # show the details of a single element, including the tool's input schema
     $ php bin/console debug:mcp current-time
 
+Its last section, *Not exposed by any server*, lists the services that carry an MCP attribute but that no
+server's capability list matches.
+
+The same command covers the client side. Both listings read the compiled container and open no
+connection; only ``--client`` connects, and it always disconnects afterwards:
+
+.. code-block:: terminal
+
+    # list the configured clients and their servers
+    $ php bin/console debug:mcp --clients
+
+    # connect and show the remote server's info, instructions, tools, prompts and resources
+    $ php bin/console debug:mcp --client=research --server=github
+
+``--server`` names a configured server on its own, and the client's remote server when combined with
+``--client``. It can be omitted when the client reaches exactly one server.
+
 Profiler
 --------
 
-When the Symfony Web Profiler is enabled, the MCP Bundle automatically adds a dedicated panel showing all registered MCP capabilities in your application:
+When the Symfony Web Profiler is enabled, the MCP Bundle automatically adds a dedicated panel showing the registered MCP capabilities of every configured server:
 
 .. image:: images/profiler-mcp.png
    :alt: MCP Profiler Panel
 
-The profiler displays:
+The profiler displays, per server:
 
 - **Tools**: All registered MCP tools with their descriptions and input schemas
 - **Prompts**: Available prompts with their arguments and requirements
@@ -629,5 +945,4 @@ The events are simple marker events that notify when lists have changed, but don
 .. _`mcp/sdk`: https://github.com/modelcontextprotocol/php-sdk
 .. _`Claude Desktop`: https://claude.ai/download
 .. _`MCP Server List`: https://modelcontextprotocol.io/examples
-.. _`AI Bundle`: https://github.com/symfony/ai-bundle
 .. _`Symfony Cache documentation`: https://symfony.com/doc/current/components/cache.html

--- a/docs/cookbook/build-an-mcp-server.rst
+++ b/docs/cookbook/build-an-mcp-server.rst
@@ -64,23 +64,28 @@ tool name and can invoke it with parameters::
 Step 4: Configure Transport
 ---------------------------
 
-Enable STDIO and/or HTTP transport in the bundle configuration. The STDIO transport is used by
-command-line clients; HTTP is used by web-based clients and the MCP Inspector:
+Declare your server and the transports it offers. The STDIO transport is used by command-line clients;
+HTTP is used by web-based clients and the MCP Inspector. A server exposes only what its capability lists
+name, so ``['*']`` hands it everything you annotate:
 
 .. code-block:: yaml
 
     # config/packages/mcp.yaml
     mcp:
-        app: 'my-app'
-        version: '1.0.0'
-        description: 'My Symfony MCP server'
+        servers:
+            default:
+                name: 'my-app'
+                version: '1.0.0'
+                description: 'My Symfony MCP server'
 
-        client_transports:
-            stdio: true
-            http: true
+                transports:
+                    stdio: true
+                    http: true
 
-        http:
-            path: /_mcp
+                http:
+                    path: /_mcp
+
+                registry: '*'
 
 Step 5: Create a Prompt
 -----------------------
@@ -157,7 +162,8 @@ For the HTTP transport, point the client at your application's MCP endpoint inst
 .. tip::
 
     Run ``symfony console mcp:server`` to start the STDIO server manually. This is useful for
-    debugging before connecting a client.
+    debugging before connecting a client. With more than one server configured for STDIO, name the
+    one to run: ``symfony console mcp:server default``.
 
 Learn More
 ----------

--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -1,6 +1,23 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Add support for multiple MCP servers per application, configured under `servers:` — each with its own
+   identity, transports, session store, HTTP route and set of exposed capabilities
+ * Add a required per-server `registry:` option listing what the server exposes — either one list covering
+   every kind or a map of `tools`, `prompts`, `resources`, `resource_templates` and `apps` — matching service
+   ids, class names, namespace prefixes or `*`, replacing the implicit "every element on the one server"
+ * Add `clients:` configuration to act as an MCP client: each named client owns a set of remote `servers:`
+   reached over the stdio or HTTP transport
+ * Add `Symfony\AI\McpBundle\Client\McpClientInterface` (service `mcp.client.<name>`) and
+   `Symfony\AI\McpBundle\Client\ServerConnectionInterface` (service `mcp.client.<name>.server.<server>`),
+   which own the connection lifecycle: connecting on first use and disconnecting on kernel reset
+ * Add `--clients` and `--client` options to `debug:mcp`, which now covers both sides of the bundle:
+   the configured servers and what the configured clients reach
+ * Add a `--server` option to `debug:mcp` and a server argument to `mcp:server`
+
 0.12
 ----
 

--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -45,6 +45,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "Symfony\\AI\\McpBundle\\Tests\\": "tests/",
             "Symfony\\AI\\PHPStan\\": "../../.phpstan"
         }
     },

--- a/src/mcp-bundle/config/options.php
+++ b/src/mcp-bundle/config/options.php
@@ -11,62 +11,264 @@
 
 namespace Symfony\Component\Config\Definition\Configurator;
 
+use Mcp\Schema\Enum\ProtocolVersion;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
 return static function (DefinitionConfigurator $configurator): void {
+    /**
+     * The kinds of element a server can expose, mapped to their label in the messages.
+     */
+    $kinds = [
+        'tools' => 'tools',
+        'prompts' => 'prompts',
+        'resources' => 'resources',
+        'resource_templates' => 'resource templates',
+        'apps' => 'MCP Apps',
+    ];
+
+    /**
+     * The elements of one kind a server exposes: service ids, FQCNs, namespace prefixes
+     * (trailing backslash), or "*" for every element of that kind.
+     */
+    $elements = static fn (string $key, string $kind): ArrayNodeDefinition => (new ArrayNodeDefinition($key))
+        ->info(\sprintf('The %s this server exposes: service ids, FQCNs, namespace prefixes (trailing "\\"), or "*" for all of them.', $kind))
+        ->beforeNormalization()
+            ->ifString()
+            ->then(static fn (string $v): array => [$v])
+        ->end()
+        ->scalarPrototype()->cannotBeEmpty()->end()
+        ->defaultValue([])
+        ->validate()
+            ->ifTrue(static fn (array $v): bool => \in_array('*', $v, true) && 1 < \count($v))
+            ->thenInvalid('The "*" wildcard cannot be combined with explicit entries, got %s.')
+        ->end()
+    ;
+
+    /**
+     * What a server puts into its registry, in either of two forms: one pattern list for
+     * every kind at once, or a map narrowing each kind separately.
+     *
+     *     registry: ['App\\Mcp\\']
+     *     registry: { tools: ['App\\Mcp\\Tool\\'], apps: ['App\\Apps\\'] }
+     *
+     * @param array<string, string>                         $kinds
+     * @param callable(string, string): ArrayNodeDefinition $elements
+     */
+    $registry = static function (array $kinds, callable $elements): ArrayNodeDefinition {
+        $node = (new ArrayNodeDefinition('registry'))
+            ->info('The elements this server exposes, either as one list covering every kind or as a map narrowing each kind.')
+            ->isRequired()
+            ->addDefaultsIfNotSet()
+            ->beforeNormalization()
+                ->ifTrue(static fn ($v): bool => \is_string($v) || (\is_array($v) && array_is_list($v)))
+                ->then(static fn ($v): array => array_fill_keys(array_keys($kinds), \is_string($v) ? [$v] : $v))
+            ->end()
+            ->validate()
+                ->ifTrue(static fn (array $v): bool => [] === array_filter($v, static fn (array $patterns): bool => [] !== $patterns))
+                ->thenInvalid('An MCP server must expose at least one of "tools", "prompts", "resources", "resource_templates" or "apps". Use "*" to expose everything.')
+            ->end()
+        ;
+
+        foreach ($kinds as $key => $label) {
+            $node->append($elements($key, $label));
+        }
+
+        return $node;
+    };
+
+    $namesAreValid = static fn (array $v): bool => [] === array_filter(
+        array_keys($v),
+        static fn (int|string $name): bool => !\is_string($name) || 1 !== preg_match('/^[a-zA-Z0-9_-]++$/', $name),
+    );
+
     $configurator->rootNode()
         ->children()
-            ->scalarNode('app')->defaultValue('app')->end()
-            ->scalarNode('version')->defaultValue('0.0.1')->end()
-            ->scalarNode('description')->defaultNull()->end()
-            ->arrayNode('icons')
+            ->arrayNode('servers')
+                ->info('The MCP servers this application exposes, each with its own identity, transports, session store and capabilities.')
+                // No useAttributeAsKey() here: it would consume the "name" child as the array key.
+                ->validate()
+                    ->ifTrue(static fn (array $v): bool => !$namesAreValid($v))
+                    ->thenInvalid('MCP server names must only contain letters, digits, underscores and hyphens, got %s.')
+                ->end()
                 ->arrayPrototype()
                     ->children()
-                        ->scalarNode('src')->isRequired()->end()
-                        ->scalarNode('mime_type')->defaultNull()->end()
-                        ->arrayNode('sizes')
-                            ->scalarPrototype()->end()
-                            ->defaultValue(['any'])
+                        ->stringNode('name')->defaultNull()->info('Name advertised to clients. Defaults to the configuration key.')->end()
+                        ->stringNode('version')->defaultValue('0.0.1')->end()
+                        ->stringNode('description')->defaultNull()->end()
+                        ->arrayNode('icons')
+                            ->arrayPrototype()
+                                ->children()
+                                    ->stringNode('src')->isRequired()->end()
+                                    ->stringNode('mime_type')->defaultNull()->end()
+                                    ->arrayNode('sizes')
+                                        ->scalarPrototype()->end()
+                                        ->defaultValue(['any'])
+                                    ->end()
+                                ->end()
+                            ->end()
                         ->end()
+                        ->stringNode('website_url')->defaultNull()->end()
+                        ->integerNode('pagination_limit')->min(1)->defaultValue(50)->end()
+                        ->stringNode('instructions')->defaultNull()->end()
+
+                        ->arrayNode('transports')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->booleanNode('stdio')->defaultFalse()->info('Expose the server over STDIO via the "mcp:server" command.')->end()
+                                ->booleanNode('http')->defaultTrue()->info('Expose the server over HTTP via a controller and route.')->end()
+                            ->end()
+                        ->end()
+
+                        ->arrayNode('http')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->stringNode('path')->defaultNull()->info('HTTP endpoint path. Defaults to "/mcp/<name>".')->end()
+                                ->variableNode('allowed_hosts')
+                                    ->info('DNS rebinding protection hosts (without port). Leave unset to keep the SDK default (localhost only), set an array of hostnames to expose a public MCP server, or false to disable the protection entirely.')
+                                    ->defaultNull()
+                                    ->validate()
+                                        ->ifTrue(static fn ($v): bool => null !== $v && false !== $v && !\is_array($v))
+                                        ->thenInvalid('The "allowed_hosts" option must be an array of hostnames or false, got %s.')
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+
+                        ->arrayNode('session')
+                            ->addDefaultsIfNotSet()
+                            ->info('Session storage. Every server needs its own store: session ids are not namespaced by server, so a shared store makes a session minted on one server valid on the others.')
+                            ->children()
+                                ->enumNode('store')->values(['file', 'memory', 'cache', 'framework'])->defaultValue('file')->end()
+                                ->stringNode('directory')->defaultNull()->info('Directory for the "file" store. Defaults to "%kernel.cache_dir%/mcp-sessions/<name>".')->end()
+                                ->stringNode('cache_pool')->defaultValue('cache.mcp.sessions')->info('PSR-16 cache service for the "cache" store.')->end()
+                                ->stringNode('prefix')->defaultNull()->info('Key prefix for the "cache" and "framework" stores. Defaults to "mcp-<name>-".')->end()
+                                ->integerNode('ttl')->min(1)->defaultValue(3600)->end()
+                            ->end()
+                        ->end()
+
+                        ->append($registry($kinds, $elements))
                     ->end()
                 ->end()
             ->end()
-            ->scalarNode('website_url')->defaultNull()->end()
-            ->integerNode('pagination_limit')->defaultValue(50)->end()
-            ->scalarNode('instructions')->defaultNull()->end()
-            ->arrayNode('client_transports')
-                ->children()
-                    ->booleanNode('stdio')->defaultFalse()->end()
-                    ->booleanNode('http')->defaultFalse()->end()
+
+            ->arrayNode('clients')
+                ->info('The MCP clients this application uses to reach remote MCP servers. Each client owns a named set of server connections.')
+                ->defaultValue([])
+                ->validate()
+                    ->ifTrue(static fn (array $v): bool => !$namesAreValid($v))
+                    ->thenInvalid('MCP client names must only contain letters, digits, underscores and hyphens, got %s.')
                 ->end()
-            ->end()
-            ->arrayNode('apps')
-                ->addDefaultsIfNotSet()
-                ->info('MCP Apps support (interactive HTML UI resources). Apps are registered with the #[AsMcpApp] attribute.')
-                ->children()
-                    // null = auto: enable the MCP Apps server extension when at least one #[AsMcpApp]
-                    // exists. true/false forces the extension on/off.
-                    ->booleanNode('enabled')->defaultNull()->end()
-                ->end()
-            ->end()
-            ->arrayNode('http')
-                ->addDefaultsIfNotSet()
-                ->children()
-                    ->scalarNode('path')->defaultValue('/_mcp')->end()
-                    ->variableNode('allowed_hosts')
-                        ->info('DNS rebinding protection hosts (without port). Leave unset to keep the SDK default (localhost only), set an array of hostnames to expose a public MCP server, or false to disable the protection entirely.')
-                        ->defaultNull()
-                        ->validate()
-                            ->ifTrue(static fn ($v): bool => null !== $v && false !== $v && !\is_array($v))
-                            ->thenInvalid('The "mcp.http.allowed_hosts" option must be an array of hostnames or false, got %s.')
+                ->arrayPrototype()
+                    ->children()
+                        ->arrayNode('client_info')
+                            ->info('Identity advertised to every remote server of this client during the initialize handshake.')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->stringNode('name')->defaultNull()->info('Defaults to the configuration key.')->end()
+                                ->stringNode('version')->defaultValue('0.0.1')->end()
+                                ->stringNode('description')->defaultNull()->end()
+                            ->end()
                         ->end()
-                    ->end()
-                    ->arrayNode('session')
-                        ->addDefaultsIfNotSet()
-                        ->children()
-                            ->enumNode('store')->values(['file', 'memory', 'cache', 'framework'])->defaultValue('file')->end()
-                            ->scalarNode('directory')->defaultValue('%kernel.cache_dir%/mcp-sessions')->end()
-                            ->scalarNode('cache_pool')->defaultValue('cache.mcp.sessions')->end()
-                            ->scalarNode('prefix')->defaultValue('mcp-')->end()
-                            ->integerNode('ttl')->min(1)->defaultValue(3600)->end()
+                        ->enumNode('protocol_version')
+                            ->info('MCP protocol version to negotiate. Leave unset to keep the SDK default.')
+                            ->values(array_column(ProtocolVersion::cases(), 'value'))
+                            ->defaultNull()
+                        ->end()
+                        ->arrayNode('capabilities')
+                            ->info('Client capabilities advertised during the handshake. "sampling" and "elicitation" are derived from the handlers configured below.')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->booleanNode('roots')->defaultFalse()->end()
+                                ->booleanNode('roots_list_changed')->defaultFalse()->end()
+                            ->end()
+                        ->end()
+                        ->stringNode('sampling')
+                            ->info('Service id implementing Mcp\Client\Handler\Request\SamplingCallbackInterface. Enables the "sampling" capability.')
+                            ->defaultNull()
+                        ->end()
+                        ->stringNode('elicitation')
+                            ->info('Service id implementing Mcp\Client\Handler\Request\ElicitationCallbackInterface. Enables the "elicitation" capability.')
+                            ->defaultNull()
+                        ->end()
+                        ->booleanNode('forward_server_logs')
+                            ->info('Forward logging notifications received from the remote servers to the "mcp" logger channel.')
+                            ->defaultTrue()
+                        ->end()
+
+                        ->integerNode('init_timeout')->min(1)->defaultValue(30)->end()
+                        ->integerNode('request_timeout')->min(1)->defaultValue(120)->end()
+                        ->integerNode('max_retries')->min(0)->defaultValue(3)->end()
+
+                        ->arrayNode('servers')
+                            ->info('The remote MCP servers this client connects to.')
+                            ->isRequired()
+                            ->requiresAtLeastOneElement()
+                            ->validate()
+                                ->ifTrue(static fn (array $v): bool => !$namesAreValid($v))
+                                ->thenInvalid('MCP server names must only contain letters, digits, underscores and hyphens, got %s.')
+                            ->end()
+                            ->arrayPrototype()
+                                ->children()
+                                    ->enumNode('transport')
+                                        ->values(['stdio', 'http'])
+                                        ->isRequired()
+                                        ->info('How the server is reached: as a child process (stdio) or over a remote HTTP endpoint (http).')
+                                    ->end()
+
+                                    ->arrayNode('command')
+                                        ->info('Program and arguments for the stdio transport, e.g. ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"]. The first element is the program, not a shell string.')
+                                        ->scalarPrototype()->end()
+                                        ->defaultValue([])
+                                    ->end()
+                                    ->stringNode('cwd')->defaultNull()->info('Working directory of the stdio child process.')->end()
+                                    ->arrayNode('env')
+                                        ->info('Environment variables for the stdio child process.')
+                                        ->normalizeKeys(false)
+                                        ->scalarPrototype()->end()
+                                        ->defaultValue([])
+                                    ->end()
+                                    ->booleanNode('inherit_env')
+                                        ->info('Merge "env" on top of the current process environment instead of replacing it.')
+                                        ->defaultTrue()
+                                    ->end()
+                                    ->integerNode('max_buffer_size')->min(1)->defaultNull()->info('Maximum bytes buffered while waiting for a newline. Defaults to the SDK value.')->end()
+
+                                    ->stringNode('url')->defaultNull()->info('Endpoint URL of the remote MCP server.')->end()
+                                    ->arrayNode('headers')
+                                        ->info('Additional request headers, e.g. Authorization.')
+                                        ->normalizeKeys(false)
+                                        ->scalarPrototype()->end()
+                                        ->defaultValue([])
+                                    ->end()
+                                    ->stringNode('http_client')
+                                        ->info('Service id of a PSR-18 HTTP client. Defaults to "psr18.http_client" when available.')
+                                        ->defaultNull()
+                                    ->end()
+                                    ->integerNode('max_sse_buffer_bytes')->min(1)->defaultNull()->info('Maximum bytes buffered per SSE event. Defaults to the SDK value.')->end()
+
+                                    ->integerNode('init_timeout')->min(1)->defaultNull()->info('Overrides the client-level value.')->end()
+                                    ->integerNode('request_timeout')->min(1)->defaultNull()->info('Overrides the client-level value.')->end()
+                                    ->integerNode('max_retries')->min(0)->defaultNull()->info('Overrides the client-level value.')->end()
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(static fn (array $v): bool => 'stdio' === $v['transport'] && [] === $v['command'])
+                                    ->thenInvalid('A "command" must be configured for the "stdio" transport.')
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(static fn (array $v): bool => 'http' === $v['transport'] && null === $v['url'])
+                                    ->thenInvalid('A "url" must be configured for the "http" transport.')
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(static fn (array $v): bool => 'stdio' === $v['transport']
+                                        && (null !== $v['url'] || [] !== $v['headers'] || null !== $v['http_client'] || null !== $v['max_sse_buffer_bytes']))
+                                    ->thenInvalid('The "url", "headers", "http_client" and "max_sse_buffer_bytes" options are only supported by the "http" transport.')
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(static fn (array $v): bool => 'http' === $v['transport']
+                                        && ([] !== $v['command'] || null !== $v['cwd'] || [] !== $v['env'] || null !== $v['max_buffer_size']))
+                                    ->thenInvalid('The "command", "cwd", "env" and "max_buffer_size" options are only supported by the "stdio" transport.')
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/mcp-bundle/config/services.php
+++ b/src/mcp-bundle/config/services.php
@@ -11,37 +11,28 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Mcp\Capability\Registry;
-use Mcp\Server;
-use Mcp\Server\Builder;
+use Http\Discovery\Psr17Factory;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 
+/*
+ * Only the server-agnostic services live here. Everything that carries per-server values
+ * (registry, builder, server, session store, controller) is registered per server in
+ * McpBundle::configureServer(): those values are method-call arguments on the builder, and
+ * method calls cannot be overridden through definition inheritance.
+ */
 return static function (ContainerConfigurator $container): void {
     $container->services()
-        ->set('mcp.registry', Registry::class)
-            ->args([service('event_dispatcher'), service('logger')])
-            ->tag('monolog.logger', ['channel' => 'mcp'])
+        ->set('mcp.psr17_factory', Psr17Factory::class)
 
-        ->set('mcp.server.builder', Builder::class)
-            ->factory([Server::class, 'builder'])
-            ->call('setServerInfo', [
-                param('mcp.app'),
-                param('mcp.version'),
-                param('mcp.description'),
-                param('mcp.icons'),
-                param('mcp.website_url'),
+        ->set('mcp.psr_http_factory', PsrHttpFactory::class)
+            ->args([
+                service('mcp.psr17_factory'),
+                service('mcp.psr17_factory'),
+                service('mcp.psr17_factory'),
+                service('mcp.psr17_factory'),
             ])
-            ->call('setPaginationLimit', [param('mcp.pagination_limit')])
-            ->call('setInstructions', [param('mcp.instructions')])
-            ->call('setEventDispatcher', [service('event_dispatcher')])
-            ->call('setRegistry', [service('mcp.registry')])
-            ->call('setSession', [service('mcp.session.store')])
-            ->call('addRequestHandlers', [tagged_iterator('mcp.request_handler')])
-            ->call('addNotificationHandlers', [tagged_iterator('mcp.notification_handler')])
-            ->call('addLoaders', [tagged_iterator('mcp.loader')])
-            ->call('setLogger', [service('logger')])
-            ->tag('monolog.logger', ['channel' => 'mcp'])
 
-        ->set('mcp.server', Server::class)
-            ->factory([service('mcp.server.builder'), 'build'])
+        ->set('mcp.http_foundation_factory', HttpFoundationFactory::class)
     ;
 };

--- a/src/mcp-bundle/src/Client/McpClient.php
+++ b/src/mcp-bundle/src/Client/McpClient.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Client;
+
+use Symfony\AI\McpBundle\Exception\InvalidArgumentException;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class McpClient implements McpClientInterface
+{
+    /**
+     * @param ServiceProviderInterface<ServerConnectionInterface> $connections keyed by server name
+     */
+    public function __construct(
+        private readonly string $name,
+        private readonly ServiceProviderInterface $connections,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function has(string $server): bool
+    {
+        return $this->connections->has($server);
+    }
+
+    public function get(string $server): ServerConnectionInterface
+    {
+        if (!$this->connections->has($server)) {
+            throw new InvalidArgumentException(\sprintf('The MCP client "%s" has no server named "%s". Configured: "%s".', $this->name, $server, implode(', ', $this->getServerNames())));
+        }
+
+        return $this->connections->get($server);
+    }
+
+    public function getServerNames(): array
+    {
+        return array_keys($this->connections->getProvidedServices());
+    }
+
+    public function getIterator(): \Traversable
+    {
+        foreach ($this->getServerNames() as $server) {
+            yield $server => $this->connections->get($server);
+        }
+    }
+
+    public function count(): int
+    {
+        return \count($this->getServerNames());
+    }
+
+    public function disconnect(): void
+    {
+        foreach ($this as $connection) {
+            $connection->disconnect();
+        }
+    }
+}

--- a/src/mcp-bundle/src/Client/McpClientInterface.php
+++ b/src/mcp-bundle/src/Client/McpClientInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Client;
+
+use Symfony\AI\McpBundle\Exception\InvalidArgumentException;
+
+/**
+ * A configured MCP client and the set of remote servers it connects to.
+ *
+ * Connections are resolved lazily, so iterating a client does not open any of them.
+ *
+ * @extends \IteratorAggregate<string, ServerConnectionInterface>
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+interface McpClientInterface extends \IteratorAggregate, \Countable
+{
+    /**
+     * The configured name of this client (mcp.clients.<name>).
+     */
+    public function getName(): string;
+
+    public function has(string $server): bool;
+
+    /**
+     * @throws InvalidArgumentException when this client has no such server configured
+     */
+    public function get(string $server): ServerConnectionInterface;
+
+    /**
+     * @return list<string>
+     */
+    public function getServerNames(): array;
+
+    /**
+     * Closes every connection this client has opened.
+     */
+    public function disconnect(): void;
+}

--- a/src/mcp-bundle/src/Client/ServerConnection.php
+++ b/src/mcp-bundle/src/Client/ServerConnection.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Client;
+
+use Mcp\Client;
+use Mcp\Client\Transport\TransportInterface;
+use Mcp\Exception\ExceptionInterface as McpExceptionInterface;
+use Mcp\Schema\Enum\LoggingLevel;
+use Mcp\Schema\Implementation;
+use Mcp\Schema\Result\CallToolResult;
+use Mcp\Schema\Result\GetPromptResult;
+use Mcp\Schema\Result\ListPromptsResult;
+use Mcp\Schema\Result\ListResourcesResult;
+use Mcp\Schema\Result\ListResourceTemplatesResult;
+use Mcp\Schema\Result\ListToolsResult;
+use Mcp\Schema\Result\ReadResourceResult;
+use Symfony\AI\McpBundle\Exception\ConnectionException;
+use Symfony\AI\McpBundle\Exception\ExceptionInterface;
+use Symfony\AI\McpBundle\Exception\RemoteCallException;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Connects lazily to a remote MCP server and forwards the SDK client's request surface.
+ *
+ * The SDK's {@see Client} throws unless `connect()` ran first, and a stdio transport spawns a child
+ * process — neither should leak into application code. The connection therefore opens on the first
+ * request and closes on kernel reset, so a long-running worker never carries a stale child process or
+ * a dead HTTP session from one message into the next.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ServerConnection implements ServerConnectionInterface, ResetInterface
+{
+    private bool $connected = false;
+
+    public function __construct(
+        private readonly string $clientName,
+        private readonly string $name,
+        private readonly Client $client,
+        private readonly TransportInterface $transport,
+    ) {
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->disconnect();
+        } catch (\Throwable) {
+            // Without this, PHP closes the stdio child's process handle at shutdown with a blocking wait.
+        }
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getClientName(): string
+    {
+        return $this->clientName;
+    }
+
+    public function isConnected(): bool
+    {
+        return $this->connected && $this->client->isConnected();
+    }
+
+    public function disconnect(): void
+    {
+        if (!$this->connected) {
+            return;
+        }
+
+        // Cleared first: a failing close must not leave the connection looking usable.
+        $this->connected = false;
+
+        try {
+            $this->client->disconnect();
+        } catch (McpExceptionInterface $e) {
+            throw ConnectionException::disconnectFailed($this->clientName, $this->name, $e);
+        }
+    }
+
+    public function reset(): void
+    {
+        try {
+            $this->disconnect();
+        } catch (ExceptionInterface) {
+            // Resetting the container must never fail because a remote server misbehaved.
+        }
+    }
+
+    public function getServerInfo(): ?Implementation
+    {
+        $this->connect();
+
+        return $this->client->getServerInfo();
+    }
+
+    public function getInstructions(): ?string
+    {
+        $this->connect();
+
+        return $this->client->getInstructions();
+    }
+
+    public function ping(): void
+    {
+        $this->call('ping', fn () => $this->client->ping());
+    }
+
+    public function listTools(?string $cursor = null): ListToolsResult
+    {
+        return $this->call('tools/list', fn (): ListToolsResult => $this->client->listTools($cursor));
+    }
+
+    public function getTools(): array
+    {
+        return $this->paginate(fn (?string $cursor): ListToolsResult => $this->listTools($cursor), 'tools');
+    }
+
+    public function callTool(string $name, array $arguments = [], ?callable $onProgress = null): CallToolResult
+    {
+        return $this->call('tools/call', fn (): CallToolResult => $this->client->callTool($name, $arguments, $onProgress));
+    }
+
+    public function listResources(?string $cursor = null): ListResourcesResult
+    {
+        return $this->call('resources/list', fn (): ListResourcesResult => $this->client->listResources($cursor));
+    }
+
+    public function getResources(): array
+    {
+        return $this->paginate(fn (?string $cursor): ListResourcesResult => $this->listResources($cursor), 'resources');
+    }
+
+    public function readResource(string $uri, ?callable $onProgress = null): ReadResourceResult
+    {
+        return $this->call('resources/read', fn (): ReadResourceResult => $this->client->readResource($uri, $onProgress));
+    }
+
+    public function listResourceTemplates(?string $cursor = null): ListResourceTemplatesResult
+    {
+        return $this->call('resources/templates/list', fn (): ListResourceTemplatesResult => $this->client->listResourceTemplates($cursor));
+    }
+
+    public function getResourceTemplates(): array
+    {
+        return $this->paginate(fn (?string $cursor): ListResourceTemplatesResult => $this->listResourceTemplates($cursor), 'resourceTemplates');
+    }
+
+    public function listPrompts(?string $cursor = null): ListPromptsResult
+    {
+        return $this->call('prompts/list', fn (): ListPromptsResult => $this->client->listPrompts($cursor));
+    }
+
+    public function getPrompts(): array
+    {
+        return $this->paginate(fn (?string $cursor): ListPromptsResult => $this->listPrompts($cursor), 'prompts');
+    }
+
+    public function getPrompt(string $name, array $arguments = [], ?callable $onProgress = null): GetPromptResult
+    {
+        return $this->call('prompts/get', fn (): GetPromptResult => $this->client->getPrompt($name, $arguments, $onProgress));
+    }
+
+    public function setLoggingLevel(LoggingLevel $level): void
+    {
+        $this->call('logging/setLevel', fn () => $this->client->setLoggingLevel($level));
+    }
+
+    /**
+     * @template T of ListToolsResult|ListResourcesResult|ListResourceTemplatesResult|ListPromptsResult
+     *
+     * @param callable(?string): T $page
+     *
+     * @return list<mixed>
+     */
+    private function paginate(callable $page, string $property): array
+    {
+        $items = [];
+        $cursor = null;
+
+        do {
+            $result = $page($cursor);
+            foreach ($result->{$property} as $item) {
+                $items[] = $item;
+            }
+            $cursor = $result->nextCursor;
+        } while (null !== $cursor);
+
+        return $items;
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(): T $request
+     *
+     * @return T
+     */
+    private function call(string $operation, callable $request): mixed
+    {
+        $this->connect();
+
+        try {
+            return $request();
+        } catch (McpExceptionInterface|\JsonException $e) {
+            throw RemoteCallException::failed($this->clientName, $this->name, $operation, $e);
+        }
+    }
+
+    private function connect(): void
+    {
+        if ($this->connected) {
+            return;
+        }
+
+        try {
+            $this->client->connect($this->transport);
+        } catch (McpExceptionInterface $e) {
+            throw ConnectionException::connectFailed($this->clientName, $this->name, $e);
+        }
+
+        $this->connected = true;
+    }
+}

--- a/src/mcp-bundle/src/Client/ServerConnectionInterface.php
+++ b/src/mcp-bundle/src/Client/ServerConnectionInterface.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Client;
+
+use Mcp\Schema\Enum\LoggingLevel;
+use Mcp\Schema\Implementation;
+use Mcp\Schema\Prompt;
+use Mcp\Schema\ResourceDefinition;
+use Mcp\Schema\ResourceTemplate;
+use Mcp\Schema\Result\CallToolResult;
+use Mcp\Schema\Result\GetPromptResult;
+use Mcp\Schema\Result\ListPromptsResult;
+use Mcp\Schema\Result\ListResourcesResult;
+use Mcp\Schema\Result\ListResourceTemplatesResult;
+use Mcp\Schema\Result\ListToolsResult;
+use Mcp\Schema\Result\ReadResourceResult;
+use Mcp\Schema\Tool;
+
+/**
+ * One connection of a configured MCP client to one remote MCP server.
+ *
+ * The connection is opened on first use and closed on kernel reset, so callers never deal with
+ * transports or with the SDK's explicit connect/disconnect lifecycle.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+interface ServerConnectionInterface
+{
+    /**
+     * The configured name of the remote server (mcp.clients.<client>.servers.<name>).
+     */
+    public function getName(): string;
+
+    /**
+     * The configured name of the client owning this connection (mcp.clients.<name>).
+     */
+    public function getClientName(): string;
+
+    public function isConnected(): bool;
+
+    /**
+     * Closes the connection. Idempotent, and reconnects transparently on the next call.
+     */
+    public function disconnect(): void;
+
+    public function getServerInfo(): ?Implementation;
+
+    public function getInstructions(): ?string;
+
+    public function ping(): void;
+
+    public function listTools(?string $cursor = null): ListToolsResult;
+
+    /**
+     * Every tool the server advertises, following pagination to its end.
+     *
+     * @return list<Tool>
+     */
+    public function getTools(): array;
+
+    /**
+     * @param array<string, mixed>                                                    $arguments
+     * @param (callable(float $progress, ?float $total, ?string $message): void)|null $onProgress
+     */
+    public function callTool(string $name, array $arguments = [], ?callable $onProgress = null): CallToolResult;
+
+    public function listResources(?string $cursor = null): ListResourcesResult;
+
+    /**
+     * @return list<ResourceDefinition>
+     */
+    public function getResources(): array;
+
+    /**
+     * @param (callable(float $progress, ?float $total, ?string $message): void)|null $onProgress
+     */
+    public function readResource(string $uri, ?callable $onProgress = null): ReadResourceResult;
+
+    public function listResourceTemplates(?string $cursor = null): ListResourceTemplatesResult;
+
+    /**
+     * @return list<ResourceTemplate>
+     */
+    public function getResourceTemplates(): array;
+
+    public function listPrompts(?string $cursor = null): ListPromptsResult;
+
+    /**
+     * @return list<Prompt>
+     */
+    public function getPrompts(): array;
+
+    /**
+     * @param array<string, string>                                                   $arguments
+     * @param (callable(float $progress, ?float $total, ?string $message): void)|null $onProgress
+     */
+    public function getPrompt(string $name, array $arguments = [], ?callable $onProgress = null): GetPromptResult;
+
+    public function setLoggingLevel(LoggingLevel $level): void;
+}

--- a/src/mcp-bundle/src/Client/ServerLogForwarder.php
+++ b/src/mcp-bundle/src/Client/ServerLogForwarder.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Client;
+
+use Mcp\Schema\Notification\LoggingMessageNotification;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Writes the logging notifications a remote MCP server sends to the application's "mcp" channel.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ServerLogForwarder
+{
+    public function __construct(
+        private readonly string $clientName,
+        private readonly string $serverName,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function __invoke(LoggingMessageNotification $notification): void
+    {
+        $this->logger->log($notification->level->value, $this->format($notification->data), [
+            'mcp_client' => $this->clientName,
+            'mcp_server' => $this->serverName,
+            'mcp_logger' => $notification->logger,
+        ]);
+    }
+
+    private function format(mixed $data): string
+    {
+        if (\is_string($data)) {
+            return $data;
+        }
+
+        return json_encode($data, \JSON_UNESCAPED_SLASHES | \JSON_PARTIAL_OUTPUT_ON_ERROR) ?: '';
+    }
+}

--- a/src/mcp-bundle/src/Client/TransportFactory.php
+++ b/src/mcp-bundle/src/Client/TransportFactory.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Client;
+
+use Http\Discovery\Exception\NotFoundException;
+use Mcp\Client\Transport\HttpTransport;
+use Mcp\Client\Transport\StdioTransport;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\AI\McpBundle\Exception\LogicException;
+use Symfony\AI\McpBundle\Exception\RuntimeException;
+
+/**
+ * Builds the SDK client transports from configuration.
+ *
+ * Three things cannot be decided when the container is compiled: an empty `env` must reach
+ * `proc_open()` as `null` (an empty environment strips `PATH`, and `npx` then fails to start), the
+ * inherited environment is only known at runtime, and the SDK's buffer sizes are non-nullable, so an
+ * unset option has to select the shorter constructor call rather than pass `null`.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class TransportFactory
+{
+    /**
+     * @param list<string>          $command the program followed by its arguments
+     * @param array<string, string> $env
+     */
+    public static function stdio(array $command, ?string $cwd, array $env, bool $inheritEnv, ?int $maxBufferSize, ?LoggerInterface $logger): StdioTransport
+    {
+        $program = array_shift($command);
+        if (null === $program) {
+            throw new LogicException('An MCP client server configured with the "stdio" transport needs a "command".');
+        }
+
+        $environment = null;
+        if ([] !== $env) {
+            $environment = $inheritEnv ? [...getenv(), ...$env] : $env;
+        }
+
+        if (null === $maxBufferSize) {
+            return new StdioTransport($program, $command, $cwd, $environment, $logger);
+        }
+
+        return new StdioTransport($program, $command, $cwd, $environment, $logger, $maxBufferSize);
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public static function http(
+        string $endpoint,
+        array $headers,
+        ?ClientInterface $httpClient,
+        ?RequestFactoryInterface $requestFactory,
+        ?StreamFactoryInterface $streamFactory,
+        ?LoggerInterface $logger,
+        ?int $maxSseBufferBytes,
+    ): HttpTransport {
+        try {
+            if (null === $maxSseBufferBytes) {
+                return new HttpTransport($endpoint, $headers, $httpClient, $requestFactory, $streamFactory, $logger);
+            }
+
+            return new HttpTransport($endpoint, $headers, $httpClient, $requestFactory, $streamFactory, $logger, $maxSseBufferBytes);
+        } catch (NotFoundException $e) {
+            // Without a PSR-18 client the SDK falls back to discovery, whose failure message says
+            // nothing about MCP.
+            throw new RuntimeException(\sprintf('No PSR-18 HTTP client is available to reach the MCP server at "%s". Run "composer require symfony/http-client" or point the "http_client" option at your own PSR-18 service.', $endpoint), 0, $e);
+        }
+    }
+}

--- a/src/mcp-bundle/src/Command/DebugCommand.php
+++ b/src/mcp-bundle/src/Command/DebugCommand.php
@@ -17,25 +17,42 @@ use Mcp\Schema\ResourceDefinition;
 use Mcp\Schema\ResourceTemplate;
 use Mcp\Schema\Tool;
 use Mcp\Server\Builder;
+use Symfony\AI\McpBundle\Client\McpClientInterface;
+use Symfony\AI\McpBundle\Client\ServerConnectionInterface;
+use Symfony\AI\McpBundle\Exception\ExceptionInterface;
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Contracts\Service\ServiceProviderInterface;
 
 /**
- * Lists the MCP capabilities (tools, prompts, resources, resource templates) registered with the server.
+ * Shows both sides of the bundle: what the configured servers expose, and what the configured
+ * clients reach.
  *
  * Useful to verify that an attributed class was actually picked up: elements are registered from
- * container services, so a class that is not a registered (autoconfigured) service will not show up.
+ * container services and have to be listed by a server, so a class that is neither a registered
+ * (autoconfigured) service nor matched by a capability list will not show up.
+ *
+ * Only the client modes open a connection; everything else reads the compiled container.
  *
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-#[AsCommand('debug:mcp', 'Display the MCP capabilities registered with the server')]
+#[AsCommand('debug:mcp', 'Display the configured MCP servers and clients')]
 final class DebugCommand
 {
+    /**
+     * @param ServiceProviderInterface<Builder>            $builders
+     * @param ServiceProviderInterface<RegistryInterface>  $registries
+     * @param ServiceProviderInterface<McpClientInterface> $clients
+     * @param array<string, list<string>>                  $unassigned kind => service ids no server exposes
+     */
     public function __construct(
-        private readonly Builder $builder,
-        private readonly RegistryInterface $registry,
+        private readonly ServiceProviderInterface $builders,
+        private readonly ServiceProviderInterface $registries,
+        private readonly ServiceProviderInterface $clients,
+        private readonly array $unassigned = [],
     ) {
     }
 
@@ -43,36 +60,316 @@ final class DebugCommand
         SymfonyStyle $io,
         #[Argument(description: 'A tool/prompt name, resource URI, or resource template to show details for')]
         ?string $name = null,
+        #[Option(description: 'Restrict the output to one server. With --client, the remote server to connect to.', suggestedValues: [self::class, 'suggestServers'])]
+        ?string $server = null,
+        #[Option(description: 'Connect a configured client (mcp.clients.<name>) and list what its server advertises', suggestedValues: [self::class, 'suggestClients'])]
+        ?string $client = null,
+        #[Option(description: 'List the configured clients and their servers without connecting to any')]
+        bool $clients = false,
     ): int {
-        // The registry is populated by the loaders when the server is built.
-        $this->builder->build();
-
-        if (null !== $name) {
-            return $this->describeElement($io, $name);
+        if (null !== $client) {
+            return $this->describeConnection($io, $client, $server);
         }
 
-        $tools = iterator_to_array($this->registry->getTools());
-        $prompts = iterator_to_array($this->registry->getPrompts());
-        $resources = iterator_to_array($this->registry->getResources());
-        $resourceTemplates = iterator_to_array($this->registry->getResourceTemplates());
+        if ($clients) {
+            return $this->listClients($io);
+        }
+
+        $names = $this->getServerNames();
+
+        if (null !== $server) {
+            if (!$this->registries->has($server)) {
+                $io->error(\sprintf('No MCP server named "%s" is configured.%s', $server, [] === $names ? '' : \sprintf(' Available: %s.', implode(', ', $names))));
+
+                return Command::INVALID;
+            }
+
+            $names = [$server];
+        }
+
+        if ([] === $names) {
+            $io->warning('No MCP server is configured. Declare one under "mcp.servers" in config/packages/mcp.yaml.');
+
+            return Command::SUCCESS;
+        }
+
+        $found = false;
+        foreach ($names as $current) {
+            // The registry is populated by the loaders when the server is built.
+            $this->builders->get($current)->build();
+            $registry = $this->registries->get($current);
+
+            if (null !== $name) {
+                $found = $this->describeElement($io, $registry, $current, $name) || $found;
+
+                continue;
+            }
+
+            if (1 < \count($names) || null !== $server) {
+                $io->title(\sprintf('Server "%s"', $current));
+            }
+
+            $this->listElements($io, $registry);
+        }
+
+        if (null !== $name && !$found) {
+            $io->error(\sprintf('No MCP capability named "%s" is registered. Run "debug:mcp" without arguments to list all.', $name));
+
+            return Command::FAILURE;
+        }
+
+        if (null === $name) {
+            $this->reportUnassigned($io);
+            $this->summarizeClients($io);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function suggestServers(): array
+    {
+        return $this->getServerNames();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function suggestClients(): array
+    {
+        return $this->getClientNames();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getServerNames(): array
+    {
+        return array_keys($this->registries->getProvidedServices());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getClientNames(): array
+    {
+        return array_keys($this->clients->getProvidedServices());
+    }
+
+    /**
+     * Container introspection only: answering "which clients do I have" must not spawn a stdio
+     * child process or open an HTTP session.
+     */
+    private function listClients(SymfonyStyle $io): int
+    {
+        $names = $this->getClientNames();
+
+        if ([] === $names) {
+            $io->warning('No MCP client is configured. Declare one under "mcp.clients" in config/packages/mcp.yaml.');
+
+            return Command::SUCCESS;
+        }
+
+        $io->title('Configured MCP clients');
+        $io->table(['Client', 'Servers'], array_map(
+            fn (string $name): array => [$name, implode(', ', $this->clients->get($name)->getServerNames())],
+            $names,
+        ));
+        $io->text('Run "debug:mcp --client=<client> --server=<server>" to connect and list what a server advertises.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Mentioned after the server listing so one command still shows both sides of the bundle.
+     */
+    private function summarizeClients(SymfonyStyle $io): void
+    {
+        $names = $this->getClientNames();
+        if ([] === $names) {
+            return;
+        }
+
+        $io->section(\sprintf('Clients (%d)', \count($names)));
+        $io->table(['Client', 'Servers'], array_map(
+            fn (string $name): array => [$name, implode(', ', $this->clients->get($name)->getServerNames())],
+            $names,
+        ));
+        $io->text('Run "debug:mcp --client=<client>" to connect and list what a server advertises.');
+    }
+
+    private function describeConnection(SymfonyStyle $io, string $client, ?string $server): int
+    {
+        $names = $this->getClientNames();
+
+        if (!$this->clients->has($client)) {
+            $io->error(\sprintf('No MCP client named "%s" is configured.%s', $client, [] === $names ? '' : \sprintf(' Available: %s.', implode(', ', $names))));
+
+            return Command::INVALID;
+        }
+
+        $mcpClient = $this->clients->get($client);
+        $servers = $mcpClient->getServerNames();
+
+        if (null === $server) {
+            if (1 !== \count($servers)) {
+                $io->error(\sprintf('The MCP client "%s" connects to several servers, name the one to inspect with --server: %s.', $client, implode(', ', $servers)));
+
+                return Command::INVALID;
+            }
+
+            $server = $servers[0];
+        }
+
+        if (!$mcpClient->has($server)) {
+            $io->error(\sprintf('The MCP client "%s" has no server named "%s". Configured: %s.', $client, $server, implode(', ', $servers)));
+
+            return Command::INVALID;
+        }
+
+        return $this->describeRemote($io, $mcpClient->get($server));
+    }
+
+    private function describeRemote(SymfonyStyle $io, ServerConnectionInterface $connection): int
+    {
+        $io->title(\sprintf('MCP client "%s" → server "%s"', $connection->getClientName(), $connection->getName()));
+
+        try {
+            // The connection opens on this first call; there is no connect() to forget.
+            $info = $connection->getServerInfo();
+
+            if (null !== $info) {
+                $io->definitionList(
+                    ['Name' => $info->name],
+                    ['Version' => $info->version],
+                );
+            }
+
+            if (null !== ($instructions = $connection->getInstructions())) {
+                $io->section('Instructions');
+                $io->writeln($instructions);
+            }
+
+            $this->renderRemoteTools($io, $connection->getTools());
+            $this->renderRemotePrompts($io, $connection->getPrompts());
+            $this->renderRemoteResources($io, $connection->getResources(), $connection->getResourceTemplates());
+        } catch (ExceptionInterface $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        } finally {
+            // Always terminates a stdio child process, including on failure.
+            $connection->disconnect();
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param list<Tool> $tools
+     */
+    private function renderRemoteTools(SymfonyStyle $io, array $tools): void
+    {
+        $io->section(\sprintf('Tools (%d)', \count($tools)));
+
+        if ([] === $tools) {
+            $io->writeln('<comment>No tools advertised by the server.</comment>');
+
+            return;
+        }
+
+        $io->table(['Name', 'Description', 'Required arguments'], array_map(fn (Tool $tool): array => [
+            $tool->name,
+            $this->truncate($tool->description),
+            implode(', ', $tool->inputSchema['required'] ?? []),
+        ], $tools));
+    }
+
+    /**
+     * @param list<Prompt> $prompts
+     */
+    private function renderRemotePrompts(SymfonyStyle $io, array $prompts): void
+    {
+        if ([] === $prompts) {
+            return;
+        }
+
+        $io->section(\sprintf('Prompts (%d)', \count($prompts)));
+        $io->table(['Name', 'Description', 'Arguments'], array_map(fn (Prompt $prompt): array => [
+            $prompt->name,
+            $this->truncate($prompt->description),
+            implode(', ', array_map(
+                static fn ($argument): string => $argument->name.($argument->required ? '' : '?'),
+                $prompt->arguments ?? [],
+            )),
+        ], $prompts));
+    }
+
+    /**
+     * @param list<ResourceDefinition> $resources
+     * @param list<ResourceTemplate>   $templates
+     */
+    private function renderRemoteResources(SymfonyStyle $io, array $resources, array $templates): void
+    {
+        if ([] !== $resources) {
+            $io->section(\sprintf('Resources (%d)', \count($resources)));
+            $io->table(['URI', 'Name', 'MIME Type'], array_map(static fn (ResourceDefinition $resource): array => [
+                $resource->uri,
+                $resource->name,
+                $resource->mimeType ?? '',
+            ], $resources));
+        }
+
+        if ([] === $templates) {
+            return;
+        }
+
+        $io->section(\sprintf('Resource Templates (%d)', \count($templates)));
+        $io->table(['URI Template', 'Name', 'MIME Type'], array_map(static fn (ResourceTemplate $template): array => [
+            $template->uriTemplate,
+            $template->name,
+            $template->mimeType ?? '',
+        ], $templates));
+    }
+
+    private function reportUnassigned(SymfonyStyle $io): void
+    {
+        $ids = array_merge(...array_values($this->unassigned));
+        if ([] === $ids) {
+            return;
+        }
+
+        $io->section('Not exposed by any server');
+        $io->text('These services carry an MCP attribute but no server lists them. Add them to a server\'s element list to expose them.');
+        $io->listing(array_values(array_unique($ids)));
+    }
+
+    private function listElements(SymfonyStyle $io, RegistryInterface $registry): void
+    {
+        $tools = iterator_to_array($registry->getTools());
+        $prompts = iterator_to_array($registry->getPrompts());
+        $resources = iterator_to_array($registry->getResources());
+        $resourceTemplates = iterator_to_array($registry->getResourceTemplates());
 
         if ([] === $tools && [] === $prompts && [] === $resources && [] === $resourceTemplates) {
             $io->warning('No MCP capabilities are registered.');
             $io->text([
                 'Capabilities are registered from container services carrying one of the MCP attributes',
-                '(#[McpTool], #[McpPrompt], #[McpResource], #[McpResourceTemplate]).',
-                'Make sure the classes are registered as services with autoconfiguration enabled',
-                'and not excluded from service registration in config/services.yaml.',
+                '(#[McpTool], #[McpPrompt], #[McpResource], #[McpResourceTemplate]) and listed by a server',
+                'under "mcp.servers.<name>.tools" and friends. Make sure the classes are registered as',
+                'services with autoconfiguration enabled and matched by one of those lists.',
             ]);
 
-            return Command::SUCCESS;
+            return;
         }
 
         if ([] !== $tools) {
             $io->section(\sprintf('Tools (%d)', \count($tools)));
             $io->table(['Name', 'Handler', 'Description'], array_map(fn (Tool $tool): array => [
                 $tool->name,
-                $this->formatHandler($this->registry->getTool($tool->name)->handler),
+                $this->formatHandler($registry->getTool($tool->name)->handler),
                 $this->truncate($tool->description),
             ], $tools));
         }
@@ -81,7 +378,7 @@ final class DebugCommand
             $io->section(\sprintf('Prompts (%d)', \count($prompts)));
             $io->table(['Name', 'Handler', 'Description'], array_map(fn (Prompt $prompt): array => [
                 $prompt->name,
-                $this->formatHandler($this->registry->getPrompt($prompt->name)->handler),
+                $this->formatHandler($registry->getPrompt($prompt->name)->handler),
                 $this->truncate($prompt->description),
             ], $prompts));
         }
@@ -91,7 +388,7 @@ final class DebugCommand
             $io->table(['URI', 'Name', 'Handler', 'MIME Type'], array_map(fn (ResourceDefinition $resource): array => [
                 $resource->uri,
                 $resource->name,
-                $this->formatHandler($this->registry->getResource($resource->uri, false)->handler),
+                $this->formatHandler($registry->getResource($resource->uri, false)->handler),
                 $resource->mimeType ?? '',
             ], $resources));
         }
@@ -101,24 +398,22 @@ final class DebugCommand
             $io->table(['URI Template', 'Name', 'Handler', 'MIME Type'], array_map(fn (ResourceTemplate $template): array => [
                 $template->uriTemplate,
                 $template->name,
-                $this->formatHandler($this->registry->getResourceTemplate($template->uriTemplate)->handler),
+                $this->formatHandler($registry->getResourceTemplate($template->uriTemplate)->handler),
                 $template->mimeType ?? '',
             ], $resourceTemplates));
         }
-
-        return Command::SUCCESS;
     }
 
-    private function describeElement(SymfonyStyle $io, string $name): int
+    private function describeElement(SymfonyStyle $io, RegistryInterface $registry, string $server, string $name): bool
     {
-        foreach ($this->registry->getTools() as $tool) {
+        foreach ($registry->getTools() as $tool) {
             if ($tool->name === $name) {
-                $io->title(\sprintf('Tool "%s"', $name));
+                $io->title(\sprintf('Tool "%s" on server "%s"', $name, $server));
                 $io->definitionList(
                     ['Name' => $tool->name],
                     ['Title' => $tool->title ?? '-'],
                     ['Description' => $tool->description ?? '-'],
-                    ['Handler' => $this->formatHandler($this->registry->getTool($name)->handler)],
+                    ['Handler' => $this->formatHandler($registry->getTool($name)->handler)],
                 );
                 $io->section('Input Schema');
                 $io->writeln(json_encode($tool->inputSchema, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
@@ -127,61 +422,59 @@ final class DebugCommand
                     $io->writeln(json_encode($tool->outputSchema, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
                 }
 
-                return Command::SUCCESS;
+                return true;
             }
         }
 
-        foreach ($this->registry->getPrompts() as $prompt) {
+        foreach ($registry->getPrompts() as $prompt) {
             if ($prompt->name === $name) {
-                $io->title(\sprintf('Prompt "%s"', $name));
+                $io->title(\sprintf('Prompt "%s" on server "%s"', $name, $server));
                 $io->definitionList(
                     ['Name' => $prompt->name],
                     ['Title' => $prompt->title ?? '-'],
                     ['Description' => $prompt->description ?? '-'],
-                    ['Handler' => $this->formatHandler($this->registry->getPrompt($name)->handler)],
+                    ['Handler' => $this->formatHandler($registry->getPrompt($name)->handler)],
                     ['Arguments' => implode(', ', array_map(
                         static fn ($argument): string => $argument->name.($argument->required ? '' : '?'),
                         $prompt->arguments ?? [],
                     )) ?: '-'],
                 );
 
-                return Command::SUCCESS;
+                return true;
             }
         }
 
-        foreach ($this->registry->getResources() as $resource) {
+        foreach ($registry->getResources() as $resource) {
             if ($resource->uri === $name || $resource->name === $name) {
-                $io->title(\sprintf('Resource "%s"', $resource->uri));
+                $io->title(\sprintf('Resource "%s" on server "%s"', $resource->uri, $server));
                 $io->definitionList(
                     ['URI' => $resource->uri],
                     ['Name' => $resource->name],
                     ['Description' => $resource->description ?? '-'],
                     ['MIME Type' => $resource->mimeType ?? '-'],
-                    ['Handler' => $this->formatHandler($this->registry->getResource($resource->uri, false)->handler)],
+                    ['Handler' => $this->formatHandler($registry->getResource($resource->uri, false)->handler)],
                 );
 
-                return Command::SUCCESS;
+                return true;
             }
         }
 
-        foreach ($this->registry->getResourceTemplates() as $template) {
+        foreach ($registry->getResourceTemplates() as $template) {
             if ($template->uriTemplate === $name || $template->name === $name) {
-                $io->title(\sprintf('Resource Template "%s"', $template->uriTemplate));
+                $io->title(\sprintf('Resource Template "%s" on server "%s"', $template->uriTemplate, $server));
                 $io->definitionList(
                     ['URI Template' => $template->uriTemplate],
                     ['Name' => $template->name],
                     ['Description' => $template->description ?? '-'],
                     ['MIME Type' => $template->mimeType ?? '-'],
-                    ['Handler' => $this->formatHandler($this->registry->getResourceTemplate($template->uriTemplate)->handler)],
+                    ['Handler' => $this->formatHandler($registry->getResourceTemplate($template->uriTemplate)->handler)],
                 );
 
-                return Command::SUCCESS;
+                return true;
             }
         }
 
-        $io->error(\sprintf('No MCP capability named "%s" is registered. Run "debug:mcp" without arguments to list all.', $name));
-
-        return Command::FAILURE;
+        return false;
     }
 
     /**

--- a/src/mcp-bundle/src/Command/McpCommand.php
+++ b/src/mcp-bundle/src/Command/McpCommand.php
@@ -14,26 +14,71 @@ namespace Symfony\AI\McpBundle\Command;
 use Mcp\Server;
 use Mcp\Server\Transport\StdioTransport;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Contracts\Service\ServiceProviderInterface;
 
-#[AsCommand('mcp:server', 'Starts an MCP server')]
-class McpCommand extends Command
+/**
+ * Runs one configured MCP server over STDIO.
+ *
+ * The transport owns the process' STDIN and STDOUT, so exactly one server can be served per
+ * invocation — hence a server argument rather than one command per server.
+ */
+#[AsCommand('mcp:server', 'Starts an MCP server over STDIO')]
+final class McpCommand
 {
+    /**
+     * @param ServiceProviderInterface<Server> $servers the servers with the STDIO transport enabled
+     */
     public function __construct(
-        private readonly Server $server,
+        private readonly ServiceProviderInterface $servers,
         private readonly ?LoggerInterface $logger = null,
     ) {
-        parent::__construct();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $transport = new StdioTransport(logger: $this->logger);
-        $this->server->run($transport);
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Argument(description: 'Name of the server to run (mcp.servers.<name>)', suggestedValues: [self::class, 'suggestServers'])]
+        ?string $name = null,
+    ): int {
+        $names = $this->getServerNames();
+
+        if (null === $name) {
+            if (1 !== \count($names)) {
+                $io->error(\sprintf('Several MCP servers expose the STDIO transport, name the one to run: %s.', implode(', ', $names)));
+
+                return Command::INVALID;
+            }
+
+            $name = $names[0];
+        }
+
+        if (!$this->servers->has($name)) {
+            $io->error(\sprintf('No MCP server named "%s" exposes the STDIO transport.%s', $name, [] === $names ? '' : \sprintf(' Available: %s.', implode(', ', $names))));
+
+            return Command::INVALID;
+        }
+
+        $this->servers->get($name)->run(new StdioTransport(logger: $this->logger));
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function suggestServers(): array
+    {
+        return $this->getServerNames();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getServerNames(): array
+    {
+        return array_keys($this->servers->getProvidedServices());
     }
 }

--- a/src/mcp-bundle/src/DependencyInjection/ElementMatcher.php
+++ b/src/mcp-bundle/src/DependencyInjection/ElementMatcher.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\DependencyInjection;
+
+/**
+ * Matches MCP elements against the patterns a server lists for a kind of element.
+ *
+ * A pattern is either the "*" wildcard, an exact service id, an exact class name, or a
+ * namespace prefix (recognized by its trailing backslash). Both the service id and the
+ * resolved class are checked, because MCP elements can be registered under a service id
+ * that is not their class name.
+ *
+ * Which patterns actually matched something is recorded so {@see McpPass} can report a
+ * configured pattern that matches nothing — practically always a typo.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ElementMatcher
+{
+    public const WILDCARD = '*';
+
+    /**
+     * @var array<string, array<string, true>> server => pattern => true
+     */
+    private array $used = [];
+
+    /**
+     * @param array<string, array<string, list<string>>> $servers server => kind => patterns
+     */
+    public function __construct(
+        private readonly array $servers,
+    ) {
+    }
+
+    /**
+     * Returns the names of the servers exposing the given element.
+     *
+     * @param class-string $class
+     *
+     * @return list<string>
+     */
+    public function match(string $kind, string $serviceId, string $class): array
+    {
+        $servers = [];
+
+        foreach ($this->servers as $server => $kinds) {
+            foreach ($kinds[$kind] ?? [] as $pattern) {
+                if (!$this->matches($pattern, $serviceId, $class)) {
+                    continue;
+                }
+
+                $this->used[$server][$pattern] = true;
+                $servers[] = $server;
+
+                break;
+            }
+        }
+
+        return $servers;
+    }
+
+    /**
+     * Returns the configured patterns that did not match any element at all, as a list of
+     * `[server, pattern]` pairs.
+     *
+     * A pattern counts as used as soon as it matched on any kind of the server, not on the
+     * kind it is listed under. The check exists to catch a typo, and a pattern that matched
+     * something is not one: "registry: ['App\\Mcp\\']" deliberately hands the same prefix to
+     * every kind, and few applications carry all five.
+     *
+     * The wildcard is exempt too: the configuration already enforces that a server lists
+     * something, and "*" legitimately matches nothing when an application has no element of
+     * that kind yet.
+     *
+     * @return list<array{string, string}>
+     */
+    public function getUnusedPatterns(): array
+    {
+        $unused = [];
+
+        foreach ($this->servers as $server => $kinds) {
+            foreach (array_unique(array_merge(...array_values($kinds))) as $pattern) {
+                if (self::WILDCARD === $pattern || isset($this->used[$server][$pattern])) {
+                    continue;
+                }
+
+                $unused[] = [$server, $pattern];
+            }
+        }
+
+        return $unused;
+    }
+
+    private function matches(string $pattern, string $serviceId, string $class): bool
+    {
+        if (self::WILDCARD === $pattern) {
+            return true;
+        }
+
+        if ($pattern === $serviceId || $pattern === $class) {
+            return true;
+        }
+
+        if (!str_ends_with($pattern, '\\')) {
+            return false;
+        }
+
+        return str_starts_with($class, $pattern) || str_starts_with($serviceId, $pattern);
+    }
+}

--- a/src/mcp-bundle/src/DependencyInjection/McpAppPass.php
+++ b/src/mcp-bundle/src/DependencyInjection/McpAppPass.php
@@ -35,82 +35,105 @@ use Symfony\Component\DependencyInjection\Reference;
  * when the app declares a handler method — registers the linked tool with its `ui` link auto-set to
  * this app.
  *
- * Template-based apps share a single {@see McpAppResourceRenderer} service (the SDK resolves a manual
- * handler's instance by its class name, so a per-app service is not possible); the renderer dispatches
- * on the requested URI. Must run BEFORE {@see McpPass}: the services it tags `mcp.tool`/`mcp.resource`
- * here are what McpPass collects into the handler service locator.
+ * Which servers expose an app is decided by their `apps` configuration list, matched the same way as
+ * every other element (see {@see ElementMatcher}), so the same app can back several servers.
+ *
+ * Template-based apps share one {@see McpAppResourceRenderer} service per server (the SDK resolves a
+ * manual handler's instance by its class name, so a per-app service is not possible); the renderer
+ * dispatches on the requested URI. Must run BEFORE {@see McpPass}: the handler references it records in
+ * the `mcp.servers.app_handlers` parameter are what McpPass adds to each server's service locator.
  */
 final class McpAppPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('mcp.server.builder')) {
+        /** @var array<string, array<string, list<string>>> $servers */
+        $servers = $container->hasParameter('mcp.servers.elements') ? $container->getParameter('mcp.servers.elements') : [];
+        if ([] === $servers) {
             return;
         }
 
-        $enabledFlag = $container->hasParameter('mcp.apps.enabled')
-            ? $container->getParameter('mcp.apps.enabled')
-            : null;
-
-        // Hard-disabled: register nothing, even if apps are present.
-        if (false === $enabledFlag) {
-            return;
-        }
-
+        $matcher = new ElementMatcher($servers);
         $appServiceIds = array_keys($container->findTaggedServiceIds('mcp.app'));
-        $builder = $container->getDefinition('mcp.server.builder');
 
-        if ((true === $enabledFlag || [] !== $appServiceIds) && !$this->extensionAlreadyEnabled($builder)) {
-            $builder->addMethodCall('enableExtension', [new Definition(McpApps::class)]);
-        }
-
-        $templateApps = [];
-        $toolTemplates = [];
-
+        $appsPerServer = [];
         foreach ($appServiceIds as $serviceId) {
             $class = $this->resolveClass($container, $serviceId);
-            $app = $this->readAttribute($class, $serviceId);
-
-            $uri = $app->uri ?? 'ui://'.$this->kebab($class);
-            if (!str_starts_with($uri, McpApps::URI_SCHEME.'://')) {
-                throw new LogicException(\sprintf('The MCP App "%s" must use a "%s://" URI, got "%s".', $class, McpApps::URI_SCHEME, $uri));
+            foreach ($matcher->match('apps', $serviceId, $class) as $server) {
+                $appsPerServer[$server][] = $serviceId;
             }
-            $slug = substr($uri, \strlen(McpApps::URI_SCHEME.'://'));
-
-            $handler = $this->resolveResourceHandler($container, $serviceId, $class, $app, $uri, $templateApps);
-
-            $descriptorMarker = (new Definition(\stdClass::class))->setFactory([McpApps::class, 'resourceMarker']);
-
-            $builder->addMethodCall('addResource', [
-                $handler,
-                $uri,
-                $slug, // resource name, derived from the URI ($name is the tool's)
-                $app->title,
-                null, // resource description (the model-facing description is the tool's)
-                McpApps::MIME_TYPE,
-                null, // size
-                null, // annotations
-                null, // icons
-                ['ui' => $descriptorMarker],
-            ]);
-
-            $this->registerTool($container, $serviceId, $class, $app, $uri, $slug, $builder, $toolTemplates);
-            $this->registerAppToolMethods($container, $serviceId, $class, $app, $uri, $builder, $toolTemplates);
         }
 
-        if ([] !== $templateApps) {
-            $container->register(McpAppResourceRenderer::class, McpAppResourceRenderer::class)
-                ->setArguments([new Reference(McpAppRenderer::SERVICE_ID), $templateApps])
-                ->addTag('mcp.resource');
+        $handlers = [];
+        $allToolTemplates = [];
+
+        foreach ($appsPerServer as $server => $serviceIds) {
+            $builder = $container->getDefinition('mcp.server.'.$server.'.builder');
+
+            if (!$this->extensionAlreadyEnabled($builder)) {
+                $builder->addMethodCall('enableExtension', [new Definition(McpApps::class)]);
+            }
+
+            $templateApps = [];
+            $toolTemplates = [];
+
+            foreach ($serviceIds as $serviceId) {
+                $class = $this->resolveClass($container, $serviceId);
+                $app = $this->readAttribute($class, $serviceId);
+
+                $uri = $app->uri ?? 'ui://'.$this->kebab($class);
+                if (!str_starts_with($uri, McpApps::URI_SCHEME.'://')) {
+                    throw new LogicException(\sprintf('The MCP App "%s" must use a "%s://" URI, got "%s".', $class, McpApps::URI_SCHEME, $uri));
+                }
+                $slug = substr($uri, \strlen(McpApps::URI_SCHEME.'://'));
+
+                $handler = $this->resolveResourceHandler($container, $serviceId, $class, $app, $uri, $templateApps);
+
+                $descriptorMarker = (new Definition(\stdClass::class))->setFactory([McpApps::class, 'resourceMarker']);
+
+                $builder->addMethodCall('addResource', [
+                    $handler,
+                    $uri,
+                    $slug, // resource name, derived from the URI ($name is the tool's)
+                    $app->title,
+                    null, // resource description (the model-facing description is the tool's)
+                    McpApps::MIME_TYPE,
+                    null, // size
+                    null, // annotations
+                    null, // icons
+                    ['ui' => $descriptorMarker],
+                ]);
+
+                $this->registerTool($container, $serviceId, $class, $app, $uri, $slug, $builder, $toolTemplates);
+                $this->registerAppToolMethods($container, $serviceId, $class, $app, $uri, $builder, $toolTemplates);
+
+                // App services are not matched against the "tools"/"resources" lists, so hand their
+                // handler references to McpPass explicitly for this server's locator.
+                $handlers[$server][$class] = $serviceId;
+                $handlers[$server][$serviceId] = $serviceId;
+            }
+
+            if ([] !== $templateApps) {
+                // One renderer per server: the SDK resolves a manual handler's instance by class name,
+                // and each server's locator must map that class to its own template set.
+                $rendererId = \sprintf('mcp.server.%s.app.resource_renderer', $server);
+                $container->register($rendererId, McpAppResourceRenderer::class)
+                    ->setArguments([new Reference(McpAppRenderer::SERVICE_ID), $templateApps]);
+
+                $handlers[$server][McpAppResourceRenderer::class] = $rendererId;
+            }
+
+            if ([] !== $toolTemplates && !$container->hasDefinition(McpAppRenderer::SERVICE_ID)) {
+                throw new LogicException('An MCP App tool declares a Twig template but Twig is not available. Run "composer require symfony/twig-bundle".');
+            }
+
+            $allToolTemplates[$server] = $toolTemplates;
         }
 
-        if ([] !== $toolTemplates && !$container->hasDefinition(McpAppRenderer::SERVICE_ID)) {
-            throw new LogicException('An MCP App tool declares a Twig template but Twig is not available. Run "composer require symfony/twig-bundle".');
-        }
-
-        // Consumed by McpPass to wire the McpAppReferenceHandler that renders these templates into the
-        // tool result's `html` field (keeps Twig out of the developer's tool methods).
-        $container->setParameter('mcp.apps.tool_templates', $toolTemplates);
+        // Consumed by McpPass: the handler references join each server's service locator, and the tool
+        // templates wire the McpAppReferenceHandler rendering them into the tool result's `html` field.
+        $container->setParameter('mcp.servers.app_handlers', $handlers);
+        $container->setParameter('mcp.servers.app_tool_templates', $allToolTemplates);
     }
 
     /**
@@ -125,8 +148,6 @@ final class McpAppPass implements CompilerPassInterface
     {
         // A class-level __invoke owns the full response, including its own content metadata.
         if (method_exists($class, '__invoke')) {
-            $container->getDefinition($serviceId)->addTag('mcp.resource');
-
             return [$class, '__invoke'];
         }
 
@@ -201,8 +222,6 @@ final class McpAppPass implements CompilerPassInterface
      */
     private function addTool(ContainerBuilder $container, Definition $builder, string $serviceId, string $method, string $name, ?string $title, ?string $description, string $uri, bool $appOnly, ?string $template, array &$toolTemplates): void
     {
-        $container->getDefinition($serviceId)->addTag('mcp.tool');
-
         $visibility = $appOnly ? [ToolVisibility::App] : [ToolVisibility::Model, ToolVisibility::App];
 
         $builder->addMethodCall('addTool', [

--- a/src/mcp-bundle/src/DependencyInjection/McpPass.php
+++ b/src/mcp-bundle/src/DependencyInjection/McpPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\McpBundle\DependencyInjection;
 
+use Mcp\Capability\Attribute\CompletionProvider;
 use Mcp\Capability\Attribute\McpPrompt;
 use Mcp\Capability\Attribute\McpResource;
 use Mcp\Capability\Attribute\McpResourceTemplate;
@@ -51,17 +52,39 @@ final class McpPass implements CompilerPassInterface
         'mcp.resource_template' => McpResourceTemplate::class,
     ];
 
+    private const TAG_KINDS = [
+        'mcp.tool' => 'tools',
+        'mcp.prompt' => 'prompts',
+        'mcp.resource' => 'resources',
+        'mcp.resource_template' => 'resource_templates',
+    ];
+
+    private const TAG_CALLS = [
+        'mcp.tool' => 'addTool',
+        'mcp.prompt' => 'addPrompt',
+        'mcp.resource' => 'addResource',
+        'mcp.resource_template' => 'addResourceTemplate',
+    ];
+
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('mcp.server.builder')) {
+        /** @var array<string, array<string, list<string>>> $servers */
+        $servers = $container->hasParameter('mcp.servers.elements') ? $container->getParameter('mcp.servers.elements') : [];
+        if ([] === $servers) {
             return;
         }
 
-        $builder = $container->getDefinition('mcp.server.builder');
+        $builders = [];
+        foreach (array_keys($servers) as $name) {
+            $builders[$name] = $container->getDefinition('mcp.server.'.$name.'.builder');
+        }
+
+        $matcher = new ElementMatcher($servers);
         $schemaGenerator = new SchemaGenerator(new DocBlockParser());
 
         $serviceReferences = [];
         $registered = [];
+        $unassigned = [];
 
         foreach (self::ELEMENT_TAGS as $tag => $attributeClass) {
             foreach ($container->findTaggedServiceIds($tag) as $serviceId => $tags) {
@@ -75,10 +98,20 @@ final class McpPass implements CompilerPassInterface
                     throw new LogicException(\sprintf('The MCP service "%s" is tagged "%s" but maps to class "%s" which does not exist.', $serviceId, $tag, $class));
                 }
 
-                // The SDK's ReferenceHandler resolves [class, method] handlers by class name; keep the
-                // service id as an additional key for handlers registered with a non-class service id.
-                $serviceReferences[$class] = new Reference($serviceId);
-                $serviceReferences[$serviceId] ??= new Reference($serviceId);
+                $targets = $matcher->match(self::TAG_KINDS[$tag], $serviceId, $class);
+                if ([] === $targets) {
+                    // Not an error: a third-party bundle may ship MCP elements this application
+                    // deliberately does not expose. Recorded so "debug:mcp" can report them.
+                    $unassigned[self::TAG_KINDS[$tag]][] = $serviceId;
+                    continue;
+                }
+
+                foreach ($targets as $server) {
+                    // The SDK's ReferenceHandler resolves [class, method] handlers by class name; keep
+                    // the service id as an additional key for handlers registered with a non-class id.
+                    $serviceReferences[$server][$class] = new Reference($serviceId);
+                    $serviceReferences[$server][$serviceId] ??= new Reference($serviceId);
+                }
 
                 foreach ($tags as $tagAttributes) {
                     $hasExplicitMethod = isset($tagAttributes['method']);
@@ -109,24 +142,151 @@ final class McpPass implements CompilerPassInterface
 
                     $registered[$tag][$class][$method] = true;
 
-                    match ($tag) {
-                        'mcp.tool' => $this->registerTool($builder, $class, $method, $attribute, $schemaGenerator, $serviceId),
-                        'mcp.prompt' => $this->registerPrompt($builder, $class, $method, $attribute),
-                        'mcp.resource' => $this->registerResource($builder, $class, $method, $attribute),
-                        'mcp.resource_template' => $this->registerResourceTemplate($builder, $class, $method, $attribute),
+                    // A completion provider named by class is looked up in the same locator as the
+                    // handlers when a completion request comes in; one that is not a service falls
+                    // back to "new $provider()" at runtime, so only services are referenced here.
+                    if (\in_array($tag, ['mcp.prompt', 'mcp.resource_template'], true)) {
+                        foreach ($this->completionProviderClasses($class, $method) as $providerClass) {
+                            if (!$container->hasDefinition($providerClass) && !$container->hasAlias($providerClass)) {
+                                continue;
+                            }
+
+                            foreach ($targets as $server) {
+                                $serviceReferences[$server][$providerClass] ??= new Reference($providerClass);
+                            }
+                        }
+                    }
+
+                    // Reflection and schema generation run once per element, no matter how many
+                    // servers expose it; only the resulting method call is repeated.
+                    $arguments = match ($tag) {
+                        'mcp.tool' => $this->toolArguments($class, $method, $attribute, $schemaGenerator, $serviceId),
+                        'mcp.prompt' => $this->promptArguments($class, $method, $attribute),
+                        'mcp.resource' => $this->resourceArguments($class, $method, $attribute),
+                        'mcp.resource_template' => $this->resourceTemplateArguments($class, $method, $attribute),
                     };
+
+                    foreach ($targets as $server) {
+                        $builders[$server]->addMethodCall(self::TAG_CALLS[$tag], $this->copy($arguments));
+                    }
                 }
             }
         }
 
-        if ([] === $serviceReferences) {
+        // The "apps" kind is consumed by McpAppPass with a matcher of its own; replayed here only so
+        // a configured app pattern counts as used and the assert below stays about typos.
+        foreach (array_keys($container->findTaggedServiceIds('mcp.app')) as $serviceId) {
+            $class = $container->getParameterBag()->resolveValue($container->getDefinition($serviceId)->getClass() ?? $serviceId);
+            $matcher->match('apps', $serviceId, $class);
+        }
+
+        $this->assertPatternsAreUsed($matcher);
+
+        $container->setParameter('mcp.servers.unassigned', $unassigned);
+
+        /** @var array<string, array<string, string>> $appHandlers */
+        $appHandlers = $container->hasParameter('mcp.servers.app_handlers') ? $container->getParameter('mcp.servers.app_handlers') : [];
+        /** @var array<string, array<string, array{template: string, meta: array<string, mixed>|null}>> $appTemplates */
+        $appTemplates = $container->hasParameter('mcp.servers.app_tool_templates') ? $container->getParameter('mcp.servers.app_tool_templates') : [];
+
+        foreach (array_keys($servers) as $server) {
+            foreach ($appHandlers[$server] ?? [] as $key => $id) {
+                $serviceReferences[$server][$key] ??= new Reference($id);
+            }
+
+            if ([] === ($serviceReferences[$server] ?? [])) {
+                continue;
+            }
+
+            $serviceLocatorRef = ServiceLocatorTagPass::register($container, $serviceReferences[$server]);
+            $builders[$server]->addMethodCall('setContainer', [$serviceLocatorRef]);
+
+            $this->configureAppReferenceHandler($container, $server, $serviceLocatorRef, $appTemplates[$server] ?? []);
+        }
+    }
+
+    private function assertPatternsAreUsed(ElementMatcher $matcher): void
+    {
+        $unused = $matcher->getUnusedPatterns();
+        if ([] === $unused) {
             return;
         }
 
-        $serviceLocatorRef = ServiceLocatorTagPass::register($container, $serviceReferences);
-        $builder->addMethodCall('setContainer', [$serviceLocatorRef]);
+        $messages = array_map(
+            static fn (array $entry): string => \sprintf('"%s" under "mcp.servers.%s.registry"', $entry[1], $entry[0]),
+            $unused,
+        );
 
-        $this->configureAppReferenceHandler($container, $serviceLocatorRef);
+        throw new LogicException(\sprintf('The following MCP element patterns do not match any registered service: "%s". Elements are collected from container services carrying an MCP attribute, so check for a typo or make sure the class is registered as a service.', implode(', ', $messages)));
+    }
+
+    /**
+     * Deep-copies the inline definitions in a method call's arguments so two server builders
+     * never share the same Definition instance.
+     *
+     * @param list<mixed> $arguments
+     *
+     * @return list<mixed>
+     */
+    private function copy(array $arguments): array
+    {
+        foreach ($arguments as $key => $argument) {
+            if ($argument instanceof Definition) {
+                $copy = clone $argument;
+                $copy->setArguments($this->copy(array_values($argument->getArguments())));
+                $copy->setProperties($this->copyMap($argument->getProperties()));
+                $arguments[$key] = $copy;
+            } elseif (\is_array($argument)) {
+                $arguments[$key] = $this->copyMap($argument);
+            }
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * @param array<array-key, mixed> $values
+     *
+     * @return array<array-key, mixed>
+     */
+    private function copyMap(array $values): array
+    {
+        foreach ($values as $key => $value) {
+            if ($value instanceof Definition) {
+                $copy = clone $value;
+                $copy->setArguments($this->copy(array_values($value->getArguments())));
+                $copy->setProperties($this->copyMap($value->getProperties()));
+                $values[$key] = $copy;
+            } elseif (\is_array($value)) {
+                $values[$key] = $this->copyMap($value);
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * The completion providers the element's parameters name by class-string, to be resolved
+     * from the handler locator at the point of use.
+     *
+     * @param class-string $class
+     *
+     * @return list<class-string>
+     */
+    private function completionProviderClasses(string $class, string $method): array
+    {
+        $classes = [];
+        foreach ((new \ReflectionMethod($class, $method))->getParameters() as $parameter) {
+            foreach ($parameter->getAttributes(CompletionProvider::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                $instance = $attribute->newInstance();
+                $provider = $instance->provider ?? $instance->providerClass;
+                if (\is_string($provider) && class_exists($provider)) {
+                    $classes[] = $provider;
+                }
+            }
+        }
+
+        return $classes;
     }
 
     /**
@@ -152,7 +312,10 @@ final class McpPass implements CompilerPassInterface
         return ([] !== $attributes) ? $attributes[0]->newInstance() : null;
     }
 
-    private function registerTool(Definition $builder, string $class, string $method, McpTool $attribute, SchemaGenerator $schemaGenerator, string $serviceId): void
+    /**
+     * @return list<mixed>
+     */
+    private function toolArguments(string $class, string $method, McpTool $attribute, SchemaGenerator $schemaGenerator, string $serviceId): array
     {
         try {
             $inputSchema = $schemaGenerator->generate(new \ReflectionMethod($class, $method));
@@ -160,7 +323,7 @@ final class McpPass implements CompilerPassInterface
             throw new LogicException(\sprintf('Cannot generate the input schema for MCP tool "%s::%s()" (service "%s"): "%s"', $class, $method, $serviceId, $e->getMessage()), 0, $e);
         }
 
-        $builder->addMethodCall('addTool', [
+        return [
             [$class, $method],
             $attribute->name,
             $attribute->title,
@@ -170,24 +333,30 @@ final class McpPass implements CompilerPassInterface
             $this->iconDefinitions($attribute->icons),
             $this->dumpableOrNull($attribute->meta),
             $this->dumpableOrNull($attribute->outputSchema),
-        ]);
+        ];
     }
 
-    private function registerPrompt(Definition $builder, string $class, string $method, McpPrompt $attribute): void
+    /**
+     * @return list<mixed>
+     */
+    private function promptArguments(string $class, string $method, McpPrompt $attribute): array
     {
-        $builder->addMethodCall('addPrompt', [
+        return [
             [$class, $method],
             $attribute->name,
             $attribute->title,
             $attribute->description,
             $this->iconDefinitions($attribute->icons),
             $this->dumpableOrNull($attribute->meta),
-        ]);
+        ];
     }
 
-    private function registerResource(Definition $builder, string $class, string $method, McpResource $attribute): void
+    /**
+     * @return list<mixed>
+     */
+    private function resourceArguments(string $class, string $method, McpResource $attribute): array
     {
-        $builder->addMethodCall('addResource', [
+        return [
             [$class, $method],
             $attribute->uri,
             $attribute->name,
@@ -198,12 +367,15 @@ final class McpPass implements CompilerPassInterface
             $this->annotationsDefinition($attribute->annotations),
             $this->iconDefinitions($attribute->icons),
             $this->dumpableOrNull($attribute->meta),
-        ]);
+        ];
     }
 
-    private function registerResourceTemplate(Definition $builder, string $class, string $method, McpResourceTemplate $attribute): void
+    /**
+     * @return list<mixed>
+     */
+    private function resourceTemplateArguments(string $class, string $method, McpResourceTemplate $attribute): array
     {
-        $builder->addMethodCall('addResourceTemplate', [
+        return [
             [$class, $method],
             $attribute->uriTemplate,
             $attribute->name,
@@ -212,7 +384,7 @@ final class McpPass implements CompilerPassInterface
             $attribute->mimeType,
             $this->annotationsDefinition($attribute->annotations),
             $this->dumpableOrNull($attribute->meta),
-        ]);
+        ];
     }
 
     private function toolAnnotationsDefinition(?ToolAnnotations $annotations): ?Definition
@@ -298,26 +470,26 @@ final class McpPass implements CompilerPassInterface
      * into the tool result's `html` field. It decorates the SDK default handler, which keeps the
      * reflection-derived input schema and argument mapping intact.
      */
-    private function configureAppReferenceHandler(ContainerBuilder $container, Reference $serviceLocatorRef): void
+    /**
+     * @param array<string, mixed> $toolTemplates
+     */
+    private function configureAppReferenceHandler(ContainerBuilder $container, string $server, Reference $serviceLocatorRef, array $toolTemplates): void
     {
-        $toolTemplates = $container->hasParameter('mcp.apps.tool_templates')
-            ? $container->getParameter('mcp.apps.tool_templates')
-            : [];
-
         if ([] === $toolTemplates) {
             return;
         }
 
+        $handlerId = \sprintf('mcp.server.%s.app.reference_handler', $server);
         $innerHandler = new Definition(ReferenceHandler::class, [$serviceLocatorRef]);
 
-        $container->register('mcp.app.reference_handler', McpAppReferenceHandler::class)
+        $container->register($handlerId, McpAppReferenceHandler::class)
             ->setArguments([
                 $innerHandler,
                 new Reference(McpAppRenderer::SERVICE_ID),
                 $toolTemplates,
             ]);
 
-        $container->getDefinition('mcp.server.builder')
-            ->addMethodCall('setReferenceHandler', [new Reference('mcp.app.reference_handler')]);
+        $container->getDefinition('mcp.server.'.$server.'.builder')
+            ->addMethodCall('setReferenceHandler', [new Reference($handlerId)]);
     }
 }

--- a/src/mcp-bundle/src/Exception/ConnectionException.php
+++ b/src/mcp-bundle/src/Exception/ConnectionException.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Exception;
+
+/**
+ * Thrown when a configured MCP client cannot open or close a connection to a remote server.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+class ConnectionException extends RuntimeException
+{
+    public static function connectFailed(string $client, string $server, \Throwable $previous): self
+    {
+        return new self(\sprintf('Failed to connect MCP client "%s" to server "%s": %s', $client, $server, $previous->getMessage()), 0, $previous);
+    }
+
+    public static function disconnectFailed(string $client, string $server, \Throwable $previous): self
+    {
+        return new self(\sprintf('Failed to disconnect MCP client "%s" from server "%s": %s', $client, $server, $previous->getMessage()), 0, $previous);
+    }
+}

--- a/src/mcp-bundle/src/Exception/InvalidArgumentException.php
+++ b/src/mcp-bundle/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/mcp-bundle/src/Exception/RemoteCallException.php
+++ b/src/mcp-bundle/src/Exception/RemoteCallException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Exception;
+
+/**
+ * Thrown when a request a configured MCP client sent to a remote server failed.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+class RemoteCallException extends RuntimeException
+{
+    public static function failed(string $client, string $server, string $operation, \Throwable $previous): self
+    {
+        return new self(\sprintf('The "%s" request of MCP client "%s" to server "%s" failed: %s', $operation, $client, $server, $previous->getMessage()), 0, $previous);
+    }
+}

--- a/src/mcp-bundle/src/Exception/RuntimeException.php
+++ b/src/mcp-bundle/src/Exception/RuntimeException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Exception;
+
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -11,12 +11,24 @@
 
 namespace Symfony\AI\McpBundle;
 
-use Http\Discovery\Psr17Factory;
 use Mcp\Capability\Attribute\McpPrompt;
 use Mcp\Capability\Attribute\McpResource;
 use Mcp\Capability\Attribute\McpResourceTemplate;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Registry;
 use Mcp\Capability\Registry\Loader\LoaderInterface;
+use Mcp\Client as McpSdkClient;
+use Mcp\Client\Builder as McpSdkClientBuilder;
+use Mcp\Client\Handler\Notification\LoggingNotificationHandler;
+use Mcp\Client\Handler\Request\ElicitationRequestHandler;
+use Mcp\Client\Handler\Request\SamplingRequestHandler;
+use Mcp\Client\Transport\HttpTransport;
+use Mcp\Client\Transport\StdioTransport;
+use Mcp\Schema\ClientCapabilities;
+use Mcp\Schema\Enum\ProtocolVersion;
+use Mcp\Schema\Icon;
+use Mcp\Server;
+use Mcp\Server\Builder;
 use Mcp\Server\Handler\Notification\NotificationHandlerInterface;
 use Mcp\Server\Handler\Request\RequestHandlerInterface;
 use Mcp\Server\Session\FileSessionStore;
@@ -24,6 +36,11 @@ use Mcp\Server\Session\InMemorySessionStore;
 use Mcp\Server\Session\Psr16SessionStore;
 use Symfony\AI\McpBundle\App\McpAppRenderer;
 use Symfony\AI\McpBundle\Attribute\AsMcpApp;
+use Symfony\AI\McpBundle\Client\McpClient;
+use Symfony\AI\McpBundle\Client\McpClientInterface;
+use Symfony\AI\McpBundle\Client\ServerConnection;
+use Symfony\AI\McpBundle\Client\ServerLogForwarder;
+use Symfony\AI\McpBundle\Client\TransportFactory;
 use Symfony\AI\McpBundle\Command\DebugCommand;
 use Symfony\AI\McpBundle\Command\McpCommand;
 use Symfony\AI\McpBundle\Controller\McpController;
@@ -34,41 +51,41 @@ use Symfony\AI\McpBundle\Http\MiddlewareFactory;
 use Symfony\AI\McpBundle\Profiler\DataCollector;
 use Symfony\AI\McpBundle\Routing\RouteLoader;
 use Symfony\AI\McpBundle\Session\FrameworkSessionStore;
-use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
-use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 use Twig\Environment;
 
 final class McpBundle extends AbstractBundle
 {
+    /**
+     * The kinds of element a server can expose, mapped to the tag carrying them.
+     */
+    public const ELEMENT_KINDS = [
+        'tools' => 'mcp.tool',
+        'prompts' => 'mcp.prompt',
+        'resources' => 'mcp.resource',
+        'resource_templates' => 'mcp.resource_template',
+        'apps' => 'mcp.app',
+    ];
+
     public function configure(DefinitionConfigurator $definition): void
     {
         $definition->import('../config/options.php');
     }
 
     /**
-     * @param array<string, mixed> $config
+     * @param array{servers: array<string, array<string, mixed>>, clients: array<string, array<string, mixed>>} $config
      */
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        $container->import('../config/services.php');
-
-        $builder->setParameter('mcp.app', $config['app']);
-        $builder->setParameter('mcp.version', $config['version']);
-        $builder->setParameter('mcp.description', $config['description']);
-        $builder->setParameter('mcp.website_url', $config['website_url']);
-        $builder->setParameter('mcp.icons', $config['icons']);
-        $builder->setParameter('mcp.pagination_limit', $config['pagination_limit']);
-        $builder->setParameter('mcp.instructions', $config['instructions']);
-        $builder->setParameter('mcp.apps.enabled', $config['apps']['enabled']);
-
         $this->registerMcpAttributes($builder);
         $this->configureApps($builder);
 
@@ -81,17 +98,444 @@ final class McpBundle extends AbstractBundle
         $builder->registerForAutoconfiguration(NotificationHandlerInterface::class)
             ->addTag('mcp.notification_handler');
 
-        if (isset($config['client_transports'])) {
-            $this->configureClient($config['client_transports'], $config['http'], $builder);
+        if ([] === $config['servers'] && [] === $config['clients']) {
+            return;
         }
+
+        $container->import('../config/services.php');
+
+        // Always defined: the debug command reads it even when only clients are configured.
+        $builder->setParameter('mcp.servers.unassigned', []);
+
+        if ([] !== $config['servers']) {
+            $this->configureServers($config['servers'], $builder);
+        }
+
+        if ([] !== $config['clients']) {
+            $this->configureClients($config['clients'], $builder);
+        }
+
+        $this->configureDebugCommand($builder);
     }
 
     public function build(ContainerBuilder $container): void
     {
         // McpAppPass runs before McpPass so the bound app-renderer handler services it creates are
-        // included in the handler service locator McpPass builds.
+        // included in the handler service locators McpPass builds.
         $container->addCompilerPass(new McpAppPass(), priority: 10);
         $container->addCompilerPass(new McpPass());
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $clients
+     */
+    private function configureClients(array $clients, ContainerBuilder $container): void
+    {
+        $logger = new Reference('logger', ContainerBuilder::NULL_ON_INVALID_REFERENCE);
+        $clientReferences = [];
+
+        foreach ($clients as $clientName => $client) {
+            $connectionReferences = [];
+
+            foreach ($client['servers'] as $serverName => $server) {
+                $id = \sprintf('mcp.client.%s.server.%s', $clientName, $serverName);
+
+                $container->setDefinition($id.'.transport', $this->clientTransport($server, $logger, $container))
+                    ->addTag('monolog.logger', ['channel' => 'mcp']);
+
+                $container->setDefinition($id.'.builder', $this->clientBuilder($clientName, $serverName, $client, $server, $logger));
+
+                $container->register($id.'.client', McpSdkClient::class)
+                    ->setFactory([new Reference($id.'.builder'), 'build'])
+                    ->addTag('monolog.logger', ['channel' => 'mcp']);
+
+                $container->register($id, ServerConnection::class)
+                    ->setArguments([$clientName, $serverName, new Reference($id.'.client'), new Reference($id.'.transport')])
+                    ->addTag('mcp.client.connection', ['client' => $clientName, 'server' => $serverName])
+                    // Stdio connections own a child process; a worker must not carry one across messages.
+                    ->addTag('kernel.reset', ['method' => 'reset']);
+
+                $connectionReferences[$serverName] = new Reference($id);
+            }
+
+            $locatorId = \sprintf('mcp.client.%s.locator', $clientName);
+            $container->register($locatorId, ServiceLocator::class)
+                ->setArguments([$connectionReferences])
+                ->addTag('container.service_locator');
+
+            $container->register('mcp.client.'.$clientName, McpClient::class)
+                ->setArguments([$clientName, new Reference($locatorId)])
+                ->addTag('mcp.client', ['name' => $clientName]);
+
+            $container->registerAliasForArgument('mcp.client.'.$clientName, McpClientInterface::class, $clientName.' client');
+
+            $clientReferences[$clientName] = new Reference('mcp.client.'.$clientName);
+        }
+
+        if (1 === \count($clients)) {
+            $container->setAlias(McpClientInterface::class, 'mcp.client.'.array_key_first($clients));
+        }
+
+        $container->register('mcp.client.locator', ServiceLocator::class)
+            ->setArguments([$clientReferences])
+            ->addTag('container.service_locator');
+    }
+
+    /**
+     * @param array<string, mixed> $server
+     */
+    private function clientTransport(array $server, Reference $logger, ContainerBuilder $container): Definition
+    {
+        if ('stdio' === $server['transport']) {
+            return (new Definition(StdioTransport::class))
+                ->setFactory([TransportFactory::class, 'stdio'])
+                ->setArguments([
+                    $server['command'],
+                    $server['cwd'],
+                    $server['env'],
+                    $server['inherit_env'],
+                    $server['max_buffer_size'],
+                    $logger,
+                ]);
+        }
+
+        // Falls back to the SDK's PSR-18 discovery when the framework's client is unavailable.
+        $httpClient = null !== $server['http_client']
+            ? new Reference($server['http_client'])
+            : new Reference('psr18.http_client', ContainerBuilder::NULL_ON_INVALID_REFERENCE);
+
+        return (new Definition(HttpTransport::class))
+            ->setFactory([TransportFactory::class, 'http'])
+            ->setArguments([
+                $server['url'],
+                $server['headers'],
+                $httpClient,
+                new Reference('mcp.psr17_factory'),
+                new Reference('mcp.psr17_factory'),
+                $logger,
+                $server['max_sse_buffer_bytes'],
+            ]);
+    }
+
+    /**
+     * @param array<string, mixed> $client
+     * @param array<string, mixed> $server
+     */
+    private function clientBuilder(string $clientName, string $serverName, array $client, array $server, Reference $logger): Definition
+    {
+        $definition = (new Definition(McpSdkClientBuilder::class))
+            ->setFactory([McpSdkClient::class, 'builder'])
+            ->addMethodCall('setClientInfo', [
+                $client['client_info']['name'] ?? $clientName,
+                $client['client_info']['version'],
+                $client['client_info']['description'],
+            ])
+            ->addMethodCall('setCapabilities', [new Definition(ClientCapabilities::class, [
+                $client['capabilities']['roots'],
+                $client['capabilities']['roots_list_changed'],
+                // Advertised only when a handler backs them, otherwise the server gets "method not found".
+                null !== $client['sampling'],
+                null !== $client['elicitation'],
+            ])])
+            ->addMethodCall('setInitTimeout', [$server['init_timeout'] ?? $client['init_timeout']])
+            ->addMethodCall('setRequestTimeout', [$server['request_timeout'] ?? $client['request_timeout']])
+            ->addMethodCall('setMaxRetries', [$server['max_retries'] ?? $client['max_retries']])
+            ->addMethodCall('setLogger', [$logger])
+            ->addTag('monolog.logger', ['channel' => 'mcp']);
+
+        if (null !== $client['protocol_version']) {
+            $definition->addMethodCall('setProtocolVersion', [
+                (new Definition(ProtocolVersion::class))
+                    ->setFactory([ProtocolVersion::class, 'from'])
+                    ->setArguments([$client['protocol_version']]),
+            ]);
+        }
+
+        if (null !== $client['sampling']) {
+            $definition->addMethodCall('addRequestHandler', [
+                new Definition(SamplingRequestHandler::class, [new Reference($client['sampling']), $logger]),
+            ]);
+        }
+
+        if (null !== $client['elicitation']) {
+            $definition->addMethodCall('addRequestHandler', [
+                new Definition(ElicitationRequestHandler::class, [new Reference($client['elicitation']), $logger]),
+            ]);
+        }
+
+        if ($client['forward_server_logs']) {
+            $definition->addMethodCall('addNotificationHandler', [
+                new Definition(LoggingNotificationHandler::class, [
+                    new Definition(ServerLogForwarder::class, [$clientName, $serverName, $logger]),
+                ]),
+            ]);
+        }
+
+        return $definition;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $servers
+     */
+    private function configureServers(array $servers, ContainerBuilder $container): void
+    {
+        $this->assertServersAreIsolated($servers);
+
+        $elements = [];
+        foreach ($servers as $name => $server) {
+            foreach (array_keys(self::ELEMENT_KINDS) as $kind) {
+                // Normalized so a leading backslash in the configuration is irrelevant.
+                $elements[$name][$kind] = array_values(array_map(
+                    static fn (string $pattern): string => ltrim($pattern, '\\'),
+                    $server['registry'][$kind],
+                ));
+            }
+
+            $this->configureServer($name, $server, $container);
+        }
+
+        // The compiler passes are registered in build(), before this extension is loaded, so a
+        // container parameter is the only channel to hand them the per-server element lists.
+        $container->setParameter('mcp.servers.elements', $elements);
+
+        $this->registerServerLocator('mcp.server_locator.builder', array_keys($servers), 'builder', $container);
+        $this->registerServerLocator('mcp.server_locator.registry', array_keys($servers), 'registry', $container);
+
+        $this->configureRouting($servers, $container);
+        $this->configureCommands($servers, $container);
+        $this->configureProfiler($servers, $container);
+    }
+
+    /**
+     * One debug command covers the whole component, so it is registered once both sides have had
+     * their chance to create the locators it reads.
+     */
+    private function configureDebugCommand(ContainerBuilder $container): void
+    {
+        foreach (['mcp.server_locator.builder', 'mcp.server_locator.registry', 'mcp.client.locator'] as $locatorId) {
+            if (!$container->hasDefinition($locatorId)) {
+                $container->register($locatorId, ServiceLocator::class)
+                    ->setArguments([[]])
+                    ->addTag('container.service_locator');
+            }
+        }
+
+        $container->register('mcp.debug_command', DebugCommand::class)
+            ->setArguments([
+                new Reference('mcp.server_locator.builder'),
+                new Reference('mcp.server_locator.registry'),
+                new Reference('mcp.client.locator'),
+                // Filled by McpPass, which runs after this extension; the placeholder is resolved later.
+                '%mcp.servers.unassigned%',
+            ])
+            ->addTag('console.command');
+    }
+
+    /**
+     * @param array<string, mixed> $server
+     */
+    private function configureServer(string $name, array $server, ContainerBuilder $container): void
+    {
+        $registryId = \sprintf('mcp.server.%s.registry', $name);
+        $builderId = \sprintf('mcp.server.%s.builder', $name);
+        $sessionId = $this->configureSessionStore($name, $server['session'], $container);
+
+        $container->register($registryId, Registry::class)
+            ->setArguments([new Reference('event_dispatcher'), new Reference('logger')])
+            ->addTag('monolog.logger', ['channel' => 'mcp']);
+
+        $container->register($builderId, Builder::class)
+            ->setFactory([Server::class, 'builder'])
+            ->addMethodCall('setServerInfo', [
+                $server['name'] ?? $name,
+                $server['version'],
+                $server['description'],
+                $this->iconDefinitions($server['icons']),
+                $server['website_url'],
+            ])
+            ->addMethodCall('setPaginationLimit', [$server['pagination_limit']])
+            ->addMethodCall('setInstructions', [$server['instructions']])
+            ->addMethodCall('setEventDispatcher', [new Reference('event_dispatcher')])
+            ->addMethodCall('setRegistry', [new Reference($registryId)])
+            ->addMethodCall('setSession', [new Reference($sessionId)])
+            ->addMethodCall('addRequestHandlers', [new TaggedIteratorArgument('mcp.request_handler')])
+            ->addMethodCall('addNotificationHandlers', [new TaggedIteratorArgument('mcp.notification_handler')])
+            ->addMethodCall('addLoaders', [new TaggedIteratorArgument('mcp.loader')])
+            ->addMethodCall('setLogger', [new Reference('logger')])
+            ->addTag('mcp.server.builder', ['server' => $name])
+            ->addTag('monolog.logger', ['channel' => 'mcp']);
+
+        $container->register('mcp.server.'.$name, Server::class)
+            ->setFactory([new Reference($builderId), 'build']);
+
+        $container->registerAliasForArgument('mcp.server.'.$name, Server::class, $name.' server');
+
+        if (!$server['transports']['http']) {
+            return;
+        }
+
+        $container->register(\sprintf('mcp.server.%s.middleware_factory', $name), MiddlewareFactory::class)
+            ->setArguments([$server['http']['allowed_hosts']]);
+
+        $container->register(\sprintf('mcp.server.%s.controller', $name), McpController::class)
+            ->setArguments([
+                new Reference('mcp.server.'.$name),
+                new Reference('mcp.psr_http_factory'),
+                new Reference('mcp.http_foundation_factory'),
+                new Reference('mcp.psr17_factory'),
+                new Reference('mcp.psr17_factory'),
+                new Reference(\sprintf('mcp.server.%s.middleware_factory', $name)),
+                new Reference('logger'),
+            ])
+            ->setPublic(true)
+            ->addTag('controller.service_arguments')
+            ->addTag('monolog.logger', ['channel' => 'mcp']);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $servers
+     */
+    private function configureRouting(array $servers, ContainerBuilder $container): void
+    {
+        $routes = [];
+        foreach ($servers as $name => $server) {
+            if (!$server['transports']['http']) {
+                continue;
+            }
+
+            $routes[] = [
+                'name' => $name,
+                'path' => $this->httpPath($name, $server),
+                'controller' => \sprintf('mcp.server.%s.controller::handle', $name),
+            ];
+        }
+
+        $container->register('mcp.server.route_loader', RouteLoader::class)
+            ->setArguments([$routes])
+            ->addTag('routing.loader');
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $servers
+     */
+    private function configureCommands(array $servers, ContainerBuilder $container): void
+    {
+        $stdio = array_filter($servers, static fn (array $server): bool => $server['transports']['stdio']);
+        if ([] === $stdio) {
+            return;
+        }
+
+        $container->register('mcp.server.command', McpCommand::class)
+            ->setArguments([
+                $this->registerServerLocator('mcp.server_locator.stdio', array_keys($stdio), null, $container),
+                new Reference('logger'),
+            ])
+            ->addTag('console.command')
+            ->addTag('monolog.logger', ['channel' => 'mcp']);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $servers
+     */
+    private function configureProfiler(array $servers, ContainerBuilder $container): void
+    {
+        if (!$container->getParameter('kernel.debug')) {
+            return;
+        }
+
+        // The collector builds every server itself so each profiled request shows the full
+        // capability set, not only the one that happened to serve an MCP request.
+        $container->setDefinition('mcp.data_collector', (new Definition(DataCollector::class))
+            ->setArguments([
+                new Reference('mcp.server_locator.builder'),
+                new Reference('mcp.server_locator.registry'),
+            ])
+            ->addTag('data_collector', ['id' => 'mcp']));
+    }
+
+    /**
+     * @param list<string> $names
+     */
+    private function registerServerLocator(string $locatorId, array $names, ?string $suffix, ContainerBuilder $container): Reference
+    {
+        $references = [];
+        foreach ($names as $name) {
+            $references[$name] = new Reference(null === $suffix ? 'mcp.server.'.$name : \sprintf('mcp.server.%s.%s', $name, $suffix));
+        }
+
+        $container->register($locatorId, ServiceLocator::class)
+            ->setArguments([$references])
+            ->addTag('container.service_locator');
+
+        return new Reference($locatorId);
+    }
+
+    /**
+     * @param array<string, mixed> $server
+     */
+    private function httpPath(string $name, array $server): string
+    {
+        // Always derived from the name: a count-dependent default ("/mcp" for the only server")
+        // would silently move an existing endpoint the day a second server is added.
+        return $server['http']['path'] ?? '/mcp/'.$name;
+    }
+
+    /**
+     * Session ids are not namespaced by server and the SDK's session manager accepts any id
+     * present in the store, so two servers sharing a store means a session minted on one is
+     * valid on the other — across a firewall boundary that is privilege escalation.
+     *
+     * @param array<string, array<string, mixed>> $servers
+     */
+    private function assertServersAreIsolated(array $servers): void
+    {
+        $paths = [];
+        $stores = [];
+
+        foreach ($servers as $name => $server) {
+            if ($server['transports']['http']) {
+                $path = $this->httpPath($name, $server);
+                if (isset($paths[$path])) {
+                    throw new LogicException(\sprintf('The MCP servers "%s" and "%s" are both configured on the HTTP path "%s". Give each server its own "http.path".', $paths[$path], $name, $path));
+                }
+                $paths[$path] = $name;
+            }
+
+            $session = $server['session'];
+            $key = match ($session['store']) {
+                'file' => 'file:'.($session['directory'] ?? '%kernel.cache_dir%/mcp-sessions/'.$name),
+                'cache' => 'cache:'.$session['cache_pool'].':'.($session['prefix'] ?? 'mcp-'.$name.'-'),
+                'framework' => 'framework:'.($session['prefix'] ?? 'mcp-'.$name.'-'),
+                default => null,
+            };
+
+            if (null === $key) {
+                continue;
+            }
+
+            if (isset($stores[$key])) {
+                throw new LogicException(\sprintf('The MCP servers "%s" and "%s" share the same session storage. Sessions are not namespaced by server, so a session created on one would be accepted by the other; give each server its own "session.directory" or "session.prefix".', $stores[$key], $name));
+            }
+            $stores[$key] = $name;
+        }
+    }
+
+    /**
+     * @param list<array{src: string, mime_type: string|null, sizes: list<string>}> $icons
+     *
+     * @return list<Definition>|null
+     */
+    private function iconDefinitions(array $icons): ?array
+    {
+        if ([] === $icons) {
+            // Not an empty array: the SDK would advertise "icons": [] in the initialize result.
+            return null;
+        }
+
+        return array_map(
+            static fn (array $icon): Definition => new Definition(Icon::class, [$icon['src'], $icon['mime_type'], $icon['sizes']]),
+            $icons,
+        );
     }
 
     private function configureApps(ContainerBuilder $builder): void
@@ -146,98 +590,22 @@ final class McpBundle extends AbstractBundle
     }
 
     /**
-     * @param array{stdio: bool, http: bool}                                                                                                                              $transports
-     * @param array{path: string, allowed_hosts: list<string>|false|null, session: array{store: string, directory: string, cache_pool: string, prefix: string, ttl: int}} $httpConfig
+     * @param array{store: string, directory: string|null, cache_pool: string, prefix: string|null, ttl: int} $session
      */
-    private function configureClient(array $transports, array $httpConfig, ContainerBuilder $container): void
+    private function configureSessionStore(string $name, array $session, ContainerBuilder $container): string
     {
-        if (!$transports['stdio'] && !$transports['http']) {
-            return;
+        $id = \sprintf('mcp.server.%s.session.store', $name);
+        $prefix = $session['prefix'] ?? \sprintf('mcp-%s-', $name);
+
+        if ('memory' === $session['store']) {
+            $container->register($id, InMemorySessionStore::class)
+                ->setArguments([$session['ttl']]);
+
+            return $id;
         }
 
-        // Register PSR factories
-        $container->register('mcp.psr17_factory', Psr17Factory::class);
-
-        $container->register('mcp.psr_http_factory', PsrHttpFactory::class)
-            ->setArguments([
-                new Reference('mcp.psr17_factory'),
-                new Reference('mcp.psr17_factory'),
-                new Reference('mcp.psr17_factory'),
-                new Reference('mcp.psr17_factory'),
-            ]);
-
-        $container->register('mcp.http_foundation_factory', HttpFoundationFactory::class);
-
-        // Configure session store based on HTTP config
-        $this->configureSessionStore($httpConfig['session'], $container);
-
-        $container->register('mcp.server.debug_command', DebugCommand::class)
-            ->setArguments([
-                new Reference('mcp.server.builder'),
-                new Reference('mcp.registry'),
-            ])
-            ->addTag('console.command');
-
-        // The collector builds the server itself so every profiled request shows the full
-        // capability set. It needs the same transport prerequisites as the server (session store),
-        // hence the registration here and not unconditionally.
-        if ($container->getParameter('kernel.debug')) {
-            $dataCollector = (new Definition(DataCollector::class))
-                ->setArguments([
-                    new Reference('mcp.server.builder'),
-                    new Reference('mcp.registry'),
-                ])
-                ->addTag('data_collector', ['id' => 'mcp']);
-            $container->setDefinition('mcp.data_collector', $dataCollector);
-        }
-
-        if ($transports['stdio']) {
-            $container->register('mcp.server.command', McpCommand::class)
-                ->setArguments([
-                    new Reference('mcp.server'),
-                    new Reference('logger'),
-                ])
-                ->addTag('console.command')
-                ->addTag('monolog.logger', ['channel' => 'mcp']);
-        }
-
-        if ($transports['http']) {
-            $container->register('mcp.middleware_factory', MiddlewareFactory::class)
-                ->setArguments([$httpConfig['allowed_hosts']]);
-
-            $container->register('mcp.server.controller', McpController::class)
-                ->setArguments([
-                    new Reference('mcp.server'),
-                    new Reference('mcp.psr_http_factory'),
-                    new Reference('mcp.http_foundation_factory'),
-                    new Reference('mcp.psr17_factory'),
-                    new Reference('mcp.psr17_factory'),
-                    new Reference('mcp.middleware_factory'),
-                    new Reference('logger'),
-                ])
-                ->setPublic(true)
-                ->addTag('controller.service_arguments')
-                ->addTag('monolog.logger', ['channel' => 'mcp']);
-        }
-
-        $container->register('mcp.server.route_loader', RouteLoader::class)
-            ->setArguments([
-                $transports['http'],
-                $httpConfig['path'],
-            ])
-            ->addTag('routing.loader');
-    }
-
-    /**
-     * @param array{store: string, directory: string, cache_pool: string, prefix: string, ttl: int} $sessionConfig
-     */
-    private function configureSessionStore(array $sessionConfig, ContainerBuilder $container): void
-    {
-        if ('memory' === $sessionConfig['store']) {
-            $container->register('mcp.session.store', InMemorySessionStore::class)
-                ->setArguments([$sessionConfig['ttl']]);
-        } elseif ('cache' === $sessionConfig['store']) {
-            $cachePoolId = $sessionConfig['cache_pool'];
+        if ('cache' === $session['store']) {
+            $cachePoolId = $session['cache_pool'];
 
             // Create the default cache pool as a PSR-16 wrapper around cache.app if it doesn't exist
             if ('cache.mcp.sessions' === $cachePoolId && !$container->hasDefinition($cachePoolId) && !$container->hasAlias($cachePoolId)) {
@@ -245,22 +613,22 @@ final class McpBundle extends AbstractBundle
                     ->setArguments([new Reference('cache.app')]);
             }
 
-            $container->register('mcp.session.store', Psr16SessionStore::class)
-                ->setArguments([
-                    new Reference($sessionConfig['cache_pool']),
-                    $sessionConfig['prefix'],
-                    $sessionConfig['ttl'],
-                ]);
-        } elseif ('framework' === $sessionConfig['store']) {
-            $container->register('mcp.session.store', FrameworkSessionStore::class)
-                ->setArguments([
-                    new Reference('session.handler'),
-                    $sessionConfig['prefix'],
-                    $sessionConfig['ttl'],
-                ]);
-        } else {
-            $container->register('mcp.session.store', FileSessionStore::class)
-                ->setArguments([$sessionConfig['directory'], $sessionConfig['ttl']]);
+            $container->register($id, Psr16SessionStore::class)
+                ->setArguments([new Reference($cachePoolId), $prefix, $session['ttl']]);
+
+            return $id;
         }
+
+        if ('framework' === $session['store']) {
+            $container->register($id, FrameworkSessionStore::class)
+                ->setArguments([new Reference('session.handler'), $prefix, $session['ttl']]);
+
+            return $id;
+        }
+
+        $container->register($id, FileSessionStore::class)
+            ->setArguments([$session['directory'] ?? '%kernel.cache_dir%/mcp-sessions/'.$name, $session['ttl']]);
+
+        return $id;
     }
 }

--- a/src/mcp-bundle/src/Profiler/DataCollector.php
+++ b/src/mcp-bundle/src/Profiler/DataCollector.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
+use Symfony\Contracts\Service\ServiceProviderInterface;
 
 /**
  * Collects MCP server capabilities for the Web Profiler.
@@ -28,9 +29,13 @@ use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
  */
 final class DataCollector extends AbstractDataCollector implements LateDataCollectorInterface
 {
+    /**
+     * @param ServiceProviderInterface<Builder>           $builders
+     * @param ServiceProviderInterface<RegistryInterface> $registries
+     */
     public function __construct(
-        private readonly Builder $builder,
-        private readonly RegistryInterface $registry,
+        private readonly ServiceProviderInterface $builders,
+        private readonly ServiceProviderInterface $registries,
     ) {
     }
 
@@ -40,99 +45,95 @@ final class DataCollector extends AbstractDataCollector implements LateDataColle
 
     public function lateCollect(): void
     {
-        // The registry is populated by the loaders when the server is built. Re-building on an MCP
-        // request is harmless: the same elements are registered again onto the shared registry.
-        $this->builder->build();
+        $this->data = ['servers' => []];
 
-        $tools = [];
-        foreach ($this->registry->getTools()->references as $tool) {
-            $tools[] = [
-                'name' => $tool->name,
-                'description' => $tool->description,
-                'inputSchema' => $tool->inputSchema,
-                'handler' => $this->formatHandler($this->registry->getTool($tool->name)->handler),
+        foreach (array_keys($this->registries->getProvidedServices()) as $server) {
+            // The registry is populated by the loaders when the server is built. Re-building on an MCP
+            // request is harmless: the same elements are registered again onto the shared registry.
+            $this->builders->get($server)->build();
+            $registry = $this->registries->get($server);
+
+            $tools = [];
+            foreach ($registry->getTools()->references as $tool) {
+                $tools[] = [
+                    'name' => $tool->name,
+                    'description' => $tool->description,
+                    'inputSchema' => $tool->inputSchema,
+                    'handler' => $this->formatHandler($registry->getTool($tool->name)->handler),
+                ];
+            }
+
+            $prompts = [];
+            foreach ($registry->getPrompts()->references as $prompt) {
+                $prompts[] = [
+                    'name' => $prompt->name,
+                    'description' => $prompt->description,
+                    'arguments' => array_map(static fn ($arg) => [
+                        'name' => $arg->name,
+                        'description' => $arg->description,
+                        'required' => $arg->required,
+                    ], $prompt->arguments ?? []),
+                    'handler' => $this->formatHandler($registry->getPrompt($prompt->name)->handler),
+                ];
+            }
+
+            $resources = [];
+            foreach ($registry->getResources()->references as $resource) {
+                $resources[] = [
+                    'uri' => $resource->uri,
+                    'name' => $resource->name,
+                    'description' => $resource->description,
+                    'mimeType' => $resource->mimeType,
+                    'handler' => $this->formatHandler($registry->getResource($resource->uri, false)->handler),
+                ];
+            }
+
+            $resourceTemplates = [];
+            foreach ($registry->getResourceTemplates()->references as $template) {
+                $resourceTemplates[] = [
+                    'uriTemplate' => $template->uriTemplate,
+                    'name' => $template->name,
+                    'description' => $template->description,
+                    'mimeType' => $template->mimeType,
+                    'handler' => $this->formatHandler($registry->getResourceTemplate($template->uriTemplate)->handler),
+                ];
+            }
+
+            $this->data['servers'][$server] = [
+                'tools' => $tools,
+                'prompts' => $prompts,
+                'resources' => $resources,
+                'resourceTemplates' => $resourceTemplates,
             ];
         }
-
-        $prompts = [];
-        foreach ($this->registry->getPrompts()->references as $prompt) {
-            $prompts[] = [
-                'name' => $prompt->name,
-                'description' => $prompt->description,
-                'arguments' => array_map(static fn ($arg) => [
-                    'name' => $arg->name,
-                    'description' => $arg->description,
-                    'required' => $arg->required,
-                ], $prompt->arguments ?? []),
-                'handler' => $this->formatHandler($this->registry->getPrompt($prompt->name)->handler),
-            ];
-        }
-
-        $resources = [];
-        foreach ($this->registry->getResources()->references as $resource) {
-            $resources[] = [
-                'uri' => $resource->uri,
-                'name' => $resource->name,
-                'description' => $resource->description,
-                'mimeType' => $resource->mimeType,
-                'handler' => $this->formatHandler($this->registry->getResource($resource->uri, false)->handler),
-            ];
-        }
-
-        $resourceTemplates = [];
-        foreach ($this->registry->getResourceTemplates()->references as $template) {
-            $resourceTemplates[] = [
-                'uriTemplate' => $template->uriTemplate,
-                'name' => $template->name,
-                'description' => $template->description,
-                'mimeType' => $template->mimeType,
-                'handler' => $this->formatHandler($this->registry->getResourceTemplate($template->uriTemplate)->handler),
-            ];
-        }
-
-        $this->data = [
-            'tools' => $tools,
-            'prompts' => $prompts,
-            'resources' => $resources,
-            'resourceTemplates' => $resourceTemplates,
-        ];
     }
 
     /**
-     * @return array<array{name: string, description: ?string, inputSchema: array<mixed>, handler: string}>
+     * @return array<string, array{
+     *     tools: array<array{name: string, description: ?string, inputSchema: array<mixed>, handler: string}>,
+     *     prompts: array<array{name: string, description: ?string, arguments: array<mixed>, handler: string}>,
+     *     resources: array<array{uri: string, name: string, description: ?string, mimeType: ?string, handler: string}>,
+     *     resourceTemplates: array<array{uriTemplate: string, name: string, description: ?string, mimeType: ?string, handler: string}>,
+     * }>
      */
-    public function getTools(): array
+    public function getServers(): array
     {
-        return $this->data['tools'] ?? [];
+        return $this->data['servers'] ?? [];
     }
 
-    /**
-     * @return array<array{name: string, description: ?string, arguments: array<mixed>, handler: string}>
-     */
-    public function getPrompts(): array
+    public function getServerCount(): int
     {
-        return $this->data['prompts'] ?? [];
-    }
-
-    /**
-     * @return array<array{uri: string, name: string, description: ?string, mimeType: ?string, handler: string}>
-     */
-    public function getResources(): array
-    {
-        return $this->data['resources'] ?? [];
-    }
-
-    /**
-     * @return array<array{uriTemplate: string, name: string, description: ?string, mimeType: ?string, handler: string}>
-     */
-    public function getResourceTemplates(): array
-    {
-        return $this->data['resourceTemplates'] ?? [];
+        return \count($this->getServers());
     }
 
     public function getTotalCount(): int
     {
-        return \count($this->getTools()) + \count($this->getPrompts()) + \count($this->getResources()) + \count($this->getResourceTemplates());
+        $total = 0;
+        foreach ($this->getServers() as $server) {
+            $total += \count($server['tools']) + \count($server['prompts']) + \count($server['resources']) + \count($server['resourceTemplates']);
+        }
+
+        return $total;
     }
 
     public function getName(): string

--- a/src/mcp-bundle/src/Routing/RouteLoader.php
+++ b/src/mcp-bundle/src/Routing/RouteLoader.php
@@ -21,9 +21,11 @@ final class RouteLoader extends Loader
 {
     private bool $loaded = false;
 
+    /**
+     * @param list<array{name: string, path: string, controller: string}> $servers the MCP servers exposed over HTTP
+     */
     public function __construct(
-        private bool $httpTransportEnabled,
-        private string $httpPath,
+        private array $servers,
     ) {
         parent::__construct();
     }
@@ -36,13 +38,15 @@ final class RouteLoader extends Loader
 
         $this->loaded = true;
 
-        if (!$this->httpTransportEnabled) {
-            return new RouteCollection();
-        }
-
         $collection = new RouteCollection();
 
-        $collection->add('_mcp_endpoint', new Route($this->httpPath, ['_controller' => 'mcp.server.controller::handle'], methods: [Request::METHOD_GET, Request::METHOD_POST, Request::METHOD_DELETE, Request::METHOD_OPTIONS]));
+        foreach ($this->servers as $server) {
+            $collection->add('_mcp_endpoint_'.$server['name'], new Route(
+                $server['path'],
+                ['_controller' => $server['controller']],
+                methods: [Request::METHOD_GET, Request::METHOD_POST, Request::METHOD_DELETE, Request::METHOD_OPTIONS],
+            ));
+        }
 
         return $collection;
     }

--- a/src/mcp-bundle/templates/app/base.html.twig
+++ b/src/mcp-bundle/templates/app/base.html.twig
@@ -50,6 +50,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}MCP App{% endblock %}</title>
     {% block head %}{% endblock %}
+    <script>{% block head_script %}{% endblock %}</script>
     <style>{% block style %}{% endblock %}</style>
 </head>
 <body{% block body_attributes %}{% endblock %}>

--- a/src/mcp-bundle/templates/data_collector.html.twig
+++ b/src/mcp-bundle/templates/data_collector.html.twig
@@ -12,21 +12,15 @@
 
         {% set text %}
             <div class="sf-toolbar-info-piece">
-                <b class="label">Tools</b>
-                <span class="sf-toolbar-status">{{ collector.tools|length }}</span>
+                <b class="label">Servers</b>
+                <span class="sf-toolbar-status">{{ collector.serverCount }}</span>
             </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Prompts</b>
-                <span class="sf-toolbar-status">{{ collector.prompts|length }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Resources</b>
-                <span class="sf-toolbar-status">{{ collector.resources|length }}</span>
-            </div>
-            <div class="sf-toolbar-info-piece">
-                <b class="label">Resource Templates</b>
-                <span class="sf-toolbar-status">{{ collector.resourceTemplates|length }}</span>
-            </div>
+            {% for name, server in collector.servers %}
+                <div class="sf-toolbar-info-piece">
+                    <b class="label">{{ name }}</b>
+                    <span class="sf-toolbar-status">{{ server.tools|length }} tools, {{ server.prompts|length }} prompts, {{ server.resources|length }} resources, {{ server.resourceTemplates|length }} templates</span>
+                </div>
+            {% endfor %}
         {% endset %}
 
         {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { 'link': true }) }}
@@ -43,57 +37,68 @@
 
 {% block panel %}
     <h2>MCP Capabilities</h2>
-    <section class="metrics">
-        <div class="metric-group">
-            <div class="metric">
-                <span class="value">{{ collector.tools|length }}</span>
-                <span class="label">Tools</span>
-            </div>
-            <div class="metric">
-                <span class="value">{{ collector.prompts|length }}</span>
-                <span class="label">Prompts</span>
-            </div>
-        </div>
-        <div class="metric-divider"></div>
-        <div class="metric-group">
-            <div class="metric">
-                <span class="value">{{ collector.resources|length }}</span>
-                <span class="label">Resources</span>
-            </div>
-            <div class="metric">
-                <span class="value">{{ collector.resourceTemplates|length }}</span>
-                <span class="label">Resource Templates</span>
-            </div>
-        </div>
-    </section>
 
-    <div class="sf-tabs">
-        <div class="tab {{ collector.tools is empty ? 'disabled' }}">
-            <h3 class="tab-title">Tools <span class="badge">{{ collector.tools|length }}</span></h3>
-            <div class="tab-content">
-                {{ include('@Mcp/tools.html.twig') }}
-            </div>
+    {% if collector.servers is empty %}
+        <div class="empty">
+            <p>No MCP server is configured. Declare one under <code>mcp.servers</code> in <code>config/packages/mcp.yaml</code>.</p>
         </div>
+    {% endif %}
 
-        <div class="tab {{ collector.prompts is empty ? 'disabled' }}">
-            <h3 class="tab-title">Prompts <span class="badge">{{ collector.prompts|length }}</span></h3>
-            <div class="tab-content">
-                {{ include('@Mcp/prompts.html.twig') }}
-            </div>
-        </div>
+    {% for name, server in collector.servers %}
+        <h3>Server <code>{{ name }}</code></h3>
 
-        <div class="tab {{ collector.resources is empty ? 'disabled' }}">
-            <h3 class="tab-title">Resources <span class="badge">{{ collector.resources|length }}</span></h3>
-            <div class="tab-content">
-                {{ include('@Mcp/resources.html.twig') }}
+        <section class="metrics">
+            <div class="metric-group">
+                <div class="metric">
+                    <span class="value">{{ server.tools|length }}</span>
+                    <span class="label">Tools</span>
+                </div>
+                <div class="metric">
+                    <span class="value">{{ server.prompts|length }}</span>
+                    <span class="label">Prompts</span>
+                </div>
             </div>
-        </div>
+            <div class="metric-divider"></div>
+            <div class="metric-group">
+                <div class="metric">
+                    <span class="value">{{ server.resources|length }}</span>
+                    <span class="label">Resources</span>
+                </div>
+                <div class="metric">
+                    <span class="value">{{ server.resourceTemplates|length }}</span>
+                    <span class="label">Resource Templates</span>
+                </div>
+            </div>
+        </section>
 
-        <div class="tab {{ collector.resourceTemplates is empty ? 'disabled' }}">
-            <h3 class="tab-title">Resource Templates <span class="badge">{{ collector.resourceTemplates|length }}</span></h3>
-            <div class="tab-content">
-                {{ include('@Mcp/resource_templates.html.twig') }}
+        <div class="sf-tabs">
+            <div class="tab {{ server.tools is empty ? 'disabled' }}">
+                <h3 class="tab-title">Tools <span class="badge">{{ server.tools|length }}</span></h3>
+                <div class="tab-content">
+                    {{ include('@Mcp/tools.html.twig', { tools: server.tools }, with_context = false) }}
+                </div>
+            </div>
+
+            <div class="tab {{ server.prompts is empty ? 'disabled' }}">
+                <h3 class="tab-title">Prompts <span class="badge">{{ server.prompts|length }}</span></h3>
+                <div class="tab-content">
+                    {{ include('@Mcp/prompts.html.twig', { prompts: server.prompts }, with_context = false) }}
+                </div>
+            </div>
+
+            <div class="tab {{ server.resources is empty ? 'disabled' }}">
+                <h3 class="tab-title">Resources <span class="badge">{{ server.resources|length }}</span></h3>
+                <div class="tab-content">
+                    {{ include('@Mcp/resources.html.twig', { resources: server.resources }, with_context = false) }}
+                </div>
+            </div>
+
+            <div class="tab {{ server.resourceTemplates is empty ? 'disabled' }}">
+                <h3 class="tab-title">Resource Templates <span class="badge">{{ server.resourceTemplates|length }}</span></h3>
+                <div class="tab-content">
+                    {{ include('@Mcp/resource_templates.html.twig', { resourceTemplates: server.resourceTemplates }, with_context = false) }}
+                </div>
             </div>
         </div>
-    </div>
+    {% endfor %}
 {% endblock %}

--- a/src/mcp-bundle/templates/prompts.html.twig
+++ b/src/mcp-bundle/templates/prompts.html.twig
@@ -1,6 +1,6 @@
-{% if collector.prompts|length %}
+{% if prompts|length %}
     <div class="sf-tabs">
-        {% for prompt in collector.prompts %}
+        {% for prompt in prompts %}
             <div class="tab">
                 <h3 class="tab-title">{{ prompt.name }}</h3>
                 <div class="tab-content">

--- a/src/mcp-bundle/templates/resource_templates.html.twig
+++ b/src/mcp-bundle/templates/resource_templates.html.twig
@@ -1,6 +1,6 @@
-{% if collector.resourceTemplates|length %}
+{% if resourceTemplates|length %}
     <div class="sf-tabs">
-        {% for template in collector.resourceTemplates %}
+        {% for template in resourceTemplates %}
             <div class="tab">
                 <h3 class="tab-title">{{ template.name }}</h3>
                 <div class="tab-content">

--- a/src/mcp-bundle/templates/resources.html.twig
+++ b/src/mcp-bundle/templates/resources.html.twig
@@ -1,6 +1,6 @@
-{% if collector.resources|length %}
+{% if resources|length %}
     <div class="sf-tabs">
-        {% for resource in collector.resources %}
+        {% for resource in resources %}
             <div class="tab">
                 <h3 class="tab-title">{{ resource.name }}</h3>
                 <div class="tab-content">

--- a/src/mcp-bundle/templates/tools.html.twig
+++ b/src/mcp-bundle/templates/tools.html.twig
@@ -1,6 +1,6 @@
-{% if collector.tools|length %}
+{% if tools|length %}
     <div class="sf-tabs">
-        {% for tool in collector.tools %}
+        {% for tool in tools %}
             <div class="tab">
                 <h3 class="tab-title">{{ tool.name }}</h3>
                 <div class="tab-content">

--- a/src/mcp-bundle/tests/Client/McpClientTest.php
+++ b/src/mcp-bundle/tests/Client/McpClientTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\Client;
+
+use Mcp\Client;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\Client\McpClient;
+use Symfony\AI\McpBundle\Client\ServerConnection;
+use Symfony\AI\McpBundle\Exception\InvalidArgumentException;
+use Symfony\AI\McpBundle\Tests\Double\InMemoryTransport;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class McpClientTest extends TestCase
+{
+    public function testExposesItsServers()
+    {
+        $client = $this->createClient(['github' => new InMemoryTransport(), 'filesystem' => new InMemoryTransport()]);
+
+        $this->assertSame('research', $client->getName());
+        $this->assertSame(['github', 'filesystem'], $client->getServerNames());
+        $this->assertCount(2, $client);
+        $this->assertTrue($client->has('github'));
+        $this->assertFalse($client->has('gitlab'));
+        $this->assertSame('github', $client->get('github')->getName());
+    }
+
+    public function testUnknownServerListsTheConfiguredOnes()
+    {
+        $client = $this->createClient(['github' => new InMemoryTransport()]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The MCP client "research" has no server named "gitlab". Configured: "github".');
+
+        $client->get('gitlab');
+    }
+
+    public function testIterationYieldsConnectionsWithoutConnectingThem()
+    {
+        $transports = ['github' => new InMemoryTransport(), 'filesystem' => new InMemoryTransport()];
+        $client = $this->createClient($transports);
+
+        $names = [];
+        foreach ($client as $name => $connection) {
+            $names[] = $name;
+            $this->assertSame($name, $connection->getName());
+        }
+
+        $this->assertSame(['github', 'filesystem'], $names);
+        $this->assertSame(0, $transports['github']->connectCount);
+        $this->assertSame(0, $transports['filesystem']->connectCount);
+    }
+
+    public function testDisconnectClosesEveryOpenConnection()
+    {
+        $transports = ['github' => new InMemoryTransport(), 'filesystem' => new InMemoryTransport()];
+        $client = $this->createClient($transports);
+
+        $client->get('github')->getServerInfo();
+        $client->disconnect();
+
+        $this->assertSame(1, $transports['github']->closeCount);
+        // Never used, so nothing to close.
+        $this->assertSame(0, $transports['filesystem']->closeCount);
+    }
+
+    /**
+     * @param array<string, InMemoryTransport> $transports
+     */
+    private function createClient(array $transports): McpClient
+    {
+        $connections = [];
+        foreach ($transports as $name => $transport) {
+            $connections[$name] = static fn (): ServerConnection => new ServerConnection('research', $name, Client::builder()->build(), $transport);
+        }
+
+        return new McpClient('research', new ServiceLocator($connections));
+    }
+}

--- a/src/mcp-bundle/tests/Client/ServerConnectionTest.php
+++ b/src/mcp-bundle/tests/Client/ServerConnectionTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\Client;
+
+use Mcp\Client;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\Client\ServerConnection;
+use Symfony\AI\McpBundle\Exception\ConnectionException;
+use Symfony\AI\McpBundle\Exception\RemoteCallException;
+use Symfony\AI\McpBundle\Tests\Double\InMemoryTransport;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ServerConnectionTest extends TestCase
+{
+    public function testDoesNotConnectOnConstruction()
+    {
+        $transport = new InMemoryTransport();
+        $connection = $this->createConnection($transport);
+
+        $this->assertSame(0, $transport->connectCount);
+        $this->assertFalse($connection->isConnected());
+    }
+
+    public function testConnectsOnFirstUseAndOnlyOnce()
+    {
+        $transport = new InMemoryTransport(['tools/list' => [['tools' => []]]]);
+        $connection = $this->createConnection($transport);
+
+        $connection->listTools();
+        $connection->listTools();
+        $connection->listTools();
+
+        $this->assertSame(1, $transport->connectCount);
+        $this->assertTrue($connection->isConnected());
+    }
+
+    public function testCallToolForwardsNameAndArguments()
+    {
+        $transport = new InMemoryTransport(['tools/call' => [['content' => [['type' => 'text', 'text' => 'ok']]]]]);
+        $connection = $this->createConnection($transport);
+
+        $connection->callTool('publish', ['id' => 42]);
+
+        $call = end($transport->sent);
+        $this->assertSame('tools/call', $call['method']);
+        $this->assertSame('publish', $call['params']['name']);
+        $this->assertSame(['id' => 42], $call['params']['arguments']);
+    }
+
+    public function testGetToolsFollowsPaginationToItsEnd()
+    {
+        $transport = new InMemoryTransport(['tools/list' => [
+            ['tools' => [$this->tool('first')], 'nextCursor' => 'page-2'],
+            ['tools' => [$this->tool('second')]],
+        ]]);
+
+        $tools = $this->createConnection($transport)->getTools();
+
+        $this->assertCount(2, $tools);
+        $this->assertSame(['first', 'second'], array_map(static fn ($tool): string => $tool->name, $tools));
+    }
+
+    public function testServerInfoAndInstructionsComeFromTheHandshake()
+    {
+        $connection = $this->createConnection(new InMemoryTransport());
+
+        $this->assertSame('test-server', $connection->getServerInfo()?->name);
+        $this->assertSame('Be nice.', $connection->getInstructions());
+    }
+
+    public function testDisconnectIsIdempotent()
+    {
+        $transport = new InMemoryTransport(['tools/list' => [['tools' => []]]]);
+        $connection = $this->createConnection($transport);
+
+        $connection->listTools();
+        $connection->disconnect();
+        $connection->disconnect();
+
+        $this->assertSame(1, $transport->closeCount);
+        $this->assertFalse($connection->isConnected());
+    }
+
+    public function testDisconnectingWithoutHavingConnectedDoesNothing()
+    {
+        $transport = new InMemoryTransport();
+
+        $this->createConnection($transport)->disconnect();
+
+        $this->assertSame(0, $transport->closeCount);
+    }
+
+    public function testReconnectsAfterDisconnect()
+    {
+        $transport = new InMemoryTransport(['tools/list' => [['tools' => []]]]);
+        $connection = $this->createConnection($transport);
+
+        $connection->listTools();
+        $connection->disconnect();
+        $connection->listTools();
+
+        $this->assertSame(2, $transport->connectCount);
+        $this->assertTrue($connection->isConnected());
+    }
+
+    public function testConnectionFailureIsTranslatedAndLeavesTheConnectionRetryable()
+    {
+        $transport = new InMemoryTransport(failOnConnect: true);
+        $connection = $this->createConnection($transport);
+
+        try {
+            $connection->listTools();
+            $this->fail('Expected a ConnectionException.');
+        } catch (ConnectionException $e) {
+            $this->assertSame('Failed to connect MCP client "research" to server "github": Initialization failed: the double refuses to connect.', $e->getMessage());
+        }
+
+        $this->assertFalse($connection->isConnected());
+
+        // A failed connect must not latch: the next call tries again.
+        $this->expectException(ConnectionException::class);
+        $connection->listTools();
+    }
+
+    public function testRequestFailureIsTranslatedAndNamesTheOperation()
+    {
+        $transport = new InMemoryTransport(failures: ['tools/call' => 'tool exploded']);
+        $connection = $this->createConnection($transport);
+
+        $this->expectException(RemoteCallException::class);
+        $this->expectExceptionMessage('The "tools/call" request of MCP client "research" to server "github" failed: tool exploded');
+
+        $connection->callTool('publish');
+    }
+
+    public function testResetSwallowsDisconnectFailures()
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('isConnected')->willReturn(true);
+        $client->method('disconnect')->willThrowException(new \Mcp\Exception\ConnectionException('already gone'));
+
+        $transport = new InMemoryTransport();
+        $connection = new ServerConnection('research', 'github', $client, $transport);
+
+        // Opens the connection through the real handshake path before resetting.
+        $connection->getServerInfo();
+        $connection->reset();
+
+        $this->assertFalse($connection->isConnected());
+    }
+
+    public function testNamesAreExposed()
+    {
+        $connection = $this->createConnection(new InMemoryTransport());
+
+        $this->assertSame('github', $connection->getName());
+        $this->assertSame('research', $connection->getClientName());
+    }
+
+    private function createConnection(InMemoryTransport $transport): ServerConnection
+    {
+        return new ServerConnection('research', 'github', Client::builder()->build(), $transport);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function tool(string $name): array
+    {
+        return ['name' => $name, 'inputSchema' => ['type' => 'object']];
+    }
+}

--- a/src/mcp-bundle/tests/Command/DebugCommandTest.php
+++ b/src/mcp-bundle/tests/Command/DebugCommandTest.php
@@ -12,16 +12,24 @@
 namespace Symfony\AI\McpBundle\Tests\Command;
 
 use Mcp\Capability\Registry;
+use Mcp\Client;
 use Mcp\Schema\Prompt;
 use Mcp\Schema\PromptArgument;
 use Mcp\Schema\ResourceDefinition;
 use Mcp\Schema\ResourceTemplate;
 use Mcp\Schema\Tool;
 use Mcp\Server;
+use Mcp\Server\Builder;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\Client\McpClient;
+use Symfony\AI\McpBundle\Client\McpClientInterface;
+use Symfony\AI\McpBundle\Client\ServerConnection;
 use Symfony\AI\McpBundle\Command\DebugCommand;
+use Symfony\AI\McpBundle\Tests\Double\InMemoryTransport;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class DebugCommandTest extends TestCase
 {
@@ -53,7 +61,7 @@ final class DebugCommandTest extends TestCase
 
         $this->assertSame(Command::SUCCESS, $exitCode);
         $this->assertStringContainsString('No MCP capabilities are registered.', $display);
-        $this->assertStringContainsString('registered as services with autoconfiguration enabled', $display);
+        $this->assertStringContainsString('autoconfiguration enabled', $display);
     }
 
     public function testDescribesToolWithInputSchema()
@@ -92,12 +100,211 @@ final class DebugCommandTest extends TestCase
         $this->assertStringContainsString('No MCP capability named "unknown-element" is registered.', $tester->getDisplay());
     }
 
-    private function createTester(Registry $registry): CommandTester
+    public function testListsEveryServerSeparately()
     {
-        $command = new Command('debug:mcp');
-        $command->setCode(new DebugCommand(Server::builder()->setRegistry($registry), $registry));
+        $tester = $this->createTester(['public' => new Registry(), 'editors' => $this->createPopulatedRegistry()]);
 
-        return new CommandTester($command);
+        $this->assertSame(Command::SUCCESS, $tester->execute([]));
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Server "public"', $display);
+        $this->assertStringContainsString('Server "editors"', $display);
+        $this->assertStringContainsString('current-time', $display);
+    }
+
+    public function testRestrictsOutputToOneServer()
+    {
+        $tester = $this->createTester(['public' => new Registry(), 'editors' => $this->createPopulatedRegistry()]);
+
+        $this->assertSame(Command::SUCCESS, $tester->execute(['--server' => 'editors']));
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Server "editors"', $display);
+        $this->assertStringNotContainsString('Server "public"', $display);
+    }
+
+    public function testReportsUnknownServer()
+    {
+        $tester = $this->createTester(['editors' => $this->createPopulatedRegistry()]);
+
+        $this->assertSame(Command::INVALID, $tester->execute(['--server' => 'missing']));
+        $this->assertStringContainsString('No MCP server named "missing" is configured.', $tester->getDisplay());
+        $this->assertStringContainsString('Available: editors.', $tester->getDisplay());
+    }
+
+    public function testDescribingAnElementNamesTheServerExposingIt()
+    {
+        $tester = $this->createTester(['public' => new Registry(), 'editors' => $this->createPopulatedRegistry()]);
+
+        $this->assertSame(Command::SUCCESS, $tester->execute(['name' => 'current-time']));
+        $this->assertStringContainsString('Tool "current-time" on server "editors"', $tester->getDisplay());
+    }
+
+    public function testListsConfiguredClientsWithoutConnecting()
+    {
+        $transport = $this->populatedTransport();
+        $tester = $this->createTester(new Registry(), ['research' => ['github' => $transport, 'filesystem' => new InMemoryTransport()]]);
+
+        $this->assertSame(Command::SUCCESS, $tester->execute(['--clients' => true]));
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('research', $display);
+        $this->assertStringContainsString('github, filesystem', $display);
+        // Asking which clients exist must not spawn processes or open sessions.
+        $this->assertSame(0, $transport->connectCount);
+    }
+
+    public function testDefaultOutputSummarizesClientsWithoutConnecting()
+    {
+        $transport = $this->populatedTransport();
+        $tester = $this->createTester($this->createPopulatedRegistry(), ['research' => ['github' => $transport]]);
+
+        $this->assertSame(Command::SUCCESS, $tester->execute([]));
+
+        $display = $tester->getDisplay();
+        // Both sides of the bundle in one command.
+        $this->assertStringContainsString('current-time', $display);
+        $this->assertStringContainsString('Clients (1)', $display);
+        $this->assertSame(0, $transport->connectCount);
+    }
+
+    public function testWarnsWhenNoClientIsConfigured()
+    {
+        $tester = $this->createTester(new Registry());
+
+        $this->assertSame(Command::SUCCESS, $tester->execute(['--clients' => true]));
+        $this->assertStringContainsString('No MCP client is configured.', $tester->getDisplay());
+    }
+
+    public function testDescribesARemoteServer()
+    {
+        $tester = $this->createTester(new Registry(), ['research' => ['github' => $this->populatedTransport()]]);
+
+        $this->assertSame(Command::SUCCESS, $tester->execute(['--client' => 'research', '--server' => 'github']));
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('MCP client "research" → server "github"', $display);
+        $this->assertStringContainsString('test-server', $display);
+        $this->assertStringContainsString('Be nice.', $display);
+        $this->assertStringContainsString('Tools (1)', $display);
+        $this->assertStringContainsString('read_file', $display);
+        $this->assertStringContainsString('Read a file from disk.', $display);
+    }
+
+    public function testSingleServerClientNeedsNoServerOption()
+    {
+        $tester = $this->createTester(new Registry(), ['research' => ['github' => $this->populatedTransport()]]);
+
+        $this->assertSame(Command::SUCCESS, $tester->execute(['--client' => 'research']));
+        $this->assertStringContainsString('server "github"', $tester->getDisplay());
+    }
+
+    public function testMultiServerClientRequiresTheServerOption()
+    {
+        $tester = $this->createTester(new Registry(), ['research' => ['github' => new InMemoryTransport(), 'filesystem' => new InMemoryTransport()]]);
+
+        $this->assertSame(Command::INVALID, $tester->execute(['--client' => 'research']));
+        $this->assertStringContainsString('connects to several servers', $tester->getDisplay());
+    }
+
+    public function testReportsUnknownClient()
+    {
+        $tester = $this->createTester(new Registry(), ['research' => ['github' => new InMemoryTransport()]]);
+
+        $this->assertSame(Command::INVALID, $tester->execute(['--client' => 'missing']));
+        $this->assertStringContainsString('No MCP client named "missing" is configured.', $tester->getDisplay());
+        $this->assertStringContainsString('research', $tester->getDisplay());
+    }
+
+    public function testReportsUnknownRemoteServer()
+    {
+        $tester = $this->createTester(new Registry(), ['research' => ['github' => new InMemoryTransport()]]);
+
+        $this->assertSame(Command::INVALID, $tester->execute(['--client' => 'research', '--server' => 'gitlab']));
+        $this->assertStringContainsString('has no server named "gitlab"', $tester->getDisplay());
+    }
+
+    public function testReportsRemoteConnectionFailure()
+    {
+        $tester = $this->createTester(new Registry(), ['research' => ['github' => new InMemoryTransport(failOnConnect: true)]]);
+
+        $this->assertSame(Command::FAILURE, $tester->execute(['--client' => 'research', '--server' => 'github']));
+        $this->assertStringContainsString('Failed to connect MCP client "research" to server "github"', $tester->getDisplay());
+    }
+
+    public function testDisconnectsAfterDescribingARemoteServer()
+    {
+        $transport = $this->populatedTransport();
+        $tester = $this->createTester(new Registry(), ['research' => ['github' => $transport]]);
+
+        $tester->execute(['--client' => 'research', '--server' => 'github']);
+
+        $this->assertSame(1, $transport->closeCount);
+    }
+
+    public function testCompletesServersAndClients()
+    {
+        $tester = new CommandCompletionTester($this->createCommand(
+            ['public' => new Registry(), 'editors' => new Registry()],
+            ['research' => ['github' => new InMemoryTransport()], 'simple' => ['github' => new InMemoryTransport()]],
+        ));
+
+        $this->assertSame(['public', 'editors'], $tester->complete(['--server', '']));
+        $this->assertSame(['research', 'simple'], $tester->complete(['--client', '']));
+    }
+
+    /**
+     * @param array<string, Registry>                         $registries
+     * @param array<string, array<string, InMemoryTransport>> $clients
+     */
+    private function createTester(Registry|array $registries, array $clients = []): CommandTester
+    {
+        return new CommandTester($this->createCommand($registries, $clients));
+    }
+
+    /**
+     * @param array<string, Registry>                         $registries
+     * @param array<string, array<string, InMemoryTransport>> $clients
+     */
+    private function createCommand(Registry|array $registries, array $clients = []): Command
+    {
+        $registries = $registries instanceof Registry ? ['default' => $registries] : $registries;
+
+        $clientServices = [];
+        foreach ($clients as $clientName => $servers) {
+            $connections = [];
+            foreach ($servers as $serverName => $transport) {
+                $connections[$serverName] = static fn (): ServerConnection => new ServerConnection($clientName, $serverName, Client::builder()->build(), $transport);
+            }
+
+            $clientServices[$clientName] = static fn (): McpClientInterface => new McpClient($clientName, new ServiceLocator($connections));
+        }
+
+        $command = new Command('debug:mcp');
+        $command->setCode(new DebugCommand(
+            new ServiceLocator(array_map(
+                static fn (Registry $registry): \Closure => static fn (): Builder => Server::builder()->setRegistry($registry),
+                $registries,
+            )),
+            new ServiceLocator(array_map(
+                static fn (Registry $registry): \Closure => static fn (): Registry => $registry,
+                $registries,
+            )),
+            new ServiceLocator($clientServices),
+        ));
+
+        return $command;
+    }
+
+    private function populatedTransport(): InMemoryTransport
+    {
+        return new InMemoryTransport([
+            'tools/list' => [['tools' => [[
+                'name' => 'read_file',
+                'description' => 'Read a file from disk.',
+                'inputSchema' => ['type' => 'object', 'properties' => ['path' => ['type' => 'string']], 'required' => ['path']],
+            ]]]],
+        ]);
     }
 
     private function createPopulatedRegistry(): Registry

--- a/src/mcp-bundle/tests/Command/McpCommandTest.php
+++ b/src/mcp-bundle/tests/Command/McpCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\Command;
+
+use Mcp\Server;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\Command\McpCommand;
+use Symfony\AI\McpBundle\Exception\RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class McpCommandTest extends TestCase
+{
+    public function testRequiresTheNameWithSeveralStdioServers()
+    {
+        $tester = $this->createTester(['default', 'editors']);
+
+        $this->assertSame(Command::INVALID, $tester->execute([]));
+        $this->assertStringContainsString('Several MCP servers expose the STDIO transport, name the one to run', $tester->getDisplay());
+    }
+
+    public function testReportsUnknownServer()
+    {
+        $tester = $this->createTester(['editors']);
+
+        $this->assertSame(Command::INVALID, $tester->execute(['name' => 'missing']));
+        $this->assertStringContainsString('No MCP server named "missing" exposes the STDIO transport.', $tester->getDisplay());
+        $this->assertStringContainsString('editors.', $tester->getDisplay());
+    }
+
+    public function testRunsTheNamedServer()
+    {
+        $tester = $this->createTester(['editors', 'public']);
+
+        // Mcp\Server is final, so the locator reports which server was picked instead of running it —
+        // running would hand STDIN and STDOUT to a real transport.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('resolved server "editors"');
+
+        $tester->execute(['name' => 'editors']);
+    }
+
+    public function testRunsTheOnlyStdioServerWithoutAnArgument()
+    {
+        $tester = $this->createTester(['editors']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('resolved server "editors"');
+
+        $tester->execute([]);
+    }
+
+    public function testCompletesServerNames()
+    {
+        $tester = new CommandCompletionTester($this->createCommand(['public', 'editors']));
+
+        $this->assertSame(['public', 'editors'], $tester->complete(['']));
+    }
+
+    /**
+     * @param list<string> $servers
+     */
+    private function createTester(array $servers): CommandTester
+    {
+        return new CommandTester($this->createCommand($servers));
+    }
+
+    /**
+     * @param list<string> $servers
+     */
+    private function createCommand(array $servers): Command
+    {
+        $factories = [];
+        foreach ($servers as $name) {
+            $factories[$name] = static function () use ($name): Server {
+                throw new RuntimeException(\sprintf('resolved server "%s"', $name));
+            };
+        }
+
+        $command = new Command('mcp:server');
+        $command->setCode(new McpCommand(new ServiceLocator($factories)));
+
+        return $command;
+    }
+}

--- a/src/mcp-bundle/tests/DependencyInjection/McpAppPassTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpAppPassTest.php
@@ -34,7 +34,7 @@ final class McpAppPassTest extends TestCase
 
         (new McpAppPass())->process($container);
 
-        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $calls = $container->getDefinition('mcp.server.default.builder')->getMethodCalls();
 
         $enable = $this->callsNamed($calls, 'enableExtension');
         $this->assertCount(1, $enable);
@@ -56,11 +56,14 @@ final class McpAppPassTest extends TestCase
         $this->assertSame(\stdClass::class, $marker->getClass());
         $this->assertSame([McpApps::class, 'resourceMarker'], $marker->getFactory());
 
-        // template apps share one URI-dispatched renderer service (keyed by its FQCN)
+        // template apps share one URI-dispatched renderer service per server, resolved by its FQCN
         $this->assertSame([McpAppResourceRenderer::class, '__invoke'], $args[0]);
-        $this->assertTrue($container->hasDefinition(McpAppResourceRenderer::class));
-        $rendererDef = $container->getDefinition(McpAppResourceRenderer::class);
-        $this->assertArrayHasKey('mcp.resource', $rendererDef->getTags());
+        $this->assertTrue($container->hasDefinition('mcp.server.default.app.resource_renderer'));
+        $rendererDef = $container->getDefinition('mcp.server.default.app.resource_renderer');
+        $this->assertSame(
+            'mcp.server.default.app.resource_renderer',
+            $container->getParameter('mcp.servers.app_handlers')['default'][McpAppResourceRenderer::class],
+        );
 
         // the renderer's URI => {template, contentMeta} map carries this app
         $map = $rendererDef->getArgument(1);
@@ -82,14 +85,15 @@ final class McpAppPassTest extends TestCase
 
         (new McpAppPass())->process($container);
 
-        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $calls = $container->getDefinition('mcp.server.default.builder')->getMethodCalls();
         $resources = $this->callsNamed($calls, 'addResource');
         $this->assertCount(1, $resources);
         $this->assertSame([CustomHandlerApp::class, '__invoke'], $resources[0][1][0]);
         $this->assertSame('ui://custom', $resources[0][1][1]);
 
-        // the user class itself is tagged mcp.resource so McpPass adds it to the locator
-        $this->assertArrayHasKey('mcp.resource', $container->getDefinition(CustomHandlerApp::class)->getTags());
+        // the user class is handed to McpPass explicitly so it joins this server's handler locator
+        $handlers = $container->getParameter('mcp.servers.app_handlers')['default'];
+        $this->assertSame(CustomHandlerApp::class, $handlers[CustomHandlerApp::class]);
     }
 
     public function testExtensionEnabledOnlyOnceForMultipleApps()
@@ -100,41 +104,38 @@ final class McpAppPassTest extends TestCase
 
         (new McpAppPass())->process($container);
 
-        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $calls = $container->getDefinition('mcp.server.default.builder')->getMethodCalls();
         $this->assertCount(1, $this->callsNamed($calls, 'enableExtension'));
         $this->assertCount(2, $this->callsNamed($calls, 'addResource'));
     }
 
-    public function testDisabledFlagRegistersNothing()
+    public function testEmptyAppListRegistersNothing()
     {
-        $container = $this->containerWithBuilder(withRenderer: true);
-        $container->setParameter('mcp.apps.enabled', false);
+        $container = $this->containerWithBuilder(withRenderer: true, apps: []);
         $container->setDefinition(StaticTemplateApp::class, (new Definition(StaticTemplateApp::class))->addTag('mcp.app'));
 
         (new McpAppPass())->process($container);
 
-        $this->assertEmpty($container->getDefinition('mcp.server.builder')->getMethodCalls());
+        $this->assertEmpty($container->getDefinition('mcp.server.default.builder')->getMethodCalls());
     }
 
-    public function testForcedEnabledWithoutAppsEnablesExtensionOnly()
+    public function testAppListNotMatchingTheAppRegistersNothing()
     {
-        $container = $this->containerWithBuilder(withRenderer: false);
-        $container->setParameter('mcp.apps.enabled', true);
+        $container = $this->containerWithBuilder(withRenderer: true, apps: ['App\\Other\\']);
+        $container->setDefinition(StaticTemplateApp::class, (new Definition(StaticTemplateApp::class))->addTag('mcp.app'));
 
         (new McpAppPass())->process($container);
 
-        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
-        $this->assertCount(1, $this->callsNamed($calls, 'enableExtension'));
-        $this->assertCount(0, $this->callsNamed($calls, 'addResource'));
+        $this->assertEmpty($container->getDefinition('mcp.server.default.builder')->getMethodCalls());
     }
 
-    public function testAutoModeWithoutAppsDoesNothing()
+    public function testWithoutAppsDoesNothing()
     {
         $container = $this->containerWithBuilder(withRenderer: false);
 
         (new McpAppPass())->process($container);
 
-        $this->assertEmpty($container->getDefinition('mcp.server.builder')->getMethodCalls());
+        $this->assertEmpty($container->getDefinition('mcp.server.default.builder')->getMethodCalls());
     }
 
     public function testTemplateAppWithoutTwigThrows()
@@ -155,7 +156,7 @@ final class McpAppPassTest extends TestCase
 
         (new McpAppPass())->process($container);
 
-        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $calls = $container->getDefinition('mcp.server.default.builder')->getMethodCalls();
         $tools = $this->callsNamed($calls, 'addTool');
         $this->assertCount(1, $tools);
 
@@ -172,8 +173,9 @@ final class McpAppPassTest extends TestCase
         $this->assertSame('ui://widget', $ui->getArgument(0));
         $this->assertSame([ToolVisibility::Model, ToolVisibility::App], $ui->getArgument(1));
 
-        // app service tagged mcp.tool so McpPass adds it to the handler locator
-        $this->assertArrayHasKey('mcp.tool', $container->getDefinition(WidgetApp::class)->getTags());
+        // app service handed to McpPass explicitly so it joins this server's handler locator
+        $handlers = $container->getParameter('mcp.servers.app_handlers')['default'];
+        $this->assertSame(WidgetApp::class, $handlers[WidgetApp::class]);
     }
 
     public function testTemplateAppWithoutRenderMethodRegistersNoTool()
@@ -183,7 +185,7 @@ final class McpAppPassTest extends TestCase
 
         (new McpAppPass())->process($container);
 
-        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $calls = $container->getDefinition('mcp.server.default.builder')->getMethodCalls();
         $this->assertCount(0, $this->callsNamed($calls, 'addTool'));
     }
 
@@ -205,7 +207,7 @@ final class McpAppPassTest extends TestCase
 
         (new McpAppPass())->process($container);
 
-        $templates = $container->getParameter('mcp.apps.tool_templates');
+        $templates = $container->getParameter('mcp.servers.app_tool_templates')['default'];
         $this->assertSame('grid.html.twig', $templates[MultiToolApp::class.'::render']);
         $this->assertSame('detail.html.twig', $templates[MultiToolApp::class.'::showDetail']);
         $this->assertArrayNotHasKey(MultiToolApp::class.'::plain', $templates); // no template declared
@@ -218,7 +220,7 @@ final class McpAppPassTest extends TestCase
 
         (new McpAppPass())->process($container);
 
-        $calls = $container->getDefinition('mcp.server.builder')->getMethodCalls();
+        $calls = $container->getDefinition('mcp.server.default.builder')->getMethodCalls();
         $byName = [];
         foreach ($this->callsNamed($calls, 'addTool') as $tool) {
             $byName[$tool[1][1]] = $tool[1];
@@ -260,20 +262,25 @@ final class McpAppPassTest extends TestCase
         (new McpAppPass())->process($container);
     }
 
-    public function testDoesNothingWhenNoServerBuilder()
+    public function testDoesNothingWhenNoServerConfigured()
     {
         $container = new ContainerBuilder();
         $container->setDefinition(StaticTemplateApp::class, (new Definition(StaticTemplateApp::class))->addTag('mcp.app'));
 
         (new McpAppPass())->process($container);
 
-        $this->assertFalse($container->hasDefinition('mcp.server.builder'));
+        $this->assertFalse($container->hasDefinition('mcp.server.default.builder'));
     }
 
-    private function containerWithBuilder(bool $withRenderer): ContainerBuilder
+    /**
+     * @param list<string> $apps the "apps" element list of the "default" server
+     */
+    private function containerWithBuilder(bool $withRenderer, array $apps = ['*']): ContainerBuilder
     {
         $container = new ContainerBuilder();
-        $container->setDefinition('mcp.server.builder', new Definition());
+        $container->setDefinition('mcp.server.default.builder', new Definition());
+        $container->setParameter('mcp.servers.elements', ['default' => ['apps' => $apps]]);
+
         if ($withRenderer) {
             $container->setDefinition(McpAppRenderer::SERVICE_ID, new Definition(McpAppRenderer::class));
         }

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleClientTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleClientTest.php
@@ -1,0 +1,372 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\DependencyInjection;
+
+use Http\Discovery\Exception\NotFoundException;
+use Http\Discovery\Psr18ClientDiscovery;
+use Mcp\Client as McpSdkClient;
+use Mcp\Client\Transport\HttpTransport;
+use Mcp\Client\Transport\StdioTransport;
+use Mcp\Schema\ClientCapabilities;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\AI\McpBundle\Client\McpClient;
+use Symfony\AI\McpBundle\Client\McpClientInterface;
+use Symfony\AI\McpBundle\Client\ServerConnection;
+use Symfony\AI\McpBundle\Client\TransportFactory;
+use Symfony\AI\McpBundle\Exception\RuntimeException;
+use Symfony\AI\McpBundle\McpBundle;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class McpBundleClientTest extends TestCase
+{
+    public function testNoClientsRegistersNothing()
+    {
+        $container = $this->buildContainer([]);
+
+        $this->assertFalse($container->hasDefinition('mcp.client.locator'));
+        $this->assertFalse($container->hasDefinition('mcp.debug_command'));
+    }
+
+    public function testRegistersTheFullGraphPerConnection()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => ['servers' => [
+                'github' => ['transport' => 'http', 'url' => 'https://example.com/mcp'],
+                'filesystem' => ['transport' => 'stdio', 'command' => ['npx', '-y', 'server-filesystem', '/tmp']],
+            ]],
+        ]));
+
+        foreach (['github', 'filesystem'] as $server) {
+            $id = 'mcp.client.research.server.'.$server;
+            $this->assertTrue($container->hasDefinition($id));
+            $this->assertTrue($container->hasDefinition($id.'.client'));
+            $this->assertTrue($container->hasDefinition($id.'.builder'));
+            $this->assertTrue($container->hasDefinition($id.'.transport'));
+
+            $connection = $container->getDefinition($id);
+            $this->assertSame(ServerConnection::class, $connection->getClass());
+            $this->assertSame([['client' => 'research', 'server' => $server]], $connection->getTag('mcp.client.connection'));
+            // Stdio connections own a child process, so a worker must drop them between messages.
+            $this->assertSame([['method' => 'reset']], $connection->getTag('kernel.reset'));
+        }
+
+        $aggregate = $container->getDefinition('mcp.client.research');
+        $this->assertSame(McpClient::class, $aggregate->getClass());
+        $this->assertSame([['name' => 'research']], $aggregate->getTag('mcp.client'));
+
+        $locator = $container->getDefinition('mcp.client.research.locator');
+        $this->assertSame(['github', 'filesystem'], array_keys($locator->getArgument(0)));
+
+        $this->assertTrue($container->hasDefinition('mcp.debug_command'));
+    }
+
+    public function testStdioTransportGoesThroughTheFactory()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => ['servers' => ['filesystem' => [
+                'transport' => 'stdio',
+                'command' => ['npx', '-y', 'server-filesystem', '/tmp'],
+                'cwd' => '/srv',
+                'env' => ['TOKEN' => 'secret'],
+                'inherit_env' => false,
+            ]]],
+        ]));
+
+        $transport = $container->getDefinition('mcp.client.research.server.filesystem.transport');
+
+        $this->assertSame(StdioTransport::class, $transport->getClass());
+        $this->assertSame([TransportFactory::class, 'stdio'], $transport->getFactory());
+        $this->assertSame(['npx', '-y', 'server-filesystem', '/tmp'], $transport->getArgument(0));
+        $this->assertSame('/srv', $transport->getArgument(1));
+        $this->assertSame(['TOKEN' => 'secret'], $transport->getArgument(2));
+        $this->assertFalse($transport->getArgument(3));
+        $this->assertNull($transport->getArgument(4));
+    }
+
+    public function testHttpTransportFallsBackToTheFrameworkClient()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => ['servers' => ['github' => [
+                'transport' => 'http',
+                'url' => 'https://example.com/mcp',
+                'headers' => ['Authorization' => 'Bearer t'],
+            ]]],
+        ]));
+
+        $transport = $container->getDefinition('mcp.client.research.server.github.transport');
+
+        $this->assertSame(HttpTransport::class, $transport->getClass());
+        $this->assertSame([TransportFactory::class, 'http'], $transport->getFactory());
+        $this->assertSame('https://example.com/mcp', $transport->getArgument(0));
+        $this->assertSame(['Authorization' => 'Bearer t'], $transport->getArgument(1));
+
+        $httpClient = $transport->getArgument(2);
+        $this->assertInstanceOf(Reference::class, $httpClient);
+        $this->assertSame('psr18.http_client', (string) $httpClient);
+        // Degrades to the SDK's own discovery when symfony/http-client is absent.
+        $this->assertSame(ContainerBuilder::NULL_ON_INVALID_REFERENCE, $httpClient->getInvalidBehavior());
+    }
+
+    public function testCustomHttpClientIsUsed()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => ['servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp', 'http_client' => 'app.psr18']]],
+        ]));
+
+        $this->assertSame('app.psr18', (string) $container->getDefinition('mcp.client.research.server.github.transport')->getArgument(2));
+    }
+
+    public function testClientInfoDefaultsToTheConfigurationKey()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => ['servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']]],
+        ]));
+
+        $this->assertSame(['research', '0.0.1', null], $this->callsNamed($container, 'research', 'github', 'setClientInfo')[0][1]);
+    }
+
+    public function testTimeoutsInheritFromTheClientAndCanBeOverriddenPerServer()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => [
+                'request_timeout' => 60,
+                'servers' => [
+                    'github' => ['transport' => 'http', 'url' => 'https://example.com/mcp'],
+                    'slow' => ['transport' => 'http', 'url' => 'https://example.com/slow', 'request_timeout' => 300],
+                ],
+            ],
+        ]));
+
+        $this->assertSame([60], $this->callsNamed($container, 'research', 'github', 'setRequestTimeout')[0][1]);
+        $this->assertSame([300], $this->callsNamed($container, 'research', 'slow', 'setRequestTimeout')[0][1]);
+    }
+
+    public function testCapabilitiesAreDerivedFromTheConfiguredHandlers()
+    {
+        $container = $this->buildContainer($this->config([
+            'plain' => ['servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']]],
+            'rich' => [
+                'sampling' => 'app.sampling',
+                'elicitation' => 'app.elicitation',
+                'capabilities' => ['roots' => true],
+                'servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']],
+            ],
+        ]));
+
+        $plain = $this->callsNamed($container, 'plain', 'github', 'setCapabilities')[0][1][0];
+        $this->assertInstanceOf(Definition::class, $plain);
+        $this->assertSame(ClientCapabilities::class, $plain->getClass());
+        // Advertising a capability without a handler makes the server get "method not found".
+        $this->assertSame([false, false, false, false], $plain->getArguments());
+
+        $rich = $this->callsNamed($container, 'rich', 'github', 'setCapabilities')[0][1][0];
+        $this->assertSame([true, false, true, true], $rich->getArguments());
+        $this->assertCount(2, $this->callsNamed($container, 'rich', 'github', 'addRequestHandler'));
+    }
+
+    public function testServerLogsAreForwardedByDefault()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => ['servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']]],
+            'quiet' => ['forward_server_logs' => false, 'servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']]],
+        ]));
+
+        $this->assertCount(1, $this->callsNamed($container, 'research', 'github', 'addNotificationHandler'));
+        $this->assertCount(0, $this->callsNamed($container, 'quiet', 'github', 'addNotificationHandler'));
+    }
+
+    public function testTwoClientsSharingAServerNameGetSeparateConnections()
+    {
+        $server = ['transport' => 'http', 'url' => 'https://example.com/mcp'];
+        $container = $this->buildContainer($this->config([
+            'research' => ['servers' => ['github' => $server, 'filesystem' => ['transport' => 'stdio', 'command' => ['npx']]]],
+            'simple' => ['servers' => ['github' => $server]],
+        ]));
+
+        $this->assertTrue($container->hasDefinition('mcp.client.research.server.github'));
+        $this->assertTrue($container->hasDefinition('mcp.client.simple.server.github'));
+        $this->assertSame(['github', 'filesystem'], array_keys($container->getDefinition('mcp.client.research.locator')->getArgument(0)));
+        $this->assertSame(['github'], array_keys($container->getDefinition('mcp.client.simple.locator')->getArgument(0)));
+    }
+
+    public function testClientIsAliasedForArgument()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => ['servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']]],
+        ]));
+
+        $this->assertSame('mcp.client.research', (string) $container->getAlias(McpClientInterface::class.' $researchClient'));
+        // A single client also answers a plain McpClientInterface type hint.
+        $this->assertSame('mcp.client.research', (string) $container->getAlias(McpClientInterface::class));
+    }
+
+    public function testInterfaceIsNotAliasedWithSeveralClients()
+    {
+        $server = ['transport' => 'http', 'url' => 'https://example.com/mcp'];
+        $container = $this->buildContainer($this->config([
+            'research' => ['servers' => ['github' => $server]],
+            'simple' => ['servers' => ['github' => $server]],
+        ]));
+
+        $this->assertFalse($container->hasAlias(McpClientInterface::class));
+    }
+
+    public function testProtocolVersionIsOptional()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => ['protocol_version' => '2025-11-25', 'servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']]],
+        ]));
+
+        $this->assertCount(1, $this->callsNamed($container, 'research', 'github', 'setProtocolVersion'));
+    }
+
+    public function testContainerCompilesAndBuildsTheConnections()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => [
+                'protocol_version' => '2025-11-25',
+                'servers' => [
+                    'github' => ['transport' => 'http', 'url' => 'https://example.com/mcp'],
+                    'filesystem' => ['transport' => 'stdio', 'command' => ['php', '-r', 'exit;']],
+                ],
+            ],
+        ]));
+
+        $container->getDefinition('mcp.client.research')->setPublic(true);
+        $container->getDefinition('mcp.client.research.server.github.client')->setPublic(true);
+        $container->register('logger', NullLogger::class);
+        $container->compile();
+
+        $client = $container->get('mcp.client.research');
+        $this->assertInstanceOf(McpClientInterface::class, $client);
+        $this->assertSame(['github', 'filesystem'], $client->getServerNames());
+        $this->assertInstanceOf(McpSdkClient::class, $container->get('mcp.client.research.server.github.client'));
+
+        // The stdio connection resolves without I/O; the HTTP one is left alone because no PSR-18
+        // client is installed in this test environment (covered by testHttpWithoutPsr18ClientFails).
+        $connection = $client->get('filesystem');
+        $this->assertFalse($connection->isConnected());
+    }
+
+    public function testHttpWithoutPsr18ClientFailsWithAnActionableMessage()
+    {
+        try {
+            Psr18ClientDiscovery::find();
+            $this->markTestSkipped('A PSR-18 client is installed, so discovery succeeds and the fallback cannot be reached.');
+        } catch (NotFoundException) {
+            // No PSR-18 client: this is the case the message is written for.
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No PSR-18 HTTP client is available to reach the MCP server at "https://example.com/mcp".');
+
+        TransportFactory::http('https://example.com/mcp', [], null, null, null, null, null);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>, 1: string}>
+     */
+    public static function provideInvalidServerConfigurations(): iterable
+    {
+        yield 'stdio without command' => [
+            ['transport' => 'stdio'],
+            'A "command" must be configured for the "stdio" transport.',
+        ];
+
+        yield 'http without url' => [
+            ['transport' => 'http'],
+            'A "url" must be configured for the "http" transport.',
+        ];
+
+        yield 'stdio with http options' => [
+            ['transport' => 'stdio', 'command' => ['npx'], 'url' => 'https://example.com'],
+            'are only supported by the "http" transport',
+        ];
+
+        yield 'http with stdio options' => [
+            ['transport' => 'http', 'url' => 'https://example.com', 'command' => ['npx']],
+            'are only supported by the "stdio" transport',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $server
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideInvalidServerConfigurations')]
+    public function testInvalidServerConfigurationIsRejected(array $server, string $message)
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage($message);
+
+        $this->buildContainer($this->config(['research' => ['servers' => ['github' => $server]]]));
+    }
+
+    public function testClientWithoutServersIsRejected()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->buildContainer(['mcp' => ['clients' => ['research' => []]]]);
+    }
+
+    public function testInvalidClientNameIsRejected()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('MCP client names must only contain letters, digits, underscores and hyphens');
+
+        $this->buildContainer($this->config(['my.client' => ['servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']]]]));
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $clients
+     *
+     * @return array<string, mixed>
+     */
+    private function config(array $clients): array
+    {
+        return ['mcp' => ['clients' => $clients]];
+    }
+
+    /**
+     * @return list<array{0: string, 1: array<int, mixed>}>
+     */
+    private function callsNamed(ContainerBuilder $container, string $client, string $server, string $method): array
+    {
+        return array_values(array_filter(
+            $container->getDefinition(\sprintf('mcp.client.%s.server.%s.builder', $client, $server))->getMethodCalls(),
+            static fn (array $call): bool => $call[0] === $method,
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function buildContainer(array $configuration): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', true);
+        $container->setParameter('kernel.environment', 'test');
+        $container->setParameter('kernel.build_dir', 'public');
+        $container->setParameter('kernel.project_dir', '/path/to/project');
+
+        $extension = (new McpBundle())->getContainerExtension();
+        $extension->load($configuration, $container);
+
+        return $container;
+    }
+}

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -16,6 +16,8 @@ use Mcp\Capability\Attribute\McpResource;
 use Mcp\Capability\Attribute\McpResourceTemplate;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Capability\Registry\Loader\LoaderInterface;
+use Mcp\Schema\Icon;
+use Mcp\Server;
 use Mcp\Server\Handler\Notification\NotificationHandlerInterface;
 use Mcp\Server\Handler\Request\RequestHandlerInterface;
 use Mcp\Server\Session\FileSessionStore;
@@ -29,509 +31,437 @@ use Symfony\AI\McpBundle\Exception\LogicException;
 use Symfony\AI\McpBundle\McpBundle;
 use Symfony\AI\McpBundle\Session\FrameworkSessionStore;
 use Symfony\Component\Cache\Psr16Cache;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
 
 class McpBundleTest extends TestCase
 {
-    public function testDefaultConfiguration()
+    public function testNoServersRegistersNothing()
     {
         $container = $this->buildContainer([]);
 
-        $this->assertSame('app', $container->getParameter('mcp.app'));
-        $this->assertSame('0.0.1', $container->getParameter('mcp.version'));
-        $this->assertNull($container->getParameter('mcp.description'));
-        $this->assertSame([], $container->getParameter('mcp.icons'));
-        $this->assertNull($container->getParameter('mcp.website_url'));
-        $this->assertSame(50, $container->getParameter('mcp.pagination_limit'));
-        $this->assertNull($container->getParameter('mcp.instructions'));
+        $this->assertFalse($container->hasDefinition('mcp.server.default'));
+        $this->assertFalse($container->hasDefinition('mcp.server.route_loader'));
+        $this->assertFalse($container->hasDefinition('mcp.data_collector'));
+        $this->assertFalse($container->hasParameter('mcp.servers.elements'));
+    }
+
+    public function testServerIdentityDefaults()
+    {
+        $container = $this->buildContainer($this->config(['default' => []]));
+
+        $calls = $this->callsNamed($container, 'setServerInfo');
+        $this->assertSame(['default', '0.0.1', null, null, null], $calls[0][1]);
+        $this->assertSame([50], $this->callsNamed($container, 'setPaginationLimit')[0][1]);
+        $this->assertSame([null], $this->callsNamed($container, 'setInstructions')[0][1]);
+    }
+
+    public function testServerIdentityCustom()
+    {
+        $container = $this->buildContainer($this->config(['default' => [
+            'name' => 'my-mcp-app',
+            'version' => '1.2.3',
+            'description' => 'My MCP Application',
+            'icons' => [
+                ['src' => 'https://example.com/icon.png', 'mime_type' => 'image/png', 'sizes' => ['64x64', '128x128']],
+            ],
+            'website_url' => 'https://example.com/mcp',
+            'pagination_limit' => 25,
+            'instructions' => 'This server provides weather and calendar tools',
+        ]]));
+
+        $arguments = $this->callsNamed($container, 'setServerInfo')[0][1];
+
+        $this->assertSame('my-mcp-app', $arguments[0]);
+        $this->assertSame('1.2.3', $arguments[1]);
+        $this->assertSame('My MCP Application', $arguments[2]);
+        $this->assertSame('https://example.com/mcp', $arguments[4]);
+
+        // Icons must reach the SDK as Icon objects: the raw config array would be serialized
+        // with its snake_case "mime_type" key instead of the protocol's "mimeType".
+        $this->assertCount(1, $arguments[3]);
+        $this->assertInstanceOf(Definition::class, $arguments[3][0]);
+        $this->assertSame(Icon::class, $arguments[3][0]->getClass());
+        $this->assertSame(['https://example.com/icon.png', 'image/png', ['64x64', '128x128']], $arguments[3][0]->getArguments());
+
+        $this->assertSame([25], $this->callsNamed($container, 'setPaginationLimit')[0][1]);
+        $this->assertSame(['This server provides weather and calendar tools'], $this->callsNamed($container, 'setInstructions')[0][1]);
+    }
+
+    public function testIconsDefaultToNullInsteadOfAnEmptyList()
+    {
+        $container = $this->buildContainer($this->config(['default' => []]));
+
+        $this->assertNull($this->callsNamed($container, 'setServerInfo')[0][1][3]);
+    }
+
+    /**
+     * @param array<string, bool> $transports
+     * @param array<string, bool> $expectedServices
+     */
+    #[DataProvider('provideTransportsConfiguration')]
+    public function testTransportsConfiguration(array $transports, array $expectedServices)
+    {
+        $container = $this->buildContainer($this->config(['default' => ['transports' => $transports]]));
+
+        foreach ($expectedServices as $serviceId => $shouldExist) {
+            $this->assertSame($shouldExist, $container->hasDefinition($serviceId), \sprintf('Service "%s"', $serviceId));
+        }
+    }
+
+    public static function provideTransportsConfiguration(): iterable
+    {
+        yield 'no transports enabled' => [
+            'transports' => ['stdio' => false, 'http' => false],
+            'expectedServices' => [
+                'mcp.server.command' => false,
+                'mcp.server.default.controller' => false,
+                'mcp.server.route_loader' => true,
+                'mcp.debug_command' => true,
+            ],
+        ];
+
+        yield 'stdio transport enabled' => [
+            'transports' => ['stdio' => true, 'http' => false],
+            'expectedServices' => [
+                'mcp.server.command' => true,
+                'mcp.server.default.controller' => false,
+                'mcp.debug_command' => true,
+            ],
+        ];
+
+        yield 'http transport enabled' => [
+            'transports' => ['stdio' => false, 'http' => true],
+            'expectedServices' => [
+                'mcp.server.command' => false,
+                'mcp.server.default.controller' => true,
+                'mcp.server.default.middleware_factory' => true,
+            ],
+        ];
+
+        yield 'both transports enabled' => [
+            'transports' => ['stdio' => true, 'http' => true],
+            'expectedServices' => [
+                'mcp.server.command' => true,
+                'mcp.server.default.controller' => true,
+            ],
+        ];
+    }
+
+    public function testMultipleServersGetTheirOwnServiceGraph()
+    {
+        $container = $this->buildContainer($this->config([
+            'public' => ['http' => ['path' => '/mcp'], 'registry' => ['tools' => ['App\\Mcp\\Public\\']]],
+            'editors' => ['http' => ['path' => '/mcp/editors'], 'registry' => ['tools' => ['*']]],
+        ]));
+
+        foreach (['public', 'editors'] as $name) {
+            $this->assertTrue($container->hasDefinition('mcp.server.'.$name));
+            $this->assertTrue($container->hasDefinition('mcp.server.'.$name.'.builder'));
+            $this->assertTrue($container->hasDefinition('mcp.server.'.$name.'.registry'));
+            $this->assertTrue($container->hasDefinition('mcp.server.'.$name.'.session.store'));
+            $this->assertTrue($container->hasDefinition('mcp.server.'.$name.'.controller'));
+        }
+
+        // A shared registry would merge both servers' elements: the builder loads into it eagerly.
+        $this->assertNotSame(
+            $container->getDefinition('mcp.server.public.builder')->getMethodCalls(),
+            $container->getDefinition('mcp.server.editors.builder')->getMethodCalls(),
+        );
+
+        $this->assertSame([
+            'public' => ['tools' => ['App\\Mcp\\Public\\'], 'prompts' => [], 'resources' => [], 'resource_templates' => [], 'apps' => []],
+            'editors' => ['tools' => ['*'], 'prompts' => [], 'resources' => [], 'resource_templates' => [], 'apps' => []],
+        ], $container->getParameter('mcp.servers.elements'));
+    }
+
+    public function testElementPatternsAreNormalized()
+    {
+        $container = $this->buildContainer($this->config(['default' => ['registry' => ['tools' => ['\\App\\Mcp\\SearchTool']]]]));
+
+        $this->assertSame(['App\\Mcp\\SearchTool'], $container->getParameter('mcp.servers.elements')['default']['tools']);
+    }
+
+    public function testServerWithoutARegistryIsRejected()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The child config "registry" under "mcp.servers.default" must be configured');
+
+        $this->buildContainer(['mcp' => ['servers' => ['default' => []]]]);
+    }
+
+    public function testServerWithAnEmptyRegistryIsRejected()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('An MCP server must expose at least one of "tools", "prompts", "resources", "resource_templates" or "apps".');
+
+        $this->buildContainer(['mcp' => ['servers' => ['default' => ['registry' => []]]]]);
+    }
+
+    public function testRegistryAcceptsOneListForEveryKind()
+    {
+        $container = $this->buildContainer(['mcp' => ['servers' => ['default' => ['registry' => ['App\\Mcp\\']]]]]);
+
+        $this->assertSame([
+            'tools' => ['App\\Mcp\\'],
+            'prompts' => ['App\\Mcp\\'],
+            'resources' => ['App\\Mcp\\'],
+            'resource_templates' => ['App\\Mcp\\'],
+            'apps' => ['App\\Mcp\\'],
+        ], $container->getParameter('mcp.servers.elements')['default']);
+    }
+
+    public function testRegistryAcceptsASingleStringForEveryKind()
+    {
+        $container = $this->buildContainer(['mcp' => ['servers' => ['default' => ['registry' => '*']]]]);
+
+        $this->assertSame(array_fill_keys(
+            ['tools', 'prompts', 'resources', 'resource_templates', 'apps'],
+            ['*'],
+        ), $container->getParameter('mcp.servers.elements')['default']);
+    }
+
+    public function testRegistryNarrowsEachKindSeparately()
+    {
+        $container = $this->buildContainer(['mcp' => ['servers' => ['default' => ['registry' => [
+            'tools' => ['App\\Mcp\\Tool\\'],
+            'apps' => ['App\\Apps\\'],
+        ]]]]]);
+
+        $this->assertSame([
+            'tools' => ['App\\Mcp\\Tool\\'],
+            'prompts' => [],
+            'resources' => [],
+            'resource_templates' => [],
+            'apps' => ['App\\Apps\\'],
+        ], $container->getParameter('mcp.servers.elements')['default']);
+    }
+
+    public function testWildcardCannotBeCombinedWithExplicitEntries()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The "*" wildcard cannot be combined with explicit entries');
+
+        $this->buildContainer($this->config(['default' => ['registry' => ['tools' => ['*', 'App\\Mcp\\SearchTool']]]]));
+    }
+
+    public function testInvalidServerNameIsRejected()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('MCP server names must only contain letters, digits, underscores and hyphens');
+
+        $this->buildContainer($this->config(['my.server' => []]));
+    }
+
+    public function testCollidingHttpPathsAreRejected()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('are both configured on the HTTP path "/mcp"');
+
+        $this->buildContainer($this->config([
+            'one' => ['http' => ['path' => '/mcp']],
+            'two' => ['http' => ['path' => '/mcp']],
+        ]));
+    }
+
+    public function testSharedSessionStorageIsRejected()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('share the same session storage');
+
+        $this->buildContainer($this->config([
+            'public' => ['http' => ['path' => '/mcp'], 'session' => ['store' => 'file', 'directory' => '/var/cache/mcp']],
+            'editors' => ['http' => ['path' => '/mcp/editors'], 'session' => ['store' => 'file', 'directory' => '/var/cache/mcp']],
+        ]));
     }
 
     public function testDataCollectorTagIncludesId()
     {
-        $container = $this->buildContainer(['mcp' => ['client_transports' => ['http' => true]]]);
+        $container = $this->buildContainer($this->config(['default' => []]));
+
         $definition = $container->getDefinition('mcp.data_collector');
         $this->assertTrue($definition->hasTag('data_collector'));
         $this->assertSame([['id' => 'mcp']], $definition->getTag('data_collector'));
     }
 
-    public function testDataCollectorNotRegisteredWithoutTransports()
+    public function testBuilderIsConfiguredWithTheSharedTaggedIterators()
     {
-        $container = $this->buildContainer([]);
+        $container = $this->buildContainer($this->config(['default' => ['transports' => ['stdio' => true, 'http' => true]]]));
 
-        $this->assertFalse($container->hasDefinition('mcp.data_collector'));
+        $this->assertCount(1, $this->callsNamed($container, 'setEventDispatcher'));
+
+        foreach (['addRequestHandlers' => 'mcp.request_handler', 'addNotificationHandlers' => 'mcp.notification_handler', 'addLoaders' => 'mcp.loader'] as $method => $tag) {
+            $argument = $this->callsNamed($container, $method)[0][1][0];
+            $this->assertInstanceOf(TaggedIteratorArgument::class, $argument);
+            $this->assertSame($tag, $argument->getTag());
+        }
     }
 
-    public function testCustomConfiguration()
+    public function testRegistryAndSessionStoreAreBoundToTheServer()
     {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'app' => 'my-mcp-app',
-                'version' => '1.2.3',
-                'description' => 'My MCP Application',
-                'icons' => [
-                    [
-                        'src' => 'https://example.com/icon.png',
-                        'mime_type' => 'image/png',
-                        'sizes' => ['64x64', '128x128'],
-                    ],
-                ],
-                'website_url' => 'https://example.com/mcp',
-                'pagination_limit' => 25,
-                'instructions' => 'This server provides weather and calendar tools',
-            ],
-        ]);
+        $container = $this->buildContainer($this->config(['default' => []]));
 
-        $this->assertSame('my-mcp-app', $container->getParameter('mcp.app'));
-        $this->assertSame('1.2.3', $container->getParameter('mcp.version'));
-        $this->assertSame('My MCP Application', $container->getParameter('mcp.description'));
+        $this->assertSame('mcp.server.default.registry', (string) $this->callsNamed($container, 'setRegistry')[0][1][0]);
+        $this->assertSame('mcp.server.default.session.store', (string) $this->callsNamed($container, 'setSession')[0][1][0]);
+    }
+
+    public function testRouteLoaderCarriesOneEntryPerHttpServer()
+    {
+        $container = $this->buildContainer($this->config([
+            'public' => ['http' => ['path' => '/mcp']],
+            'editors' => [],
+            'cli' => ['transports' => ['stdio' => true, 'http' => false]],
+        ]));
+
         $this->assertSame([
-            [
-                'src' => 'https://example.com/icon.png',
-                'mime_type' => 'image/png',
-                'sizes' => ['64x64', '128x128'],
-            ],
-        ], $container->getParameter('mcp.icons'));
-        $this->assertSame('https://example.com/mcp', $container->getParameter('mcp.website_url'));
-        $this->assertSame(25, $container->getParameter('mcp.pagination_limit'));
-        $this->assertSame('This server provides weather and calendar tools', $container->getParameter('mcp.instructions'));
+            ['name' => 'public', 'path' => '/mcp', 'controller' => 'mcp.server.public.controller::handle'],
+            // No explicit path: derived from the server name, never a bare "/mcp".
+            ['name' => 'editors', 'path' => '/mcp/editors', 'controller' => 'mcp.server.editors.controller::handle'],
+        ], $container->getDefinition('mcp.server.route_loader')->getArgument(0));
     }
 
-    /**
-     * @param array<string, mixed> $config
-     * @param array<string, bool>  $expectedServices
-     */
-    #[DataProvider('provideClientTransportsConfiguration')]
-    public function testClientTransportsConfiguration(array $config, array $expectedServices)
+    public function testStdioCommandOnlyKnowsStdioServers()
     {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => $config,
-            ],
-        ]);
+        $container = $this->buildContainer($this->config([
+            'public' => ['http' => ['path' => '/mcp']],
+            'cli' => ['transports' => ['stdio' => true, 'http' => false]],
+        ]));
 
-        foreach ($expectedServices as $serviceId => $shouldExist) {
-            if ($shouldExist) {
-                $this->assertTrue($container->hasDefinition($serviceId), \sprintf('Service "%s" should exist', $serviceId));
-            } else {
-                $this->assertFalse($container->hasDefinition($serviceId), \sprintf('Service "%s" should not exist', $serviceId));
-            }
-        }
+        $locatorId = (string) $container->getDefinition('mcp.server.command')->getArgument(0);
+        $this->assertSame(['cli'], array_keys($container->getDefinition($locatorId)->getArgument(0)));
     }
 
-    public static function provideClientTransportsConfiguration(): iterable
+    public function testStdioCommandNotRegisteredWithoutStdioServer()
     {
-        yield 'no transports enabled' => [
-            'config' => [
-                'stdio' => false,
-                'http' => false,
-            ],
-            'expectedServices' => [
-                'mcp.server.command' => false,
-                'mcp.server.controller' => false,
-                'mcp.server.route_loader' => false,
-                'mcp.server.debug_command' => false,
-            ],
-        ];
+        $container = $this->buildContainer($this->config(['default' => []]));
 
-        yield 'stdio transport enabled' => [
-            'config' => [
-                'stdio' => true,
-                'http' => false,
-            ],
-            'expectedServices' => [
-                'mcp.server.command' => true,
-                'mcp.server.controller' => false,
-                'mcp.server.route_loader' => true,
-                'mcp.server.debug_command' => true,
-            ],
-        ];
-
-        yield 'http transport enabled' => [
-            'config' => [
-                'stdio' => false,
-                'http' => true,
-            ],
-            'expectedServices' => [
-                'mcp.server.command' => false,
-                'mcp.server.controller' => true,
-                'mcp.server.route_loader' => true,
-                'mcp.server.debug_command' => true,
-            ],
-        ];
-
-        yield 'both transports enabled' => [
-            'config' => [
-                'stdio' => true,
-                'http' => true,
-            ],
-            'expectedServices' => [
-                'mcp.server.command' => true,
-                'mcp.server.controller' => true,
-                'mcp.server.route_loader' => true,
-                'mcp.server.debug_command' => true,
-            ],
-        ];
+        $this->assertFalse($container->hasDefinition('mcp.server.command'));
     }
 
-    public function testServerServices()
+    public function testServerIsAliasedForArgument()
     {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'stdio' => true,
-                    'http' => true,
-                ],
-            ],
-        ]);
+        $container = $this->buildContainer($this->config(['editors' => []]));
 
-        // Test that core MCP services are registered
-        $this->assertTrue($container->hasDefinition('mcp.server'));
-        $this->assertTrue($container->hasDefinition('mcp.session.store'));
-
-        // Test that ServerBuilder is properly configured with EventDispatcher
-        $builderDefinition = $container->getDefinition('mcp.server.builder');
-        $methodCalls = $builderDefinition->getMethodCalls();
-
-        $hasEventDispatcherCall = false;
-        $hasRequestHandlers = false;
-        $hasNotificationHandlers = false;
-        $hasLoaders = false;
-
-        foreach ($methodCalls as $call) {
-            if ('setEventDispatcher' === $call[0]) {
-                $hasEventDispatcherCall = true;
-            }
-
-            if ('addRequestHandlers' === $call[0]) {
-                $argument = $call[1][0];
-                if (
-                    $argument instanceof TaggedIteratorArgument
-                    && 'mcp.request_handler' === $argument->getTag()
-                ) {
-                    $hasRequestHandlers = true;
-                }
-            }
-
-            if ('addNotificationHandlers' === $call[0]) {
-                $argument = $call[1][0];
-                if (
-                    $argument instanceof TaggedIteratorArgument
-                    && 'mcp.notification_handler' === $argument->getTag()
-                ) {
-                    $hasNotificationHandlers = true;
-                }
-            }
-
-            if ('addLoaders' === $call[0]) {
-                $argument = $call[1][0];
-                if (
-                    $argument instanceof TaggedIteratorArgument
-                    && 'mcp.loader' === $argument->getTag()
-                ) {
-                    $hasLoaders = true;
-                }
-            }
-        }
-
-        $this->assertTrue($hasEventDispatcherCall, 'ServerBuilder should have setEventDispatcher method call');
-        $this->assertTrue($hasRequestHandlers, 'ServerBuilder should have addRequestHandlers with mcp.request_handler tag');
-        $this->assertTrue($hasNotificationHandlers, 'ServerBuilder should have addNotificationHandlers with mcp.notification_handler tag');
-        $this->assertTrue($hasLoaders, 'ServerBuilder should have addLoaders with mcp.loader tag');
-    }
-
-    public function testMcpToolAttributeAutoconfiguration()
-    {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'stdio' => true,
-                ],
-            ],
-        ]);
-
-        // Test that McpTool attribute is autoconfigured with mcp.tool tag
-        $attributeAutoconfigurators = $container->getAttributeAutoconfigurators();
-        $this->assertArrayHasKey(McpTool::class, $attributeAutoconfigurators);
-    }
-
-    public function testMcpPromptAttributeAutoconfiguration()
-    {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'stdio' => true,
-                ],
-            ],
-        ]);
-
-        // Test that McpPrompt attribute is autoconfigured with mcp.prompt tag
-        $attributeAutoconfigurators = $container->getAttributeAutoconfigurators();
-        $this->assertArrayHasKey(McpPrompt::class, $attributeAutoconfigurators);
-    }
-
-    public function testMcpResourceAttributeAutoconfiguration()
-    {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'stdio' => true,
-                ],
-            ],
-        ]);
-
-        // Test that McpResource attribute is autoconfigured with mcp.resource tag
-        $attributeAutoconfigurators = $container->getAttributeAutoconfigurators();
-        $this->assertArrayHasKey(McpResource::class, $attributeAutoconfigurators);
-    }
-
-    public function testMcpResourceTemplateAttributeAutoconfiguration()
-    {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'stdio' => true,
-                ],
-            ],
-        ]);
-
-        // Test that McpResourceTemplate attribute is autoconfigured with mcp.resource_template tag
-        $attributeAutoconfigurators = $container->getAttributeAutoconfigurators();
-        $this->assertArrayHasKey(McpResourceTemplate::class, $attributeAutoconfigurators);
-    }
-
-    public function testHttpConfigurationDefaults()
-    {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'http' => true,
-                ],
-            ],
-        ]);
-
-        // Test HTTP route loader defaults
-        $this->assertTrue($container->hasDefinition('mcp.server.route_loader'));
-        $routeLoaderDefinition = $container->getDefinition('mcp.server.route_loader');
-        $arguments = $routeLoaderDefinition->getArguments();
-        $this->assertTrue($arguments[0]); // HTTP transport enabled
-        $this->assertSame('/_mcp', $arguments[1]); // Default path
-
-        // Test session store defaults (file store)
-        $this->assertTrue($container->hasDefinition('mcp.session.store'));
-        $sessionStoreDefinition = $container->getDefinition('mcp.session.store');
-        $this->assertSame(FileSessionStore::class, $sessionStoreDefinition->getClass());
-        $sessionArguments = $sessionStoreDefinition->getArguments();
-        $this->assertSame('%kernel.cache_dir%/mcp-sessions', $sessionArguments[0]); // Default directory
-        $this->assertSame(3600, $sessionArguments[1]); // Default TTL
-    }
-
-    public function testHttpConfigurationCustom()
-    {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'http' => true,
-                ],
-                'http' => [
-                    'path' => '/custom-mcp',
-                    'session' => [
-                        'store' => 'memory',
-                        'directory' => '/custom/sessions',
-                        'ttl' => 7200,
-                    ],
-                ],
-            ],
-        ]);
-
-        // Test custom HTTP path
-        $routeLoaderDefinition = $container->getDefinition('mcp.server.route_loader');
-        $arguments = $routeLoaderDefinition->getArguments();
-        $this->assertSame('/custom-mcp', $arguments[1]);
-
-        // Test custom session store (memory)
-        $sessionStoreDefinition = $container->getDefinition('mcp.session.store');
-        $this->assertSame(InMemorySessionStore::class, $sessionStoreDefinition->getClass());
-        $sessionArguments = $sessionStoreDefinition->getArguments();
-        $this->assertSame(7200, $sessionArguments[0]); // Custom TTL for memory store
+        $this->assertTrue($container->hasAlias(Server::class.' $editorsServer'));
+        $this->assertSame('mcp.server.editors', (string) $container->getAlias(Server::class.' $editorsServer'));
     }
 
     public function testDnsRebindingProtectionDefaults()
     {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'http' => true,
-                ],
-            ],
-        ]);
+        $container = $this->buildContainer($this->config(['default' => []]));
 
-        $factoryDefinition = $container->getDefinition('mcp.middleware_factory');
-        $arguments = $factoryDefinition->getArguments();
-        $this->assertNull($arguments[0]); // No allowed hosts configured: keep the SDK default (localhost only)
+        // No allowed hosts configured: keep the SDK default (localhost only).
+        $this->assertNull($container->getDefinition('mcp.server.default.middleware_factory')->getArgument(0));
     }
 
     public function testDnsRebindingProtectionWithAllowedHosts()
     {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'http' => true,
-                ],
-                'http' => [
-                    'allowed_hosts' => ['example.com', 'mcp.example.com'],
-                ],
-            ],
-        ]);
+        $container = $this->buildContainer($this->config(['default' => ['http' => ['allowed_hosts' => ['example.com', 'mcp.example.com']]]]));
 
-        $factoryDefinition = $container->getDefinition('mcp.middleware_factory');
-        $arguments = $factoryDefinition->getArguments();
-        $this->assertSame(['example.com', 'mcp.example.com'], $arguments[0]);
+        $this->assertSame(['example.com', 'mcp.example.com'], $container->getDefinition('mcp.server.default.middleware_factory')->getArgument(0));
     }
 
     public function testDnsRebindingProtectionDisabled()
     {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'http' => true,
-                ],
-                'http' => [
-                    'allowed_hosts' => false,
-                ],
-            ],
-        ]);
+        $container = $this->buildContainer($this->config(['default' => ['http' => ['allowed_hosts' => false]]]));
 
-        $factoryDefinition = $container->getDefinition('mcp.middleware_factory');
-        $arguments = $factoryDefinition->getArguments();
-        $this->assertFalse($arguments[0]);
+        $this->assertFalse($container->getDefinition('mcp.server.default.middleware_factory')->getArgument(0));
     }
 
-    public function testSessionStoreFileConfiguration()
+    public function testSessionStoreFileDefaultsAreScopedToTheServer()
     {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'http' => true,
-                ],
-                'http' => [
-                    'session' => [
-                        'store' => 'file',
-                        'directory' => '/var/cache/mcp',
-                        'ttl' => 1800,
-                    ],
-                ],
-            ],
-        ]);
+        $container = $this->buildContainer($this->config(['editors' => []]));
 
-        $sessionStoreDefinition = $container->getDefinition('mcp.session.store');
-        $this->assertSame(FileSessionStore::class, $sessionStoreDefinition->getClass());
-        $arguments = $sessionStoreDefinition->getArguments();
-        $this->assertSame('/var/cache/mcp', $arguments[0]); // Custom directory
-        $this->assertSame(1800, $arguments[1]); // Custom TTL
+        $definition = $container->getDefinition('mcp.server.editors.session.store');
+        $this->assertSame(FileSessionStore::class, $definition->getClass());
+        $this->assertSame('%kernel.cache_dir%/mcp-sessions/editors', $definition->getArgument(0));
+        $this->assertSame(3600, $definition->getArgument(1));
     }
 
-    public function testSessionStoreCacheConfigurationDefault()
+    public function testSessionStoreFileCustom()
     {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'http' => true,
-                ],
-                'http' => [
-                    'session' => [
-                        'store' => 'cache',
-                    ],
-                ],
-            ],
-        ]);
+        $container = $this->buildContainer($this->config(['default' => ['session' => ['store' => 'file', 'directory' => '/var/cache/mcp', 'ttl' => 1800]]]));
 
-        // Verify session store is configured with Psr16SessionStore
-        $sessionStoreDefinition = $container->getDefinition('mcp.session.store');
-        $this->assertSame(Psr16SessionStore::class, $sessionStoreDefinition->getClass());
-        $arguments = $sessionStoreDefinition->getArguments();
-
-        // Check arguments
-        $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertSame('cache.mcp.sessions', (string) $arguments[0]); // Default cache pool
-        $this->assertSame('mcp-', $arguments[1]); // Default prefix
-        $this->assertSame(3600, $arguments[2]); // Default TTL
-
-        // Verify default cache pool was created as PSR-16 wrapper
-        $this->assertTrue($container->hasDefinition('cache.mcp.sessions'));
-        $cachePoolDefinition = $container->getDefinition('cache.mcp.sessions');
-        $this->assertSame(Psr16Cache::class, $cachePoolDefinition->getClass());
-        $cachePoolArgs = $cachePoolDefinition->getArguments();
-        $this->assertInstanceOf(Reference::class, $cachePoolArgs[0]);
-        $this->assertSame('cache.app', (string) $cachePoolArgs[0]);
+        $definition = $container->getDefinition('mcp.server.default.session.store');
+        $this->assertSame(FileSessionStore::class, $definition->getClass());
+        $this->assertSame('/var/cache/mcp', $definition->getArgument(0));
+        $this->assertSame(1800, $definition->getArgument(1));
     }
 
-    public function testSessionStoreCacheConfigurationCustom()
+    public function testSessionStoreMemory()
     {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'http' => true,
-                ],
-                'http' => [
-                    'session' => [
-                        'store' => 'cache',
-                        'cache_pool' => 'app.custom_cache',
-                        'prefix' => 'session-',
-                        'ttl' => 7200,
-                    ],
-                ],
-            ],
-        ]);
+        $container = $this->buildContainer($this->config(['default' => ['session' => ['store' => 'memory', 'ttl' => 7200]]]));
 
-        $sessionStoreDefinition = $container->getDefinition('mcp.session.store');
-        $this->assertSame(Psr16SessionStore::class, $sessionStoreDefinition->getClass());
-        $arguments = $sessionStoreDefinition->getArguments();
+        $definition = $container->getDefinition('mcp.server.default.session.store');
+        $this->assertSame(InMemorySessionStore::class, $definition->getClass());
+        $this->assertSame(7200, $definition->getArgument(0));
+    }
 
-        $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertSame('app.custom_cache', (string) $arguments[0]); // Custom cache pool
-        $this->assertSame('session-', $arguments[1]); // Custom prefix
-        $this->assertSame(7200, $arguments[2]); // Custom TTL
+    public function testSessionStoreCacheDefaultsAreScopedToTheServer()
+    {
+        $container = $this->buildContainer($this->config(['editors' => ['session' => ['store' => 'cache']]]));
 
-        // No default cache pool definition should be created for custom cache pool
+        $definition = $container->getDefinition('mcp.server.editors.session.store');
+        $this->assertSame(Psr16SessionStore::class, $definition->getClass());
+        $this->assertSame('cache.mcp.sessions', (string) $definition->getArgument(0));
+        $this->assertSame('mcp-editors-', $definition->getArgument(1));
+        $this->assertSame(3600, $definition->getArgument(2));
+
+        // The default pool is auto-created as a PSR-16 wrapper around cache.app.
+        $cachePool = $container->getDefinition('cache.mcp.sessions');
+        $this->assertSame(Psr16Cache::class, $cachePool->getClass());
+        $this->assertSame('cache.app', (string) $cachePool->getArgument(0));
+    }
+
+    public function testSessionStoreCacheCustom()
+    {
+        $container = $this->buildContainer($this->config(['default' => ['session' => [
+            'store' => 'cache',
+            'cache_pool' => 'app.custom_cache',
+            'prefix' => 'session-',
+            'ttl' => 7200,
+        ]]]));
+
+        $definition = $container->getDefinition('mcp.server.default.session.store');
+        $this->assertSame(Psr16SessionStore::class, $definition->getClass());
+        $this->assertSame('app.custom_cache', (string) $definition->getArgument(0));
+        $this->assertSame('session-', $definition->getArgument(1));
+        $this->assertSame(7200, $definition->getArgument(2));
+
         $this->assertFalse($container->hasDefinition('cache.mcp.sessions'));
     }
 
-    public function testSessionStoreFrameworkConfiguration()
+    public function testSessionStoreFramework()
     {
-        $container = $this->buildContainer([
-            'mcp' => [
-                'client_transports' => [
-                    'http' => true,
-                ],
-                'http' => [
-                    'session' => [
-                        'store' => 'framework',
-                        'prefix' => 'mcp-',
-                        'ttl' => 1800,
-                    ],
-                ],
-            ],
-        ]);
+        $container = $this->buildContainer($this->config(['default' => ['session' => ['store' => 'framework', 'prefix' => 'mcp-', 'ttl' => 1800]]]));
 
-        $sessionStoreDefinition = $container->getDefinition('mcp.session.store');
-        $this->assertSame(FrameworkSessionStore::class, $sessionStoreDefinition->getClass());
-        $arguments = $sessionStoreDefinition->getArguments();
-
-        $this->assertInstanceOf(Reference::class, $arguments[0]);
-        $this->assertSame('session.handler', (string) $arguments[0]);
-        $this->assertSame('mcp-', $arguments[1]);
-        $this->assertSame(1800, $arguments[2]);
+        $definition = $container->getDefinition('mcp.server.default.session.store');
+        $this->assertSame(FrameworkSessionStore::class, $definition->getClass());
+        $this->assertSame('session.handler', (string) $definition->getArgument(0));
+        $this->assertSame('mcp-', $definition->getArgument(1));
+        $this->assertSame(1800, $definition->getArgument(2));
     }
 
     public function testNoDiscoveryMethodCallOnBuilder()
     {
+        $container = $this->buildContainer($this->config(['default' => []]));
+
+        foreach ($container->getDefinition('mcp.server.default.builder')->getMethodCalls() as $call) {
+            $this->assertNotSame('setDiscovery', $call[0], 'ServerBuilder must not use file-based discovery');
+        }
+    }
+
+    public function testMcpAttributeAutoconfiguration()
+    {
         $container = $this->buildContainer([]);
 
-        foreach ($container->getDefinition('mcp.server.builder')->getMethodCalls() as $call) {
-            $this->assertNotSame('setDiscovery', $call[0], 'ServerBuilder must not use file-based discovery');
+        $autoconfigurators = $container->getAttributeAutoconfigurators();
+
+        foreach ([McpTool::class, McpPrompt::class, McpResource::class, McpResourceTemplate::class, AsMcpApp::class] as $attributeClass) {
+            $this->assertArrayHasKey($attributeClass, $autoconfigurators);
         }
     }
 
@@ -539,20 +469,7 @@ class McpBundleTest extends TestCase
     {
         $container = $this->buildContainer([]);
 
-        $attributes = [
-            McpTool::class => 'mcp.tool',
-            McpPrompt::class => 'mcp.prompt',
-            McpResource::class => 'mcp.resource',
-            McpResourceTemplate::class => 'mcp.resource_template',
-        ];
-
-        $autoconfigurators = $container->getAttributeAutoconfigurators();
-
-        foreach ($attributes as $attributeClass => $tag) {
-            $this->assertArrayHasKey($attributeClass, $autoconfigurators);
-        }
-
-        $configurator = $autoconfigurators[McpTool::class][0];
+        $configurator = $container->getAttributeAutoconfigurators()[McpTool::class][0];
 
         $definition = new ChildDefinition('abstract');
         $configurator($definition, new McpTool(), new \ReflectionMethod(InvokableService::class, '__invoke'));
@@ -580,8 +497,7 @@ class McpBundleTest extends TestCase
         $container = $this->buildContainer([]);
         $autoconfigured = $container->getAutoconfiguredInstanceof();
         $this->assertArrayHasKey(LoaderInterface::class, $autoconfigured);
-        $definition = $autoconfigured[LoaderInterface::class];
-        $this->assertTrue($definition->hasTag('mcp.loader'));
+        $this->assertTrue($autoconfigured[LoaderInterface::class]->hasTag('mcp.loader'));
     }
 
     public function testRequestHandlerInterfaceAutoconfiguration()
@@ -589,8 +505,7 @@ class McpBundleTest extends TestCase
         $container = $this->buildContainer([]);
         $autoconfigured = $container->getAutoconfiguredInstanceof();
         $this->assertArrayHasKey(RequestHandlerInterface::class, $autoconfigured);
-        $definition = $autoconfigured[RequestHandlerInterface::class];
-        $this->assertTrue($definition->hasTag('mcp.request_handler'));
+        $this->assertTrue($autoconfigured[RequestHandlerInterface::class]->hasTag('mcp.request_handler'));
     }
 
     public function testNotificationHandlerInterfaceAutoconfiguration()
@@ -598,30 +513,7 @@ class McpBundleTest extends TestCase
         $container = $this->buildContainer([]);
         $autoconfigured = $container->getAutoconfiguredInstanceof();
         $this->assertArrayHasKey(NotificationHandlerInterface::class, $autoconfigured);
-        $definition = $autoconfigured[NotificationHandlerInterface::class];
-        $this->assertTrue($definition->hasTag('mcp.notification_handler'));
-    }
-
-    public function testAppsDefaultConfiguration()
-    {
-        $container = $this->buildContainer([]);
-
-        $this->assertNull($container->getParameter('mcp.apps.enabled'));
-    }
-
-    public function testAppsEnabledFlag()
-    {
-        $container = $this->buildContainer(['mcp' => ['apps' => ['enabled' => true]]]);
-
-        $this->assertTrue($container->getParameter('mcp.apps.enabled'));
-    }
-
-    public function testAsMcpAppAttributeAutoconfiguration()
-    {
-        $container = $this->buildContainer([]);
-
-        $attributeAutoconfigurators = $container->getAttributeAutoconfigurators();
-        $this->assertArrayHasKey(AsMcpApp::class, $attributeAutoconfigurators);
+        $this->assertTrue($autoconfigured[NotificationHandlerInterface::class]->hasTag('mcp.notification_handler'));
     }
 
     public function testAppRendererRegisteredWhenTwigAvailable()
@@ -631,6 +523,34 @@ class McpBundleTest extends TestCase
         // Twig is a dev dependency of the bundle, so the renderer must be registered.
         $this->assertTrue(class_exists(\Twig\Environment::class));
         $this->assertTrue($container->hasDefinition(McpAppRenderer::SERVICE_ID));
+    }
+
+    /**
+     * Builds an "mcp" configuration from partial server definitions, defaulting each server to
+     * exposing every tool so the "at least one element list" validation is satisfied.
+     *
+     * @param array<string, array<string, mixed>> $servers
+     *
+     * @return array<string, mixed>
+     */
+    private function config(array $servers): array
+    {
+        foreach ($servers as $name => $server) {
+            $servers[$name] += ['registry' => '*'];
+        }
+
+        return ['mcp' => ['servers' => $servers]];
+    }
+
+    /**
+     * @return list<array{0: string, 1: array<int, mixed>}>
+     */
+    private function callsNamed(ContainerBuilder $container, string $method, string $server = 'default'): array
+    {
+        return array_values(array_filter(
+            $container->getDefinition('mcp.server.'.$server.'.builder')->getMethodCalls(),
+            static fn (array $call): bool => $call[0] === $method,
+        ));
     }
 
     /**

--- a/src/mcp-bundle/tests/DependencyInjection/McpPassTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpPassTest.php
@@ -20,6 +20,7 @@ use Mcp\Schema\ToolAnnotations;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpBundle\DependencyInjection\McpPass;
 use Symfony\AI\McpBundle\Exception\LogicException;
+use Symfony\AI\McpBundle\McpBundle;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -236,7 +237,7 @@ final class McpPassTest extends TestCase
         (new McpPass())->process($container);
 
         $this->assertSame([], $this->callsNamed($container, 'addTool'));
-        $this->assertSame([], $container->getDefinition('mcp.server.builder')->getMethodCalls());
+        $this->assertSame([], $container->getDefinition('mcp.server.default.builder')->getMethodCalls());
     }
 
     public function testDoesNothingWhenNoMcpServicesTagged()
@@ -245,10 +246,10 @@ final class McpPassTest extends TestCase
 
         (new McpPass())->process($container);
 
-        $this->assertSame([], $container->getDefinition('mcp.server.builder')->getMethodCalls());
+        $this->assertSame([], $container->getDefinition('mcp.server.default.builder')->getMethodCalls());
     }
 
-    public function testDoesNothingWhenNoServerBuilder()
+    public function testDoesNothingWhenNoServerConfigured()
     {
         $container = new ContainerBuilder();
         $container->setDefinition(TimeTool::class, (new Definition(TimeTool::class))->addTag('mcp.tool', ['method' => 'getCurrentTime']));
@@ -263,10 +264,49 @@ final class McpPassTest extends TestCase
         $this->assertSame([], $serviceLocators);
     }
 
-    private function containerWithBuilder(): ContainerBuilder
+    public function testPatternMatchingOnlySomeKindsIsAccepted()
+    {
+        // What "registry: ['App\\Mcp\\']" expands to: the same prefix on every kind, while the
+        // application only has a tool under it.
+        $prefix = 'Symfony\\AI\\McpBundle\\Tests\\DependencyInjection\\';
+        $container = $this->containerWithBuilder(['default' => array_fill_keys(
+            array_keys(McpBundle::ELEMENT_KINDS),
+            [$prefix],
+        )]);
+        $container->setDefinition(TimeTool::class, (new Definition(TimeTool::class))->addTag('mcp.tool', ['method' => 'getCurrentTime']));
+
+        (new McpPass())->process($container);
+
+        $this->assertCount(1, $this->callsNamed($container, 'addTool'));
+    }
+
+    public function testPatternMatchingNothingAtAllIsRejected()
+    {
+        $container = $this->containerWithBuilder(['default' => ['tools' => ['App\\Typo\\']]]);
+        $container->setDefinition(TimeTool::class, (new Definition(TimeTool::class))->addTag('mcp.tool', ['method' => 'getCurrentTime']));
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('"App\\Typo\\" under "mcp.servers.default.registry"');
+
+        (new McpPass())->process($container);
+    }
+
+    /**
+     * @param array<string, array<string, list<string>>> $elements
+     */
+    private function containerWithBuilder(array $elements = ['default' => []]): ContainerBuilder
     {
         $container = new ContainerBuilder();
-        $container->setDefinition('mcp.server.builder', new Definition());
+
+        foreach ($elements as $server => $lists) {
+            $container->setDefinition('mcp.server.'.$server.'.builder', new Definition());
+
+            foreach (array_keys(McpBundle::ELEMENT_KINDS) as $kind) {
+                $elements[$server][$kind] ??= ['*'];
+            }
+        }
+
+        $container->setParameter('mcp.servers.elements', $elements);
 
         return $container;
     }
@@ -274,10 +314,10 @@ final class McpPassTest extends TestCase
     /**
      * @return list<array{0: string, 1: array<int, mixed>}>
      */
-    private function callsNamed(ContainerBuilder $container, string $method): array
+    private function callsNamed(ContainerBuilder $container, string $method, string $server = 'default'): array
     {
         return array_values(array_filter(
-            $container->getDefinition('mcp.server.builder')->getMethodCalls(),
+            $container->getDefinition('mcp.server.'.$server.'.builder')->getMethodCalls(),
             static fn (array $call): bool => $call[0] === $method,
         ));
     }
@@ -285,9 +325,9 @@ final class McpPassTest extends TestCase
     /**
      * @return array<string, ServiceClosureArgument>
      */
-    private function locatorServices(ContainerBuilder $container): array
+    private function locatorServices(ContainerBuilder $container, string $server = 'default'): array
     {
-        $setContainerCalls = $this->callsNamed($container, 'setContainer');
+        $setContainerCalls = $this->callsNamed($container, 'setContainer', $server);
         $this->assertCount(1, $setContainerCalls);
 
         $serviceLocatorId = (string) $setContainerCalls[0][1][0];

--- a/src/mcp-bundle/tests/Double/InMemoryTransport.php
+++ b/src/mcp-bundle/tests/Double/InMemoryTransport.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\Double;
+
+use Mcp\Client\Transport\BaseTransport;
+use Mcp\Exception\ConnectionException;
+use Mcp\Schema\JsonRpc\Error;
+use Mcp\Schema\JsonRpc\Response;
+
+/**
+ * Answers every request in-process from canned results, so a real Mcp\Client — including its
+ * initialize handshake — can be exercised without a child process or an HTTP round trip.
+ *
+ * Each response is fed back through handleMessage() while send() is still running, which makes
+ * Protocol::request() find it via consumeResponse() and return without ever suspending the fiber.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class InMemoryTransport extends BaseTransport
+{
+    public int $connectCount = 0;
+    public int $closeCount = 0;
+
+    /** @var list<array<string, mixed>> */
+    public array $sent = [];
+
+    /**
+     * @param array<string, list<array<string, mixed>>> $results  method => the result of each successive call
+     * @param array<string, string>                     $failures method => JSON-RPC error message
+     */
+    public function __construct(
+        private array $results = [],
+        private readonly array $failures = [],
+        private readonly bool $failOnConnect = false,
+    ) {
+        parent::__construct();
+    }
+
+    public function connect(): void
+    {
+        ++$this->connectCount;
+
+        if ($this->failOnConnect) {
+            throw new ConnectionException('Initialization failed: the double refuses to connect.');
+        }
+
+        $fiber = new \Fiber(fn () => $this->handleInitialize());
+        $fiber->start();
+
+        $result = $fiber->getReturn();
+        if ($result instanceof Error) {
+            throw new ConnectionException('Initialization failed: '.$result->message);
+        }
+    }
+
+    public function send(string $data): void
+    {
+        /** @var array<string, mixed> $message */
+        $message = json_decode($data, true, 512, \JSON_THROW_ON_ERROR);
+        $this->sent[] = $message;
+
+        // Notifications carry no id and expect no answer.
+        if (!isset($message['id'])) {
+            return;
+        }
+
+        $method = (string) ($message['method'] ?? '');
+
+        if (isset($this->failures[$method])) {
+            $this->handleMessage(json_encode([
+                'jsonrpc' => '2.0',
+                'id' => $message['id'],
+                'error' => ['code' => -32000, 'message' => $this->failures[$method]],
+            ], \JSON_THROW_ON_ERROR));
+
+            return;
+        }
+
+        $this->handleMessage(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => $message['id'],
+            'result' => $this->nextResult($method),
+        ], \JSON_THROW_ON_ERROR));
+    }
+
+    public function runRequest(\Fiber $fiber, ?callable $onProgress = null): Response|Error
+    {
+        $fiber->start();
+
+        return $fiber->getReturn();
+    }
+
+    public function close(): void
+    {
+        ++$this->closeCount;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function nextResult(string $method): array
+    {
+        if ('initialize' === $method && !isset($this->results['initialize'])) {
+            return [
+                'protocolVersion' => '2025-11-25',
+                'capabilities' => [],
+                'serverInfo' => ['name' => 'test-server', 'version' => '1.0.0'],
+                'instructions' => 'Be nice.',
+            ];
+        }
+
+        $results = $this->results[$method] ?? [];
+        if ([] === $results) {
+            // The list results require their collection key to be present, even when empty.
+            return match ($method) {
+                'tools/list' => ['tools' => []],
+                'prompts/list' => ['prompts' => []],
+                'resources/list' => ['resources' => []],
+                'resources/templates/list' => ['resourceTemplates' => []],
+                default => [],
+            };
+        }
+
+        // Successive calls walk the list, so pagination can be scripted; the last entry repeats.
+        $next = array_shift($results);
+        if ([] !== $results) {
+            $this->results[$method] = $results;
+        }
+
+        return $next;
+    }
+}

--- a/src/mcp-bundle/tests/Profiler/DataCollectorTest.php
+++ b/src/mcp-bundle/tests/Profiler/DataCollectorTest.php
@@ -13,9 +13,11 @@ namespace Symfony\AI\McpBundle\Tests\Profiler;
 
 use Mcp\Capability\Registry;
 use Mcp\Server;
+use Mcp\Server\Builder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\AI\McpBundle\Profiler\DataCollector;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
  * @author Johannes Wachter <johannes@sulu.io>
@@ -25,7 +27,7 @@ final class DataCollectorTest extends TestCase
     public function testGetNameReturnsShortName()
     {
         $registry = new Registry(null, new NullLogger());
-        $dataCollector = new DataCollector(Server::builder()->setRegistry($registry), $registry);
+        $dataCollector = $this->createCollector($registry);
 
         $name = $dataCollector->getName();
 
@@ -42,14 +44,14 @@ final class DataCollectorTest extends TestCase
             ->setRegistry($registry)
             ->addTool([ToolFixture::class, 'greet'], 'greeting', description: 'Greets a person');
 
-        $dataCollector = new DataCollector($builder, $registry);
+        $dataCollector = $this->createCollector($registry, $builder);
 
         // The registry is empty before collection — as on a request that never served MCP.
         $this->assertFalse($registry->hasTools());
 
         $dataCollector->lateCollect();
 
-        $tools = $dataCollector->getTools();
+        $tools = $dataCollector->getServers()['default']['tools'];
         $this->assertCount(1, $tools);
         $this->assertSame('greeting', $tools[0]['name']);
         $this->assertSame('Greets a person', $tools[0]['description']);
@@ -61,11 +63,48 @@ final class DataCollectorTest extends TestCase
     public function testGetTotalCountReturnsZeroForEmptyRegistry()
     {
         $registry = new Registry(null, new NullLogger());
-        $dataCollector = new DataCollector(Server::builder()->setRegistry($registry), $registry);
+        $dataCollector = $this->createCollector($registry);
 
         $dataCollector->lateCollect();
 
         $this->assertSame(0, $dataCollector->getTotalCount());
+    }
+
+    public function testCollectsEveryServerSeparately()
+    {
+        $public = new Registry(null, new NullLogger());
+        $editors = new Registry(null, new NullLogger());
+
+        $dataCollector = new DataCollector(
+            new ServiceLocator([
+                'public' => static fn (): Builder => Server::builder()->setRegistry($public),
+                'editors' => static fn (): Builder => Server::builder()->setRegistry($editors)
+                    ->addTool([ToolFixture::class, 'greet'], 'greeting'),
+            ]),
+            new ServiceLocator([
+                'public' => static fn (): Registry => $public,
+                'editors' => static fn (): Registry => $editors,
+            ]),
+        );
+
+        $dataCollector->lateCollect();
+
+        $servers = $dataCollector->getServers();
+        $this->assertSame(['public', 'editors'], array_keys($servers));
+        $this->assertSame([], $servers['public']['tools']);
+        $this->assertCount(1, $servers['editors']['tools']);
+        $this->assertSame(2, $dataCollector->getServerCount());
+        $this->assertSame(1, $dataCollector->getTotalCount());
+    }
+
+    private function createCollector(Registry $registry, ?Builder $builder = null): DataCollector
+    {
+        $builder ??= Server::builder()->setRegistry($registry);
+
+        return new DataCollector(
+            new ServiceLocator(['default' => static fn (): Builder => $builder]),
+            new ServiceLocator(['default' => static fn (): Registry => $registry]),
+        );
     }
 }
 

--- a/src/mcp-bundle/tests/Routing/RouteLoaderTest.php
+++ b/src/mcp-bundle/tests/Routing/RouteLoaderTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\Routing;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\Routing\RouteLoader;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\LogicException;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class RouteLoaderTest extends TestCase
+{
+    public function testSupportsTheMcpType()
+    {
+        $loader = new RouteLoader([]);
+
+        $this->assertTrue($loader->supports('.', 'mcp'));
+        $this->assertFalse($loader->supports('.', 'yaml'));
+    }
+
+    public function testEmitsOneRoutePerServer()
+    {
+        $loader = new RouteLoader([
+            ['name' => 'public', 'path' => '/mcp', 'controller' => 'mcp.server.public.controller::handle'],
+            ['name' => 'editors', 'path' => '/mcp/editors', 'controller' => 'mcp.server.editors.controller::handle'],
+        ]);
+
+        $collection = $loader->load('.', 'mcp');
+
+        $this->assertCount(2, $collection);
+        $this->assertSame(['_mcp_endpoint_public', '_mcp_endpoint_editors'], array_keys($collection->all()));
+
+        $editors = $collection->get('_mcp_endpoint_editors');
+        $this->assertSame('/mcp/editors', $editors->getPath());
+        $this->assertSame('mcp.server.editors.controller::handle', $editors->getDefault('_controller'));
+        $this->assertSame(
+            [Request::METHOD_GET, Request::METHOD_POST, Request::METHOD_DELETE, Request::METHOD_OPTIONS],
+            $editors->getMethods(),
+        );
+    }
+
+    public function testEmitsNothingWithoutHttpServers()
+    {
+        $this->assertCount(0, (new RouteLoader([]))->load('.', 'mcp'));
+    }
+
+    public function testRefusesToLoadTwice()
+    {
+        $loader = new RouteLoader([]);
+        $loader->load('.', 'mcp');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Do not add the "mcp" loader twice.');
+
+        $loader->load('.', 'mcp');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Turns the MCP Bundle config terminology around and lifts the one-server limit.

`servers:` now configures the MCP servers the application **exposes**, `clients:` the MCP
clients it uses to **reach** remote servers. Both take named entries. Previously
`client_transports:` configured the server's own transports (despite the name), and the
documented `servers:` key was an unimplemented placeholder for the client side.

### Multiple servers

Each entry gets its own registry, builder, session store, route (`_mcp_endpoint_<name>`)
and identity. A server exposes only what its `registry:` names — service ids, class names,
namespace prefixes or `*` — given either as one list covering every kind of capability or
as a map narrowing each kind:

```yaml
mcp:
    servers:
        public:
            http: { path: /mcp }
            registry:
                tools: ['App\Mcp\Public\']
                resources: ['*']
        editors:
            http: { path: /mcp/editors }
            registry: '*'
        reporting:
            http: { path: /mcp/reporting }
            registry: ['App\Mcp\Reporting\']   # every kind, from one namespace
```

Access control stays plain Symfony security against those paths.

### Multiple clients

A client is a named group of remote server connections:

```yaml
mcp:
    clients:
        research:
            servers:
                github:     { transport: http, url: '…' }
                filesystem: { transport: stdio, command: ['npx', '-y', '@mcp/fs', '/tmp'] }
        simple:
            servers:
                github:     { transport: http, url: '…' }
```

Connections are `McpClientInterface` / `ServerConnectionInterface` services. The bundle owns
the lifecycle: a connection opens on first use and closes on `kernel.reset`, so callers never
touch `connect()` and a worker never carries a stale stdio child process between messages.

`debug:mcp` now covers both sides of the bundle — the configured servers and their
capabilities, plus `--clients` / `--client=<name>` for what the clients reach. `mcp:server`
gained a name argument.

### Notes

- **BC break** — every server option moved under `servers.<name>:`, documented in `UPGRADE.md`.
  Capabilities are no longer exposed implicitly; `registry: '*'` is the 1:1 migration.
- Session storage is isolated per server by default and a shared store is rejected at compile
  time: session ids are not namespaced by server, so a session minted on a public server would
  otherwise be accepted by a firewalled one.
- Fixes a pre-existing bug where icons reached clients as `mime_type` instead of `mimeType`.
- A pattern matching nothing **at all** on its server fails at compile time — practically always
  a typo. Matching only some kinds is fine, which is what makes `registry: ['App\Mcp\']` usable:
  few applications carry all five kinds under one namespace. An attributed service that no server
  lists is simply not exposed, and `debug:mcp` reports it.

171 tests / 514 assertions, PHPStan and CS clean. Verified end-to-end on the demo app with two
servers (distinct routes, identities and tool sets, cross-server session replay rejected) and a
client reaching both endpoints — plus, on a stacked branch, against the public third-party MCP
server at `subwayinfo.nyc`, which exercised the HTTP transport against SSE-framed responses.
