### PR TITLE
[Agent] Fix tool call budget being shared across concurrent streaming calls

### DIFF
--- a/src/agent/src/Execution/Runner.php
+++ b/src/agent/src/Execution/Runner.php
@@ -12,7 +12,6 @@
 namespace Symfony\AI\Agent\Execution;
 
 use Symfony\AI\Agent\AgentInterface;
-use Symfony\AI\Agent\Exception\MaxIterationsExceededException;
 use Symfony\AI\Agent\Toolbox\Event\ToolCallsExecuted;
 use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
 use Symfony\AI\Agent\Toolbox\StreamListener;
@@ -52,9 +51,9 @@ final class Runner
     private int $nestingLevel = 0;
 
     /**
-     * Counts the tool calling rounds of one agent call, including the ones happening in nested agent calls.
+     * Budget of the agent call currently driving the tool calling loop, shared with its nested calls.
      */
-    private int $iterations = 0;
+    private ToolCallBudget $budget;
 
     public function __construct(
         private readonly PlatformInterface $platform,
@@ -67,6 +66,7 @@ final class Runner
         private readonly ToolResultConverter $resultConverter = new ToolResultConverter(),
     ) {
         $this->sources = new SourceCollection();
+        $this->budget = new ToolCallBudget($maxToolCalls);
     }
 
     /**
@@ -76,8 +76,12 @@ final class Runner
     {
         // nested calls continue the tool calling loop of the outermost call and share its budget
         if (0 === $this->nestingLevel) {
-            $this->iterations = 0;
+            $this->budget = new ToolCallBudget($this->maxToolCalls);
         }
+
+        // the streaming loop starts when the result is consumed, which can be after another call
+        // already replaced the current budget, so it is captured here and passed along explicitly
+        $budget = $this->budget;
 
         $options = $this->exposeTools($options);
 
@@ -89,7 +93,7 @@ final class Runner
 
         if ($result instanceof StreamResult) {
             $result->addListener(new StreamListener(
-                fn (ToolCallResult $toolCallResult, ?AssistantMessage $streamedAssistantResponse = null): ResultInterface => $this->handleToolCalls($agent, $messages, $options, $toolCallResult, $streamedAssistantResponse),
+                fn (ToolCallResult $toolCallResult, ?AssistantMessage $streamedAssistantResponse = null): ResultInterface => $this->handleToolCalls($budget, $agent, $messages, $options, $toolCallResult, $streamedAssistantResponse),
             ));
 
             return $result;
@@ -101,7 +105,7 @@ final class Runner
             return $result;
         }
 
-        return $this->handleToolCalls($agent, $messages, $options, $toolCallResult);
+        return $this->handleToolCalls($budget, $agent, $messages, $options, $toolCallResult);
     }
 
     /**
@@ -141,10 +145,15 @@ final class Runner
     /**
      * @param array<string, mixed> $options
      */
