### PR TITLE
[Platform][Mistral] Fix streaming/buffered crash on reasoning (thinking) content

### DIFF
--- a/examples/mistral/chat-stream-reasoning.php
+++ b/examples/mistral/chat-stream-reasoning.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Platform\Bridge\Mistral\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('MISTRAL_API_KEY'), http_client());
+
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant.'),
+    Message::ofUser('What is 23 * 17?'),
+);
+
+// With `reasoning_effort: high`, Mistral returns the thinking trace as array-shaped content
+// chunks, which the bridge maps to ThinkingDelta/ThinkingComplete before the answer TextDeltas.
+$result = $platform->invoke('mistral-medium-2604', $messages, [
+    'stream' => true,
+    'reasoning_effort' => 'high',
+]);
+
+$thinking = false;
+foreach ($result->asStream() as $delta) {
+    if ($delta instanceof ThinkingDelta) {
+        if (!$thinking) {
+            output()->writeln('<info><thinking></info>');
+            $thinking = true;
+        }
+        output()->write('<fg=#999999>'.$delta->getThinking().'</>');
+    }
+    if ($delta instanceof ThinkingComplete) {
+        output()->writeln(\PHP_EOL.'<info></thinking></info>');
+        $thinking = false;
+    }
+    if ($delta instanceof TextDelta) {
+        echo $delta;
+    }
+}
+echo \PHP_EOL;

--- a/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
+++ b/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
@@ -90,23 +90,7 @@ trait CompletionsConversionTrait
                 yield new ToolCallComplete(array_map($this->convertToolCall(...), $toolCalls));
             }
 
