### PR TITLE
[Platform] Preserve result metadata and token usage in provider cassettes

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -1762,7 +1762,27 @@ closure to normalize those parts before hashing::
     ));
 
 Supported result types are text, structured output (``ObjectResult``), embeddings (``VectorResult``),
-tool calls (``ToolCallResult``) and text streams; result metadata and token usage are not preserved.
+tool calls (``ToolCallResult``) and text streams.
+
+Result metadata is recorded too, so a replayed result can be asserted on for what the provider
+reported alongside the answer - most usefully token usage::
+
+    $result = $provider->invoke('claude-sonnet-4-5', $messages);
+
+    // read the result first: a DeferredResult copies the metadata up when it resolves,
+    // so getMetadata() is empty until asText() (or another as*() call) has run
+    $result->asText();
+
+    $result->getMetadata()->get('token_usage')->getTotalTokens();
+    $result->getMetadata()->get('finish_reason')->getCase();
+
+Metadata is preserved for the values a provider reports at this boundary: scalars, ``null``,
+:class:`Symfony\\AI\\Platform\\FinishReason\\FinishReason` and token usage
+(:class:`Symfony\\AI\\Platform\\TokenUsage\\TokenUsage` and
+:class:`Symfony\\AI\\Platform\\TokenUsage\\TokenUsageAggregation`), plus arrays nesting any of
+those to any depth. Values keep their type across a round trip, floats included. Anything else
+throws while recording rather than being dropped silently, so a cassette never claims to hold
+something it lost.
 
 A cassette stores the model name, the signature and the result. The input itself is never written,
 only its hash, but a recorded answer can still repeat back what the prompt contained, so treat a

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -6,7 +6,9 @@ CHANGELOG
 
  * [BC BREAK] Add `ListenerInterface::onError()` and `Result\Stream\ErrorEvent`, dispatched when draining a `StreamResult` throws, so a listener can finalize on a failed stream where `onComplete()` never fires; `AbstractStreamListener` provides a no-op default
  * Add `Test\Replay\CassetteHttpClient` and `Test\Replay\HttpCassette` to record real HTTP responses (when the cassette file is missing) and replay them offline through the real bridge pipeline (Contract, `ModelClient`, `ResultConverter`) in tests, including raw Server-Sent Event streams
