### PR TITLE
[Platform][OpenAI] Add Realtime sessions support for bidirectional audio & voice agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 composer.lock
 vendor
+.idea

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.13
 ----
 
+ * Add `Capability::REALTIME_SESSION` and `Result\RealtimeSessionResult` for long-lived realtime sessions (ephemeral client credentials for WebRTC/WebSocket voice agents)
  * [BC BREAK] Add `ListenerInterface::onError()` and `Result\Stream\ErrorEvent`, dispatched when draining a `StreamResult` throws, so a listener can finalize on a failed stream where `onComplete()` never fires; `AbstractStreamListener` provides a no-op default
  * Add `Test\Replay\CassetteHttpClient` and `Test\Replay\HttpCassette` to record real HTTP responses (when the cassette file is missing) and replay them offline through the real bridge pipeline (Contract, `ModelClient`, `ResultConverter`) in tests, including raw Server-Sent Event streams
  * Add `Test\Recording\RecordingProvider` (with `Cassette`/`ResultSerializer`) to record a real provider's result once (when the cassette file is missing) and replay it offline in tests

--- a/src/platform/src/Bridge/OpenAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenAi/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.11
 ----
 
+ * Add `Realtime` model, `Realtime\ModelClient`, `Realtime\ResultConverter`, and catalog entries (`gpt-4o-realtime-preview`, `gpt-4o-mini-realtime-preview`) for `POST /v1/realtime/sessions`
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Throw typed exceptions on rate limit and server error events mid-stream
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream

--- a/src/platform/src/Bridge/OpenAi/CHANGELOG.md
+++ b/src/platform/src/Bridge/OpenAi/CHANGELOG.md
@@ -1,10 +1,14 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Add `Realtime` model, `Realtime\ModelClient`, `Realtime\ResultConverter`, and catalog entries (`gpt-4o-realtime-preview`, `gpt-4o-mini-realtime-preview`) for `POST /v1/realtime/client_secrets`
+
 0.11
 ----
 
- * Add `Realtime` model, `Realtime\ModelClient`, `Realtime\ResultConverter`, and catalog entries (`gpt-4o-realtime-preview`, `gpt-4o-mini-realtime-preview`) for `POST /v1/realtime/sessions`
  * Throw `ServerException` on server errors (HTTP 5xx) instead of a generic `RuntimeException`
  * Throw typed exceptions on rate limit and server error events mid-stream
  * Raise a `RuntimeException` on unhandled HTTP error statuses before streaming, instead of returning an empty stream

--- a/src/platform/src/Bridge/OpenAi/Factory.php
+++ b/src/platform/src/Bridge/OpenAi/Factory.php
@@ -53,6 +53,7 @@ final class Factory
                 new Image\ModelClient($httpClient, $apiKey, $region),
                 new TextToSpeech\ModelClient($httpClient, $apiKey, $region),
                 new Whisper\ModelClient($httpClient, $apiKey, $region),
+                new Realtime\ModelClient($httpClient, $apiKey, $region),
             ],
             [
                 new Gpt\ResultConverter(),
@@ -60,6 +61,7 @@ final class Factory
                 new Image\ResultConverter(),
                 new TextToSpeech\ResultConverter(),
                 new Whisper\ResultConverter(),
+                new Realtime\ResultConverter(),
             ],
             $modelCatalog,
             $contract ?? OpenAiContract::create(),

--- a/src/platform/src/Bridge/OpenAi/ModelCatalog.php
+++ b/src/platform/src/Bridge/OpenAi/ModelCatalog.php
@@ -180,6 +180,18 @@ final class ModelCatalog extends AbstractModelCatalog
                     Capability::OUTPUT_STRUCTURED,
                 ],
             ],