-            $reasoningContent = $data['choices'][0]['delta']['reasoning_content']
-                ?? $data['choices'][0]['delta']['reasoning'] ?? null;
-            if (null !== $reasoningContent && '' !== $reasoningContent) {
-                $reasoning .= $reasoningContent;
-                yield new ThinkingDelta($reasoningContent);
-            }
-
-            if ('' !== $reasoning && isset($data['choices'][0]['delta']['content']) && '' !== $data['choices'][0]['delta']['content']) {
-                yield new ThinkingComplete($reasoning);
-                $reasoning = '';
-            }
-
-            if (!isset($data['choices'][0]['delta']['content'])) {
-                continue;
-            }
-
-            yield new TextDelta($data['choices'][0]['delta']['content']);
+            $reasoning = yield from $this->yieldContentDeltas($data['choices'][0]['delta'] ?? [], $reasoning);
         }
 
         if ('' !== $reasoning) {
@@ -122,6 +106,32 @@ trait CompletionsConversionTrait
         if (null !== $finishReason) {
             yield new MetadataDelta('finish_reason', $finishReason);
         }
+    }
+
+    /**
+     * @param array<string, mixed> $delta     The `choices[0].delta` payload
+     * @param string               $reasoning Reasoning accumulated by the previous chunks
+     *
+     * @return \Generator<int, ThinkingDelta|ThinkingComplete|TextDelta, mixed, string> Yields the content deltas; returns the updated reasoning
+     */
+    protected function yieldContentDeltas(array $delta, string $reasoning): \Generator
+    {
+        $reasoningContent = $delta['reasoning_content'] ?? $delta['reasoning'] ?? null;
+        if (null !== $reasoningContent && '' !== $reasoningContent) {
+            $reasoning .= $reasoningContent;
+            yield new ThinkingDelta($reasoningContent);
+        }
+
+        if ('' !== $reasoning && isset($delta['content']) && '' !== $delta['content']) {
+            yield new ThinkingComplete($reasoning);
+            $reasoning = '';
+        }
+
+        if (isset($delta['content'])) {
+            yield new TextDelta($delta['content']);
+        }
+
+        return $reasoning;
     }
 
     /**

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -12,16 +12,23 @@
 namespace Symfony\AI\Platform\Bridge\Mistral\Llm;
 
 use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
+use Symfony\AI\Platform\Bridge\Generic\Completions\FinishReasonMapper;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
 use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 
 /**
@@ -29,7 +36,10 @@ use Symfony\AI\Platform\ResultConverterInterface;
  */
 final class ResultConverter implements ResultConverterInterface
 {
-    use CompletionsConversionTrait;
+    use CompletionsConversionTrait {
+        yieldContentDeltas as private yieldOpenAiContentDeltas;
+        convertChoice as private convertOpenAiChoice;
+    }
     use HttpStatusErrorHandlingTrait;
 
     public function supports(Model $model): bool
@@ -78,5 +88,94 @@ final class ResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): TokenUsageExtractor
     {
         return new TokenUsageExtractor();
+    }
+
+    /**
+     * @param array<string, mixed> $delta
+     *
+     * @return \Generator<int, ThinkingDelta|ThinkingComplete|TextDelta, mixed, string>
+     */
+    protected function yieldContentDeltas(array $delta, string $reasoning): \Generator
+    {
+        $content = $delta['content'] ?? null;
+
+        if (!\is_array($content)) {
+            return yield from $this->yieldOpenAiContentDeltas($delta, $reasoning);
+        }
+
+        foreach ($content as $chunk) {
+            $type = \is_array($chunk) ? ($chunk['type'] ?? null) : null;
+
+            if ('thinking' === $type) {
+                $thinking = $this->flattenThinking($chunk['thinking'] ?? []);
+                if ('' !== $thinking) {
+                    $reasoning .= $thinking;
+                    yield new ThinkingDelta($thinking);
+                }
+
+                continue;
+            }
+
+            if ('text' === $type) {
+                if ('' !== $reasoning) {
+                    yield new ThinkingComplete($reasoning);
+                    $reasoning = '';
+                }
+
+                $text = \is_string($chunk['text'] ?? null) ? $chunk['text'] : '';
+                if ('' !== $text) {
+                    yield new TextDelta($text);
+                }
+            }
+        }
+
+        return $reasoning;
+    }
+
+    /**
+     * @param array<string, mixed> $choice
+     */
+    protected function convertChoice(array $choice): ResultInterface
+    {
+        $content = $choice['message']['content'] ?? null;
+
+        if (!\is_array($content) || 'tool_calls' === ($choice['finish_reason'] ?? null)) {
+            return $this->convertOpenAiChoice($choice);
+        }
+
+        $results = [];
+        foreach ($content as $chunk) {
+            $type = \is_array($chunk) ? ($chunk['type'] ?? null) : null;
+
+            if ('thinking' === $type) {
+                $results[] = new ThinkingResult($this->flattenThinking($chunk['thinking'] ?? []));
+            } elseif ('text' === $type && \is_string($chunk['text'] ?? null)) {
+                $results[] = new TextResult($chunk['text']);
+            }
+        }
+
+        if ([] === $results) {
+            $results[] = new TextResult('');
+        }
+
+        return $this->withFinishReason(
+            1 === \count($results) ? $results[0] : new MultiPartResult($results),
+            FinishReasonMapper::map($choice['finish_reason'] ?? null),
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $chunks
+     */
+    private function flattenThinking(array $chunks): string
+    {
+        $thinking = '';
+        foreach ($chunks as $chunk) {
+            if ('text' === ($chunk['type'] ?? null) && \is_string($chunk['text'] ?? null)) {
+                $thinking .= $chunk['text'];
+            }
+        }
+
+        return $thinking;
     }
 }

--- a/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
@@ -16,9 +16,20 @@ use Symfony\AI\Platform\Bridge\Mistral\Llm\ResultConverter;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class ResultConverterTest extends TestCase
 {
@@ -62,5 +73,188 @@ final class ResultConverterTest extends TestCase
         $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
+
+    /**
+     * With `reasoning_effort: high`, Mistral streams the thinking trace inside an array-shaped
+     * `delta.content` (a `thinking` chunk), then a transition chunk carrying the closing thinking
+     * plus the first text chunk, then plain-string `content` for the answer.
+     *
+     * @see https://docs.mistral.ai/capabilities/reasoning/
+     */
+    public function testStreamingReasoningEffortHighEmitsThinkingThenTextDeltas()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => [
+                ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'Let me']]],
+            ]], 'finish_reason' => null]]],
+            ['choices' => [['index' => 0, 'delta' => ['content' => [
+                ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => ' think.']]],
+                ['type' => 'text', 'text' => 'The answer'],
+            ]], 'finish_reason' => null]]],
+            ['choices' => [['index' => 0, 'delta' => ['content' => ' is 391.'], 'finish_reason' => null]]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2]],
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+
+        $this->assertInstanceOf(StreamResult::class, $streamResult);
+
+        $chunks = iterator_to_array($streamResult->getContent(), false);
+
+        $thinkingDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof ThinkingDelta));
+        $this->assertCount(2, $thinkingDeltas);
+        $this->assertSame('Let me', $thinkingDeltas[0]->getThinking());
+        $this->assertSame(' think.', $thinkingDeltas[1]->getThinking());
+
+        $thinkingCompletes = array_values(array_filter($chunks, static fn ($c) => $c instanceof ThinkingComplete));
+        $this->assertCount(1, $thinkingCompletes);
+        $this->assertSame('Let me think.', $thinkingCompletes[0]->getThinking());
+
+        $textDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof TextDelta));
+        $this->assertCount(2, $textDeltas);
+        $this->assertSame('The answer', $textDeltas[0]->getText());
+        $this->assertSame(' is 391.', $textDeltas[1]->getText());
+
+        $metadataDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof MetadataDelta));
+        $this->assertCount(1, $metadataDeltas);
+        $this->assertSame('finish_reason', $metadataDeltas[0]->getKey());
+        $this->assertSame(FinishReasonCase::STOP, $metadataDeltas[0]->getValue()->getCase());
+
+        // ThinkingComplete must precede the first TextDelta.
+        $thinkingCompleteIndex = array_search($thinkingCompletes[0], $chunks, true);
+        $firstTextDeltaIndex = array_search($textDeltas[0], $chunks, true);
+        $this->assertLessThan($firstTextDeltaIndex, $thinkingCompleteIndex);
+    }
+
+    /**
+     * Regression guard for the OpenAI-compatible path: with `reasoning_effort: none`, `delta.content`
+     * is a plain string and must yield only text deltas.
+     */
+    public function testStreamingReasoningEffortNoneEmitsOnlyTextDeltas()
+    {
+        $converter = new ResultConverter();
+
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'Hello, '], 'finish_reason' => null]]],
+            ['choices' => [['index' => 0, 'delta' => ['content' => 'world!'], 'finish_reason' => 'stop']]],
+        ];
+
+        $streamResult = $converter->convert(new InMemoryRawResult([], $events, $this->httpResponseStub()), ['stream' => true]);
+
+        $chunks = iterator_to_array($streamResult->getContent(), false);
+
+        $this->assertCount(0, array_filter($chunks, static fn ($c) => $c instanceof ThinkingDelta));
+        $this->assertCount(0, array_filter($chunks, static fn ($c) => $c instanceof ThinkingComplete));
+
+        $textDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof TextDelta));
+        $this->assertCount(2, $textDeltas);
+        $this->assertSame('Hello, ', $textDeltas[0]->getText());
+        $this->assertSame('world!', $textDeltas[1]->getText());
+
+        $metadataDeltas = array_values(array_filter($chunks, static fn ($c) => $c instanceof MetadataDelta));
+        $this->assertCount(1, $metadataDeltas);
+        $this->assertSame(FinishReasonCase::STOP, $metadataDeltas[0]->getValue()->getCase());
+    }
+
+    /**
+     * With `reasoning_effort: high`, the buffered `message.content` is an array of thinking/text
+     * chunks and must split into a {@see MultiPartResult} of {@see ThinkingResult} + {@see TextResult}.
+     */
+    public function testBufferedReasoningEffortHighSplitsThinkingAndText()
+    {
+        $converter = new ResultConverter();
+
+        $data = [
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => [
+                            ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'Let me think.']]],
+                            ['type' => 'text', 'text' => 'The answer is 391.'],
+                        ],
+                    ],
+                    'finish_reason' => 'stop',
+                ],
+            ],
+        ];
+
+        $result = $converter->convert(new InMemoryRawResult($data, [], $this->httpResponseStub()));
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+
+        $parts = $result->getContent();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(ThinkingResult::class, $parts[0]);
+        $this->assertSame('Let me think.', $parts[0]->getContent());
+        $this->assertInstanceOf(TextResult::class, $parts[1]);
+        $this->assertSame('The answer is 391.', $parts[1]->getContent());
+        $this->assertSame('The answer is 391.', $result->asText());
+
+        $this->assertTrue($result->getMetadata()->get('finish_reason')->is(FinishReasonCase::STOP));
+    }
+
+    /**
+     * A buffered response with a single thinking chunk (no text) must collapse to a lone
+     * {@see ThinkingResult} rather than a {@see MultiPartResult}.
+     */
+    public function testBufferedReasoningEffortHighWithThinkingOnlyReturnsThinkingResult()
+    {
+        $converter = new ResultConverter();
+
+        $data = [
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => [
+                            ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'Still thinking...']]],
+                        ],
+                    ],
+                    'finish_reason' => 'length',
+                ],
+            ],
+        ];
+
+        $result = $converter->convert(new InMemoryRawResult($data, [], $this->httpResponseStub()));
+
+        $this->assertInstanceOf(ThinkingResult::class, $result);
+        $this->assertSame('Still thinking...', $result->getContent());
+        $this->assertTrue($result->getMetadata()->get('finish_reason')->is(FinishReasonCase::LENGTH));
+    }
+
+    /**
+     * Regression guard for the OpenAI-compatible path: a plain-string buffered `message.content`
+     * must still produce a {@see TextResult}.
+     */
+    public function testBufferedReasoningEffortNoneReturnsTextResult()
+    {
+        $converter = new ResultConverter();
+
+        $data = [
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => ['role' => 'assistant', 'content' => 'Hello world'],
+                    'finish_reason' => 'stop',
+                ],
+            ],
+        ];
+
+        $result = $converter->convert(new InMemoryRawResult($data, [], $this->httpResponseStub()));
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Hello world', $result->getContent());
+    }
+
+    private function httpResponseStub(): ResponseInterface
+    {
+        return (new MockHttpClient(new JsonMockResponse([], ['http_code' => 200])))
+            ->request('POST', 'https://api.mistral.ai/v1/chat/completions');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2422
| License       | MIT

The Mistral `Llm\ResultConverter` reuses `CompletionsConversionTrait`, which assumes the OpenAI chat-completions schema where `choices[].delta.content` (and `message.content`) is always a string. With `reasoning_effort: high` (catalog thinking models such as `mistral-medium-2604` and `mistral-small-2603`), Mistral returns `content` as an array of thinking/text chunks (https://docs.mistral.ai/capabilities/reasoning/), so streaming throws `TextDelta::__construct(): Argument #1 ($text) must be of type string, array given` and the buffered path throws the equivalent for `TextResult`.

This extracts the per-delta content handling into a protected `yieldContentDeltas()` seam on the trait (behaviour-preserving for all OpenAI-compatible providers) and overrides it — plus `convertChoice()` — in the Mistral bridge to parse the chunks into `ThinkingDelta`/`ThinkingComplete`/ `TextDelta` (streaming) and `ThinkingResult` + `TextResult` in a `MultiPartResult` (buffered), matching the Anthropic bridge's thinking model.

An `examples/mistral/chat-stream-reasoning.php` example is added (`mistral-medium-2604`), and the generic completions regression tests confirm the OpenAI-compatible paths are unchanged.