### PR TITLE
[Platform][Mistral] Handle chunked reasoning content in completions results

### DIFF
--- a/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
+++ b/src/platform/src/Bridge/Generic/Completions/CompletionsConversionTrait.php
@@ -50,6 +50,8 @@ trait CompletionsConversionTrait
         $finishReason = null;
 
         foreach ($result->getDataStream() as $data) {
+            $data = $this->normalizeStreamChunk($data);
+
             if (isset($data['error'])) {
                 $message = \is_array($data['error']) ? ($data['error']['message'] ?? 'Unknown error') : (string) $data['error'];
                 $code = \is_array($data['error']) ? ($data['error']['code'] ?? null) : null;
@@ -122,6 +124,18 @@ trait CompletionsConversionTrait
         if (null !== $finishReason) {
             yield new MetadataDelta('finish_reason', $finishReason);
         }
+    }
+
+    /**
+     * Reshapes a stream chunk for bridges whose delta payload deviates from the OpenAI schema.
+     *
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    protected function normalizeStreamChunk(array $data): array
+    {
+        return $data;
     }
 
     /**

--- a/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
+++ b/src/platform/src/Bridge/Mistral/Llm/ResultConverter.php
@@ -12,16 +12,19 @@
 namespace Symfony\AI\Platform\Bridge\Mistral\Llm;
 
 use Symfony\AI\Platform\Bridge\Generic\Completions\CompletionsConversionTrait;
+use Symfony\AI\Platform\Bridge\Generic\Completions\FinishReasonMapper;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\ChoiceResult;
 use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\ResultConverterInterface;
 
 /**
@@ -70,7 +73,7 @@ final class ResultConverter implements ResultConverterInterface
             throw new RuntimeException('Response does not contain choices.');
         }
 
-        $choices = array_map($this->convertChoice(...), $data['choices']);
+        $choices = array_map($this->convertReasoningChoice(...), $data['choices']);
 
         return 1 === \count($choices) ? $choices[0] : new ChoiceResult($choices);
     }
@@ -78,5 +81,94 @@ final class ResultConverter implements ResultConverterInterface
     public function getTokenUsageExtractor(): TokenUsageExtractor
     {
         return new TokenUsageExtractor();
+    }
+
+    /**
+     * With `reasoning_effort` enabled, Mistral sends `delta.content` as a list of thinking and text
+     * chunks until the thinking block closes, and as a plain string afterwards.
+     *
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    protected function normalizeStreamChunk(array $data): array
+    {
+        if (!\is_array($data['choices'][0]['delta']['content'] ?? null)) {
+            return $data;
+        }
+
+        [$thinking, $text] = $this->flattenContentChunks($data['choices'][0]['delta']['content']);
+
+        unset($data['choices'][0]['delta']['content']);
+
+        if ('' !== $thinking) {
+            $data['choices'][0]['delta']['reasoning_content'] = $thinking;
+        }
+
+        if ('' !== $text) {
+            $data['choices'][0]['delta']['content'] = $text;
+        }
+
+        return $data;
+    }
+
+    /**
+     * With `reasoning_effort` enabled, `message.content` carries the same chunk list as the stream,
+     * so the thinking trace becomes its own part next to the answer.
+     *
+     * @param array<string, mixed> $choice
+     */
+    private function convertReasoningChoice(array $choice): ResultInterface
+    {
+        if (!\is_array($choice['message']['content'] ?? null)) {
+            return $this->convertChoice($choice);
+        }
+
+        [$thinking, $text, $signature] = $this->flattenContentChunks($choice['message']['content']);
+
+        $choice['message']['content'] = $text;
+
+        if ('' === $thinking) {
+            return $this->convertChoice($choice);
+        }
+
+        $thinkingResult = new ThinkingResult($thinking, $signature);
+
+        if ('' === $text && 'tool_calls' !== $choice['finish_reason']) {
+            return $this->withFinishReason($thinkingResult, FinishReasonMapper::map($choice['finish_reason']));
+        }
+
+        return $this->withFinishReason(
+            new MultiPartResult([$thinkingResult, $this->convertChoice($choice)]),
+            FinishReasonMapper::map($choice['finish_reason']),
+        );
+    }
+
+    /**
+     * @param list<array{type?: string, text?: string, thinking?: list<array{text?: string}>, signature?: ?string}> $content
+     *
+     * @return array{string, string, ?string}
+     */
+    private function flattenContentChunks(array $content): array
+    {
+        $thinking = '';
+        $text = '';
+        $signature = null;
+
+        foreach ($content as $chunk) {
+            if ('thinking' === ($chunk['type'] ?? null)) {
+                foreach (\is_array($chunk['thinking'] ?? null) ? $chunk['thinking'] : [] as $part) {
+                    $thinking .= $part['text'] ?? '';
+                }
+
+                $signature ??= $chunk['signature'] ?? null;
+
+                continue;
+            }
+
+            $text .= $chunk['text'] ?? '';
+        }
+
+        return [$thinking, $text, $signature];
     }
 }

--- a/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Llm/ResultConverterTest.php
@@ -16,7 +16,16 @@ use Symfony\AI\Platform\Bridge\Mistral\Llm\ResultConverter;
 use Symfony\AI\Platform\Bridge\Mistral\Mistral;
 use Symfony\AI\Platform\Exception\ExceedContextSizeException;
 use Symfony\AI\Platform\Exception\ServerException;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 