+            'gpt-4o-realtime-preview' => [
+                'class' => Realtime::class,
+                'capabilities' => [
+                    Capability::REALTIME_SESSION,
+                ],
+            ],
+            'gpt-4o-mini-realtime-preview' => [
+                'class' => Realtime::class,
+                'capabilities' => [
+                    Capability::REALTIME_SESSION,
+                ],
+            ],
             'gpt-4o-mini' => [
                 'class' => Gpt::class,
                 'capabilities' => [

--- a/src/platform/src/Bridge/OpenAi/Realtime.php
+++ b/src/platform/src/Bridge/OpenAi/Realtime.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenAi;
+
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Model;
+
+/**
+ * @author Saiful Islam Feroz <saiful.feroz@gmail.com>
+ */
+class Realtime extends Model
+{
+    /**
+     * @param non-empty-string     $name
+     * @param Capability[]         $capabilities
+     * @param array<string, mixed> $options
+     */
+    public function __construct(string $name, array $capabilities = [Capability::REALTIME_SESSION], array $options = [])
+    {
+        parent::__construct($name, $capabilities, $options);
+    }
+}

--- a/src/platform/src/Bridge/OpenAi/Realtime/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Realtime/ModelClient.php
@@ -38,27 +38,34 @@ final class ModelClient extends AbstractModelClient implements ModelClientInterf
 
     public function request(Model $model, array|string|object $payload, array $options = []): RawHttpResult
     {
-        $body = array_merge($model->getOptions(), $options);
-        $body['model'] = $model->getName();
+        $session = array_merge($model->getOptions(), $options);
+        $session['model'] = $model->getName();
 
         if (\is_array($payload)) {
-            $body = array_merge($body, $payload);
+            $session = array_merge($session, $payload);
         } elseif (\is_string($payload) && '' !== trim($payload)) {
-            $body['instructions'] = $payload;
+            $session['instructions'] = $payload;
         }
 
-        if (!isset($body['modalities'])) {
-            $body['modalities'] = ['text', 'audio'];
+        if (!isset($session['type'])) {
+            $session['type'] = 'realtime';
         }
 
-        if (!isset($body['voice'])) {
-            $body['voice'] = 'alloy';
+        if (!isset($session['modalities'])) {
+            $session['modalities'] = ['text', 'audio'];
         }
 
-        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/v1/realtime/sessions', self::getBaseUrl($this->region)), [
+        if (isset($session['voice'])) {
+            $session['audio']['output']['voice'] = $session['voice'];
+            unset($session['voice']);
+        } elseif (!isset($session['audio']['output']['voice'])) {
+            $session['audio']['output']['voice'] = 'alloy';
+        }
+
+        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/v1/realtime/client_secrets', self::getBaseUrl($this->region)), [
             'auth_bearer' => $this->apiKey,
             'headers' => ['Content-Type' => 'application/json'],
-            'json' => $body,
+            'json' => ['session' => $session],
         ]));
     }
 }

--- a/src/platform/src/Bridge/OpenAi/Realtime/ModelClient.php
+++ b/src/platform/src/Bridge/OpenAi/Realtime/ModelClient.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenAi\Realtime;
+
+use Symfony\AI\Platform\Bridge\OpenAi\AbstractModelClient;
+use Symfony\AI\Platform\Bridge\OpenAi\Realtime;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelClientInterface;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Saiful Islam Feroz <saiful.feroz@gmail.com>
+ */
+final class ModelClient extends AbstractModelClient implements ModelClientInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        #[\SensitiveParameter] private readonly string $apiKey,
+        private readonly ?string $region = null,
+    ) {
+        self::validateApiKey($apiKey);
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Realtime;
+    }
+
+    public function request(Model $model, array|string|object $payload, array $options = []): RawHttpResult
+    {
+        $body = array_merge($model->getOptions(), $options);
+        $body['model'] = $model->getName();
+
+        if (\is_array($payload)) {
+            $body = array_merge($body, $payload);
+        } elseif (\is_string($payload) && '' !== trim($payload)) {
+            $body['instructions'] = $payload;
+        }
+
+        if (!isset($body['modalities'])) {
+            $body['modalities'] = ['text', 'audio'];
+        }
+
+        if (!isset($body['voice'])) {
+            $body['voice'] = 'alloy';
+        }
+
+        return new RawHttpResult($this->httpClient->request('POST', \sprintf('%s/v1/realtime/sessions', self::getBaseUrl($this->region)), [
+            'auth_bearer' => $this->apiKey,
+            'headers' => ['Content-Type' => 'application/json'],
+            'json' => $body,
+        ]));
+    }
+}

