### PR TITLE
[Mate] Add skills:enable and skills:disable

### DIFF
--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -491,7 +491,8 @@ skill change into a reviewable diff instead of something that lands silently.
 
 All skill state lives in ``mate/extensions.php``. Two keys per skill carry your intent:
 
-* ``enabled`` controls whether the skill is installed at all.
+* ``enabled`` controls whether the skill is installed at all. Use ``mate skills:disable <name>`` and
+  ``mate skills:enable <name>`` to flip it.
 * ``mode`` is either ``managed``, where Mate builds the skill from the package, or ``override``,
   which hands ownership to you: Mate then builds from your own ``mate/skills/<name>/`` copy and
   never writes into ``mate/skills/``. Use ``mate skills:override <name>`` to switch, and
@@ -584,6 +585,14 @@ Commands
 ``mate skills:reset <name>``
     Hand an overridden skill back to Mate, so it is built from the package again. Your copy under
     ``mate/skills/<name>/`` is kept unless you pass ``--delete-copy``. See `Skills`_.
+
+``mate skills:disable <name>``
+    Hide a skill from coding agents: remove its generated folders and record it as disabled. The
+    entry stays in ``mate/extensions.php``, and a copy of your own under ``mate/skills/`` is left
+    untouched. See `Skills`_.
+
+``mate skills:enable <name>``
+    Make a disabled skill visible again and rebuild its generated folders. See `Skills`_.
 
 ``mate serve``
     Start the MCP server with stdio transport.

--- a/src/mate/AGENTS.md
+++ b/src/mate/AGENTS.md
@@ -51,6 +51,8 @@ bin/mate skills:validate                    # Check generated folders and conten
 bin/mate skills:prune                       # Remove leftover generated mate-* folders
 bin/mate skills:override mate-system-information  # Copy into mate/skills/ and own it
 bin/mate skills:reset mate-system-information     # Hand it back to Mate
+bin/mate skills:disable mate-system-information   # Hide it from coding agents
+bin/mate skills:enable mate-system-information    # Show it again
 bin/mate serve                              # Start MCP server
 bin/mate clear-cache                        # Clear cache
 

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add `skills:override` and `skills:reset` commands: take ownership of a skill by copying it into `mate/skills/<name>/`, and hand it back to Mate again
  * Add `--dry-run` to `skills:install`, reporting what the run would install, rebuild or remove without writing anything
  * Add content checks to `skills:validate`: a warning when SKILL.md links to a file that is not part of the installed skill (failing `--strict` like any other warning), and suggestions when a description is shorter than 40 characters or never says when the skill applies (printed only, never changing the exit code, not even with `--strict`)
+ * Add `skills:disable` and `skills:enable` commands: flip `enabled` for a single skill and rebuild or remove its generated folders
 
 0.12
 ----

--- a/src/mate/src/App.php
+++ b/src/mate/src/App.php
@@ -20,6 +20,8 @@ use Symfony\AI\Mate\Command\DiscoverCommand;
 use Symfony\AI\Mate\Command\InitCommand;
 use Symfony\AI\Mate\Command\ResourcesReadCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
+use Symfony\AI\Mate\Command\SkillsDisableCommand;
+use Symfony\AI\Mate\Command\SkillsEnableCommand;
 use Symfony\AI\Mate\Command\SkillsInstallCommand;
 use Symfony\AI\Mate\Command\SkillsListCommand;
 use Symfony\AI\Mate\Command\SkillsOverrideCommand;
@@ -66,6 +68,8 @@ final class App
             SkillsPruneCommand::class,
             SkillsOverrideCommand::class,
             SkillsResetCommand::class,
