### PR TITLE
[Chat] Name the message kind in unknown-content-type errors

### DIFF
--- a/src/chat/src/MessageNormalizer.php
+++ b/src/chat/src/MessageNormalizer.php
@@ -57,14 +57,14 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
         $message = match ($type) {
             SystemMessage::class => new SystemMessage($content),
             AssistantMessage::class => new AssistantMessage(...self::denormalizeAssistantParts($data)),
-            UserMessage::class => new UserMessage(...self::denormalizeContentParts($contentAsBase64)),
+            UserMessage::class => new UserMessage(...self::denormalizeContentParts($contentAsBase64, 'user message content type')),
             ToolCallMessage::class => new ToolCallMessage(
                 new ToolCall(
                     $data['toolsCalls']['id'],
                     $data['toolsCalls']['function']['name'],
                     json_decode($data['toolsCalls']['function']['arguments'], true)
                 ),
-                ...([] !== $contentAsBase64 ? self::denormalizeContentParts($contentAsBase64) : [new Text($content)]),
+                ...([] !== $contentAsBase64 ? self::denormalizeContentParts($contentAsBase64, 'tool call content type') : [new Text($content)]),
             ),
             default => throw new LogicException(\sprintf('Unknown message type "%s".', $type)),
         };
@@ -192,7 +192,7 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
      *
      * @return list<ContentInterface>
      */
-    private static function denormalizeContentParts(array $parts): array
+    private static function denormalizeContentParts(array $parts, string $subject): array
     {
         return array_map(
             static fn (array $part): ContentInterface => match ($part['type']) {
@@ -204,7 +204,7 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
                 Text::class => new Text($part['content']),
                 ImageUrl::class => new ImageUrl($part['content']),
                 DocumentUrl::class => new DocumentUrl($part['content']),
-                default => throw new LogicException(\sprintf('Unknown content type "%s".', $part['type'])),
+                default => throw new LogicException(\sprintf('Unknown %s "%s".', $subject, $part['type'])),
             },
             $parts,
         );
@@ -228,7 +228,7 @@ final class MessageNormalizer implements NormalizerInterface, DenormalizerInterf
                         $part['toolCall']['function']['name'],
                         json_decode($part['toolCall']['function']['arguments'], true),
                     ),
-                    default => self::denormalizeContentParts([$part])[0],
+                    default => self::denormalizeContentParts([$part], 'assistant part type')[0],
                 };
             }
 

--- a/src/chat/tests/MessageNormalizerTest.php
+++ b/src/chat/tests/MessageNormalizerTest.php
@@ -115,7 +115,7 @@ final class MessageNormalizerTest extends TestCase
         $normalizer = new MessageNormalizer();
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(\sprintf('Unknown content type "%s".', \stdClass::class));
+        $this->expectExceptionMessage(\sprintf('Unknown user message content type "%s".', \stdClass::class));
 
         $normalizer->denormalize([
             'id' => Uuid::v7()->toRfc4122(),
@@ -128,6 +128,56 @@ final class MessageNormalizerTest extends TestCase
                 ],
             ],
             'toolsCalls' => [],
+            'metadata' => [],
+            'addedAt' => (new \DateTimeImmutable())->getTimestamp(),
+        ], MessageInterface::class);
+    }
+
+    public function testItRejectsUnknownToolCallMessageContentType()
+    {
+        $normalizer = new MessageNormalizer();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Unknown tool call content type "%s".', \stdClass::class));
+
+        $normalizer->denormalize([
+            'id' => Uuid::v7()->toRfc4122(),
+            'type' => ToolCallMessage::class,
+            'content' => '',
+            'contentAsBase64' => [
+                [
+                    'type' => \stdClass::class,
+                    'content' => 'arbitrary-constructor-argument',
+                ],
+            ],
+            'toolsCalls' => [
+                'id' => 'call-1',
+                'function' => ['name' => 'screenshot', 'arguments' => '[]'],
+            ],
+            'metadata' => [],
+            'addedAt' => (new \DateTimeImmutable())->getTimestamp(),
+        ], MessageInterface::class);
+    }
+
+    public function testItRejectsUnknownAssistantPartType()
+    {
+        $normalizer = new MessageNormalizer();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Unknown assistant part type "%s".', \stdClass::class));
+
+        $normalizer->denormalize([
+            'id' => Uuid::v7()->toRfc4122(),
+            'type' => AssistantMessage::class,
+            'content' => '',
+            'contentAsBase64' => [],
+            'toolsCalls' => [],
+            'parts' => [
+                [
+                    'type' => \stdClass::class,
+                    'content' => 'arbitrary-constructor-argument',
+                ],
+            ],
             'metadata' => [],
             'addedAt' => (new \DateTimeImmutable())->getTimestamp(),
         ], MessageInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Follow-up to #2265, improving what a corrupt stored payload tells you.

#2265 replaced the `default` arm of `denormalizeAssistantParts()` with a delegation to the shared `denormalizeContentParts()`. The delegation is right, it removed logic that was duplicated in the same file and keeps the user and assistant paths from drifting apart again, but it made an unhandled assistant part report `Unknown content type "..."` instead of `Unknown assistant part type "..."`, losing the pointer to where the bad data sits.

Rather than restoring that by re-listing the seven allowed content classes at the call site, which would reintroduce exactly the duplication #2265 removed, the helper now takes the subject as a required argument. Every caller says what it was denormalizing:

| Path | Message |
| --- | --- |
| `UserMessage` | `Unknown user message content type "..."` |
| `ToolCallMessage` | `Unknown tool call content type "..."` |
| assistant parts | `Unknown assistant part type "..."` |

The argument is required rather than defaulted, so no call site can silently fall back to generic wording.

Only reachable with a stored payload this version did not write, so this is a diagnostics change, not a behavioural one.

### Tests

- `testItRejectsUnknownAssistantPartType()`, new, covers the path #2265 changed
- `testItRejectsUnknownToolCallMessageContentType()`, new, that path had no coverage
- `testItRejectsUnknownUserMessageContentType()`, updated to the more specific wording

### Not included

`normalizeContentParts()` keeps its generic message. Its assistant call site is guarded by `instanceof File|ImageUrl|DocumentUrl`, so unhandled types are skipped before they reach it, and its other call site serves `UserMessage` and `ToolCallMessage` from one ternary. Splitting the subject there would mean restructuring that expression for a message that is close to unreachable. Happy to do it for symmetry if preferred.
