### PR TITLE
[Platform] Mark ModelOptionsParser as internal

### DIFF
--- a/src/platform/src/ModelOptionsParser.php
+++ b/src/platform/src/ModelOptionsParser.php
@@ -18,6 +18,8 @@ namespace Symfony\AI\Platform;
  * of turning them into underscores, so that provider options like
  * "reasoning.effort" survive.
  *
+ * @internal
+ *
  * @author Saiful Islam Feroz <saif012@gmail.com>
  */
 final class ModelOptionsParser


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Follow-up to #2404. `ModelOptionsParser` was introduced there as a helper for the two places that parse a model query string, but it landed as public API. Marking it `@internal` keeps it out of the BC surface. It is not released yet, so this is not a BC break.

It is used from `src/ai-bundle/config/options.php` and therefore crosses a package boundary, same as Symfony does with `VarExporter\Internal`.