--- a/src/platform/src/Bridge/OpenAi/Realtime/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Realtime/ResultConverter.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenAi\Realtime;
+
+use Symfony\AI\Platform\Bridge\OpenAi\Realtime;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\HttpStatusErrorHandlingTrait;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\RealtimeSessionResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+
+/**
+ * @author Saiful Islam Feroz <saiful.feroz@gmail.com>
+ */
+final class ResultConverter implements ResultConverterInterface
+{
+    use HttpStatusErrorHandlingTrait;
+
+    public function supports(Model $model): bool
+    {
+        return $model instanceof Realtime;
+    }
+
+    public function convert(RawResultInterface|RawHttpResult $result, array $options = []): ResultInterface
+    {
+        $response = $result->getObject();
+
+        $this->throwOnHttpError($response);
+
+        if (200 !== $response->getStatusCode()) {
+            throw new RuntimeException(\sprintf('The OpenAI Realtime API returned an error: "%s"', $response->getContent(false)));
+        }
+
+        $data = $response->toArray();
+
+        $clientSecret = $data['client_secret']['value'] ?? ($data['client_secret'] ?? '');
+        $expiresAt = (int) ($data['client_secret']['expires_at'] ?? ($data['expires_at'] ?? 0));
+
+        return new RealtimeSessionResult(
+            id: $data['id'] ?? '',
+            clientSecret: $clientSecret,
+            expiresAt: $expiresAt,
+            model: $data['model'] ?? '',
+            voice: $data['voice'] ?? null,
+            modalities: $data['modalities'] ?? ['text', 'audio'],
+            raw: $data,
+        );
+    }
+
+    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    {
+        return null;
+    }
+}

--- a/src/platform/src/Bridge/OpenAi/Realtime/ResultConverter.php
+++ b/src/platform/src/Bridge/OpenAi/Realtime/ResultConverter.php
@@ -46,16 +46,19 @@ final class ResultConverter implements ResultConverterInterface
 
         $data = $response->toArray();
 
-        $clientSecret = $data['client_secret']['value'] ?? ($data['client_secret'] ?? '');
-        $expiresAt = (int) ($data['client_secret']['expires_at'] ?? ($data['expires_at'] ?? 0));
+        $clientSecret = $data['value'] ?? ($data['client_secret']['value'] ?? ($data['client_secret'] ?? ''));
+        $expiresAt = (int) ($data['expires_at'] ?? ($data['client_secret']['expires_at'] ?? 0));
+        $model = $data['session']['model'] ?? ($data['model'] ?? '');
+        $voice = $data['session']['audio']['output']['voice'] ?? ($data['session']['voice'] ?? ($data['voice'] ?? null));
+        $modalities = $data['session']['modalities'] ?? ($data['modalities'] ?? ['text', 'audio']);
 
         return new RealtimeSessionResult(
             id: $data['id'] ?? '',
             clientSecret: $clientSecret,
             expiresAt: $expiresAt,
-            model: $data['model'] ?? '',
-            voice: $data['voice'] ?? null,
-            modalities: $data['modalities'] ?? ['text', 'audio'],
+            model: $model,
+            voice: $voice,
+            modalities: $modalities,
             raw: $data,
         );
     }