- * Add `Test\Recording\RecordingProvider` (with `Cassette`/`ResultSerializer`) to record a real provider's result once (when the cassette file is missing) and replay it offline in tests
+ * Add `Test\Recording\RecordingProvider` (with `Cassette`/`ResultSerializer`) to record a real provider's result once (when the cassette file is missing) and replay it offline in tests, preserving the result metadata a provider reports alongside the answer - scalars, `null`, arrays, `FinishReason\FinishReason` and token usage - so a replayed result can be asserted on for usage; a metadata value the serializer cannot rebuild throws instead of being dropped silently
+ * Add `TokenUsage\TokenUsageAggregation::getTokenUsages()` to read back the individual usages an aggregation sums up
+ * Encode `Test\Recording\Cassette` with `JSON_THROW_ON_ERROR` and `JSON_PRESERVE_ZERO_FRACTION` and check the write, so a result holding a value JSON cannot represent (`NAN`, `INF`, invalid UTF-8) raises instead of truncating the cassette and destroying the interactions already recorded in it, and a recorded float with no fractional part no longer replays as an integer
  * Add `Result\CustomToolCallResult` for `custom_tool_call` output items reported by provider-specific server-side tools (e.g. xAI's `x_search`), converted the same way as the other built-in tool call results instead of being surfaced as a `ToolCall` the application is expected to execute
 
 0.12

--- a/src/platform/src/Test/Recording/Cassette.php
+++ b/src/platform/src/Test/Recording/Cassette.php
@@ -26,6 +26,8 @@ use Symfony\AI\Platform\Exception\RuntimeException;
  */
 final class Cassette
 {
+    private const DIRECTORY_MODE = 0777;
+
     /**
      * @var list<Interaction>
      */
@@ -114,10 +116,25 @@ final class Cassette
     private function save(): void
     {
         $directory = \dirname($this->path);
-        if (!is_dir($directory)) {
-            mkdir($directory, 0777, true);
+        if (!is_dir($directory) && !@mkdir($directory, self::DIRECTORY_MODE, true) && !is_dir($directory)) {
+            throw new RuntimeException(\sprintf('Cannot create cassette directory "%s".', $directory));
         }
 
-        file_put_contents($this->path, json_encode(['interactions' => $this->interactions], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)."\n");
+        // JSON_THROW_ON_ERROR: without it an unencodable value (NAN, INF, invalid UTF-8) makes
+        // json_encode() return false, and the file would be overwritten with a bare newline,
+        // destroying every interaction recorded so far.
+        // JSON_PRESERVE_ZERO_FRACTION: without it a float with no fractional part is written as
+        // an integer, so a recorded 2.0 replays as int(2) and the cassette silently retypes what
+        // the provider reported.
+        try {
+            $json = json_encode(['interactions' => $this->interactions], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new RuntimeException(\sprintf('Cannot encode cassette "%s"; the recorded result holds a value JSON cannot represent.', $this->path), previous: $exception);
+        }
+
+        $contents = $json."\n";
+        if (\strlen($contents) !== file_put_contents($this->path, $contents)) {
+            throw new RuntimeException(\sprintf('Cannot write cassette "%s".', $this->path));
+        }
     }
 }

--- a/src/platform/src/Test/Recording/ResultSerializer.php
+++ b/src/platform/src/Test/Recording/ResultSerializer.php
@@ -12,6 +12,9 @@
 namespace Symfony\AI\Platform\Test\Recording;
 
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+use Symfony\AI\Platform\Metadata\Metadata;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
@@ -20,22 +23,79 @@ use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\Result\VectorResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageAggregation;
+use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
 use Symfony\AI\Platform\Vector\Vector;
 
 /**
  * Converts a {@see ResultInterface} to and from a JSON-serializable array for {@see Cassette}.
  *
- * Supported result types (v1): text, object, vector, tool call, and text-delta streams. Result
- * metadata and token usage are not preserved. Unsupported result or delta types throw.
+ * Supported result types (v1): text, object, vector, tool call, and text-delta streams.
+ *
+ * Result metadata is preserved for the values a provider actually reports at this boundary:
+ * scalars, `null`, {@see FinishReason}, token usage ({@see TokenUsage} and
+ * {@see TokenUsageAggregation}), and arrays nesting any of those to any depth. An unsupported
+ * result type, delta type, or metadata value throws
+ * rather than being dropped silently, so a cassette never claims to hold something it lost.
  *
  * @author Johannes Wachter <johannes@sulu.io>
  */
 final class ResultSerializer
 {
+    private const METADATA_KEY = 'metadata';
+
+    /**
+     * Marks a serialized metadata value that is not a plain scalar or array. Reserved: a metadata
+     * array carrying this key would be indistinguishable from one of the envelopes below.
+     */
+    private const TYPE_KEY = '#type';
+
+    private const TYPE_FINISH_REASON = 'finish_reason';
+    private const TYPE_TOKEN_USAGE = 'token_usage';
+    private const TYPE_TOKEN_USAGE_AGGREGATION = 'token_usage_aggregation';
+
     /**
      * @return array<string, mixed>
      */
     public static function toArray(ResultInterface $result): array
+    {
+        // The content pass runs first on purpose: a StreamResult only fills its metadata while its
+        // generator is drained, so reading the metadata any earlier would always see it empty.
+        $data = self::contentToArray($result);
+        $metadata = self::metadataToArray($result->getMetadata());
+
+        if ([] !== $metadata) {
+            $data[self::METADATA_KEY] = $metadata;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): ResultInterface
+    {
+        $result = self::contentFromArray($data);
+
+        // Presence, not non-nullness: toArray() omits the key entirely when there is no metadata,
+        // so a key that is present but not an array is a malformed cassette, `null` included.
+        if (\array_key_exists(self::METADATA_KEY, $data)) {
+            $metadata = self::metadataFromArray($data[self::METADATA_KEY]);
+
+            if ([] !== $metadata) {
+                $result->getMetadata()->set($metadata);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function contentToArray(ResultInterface $result): array
     {
         if ($result instanceof TextResult) {
             return [
@@ -96,7 +156,7 @@ final class ResultSerializer
     /**
      * @param array<string, mixed> $data
      */
-    public static function fromArray(array $data): ResultInterface
+    private static function contentFromArray(array $data): ResultInterface
     {
         $type = $data['type'] ?? null;
 
@@ -140,5 +200,204 @@ final class ResultSerializer
         }
 
         throw new InvalidArgumentException(\sprintf('Cannot rebuild result of unknown type "%s".', \is_string($type) ? $type : get_debug_type($type)));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function metadataToArray(Metadata $metadata): array
+    {
+        $data = [];
+        foreach ($metadata->all() as $key => $value) {
+            $data[$key] = self::metadataValueToArray((string) $key, $value);
+        }
+
+        return $data;
+    }
+
+    private static function metadataValueToArray(string $key, mixed $value): mixed
+    {
+        if (null === $value || \is_scalar($value)) {
+            return $value;
+        }
+
+        if (\is_array($value)) {
+            if (\array_key_exists(self::TYPE_KEY, $value)) {
+                throw new InvalidArgumentException(\sprintf('Cannot record result metadata "%s": an array value must not use the reserved key "%s".', $key, self::TYPE_KEY));
+            }
+
+            return array_map(static fn (mixed $item): mixed => self::metadataValueToArray($key, $item), $value);
+        }
+
+        if ($value instanceof FinishReason) {
+            return [
+                self::TYPE_KEY => self::TYPE_FINISH_REASON,
+                'case' => $value->getCase()->value,
+                'raw' => $value->getRaw(),
+            ];
+        }
+
+        if ($value instanceof TokenUsageAggregation) {
+            return [
+                self::TYPE_KEY => self::TYPE_TOKEN_USAGE_AGGREGATION,
+                'usages' => array_map(
+                    static fn (mixed $usage): mixed => self::metadataValueToArray($key, $usage),
+                    $value->getTokenUsages(),
+                ),
+            ];
+        }
+
+        if ($value instanceof TokenUsage) {
+            return [
+                self::TYPE_KEY => self::TYPE_TOKEN_USAGE,
+                'prompt_tokens' => $value->getPromptTokens(),
+                'completion_tokens' => $value->getCompletionTokens(),
+                'thinking_tokens' => $value->getThinkingTokens(),
+                'tool_tokens' => $value->getToolTokens(),
+                'cached_tokens' => $value->getCachedTokens(),
+                'cache_creation_tokens' => $value->getCacheCreationTokens(),
+                'cache_read_tokens' => $value->getCacheReadTokens(),
+                'remaining_tokens' => $value->getRemainingTokens(),
+                'remaining_tokens_minute' => $value->getRemainingTokensMinute(),
+                'remaining_tokens_month' => $value->getRemainingTokensMonth(),
+                'total_tokens' => $value->getTotalTokens(),
+            ];
+        }
+
+        throw new InvalidArgumentException(\sprintf('Cannot record result metadata "%s" of type "%s"; only scalars, arrays of those, finish reasons and token usage can be replayed.', $key, get_debug_type($value)));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    private static function metadataFromArray(mixed $data): array
+    {
+        if (!\is_array($data)) {
+            throw new InvalidArgumentException(\sprintf('Cannot rebuild result metadata from "%s"; expected an array.', get_debug_type($data)));
+        }
+
+        $metadata = [];
+        foreach ($data as $key => $value) {
+            $metadata[$key] = self::metadataValueFromArray((string) $key, $value);
+        }
+
+        return $metadata;
+    }
+
+    private static function metadataValueFromArray(string $key, mixed $value): mixed
+    {
+        if (!\is_array($value)) {
+            return $value;
+        }
+
+        if (!\array_key_exists(self::TYPE_KEY, $value)) {
+            return array_map(static fn (mixed $item): mixed => self::metadataValueFromArray($key, $item), $value);
+        }
+
+        return match ($value[self::TYPE_KEY]) {
+            self::TYPE_FINISH_REASON => self::finishReasonFromArray($key, $value),
+            self::TYPE_TOKEN_USAGE => new TokenUsage(
+                promptTokens: self::envelopeInt($key, $value, 'prompt_tokens'),
+                completionTokens: self::envelopeInt($key, $value, 'completion_tokens'),
+                thinkingTokens: self::envelopeInt($key, $value, 'thinking_tokens'),
+                toolTokens: self::envelopeInt($key, $value, 'tool_tokens'),
+                cachedTokens: self::envelopeInt($key, $value, 'cached_tokens'),
+                cacheCreationTokens: self::envelopeInt($key, $value, 'cache_creation_tokens'),
+                cacheReadTokens: self::envelopeInt($key, $value, 'cache_read_tokens'),
+                remainingTokens: self::envelopeInt($key, $value, 'remaining_tokens'),
+                remainingTokensMinute: self::envelopeInt($key, $value, 'remaining_tokens_minute'),
+                remainingTokensMonth: self::envelopeInt($key, $value, 'remaining_tokens_month'),
+                totalTokens: self::envelopeInt($key, $value, 'total_tokens'),
+            ),
+            self::TYPE_TOKEN_USAGE_AGGREGATION => new TokenUsageAggregation(array_map(
+                static fn (mixed $usage): TokenUsageInterface => self::aggregatedUsageFromArray($key, $usage),
+                self::envelopeList($key, $value, 'usages'),
+            )),
+            default => throw new InvalidArgumentException(\sprintf('Cannot rebuild result metadata "%s" of unknown type "%s".', $key, \is_string($value[self::TYPE_KEY]) ? $value[self::TYPE_KEY] : get_debug_type($value[self::TYPE_KEY]))),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $envelope
+     */
+    private static function finishReasonFromArray(string $key, array $envelope): FinishReason
+    {
+        $case = self::envelopeString($key, $envelope, 'case');
+
+        return new FinishReason(
+            FinishReasonCase::tryFrom($case)
+                ?? throw new InvalidArgumentException(\sprintf('Cannot rebuild result metadata "%s": "%s" is not a known finish reason case.', $key, $case)),
+            self::envelopeString($key, $envelope, 'raw'),
+        );
+    }
+
+    /**
+     * An aggregation may nest another aggregation, so this recurses through the same read path and
+     * only accepts what a {@see TokenUsageAggregation} can actually hold.
+     */
+    private static function aggregatedUsageFromArray(string $key, mixed $usage): TokenUsageInterface
+    {
+        $rebuilt = self::metadataValueFromArray($key, $usage);
+
+        if (!$rebuilt instanceof TokenUsageInterface) {
+            throw new InvalidArgumentException(\sprintf('Cannot rebuild result metadata "%s": an aggregated usage of type "%s" is not a token usage.', $key, get_debug_type($rebuilt)));
+        }
+
+        return $rebuilt;
+    }
+
+    /**
+     * A cassette is a committed fixture that gets hand-edited, so every envelope field is read
+     * through one of these: a malformed one must raise the project exception rather than a PHP
+     * warning, a \TypeError, or a silent coercion.
+     *
+     * @param array<string, mixed> $envelope
+     */
+    private static function envelopeString(string $key, array $envelope, string $field): string
+    {
+        $value = $envelope[$field] ?? null;
+
+        if (!\is_string($value)) {
+            throw new InvalidArgumentException(\sprintf('Cannot rebuild result metadata "%s": field "%s" must be a string, got "%s".', $key, $field, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $envelope
+     */
+    private static function envelopeInt(string $key, array $envelope, string $field): ?int
+    {
+        $value = $envelope[$field] ?? null;
+
+        if (null === $value) {
+            return null;
+        }
+
+        // A JSON cassette can only carry an int here; anything else lost its type on the way in.
+        if (!\is_int($value)) {
+            throw new InvalidArgumentException(\sprintf('Cannot rebuild result metadata "%s": field "%s" must be an integer or null, got "%s".', $key, $field, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $envelope
+     *
+     * @return list<mixed>
+     */
+    private static function envelopeList(string $key, array $envelope, string $field): array
+    {
+        $value = $envelope[$field] ?? null;
+
+        if (!\is_array($value) || !array_is_list($value)) {
+            throw new InvalidArgumentException(\sprintf('Cannot rebuild result metadata "%s": field "%s" must be a list, got "%s".', $key, $field, get_debug_type($value)));
+        }
+
+        return $value;
     }
 }

--- a/src/platform/src/TokenUsage/TokenUsageAggregation.php
+++ b/src/platform/src/TokenUsage/TokenUsageAggregation.php
@@ -32,6 +32,16 @@ final class TokenUsageAggregation implements TokenUsageInterface, MergeableMetad
         $this->tokenUsages[] = $tokenUsage;
     }
 
+    /**
+     * The individual usages this aggregation sums up, in the order they were reported.
+     *
+     * @return TokenUsageInterface[]
+     */
+    public function getTokenUsages(): array
+    {
+        return $this->tokenUsages;
+    }
+
     public function merge(MergeableMetadataInterface $metadata): self
     {
         if (!$metadata instanceof TokenUsageInterface) {

--- a/src/platform/tests/Test/Recording/CassetteTest.php
+++ b/src/platform/tests/Test/Recording/CassetteTest.php
@@ -31,6 +31,24 @@ final class CassetteTest extends TestCase
         }
     }
 
+    public function testUnencodableInteractionThrowsAndLeavesEarlierRecordingsIntact()
+    {
+        $cassette = new Cassette($this->path);
+        $cassette->record('gpt-4o', 'sig', ['type' => 'text', 'content' => 'hi']);
+
+        try {
+            $cassette->record('gpt-4o', 'other', ['type' => 'text', 'content' => "invalid \xB1\x31 utf8"]);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', RuntimeException::class));
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString('JSON cannot represent', $exception->getMessage());
+        }
+
+        $data = json_decode((string) file_get_contents($this->path), true, flags: \JSON_THROW_ON_ERROR);
+
+        $this->assertCount(1, $data['interactions']);
+        $this->assertSame('hi', $data['interactions'][0]['result']['content']);
+    }
+
     public function testExistsReflectsFilePresence()
     {
         $cassette = new Cassette($this->path);

--- a/src/platform/tests/Test/Recording/RecordingProviderTest.php
+++ b/src/platform/tests/Test/Recording/RecordingProviderTest.php
@@ -23,12 +23,14 @@ use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\Test\MockPlatformFactory as MockFactory;
 use Symfony\AI\Platform\Test\Recording\Cassette;
 use Symfony\AI\Platform\Test\Recording\RecordingProvider;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
@@ -155,6 +157,66 @@ final class RecordingProviderTest extends TestCase
         $replay = new RecordingProvider($this->throwingProvider(), new Cassette($this->path), record: false);
 
         $this->assertSame('Recorded by Anthropic', $replay->invoke('claude-3-7-sonnet-20250219', new MessageBag(Message::ofUser('Hello')))->asText());
+    }
+
+    public function testReplayedResultExposesRecordedTokenUsage()
+    {
+        $this->record(MockFactory::createProvider(static function (): TextResult {
+            $result = new TextResult('hello');
+            $result->getMetadata()->add('token_usage', new TokenUsage(promptTokens: 12, completionTokens: 34, totalTokens: 46));
+
+            return $result;
+        }));
+
+        $result = $this->replay()->invoke('any-model', 'q');
+
+        $this->assertSame('hello', $result->asText());
+
+        $usage = $result->getMetadata()->get('token_usage');
+
+        $this->assertInstanceOf(TokenUsage::class, $usage);
+        $this->assertSame(12, $usage->getPromptTokens());
+        $this->assertSame(34, $usage->getCompletionTokens());
+        $this->assertSame(46, $usage->getTotalTokens());
+    }
+
+    public function testReplayedStreamExposesRecordedTokenUsage()
+    {
+        // No listener is wired here on purpose: DeferredResult attaches the token usage stream
+        // listener itself, which is what promotes the delta to result metadata at record time.
+        $this->record(MockFactory::createProvider(static fn (): StreamResult => new StreamResult((static function (): \Generator {
+            yield new TextDelta('Hel');
+            yield new TokenUsage(promptTokens: 4, completionTokens: 2, totalTokens: 6);
+            yield new TextDelta('lo');
+        })())));
+
+        $result = $this->replay()->invoke('any-model', 'q');
+
+        $text = '';
+        foreach ($result->asTextStream() as $delta) {
+            $text .= (string) $delta;
+        }
+
+        $usage = $result->getMetadata()->get('token_usage');
+
+        $this->assertSame('Hello', $text);
+        $this->assertInstanceOf(TokenUsage::class, $usage);
+        $this->assertSame(6, $usage->getTotalTokens());
+    }
+
+    public function testReplayedResultPreservesFloatMetadataThroughTheCassetteFile()
+    {
+        $this->record(MockFactory::createProvider(static function (): TextResult {
+            $result = new TextResult('hello');
+            $result->getMetadata()->add('usage', ['seconds' => 2.0, 'ratio' => 1.5, 'score' => 0.0]);
+
+            return $result;
+        }));
+
+        $result = $this->replay()->invoke('any-model', 'q');
+
+        $this->assertSame('hello', $result->asText());
+        $this->assertSame(['seconds' => 2.0, 'ratio' => 1.5, 'score' => 0.0], $result->getMetadata()->get('usage'));
     }
 
     public function testReplayThrowsOnSignatureMiss()

--- a/src/platform/tests/Test/Recording/ResultSerializerTest.php
+++ b/src/platform/tests/Test/Recording/ResultSerializerTest.php
@@ -13,6 +13,8 @@ namespace Symfony\AI\Platform\Tests\Test\Recording;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
@@ -23,6 +25,9 @@ use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\Test\Recording\ResultSerializer;
+use Symfony\AI\Platform\TokenUsage\StreamListener;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use Symfony\AI\Platform\TokenUsage\TokenUsageAggregation;
 use Symfony\AI\Platform\Vector\Vector;
 
 final class ResultSerializerTest extends TestCase
@@ -94,6 +99,277 @@ final class ResultSerializerTest extends TestCase
         }
 
         $this->assertSame('Hello', $text);
+    }
+
+    public function testRoundTripPreservesScalarAndArrayMetadata()
+    {
+        $source = new TextResult('Hello');
+        $source->getMetadata()->add('signature', 'sig-1');
+        $source->getMetadata()->add('usage', ['input_tokens' => 3, 'seconds' => 1.5]);
+        $source->getMetadata()->add('cached', false);
+        $source->getMetadata()->add('unset', null);
+
+        $metadata = ResultSerializer::fromArray(ResultSerializer::toArray($source))->getMetadata();
+
+        $this->assertSame('sig-1', $metadata->get('signature'));
+        $this->assertSame(['input_tokens' => 3, 'seconds' => 1.5], $metadata->get('usage'));
+        $this->assertFalse($metadata->get('cached'));
+        $this->assertTrue($metadata->has('unset'));
+        $this->assertNull($metadata->get('unset'));
+    }
+
+    public function testRoundTripPreservesFinishReason()
+    {
+        $source = new TextResult('Hello');
+        $source->getMetadata()->add('finish_reason', new FinishReason(FinishReasonCase::LENGTH, 'max_tokens'));
+
+        $finishReason = ResultSerializer::fromArray(ResultSerializer::toArray($source))->getMetadata()->get('finish_reason');
+
+        $this->assertInstanceOf(FinishReason::class, $finishReason);
+        $this->assertTrue($finishReason->is(FinishReasonCase::LENGTH));
+        $this->assertSame('max_tokens', $finishReason->getRaw());
+    }
+
+    public function testRoundTripPreservesTokenUsage()
+    {
+        $source = new TextResult('Hello');
+        $source->getMetadata()->add('token_usage', new TokenUsage(
+            promptTokens: 12,
+            completionTokens: 34,
+            cachedTokens: 5,
+            totalTokens: 46,
+        ));
+
+        $usage = ResultSerializer::fromArray(ResultSerializer::toArray($source))->getMetadata()->get('token_usage');
+
+        $this->assertInstanceOf(TokenUsage::class, $usage);
+        $this->assertSame(12, $usage->getPromptTokens());
+        $this->assertSame(34, $usage->getCompletionTokens());
+        $this->assertSame(5, $usage->getCachedTokens());
+        $this->assertSame(46, $usage->getTotalTokens());
+        $this->assertNull($usage->getThinkingTokens());
+    }
+
+    public function testRoundTripPreservesTokenUsageAggregation()
+    {
+        $source = new TextResult('Hello');
+        $source->getMetadata()->add('token_usage', new TokenUsageAggregation([
+            new TokenUsage(promptTokens: 10, totalTokens: 10),
+            new TokenUsage(promptTokens: 7, totalTokens: 7),
+        ]));
+
+        $usage = ResultSerializer::fromArray(ResultSerializer::toArray($source))->getMetadata()->get('token_usage');
+
+        $this->assertInstanceOf(TokenUsageAggregation::class, $usage);
+        $this->assertSame(2, $usage->count());
+        $this->assertSame(17, $usage->getPromptTokens());
+        $this->assertSame(17, $usage->getTotalTokens());
+    }
+
+    public function testStreamRoundTripPreservesMetadataCollectedWhileDraining()
+    {
+        $stream = new StreamResult((static function (): \Generator {
+            yield new TextDelta('Hel');
+            yield new TokenUsage(promptTokens: 4, completionTokens: 2, totalTokens: 6);
+            yield new TextDelta('lo');
+        })(), [new StreamListener()]);
+
+        $result = ResultSerializer::fromArray(ResultSerializer::toArray($stream));
+
+        $text = '';
+        foreach ($result->getContent() as $delta) {
+            $text .= (string) $delta;
+        }
+
+        $usage = $result->getMetadata()->get('token_usage');
+
+        $this->assertSame('Hello', $text);
+        $this->assertInstanceOf(TokenUsage::class, $usage);
+        $this->assertSame(6, $usage->getTotalTokens());
+    }
+
+    public function testResultWithoutMetadataDoesNotWriteMetadataKey()
+    {
+        $this->assertArrayNotHasKey('metadata', ResultSerializer::toArray(new TextResult('Hello')));
+    }
+
+    public function testUnsupportedMetadataValueThrows()
+    {
+        $source = new TextResult('Hello');
+        $source->getMetadata()->add('raw_response', new \stdClass());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot record result metadata "raw_response" of type "stdClass"');
+        ResultSerializer::toArray($source);
+    }
+
+    public function testReservedTypeKeyInMetadataArrayThrows()
+    {
+        $source = new TextResult('Hello');
+        $source->getMetadata()->add('citations', ['#type' => 'spoofed']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('reserved key "#type"');
+        ResultSerializer::toArray($source);
+    }
+
+    public function testUnknownMetadataTypeOnFromArrayThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ResultSerializer::fromArray([
+            'type' => 'text',
+            'content' => 'Hello',
+            'metadata' => ['whatever' => ['#type' => 'nope']],
+        ]);
+    }
+
+    public function testRoundTripPreservesNestedTokenUsageAggregation()
+    {
+        $source = new TextResult('Hello');
+        $source->getMetadata()->add('token_usage', new TokenUsageAggregation([
+            new TokenUsage(promptTokens: 10, totalTokens: 10),
+            new TokenUsageAggregation([
+                new TokenUsage(promptTokens: 3, totalTokens: 3),
+                new TokenUsage(promptTokens: 4, totalTokens: 4),
+            ]),
+        ]));
+
+        $usage = ResultSerializer::fromArray(ResultSerializer::toArray($source))->getMetadata()->get('token_usage');
+
+        $this->assertInstanceOf(TokenUsageAggregation::class, $usage);
+        $this->assertSame(3, $usage->count());
+        $this->assertSame(17, $usage->getPromptTokens());
+        $this->assertInstanceOf(TokenUsageAggregation::class, $usage->getTokenUsages()[1]);
+    }
+
+    public function testRoundTripPreservesObjectsNestedInsideMetadataArrays()
+    {
+        $source = new TextResult('Hello');
+        $source->getMetadata()->add('attempts', [
+            'first' => ['finish_reason' => new FinishReason(FinishReasonCase::LENGTH, 'max_tokens')],
+        ]);
+
+        $nested = ResultSerializer::fromArray(ResultSerializer::toArray($source))->getMetadata()->get('attempts');
+
+        $this->assertInstanceOf(FinishReason::class, $nested['first']['finish_reason']);
+        $this->assertTrue($nested['first']['finish_reason']->is(FinishReasonCase::LENGTH));
+    }
+
+    public function testReservedTypeKeyNestedInMetadataArrayThrows()
+    {
+        $source = new TextResult('Hello');
+        $source->getMetadata()->add('attempts', [['#type' => 'spoofed']]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('reserved key "#type"');
+        ResultSerializer::toArray($source);
+    }
+
+    public function testUnknownFinishReasonCaseOnFromArrayThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not a known finish reason case');
+        ResultSerializer::fromArray([
+            'type' => 'text',
+            'content' => 'Hello',
+            'metadata' => ['finish_reason' => ['#type' => 'finish_reason', 'case' => 'no_such_case', 'raw' => 'z']],
+        ]);
+    }
+
+    public function testNonArrayMetadataOnFromArrayThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('expected an array');
+        ResultSerializer::fromArray(['type' => 'text', 'content' => 'Hello', 'metadata' => 'not-an-array']);
+    }
+
+    public function testNullMetadataOnFromArrayThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('expected an array');
+        ResultSerializer::fromArray(['type' => 'text', 'content' => 'Hello', 'metadata' => null]);
+    }
+
+    public function testAbsentMetadataKeyOnFromArrayIsAccepted()
+    {
+        $result = ResultSerializer::fromArray(['type' => 'text', 'content' => 'Hello']);
+
+        $this->assertSame('Hello', $result->getContent());
+        $this->assertCount(0, $result->getMetadata());
+    }
+
+    public function testAggregatedUsageThatIsNotATokenUsageThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not a token usage');
+        ResultSerializer::fromArray([
+            'type' => 'text',
+            'content' => 'Hello',
+            'metadata' => ['token_usage' => ['#type' => 'token_usage_aggregation', 'usages' => ['nonsense']]],
+        ]);
+    }
+
+    public function testAggregationWithoutUsagesListThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('field "usages" must be a list');
+        ResultSerializer::fromArray([
+            'type' => 'text',
+            'content' => 'Hello',
+            'metadata' => ['token_usage' => ['#type' => 'token_usage_aggregation']],
+        ]);
+    }
+
+    public function testNonListAggregatedUsagesThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('field "usages" must be a list');
+        ResultSerializer::fromArray([
+            'type' => 'text',
+            'content' => 'Hello',
+            'metadata' => ['token_usage' => ['#type' => 'token_usage_aggregation', 'usages' => 'oops']],
+        ]);
+    }
+
+    public function testNonStringFinishReasonFieldThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('field "raw" must be a string');
+        ResultSerializer::fromArray([
+            'type' => 'text',
+            'content' => 'Hello',
+            'metadata' => ['finish_reason' => ['#type' => 'finish_reason', 'case' => 'stop', 'raw' => ['nope']]],
+        ]);
+    }
+
+    public function testNonIntegerTokenUsageFieldThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('field "prompt_tokens" must be an integer or null');
+        ResultSerializer::fromArray([
+            'type' => 'text',
+            'content' => 'Hello',
+            'metadata' => ['token_usage' => ['#type' => 'token_usage', 'prompt_tokens' => '12abc']],
+        ]);
+    }
+
+    /**
+     * The other round-trip tests hand the array straight back to fromArray(). A cassette is JSON on
+     * disk, so at least one case has to survive a real encode/decode: that is where a float with no
+     * fractional part used to come back as an int.
+     */
+    public function testRoundTripThroughRealJsonPreservesScalarTypes()
+    {
+        $source = new TextResult('Hello');
+        $source->getMetadata()->add('usage', ['seconds' => 2.0, 'ratio' => 1.5, 'score' => 0.0, 'count' => 3]);
+        $source->getMetadata()->add('token_usage', new TokenUsage(promptTokens: 12, totalTokens: 12));
+
+        $encoded = json_encode(ResultSerializer::toArray($source), \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR);
+        $metadata = ResultSerializer::fromArray(json_decode((string) $encoded, true, flags: \JSON_THROW_ON_ERROR))->getMetadata();
+
+        $this->assertSame(['seconds' => 2.0, 'ratio' => 1.5, 'score' => 0.0, 'count' => 3], $metadata->get('usage'));
+        $this->assertInstanceOf(TokenUsage::class, $metadata->get('token_usage'));
+        $this->assertSame(12, $metadata->get('token_usage')->getTotalTokens());
     }
 
     public function testUnsupportedResultTypeThrows()

--- a/src/platform/tests/TokenUsage/TokenUsageAggregationTest.php
+++ b/src/platform/tests/TokenUsage/TokenUsageAggregationTest.php
@@ -17,6 +17,27 @@ use Symfony\AI\Platform\TokenUsage\TokenUsageAggregation;
 
 class TokenUsageAggregationTest extends TestCase
 {
+    public function testGetTokenUsagesReturnsTheAggregatedUsagesInOrder()
+    {
+        $first = new TokenUsage(promptTokens: 10);
+        $second = new TokenUsage(promptTokens: 7);
+
+        $aggregation = new TokenUsageAggregation([$first, $second]);
+
+        $this->assertSame([$first, $second], $aggregation->getTokenUsages());
+    }
+
+    public function testGetTokenUsagesReflectsUsagesAddedAfterConstruction()
+    {
+        $first = new TokenUsage(promptTokens: 10);
+        $second = new TokenUsage(promptTokens: 7);
+
+        $aggregation = new TokenUsageAggregation([$first]);
+        $aggregation->add($second);
+
+        $this->assertSame([$first, $second], $aggregation->getTokenUsages());
+    }
+
     public function testAggregatesTokenUsageCorrectly()
     {
         $usage1 = new TokenUsage(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #2410
| License       | MIT

`Test\Recording\ResultSerializer` writes only a result's *content* to a cassette, so everything a
provider reports alongside the answer is lost on the way in. A replayed result therefore has empty
metadata, and the usage data #2410 asks for cannot be asserted on at all.

This adds the metadata pass that was deferred out of #2129.

### What is preserved

Metadata is written per key, and only in forms that come back as the same type:

* scalars, `null`, and arrays nesting any of these to any depth — verbatim, including a float with
  no fractional part (`signature`, Whisper's `usage`, Perplexity's `citations`/`search_results`, …)
* `FinishReason\FinishReason` — its case plus the untouched provider wording
* `TokenUsage\TokenUsage` and `TokenUsage\TokenUsageAggregation` — every field, and for an
  aggregation its individual usages, so `count()` and the sums survive a round trip

Anything else throws while recording, matching how the class already treats an unsupported result or
delta type. Dropping it silently is the defect this issue is about, and recording is a developer-time
step in a test double: the throw surfaces once, locally, to the person who can act on it.

Non-scalar values are written as a small envelope tagged with a reserved `#type` key. A plain
metadata array using that key is rejected on the write path, so an envelope can never be confused
with provider data, and every envelope field is validated on the way back out: a malformed
`#type` envelope in a hand-edited cassette raises the component's `InvalidArgumentException` rather
than a `\ValueError` or a PHP warning. That applies to the metadata envelopes this PR adds — the
existing content path (`content`, `vectors`, `tool_calls`) is unchanged and still reacts to a
corrupt cassette the way it does on `main`.

```php
$provider = new RecordingProvider($realProvider, new Cassette(__DIR__.'/fixtures/weather.json'));

$result = $provider->invoke('claude-sonnet-4-5', $messages);

$result->asText();
$result->getMetadata()->get('token_usage')->getTotalTokens();   // 46, on record *and* on replay
$result->getMetadata()->get('finish_reason')->getCase();        // FinishReasonCase::STOP
```

Metadata is read after the content pass, because a `StreamResult` only fills its metadata while its
generator is drained — a stream whose usage is promoted by `TokenUsage\StreamListener` replays that
usage too.

`TokenUsageAggregation::getTokenUsages()` is added because an aggregation cannot be serialized
without reading the parts it sums up, and the class exposed no way to do that.

`Cassette::save()` is hardened in the same PR rather than separately, because this change widens
what reaches it: it called `json_encode()` without `JSON_THROW_ON_ERROR`, so a value JSON cannot
represent (`NAN`, `INF`, invalid UTF-8) made it return `false` and the file was overwritten with a
bare newline, destroying every interaction already recorded. It now raises, the write is checked
against the length actually written, the directory creation is checked, and it encodes with
`JSON_PRESERVE_ZERO_FRACTION` so a recorded `2.0` does not replay as `int(2)`. The truncation path
is reachable on `main` today through a result's content alone.

Happy to split the `Cassette` commit out into its own PR if you would rather review it separately.

Sharing one (de)normalizer with the cache bridge is #2413 and is deliberately left alone here.

### Test verification (RED → GREEN)

28 tests are added. 26 of them fail against **unmodified `main`** (`6a95fac3`), with
`src/platform/src` bind-mounted read-only from a detached worktree so the production code is
pristine and only the new tests are applied on top:

```
1) Symfony\AI\Platform\Tests\TokenUsage\TokenUsageAggregationTest::testGetTokenUsagesReflectsUsagesAddedAfterConstruction
Error: Call to undefined method Symfony\AI\Platform\TokenUsage\TokenUsageAggregation::getTokenUsages()

/app/src/platform/tests/TokenUsage/TokenUsageAggregationTest.php:38

2) Symfony\AI\Platform\Tests\TokenUsage\TokenUsageAggregationTest::testGetTokenUsagesReturnsTheAggregatedUsagesInOrder
Error: Call to undefined method Symfony\AI\Platform\TokenUsage\TokenUsageAggregation::getTokenUsages()

/app/src/platform/tests/TokenUsage/TokenUsageAggregationTest.php:27


There were 24 failures:

2) Symfony\AI\Platform\Tests\Test\Recording\ResultSerializerTest::testAggregatedUsageThatIsNotATokenUsageThrows
Failed asserting that exception of type "Symfony\AI\Platform\Exception\InvalidArgumentException" is thrown.

3) Symfony\AI\Platform\Tests\Test\Recording\ResultSerializerTest::testRoundTripPreservesTokenUsageAggregation
Failed asserting that null is an instance of class Symfony\AI\Platform\TokenUsage\TokenUsageAggregation.

/app/src/platform/tests/Test/Recording/ResultSerializerTest.php:163

4) Symfony\AI\Platform\Tests\Test\Recording\ResultSerializerTest::testRoundTripThroughRealJsonPreservesScalarTypes
Failed asserting that null is identical to Array &0 [
    'seconds' => 2.0,
    'ratio' => 1.5,
    'score' => 0.0,
    'count' => 3,
].

/app/src/platform/tests/Test/Recording/ResultSerializerTest.php:370

Tests: 66, Assertions: 125, Errors: 2, Failures: 24.
```

(Excerpt of 5 of the 26; each test file numbers its own failures from 1.)

The two tests that pass on both sides are invariant guards rather than proof:
`testResultWithoutMetadataDoesNotWriteMetadataKey` — a result with no metadata still produces a
byte-identical cassette — and `testAbsentMetadataKeyOnFromArrayIsAccepted` — a cassette recorded
before this change still replays.

GREEN — same tests, same command, with the patch:

```
vendor/bin/phpunit -c src/platform/phpunit.xml.dist \
    --filter '/(ResultSerializerTest|RecordingProviderTest|TokenUsageAggregationTest|CassetteTest)/'

................................................................. 65 / 66 ( 98%)
.                                                                 66 / 66 (100%)

Time: 00:00.087, Memory: 22.00 MB

OK (66 tests, 165 assertions)
```

### Full local suite

Every package's suite plus the PHPStan shards, PHP-CS-Fixer, Deptrac, DOCtor-RST, the docs build and
the CHANGELOG validator, replayed on PHP 8.5 from the repo's own workflow commands:

```
find src -name phpunit.xml.dist -not -path '*/vendor/*' | sort \
    | .github/run-in-packages.sh vendor/bin/phpunit -c '{}' --exclude-group integration

Ran in 93 package(s) with parallelism 8, 1 failed.
```

`src/platform` goes from 826 to 854 tests, all green, no new skips. The one failing package is
`src/mate` (`LoggerTest::testFileWriteFailureThrowsException` and
`::testThrowsExceptionWhenDirectoryCreationFailsDueToPermissions`), identical before and after: both
assert that an unwritable path throws, which does not happen when the suite runs as root in a
container. Untouched by this PR, and present on `6a95fac3` too.
