### PR TITLE
[Mate] Add skills:override and skills:reset

### DIFF
--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -466,7 +466,8 @@ All skill state lives in ``mate/extensions.php``. Two keys per skill carry your 
 * ``enabled`` controls whether the skill is installed at all.
 * ``mode`` is either ``managed``, where Mate builds the skill from the package, or ``override``,
   which hands ownership to you: Mate then builds from your own ``mate/skills/<name>/`` copy and
-  never writes into ``mate/skills/``.
+  never writes into ``mate/skills/``. Use ``mate skills:override <name>`` to switch, and
+  ``mate skills:reset <name>`` to hand the skill back.
 
 The ``skills:*`` commands set both for you, which is the recommended way to change them — they also
 reinstall, so the recorded state below never falls out of step with your intent. Editing the two keys
@@ -536,6 +537,15 @@ Commands
 ``mate skills:prune``
     Remove generated ``mate-*`` folders that no longer belong to any skill. Pass ``--dry-run`` to
     see what would be removed. See `Skills`_.
+
+``mate skills:override <name>``
+    Take ownership of a skill: copy the package's version into ``mate/skills/<name>/`` and switch it
+    to ``'mode' => 'override'``. Accepts the installed (``mate-…``) or the original name. Pass
+    ``--force`` to replace an existing copy. See `Skills`_.
+
+``mate skills:reset <name>``
+    Hand an overridden skill back to Mate, so it is built from the package again. Your copy under
+    ``mate/skills/<name>/`` is kept unless you pass ``--delete-copy``. See `Skills`_.
 
 ``mate serve``
     Start the MCP server with stdio transport.

--- a/src/mate/AGENTS.md
+++ b/src/mate/AGENTS.md
@@ -48,6 +48,8 @@ bin/mate skills:install                     # Install extension skills
 bin/mate skills:list                        # List skills with mode, state and status
 bin/mate skills:validate                    # Check generated folders against recorded state
 bin/mate skills:prune                       # Remove leftover generated mate-* folders
+bin/mate skills:override mate-system-information  # Copy into mate/skills/ and own it
+bin/mate skills:reset mate-system-information     # Hand it back to Mate
 bin/mate serve                              # Start MCP server
 bin/mate clear-cache                        # Clear cache
 

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `skills:list` command: a read-only diagnostic listing declared and installed skills with their enabled/mode/state/status (including stale and broken detection)
  * Add `skills:validate` command: checks the generated folders against the recorded state and fails on hand-edited content, missing folders or a mispointed mirror (`--strict` also fails on warnings)
  * Add `skills:prune` command: removes generated `mate-*` folders that no longer belong to any skill (`--dry-run` to preview)
+ * Add `skills:override` and `skills:reset` commands: take ownership of a skill by copying it into `mate/skills/<name>/`, and hand it back to Mate again
 
 0.12
 ----

--- a/src/mate/src/App.php
+++ b/src/mate/src/App.php
@@ -22,7 +22,9 @@ use Symfony\AI\Mate\Command\ResourcesReadCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
 use Symfony\AI\Mate\Command\SkillsInstallCommand;
 use Symfony\AI\Mate\Command\SkillsListCommand;
+use Symfony\AI\Mate\Command\SkillsOverrideCommand;
 use Symfony\AI\Mate\Command\SkillsPruneCommand;
+use Symfony\AI\Mate\Command\SkillsResetCommand;
 use Symfony\AI\Mate\Command\SkillsValidateCommand;
 use Symfony\AI\Mate\Command\StopCommand;
 use Symfony\AI\Mate\Command\ToolsCallCommand;
@@ -62,6 +64,8 @@ final class App
             SkillsListCommand::class,
             SkillsValidateCommand::class,
             SkillsPruneCommand::class,