--- a/src/platform/src/Bridge/OpenAi/Tests/Realtime/ModelClientTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Realtime/ModelClientTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenAi\Tests\Realtime;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\OpenAi\Realtime;
+use Symfony\AI\Platform\Bridge\OpenAi\Realtime\ModelClient;
+use Symfony\AI\Platform\Model;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
+
+/**
+ * @author Saiful Islam Feroz <saiful.feroz@gmail.com>
+ */
+final class ModelClientTest extends TestCase
+{
+    public function testSupportsRealtimeModel(): void
+    {
+        $httpClient = new MockHttpClient();
+        $modelClient = new ModelClient($httpClient, 'sk-test-key');
+        $model = new Realtime('gpt-4o-realtime-preview');
+
+        $this->assertTrue($modelClient->supports($model));
+    }
+
+    public function testDoesNotSupportOtherModels(): void
+    {
+        $httpClient = new MockHttpClient();
+        $modelClient = new ModelClient($httpClient, 'sk-test-key');
+        $model = new Model('other-model');
+
+        $this->assertFalse($modelClient->supports($model));
+    }
+
+    public function testRealtimeSessionRequest(): void
+    {
+        $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
+            self::assertSame('POST', $method);
+            self::assertSame('https://api.openai.com/v1/realtime/sessions', $url);
+            self::assertSame('Authorization: Bearer sk-test-key', $options['normalized_headers']['authorization'][0]);
+
+            $body = json_decode($options['body'], true);
+            self::assertSame('gpt-4o-realtime-preview', $body['model']);
+            self::assertSame('You are a helpful customer service voice assistant.', $body['instructions']);
+            self::assertSame('alloy', $body['voice']);
+            self::assertSame(['text', 'audio'], $body['modalities']);
+
+            return new MockResponse(json_encode([
+                'id' => 'sess_12345',
+                'object' => 'realtime.session',
+                'model' => 'gpt-4o-realtime-preview',
+                'modalities' => ['text', 'audio'],
+                'instructions' => 'You are a helpful customer service voice assistant.',
+                'voice' => 'alloy',
+                'client_secret' => [
+                    'value' => 'ek_secret_123',
+                    'expires_at' => 1790000000,
+                ],
+            ]));
+        };
+
+        $httpClient = new MockHttpClient([$resultCallback]);
+        $modelClient = new ModelClient($httpClient, 'sk-test-key');
+
+        $modelClient->request(
+            new Realtime('gpt-4o-realtime-preview'),
+            'You are a helpful customer service voice assistant.',
+            ['voice' => 'alloy']
+        );
+    }
+}