+            SkillsEnableCommand::class,
+            SkillsDisableCommand::class,
         ];
 
         foreach ($commands as $commandClass) {

--- a/src/mate/src/Command/SkillsDisableCommand.php
+++ b/src/mate/src/Command/SkillsDisableCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command;
+
+use Symfony\AI\Mate\Command\Trait\RendersSkillOutcomeTrait;
+use Symfony\AI\Mate\Skill\SkillManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Hides a skill from coding agents without uninstalling its package.
+ *
+ * The generated folders are removed and the entry is recorded as disabled, so the skill stays in
+ * mate/extensions.php and can be switched back on later. An override copy under mate/skills/ is
+ * left untouched.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('skills:disable', 'Hide a skill from coding agents')]
+class SkillsDisableCommand extends Command
+{
+    use RendersSkillOutcomeTrait;
+
+    public function __construct(
+        private SkillManager $manager,
+    ) {
+        parent::__construct(self::getDefaultName());
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'skills:disable';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Hide a skill from coding agents';
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('name', InputArgument::REQUIRED, 'Installed ("mate-…") or original skill name');
+        $this->setHelp(
+            <<<'HELP'
+The <info>%command.name%</info> command sets <comment>'enabled' => false</comment> for a skill in
+<comment>mate/extensions.php</comment> and removes its generated folders.
+
+The entry stays in the file, so <info>mate skills:enable</info> brings the skill back. A copy of
+your own under <comment>mate/skills/</comment> is never touched.
+HELP
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $name = $input->getArgument('name');
+        \assert(\is_string($name));
+
+        $resolved = $this->resolveSkill($io, $this->manager, $name);
+        if (null === $resolved) {
+            return Command::FAILURE;
+        }
+
+        // Compared against the recorded flag, not SkillStatus::$enabled: the latter is already false
+        // when only the owning extension is disabled, and the skill itself would stay enabled.
+        $statuses = $this->manager->statusFor($resolved['name']);
+        if ([] !== $statuses && false === $this->manager->isEnabled($resolved['package'], $resolved['name'])) {
+            $io->note(\sprintf('Skill "%s" is already disabled; nothing to disable.', $statuses[0]->installedName));
+
+            return Command::SUCCESS;
+        }
+
+        $this->manager->setEnabled($resolved['package'], $resolved['name'], false);
+        $this->manager->reinstall();
+
+        $io->success(\sprintf('Skill "%s" is disabled and its generated folders were removed.', $statuses[0]->installedName));
+        $this->renderSkillRow($io, $this->manager, $resolved['name']);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/mate/src/Command/SkillsEnableCommand.php
+++ b/src/mate/src/Command/SkillsEnableCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Command;
+
+use Symfony\AI\Mate\Command\Trait\RendersSkillOutcomeTrait;
+use Symfony\AI\Mate\Skill\SkillManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Makes a previously disabled skill visible to coding agents again.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('skills:enable', 'Make a disabled skill visible to coding agents again')]
+class SkillsEnableCommand extends Command
+{
+    use RendersSkillOutcomeTrait;
+
+    public function __construct(
+        private SkillManager $manager,
+    ) {
+        parent::__construct(self::getDefaultName());
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'skills:enable';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Make a disabled skill visible to coding agents again';
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('name', InputArgument::REQUIRED, 'Installed ("mate-…") or original skill name');
+        $this->setHelp(
+            <<<'HELP'
+The <info>%command.name%</info> command sets <comment>'enabled' => true</comment> for a skill in
+<comment>mate/extensions.php</comment> and rebuilds its generated folders.
+
+If the owning extension itself is disabled, the skill stays hidden — enable the extension in
+<comment>mate/extensions.php</comment> as well.
+HELP
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $name = $input->getArgument('name');
+        \assert(\is_string($name));
+
+        $resolved = $this->resolveSkill($io, $this->manager, $name);
+        if (null === $resolved) {
+            return Command::FAILURE;
+        }
+
+        // Compared against the recorded flag, not SkillStatus::$enabled: the latter is already false
+        // when only the owning extension is disabled, and the skill itself would stay enabled.
+        $statuses = $this->manager->statusFor($resolved['name']);
+        if ([] !== $statuses && true === $this->manager->isEnabled($resolved['package'], $resolved['name'])) {
+            $io->note(\sprintf('Skill "%s" is already enabled; nothing to enable.', $statuses[0]->installedName));
+
+            // Its own flag is set, so the extension is the only thing left that can hide it. Saying
+            // nothing here would leave the user with a no-op and no explanation.
+            if (!$statuses[0]->enabled) {
+                $this->warnAboutDisabledExtension($io, $statuses[0]->installedName, $resolved['package']);
+            }
+
+            return Command::SUCCESS;
+        }
+
+        $this->manager->setEnabled($resolved['package'], $resolved['name'], true);
+        $this->manager->reinstall();
+
+        $statuses = $this->manager->statusFor($resolved['name']);
+        if ([] !== $statuses && !$statuses[0]->enabled) {
+            $this->warnAboutDisabledExtension($io, $statuses[0]->installedName, $resolved['package']);
+            $this->renderSkillRow($io, $this->manager, $resolved['name']);
+
+            return Command::SUCCESS;
+        }
+
+        $io->success(\sprintf('Skill "%s" is enabled and was installed.', $statuses[0]->installedName));
+        $this->renderSkillRow($io, $this->manager, $resolved['name']);
+
+        return Command::SUCCESS;
+    }
+
+    private function warnAboutDisabledExtension(SymfonyStyle $io, string $installedName, string $package): void
+    {
+        $io->warning(\sprintf('Skill "%s" stays hidden because the extension "%s" is disabled in mate/extensions.php.', $installedName, $package));
+    }
+}

--- a/src/mate/src/Skill/SkillManager.php
+++ b/src/mate/src/Skill/SkillManager.php
@@ -124,6 +124,31 @@ final class SkillManager
         $this->repository->setMode($package, $name, $mode);
     }
 
+    public function setEnabled(string $package, string $name, bool $enabled): void
+    {
+        $this->repository->setEnabled($package, $name, $enabled);
+    }
+
+    /**
+     * Reads the recorded "enabled" flag of a single skill.
+     *
+     * Deliberately not SkillStatus::$enabled: that one is the effective value, false as soon as the
+     * owning extension is disabled. A command that writes this flag has to compare against the flag
+     * itself, or it would call a skill "already disabled" when only its extension is.
+     *
+     * @return bool|null null when the package records no such skill
+     */
+    public function isEnabled(string $package, string $name): ?bool
+    {
+        foreach ($this->repository->findAll($name) as $match) {
+            if ($match['package'] === $package) {
+                return $match['state']['enabled'];
+            }
+        }
+
+        return null;
+    }
+
     public function overrideCopyPath(string $name): string
     {
         return SkillInstaller::OVERRIDE_SKILLS_DIR.'/'.$name;

--- a/src/mate/src/default.config.php
+++ b/src/mate/src/default.config.php
@@ -21,6 +21,8 @@ use Symfony\AI\Mate\Command\DiscoverCommand;
 use Symfony\AI\Mate\Command\InitCommand;
 use Symfony\AI\Mate\Command\ResourcesReadCommand;
 use Symfony\AI\Mate\Command\ServeCommand;
+use Symfony\AI\Mate\Command\SkillsDisableCommand;
+use Symfony\AI\Mate\Command\SkillsEnableCommand;
 use Symfony\AI\Mate\Command\SkillsInstallCommand;
 use Symfony\AI\Mate\Command\SkillsListCommand;
 use Symfony\AI\Mate\Command\SkillsOverrideCommand;
@@ -173,6 +175,12 @@ return static function (ContainerConfigurator $container): void {
             ->public()
 
         ->set(SkillsResetCommand::class)
+            ->public()
+
+        ->set(SkillsEnableCommand::class)
+            ->public()
+
+        ->set(SkillsDisableCommand::class)
             ->public()
     ;
 };

--- a/src/mate/tests/Command/SkillsDisableCommandTest.php
+++ b/src/mate/tests/Command/SkillsDisableCommandTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Command\SkillsDisableCommand;
+use Symfony\AI\Mate\Command\SkillsOverrideCommand;
+use Symfony\AI\Mate\Skill\SkillStateRepository;
+use Symfony\AI\Mate\Tests\Skill\SkillFixtureTrait;
+use Symfony\AI\Mate\Tests\Skill\SkillServicesTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SkillsDisableCommandTest extends TestCase
+{
+    use SkillFixtureTrait;
+    use SkillServicesTrait;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir().'/mate-skills-disable-cmd-'.uniqid();
+        mkdir($this->rootDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->rootDir);
+    }
+
+    public function testRemovesTheGeneratedFoldersAndRecordsDisabled()
+    {
+        $this->installFixture();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'mate-system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertDirectoryDoesNotExist($this->rootDir.'/.agents/skills/mate-system-information');
+        $this->assertFalse(is_link($this->rootDir.'/.claude/skills/mate-system-information'));
+
+        $state = (new SkillStateRepository($this->rootDir))->read()['vendor/pkg-a']['skills']['system-information'];
+        $this->assertFalse($state['enabled']);
+        $this->assertSame('disabled', $state['state']);
+        $this->assertSame([], $state['targets']);
+        $this->assertNull($state['hash']);
+    }
+
+    public function testKeepsTheEntrySoItCanBeEnabledAgain()
+    {
+        $this->installFixture();
+
+        (new CommandTester($this->command()))->execute(['name' => 'system-information']);
+
+        $config = (new SkillStateRepository($this->rootDir))->read();
+        $this->assertArrayHasKey('system-information', $config['vendor/pkg-a']['skills']);
+    }
+
+    public function testLeavesAnOverrideCopyAlone()
+    {
+        $this->installFixture();
+        (new CommandTester(new SkillsOverrideCommand($this->createManager($this->rootDir))))
+            ->execute(['name' => 'system-information']);
+
+        (new CommandTester($this->command()))->execute(['name' => 'system-information']);
+
+        $this->assertDirectoryExists($this->rootDir.'/mate/skills/system-information');
+    }
+
+    public function testDisabledSkillStaysDisabledAcrossReinstalls()
+    {
+        $this->installFixture();
+        (new CommandTester($this->command()))->execute(['name' => 'system-information']);
+
+        $this->createManager($this->rootDir)->reinstall();
+
+        $this->assertDirectoryDoesNotExist($this->rootDir.'/.agents/skills/mate-system-information');
+    }
+
+    public function testIsANoOpForAnAlreadyDisabledSkill()
+    {
+        $this->installFixture();
+        (new CommandTester($this->command()))->execute(['name' => 'system-information']);
+
+        // A second run must not reconcile anything: a hand-made folder that a reinstall would prune
+        // as a stray is the cheapest proof that the command kept its hands off the filesystem.
+        $stray = $this->rootDir.'/.agents/skills/mate-system-information';
+        mkdir($stray, 0777, true);
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('already disabled', $tester->getDisplay());
+        $this->assertDirectoryExists($stray);
+    }
+
+    public function testDisablesASkillThatIsOnlyHiddenByItsExtension()
+    {
+        $this->installFixture();
+
+        $repository = new SkillStateRepository($this->rootDir);
+        $config = $repository->read();
+        $config['vendor/pkg-a']['enabled'] = false;
+        $repository->write($config);
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringNotContainsString('already disabled', $tester->getDisplay());
+
+        $state = (new SkillStateRepository($this->rootDir))->read()['vendor/pkg-a']['skills']['system-information'];
+        $this->assertFalse($state['enabled']);
+    }
+
+    public function testFailsOnUnknownName()
+    {
+        $this->installFixture();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'nope']);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('Unknown skill', $tester->getDisplay());
+    }
+
+    private function installFixture(): void
+    {
+        $this->createInstalledPackage($this->rootDir);
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createManager($this->rootDir)->reinstall();
+    }
+
+    private function command(): SkillsDisableCommand
+    {
+        return new SkillsDisableCommand($this->createManager($this->rootDir));
+    }
+}