-    private function handleToolCalls(AgentInterface $agent, MessageBag $messages, array $options, ToolCallResult $result, ?AssistantMessage $streamedAssistantResponse = null): ResultInterface
+    private function handleToolCalls(ToolCallBudget $budget, AgentInterface $agent, MessageBag $messages, array $options, ToolCallResult $result, ?AssistantMessage $streamedAssistantResponse = null): ResultInterface
     {
         \assert($this->toolExecutor instanceof ToolExecutorInterface);
 
+        // nested agent calls have to continue on the budget of the call this loop belongs to.
+        // Safe because this loop runs to completion with no suspension point, so no other call
+        // can install its budget in between; making this method lazy would break that.
+        $previousBudget = $this->budget;
+        $this->budget = $budget;
         ++$this->nestingLevel;
         $messages = $this->excludeToolMessages ? clone $messages : $messages;
 
@@ -154,9 +163,7 @@ final class Runner
 
         try {
             do {
-                if (null !== $this->maxToolCalls && ++$this->iterations > $this->maxToolCalls) {
-                    throw new MaxIterationsExceededException($this->maxToolCalls);
-                }
+                $budget->consume();
 
                 $toolCalls = array_values($result->getContent());
                 $toolResults = $this->toolExecutor->execute($toolCalls);
@@ -181,6 +188,7 @@ final class Runner
             } while ($result instanceof ToolCallResult);
         } finally {
             --$this->nestingLevel;
+            $this->budget = $previousBudget;
 
             if ($this->includeSources && 0 === $this->nestingLevel && $result instanceof ToolCallResult) {
                 $this->sources = new SourceCollection();

--- a/src/agent/src/Execution/ToolCallBudget.php
+++ b/src/agent/src/Execution/ToolCallBudget.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Execution;
+
+use Symfony\AI\Agent\Exception\MaxIterationsExceededException;
+
+/**
+ * Budget of tool calling rounds belonging to one outermost agent call, shared with its nested calls.
+ *
+ * It is created when the outermost call starts and carried into the streaming listener, so that agent
+ * calls started before their stream is consumed do not spend each other's budget.
+ *
+ * @author Ousama Ben Younes <benyounes.ousama@gmail.com>
+ *
+ * @internal
+ */
+final class ToolCallBudget
+{
+    private int $iterations = 0;
+
+    public function __construct(
+        private readonly ?int $maxToolCalls,
+    ) {
+    }
+
+    /**
+     * @throws MaxIterationsExceededException when the configured number of tool calling rounds is exhausted
+     */
+    public function consume(): void
+    {
+        if (null === $this->maxToolCalls) {
+            return;
+        }
+
+        ++$this->iterations;
+
+        if ($this->iterations > $this->maxToolCalls) {
+            throw new MaxIterationsExceededException($this->maxToolCalls);
+        }
+    }
+}

--- a/src/agent/tests/Execution/RunnerTest.php
+++ b/src/agent/tests/Execution/RunnerTest.php
@@ -42,6 +42,8 @@ use Symfony\AI\Platform\Tool\Tool;
 
 final class RunnerTest extends TestCase
 {
+    private const MAX_TOOL_CALLS = 3;
+
     public function testWithoutRegisteredToolsTheToolsOptionStaysUntouched()
     {
         $toolbox = $this->createStub(ToolboxInterface::class);
@@ -484,6 +486,46 @@ final class RunnerTest extends TestCase
         $this->expectExceptionMessage('Maximum number of tool calling iterations (3) exceeded.');
 
         iterator_to_array($result->getContent());
+    }
+
+    public function testMaxIterationsLimitIsNotSharedBetweenConcurrentStreams()
+    {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $executions = 0;
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->method('execute')
+            ->willReturnCallback(static function () use ($toolCall, &$executions): ToolResult {
+                ++$executions;
+
+                return new ToolResult($toolCall, 'Test response');
+            });
+
+        // enough streams for both agent calls to exhaust a full budget of their own
+        $streams = array_map(static fn (): StreamResult => new StreamResult((static function () use ($toolCall) {
+            yield new ToolCallComplete([$toolCall]);
+        })()), range(1, 20));
+
+        $runner = $this->createRunner($this->platform(...$streams), $toolbox, maxToolCalls: self::MAX_TOOL_CALLS);
+        $agent = $this->recursiveAgent($runner);
+
+        // both streams are started before either one is consumed, so the tool calling loop of the
+        // first one only begins once the second call already returned its own StreamResult
+        $first = $runner->run($agent, 'gpt-4', new MessageBag(), ['stream' => true]);
+        $second = $runner->run($agent, 'gpt-4', new MessageBag(), ['stream' => true]);
+
+        // each call has to spend a full budget of its own before it gets capped
+        $expectedExecutions = 0;
+        foreach ([$first, $second] as $result) {
+            try {
+                iterator_to_array($result->getContent());
+                $this->fail('Expected MaxIterationsExceededException to be thrown.');
+            } catch (MaxIterationsExceededException) {
+            }
+
+            $expectedExecutions += self::MAX_TOOL_CALLS;
+            $this->assertSame($expectedExecutions, $executions);
+        }
     }
 
     public function testCustomMaxIterationsLimitAllowsConfiguredIterations()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2421
| License       | MIT

`Runner::$iterations` lives on the `Runner`, which is a shared service, and is reset in `run()` when
`nestingLevel` is 0. In the streaming path the tool calling loop only starts when the returned
`StreamResult` is consumed, which happens much later. Two streaming calls started before either one is
consumed therefore share a single budget: the second call's reset runs while the first has not started
counting, and the first then exhausts the counter the second inherits.

With `maxToolCalls: 3`, counting real tool rounds per stream:

```
stream A -> capped after 3 tool rounds
stream B -> capped after 0 tool rounds
```

Stream B is refused before executing a single tool.

### The fix

The budget now belongs to one outermost agent call instead of to the `Runner` instance. A
`ToolCallBudget` is created in `run()` at nesting level 0, captured there, and passed into the stream
listener closure, so the loop always spends the budget of the call it belongs to — whenever the stream
is consumed.

`handleToolCalls()` installs the budget it was handed for the duration of the loop and restores the
previously active one when it unwinds, so nested agent calls keep continuing on the budget of the loop
they belong to rather than opening a fresh one. That is the part the obvious "reset when nesting
level becomes 1" fix gets wrong: in the streaming path the parent's `handleToolCalls()` returns before
the nested round runs, so nesting has already unwound by the time the next round starts.

`$sources` and `$nestingLevel` are deliberately left on the `Runner` for now: `$nestingLevel` correctly
tracks the synchronous call stack (`handleToolCalls()` has no suspension point, so it always runs to
completion once the listener fires), and I could not construct a failing case for `$sources` under
concurrent streams — each level already attaches and resets it before unwinding. Happy to move them
into the same per-call object if you prefer that as one deliberate change.

### Test verification (RED → GREEN)

RED — new test on unmodified `main`, production code untouched (`git status --porcelain -- src/agent/src/` empty):

```
$ vendor/bin/phpunit -c src/agent/phpunit.xml.dist --filter testMaxIterationsLimitIsNotSharedBetweenConcurrentStreams
PHPUnit 11.5.56 by Sebastian Bergmann and contributors.

F                                                                   1 / 1 (100%)

There was 1 failure:

1) Symfony\AI\Agent\Tests\Execution\RunnerTest::testMaxIterationsLimitIsNotSharedBetweenConcurrentStreams
Failed asserting that 3 is identical to 6.

src/agent/tests/Execution/RunnerTest.php:527

FAILURES!
Tests: 1, Assertions: 2, Failures: 1.
```

The first assertion passes and the second fails at `3`, which is exactly the reported behaviour: the
first stream spends its 3 rounds, the second gets 0.

GREEN — same test with the fix:

```
$ vendor/bin/phpunit -c src/agent/phpunit.xml.dist --filter testMaxIterationsLimitIsNotSharedBetweenConcurrentStreams
.                                                                   1 / 1 (100%)

OK (1 test, 2 assertions)
```

No regressions in the component — `main` was `OK (276 tests, 656 assertions)`, the branch is:

```
$ vendor/bin/phpunit -c src/agent/phpunit.xml.dist
OK (277 tests, 658 assertions)
```

`php-cs-fixer` reports 0 fixable files and `phpstan analyse` reports no errors for `src/agent`.