--- a/src/platform/src/Bridge/OpenAi/Tests/Realtime/ModelClientTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Realtime/ModelClientTest.php
@@ -46,25 +46,33 @@ final class ModelClientTest extends TestCase
     {
         $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
             self::assertSame('POST', $method);
-            self::assertSame('https://api.openai.com/v1/realtime/sessions', $url);
+            self::assertSame('https://api.openai.com/v1/realtime/client_secrets', $url);
             self::assertSame('Authorization: Bearer sk-test-key', $options['normalized_headers']['authorization'][0]);
 
             $body = json_decode($options['body'], true);
-            self::assertSame('gpt-4o-realtime-preview', $body['model']);
-            self::assertSame('You are a helpful customer service voice assistant.', $body['instructions']);
-            self::assertSame('alloy', $body['voice']);
-            self::assertSame(['text', 'audio'], $body['modalities']);
+            $session = $body['session'] ?? [];
+
+            self::assertSame('realtime', $session['type']);
+            self::assertSame('gpt-4o-realtime-preview', $session['model']);
+            self::assertSame('You are a helpful customer service voice assistant.', $session['instructions']);
+            self::assertSame('alloy', $session['audio']['output']['voice']);
+            self::assertSame(['text', 'audio'], $session['modalities']);
 
             return new MockResponse(json_encode([
                 'id' => 'sess_12345',
-                'object' => 'realtime.session',
-                'model' => 'gpt-4o-realtime-preview',
-                'modalities' => ['text', 'audio'],
-                'instructions' => 'You are a helpful customer service voice assistant.',
-                'voice' => 'alloy',
-                'client_secret' => [
-                    'value' => 'ek_secret_123',
-                    'expires_at' => 1790000000,
+                'object' => 'realtime.client_secret',
+                'value' => 'ek_secret_123',
+                'expires_at' => 1790000000,
+                'session' => [
+                    'type' => 'realtime',
+                    'model' => 'gpt-4o-realtime-preview',
+                    'modalities' => ['text', 'audio'],
+                    'instructions' => 'You are a helpful customer service voice assistant.',
+                    'audio' => [
+                        'output' => [
+                            'voice' => 'alloy',
+                        ],
+                    ],
                 ],
             ]));
         };

--- a/src/platform/src/Bridge/OpenAi/Tests/Realtime/ModelClientTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Realtime/ModelClientTest.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface as HttpResponse;
  */
 final class ModelClientTest extends TestCase
 {
-    public function testSupportsRealtimeModel(): void
+    public function testSupportsRealtimeModel()
     {
         $httpClient = new MockHttpClient();
         $modelClient = new ModelClient($httpClient, 'sk-test-key');
@@ -33,7 +33,7 @@ final class ModelClientTest extends TestCase
         $this->assertTrue($modelClient->supports($model));
     }
 
-    public function testDoesNotSupportOtherModels(): void
+    public function testDoesNotSupportOtherModels()
     {
         $httpClient = new MockHttpClient();
         $modelClient = new ModelClient($httpClient, 'sk-test-key');
@@ -42,7 +42,7 @@ final class ModelClientTest extends TestCase
         $this->assertFalse($modelClient->supports($model));
     }
 
-    public function testRealtimeSessionRequest(): void
+    public function testRealtimeSessionRequest()
     {
         $resultCallback = static function (string $method, string $url, array $options): HttpResponse {
             self::assertSame('POST', $method);

--- a/src/platform/src/Bridge/OpenAi/Tests/Realtime/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Realtime/ResultConverterTest.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class ResultConverterTest extends TestCase
 {
-    public function testSupportsRealtimeModel(): void
+    public function testSupportsRealtimeModel()
     {
         $converter = new ResultConverter();
         $model = new Realtime('gpt-4o-realtime-preview');
@@ -34,7 +34,7 @@ final class ResultConverterTest extends TestCase
         $this->assertTrue($converter->supports($model));
     }
 
-    public function testDoesNotSupportOtherModels(): void
+    public function testDoesNotSupportOtherModels()
     {
         $converter = new ResultConverter();
         $model = new Model('other-model');
@@ -42,7 +42,7 @@ final class ResultConverterTest extends TestCase
         $this->assertFalse($converter->supports($model));
     }
 
-    public function testThrowsOnAuthenticationError(): void
+    public function testThrowsOnAuthenticationError()
     {
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('Unauthorized');
@@ -54,7 +54,7 @@ final class ResultConverterTest extends TestCase
         (new ResultConverter())->convert(new RawHttpResult($response));
     }
 
-    public function testThrowsOnUnexpectedStatusCode(): void
+    public function testThrowsOnUnexpectedStatusCode()
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The OpenAI Realtime API returned an error: "Unexpected"');
@@ -66,7 +66,7 @@ final class ResultConverterTest extends TestCase
         (new ResultConverter())->convert(new RawHttpResult($response));
     }
 
-    public function testConvertsRealtimeSessionResponse(): void
+    public function testConvertsRealtimeSessionResponse()
     {
         $mockData = [
             'id' => 'sess_test_999',

--- a/src/platform/src/Bridge/OpenAi/Tests/Realtime/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Realtime/ResultConverterTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenAi\Tests\Realtime;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\OpenAi\Realtime;
+use Symfony\AI\Platform\Bridge\OpenAi\Realtime\ResultConverter;
+use Symfony\AI\Platform\Exception\AuthenticationException;
+use Symfony\AI\Platform\Exception\RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RealtimeSessionResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Saiful Islam Feroz <saiful.feroz@gmail.com>
+ */
+final class ResultConverterTest extends TestCase
+{
+    public function testSupportsRealtimeModel(): void
+    {
+        $converter = new ResultConverter();
+        $model = new Realtime('gpt-4o-realtime-preview');
+
+        $this->assertTrue($converter->supports($model));
+    }
+
+    public function testDoesNotSupportOtherModels(): void
+    {
+        $converter = new ResultConverter();
+        $model = new Model('other-model');
+
+        $this->assertFalse($converter->supports($model));
+    }
+
+    public function testThrowsOnAuthenticationError(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthorized');
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(401);
+        $response->method('toArray')->willReturn(['error' => ['message' => 'Unauthorized']]);
+
+        (new ResultConverter())->convert(new RawHttpResult($response));
+    }
+
+    public function testThrowsOnUnexpectedStatusCode(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The OpenAI Realtime API returned an error: "Unexpected"');
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(418);
+        $response->method('getContent')->willReturn('Unexpected');
+
+        (new ResultConverter())->convert(new RawHttpResult($response));
+    }
+
+    public function testConvertsRealtimeSessionResponse(): void
+    {
+        $mockData = [
+            'id' => 'sess_test_999',
+            'object' => 'realtime.session',
+            'model' => 'gpt-4o-realtime-preview',
+            'modalities' => ['text', 'audio'],
+            'instructions' => 'Speak clearly',
+            'voice' => 'alloy',
+            'client_secret' => [
+                'value' => 'ek_secret_token_abc',
+                'expires_at' => 1795000000,
+            ],
+        ];
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->willReturn($mockData);
+
+        $rawResult = new RawHttpResult($response);
+
+        $converter = new ResultConverter();
+        $result = $converter->convert($rawResult);
+
+        $this->assertInstanceOf(RealtimeSessionResult::class, $result);
+        $this->assertSame('sess_test_999', $result->getId());
+        $this->assertSame('ek_secret_token_abc', $result->getClientSecret());
+        $this->assertSame(1795000000, $result->getExpiresAt());
+        $this->assertSame('gpt-4o-realtime-preview', $result->getModel());
+        $this->assertSame('alloy', $result->getVoice());
+        $this->assertSame(['text', 'audio'], $result->getModalities());
+        $this->assertSame([
+            'id' => 'sess_test_999',
+            'client_secret' => 'ek_secret_token_abc',
+            'expires_at' => 1795000000,
+            'model' => 'gpt-4o-realtime-preview',
+            'voice' => 'alloy',
+            'modalities' => ['text', 'audio'],
+        ], $result->getContent());
+    }
+}

--- a/src/platform/src/Bridge/OpenAi/Tests/Realtime/ResultConverterTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/Realtime/ResultConverterTest.php
@@ -70,14 +70,19 @@ final class ResultConverterTest extends TestCase
     {
         $mockData = [
             'id' => 'sess_test_999',
-            'object' => 'realtime.session',
-            'model' => 'gpt-4o-realtime-preview',
-            'modalities' => ['text', 'audio'],
-            'instructions' => 'Speak clearly',
-            'voice' => 'alloy',
-            'client_secret' => [
-                'value' => 'ek_secret_token_abc',
-                'expires_at' => 1795000000,
+            'object' => 'realtime.client_secret',
+            'value' => 'ek_secret_token_abc',
+            'expires_at' => 1795000000,
+            'session' => [
+                'type' => 'realtime',
+                'model' => 'gpt-4o-realtime-preview',
+                'modalities' => ['text', 'audio'],
+                'instructions' => 'Speak clearly',
+                'audio' => [
+                    'output' => [
+                        'voice' => 'alloy',
+                    ],
+                ],
             ],
         ];
 

--- a/src/platform/src/Bridge/OpenAi/Tests/RealtimeTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/RealtimeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenAi\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\OpenAi\Realtime;
+use Symfony\AI\Platform\Capability;
+
+/**
+ * @author Saiful Islam Feroz <saiful.feroz@gmail.com>
+ */
+final class RealtimeTest extends TestCase
+{
+    public function testRealtimeModelDefaults(): void
+    {
+        $model = new Realtime('gpt-4o-realtime-preview');
+
+        $this->assertSame('gpt-4o-realtime-preview', $model->getName());
+        $this->assertTrue($model->supports(Capability::REALTIME_SESSION));
+    }
+}

--- a/src/platform/src/Bridge/OpenAi/Tests/RealtimeTest.php
+++ b/src/platform/src/Bridge/OpenAi/Tests/RealtimeTest.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Capability;
  */
 final class RealtimeTest extends TestCase
 {
-    public function testRealtimeModelDefaults(): void
+    public function testRealtimeModelDefaults()
     {
         $model = new Realtime('gpt-4o-realtime-preview');
 

--- a/src/platform/src/Capability.php
+++ b/src/platform/src/Capability.php
@@ -44,6 +44,7 @@ enum Capability: string
     case TEXT_TO_SPEECH = 'text-to-speech';
     case TEXT_TO_SPEECH_ASYNC = 'text-to-speech-async';
     case SPEECH_TO_TEXT = 'speech-to-text';
+    case REALTIME_SESSION = 'realtime-session';
 
     // IMAGE
     case TEXT_TO_IMAGE = 'text-to-image';

--- a/src/platform/src/Result/RealtimeSessionResult.php
+++ b/src/platform/src/Result/RealtimeSessionResult.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result;
+
+/**
+ * @author Saiful Islam Feroz <saiful.feroz@gmail.com>
+ */
+final class RealtimeSessionResult extends BaseResult
+{
+    /**
+     * @param list<string>         $modalities
+     * @param array<string, mixed> $raw
+     */
+    public function __construct(
+        private readonly string $id,
+        private readonly string $clientSecret,
+        private readonly int $expiresAt,
+        private readonly string $model,
+        private readonly ?string $voice = null,
+        private readonly array $modalities = ['text', 'audio'],
+        private readonly array $raw = [],
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getClientSecret(): string
+    {
+        return $this->clientSecret;
+    }
+
+    public function getExpiresAt(): int
+    {
+        return $this->expiresAt;
+    }
+
+    public function getModel(): string
+    {
+        return $this->model;
+    }
+
+    public function getVoice(): ?string
+    {
+        return $this->voice;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getModalities(): array
+    {
+        return $this->modalities;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getRaw(): array
+    {
+        return $this->raw;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContent(): array
+    {
+        return [
+            'id' => $this->id,
+            'client_secret' => $this->clientSecret,
+            'expires_at' => $this->expiresAt,
+            'model' => $this->model,
+            'voice' => $this->voice,
+            'modalities' => $this->modalities,
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | Fix #2427
| License       | MIT

This PR introduces support for long-lived, bidirectional **Realtime sessions** (for speech-to-speech voice agents, live audio streaming, and WebRTC / WebSocket ephemeral token generation) in `symfony/ai`.

### Motivation
Instead of proxying high-bandwidth WebRTC audio streams through PHP, Symfony acts as the secure **session broker & ephemeral credential minter**, generating short-lived client tokens and session configurations (`client_secret`, instructions, voice settings, and modalities) for direct client-to-provider WebRTC connections.

### Key Changes
- **Capability**: Added `Capability::REALTIME_SESSION` to `Symfony\AI\Platform\Capability`.
- **Result DTO**: Added `RealtimeSessionResult` (`getId()`, `getClientSecret()`, `getExpiresAt()`, `getModel()`, `getVoice()`, `getModalities()`, `getContent()`).
- **OpenAI Model**: Added `Symfony\AI\Platform\Bridge\OpenAi\Realtime` model class and registered `gpt-4o-realtime-preview` & `gpt-4o-mini-realtime-preview` in `ModelCatalog`.
- **ModelClient & ResultConverter**:
  - `Symfony\AI\Platform\Bridge\OpenAi\Realtime\ModelClient` for `POST /v1/realtime/client_secrets` (OpenAI GA API).
  - `Symfony\AI\Platform\Bridge\OpenAi\Realtime\ResultConverter` converting responses into `RealtimeSessionResult`.
- **Factory**: Registered Realtime ModelClient and ResultConverter in `Bridge\OpenAi\Factory`.
- **Tests**: Comprehensive unit tests added for `ModelClient`, `ResultConverter`, and `Realtime` model.

### Example Usage
```php
use Symfony\AI\Platform\Bridge\OpenAi\Realtime;
use Symfony\AI\Platform\Bridge\OpenAi\Factory;

$platform = Factory::createPlatform($_ENV['OPENAI_API_KEY']);

$result = $platform->invoke(
    new Realtime('gpt-4o-realtime-preview'),
    'You are a friendly voice support assistant.',
    [
        'voice' => 'alloy',
        'modalities' => ['text', 'audio'],
    ]
);

$session = $result->getResult(); // RealtimeSessionResult

return new JsonResponse([
    'client_secret' => $session->getClientSecret(),
    'expires_at' => $session->getExpiresAt(),
    'session_id' => $session->getId(),
]);
```