+            SkillsOverrideCommand::class,
+            SkillsResetCommand::class,
         ];
 
         foreach ($commands as $commandClass) {

--- a/src/mate/src/Command/SkillsOverrideCommand.php
+++ b/src/mate/src/Command/SkillsOverrideCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command;
+
+use Symfony\AI\Mate\Command\Trait\RendersSkillOutcomeTrait;
+use Symfony\AI\Mate\Exception\RuntimeException;
+use Symfony\AI\Mate\Skill\SkillManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Takes ownership of a skill by copying the package's version into mate/skills/.
+ *
+ * The copy keeps the original frontmatter name — the installed "mate-" name is applied at build
+ * time, exactly as for a managed skill. From here on the installer builds from your copy and never
+ * writes into mate/skills/ again.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('skills:override', 'Take ownership of a skill by copying it into mate/skills/')]
+class SkillsOverrideCommand extends Command
+{
+    use RendersSkillOutcomeTrait;
+
+    public function __construct(
+        private SkillManager $manager,
+    ) {
+        parent::__construct(self::getDefaultName());
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'skills:override';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Take ownership of a skill by copying it into mate/skills/';
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('name', InputArgument::REQUIRED, 'Installed ("mate-…") or original skill name');
+        $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Replace an existing copy in mate/skills/');
+        $this->setHelp(
+            <<<'HELP'
+The <info>%command.name%</info> command copies a skill shipped by a package into
+<comment>mate/skills/&lt;name&gt;/</comment> and switches it to <comment>'mode' => 'override'</comment>
+in <comment>mate/extensions.php</comment>.
+
+Mate then builds the installed skill from your copy on every run and never writes into
+<comment>mate/skills/</comment> again. Use <info>mate skills:reset</info> to hand it back.
+HELP
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $name = $input->getArgument('name');
+        \assert(\is_string($name));
+
+        $resolved = $this->resolveSkill($io, $this->manager, $name);
+        if (null === $resolved) {
+            return Command::FAILURE;
+        }
+
+        $force = true === $input->getOption('force');
+
+        $statuses = $this->manager->statusFor($resolved['name']);
+        if ([] !== $statuses && 'override' === $statuses[0]->mode && !$force) {
+            $io->error(\sprintf('Skill "%s" is already overridden; your copy is at %s.', $statuses[0]->installedName, $this->manager->overrideCopyPath($resolved['name'])));
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $path = $this->manager->createOverrideCopy($resolved['package'], $resolved['name'], $force);
+        } catch (RuntimeException $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $this->manager->setMode($resolved['package'], $resolved['name'], 'override');
+        $this->manager->reinstall();
+
+        $io->success(\sprintf('Copied the skill to %s/ — edit it there and re-run "mate skills:install".', $path));
+        $this->renderSkillRow($io, $this->manager, $resolved['name']);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/mate/src/Command/SkillsResetCommand.php
+++ b/src/mate/src/Command/SkillsResetCommand.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command;
+
+use Symfony\AI\Mate\Command\Trait\RendersSkillOutcomeTrait;
+use Symfony\AI\Mate\Skill\SkillManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Hands an overridden skill back to Mate.
+ *
+ * The local copy under mate/skills/ is kept by default and only its path is reported: silently
+ * deleting content the user wrote is not something a "reset" should do. Pass --delete-copy to
+ * remove it explicitly.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('skills:reset', 'Hand an overridden skill back to Mate')]
+class SkillsResetCommand extends Command
+{
+    use RendersSkillOutcomeTrait;
+
+    public function __construct(
+        private SkillManager $manager,
+    ) {
+        parent::__construct(self::getDefaultName());
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'skills:reset';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Hand an overridden skill back to Mate';
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('name', InputArgument::REQUIRED, 'Installed ("mate-…") or original skill name');
+        $this->addOption('delete-copy', null, InputOption::VALUE_NONE, 'Also delete your copy under mate/skills/');
+        $this->setHelp(
+            <<<'HELP'
+The <info>%command.name%</info> command switches a skill back to
+<comment>'mode' => 'managed'</comment>, so Mate builds it from the package again.
+
+Your copy under <comment>mate/skills/&lt;name&gt;/</comment> is left in place and simply stops being
+used; pass <comment>--delete-copy</comment> to remove it as well.
+HELP
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $name = $input->getArgument('name');
+        \assert(\is_string($name));
+
+        $resolved = $this->resolveSkill($io, $this->manager, $name);
+        if (null === $resolved) {
+            return Command::FAILURE;
+        }
+
+        $statuses = $this->manager->statusFor($resolved['name']);
+        if ([] !== $statuses && 'managed' === $statuses[0]->mode) {
+            $io->note(\sprintf('Skill "%s" is already managed by Mate; nothing to reset.', $statuses[0]->installedName));
+
+            return Command::SUCCESS;
+        }
+
+        $this->manager->setMode($resolved['package'], $resolved['name'], 'managed');
+        $this->manager->reinstall();
+
+        $copyPath = $this->manager->overrideCopyPath($resolved['name']);
+
+        if (true === $input->getOption('delete-copy')) {
+            if ($this->manager->removeOverrideCopy($resolved['name'])) {
+                $io->text(\sprintf('Deleted %s/.', $copyPath));
+            }
+        } elseif ($this->manager->hasOverrideCopy($resolved['name'])) {
+            $io->note(\sprintf('Your copy is kept at %s/ but is no longer used. Delete it yourself, or re-run with --delete-copy.', $copyPath));
+        }
+
+        $io->success('The skill is managed by Mate again and was rebuilt from its package.');
+        $this->renderSkillRow($io, $this->manager, $resolved['name']);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/mate/src/Command/Trait/RendersSkillOutcomeTrait.php
+++ b/src/mate/src/Command/Trait/RendersSkillOutcomeTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command\Trait;
+
+use Symfony\AI\Mate\Exception\AmbiguousSkillException;
+use Symfony\AI\Mate\Exception\SkillNotFoundException;
+use Symfony\AI\Mate\Skill\SkillManager;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Shared name resolution and result rendering for the mutating skills:* commands.
+ *
+ * Every one of them ends by reinstalling and showing the resulting row, so intent and recorded
+ * facts are never left out of sync between two commands.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+trait RendersSkillOutcomeTrait
+{
+    /**
+     * @return array{package: string, name: string}|null null when the name could not be resolved
+     */
+    private function resolveSkill(SymfonyStyle $io, SkillManager $manager, string $input): ?array
+    {
+        try {
+            return $manager->resolve($input);
+        } catch (SkillNotFoundException|AmbiguousSkillException $exception) {
+            $io->error($exception->getMessage());
+
+            return null;
+        }
+    }
+
+    private function renderSkillRow(SymfonyStyle $io, SkillManager $manager, string $name): void
+    {
+        $statuses = $manager->statusFor($name);
+        if ([] === $statuses) {
+            return;
+        }
+
+        $table = new Table($io);
+        $table->setHeaders(['Installed Name', 'Package', 'Enabled', 'Mode', 'State', 'Status']);
+
+        foreach ($statuses as $status) {
+            $table->addRow([
+                $status->installedName,
+                $status->package,
+                $status->enabled ? 'yes' : 'no',
+                $status->mode,
+                $status->state,
+                $status->status,
+            ]);
+        }
+
+        $table->render();
+    }
+}

--- a/src/mate/src/Exception/AmbiguousSkillException.php
+++ b/src/mate/src/Exception/AmbiguousSkillException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Exception;
+
+/**
+ * Thrown when a skill name passed to a skills:* command is owned by more than one package.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class AmbiguousSkillException extends InvalidArgumentException
+{
+}

--- a/src/mate/src/Exception/SkillNotFoundException.php
+++ b/src/mate/src/Exception/SkillNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Exception;
+
+/**
+ * Thrown when a skill name passed to a skills:* command matches no recorded skill.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SkillNotFoundException extends InvalidArgumentException
+{
+}

--- a/src/mate/src/Skill/SkillInstaller.php
+++ b/src/mate/src/Skill/SkillInstaller.php
@@ -39,6 +39,7 @@ final class SkillInstaller
 {
     public const AGENTS_SKILLS_DIR = '.agents/skills';
     public const CLAUDE_SKILLS_DIR = '.claude/skills';
+    public const OVERRIDE_SKILLS_DIR = 'mate/skills';
 
     public function __construct(
         private string $rootDir,
@@ -106,7 +107,7 @@ final class SkillInstaller
                     'mode' => $state['mode'],
                 ]);
                 $skipped[$skill->installedName] = $override
-                    ? 'override source missing in mate/skills/'
+                    ? \sprintf('override source missing in %s/', self::OVERRIDE_SKILLS_DIR)
                     : 'source directory missing';
 
                 continue;
@@ -280,7 +281,7 @@ final class SkillInstaller
         $agentsTarget = $this->rootDir.'/'.self::AGENTS_SKILLS_DIR.'/'.$skill->installedName;
         $claudeTarget = $this->rootDir.'/'.self::CLAUDE_SKILLS_DIR.'/'.$skill->installedName;
 
-        $source = $override ? 'mate/skills/'.$skill->originalName : $skill->source;
+        $source = $override ? self::OVERRIDE_SKILLS_DIR.'/'.$skill->originalName : $skill->source;
         $sourceHash = $this->hasher->hash($sourceDir);
 
         $facts = [
@@ -340,7 +341,7 @@ final class SkillInstaller
 
     private function overrideSourceDir(DiscoveredSkill $skill): string
     {
-        return $this->rootDir.'/mate/skills/'.$skill->originalName;
+        return $this->rootDir.'/'.self::OVERRIDE_SKILLS_DIR.'/'.$skill->originalName;
     }
 
     /**

--- a/src/mate/src/Skill/SkillManager.php
+++ b/src/mate/src/Skill/SkillManager.php
@@ -12,9 +12,14 @@
 namespace Symfony\AI\Mate\Skill;
 
 use Symfony\AI\Mate\Discovery\ComposerExtensionDiscovery;
+use Symfony\AI\Mate\Discovery\PathGuard;
+use Symfony\AI\Mate\Exception\AmbiguousSkillException;
+use Symfony\AI\Mate\Exception\RuntimeException;
+use Symfony\AI\Mate\Exception\SkillNotFoundException;
 use Symfony\AI\Mate\Skill\Model\DiscoveredSkill;
 use Symfony\AI\Mate\Skill\Model\SkillInstallResult;
 use Symfony\AI\Mate\Skill\Model\SkillStatus;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Entry point the skills:* commands work against.
@@ -37,6 +42,7 @@ final class SkillManager
         private SkillInstaller $installer,
         private SkillContentHasher $hasher,
         private SkillFrontmatter $frontmatter,
+        private Filesystem $filesystem,
     ) {
     }
 
@@ -62,6 +68,108 @@ final class SkillManager
     public function pruneStrays(bool $dryRun): array
     {
         return $this->installer->pruneStrays($dryRun);
+    }
+
+    /**
+     * Resolves an installed ("mate-foo") or original ("foo") name to the skill that owns it.
+     *
+     * Resolution runs against the recorded state, not discovery, so a skill stays addressable while
+     * its package is temporarily absent.
+     *
+     * @return array{package: string, name: string}
+     *
+     * @throws SkillNotFoundException  when no recorded skill matches
+     * @throws AmbiguousSkillException when more than one package owns the name
+     */
+    public function resolve(string $input): array
+    {
+        $matches = $this->repository->findAll($input);
+
+        if ([] === $matches) {
+            throw new SkillNotFoundException(\sprintf('Unknown skill "%s". Run "mate skills:list" to see what is available.', $input));
+        }
+
+        if (\count($matches) > 1) {
+            $packages = array_map(static fn (array $match): string => $match['package'], $matches);
+
+            throw new AmbiguousSkillException(\sprintf('Skill "%s" is provided by more than one package (%s).', $input, implode(', ', $packages)));
+        }
+
+        $name = $matches[0]['name'];
+        if (PathGuard::hasTraversal($name)) {
+            throw new SkillNotFoundException(\sprintf('Skill name "%s" is not a valid directory name.', $name));
+        }
+
+        return ['package' => $matches[0]['package'], 'name' => $name];
+    }
+
+    /**
+     * @param 'managed'|'override' $mode
+     */
+    public function setMode(string $package, string $name, string $mode): void
+    {
+        $this->repository->setMode($package, $name, $mode);
+    }
+
+    public function overrideCopyPath(string $name): string
+    {
+        return SkillInstaller::OVERRIDE_SKILLS_DIR.'/'.$name;
+    }
+
+    /**
+     * Copies the package's version of a skill into mate/skills/<name>/ for the user to own.
+     *
+     * The copy is taken from the declared source rather than the generated folder, so it keeps the
+     * original frontmatter name; the installed name is applied at build time as for any other skill.
+     *
+     * @return string the created path, relative to the project root
+     */
+    public function createOverrideCopy(string $package, string $name, bool $force): string
+    {
+        $target = $this->rootDir.'/'.$this->overrideCopyPath($name);
+
+        if (is_dir($target) && !$force) {
+            throw new RuntimeException(\sprintf('"%s" already exists. Pass --force to replace it.', $this->overrideCopyPath($name)));
+        }
+
+        $skill = $this->findDiscovered($package, $name);
+        if (null === $skill) {
+            throw new RuntimeException(\sprintf('Skill "%s" is not currently provided by "%s", so there is nothing to copy.', $name, $package));
+        }
+
+        $this->filesystem->remove($target);
+        $this->filesystem->mirror($skill->absolutePath, $target);
+
+        return $this->overrideCopyPath($name);
+    }
+
+    public function removeOverrideCopy(string $name): bool
+    {
+        $target = $this->rootDir.'/'.$this->overrideCopyPath($name);
+        if (!is_dir($target)) {
+            return false;
+        }
+
+        $this->filesystem->remove($target);
+
+        return true;
+    }
+
+    public function hasOverrideCopy(string $name): bool
+    {
+        return is_dir($this->rootDir.'/'.$this->overrideCopyPath($name));
+    }
+
+    /**
+     * @return list<SkillStatus>
+     */
+    public function statusFor(string $installedOrOriginalName): array
+    {
+        return array_values(array_filter(
+            $this->status(),
+            static fn (SkillStatus $status): bool => $status->installedName === $installedOrOriginalName
+                || $status->originalName === $installedOrOriginalName,
+        ));
     }
 
     /**
@@ -98,6 +206,17 @@ final class SkillManager
         usort($statuses, static fn (SkillStatus $a, SkillStatus $b): int => $a->installedName <=> $b->installedName);
 
         return $statuses;
+    }
+
+    private function findDiscovered(string $package, string $name): ?DiscoveredSkill
+    {
+        foreach ($this->discover() as $skill) {
+            if ($skill->package === $package && $skill->originalName === $name) {
+                return $skill;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -161,8 +280,8 @@ final class SkillManager
             return $issues;
         }
 
-        if ('override' === $recordedState && !is_file($this->rootDir.'/mate/skills/'.$name.'/SKILL.md')) {
-            $issues[] = ['level' => 'error', 'message' => \sprintf('Overridden skill has no copy at mate/skills/%s/SKILL.md.', $name)];
+        if ('override' === $recordedState && !is_file($this->rootDir.'/'.$this->overrideCopyPath($name).'/SKILL.md')) {
+            $issues[] = ['level' => 'error', 'message' => \sprintf('Overridden skill has no copy at %s/SKILL.md.', $this->overrideCopyPath($name))];
         }
 
         foreach ($state['targets'] ?? [] as $target) {
@@ -217,7 +336,7 @@ final class SkillManager
         }
 
         $sourceDir = 'override' === ($state['state'] ?? null)
-            ? $this->rootDir.'/mate/skills/'.substr($installedName, 5)
+            ? $this->rootDir.'/'.$this->overrideCopyPath(substr($installedName, 5))
             : $skill?->absolutePath;
 
         if (null !== $sourceDir && is_dir($sourceDir)) {

--- a/src/mate/src/default.config.php
+++ b/src/mate/src/default.config.php
@@ -23,7 +23,9 @@ use Symfony\AI\Mate\Command\ResourcesReadCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
 use Symfony\AI\Mate\Command\SkillsInstallCommand;
 use Symfony\AI\Mate\Command\SkillsListCommand;
+use Symfony\AI\Mate\Command\SkillsOverrideCommand;
 use Symfony\AI\Mate\Command\SkillsPruneCommand;
+use Symfony\AI\Mate\Command\SkillsResetCommand;
 use Symfony\AI\Mate\Command\SkillsValidateCommand;
 use Symfony\AI\Mate\Command\StopCommand;
 use Symfony\AI\Mate\Command\ToolsCallCommand;
@@ -165,6 +167,12 @@ return static function (ContainerConfigurator $container): void {
             ->public()
 
         ->set(SkillsPruneCommand::class)
+            ->public()
+
+        ->set(SkillsOverrideCommand::class)
+            ->public()
+
+        ->set(SkillsResetCommand::class)
             ->public()
     ;
 };

--- a/src/mate/tests/Command/SkillsOverrideCommandTest.php
+++ b/src/mate/tests/Command/SkillsOverrideCommandTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Command\SkillsOverrideCommand;
+use Symfony\AI\Mate\Skill\SkillStateRepository;
+use Symfony\AI\Mate\Tests\Skill\SkillFixtureTrait;
+use Symfony\AI\Mate\Tests\Skill\SkillServicesTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SkillsOverrideCommandTest extends TestCase
+{
+    use SkillFixtureTrait;
+    use SkillServicesTrait;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir().'/mate-skills-override-cmd-'.uniqid();
+        mkdir($this->rootDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->rootDir);
+    }
+
+    public function testTakesOwnershipOfASkill()
+    {
+        $this->installFixture();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'mate-system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        // The user's copy keeps the original name; the mate- prefix is applied at build time.
+        $copy = file_get_contents($this->rootDir.'/mate/skills/system-information/SKILL.md');
+        $this->assertIsString($copy);
+        $this->assertStringContainsString('name: system-information', $copy);
+
+        $installed = file_get_contents($this->rootDir.'/.agents/skills/mate-system-information/SKILL.md');
+        $this->assertIsString($installed);
+        $this->assertStringContainsString('name: mate-system-information', $installed);
+
+        $state = (new SkillStateRepository($this->rootDir))->read()['vendor/pkg-a']['skills']['system-information'];
+        $this->assertSame('override', $state['mode']);
+        $this->assertSame('override', $state['state']);
+        $this->assertSame('mate/skills/system-information', $state['source']);
+    }
+
+    public function testEditsToTheCopyLandInTheGeneratedFolder()
+    {
+        $this->installFixture();
+        (new CommandTester($this->command()))->execute(['name' => 'system-information']);
+
+        file_put_contents(
+            $this->rootDir.'/mate/skills/system-information/SKILL.md',
+            "---\nname: system-information\ndescription: Mine now.\n---\n\nMY OWN CONTENT",
+        );
+        $this->createManager($this->rootDir)->reinstall();
+
+        $installed = file_get_contents($this->rootDir.'/.agents/skills/mate-system-information/SKILL.md');
+        $this->assertIsString($installed);
+        $this->assertStringContainsString('MY OWN CONTENT', $installed);
+        $this->assertStringContainsString('name: mate-system-information', $installed);
+    }
+
+    public function testRefusesWhenAlreadyOverriddenWithoutForce()
+    {
+        $this->installFixture();
+        (new CommandTester($this->command()))->execute(['name' => 'system-information']);
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information']);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('already overridden', $tester->getDisplay());
+    }
+
+    public function testForceReplacesAnExistingCopy()
+    {
+        $this->installFixture();
+        (new CommandTester($this->command()))->execute(['name' => 'system-information']);
+        file_put_contents($this->rootDir.'/mate/skills/system-information/SKILL.md', 'STALE');
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information', '--force' => true]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $copy = file_get_contents($this->rootDir.'/mate/skills/system-information/SKILL.md');
+        $this->assertIsString($copy);
+        $this->assertStringNotContainsString('STALE', $copy);
+    }
+
+    public function testFailsOnUnknownName()
+    {
+        $this->installFixture();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'nope']);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('Unknown skill', $tester->getDisplay());
+    }
+
+    private function installFixture(): void
+    {
+        $this->createInstalledPackage($this->rootDir);
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createManager($this->rootDir)->reinstall();
+    }
+
+    private function command(): SkillsOverrideCommand
+    {
+        return new SkillsOverrideCommand($this->createManager($this->rootDir));
+    }
+}

--- a/src/mate/tests/Command/SkillsResetCommandTest.php
+++ b/src/mate/tests/Command/SkillsResetCommandTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Command\SkillsOverrideCommand;
+use Symfony\AI\Mate\Command\SkillsResetCommand;
+use Symfony\AI\Mate\Skill\SkillStateRepository;
+use Symfony\AI\Mate\Tests\Skill\SkillFixtureTrait;
+use Symfony\AI\Mate\Tests\Skill\SkillServicesTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SkillsResetCommandTest extends TestCase
+{
+    use SkillFixtureTrait;
+    use SkillServicesTrait;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir().'/mate-skills-reset-cmd-'.uniqid();
+        mkdir($this->rootDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->rootDir);
+    }
+
+    public function testHandsTheSkillBackToMateAndRebuildsFromThePackage()
+    {
+        $this->overrideFixture('MY OWN CONTENT');
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'mate-system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        $state = (new SkillStateRepository($this->rootDir))->read()['vendor/pkg-a']['skills']['system-information'];
+        $this->assertSame('managed', $state['mode']);
+        $this->assertSame('managed', $state['state']);
+        $this->assertSame('vendor/vendor/pkg-a/skills/system-information', $state['source']);
+
+        $installed = file_get_contents($this->rootDir.'/.agents/skills/mate-system-information/SKILL.md');
+        $this->assertIsString($installed);
+        $this->assertStringNotContainsString('MY OWN CONTENT', $installed);
+        $this->assertStringContainsString('VENDOR CONTENT', $installed);
+    }
+
+    public function testKeepsTheLocalCopyByDefaultAndSaysWhereItIs()
+    {
+        $this->overrideFixture('MY OWN CONTENT');
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information']);
+
+        $this->assertDirectoryExists($this->rootDir.'/mate/skills/system-information');
+        $this->assertStringContainsString('mate/skills/system-information', $tester->getDisplay());
+    }
+
+    public function testDeleteCopyRemovesIt()
+    {
+        $this->overrideFixture('MY OWN CONTENT');
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information', '--delete-copy' => true]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertDirectoryDoesNotExist($this->rootDir.'/mate/skills/system-information');
+    }
+
+    public function testIsANoOpForAnAlreadyManagedSkill()
+    {
+        $this->installFixture();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('already managed', $tester->getDisplay());
+    }
+
+    public function testFailsOnUnknownName()
+    {
+        $this->installFixture();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'nope']);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+    }
+
+    private function installFixture(): void
+    {
+        $this->createInstalledPackage($this->rootDir);
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.', 'VENDOR CONTENT');
+        $this->createManager($this->rootDir)->reinstall();
+    }
+
+    private function overrideFixture(string $ownContent): void
+    {
+        $this->installFixture();
+        (new CommandTester(new SkillsOverrideCommand($this->createManager($this->rootDir))))
+            ->execute(['name' => 'system-information']);
+
+        file_put_contents(
+            $this->rootDir.'/mate/skills/system-information/SKILL.md',
+            "---\nname: system-information\ndescription: Mine now.\n---\n\n".$ownContent,
+        );
+        $this->createManager($this->rootDir)->reinstall();
+    }
+
+    private function command(): SkillsResetCommand
+    {
+        return new SkillsResetCommand($this->createManager($this->rootDir));
+    }
+}

--- a/src/mate/tests/Skill/SkillManagerTest.php
+++ b/src/mate/tests/Skill/SkillManagerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Skill;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Exception\AmbiguousSkillException;
+use Symfony\AI\Mate\Exception\RuntimeException;
+use Symfony\AI\Mate\Exception\SkillNotFoundException;
+use Symfony\AI\Mate\Skill\SkillStateRepository;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SkillManagerTest extends TestCase
+{
+    use SkillFixtureTrait;
+    use SkillServicesTrait;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir().'/mate-skill-manager-'.uniqid();
+        mkdir($this->rootDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->rootDir);
+    }
+
+    public function testResolvesByOriginalName()
+    {
+        $this->installFixture();
+
+        $this->assertSame(
+            ['package' => 'vendor/pkg-a', 'name' => 'system-information'],
+            $this->createManager($this->rootDir)->resolve('system-information'),
+        );
+    }
+
+    public function testResolvesByInstalledName()
+    {
+        $this->installFixture();
+
+        $this->assertSame(
+            ['package' => 'vendor/pkg-a', 'name' => 'system-information'],
+            $this->createManager($this->rootDir)->resolve('mate-system-information'),
+        );
+    }
+
+    public function testResolveThrowsOnUnknownName()
+    {
+        $this->installFixture();
+
+        $this->expectException(SkillNotFoundException::class);
+        $this->createManager($this->rootDir)->resolve('nope');
+    }
+
+    public function testResolveThrowsWhenTwoPackagesOwnTheName()
+    {
+        (new SkillStateRepository($this->rootDir))->write([
+            'vendor/pkg-a' => ['enabled' => true, 'skills' => ['shared' => ['enabled' => true, 'mode' => 'managed']]],
+            'vendor/pkg-b' => ['enabled' => true, 'skills' => ['shared' => ['enabled' => true, 'mode' => 'managed']]],
+        ]);
+
+        $this->expectException(AmbiguousSkillException::class);
+        $this->createManager($this->rootDir)->resolve('shared');
+    }
+
+    public function testCreateOverrideCopyKeepsTheOriginalFrontmatterName()
+    {
+        $this->installFixture();
+
+        $path = $this->createManager($this->rootDir)->createOverrideCopy('vendor/pkg-a', 'system-information', false);
+
+        $this->assertSame('mate/skills/system-information', $path);
+        $content = file_get_contents($this->rootDir.'/'.$path.'/SKILL.md');
+        $this->assertIsString($content);
+        $this->assertStringContainsString('name: system-information', $content);
+    }
+
+    public function testCreateOverrideCopyRefusesToReplaceWithoutForce()
+    {
+        $this->installFixture();
+        $manager = $this->createManager($this->rootDir);
+        $manager->createOverrideCopy('vendor/pkg-a', 'system-information', false);
+
+        $this->expectException(RuntimeException::class);
+        $manager->createOverrideCopy('vendor/pkg-a', 'system-information', false);
+    }
+
+    public function testCreateOverrideCopyFailsWhenThePackageNoLongerShipsTheSkill()
+    {
+        $this->installFixture();
+        $this->removeDirectory($this->rootDir.'/vendor/vendor/pkg-a');
+
+        $this->expectException(RuntimeException::class);
+        $this->createManager($this->rootDir)->createOverrideCopy('vendor/pkg-a', 'system-information', false);
+    }
+
+    public function testRemoveOverrideCopyReportsWhetherAnythingWasDeleted()
+    {
+        $this->installFixture();
+        $manager = $this->createManager($this->rootDir);
+
+        $this->assertFalse($manager->removeOverrideCopy('system-information'));
+
+        $manager->createOverrideCopy('vendor/pkg-a', 'system-information', false);
+        $this->assertTrue($manager->hasOverrideCopy('system-information'));
+        $this->assertTrue($manager->removeOverrideCopy('system-information'));
+        $this->assertFalse($manager->hasOverrideCopy('system-information'));
+    }
+
+    private function installFixture(): void
+    {
+        $this->createInstalledPackage($this->rootDir);
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createManager($this->rootDir)->reinstall();
+    }
+}

--- a/src/mate/tests/Skill/SkillServicesTrait.php
+++ b/src/mate/tests/Skill/SkillServicesTrait.php
@@ -36,15 +36,17 @@ trait SkillServicesTrait
         $frontmatter = new SkillFrontmatter();
         $hasher = new SkillContentHasher();
         $repository = new SkillStateRepository($rootDir);
+        $filesystem = new Filesystem();
 
         return new SkillManager(
             $rootDir,
             new ComposerExtensionDiscovery($rootDir, $logger),
             new SkillDiscovery($rootDir, $frontmatter, $logger),
             $repository,
-            new SkillInstaller($rootDir, $repository, $frontmatter, $hasher, $linker ?? new Linker(), new Filesystem(), $logger),
+            new SkillInstaller($rootDir, $repository, $frontmatter, $hasher, $linker ?? new Linker(), $filesystem, $logger),
             $hasher,
             $frontmatter,
+            $filesystem,
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Follow-up to #2370. That PR added the `mode` axis (`managed` vs `override`) to `mate/extensions.php`, but switching a skill to `override` still meant hand-editing the file and copying the folder yourself.

`skills:override` copies the package's version of a skill into `mate/skills/<name>/` and records `'mode' => 'override'`. The copy is taken from the declared source, so it keeps the original frontmatter name; the installed `mate-` name is applied at build time as for any managed skill.

`skills:reset` switches back to `managed` and rebuilds from the package. Your copy under `mate/skills/` is kept and its path reported, with `--delete-copy` to remove it explicitly.

```terminal
$ vendor/bin/mate skills:override mate-system-information
$ vendor/bin/mate skills:reset system-information
```

Both accept the installed or the original name, resolve against the recorded state so a skill stays addressable while its package is absent, and reinstall plus print the resulting row so intent and recorded facts never drift apart.