--- a/src/mate/tests/Command/SkillsEnableCommandTest.php
+++ b/src/mate/tests/Command/SkillsEnableCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Command\SkillsDisableCommand;
+use Symfony\AI\Mate\Command\SkillsEnableCommand;
+use Symfony\AI\Mate\Skill\SkillStateRepository;
+use Symfony\AI\Mate\Tests\Skill\SkillFixtureTrait;
+use Symfony\AI\Mate\Tests\Skill\SkillServicesTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class SkillsEnableCommandTest extends TestCase
+{
+    use SkillFixtureTrait;
+    use SkillServicesTrait;
+
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir().'/mate-skills-enable-cmd-'.uniqid();
+        mkdir($this->rootDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->rootDir);
+    }
+
+    public function testDisableThenEnableRestoresBothTargets()
+    {
+        $this->installFixture();
+        (new CommandTester(new SkillsDisableCommand($this->createManager($this->rootDir))))
+            ->execute(['name' => 'system-information']);
+        $this->assertDirectoryDoesNotExist($this->rootDir.'/.agents/skills/mate-system-information');
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'mate-system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertDirectoryExists($this->rootDir.'/.agents/skills/mate-system-information');
+        $this->assertTrue(is_link($this->rootDir.'/.claude/skills/mate-system-information'));
+
+        $state = (new SkillStateRepository($this->rootDir))->read()['vendor/pkg-a']['skills']['system-information'];
+        $this->assertTrue($state['enabled']);
+        $this->assertSame('managed', $state['state']);
+    }
+
+    public function testResolvesTheUnprefixedName()
+    {
+        $this->installFixture();
+        (new CommandTester(new SkillsDisableCommand($this->createManager($this->rootDir))))
+            ->execute(['name' => 'mate-system-information']);
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertDirectoryExists($this->rootDir.'/.agents/skills/mate-system-information');
+    }
+
+    public function testWarnsWhenTheOwningExtensionIsDisabled()
+    {
+        $this->installFixture();
+        (new CommandTester(new SkillsDisableCommand($this->createManager($this->rootDir))))
+            ->execute(['name' => 'system-information']);
+        $this->disableExtension();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('stays hidden', $tester->getDisplay());
+        $this->assertDirectoryDoesNotExist($this->rootDir.'/.agents/skills/mate-system-information');
+    }
+
+    public function testIsANoOpForAnAlreadyEnabledSkill()
+    {
+        $this->installFixture();
+        $installed = $this->rootDir.'/.agents/skills/mate-system-information/SKILL.md';
+        file_put_contents($installed, 'HAND EDITED');
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('already enabled', $tester->getDisplay());
+        $this->assertSame('HAND EDITED', file_get_contents($installed));
+    }
+
+    public function testTheNoOpStillPointsAtTheDisabledExtension()
+    {
+        $this->installFixture();
+        $this->disableExtension();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'system-information']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('already enabled', $tester->getDisplay());
+        $this->assertStringContainsString('stays hidden', $tester->getDisplay());
+    }
+
+    public function testFailsOnUnknownName()
+    {
+        $this->installFixture();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['name' => 'nope']);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+    }
+
+    private function installFixture(): void
+    {
+        $this->createInstalledPackage($this->rootDir);
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createManager($this->rootDir)->reinstall();
+    }
+
+    private function disableExtension(): void
+    {
+        $repository = new SkillStateRepository($this->rootDir);
+        $config = $repository->read();
+        $config['vendor/pkg-a']['enabled'] = false;
+        $repository->write($config);
+    }
+
+    private function command(): SkillsEnableCommand
+    {
+        return new SkillsEnableCommand($this->createManager($this->rootDir));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Follow-up to #2433. This completes the skill lifecycle: with `skills:enable` and `skills:disable` every state transition has a command, so `mate/extensions.php` never has to be hand-edited.

`skills:disable` sets `'enabled' => false` and removes the generated folders. The entry stays recorded as disabled, so the skill survives a `discover` run and can be switched back on, and an override copy under `mate/skills/` is left untouched. `skills:enable` flips it back and rebuilds. Both take the installed name or the original one, like the other `skills:*` commands.

Both are also no-ops when the flag already has the requested value: they report it and return without touching the filesystem, the way `skills:reset` does. The check reads the recorded per-skill flag rather than the effective one, so a skill that is only hidden because its owning extension is disabled is still disabled properly instead of being called "already disabled". In that situation `skills:enable` warns instead of claiming success, since flipping the skill's own flag cannot make it visible.

```terminal
$ vendor/bin/mate skills:disable system-information
$ vendor/bin/mate skills:enable system-information
```