@@ -62,5 +71,99 @@ final class ResultConverterTest extends TestCase
         $this->expectExceptionMessage('Server error (HTTP 500');
 
         $converter->convert(new RawHttpResult($httpResponse), ['stream' => true]);
+    }
+
+    /**
+     * Not a cassette: recording one would need a live reasoning run against a paid model. The payload
+     * below is the documented thinking/text chunk shape Mistral streams for `reasoning_effort`.
+     */
+    public function testConvertStreamSplitsReasoningContentChunksIntoThinkingAndTextDeltas()
+    {
+        $events = [
+            ['choices' => [['index' => 0, 'delta' => ['content' => [
+                ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => '23 times 17']]],
+            ]]]]],
+            ['choices' => [['index' => 0, 'delta' => ['content' => [
+                ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => ' is 391.']], 'closed' => true],
+                ['type' => 'text', 'text' => 'The answer'],
+            ]]]]],
+            ['choices' => [['index' => 0, 'delta' => ['content' => ' is 391.']]]],
+            ['choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
+        ];
+
+        $httpClient = new MockHttpClient(new JsonMockResponse([]));
+        $httpResponse = $httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions');
+
+        $converter = new ResultConverter();
+        $result = $converter->convert(new InMemoryRawResult([], $events, $httpResponse), ['stream' => true]);
+
+        $deltas = iterator_to_array($result->getContent());
+
+        $thinkingDeltas = array_values(array_filter($deltas, static fn ($delta) => $delta instanceof ThinkingDelta));
+        $this->assertCount(2, $thinkingDeltas);
+        $this->assertSame('23 times 17', $thinkingDeltas[0]->getThinking());
+        $this->assertSame(' is 391.', $thinkingDeltas[1]->getThinking());
+
+        $thinkingCompletes = array_values(array_filter($deltas, static fn ($delta) => $delta instanceof ThinkingComplete));
+        $this->assertCount(1, $thinkingCompletes);
+        $this->assertSame('23 times 17 is 391.', $thinkingCompletes[0]->getThinking());
+
+        $textDeltas = array_values(array_filter($deltas, static fn ($delta) => $delta instanceof TextDelta));
+        $this->assertCount(2, $textDeltas);
+        $this->assertSame('The answer', $textDeltas[0]->getText());
+        $this->assertSame(' is 391.', $textDeltas[1]->getText());
+    }
+
+    /**
+     * Not a cassette: see {@see testConvertStreamSplitsReasoningContentChunksIntoThinkingAndTextDeltas}.
+     */
+    public function testConvertSplitsAReasoningMessageIntoAThinkingAndATextPart()
+    {
+        $result = $this->convertMessageContent([
+            ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => '23 times 17 is 391.']], 'signature' => 'sig'],
+            ['type' => 'text', 'text' => 'The answer is 391.'],
+        ]);
+
+        $this->assertInstanceOf(MultiPartResult::class, $result);
+        $this->assertTrue($result->getMetadata()->get('finish_reason')->is(FinishReasonCase::STOP));
+
+        [$thinking, $text] = $result->getContent();
+
+        $this->assertInstanceOf(ThinkingResult::class, $thinking);
+        $this->assertSame('23 times 17 is 391.', $thinking->getContent());
+        $this->assertSame('sig', $thinking->getSignature());
+
+        $this->assertInstanceOf(TextResult::class, $text);
+        $this->assertSame('The answer is 391.', $text->getContent());
+    }
+
+    /**
+     * Not a cassette: see {@see testConvertStreamSplitsReasoningContentChunksIntoThinkingAndTextDeltas}.
+     */
+    public function testConvertReturnsThinkingOnlyWhenAReasoningMessageCarriesNoText()
+    {
+        $result = $this->convertMessageContent([
+            ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => '23 times 17']]],
+        ], 'length');
+
+        $this->assertInstanceOf(ThinkingResult::class, $result);
+        $this->assertSame('23 times 17', $result->getContent());
+        $this->assertTrue($result->getMetadata()->get('finish_reason')->is(FinishReasonCase::LENGTH));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $content
+     */
+    private function convertMessageContent(array $content, string $finishReason = 'stop'): ResultInterface
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['choices' => [[
+            'index' => 0,
+            'message' => ['role' => 'assistant', 'content' => $content],
+            'finish_reason' => $finishReason,
+        ]]]));
+
+        $httpResponse = $httpClient->request('POST', 'https://api.mistral.ai/v1/chat/completions');
+
+        return (new ResultConverter())->convert(new RawHttpResult($httpResponse));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2422
| License       | MIT

With `reasoning_effort` set to anything but `none`, Mistral no longer sends `content` as a string. It sends a list of thinking and text chunks, and only falls back to a plain string once the thinking block has closed. `CompletionsConversionTrait` assumes the OpenAI schema, so that list went straight into `TextDelta` and `TextResult` and blew up with a `TypeError` on both the streamed and the buffered path.

The Mistral converter now flattens those chunks before the shared conversion sees them. Streaming turns thinking chunks into `reasoning_content`, which the trait already surfaces as `ThinkingDelta`/`ThinkingComplete`, and text chunks into the string `content` it expects. The buffered path returns the trace as its own `ThinkingResult` next to the answer, the way the Anthropic and Gemini bridges do, so a response that is still mid-thinking when it gets truncated no longer collapses into an empty string.

Chunk reshaping happens in a new `normalizeStreamChunk()` hook that defaults to a no-op, so nothing changes for the other bridges using the trait. Happy to move the flattening elsewhere if you'd rather not widen that trait.
