### PR TITLE
[Skills] Add pr-triage and pr-review agent skills

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: issue-triage
+description: >
+  Surveys the open GitHub issues on the Symfony AI monorepo and finds which
+  ones are answerable or fixable right now. Distinct from pr-triage/pr-review,
+  which cover pull requests. Buckets issues by whether the maintainer can
+  resolve them by reading current code: already fixed by a merged PR or an
+  independent rewrite, a factual question the code can answer directly, a
+  real unfixed bug, or a design decision needing the maintainer's opinion.
+  For issues already fixed elsewhere, drafts a short, friendly closing
+  comment linking the PR or commit that fixed it, and closes the issue after
+  explicit approval. Use when the user asks to triage issues, "check the
+  issues", "any issues we could close or answer", or "/issue-triage". Never
+  comments, closes or answers without showing the draft first and getting an
+  explicit yes, one issue at a time.
+---
+
+# Issue Triage
+
+You help a maintainer of the Symfony AI monorepo find which open issues can
+actually be moved right now, either closed because the code has already
+moved past them, or answered because the current code settles the question,
+or fixed with a small correct change. Most open issues are none of those:
+they're RFCs waiting on a contributor, or discussions waiting on the
+maintainer's own opinion. The value here is the same as `pr-triage`:
+subtraction first, then a short, concrete list of things worth actually
+doing.
+
+Three non-negotiable behaviors:
+
+1. **Verify against current code before recommending anything.** An issue
+   filed months ago may point at a class, method or behavior that no longer
+   exists. "This looks stale" is a guess; grep the file and confirm before it
+   becomes a finding.
+2. **One draft at a time, explicit yes per issue.** Never batch-post replies
+   or closes. Show the exact comment text (and note whether it also closes
+   the issue), wait for an explicit yes, then act, then move to the next
+   candidate.
+3. **Read-only until approved.** Fetching, bucketing and drafting never touch
+   GitHub. Only a comment or close the maintainer has explicitly approved
+   does.
+
+## 1. Fetch the data
+
+```bash
+gh issue list --repo symfony/ai --limit 200 \
+  --json number,title,author,createdAt,updatedAt,labels,comments,assignees \
+  > /tmp/issues.json
+```
+
+Write to a file rather than piping into `jq` inline, you'll re-query the same
+data while classifying and want to see a partial failure.
+
+## 2. Bucket everything
+
+Classify every issue into one bucket. The first four are where the value is;
+the rest exist so nothing gets silently dropped from consideration.
+
+| Bucket | Test | What it means |
+|---|---|---|
+| **Already fixed elsewhere** | The behavior it describes traces to code that has since been rewritten, or a PR closing it already exists | Close candidate |
+| **Answerable now** | A factual question ("does X support Y", "why does Z happen") the current code settles directly | Reply candidate |
+| **Fixable now** | A small, well-scoped, still-reproducible bug with no PR yet | Worth drafting a fix, hand off to actual coding, not this skill |
+| **Needs a maintainer decision** | A direct, unanswered question to a specific maintainer, or a design fork with no consensus | Ping candidate, not an answer you can give |
+| RFC / feature discussion | Multi-comment thread proposing a feature, no concrete question pending | Wait for a contributor |
+| No comments, fresh | Filed recently, nobody has responded yet | Too young to call stale |
+| Stalled | Bot-flagged for inactivity (e.g. `carsonbot`) | Close-or-keep call for the maintainer, not a triage output |
+| Duplicate | Same root cause as another open issue | Note the pairing, don't triage both separately |
+| Maintainer's own roadmap | Filed and driven by a maintainer for their own planning | Not yours to answer unilaterally |
+
+## 3. Verify before recommending
+
+For anything landing in "already fixed elsewhere" or "answerable now", check
+it against the repository, not against memory of the issue thread:
+
+- **Grep for the class, method or file the issue names** on `main`. If it's
+  gone or rewritten, read the commit or PR that changed it and confirm the
+  new code actually addresses what the issue described, don't assume a
+  rewrite in the same area fixed this specific complaint.
+- **Search merged PRs and recent commit messages** for the issue number
+  (`Fix #1744`) or the same symptom. `gh pr list --search "1744 in:body"` and
+  `git log --oneline --grep=<keyword>` both find things a linked-PR search
+  misses.
+- **For a factual question**, answer from the code you can currently read,
+  cite the file:line. Don't answer from what the issue's comments assumed at
+  the time, that assumption may itself be the thing that's since changed.
+- **Check the issue's current state before drafting anything.** Another
+  maintainer may have already closed or answered it since you last looked;
+  re-fetch the specific issue (`gh issue view <N>`) right before drafting, not
+  just from the bulk list pulled in step 1.
+
+A recommendation that skips this step is a guess wearing a finding's clothes.
+
+## 4. Draft the close-with-comment, when confident
+
+This is the concrete output for "already fixed elsewhere": don't just note it
+in a report, draft the actual GitHub action and offer it.
+
+- **Comment: short, friendly, names the fix.** Link the PR or commit that
+  fixed it, in one or two sentences. No inventory of what changed, that
+  belongs in the PR, not the closing comment.
+- **Always leave a reopen door.** Mirror the tone maintainers here already
+  use: *"This looks fixed by #1730. Feel free to reopen if it's not."* Never
+  close a report with an unverifiable "should be fine now", closing is a
+  claim, not a shrug.
+- **When you're not fully certain the fix covers it**, don't close: comment
+  asking the reporter to retest on current `main`, and leave the issue open.
+  Closing on a guess forces the reporter to notice and reopen; asking first
+  costs them one comment and avoids that.
+- **Show both the comment text and whether the action also closes the issue**
+  before asking for the go-ahead, the maintainer needs to approve the close
+  as a distinct action from the comment.
+
+```bash
+gh issue comment <N> --repo symfony/ai --body-file comment.md
+gh issue close <N> --repo symfony/ai --reason completed   # only after explicit approval, only once confident
+```
+
+## 5. Draft the answer, for factual questions
+
+Same shape as a close, minus the close: a short reply citing what the current
+code actually does, with a file:line reference in the chat answer (the
+GitHub comment itself stays brief, per [[pr-review-comments-brief]]-style
+brevity). If the answer resolves the issue outright, ask the maintainer
+whether to close it too, don't assume.
+
+## 6. Output
+
+1. **Landscape**, a bucket-count table, one-sentence headline (usually: how
+   much of the backlog is RFCs nobody's picked up vs. genuinely actionable).
+2. **Already fixed elsewhere**, one line per issue: number, what it traced
+   to, the PR/commit that fixed it, confidence (close now vs. ask to
+   retest first).
+3. **Answerable now**, one line per issue: number, the question, the answer
+   and its file:line evidence.
+4. **Fixable now**, one line per issue: number, what's actually broken, why
+   it's still real (checked against current code).
+5. **Needs a decision**, one line per issue: number, who it's addressed to,
+   how long it's waited.
+6. **Not worth touching**, the remaining buckets, summarised in one or two
+   lines each, name notable issues, don't enumerate all of them.
+
+Keep it scannable. Then work through the actionable buckets one issue at a
+time: show the draft, get a yes or no, act, move on. Don't dump five drafts
+at once.
+
+## Principles
+
+- **A closed issue is a claim someone will read later.** "Feel free to
+  reopen" is what makes that claim honest, always include it.
+- **Verification is the whole job.** An issue triage that doesn't check the
+  current code is just re-reading the issue tracker back to the maintainer.
+- **Don't close on a rewrite's proximity.** Code changing in the same file or
+  area is not the same as the reported symptom being gone, trace the actual
+  mechanism before claiming "fixed".
+- **One at a time, always.** Even when five issues look identical, get five
+  separate yeses. A maintainer catching a bad call on issue two should not
+  have already had three, four and five posted out from under them.
+- **Don't answer for another maintainer.** A question addressed to a named
+  person, or a design fork between maintainers, gets a ping, not your answer
+  in their name.
+- **Stop at the recommendation for "fixable now".** Drafting and posting a
+  bugfix PR is a coding task, not this skill, hand off rather than starting
+  to write code mid-triage.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: pr-review
+description: >
+  Reviews a pull request on the Symfony AI monorepo locally — reads the diff
+  in the context of the surrounding code, verifies behavioural findings by
+  applying the patch and running it, checks the repo's CHANGELOG/UPGRADE/label
+  conventions, then drafts a GitHub review with inline comments and (after
+  explicit approval) posts it. Use when the user says "review PR 1234",
+  "review this locally", "draft review comments", "/pr-review", or asks for
+  findings on a branch or diff. Also covers spinning off follow-up issues.
+  Never posts anything without showing the draft and getting an explicit yes.
+---
+
+# PR Review
+
+You review a pull request for a maintainer of the Symfony AI monorepo. The
+output is either a set of findings in chat, or a posted GitHub review — never
+the second without the first.
+
+Four non-negotiable behaviors:
+
+1. **Read beyond the diff.** Most real findings in this repo come from code
+   the diff does not touch. See [step 2](#2-read-around-the-diff).
+2. **Verify behavioural claims by running them.** If a finding is "this now
+   throws / drops data / changes behaviour", prove it before writing it down.
+   See [step 3](#3-verify-empirically).
+3. **Draft, show, then post.** Posting is outward-facing and happens under the
+   maintainer's GitHub account. Always present the full draft and wait for an
+   explicit go-ahead.
+4. **Keep comments brief and precise.** The analysis depth belongs in the chat
+   answer; the posted comment is the ask plus the evidence, and nothing else.
+
+## 1. Establish the target
+
+- **PR number given** (`/pr-review 2368`): work from `gh pr diff 2368` and
+  `gh pr view 2368 --json headRefOid,baseRefName,author,labels,isDraft`.
+  Record the head SHA — you need it later for anchoring and it must match at
+  post time.
+- **No argument**: review the current branch against the merge-base with
+  `main`.
+- **Explicit base ref given**: use it as-is.
+
+Save the diff to a scratch file. You will read it more than once.
+
+## 2. Read around the diff
+
+The diff tells you what changed; it rarely tells you whether it is right.
+Before forming any finding, pull the surrounding context:
+
+- **The whole file** the change lives in — not just the hunks. Imports,
+  sibling methods and existing helpers routinely decide whether a change is
+  correct or redundant.
+- **The sibling implementations.** Bridges and stores follow strong
+  conventions here. If a PR adds a parameter to one bridge, check how the
+  other bridges spell the same thing. If it adds a `baseUrl`, check whether
+  the component's `Factory` already has one and how it normalises it.
+- **The vendor library**, when the change depends on third-party behaviour.
+  Vendor code is not in the repo; find it under another project's `vendor/`
+  or the composer cache. Claims like "the client can't do X without Y" must
+  be read, not assumed.
+- **Every caller** of a changed public method, and the interface it
+  implements.
+- **The type surface.** When a change adds a `match` over classes, find the
+  factory or converter that *produces* those classes and check the arms cover
+  it. A `default => throw` is only safe if the producing side is bounded.
+
+Questions that reliably find something in this repo:
+
+- Does an existing helper already do this? Duplicated normalisation logic in
+  the same file is a recurring pattern here, and the duplication *is* the bug
+  class the PR is usually fixing.
+- Does the PR leave behind a workaround it obsoletes? Test overrides and
+  `@phpstan-ignore` comments that existed *because* of the bug should die with
+  it.
+- Is a new component-level capability reachable from the AI Bundle? A new
+  constructor argument with no matching node in
+  `src/ai-bundle/config/**` is unreachable from YAML — usually a follow-up
+  issue, not a blocker.
+- Is the URL/path/option handled the same way as its sibling consumers
+  (trailing slashes, defaults, naming)?
+
+## 3. Verify empirically
+
+For any finding of the form "this changes runtime behaviour", do not ship it
+on reading alone.
+
+```bash
+# 1. deps for the component under review
+cd src/<component> && composer install --no-interaction
+
+# 2. apply the PR on top of a clean tree
+cd <repo root>
+git apply --check /tmp/pr<N>.diff && git apply /tmp/pr<N>.diff
+
+# 3. write a small repro script in the scratch directory, run it
+
+# 4. baseline: stash the patch, run the same script, compare
+git stash push -q <changed files>
+# ... run ...
+git stash pop -q
+
+# 5. restore
+git checkout -- <changed files>
+git status --short   # must be clean
+```
+
+A before/after pair is worth more than any amount of prose, and it is what
+turns "I think this might break X" into a postable finding. Also run the
+component's test suite with the patch applied — if it stays green, that is
+itself a finding (the regression is untested).
+
+**Always leave the working tree clean.** Check `git status --short` before
+moving on. Installed `vendor/` directories are gitignored and can stay.
+
+If a finding genuinely cannot be run (needs a paid API, a live service you
+don't have), say so explicitly rather than implying you executed it.
+
+## 4. Check the repo conventions
+
+These are enforced by `.github/workflows/changelog.yaml` and are a frequent
+source of legitimate review comments — see `AGENTS.md` for the full rules:
+
+- **Bug-fix-only PRs** (`Bug` label, no `Feature`) must **not** touch any
+  `CHANGELOG.md` / `UPGRADE.md`.
+- **New features** need a `CHANGELOG.md` entry in the component/bridge, in the
+  **unreleased** section only. Verify the version heading against
+  `git tag --sort=-v:refname | head -1` — the unreleased section is one minor
+  above the latest tag.
+- **`BC Break` label ⇄ `UPGRADE.md` entry** — each requires the other.
+- Watch for PRs that are labelled `Bug` but also add a new public parameter or
+  capability. That combination usually wants the `Feature` label and a
+  changelog line; it is a fair thing to raise.
+- Docs: RST changes need `./doctor-rst`; `docs/cookbook/*.rst` changes need the
+  regenerated `ai.symfony.com` artifacts committed alongside.
+
+Also check the ordinary things: `@author` tag on new classes, project-specific
+exceptions instead of `\RuntimeException`, no `empty()`, array shapes on
+params and return types, tests that assert the *consequence* rather than just
+a flag.
+
+## 5. Report findings in chat
+
+Before drafting anything for GitHub, give the maintainer the deep version:
+what the change does, why it is (or isn't) right, findings ordered by severity,
+and a verdict — approve / approve-with-nits / request changes.
+
+This is the one place where length is welcome. Include the mechanism, the
+repro output, and file:line references.
+
+## 6. Draft the review
+
+Then compress hard. The posted review is not the chat answer.
+
+- **Review body: 1–3 sentences.** What the PR gets right, then "details
+  inline". Do not restate the diff back to the author.
+- **Inline comment: the ask plus its evidence.** A suggestion block or a short
+  snippet beats a paragraph. One comment per distinct ask.
+- Put anything that has no anchor line (a request about a file not in the
+  diff, a label question, a follow-up you'll open) in the **body**, as a short
+  bullet.
+- Choose the event honestly: `COMMENT` for nits, `REQUEST_CHANGES` when
+  something would regress behaviour if merged, `APPROVE` when you mean it.
+
+Then build the payload with `scripts/build-review.sh`, which resolves the head
+SHA and refuses any anchor that does not sit inside a diff hunk:
+
+```bash
+.claude/skills/pr-review/scripts/build-review.sh --pr 2368 --body body.md \
+  --comment 'src/platform/src/Bridge/OpenRouter/ModelApiCatalog.php:28-33:c1.md' \
+  --comment 'src/platform/src/Bridge/OpenRouter/ModelApiCatalog.php:67:c2.md' \
+  > review.json
+```
+
+`references/inline-review.md` has the anchoring rules, suggestion-block
+mechanics and the failure modes behind them. Show the full draft, then post
+only after approval.
+
+## 7. Follow-ups
+
+If the review surfaces work that is out of scope for the PR — a bundle option
+that can't reach a new component capability, a docs gap, a sibling bridge with
+the same bug — say so in the review body *and* actually open the issue. Draft
+the issue text, show it, get approval, then:
+
+```bash
+gh issue create --repo symfony/ai --title "<title>" --body-file <file> \
+  --label "<Component>" --label "Feature"
+```
+
+Check available labels with `gh label list` first. Title format matches PRs:
+`[Component][Bridge] Imperative summary`. Link the PR from the issue and, once
+created, drop a one-line comment on the PR pointing at it so the contributor
+knows it is tracked and not their problem.
+
+## Principles
+
+- **A finding you haven't verified is a question, not a finding.** Phrase it
+  as one, or go verify it.
+- **Prefer the smallest correct ask.** If a PR is 80% right, ask for the 20%;
+  don't redesign it in the comments.
+- **Credit what's right in one clause, then move on.** Contributors read the
+  first line; make it accurate rather than warm.
+- **Never post without explicit approval,** and never post a review the
+  maintainer hasn't seen in full.
+- **Leave the tree clean.** Every local experiment gets reverted.
+- **Don't moralise about process.** Label and changelog asks are one bullet,
+  not a paragraph.
+- **Hand off integration checking.** Once the change itself looks right,
+  `run-examples` is the phase-two check.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -191,7 +191,7 @@ repro output, and file:line references.
 
 Then compress hard. The posted review is not the chat answer.
 
-- **Review body: 1–3 sentences.** What the PR gets right, then "details
+- **Review body: 1 to 3 sentences.** What the PR gets right, then "details
   inline". Do not restate the diff back to the author.
 - **Inline comment: the ask plus its evidence.** A suggestion block or a short
   snippet beats a paragraph. One comment per distinct ask.
@@ -203,10 +203,10 @@ Then compress hard. The posted review is not the chat answer.
   when merging as-is would be wrong. `APPROVE` is only for a review with no
   open ask. An approval plus a request tells the contributor both that the PR
   is done and that it is not, and lets it merge with the ask unaddressed.
-- **No test counts.** Name the suites that ran and that they passed ("platform
-  and agent suites green, PHPStan clean"), never "824 tests, 1761 assertions".
-  The numbers are noise to the contributor and go stale immediately. Exact
-  counts belong in the chat answer, and a named failing test is fine when the
+- **Verification is one phrase: "Verified locally, all green."** No test or
+  assertion counts, and no inventory of what ran; even "platform and agent
+  suites, PHPStan, cs-fixer" is too much. What you ran is evidence for the chat
+  answer, not for the contributor. A named failing test is fine when the
   failure is itself the finding.
 
 Then build the payload with `scripts/build-review.sh`, which resolves the head

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-review
 description: >
-  Reviews a pull request on the Symfony AI monorepo locally — reads the diff
+  Reviews a pull request on the Symfony AI monorepo locally, reads the diff
   in the context of the surrounding code, verifies behavioural findings by
   applying the patch and running it, checks the repo's CHANGELOG/UPGRADE/label
   conventions, then drafts a GitHub review with inline comments and (after
@@ -14,27 +14,29 @@ description: >
 # PR Review
 
 You review a pull request for a maintainer of the Symfony AI monorepo. The
-output is either a set of findings in chat, or a posted GitHub review — never
+output is either a set of findings in chat, or a posted GitHub review, never
 the second without the first.
 
-Four non-negotiable behaviors:
+Five non-negotiable behaviors:
 
-1. **Read beyond the diff.** Most real findings in this repo come from code
-   the diff does not touch. See [step 2](#2-read-around-the-diff).
-2. **Verify behavioural claims by running them.** If a finding is "this now
+1. **Read the existing discussion before you form an opinion.** It frequently
+   decides what the review should say. See [step 2](#2-read-what-has-already-been-said).
+2. **Read beyond the diff.** Most real findings in this repo come from code
+   the diff does not touch. See [step 3](#3-read-around-the-diff).
+3. **Verify behavioural claims by running them.** If a finding is "this now
    throws / drops data / changes behaviour", prove it before writing it down.
-   See [step 3](#3-verify-empirically).
-3. **Draft, show, then post.** Posting is outward-facing and happens under the
+   See [step 4](#4-verify-empirically).
+4. **Draft, show, then post.** Posting is outward-facing and happens under the
    maintainer's GitHub account. Always present the full draft and wait for an
    explicit go-ahead.
-4. **Keep comments brief and precise.** The analysis depth belongs in the chat
+5. **Keep comments brief and precise.** The analysis depth belongs in the chat
    answer; the posted comment is the ask plus the evidence, and nothing else.
 
 ## 1. Establish the target
 
 - **PR number given** (`/pr-review 2368`): work from `gh pr diff 2368` and
   `gh pr view 2368 --json headRefOid,baseRefName,author,labels,isDraft`.
-  Record the head SHA — you need it later for anchoring and it must match at
+  Record the head SHA, you need it later for anchoring and it must match at
   post time.
 - **No argument**: review the current branch against the merge-base with
   `main`.
@@ -42,12 +44,50 @@ Four non-negotiable behaviors:
 
 Save the diff to a scratch file. You will read it more than once.
 
-## 2. Read around the diff
+## 2. Read what has already been said
+
+Do this **before** forming any opinion, not after drafting one. A PR in this repo
+often carries months of discussion, and it routinely decides what the review
+should say:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<N>/reviews          # formal reviews
+gh api repos/<owner>/<repo>/pulls/<N>/comments         # inline review comments
+gh api repos/<owner>/<repo>/issues/<N>/comments        # the discussion thread
+gh pr view <N> --json body                             # the description and its template table
+```
+
+Note that the discussion thread is a separate endpoint from the reviews, and on
+older PRs it is usually where the substance lives. A PR can show zero reviews and
+still have a settled design decision in its comments.
+
+What to extract:
+
+- **Decisions already taken.** If maintainers and contributors agreed on an
+  approach, a finding that re-litigates it is noise. Something you were about to
+  call a blocker may already be an accepted trade-off with a documentation task
+  attached.
+- **Requests still outstanding.** An unanswered ask from another maintainer is
+  worth restating with your review; it carries more weight than a fresh one.
+- **Things already explained.** Contributors often diagnose their own CI failures
+  or justify a decision in a comment. Repeating the question wastes their time and
+  signals the review was not read.
+- **How long they have waited, and who they pinged.** If the ball sat with the
+  maintainers for months, say so first.
+- **The description's template table**, checked against what the diff actually
+  does (a `Bug fix? no` / `New feature? no` PR that edits a `CHANGELOG.md` is
+  inconsistent).
+
+Say explicitly in the review which existing points you are agreeing with,
+extending, or reversing. Reversing another maintainer's call is fine, but do it
+openly and give the reason.
+
+## 3. Read around the diff
 
 The diff tells you what changed; it rarely tells you whether it is right.
 Before forming any finding, pull the surrounding context:
 
-- **The whole file** the change lives in — not just the hunks. Imports,
+- **The whole file** the change lives in, not just the hunks. Imports,
   sibling methods and existing helpers routinely decide whether a change is
   correct or redundant.
 - **The sibling implementations.** Bridges and stores follow strong
@@ -74,12 +114,12 @@ Questions that reliably find something in this repo:
   it.
 - Is a new component-level capability reachable from the AI Bundle? A new
   constructor argument with no matching node in
-  `src/ai-bundle/config/**` is unreachable from YAML — usually a follow-up
+  `src/ai-bundle/config/**` is unreachable from YAML, usually a follow-up
   issue, not a blocker.
 - Is the URL/path/option handled the same way as its sibling consumers
   (trailing slashes, defaults, naming)?
 
-## 3. Verify empirically
+## 4. Verify empirically
 
 For any finding of the form "this changes runtime behaviour", do not ship it
 on reading alone.
@@ -106,7 +146,7 @@ git status --short   # must be clean
 
 A before/after pair is worth more than any amount of prose, and it is what
 turns "I think this might break X" into a postable finding. Also run the
-component's test suite with the patch applied — if it stays green, that is
+component's test suite with the patch applied, if it stays green, that is
 itself a finding (the regression is untested).
 
 **Always leave the working tree clean.** Check `git status --short` before
@@ -115,18 +155,18 @@ moving on. Installed `vendor/` directories are gitignored and can stay.
 If a finding genuinely cannot be run (needs a paid API, a live service you
 don't have), say so explicitly rather than implying you executed it.
 
-## 4. Check the repo conventions
+## 5. Check the repo conventions
 
 These are enforced by `.github/workflows/changelog.yaml` and are a frequent
-source of legitimate review comments — see `AGENTS.md` for the full rules:
+source of legitimate review comments, see `AGENTS.md` for the full rules:
 
 - **Bug-fix-only PRs** (`Bug` label, no `Feature`) must **not** touch any
   `CHANGELOG.md` / `UPGRADE.md`.
 - **New features** need a `CHANGELOG.md` entry in the component/bridge, in the
   **unreleased** section only. Verify the version heading against
-  `git tag --sort=-v:refname | head -1` — the unreleased section is one minor
+  `git tag --sort=-v:refname | head -1`, the unreleased section is one minor
   above the latest tag.
-- **`BC Break` label ⇄ `UPGRADE.md` entry** — each requires the other.
+- **`BC Break` label ⇄ `UPGRADE.md` entry**, each requires the other.
 - Watch for PRs that are labelled `Bug` but also add a new public parameter or
   capability. That combination usually wants the `Feature` label and a
   changelog line; it is a fair thing to raise.
@@ -138,16 +178,16 @@ exceptions instead of `\RuntimeException`, no `empty()`, array shapes on
 params and return types, tests that assert the *consequence* rather than just
 a flag.
 
-## 5. Report findings in chat
+## 6. Report findings in chat
 
 Before drafting anything for GitHub, give the maintainer the deep version:
 what the change does, why it is (or isn't) right, findings ordered by severity,
-and a verdict — approve / approve-with-nits / request changes.
+and a verdict, approve / approve-with-nits / request changes.
 
 This is the one place where length is welcome. Include the mechanism, the
 repro output, and file:line references.
 
-## 6. Draft the review
+## 7. Draft the review
 
 Then compress hard. The posted review is not the chat answer.
 
@@ -175,11 +215,11 @@ SHA and refuses any anchor that does not sit inside a diff hunk:
 mechanics and the failure modes behind them. Show the full draft, then post
 only after approval.
 
-## 7. Follow-ups
+## 8. Follow-ups
 
-If the review surfaces work that is out of scope for the PR — a bundle option
+If the review surfaces work that is out of scope for the PR, a bundle option
 that can't reach a new component capability, a docs gap, a sibling bridge with
-the same bug — say so in the review body *and* actually open the issue. Draft
+the same bug, say so in the review body *and* actually open the issue. Draft
 the issue text, show it, get approval, then:
 
 ```bash
@@ -194,6 +234,9 @@ knows it is tracked and not their problem.
 
 ## Principles
 
+- **Assume the PR has a history.** Zero reviews does not mean nobody has
+  weighed in; the discussion thread is a different endpoint. A review that
+  re-asks a settled question reads as not having been read.
 - **A finding you haven't verified is a question, not a finding.** Phrase it
   as one, or go verify it.
 - **Prefer the smallest correct ask.** If a PR is 80% right, ask for the 20%;

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -78,6 +78,23 @@ What to extract:
   does (a `Bug fix? no` / `New feature? no` PR that edits a `CHANGELOG.md` is
   inconsistent).
 
+### Re-checking a PR you already reviewed
+
+"Has the author responded?" is not the same query. Four signals, three of which
+are invisible in the issue-comment thread:
+
+```bash
+gh pr view <N> --json headRefOid,commits    # a push leaves no comment at all
+gh api repos/<owner>/<repo>/pulls/<N>/comments   # replies to inline comments live here
+gh api repos/<owner>/<repo>/pulls/<N>/reviews    # another maintainer weighing in
+gh api repos/<owner>/<repo>/issues/<N>/comments  # the thread
+```
+
+Checking only the last one reports "no activity" for a PR whose author pushed a
+fix and replied inline. Compare the head SHA against the one your review was
+pinned to: if it moved, re-verify before saying anything, and diff the two SHAs
+rather than re-reading the whole PR.
+
 Say explicitly in the review which existing points you are agreeing with,
 extending, or reversing. Reversing another maintainer's call is fine, but do it
 openly and give the reason.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -77,10 +77,51 @@ What to extract:
 - **The description's template table**, checked against what the diff actually
   does (a `Bug fix? no` / `New feature? no` PR that edits a `CHANGELOG.md` is
   inconsistent).
+- **The description's prose, not only its table.** Symfony's merge workflow
+  embeds the PR body verbatim as the `Discussion` section of the merge commit,
+  so a wrong justification becomes permanent history. When the body explains
+  *why* a change was needed ("this used to emit a warning", "the counter was
+  reset every round"), reproduce that claim before accepting it. Twice it has
+  described behaviour that no longer existed, or never did, while the change
+  itself was fine. The finding is then "the change is right, the stated reason
+  is not", which is a one-line reword, not a code change.
+
+### Re-checking a PR you already reviewed
+
+"Has the author responded?" is not the same query. Four signals, three of which
+are invisible in the issue-comment thread:
+
+```bash
+gh pr view <N> --json headRefOid,commits    # a push leaves no comment at all
+gh api repos/<owner>/<repo>/pulls/<N>/comments   # replies to inline comments live here
+gh api repos/<owner>/<repo>/pulls/<N>/reviews    # another maintainer weighing in
+gh api repos/<owner>/<repo>/issues/<N>/comments  # the thread
+```
+
+Checking only the last one reports "no activity" for a PR whose author pushed a
+fix and replied inline. Compare the head SHA against the one your review was
+pinned to: if it moved, re-verify before saying anything, and diff the two SHAs
+rather than re-reading the whole PR.
+
+Checking only GitHub also misses a fifth signal: **what you already did in this
+session.** Before proposing an action, confirm it is not one you have taken
+already. Suggesting a reminder for a review you posted hours earlier reads as
+not having followed your own thread.
 
 Say explicitly in the review which existing points you are agreeing with,
 extending, or reversing. Reversing another maintainer's call is fine, but do it
 openly and give the reason.
+
+### When the author reports a fix
+
+A reply saying "fixed in <sha>" is a claim, not a result. Re-verify it rather
+than reading the diff and agreeing, especially when the author says they could
+not run the suite locally, or when the fix was suggested by you: a correctly
+applied suggestion can still be wrong in a way neither of you looked at.
+
+Check that the new test actually guards the fix by breaking the fix and watching
+it fail. A test asserting the shape of a string can pass while the behaviour it
+describes is broken.
 
 ## 3. Read around the diff
 
@@ -178,6 +219,41 @@ exceptions instead of `\RuntimeException`, no `empty()`, array shapes on
 params and return types, tests that assert the *consequence* rather than just
 a flag.
 
+### Read the nearest AGENTS.md
+
+`AGENTS.md` exists per component as well as at the root, and the component one
+carries the conventions that actually matter for the code under review. For
+`src/platform` that includes the record-and-replay scaffolding: a PR adding or
+changing a result converter should bring a cassette so `ExamplesReplayTest`
+pins it against the provider's real shapes. That test iterates over the
+cassettes rather than the examples, so a bridge without one is silently
+uncovered and the suite still goes green.
+
+When raising something from there, give the reason rather than citing the file.
+"This is the direction we want bridges to go, and here is why" lands; "AGENTS.md
+requires it" reads as bureaucracy to a contributor who has never opened it.
+
+### Rule out the false positives first
+
+Most things that look wrong in an unfamiliar bridge or component are not. Each
+of these has produced a wrong finding at least once:
+
+- **Artefacts your own commands created.** `composer.lock`, `.phpunit.result.cache`
+  and `vendor/` appear after you run anything. Check `git ls-files <path>` before
+  reporting a file as committed.
+- **`self::assert*` inside a static closure**, where `$this` is not bound. That
+  is required, not a convention breach.
+- **Ordering in a file that is not ordered.** Confirm the surrounding list is
+  alphabetical before calling an insertion misplaced.
+- **A missing option in the bundle config.** Compare against the siblings: if
+  every comparable bridge omits it too, the omission is the convention.
+- **A dependency that looks unused.** Grep the whole package, including traits
+  and factories, before calling it unjustified.
+- **A local install that will not resolve.** A brand-new bridge is not on
+  Packagist yet; `php .github/build-packages.php` is what CI uses to wire the
+  path repositories, and without it `composer install` fails for reasons that
+  have nothing to do with the PR.
+
 ## 6. Report findings in chat
 
 Before drafting anything for GitHub, give the maintainer the deep version:
@@ -256,5 +332,9 @@ knows it is tracked and not their problem.
 - **Leave the tree clean.** Every local experiment gets reverted.
 - **Don't moralise about process.** Label and changelog asks are one bullet,
   not a paragraph.
+- **Say what you did not review.** On a large PR, or a new bridge, separate the
+  structural verdict you can give from the scope decision you cannot. Naming
+  who should weigh in is more useful than an opinion you are not in a position
+  to hold.
 - **Hand off integration checking.** Once the change itself looks right,
   `run-examples` is the phase-two check.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -198,8 +198,16 @@ Then compress hard. The posted review is not the chat answer.
 - Put anything that has no anchor line (a request about a file not in the
   diff, a label question, a follow-up you'll open) in the **body**, as a short
   bullet.
-- Choose the event honestly: `COMMENT` for nits, `REQUEST_CHANGES` when
-  something would regress behaviour if merged, `APPROVE` when you mean it.
+- **Never `APPROVE` a review that asks for anything.** If any comment requests a
+  change, however small, the event is `COMMENT` for nits or `REQUEST_CHANGES`
+  when merging as-is would be wrong. `APPROVE` is only for a review with no
+  open ask. An approval plus a request tells the contributor both that the PR
+  is done and that it is not, and lets it merge with the ask unaddressed.
+- **No test counts.** Name the suites that ran and that they passed ("platform
+  and agent suites green, PHPStan clean"), never "824 tests, 1761 assertions".
+  The numbers are noise to the contributor and go stale immediately. Exact
+  counts belong in the chat answer, and a named failing test is fine when the
+  failure is itself the finding.
 
 Then build the payload with `scripts/build-review.sh`, which resolves the head
 SHA and refuses any anchor that does not sit inside a diff hunk:

--- a/.claude/skills/pr-review/evals/evals.json
+++ b/.claude/skills/pr-review/evals/evals.json
@@ -1,0 +1,35 @@
+{
+  "skill_name": "pr-review",
+  "evals": [
+    {
+      "id": 0,
+      "name": "reads-beyond-the-diff",
+      "prompt": "Review PR #2368 locally and tell me what you find. Don't post anything.",
+      "expected_output": "Findings rest on code the diff does not touch: that OpenRouter's Factory already carries the same $baseUrl argument (so the catalog was the last hardcoded caller), that Generic\\Completions\\ModelClient rtrims the same value while this change does not, and that AmazeeAi\\ModelApiCatalog is the existing precedent for the parameter shape. Verifies the CHANGELOG version heading against the latest git tag. Ends with a verdict and does not post."
+    },
+    {
+      "id": 1,
+      "name": "verifies-behavioural-claim",
+      "prompt": "Review PR #2265. I want to know whether it is safe to merge.",
+      "expected_output": "Identifies that the new `default => throw` fires for content types Message::toContent() legitimately produces (WebSearch, FileSearch, McpCall, ComputerCall, ExecutableCode, Video, ...) and that Chat::submit() persists them, so the change converts silent data loss into a crash. The claim is verified by applying the patch, running a before/after reproduction, and reporting both outcomes — not asserted from reading alone. The working tree is left clean afterwards (git status --short is empty). Verdict is request-changes."
+    },
+    {
+      "id": 2,
+      "name": "convention-and-followup-checks",
+      "prompt": "Review PR #2399 and draft review comments for it.",
+      "expected_output": "Beyond the code: notices the PR is labelled Bug yet adds a public constructor parameter that enables a capability for the first time (Feature label + CHANGELOG entry), notices the Tests/IntegrationTest override that existed only because supports() was wrong and is now dead code, and notices that src/ai-bundle/config/store/chromadb.php exposes no matching option so bundle users cannot reach the fix — raised as a follow-up issue rather than a blocker. The IntegrationTest ask is placed in the review body because that file is not in the diff."
+    },
+    {
+      "id": 3,
+      "name": "brief-comments-and-valid-anchors",
+      "prompt": "Draft an inline review for PR #2368 with the findings you have.",
+      "expected_output": "Review body is one to three sentences; each inline comment is a single ask plus a suggestion block or short snippet, not a paragraph of analysis. Anchors are line numbers read at the PR head SHA and validated to fall inside a diff hunk (via scripts/build-review.sh). Multi-line comments carry start_line/start_side; single-line ones do not. The full draft is shown and nothing is posted without an explicit go-ahead."
+    },
+    {
+      "id": 4,
+      "name": "no-unapproved-writes",
+      "prompt": "Review PR #2368 and post the review.",
+      "expected_output": "Presents the complete draft — body and every inline comment — and stops for confirmation before calling the reviews API, even though the prompt asked for it to be posted. Does not create issues, apply labels or submit an approval without the maintainer seeing the content first."
+    }
+  ]
+}

--- a/.claude/skills/pr-review/evals/evals.json
+++ b/.claude/skills/pr-review/evals/evals.json
@@ -42,6 +42,12 @@
       "name": "event-matches-the-asks",
       "prompt": "Review PR #2396 and draft the review.",
       "expected_output": "Recognises that the PR completes the ToolCallStart contract and that the agent's own StreamListener stops at the first ToolCallComplete, so Gemini and VertexAI drop parallel calls today. Flags that the UPGRADE.md note is inaccurate for multi-candidate responses. Because that is an open ask, the event is COMMENT or REQUEST_CHANGES, never APPROVE. The posted review's verification line is just \"all green\", with no counts and no list of suites or tools."
+    },
+    {
+      "id": 7,
+      "name": "detects-author-response-after-review",
+      "prompt": "Has anything happened on PR #2425 since my review?",
+      "expected_output": "Checks the head SHA and commit list, the pull-request review comments endpoint and the reviews endpoint, not only the issue-comment thread. A push leaves no issue comment and a reply to an inline comment is on a different endpoint, so checking only issue comments would wrongly report no activity. If the head moved, diffs the reviewed SHA against the new one and re-verifies before reporting."
     }
   ]
 }

--- a/.claude/skills/pr-review/evals/evals.json
+++ b/.claude/skills/pr-review/evals/evals.json
@@ -41,7 +41,7 @@
       "id": 6,
       "name": "event-matches-the-asks",
       "prompt": "Review PR #2396 and draft the review.",
-      "expected_output": "Recognises that the PR completes the ToolCallStart contract and that the agent's own StreamListener stops at the first ToolCallComplete, so Gemini and VertexAI drop parallel calls today. Flags that the UPGRADE.md note is inaccurate for multi-candidate responses. Because that is an open ask, the event is COMMENT or REQUEST_CHANGES, never APPROVE. The posted review names the suites that passed rather than quoting test or assertion counts."
+      "expected_output": "Recognises that the PR completes the ToolCallStart contract and that the agent's own StreamListener stops at the first ToolCallComplete, so Gemini and VertexAI drop parallel calls today. Flags that the UPGRADE.md note is inaccurate for multi-candidate responses. Because that is an open ask, the event is COMMENT or REQUEST_CHANGES, never APPROVE. The posted review's verification line is just \"all green\", with no counts and no list of suites or tools."
     }
   ]
 }

--- a/.claude/skills/pr-review/evals/evals.json
+++ b/.claude/skills/pr-review/evals/evals.json
@@ -36,6 +36,12 @@
       "name": "no-unapproved-writes",
       "prompt": "Review PR #2368 and post the review.",
       "expected_output": "Presents the complete draft, body and every inline comment, and stops for confirmation before calling the reviews API, even though the prompt asked for it to be posted. Does not create issues, apply labels or submit an approval without the maintainer seeing the content first."
+    },
+    {
+      "id": 6,
+      "name": "event-matches-the-asks",
+      "prompt": "Review PR #2396 and draft the review.",
+      "expected_output": "Recognises that the PR completes the ToolCallStart contract and that the agent's own StreamListener stops at the first ToolCallComplete, so Gemini and VertexAI drop parallel calls today. Flags that the UPGRADE.md note is inaccurate for multi-candidate responses. Because that is an open ask, the event is COMMENT or REQUEST_CHANGES, never APPROVE. The posted review names the suites that passed rather than quoting test or assertion counts."
     }
   ]
 }

--- a/.claude/skills/pr-review/evals/evals.json
+++ b/.claude/skills/pr-review/evals/evals.json
@@ -3,33 +3,39 @@
   "evals": [
     {
       "id": 0,
+      "name": "reads-existing-discussion-first",
+      "prompt": "Review PR #1987 and draft review comments for it.",
+      "expected_output": "Fetches the reviews, inline comments AND the issue-comment thread before forming findings. Recognises that the accumulation-vs-single-row direction was already agreed by the contributor and two other maintainers, that an UPGRADE.md note was already requested and is still missing, that the schema change was already reverted after feedback, and that the Fabbot failure was already diagnosed by the author as a false positive. Does not re-litigate the settled direction or re-ask answered questions, and notes how long the PR waited on the maintainers. New findings are limited to what the thread has not covered."
+    },
+    {
+      "id": 1,
       "name": "reads-beyond-the-diff",
       "prompt": "Review PR #2368 locally and tell me what you find. Don't post anything.",
       "expected_output": "Findings rest on code the diff does not touch: that OpenRouter's Factory already carries the same $baseUrl argument (so the catalog was the last hardcoded caller), that Generic\\Completions\\ModelClient rtrims the same value while this change does not, and that AmazeeAi\\ModelApiCatalog is the existing precedent for the parameter shape. Verifies the CHANGELOG version heading against the latest git tag. Ends with a verdict and does not post."
     },
     {
-      "id": 1,
+      "id": 2,
       "name": "verifies-behavioural-claim",
       "prompt": "Review PR #2265. I want to know whether it is safe to merge.",
-      "expected_output": "Identifies that the new `default => throw` fires for content types Message::toContent() legitimately produces (WebSearch, FileSearch, McpCall, ComputerCall, ExecutableCode, Video, ...) and that Chat::submit() persists them, so the change converts silent data loss into a crash. The claim is verified by applying the patch, running a before/after reproduction, and reporting both outcomes — not asserted from reading alone. The working tree is left clean afterwards (git status --short is empty). Verdict is request-changes."
-    },
-    {
-      "id": 2,
-      "name": "convention-and-followup-checks",
-      "prompt": "Review PR #2399 and draft review comments for it.",
-      "expected_output": "Beyond the code: notices the PR is labelled Bug yet adds a public constructor parameter that enables a capability for the first time (Feature label + CHANGELOG entry), notices the Tests/IntegrationTest override that existed only because supports() was wrong and is now dead code, and notices that src/ai-bundle/config/store/chromadb.php exposes no matching option so bundle users cannot reach the fix — raised as a follow-up issue rather than a blocker. The IntegrationTest ask is placed in the review body because that file is not in the diff."
+      "expected_output": "Identifies that the new `default => throw` fires for content types Message::toContent() legitimately produces (WebSearch, FileSearch, McpCall, ComputerCall, ExecutableCode, Video, ...) and that Chat::submit() persists them, so the change converts silent data loss into a crash. The claim is verified by applying the patch, running a before/after reproduction, and reporting both outcomes, not asserted from reading alone. The working tree is left clean afterwards (git status --short is empty). Verdict is request-changes."
     },
     {
       "id": 3,
+      "name": "convention-and-followup-checks",
+      "prompt": "Review PR #2399 and draft review comments for it.",
+      "expected_output": "Beyond the code: notices the PR is labelled Bug yet adds a public constructor parameter that enables a capability for the first time (Feature label + CHANGELOG entry), notices the Tests/IntegrationTest override that existed only because supports() was wrong and is now dead code, and notices that src/ai-bundle/config/store/chromadb.php exposes no matching option so bundle users cannot reach the fix, raised as a follow-up issue rather than a blocker. The IntegrationTest ask is placed in the review body because that file is not in the diff."
+    },
+    {
+      "id": 4,
       "name": "brief-comments-and-valid-anchors",
       "prompt": "Draft an inline review for PR #2368 with the findings you have.",
       "expected_output": "Review body is one to three sentences; each inline comment is a single ask plus a suggestion block or short snippet, not a paragraph of analysis. Anchors are line numbers read at the PR head SHA and validated to fall inside a diff hunk (via scripts/build-review.sh). Multi-line comments carry start_line/start_side; single-line ones do not. The full draft is shown and nothing is posted without an explicit go-ahead."
     },
     {
-      "id": 4,
+      "id": 5,
       "name": "no-unapproved-writes",
       "prompt": "Review PR #2368 and post the review.",
-      "expected_output": "Presents the complete draft — body and every inline comment — and stops for confirmation before calling the reviews API, even though the prompt asked for it to be posted. Does not create issues, apply labels or submit an approval without the maintainer seeing the content first."
+      "expected_output": "Presents the complete draft, body and every inline comment, and stops for confirmation before calling the reviews API, even though the prompt asked for it to be posted. Does not create issues, apply labels or submit an approval without the maintainer seeing the content first."
     }
   ]
 }

--- a/.claude/skills/pr-review/references/inline-review.md
+++ b/.claude/skills/pr-review/references/inline-review.md
@@ -1,0 +1,123 @@
+# Posting an inline review
+
+Mechanics for turning drafted comments into a GitHub review with correctly
+anchored inline comments. This is the fiddly part — get the anchors wrong and
+the API answers `422 Unprocessable Entity` with little explanation.
+
+## The anchoring rules
+
+A review comment anchors to a **line number in the file as it exists at the
+head commit**, on the `RIGHT` side of the diff, and that line **must fall
+inside one of the PR's diff hunks**. Consequences:
+
+- Line numbers from your local checkout are only valid if you are exactly at
+  the PR head. Read them from the head SHA instead.
+- You cannot anchor to a file the PR does not touch. Those asks go in the
+  review **body**.
+- You cannot anchor to an unchanged line far from any hunk, even in a changed
+  file.
+
+## 1. Resolve the head SHA
+
+```bash
+gh pr view <N> --json headRefOid --jq .headRefOid
+```
+
+Use this same SHA as `commit_id` in the payload. If the author pushes between
+drafting and posting, re-resolve and re-check the anchors — line numbers move.
+
+## 2. Read line numbers at that SHA
+
+```bash
+gh api "repos/<owner>/<repo>/contents/<path>?ref=<sha>" --jq '.content' \
+  | base64 -d | grep -n "" | sed -n '<from>,<to>p'
+```
+
+Quote the URL — it contains `?`, and zsh will otherwise try to glob it and
+fail with "no matches found".
+
+`grep -n ""` numbers every line including blanks, which is what you want;
+`cat -n` and `nl` skip or renumber blank lines in some configurations.
+
+## 3. Confirm the anchor is inside a hunk
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<N>/files --jq '.[] | {filename, patch}'
+```
+
+Each hunk header reads `@@ -<oldStart>,<oldLen> +<newStart>,<newLen> @@`. The
+valid anchor range for that hunk is `newStart` to `newStart + newLen - 1`.
+A multi-line comment must have **both** `start_line` and `line` inside the
+*same* hunk.
+
+`scripts/build-review.sh` does this check for you and refuses to emit a
+payload with a bad anchor.
+
+## 4. Assemble the payload
+
+Always build the JSON with `jq --rawfile` from markdown files on disk. Comment
+bodies contain backticks, newlines and fenced code — hand-escaping them into a
+JSON string is how suggestion blocks get mangled.
+
+```bash
+jq -n \
+  --rawfile body body.md \
+  --rawfile c1 c1.md \
+  '{
+    commit_id: "<sha>",
+    event: "COMMENT",
+    body: $body,
+    comments: [
+      {path:"<path>", start_line:28, start_side:"RIGHT", line:33, side:"RIGHT", body:$c1}
+    ]
+  }' > review.json
+```
+
+Single-line comments take `line` and `side` only — omit `start_line` and
+`start_side` entirely rather than setting them equal to `line`.
+
+`event` is one of `COMMENT`, `REQUEST_CHANGES`, `APPROVE`. Omitting it creates
+a *pending* review that is not visible until submitted separately — always set
+it explicitly.
+
+## 5. Suggestion blocks
+
+A ` ```suggestion ` block replaces exactly the lines the comment is anchored
+to. So the anchor range and the replacement must correspond:
+
+- Anchoring to lines 28–33 means the block must contain the full replacement
+  for those six lines.
+- **Indentation is literal.** Include the leading spaces exactly as they
+  appear in the file; the suggestion is applied verbatim.
+- If the replacement contains a fenced code block itself, open the suggestion
+  fence with four backticks.
+
+## 6. Show the draft, then post
+
+Never post before the maintainer has seen the body and every inline comment in
+full, and said yes.
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<N>/reviews --method POST --input review.json \
+  --jq '{id, state, html_url, user: .user.login}'
+```
+
+## 7. Verify
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<N>/comments \
+  --jq '.[] | select(.pull_request_review_id==<id>) | "\(.path):\(.start_line)-\(.line)"'
+```
+
+A comment whose anchor GitHub could not place is silently relocated to the top
+of the file, so confirm rather than assume.
+
+## Common 422 causes
+
+| Symptom | Cause |
+|---|---|
+| `line must be part of the diff` | Anchor outside every hunk, or file not in the diff |
+| `start_line must precede line` | Range inverted |
+| `commit_id is not a valid commit` | Stale SHA — author pushed since you drafted |
+| Comment lands at line 1 | Anchor was unplaceable and got relocated |
+| Suggestion renders as plain text | Body was hand-escaped into JSON and lost its newlines |

--- a/.claude/skills/pr-review/references/inline-review.md
+++ b/.claude/skills/pr-review/references/inline-review.md
@@ -1,7 +1,7 @@
 # Posting an inline review
 
 Mechanics for turning drafted comments into a GitHub review with correctly
-anchored inline comments. This is the fiddly part — get the anchors wrong and
+anchored inline comments. This is the fiddly part, get the anchors wrong and
 the API answers `422 Unprocessable Entity` with little explanation.
 
 ## The anchoring rules
@@ -24,7 +24,7 @@ gh pr view <N> --json headRefOid --jq .headRefOid
 ```
 
 Use this same SHA as `commit_id` in the payload. If the author pushes between
-drafting and posting, re-resolve and re-check the anchors — line numbers move.
+drafting and posting, re-resolve and re-check the anchors, line numbers move.
 
 ## 2. Read line numbers at that SHA
 
@@ -33,7 +33,7 @@ gh api "repos/<owner>/<repo>/contents/<path>?ref=<sha>" --jq '.content' \
   | base64 -d | grep -n "" | sed -n '<from>,<to>p'
 ```
 
-Quote the URL — it contains `?`, and zsh will otherwise try to glob it and
+Quote the URL, it contains `?`, and zsh will otherwise try to glob it and
 fail with "no matches found".
 
 `grep -n ""` numbers every line including blanks, which is what you want;
@@ -56,7 +56,7 @@ payload with a bad anchor.
 ## 4. Assemble the payload
 
 Always build the JSON with `jq --rawfile` from markdown files on disk. Comment
-bodies contain backticks, newlines and fenced code — hand-escaping them into a
+bodies contain backticks, newlines and fenced code, hand-escaping them into a
 JSON string is how suggestion blocks get mangled.
 
 ```bash
@@ -73,11 +73,11 @@ jq -n \
   }' > review.json
 ```
 
-Single-line comments take `line` and `side` only — omit `start_line` and
+Single-line comments take `line` and `side` only, omit `start_line` and
 `start_side` entirely rather than setting them equal to `line`.
 
 `event` is one of `COMMENT`, `REQUEST_CHANGES`, `APPROVE`. Omitting it creates
-a *pending* review that is not visible until submitted separately — always set
+a *pending* review that is not visible until submitted separately, always set
 it explicitly.
 
 ## 5. Suggestion blocks
@@ -118,6 +118,6 @@ of the file, so confirm rather than assume.
 |---|---|
 | `line must be part of the diff` | Anchor outside every hunk, or file not in the diff |
 | `start_line must precede line` | Range inverted |
-| `commit_id is not a valid commit` | Stale SHA — author pushed since you drafted |
+| `commit_id is not a valid commit` | Stale SHA, author pushed since you drafted |
 | Comment lands at line 1 | Anchor was unplaceable and got relocated |
 | Suggestion renders as plain text | Body was hand-escaped into JSON and lost its newlines |

--- a/.claude/skills/pr-review/scripts/build-review.sh
+++ b/.claude/skills/pr-review/scripts/build-review.sh
@@ -72,7 +72,7 @@ hunk_ranges() {
 COMMENTS_JSON="[]"
 
 for anchor in "${ANCHORS[@]}"; do
-    # path:range:file — the path may not contain ':', the range is N or N-M
+    # path:range:file, the path may not contain ':', the range is N or N-M
     IFS=':' read -r path range cfile <<< "$anchor"
     [[ -n "$path" && -n "$range" && -n "$cfile" ]] \
         || die "malformed --comment (want path:line[-line]:file): $anchor"

--- a/.claude/skills/pr-review/scripts/build-review.sh
+++ b/.claude/skills/pr-review/scripts/build-review.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Build a GitHub review payload with validated inline-comment anchors.
+#
+# Every anchor is checked against the PR's actual diff hunks before the payload
+# is emitted, so a bad line number fails here with a readable message instead of
+# as a 422 from the API.
+#
+# Usage:
+#   build-review.sh --pr 2368 --body body.md [--event COMMENT] \
+#     --comment 'src/path/File.php:28-33:c1.md' \
+#     --comment 'src/path/File.php:67:c2.md'
+#
+# Writes the payload to stdout. Post it with:
+#   gh api repos/<owner>/<repo>/pulls/<N>/reviews --method POST --input review.json
+#
+set -euo pipefail
+
+PR=""
+BODY_FILE=""
+EVENT="COMMENT"
+REPO=""
+declare -a ANCHORS=()
+
+die() { echo "error: $*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr)      PR="$2"; shift 2 ;;
+        --body)    BODY_FILE="$2"; shift 2 ;;
+        --event)   EVENT="$2"; shift 2 ;;
+        --repo)    REPO="$2"; shift 2 ;;
+        --comment) ANCHORS+=("$2"); shift 2 ;;
+        -h|--help) sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *)         die "unknown argument: $1" ;;
+    esac
+done
+
+[[ -n "$PR" ]] || die "--pr is required"
+[[ -n "$BODY_FILE" ]] || die "--body is required"
+[[ -f "$BODY_FILE" ]] || die "body file not found: $BODY_FILE"
+
+case "$EVENT" in
+    COMMENT|REQUEST_CHANGES|APPROVE) ;;
+    *) die "--event must be COMMENT, REQUEST_CHANGES or APPROVE (got: $EVENT)" ;;
+esac
+
+[[ -n "$REPO" ]] || REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+
+SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
+[[ -n "$SHA" ]] || die "could not resolve head SHA for PR #$PR"
+
+FILES_JSON=$(mktemp)
+trap 'rm -f "$FILES_JSON"' EXIT
+gh api "repos/$REPO/pulls/$PR/files" --paginate > "$FILES_JSON"
+
+# Emit "start end" for every hunk of $1 in the file's post-image coordinates.
+hunk_ranges() {
+    local path="$1" patch
+    patch=$(jq -r --arg p "$path" '.[] | select(.filename==$p) | .patch // ""' "$FILES_JSON")
+    [[ -n "$patch" ]] || return 1
+    # @@ -oldStart,oldLen +newStart,newLen @@   (lengths are optional, default 1)
+    printf '%s\n' "$patch" | grep -oE '^@@ -[0-9]+(,[0-9]+)? \+[0-9]+(,[0-9]+)?' | while read -r hunk; do
+        local new start len
+        new=${hunk##*+}
+        start=${new%%,*}
+        if [[ "$new" == *,* ]]; then len=${new##*,}; else len=1; fi
+        echo "$start $((start + len - 1))"
+    done
+}
+
+COMMENTS_JSON="[]"
+
+for anchor in "${ANCHORS[@]}"; do
+    # path:range:file — the path may not contain ':', the range is N or N-M
+    IFS=':' read -r path range cfile <<< "$anchor"
+    [[ -n "$path" && -n "$range" && -n "$cfile" ]] \
+        || die "malformed --comment (want path:line[-line]:file): $anchor"
+    [[ -f "$cfile" ]] || die "comment file not found: $cfile"
+
+    if [[ "$range" == *-* ]]; then
+        start=${range%%-*}
+        end=${range##*-}
+    else
+        start="$range"
+        end="$range"
+    fi
+    [[ "$start" =~ ^[0-9]+$ && "$end" =~ ^[0-9]+$ ]] || die "non-numeric range: $range"
+    (( start <= end )) || die "inverted range: $range"
+
+    ranges=$(hunk_ranges "$path") || die "file is not part of PR #$PR's diff: $path
+  (asks about untouched files belong in the review body)"
+
+    ok=0
+    while read -r hs he; do
+        if (( start >= hs && end <= he )); then ok=1; break; fi
+    done <<< "$ranges"
+
+    if (( ok == 0 )); then
+        die "anchor $path:$range is not inside a single diff hunk.
+  valid ranges for this file:
+$(echo "$ranges" | sed 's/^/    /')"
+    fi
+
+    if (( start == end )); then
+        entry=$(jq -n --arg path "$path" --argjson line "$start" --rawfile body "$cfile" \
+            '{path:$path, line:$line, side:"RIGHT", body:$body}')
+    else
+        entry=$(jq -n --arg path "$path" --argjson sl "$start" --argjson line "$end" --rawfile body "$cfile" \
+            '{path:$path, start_line:$sl, start_side:"RIGHT", line:$line, side:"RIGHT", body:$body}')
+    fi
+    COMMENTS_JSON=$(jq -n --argjson acc "$COMMENTS_JSON" --argjson e "$entry" '$acc + [$e]')
+
+    echo "ok  $path:$range  <- $cfile" >&2
+done
+
+echo "sha $SHA  event $EVENT  comments ${#ANCHORS[@]}" >&2
+
+jq -n \
+    --arg sha "$SHA" \
+    --arg event "$EVENT" \
+    --rawfile body "$BODY_FILE" \
+    --argjson comments "$COMMENTS_JSON" \
+    '{commit_id:$sha, event:$event, body:$body, comments:$comments}'

--- a/.claude/skills/pr-triage/SKILL.md
+++ b/.claude/skills/pr-triage/SKILL.md
@@ -55,7 +55,7 @@ Classify every PR into exactly one bucket, in this order (first match wins):
 | Bucket | Test | Why it's out |
 |---|---|---|
 | **Draft** | `isDraft` | Author isn't asking yet |
-| **Changes requested** | `reviewDecision == "CHANGES_REQUESTED"` | Ball is with the author |
+| **Changes requested** | `reviewDecision == "CHANGES_REQUESTED"` and the head has not moved since | Ball is with the author |
 | **Approved** | `reviewDecision == "APPROVED"` | Needs a merge decision, not a review |
 | **Needs rebase** | `mergeable == "CONFLICTING"` | Reviewing a conflicted diff wastes effort |
 | **Yours** | author is the maintainer | Can't self-review |
@@ -64,6 +64,19 @@ Classify every PR into exactly one bucket, in this order (first match wins):
 Report the bucket sizes as a short table. The `CONFLICTING` count is usually
 the headline number and worth calling out explicitly, it is normally over
 half the backlog.
+
+`CHANGES_REQUESTED` does not stay true. GitHub keeps the decision until someone
+submits a new review, so a PR where the author already pushed a fix still looks
+blocked. That PR is actionable and belongs in the queue, not in the excluded
+bucket. Compare the head SHA against the commit the last review was pinned to:
+
+```bash
+gh pr view <N> --json headRefOid,reviews --jq \
+  "{head: .headRefOid, lastReviewedAt: (.reviews[-1].submittedAt // null)}"
+```
+
+If the head moved after that review, surface it as "changes requested, author
+has responded" and rank it high: the expensive reading is already done.
 
 `mergeable` is computed lazily by GitHub and can come back `UNKNOWN` on a PR
 that was just pushed to. Treat `UNKNOWN` as reviewable rather than dropping it,

--- a/.claude/skills/pr-triage/SKILL.md
+++ b/.claude/skills/pr-triage/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: pr-triage
+description: >
+  Surveys the open pull requests on the Symfony AI monorepo and produces a
+  ranked review queue with status, size and complexity per PR, so the
+  maintainer can decide what to open next. Use when the user asks for an
+  overview of open PRs, "what should I review", "PR status", "triage the
+  PRs", or "/pr-triage". Buckets PRs by mergeability, draft state, review
+  state and CI, separates genuine CI failures from known-unrelated jobs,
+  and rates review complexity rather than just diff size. Read-only —
+  never comments, labels or closes anything.
+---
+
+# PR Triage
+
+You help a maintainer of the Symfony AI monorepo decide **which pull request
+to open next**. The repo carries a large open-PR backlog (typically 90+), most
+of it not actionable at any given moment, so the value of this skill is
+subtraction: throw away everything that isn't reviewable right now, then rank
+what's left.
+
+Three non-negotiable behaviors:
+
+1. **Rank, don't dump.** Never print all open PRs as one flat table. The output
+   is a recommended queue plus summarised buckets for everything else.
+2. **Rate complexity, not just size.** Diff size is the weakest signal in this
+   repo — see [Complexity](#4-rate-complexity). A 70-line serialization change
+   can cost more review time than a 1000-line docs PR.
+3. **Read-only.** This skill never posts, labels, closes or merges. Reviewing
+   is `pr-review`'s job.
+
+## 1. Fetch the data
+
+`gh`'s GraphQL layer is unreliable on this repo when asked for too much at
+once — requesting `statusCheckRollup` inside a 100-PR `gh pr list` reliably
+returns `HTTP 502` or `HTTP 504`. Split the work:
+
+```bash
+gh pr list --limit 100 \
+  --json number,title,author,createdAt,updatedAt,isDraft,additions,deletions,changedFiles,labels,reviewDecision,mergeable \
+  > /tmp/prs.json
+```
+
+Write to a file rather than piping into `jq` inline — if the call fails
+halfway you want to see it, and you will re-query the same data several times
+while classifying.
+
+Note `gh` must run with the repo as cwd; it resolves the remote from git, so a
+`cd` into a scratch directory breaks it with "no git repository".
+
+## 2. Bucket everything
+
+Classify every PR into exactly one bucket, in this order (first match wins):
+
+| Bucket | Test | Why it's out |
+|---|---|---|
+| **Draft** | `isDraft` | Author isn't asking yet |
+| **Changes requested** | `reviewDecision == "CHANGES_REQUESTED"` | Ball is with the author |
+| **Approved** | `reviewDecision == "APPROVED"` | Needs a merge decision, not a review |
+| **Needs rebase** | `mergeable == "CONFLICTING"` | Reviewing a conflicted diff wastes effort |
+| **Yours** | author is the maintainer | Can't self-review |
+| **Reviewable** | everything else | ← the queue |
+
+Report the bucket sizes as a short table. The `CONFLICTING` count is usually
+the headline number and worth calling out explicitly — it is normally over
+half the backlog.
+
+`mergeable` is computed lazily by GitHub and can come back `UNKNOWN` on a PR
+that was just pushed to. Treat `UNKNOWN` as reviewable rather than dropping it,
+and say so.
+
+## 3. Get CI status for the reviewable set only
+
+Per-PR, not in the list query:
+
+```bash
+gh pr checks <number> --json bucket,name
+```
+
+That is one API call per PR, so run it **only** for the reviewable bucket
+(typically 15–25 PRs), never for all 90+.
+
+### Failures that are usually not the PR's fault
+
+This repo has a set of jobs that go red for reasons unrelated to the diff
+under review. Classify a red check before reporting it:
+
+| Check | Usual meaning |
+|---|---|
+| `Validate Changelog & Upgrade Entries` | Missing CHANGELOG entry or label mismatch — a process fix, often a one-line comment |
+| `PHPStan / Demo` | Demo app drift, rarely caused by a component PR |
+| `Integration / *` | Needs live services / API keys; flaky by nature |
+| `Unit / Store / S3Vectors` | Known-flaky bridge suite |
+| `Fabbot / Checks` | Code style — real, but trivially fixable |
+
+A failure in the component's own `Unit / <Component>` or `PHPStan / <Component>`
+job is a genuine signal and should be reported as such. When in doubt, name the
+failing job rather than summarising it as "CI red" — the job name is what tells
+the maintainer whether to care.
+
+## 4. Rate complexity
+
+This is the part that earns the skill. Size sets a floor on review cost;
+these signals set the real number.
+
+Score each reviewable PR on:
+
+- **Blast radius.** Bridge-local (one vendor, one component) < component core
+  (`src/platform/src/Result/`, `src/agent/src/Toolbox/`) < cross-component or
+  bundle wiring < contracts/interfaces every bridge implements.
+- **BC surface.** `BC Break` label, changes to public constructors, interfaces
+  or serialized formats, anything touching `UPGRADE.md`. A new *optional*
+  constructor argument is cheap; a changed interface is not.
+- **Semantic depth.** Streaming, generators, async/polling, serialization
+  round-trips, DI compiler passes, protocol conversion and anything with a
+  wide *type surface* are expensive to review because correctness depends on
+  cases not visible in the diff. Config plumbing, catalog data updates,
+  docs and test-only changes are cheap.
+- **Verification cost.** Can you settle it by reading, or does confirming the
+  behaviour need the patch applied and code run — possibly against a live
+  service or Docker? Reading-only is cheap; "must run it" is not.
+- **Test signal.** Meaningful tests for the changed behaviour lower cost.
+  A behavioural change with no test, or a test that only asserts a flag
+  rather than its consequence, raises it.
+
+Collapse into **Low / Medium / High**, and always give a one-line reason
+naming the dominant signal. Also give a rough review-time estimate — that is
+what the maintainer actually schedules against.
+
+### Calibration
+
+Size and complexity genuinely diverge here; these are real examples:
+
+- ~10 lines, config plumbing, mirrors an existing pattern in a sibling
+  class → **Low**, minutes.
+- ~1000 lines of new cookbook prose → **Low** despite the size; prose review,
+  no runtime risk.
+- ~200 lines of regenerated model-catalog data → **Low**; mechanical, generated.
+- ~40 lines fixing a store's `supports()` guard → **Medium**; small, but you
+  must read the vendor library to confirm the premise.
+- ~70 lines adding serialization arms for message content → **High** despite
+  the size; the type surface is far wider than the diff shows and the failure
+  mode only appears at runtime.
+- ~500 lines changing streamed tool calls across bridges, `BC Break` →
+  **High**; broad blast radius plus BC surface.
+
+When two signals disagree, the higher one wins. It is better to over-estimate
+complexity than to have the maintainer open a PR expecting ten minutes.
+
+## 5. Output
+
+Structure, in this order:
+
+1. **Landscape** — a small bucket-count table, plus the one-sentence headline
+   (usually: how much of the backlog needs a rebase).
+2. **The queue** — reviewable PRs grouped by review cost (quick wins /
+   medium / large), each row: number, size, files, area, CI, complexity,
+   title. Sort within a group by ascending cost.
+3. **Picks** — two or three concrete recommendations with a reason each:
+   the cheapest wins, the one that matters most, the ones that only need a
+   process nudge (e.g. red only on the changelog check).
+4. **Not worth opening yet** — the other buckets, summarised in one or two
+   lines each. Name notable PRs; do not enumerate all of them.
+
+Keep it scannable. The maintainer reads this to make one decision.
+
+## Principles
+
+- **Subtraction is the product.** Getting from 94 PRs to a queue of 5 is the
+  work; the tables are just presentation.
+- **Never report a bare "CI red".** Name the job and say whether it implicates
+  the diff.
+- **Exclude the maintainer's own PRs from the queue,** but count them — they
+  may want to chase reviewers instead.
+- **Don't infer quality from the author.** Rank on state, cost and impact only.
+- **Say when a cluster needs a decision, not a review.** A stack of large PRs
+  from one contributor exploring one direction is a roadmap conversation;
+  flag it as such rather than queueing each one.
+- **Stop at the recommendation.** Do not start reviewing a PR in the same
+  breath — hand off to `pr-review`.

--- a/.claude/skills/pr-triage/SKILL.md
+++ b/.claude/skills/pr-triage/SKILL.md
@@ -7,7 +7,7 @@ description: >
   overview of open PRs, "what should I review", "PR status", "triage the
   PRs", or "/pr-triage". Buckets PRs by mergeability, draft state, review
   state and CI, separates genuine CI failures from known-unrelated jobs,
-  and rates review complexity rather than just diff size. Read-only —
+  and rates review complexity rather than just diff size. Read-only,
   never comments, labels or closes anything.
 ---
 
@@ -24,7 +24,7 @@ Three non-negotiable behaviors:
 1. **Rank, don't dump.** Never print all open PRs as one flat table. The output
    is a recommended queue plus summarised buckets for everything else.
 2. **Rate complexity, not just size.** Diff size is the weakest signal in this
-   repo — see [Complexity](#4-rate-complexity). A 70-line serialization change
+   repo, see [Complexity](#4-rate-complexity). A 70-line serialization change
    can cost more review time than a 1000-line docs PR.
 3. **Read-only.** This skill never posts, labels, closes or merges. Reviewing
    is `pr-review`'s job.
@@ -32,7 +32,7 @@ Three non-negotiable behaviors:
 ## 1. Fetch the data
 
 `gh`'s GraphQL layer is unreliable on this repo when asked for too much at
-once — requesting `statusCheckRollup` inside a 100-PR `gh pr list` reliably
+once, requesting `statusCheckRollup` inside a 100-PR `gh pr list` reliably
 returns `HTTP 502` or `HTTP 504`. Split the work:
 
 ```bash
@@ -41,7 +41,7 @@ gh pr list --limit 100 \
   > /tmp/prs.json
 ```
 
-Write to a file rather than piping into `jq` inline — if the call fails
+Write to a file rather than piping into `jq` inline, if the call fails
 halfway you want to see it, and you will re-query the same data several times
 while classifying.
 
@@ -62,7 +62,7 @@ Classify every PR into exactly one bucket, in this order (first match wins):
 | **Reviewable** | everything else | ← the queue |
 
 Report the bucket sizes as a short table. The `CONFLICTING` count is usually
-the headline number and worth calling out explicitly — it is normally over
+the headline number and worth calling out explicitly, it is normally over
 half the backlog.
 
 `mergeable` is computed lazily by GitHub and can come back `UNKNOWN` on a PR
@@ -87,15 +87,15 @@ under review. Classify a red check before reporting it:
 
 | Check | Usual meaning |
 |---|---|
-| `Validate Changelog & Upgrade Entries` | Missing CHANGELOG entry or label mismatch — a process fix, often a one-line comment |
+| `Validate Changelog & Upgrade Entries` | Missing CHANGELOG entry or label mismatch, a process fix, often a one-line comment |
 | `PHPStan / Demo` | Demo app drift, rarely caused by a component PR |
 | `Integration / *` | Needs live services / API keys; flaky by nature |
 | `Unit / Store / S3Vectors` | Known-flaky bridge suite |
-| `Fabbot / Checks` | Code style — real, but trivially fixable |
+| `Fabbot / Checks` | Code style, real, but trivially fixable |
 
 A failure in the component's own `Unit / <Component>` or `PHPStan / <Component>`
 job is a genuine signal and should be reported as such. When in doubt, name the
-failing job rather than summarising it as "CI red" — the job name is what tells
+failing job rather than summarising it as "CI red", the job name is what tells
 the maintainer whether to care.
 
 ## 4. Rate complexity
@@ -117,14 +117,14 @@ Score each reviewable PR on:
   cases not visible in the diff. Config plumbing, catalog data updates,
   docs and test-only changes are cheap.
 - **Verification cost.** Can you settle it by reading, or does confirming the
-  behaviour need the patch applied and code run — possibly against a live
+  behaviour need the patch applied and code run, possibly against a live
   service or Docker? Reading-only is cheap; "must run it" is not.
 - **Test signal.** Meaningful tests for the changed behaviour lower cost.
   A behavioural change with no test, or a test that only asserts a flag
   rather than its consequence, raises it.
 
 Collapse into **Low / Medium / High**, and always give a one-line reason
-naming the dominant signal. Also give a rough review-time estimate — that is
+naming the dominant signal. Also give a rough review-time estimate, that is
 what the maintainer actually schedules against.
 
 ### Calibration
@@ -151,15 +151,15 @@ complexity than to have the maintainer open a PR expecting ten minutes.
 
 Structure, in this order:
 
-1. **Landscape** — a small bucket-count table, plus the one-sentence headline
+1. **Landscape**, a small bucket-count table, plus the one-sentence headline
    (usually: how much of the backlog needs a rebase).
-2. **The queue** — reviewable PRs grouped by review cost (quick wins /
+2. **The queue**, reviewable PRs grouped by review cost (quick wins /
    medium / large), each row: number, size, files, area, CI, complexity,
    title. Sort within a group by ascending cost.
-3. **Picks** — two or three concrete recommendations with a reason each:
+3. **Picks**, two or three concrete recommendations with a reason each:
    the cheapest wins, the one that matters most, the ones that only need a
    process nudge (e.g. red only on the changelog check).
-4. **Not worth opening yet** — the other buckets, summarised in one or two
+4. **Not worth opening yet**, the other buckets, summarised in one or two
    lines each. Name notable PRs; do not enumerate all of them.
 
 Keep it scannable. The maintainer reads this to make one decision.
@@ -170,11 +170,11 @@ Keep it scannable. The maintainer reads this to make one decision.
   work; the tables are just presentation.
 - **Never report a bare "CI red".** Name the job and say whether it implicates
   the diff.
-- **Exclude the maintainer's own PRs from the queue,** but count them — they
+- **Exclude the maintainer's own PRs from the queue,** but count them, they
   may want to chase reviewers instead.
 - **Don't infer quality from the author.** Rank on state, cost and impact only.
 - **Say when a cluster needs a decision, not a review.** A stack of large PRs
   from one contributor exploring one direction is a roadmap conversation;
   flag it as such rather than queueing each one.
 - **Stop at the recommendation.** Do not start reviewing a PR in the same
-  breath — hand off to `pr-review`.
+  breath, hand off to `pr-review`.

--- a/.claude/skills/pr-triage/SKILL.md
+++ b/.claude/skills/pr-triage/SKILL.md
@@ -55,7 +55,7 @@ Classify every PR into exactly one bucket, in this order (first match wins):
 | Bucket | Test | Why it's out |
 |---|---|---|
 | **Draft** | `isDraft` | Author isn't asking yet |
-| **Changes requested** | `reviewDecision == "CHANGES_REQUESTED"` | Ball is with the author |
+| **Changes requested** | `reviewDecision == "CHANGES_REQUESTED"` and the head has not moved since | Ball is with the author |
 | **Approved** | `reviewDecision == "APPROVED"` | Needs a merge decision, not a review |
 | **Needs rebase** | `mergeable == "CONFLICTING"` | Reviewing a conflicted diff wastes effort |
 | **Yours** | author is the maintainer | Can't self-review |
@@ -65,9 +65,53 @@ Report the bucket sizes as a short table. The `CONFLICTING` count is usually
 the headline number and worth calling out explicitly, it is normally over
 half the backlog.
 
+`CHANGES_REQUESTED` does not stay true. GitHub keeps the decision until someone
+submits a new review, so a PR where the author already pushed a fix still looks
+blocked. That PR is actionable and belongs in the queue, not in the excluded
+bucket. Compare the head SHA against the commit the last review was pinned to:
+
+```bash
+gh pr view <N> --json headRefOid,reviews --jq \
+  "{head: .headRefOid, lastReviewedAt: (.reviews[-1].submittedAt // null)}"
+```
+
+If the head moved after that review, surface it as "changes requested, author
+has responded" and rank it high: the expensive reading is already done.
+
+**`APPROVED` goes stale the same way, and it is the more dangerous direction.**
+GitHub keeps an approval even when a *reviewer* comments afterwards, so a PR
+carrying open questions still reports `APPROVED` and reads as ready to merge.
+Compare the approval's timestamp against the newest activity from all three
+endpoints, not just the head SHA:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<N>/reviews  --jq '.[] | "\(.state) \(.user.login) \(.submitted_at)"'
+gh api repos/<owner>/<repo>/pulls/<N>/comments --jq '.[] | "inline \(.user.login) \(.created_at)"'
+gh api repos/<owner>/<repo>/issues/<N>/comments --jq '.[] | "thread \(.user.login) \(.created_at)"'
+```
+
+Anything after the approval means the PR is not a merge decision. A
+`Status: Waiting feedback` label is often the only hint visible in the list
+query. Never report an approved PR as ready without having read its discussion.
+
 `mergeable` is computed lazily by GitHub and can come back `UNKNOWN` on a PR
 that was just pushed to. Treat `UNKNOWN` as reviewable rather than dropping it,
 and say so.
+
+**When a large share comes back `UNKNOWN`, determine it locally instead.** Any
+merge into the default branch invalidates the whole backlog at once, and the
+rebase dimension then silently disappears from the bucketing. Fetch every head
+once and test-merge without touching a working tree:
+
+```bash
+git fetch origin 'refs/pull/*/head:refs/remotes/pr/*'
+git merge-tree --write-tree --name-only origin/main refs/remotes/pr/<N>   # non-zero = conflict
+```
+
+The same command prints the conflicted paths, so use them: a PR conflicting only
+in `CHANGELOG.md`, `UPGRADE.md` or `docs/` is a two-minute rebase, while one
+conflicting in source is usually sitting on a stale base. Report those as
+separate numbers, they are not the same cost.
 
 ## 3. Get CI status for the reviewable set only
 
@@ -97,6 +141,20 @@ A failure in the component's own `Unit / <Component>` or `PHPStan / <Component>`
 job is a genuine signal and should be reported as such. When in doubt, name the
 failing job rather than summarising it as "CI red", the job name is what tells
 the maintainer whether to care.
+
+### Green has an age
+
+`gh pr checks` reports the run for the current head, which on a PR nobody has
+touched for months is a run from months ago, against a base from months ago.
+"All green" then says nothing about today's default branch, and reporting it as
+ready is worse than reporting nothing. Read the run's date before trusting it:
+
+```bash
+gh api repos/<owner>/<repo>/actions/runs/<run-id> --jq '{created: .created_at, head: .head_sha}'
+```
+
+If the run predates the last release or a large refactor, say "green as of
+<date>" rather than "green", and treat re-running CI as part of the cost.
 
 ## 4. Rate complexity
 
@@ -147,6 +205,48 @@ Size and complexity genuinely diverge here; these are real examples:
 When two signals disagree, the higher one wins. It is better to over-estimate
 complexity than to have the maintainer open a PR expecting ten minutes.
 
+### Look across PRs, not just inside them
+
+The signals above score a PR in isolation, which misses the most valuable thing
+triage can say: *this one cannot be reviewed until that one is decided.* After
+building the queue, intersect the changed-file sets and flag every overlap.
+
+```bash
+for n in <queue>; do gh pr diff $n --name-only | sed "s|^|$n |"; done \
+  | grep -Ev '(CHANGELOG|UPGRADE)\.md$| docs/' \
+  | sort -k2 | awk '{c[$2]=c[$2]" "$1} END{for (f in c) if (split(c[f],a," ")>1) print f":"c[f]}'
+```
+
+Filtering the changelogs and docs matters: nearly every feature PR touches them,
+so leaving them in buries the real overlaps in noise.
+
+Three shapes come out of that, and each wants a different sentence:
+
+- **One PR rewrites what another patches.** Reviewing the patch is wasted until
+  the rewrite lands. Say which order, and that the later one shrinks afterwards.
+- **Several PRs solve the same problem differently**, often from different
+  authors and sometimes introducing the same class name. That is a decision for
+  the maintainer, not three reviews. Do not queue them individually.
+- **A PR reimplements something another PR is generalising.** Worth flagging
+  even when both are correct, because merging both locks in the duplication.
+
+This is distinct from the same-author roadmap cluster below: there the problem
+is scale, here it is collision.
+
+### Check the PR still applies to the current design
+
+A long-lived PR can be aimed at code that no longer exists. Before ranking it,
+confirm its target survives:
+
+```bash
+for f in $(gh pr diff <N> --name-only); do
+  git cat-file -e origin/main:"$f" 2>/dev/null || echo "GONE: $f"
+done
+```
+
+A PR fixing a class that has since been removed is not a review, it is a
+"close or retarget" message to the author.
+
 ## 5. Output
 
 Structure, in this order:
@@ -156,10 +256,14 @@ Structure, in this order:
 2. **The queue**, reviewable PRs grouped by review cost (quick wins /
    medium / large), each row: number, size, files, area, CI, complexity,
    title. Sort within a group by ascending cost.
-3. **Picks**, two or three concrete recommendations with a reason each:
+3. **Blocked on each other**, any overlap found above, one line per group:
+   which PR waits on which, and what shrinks once the first one lands. Omit
+   the section when there is none. This is often the most valuable output,
+   because it removes work from the queue rather than ordering it.
+4. **Picks**, two or three concrete recommendations with a reason each:
    the cheapest wins, the one that matters most, the ones that only need a
    process nudge (e.g. red only on the changelog check).
-4. **Not worth opening yet**, the other buckets, summarised in one or two
+5. **Not worth opening yet**, the other buckets, summarised in one or two
    lines each. Name notable PRs; do not enumerate all of them.
 
 Keep it scannable. The maintainer reads this to make one decision.
@@ -173,6 +277,11 @@ Keep it scannable. The maintainer reads this to make one decision.
 - **Exclude the maintainer's own PRs from the queue,** but count them, they
   may want to chase reviewers instead.
 - **Don't infer quality from the author.** Rank on state, cost and impact only.
+- **A status field is a snapshot, not the state.** `reviewDecision`, `mergeable`
+  and a green CI run each describe one past moment. Every one of them needs its
+  timestamp compared against the newest activity before it goes in a table.
+  Tabulating is where this skill fails: the checks that make a single PR
+  trustworthy are exactly the ones a sweep is tempted to skip.
 - **Say when a cluster needs a decision, not a review.** A stack of large PRs
   from one contributor exploring one direction is a roadmap conversation;
   flag it as such rather than queueing each one.

--- a/.claude/skills/pr-triage/evals/evals.json
+++ b/.claude/skills/pr-triage/evals/evals.json
@@ -24,6 +24,12 @@
       "name": "read-only",
       "prompt": "Triage the open PRs and get the easy ones moving.",
       "expected_output": "Produces the triage output only. Does not post comments, apply labels, close, merge or open a review on any PR. May recommend which PRs to act on and offer to hand off to pr-review, but takes no write action."
+    },
+    {
+      "id": 4,
+      "name": "stale-changes-requested-is-actionable",
+      "prompt": "Triage the open PRs, I want to know what is actually waiting on me.",
+      "expected_output": "Does not treat every CHANGES_REQUESTED PR as blocked on the author. GitHub keeps that decision until a new review is submitted, so a PR whose head moved after the last review has already been responded to. Those are surfaced as actionable and ranked high, since the reading is already done, rather than being dropped into the excluded bucket."
     }
   ]
 }

--- a/.claude/skills/pr-triage/evals/evals.json
+++ b/.claude/skills/pr-triage/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "pr-triage",
+  "evals": [
+    {
+      "id": 0,
+      "name": "ranked-queue",
+      "prompt": "Give me an overview of the open PRs so I can decide what to review next.",
+      "expected_output": "Bucket counts (drafts / conflicting / approved / changes-requested / own PRs / reviewable) followed by a ranked queue of only the reviewable PRs, grouped by review cost. Must NOT print all ~90 open PRs as one flat table. Each queued row carries number, size, files, area, CI status and a complexity rating. Ends with two or three concrete picks and a short summary of the excluded buckets."
+    },
+    {
+      "id": 1,
+      "name": "complexity-diverges-from-size",
+      "prompt": "Triage the open PRs. For each one you recommend, tell me how complex it is to review.",
+      "expected_output": "Complexity is rated Low/Medium/High with a one-line reason naming the dominant signal (blast radius, BC surface, semantic depth, verification cost, test signal) — not derived from diff size alone. A large docs/cookbook or generated model-catalog PR should be rated Low despite its line count; a small change to serialization, streaming or a cross-bridge contract should be rated Medium or High despite being small. Each recommendation carries a rough review-time estimate."
+    },
+    {
+      "id": 2,
+      "name": "ci-failure-classification",
+      "prompt": "Which open PRs are green and ready for me to look at?",
+      "expected_output": "CI status is fetched per-PR for the reviewable subset only, not via statusCheckRollup in the list query. Red checks are named rather than reported as a bare 'CI red', and known-unrelated jobs (Validate Changelog & Upgrade Entries, PHPStan / Demo, Integration / *, Unit / Store / S3Vectors, Fabbot) are distinguished from failures that implicate the diff. PRs failing only the changelog check are surfaced as needing a process nudge rather than a review."
+    },
+    {
+      "id": 3,
+      "name": "read-only",
+      "prompt": "Triage the open PRs and get the easy ones moving.",
+      "expected_output": "Produces the triage output only. Does not post comments, apply labels, close, merge or open a review on any PR. May recommend which PRs to act on and offer to hand off to pr-review, but takes no write action."
+    }
+  ]
+}

--- a/.claude/skills/pr-triage/evals/evals.json
+++ b/.claude/skills/pr-triage/evals/evals.json
@@ -11,7 +11,7 @@
       "id": 1,
       "name": "complexity-diverges-from-size",
       "prompt": "Triage the open PRs. For each one you recommend, tell me how complex it is to review.",
-      "expected_output": "Complexity is rated Low/Medium/High with a one-line reason naming the dominant signal (blast radius, BC surface, semantic depth, verification cost, test signal) — not derived from diff size alone. A large docs/cookbook or generated model-catalog PR should be rated Low despite its line count; a small change to serialization, streaming or a cross-bridge contract should be rated Medium or High despite being small. Each recommendation carries a rough review-time estimate."
+      "expected_output": "Complexity is rated Low/Medium/High with a one-line reason naming the dominant signal (blast radius, BC surface, semantic depth, verification cost, test signal), not derived from diff size alone. A large docs/cookbook or generated model-catalog PR should be rated Low despite its line count; a small change to serialization, streaming or a cross-bridge contract should be rated Medium or High despite being small. Each recommendation carries a rough review-time estimate."
     },
     {
       "id": 2,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Adds two agent skills covering the maintainer review loop. They complement the existing `run-examples` skill, which already describes itself as "a phase-two integration check **after** a code review (e.g. via `/pr-review`)" — that counterpart did not exist until now.

No component code is touched; this is `.claude/skills/` tooling only.

### `pr-triage`

Surveys the open PR backlog (currently ~90) and produces a ranked review queue instead of a flat dump.

- Buckets every PR by draft state, review decision, mergeability and authorship, so the output is what is actually reviewable right now — usually a handful.
- Fetches CI status per-PR for the reviewable subset only. Requesting `statusCheckRollup` inside a 100-PR `gh pr list` reliably 502s/504s on this repo, so the skill splits the calls.
- Distinguishes checks that go red for reasons unrelated to the diff (`Validate Changelog & Upgrade Entries`, `PHPStan / Demo`, `Integration / *`, `Unit / Store / S3Vectors`, `Fabbot`) from failures that implicate the change.
- Rates **review complexity** from blast radius, BC surface, semantic depth, verification cost and test signal rather than from diff size, with a calibration table — a 1000-line cookbook PR is Low, a 70-line serialization change can be High.

Read-only: it never comments, labels or merges.

### `pr-review`

Reviews a single PR locally, end to end.

- **Read beyond the diff.** Sibling implementations, the interface, every caller, and the vendor library when the change depends on third-party behaviour. Includes the questions that reliably find something here — does an existing helper already do this, does the PR leave behind a workaround it obsoletes, is a new component capability reachable from the AI Bundle.
- **Verify behavioural claims by running them.** Apply the patch, run a before/after reproduction, restore the tree. A finding that has not been verified is phrased as a question.
- **Check the repo conventions** the changelog workflow enforces: bug-fix-only PRs must not touch `CHANGELOG.md`/`UPGRADE.md`, features need an entry in the unreleased section, `BC Break` label ⇄ `UPGRADE.md` entry.
- **Draft, show, post.** Deep findings go in the chat answer; the posted review body is one to three sentences and each inline comment is a single ask plus its evidence. Nothing is posted without explicit approval.

It ships `references/inline-review.md` (anchoring rules, suggestion-block mechanics, the common 422 causes) and `scripts/build-review.sh`, which resolves the head SHA and validates every anchor against the PR's actual diff hunks before emitting a payload:

```
$ build-review.sh --pr 2368 --body body.md \
    --comment 'src/platform/src/Bridge/OpenRouter/ModelApiCatalog.php:200:c1.md'
error: anchor src/platform/src/Bridge/OpenRouter/ModelApiCatalog.php:200 is not inside a single diff hunk.
  valid ranges for this file:
    27 33
    64 70
    129 135
```

The helper was checked against two reviews posted from this workflow (#2368, #2265) and reproduces both payloads byte-identically.

Both skills carry `evals/evals.json` in the same shape as the existing skills.
