### PR TITLE
[Mate] Add skills:install --dry-run and content checks to skills:validate

### DIFF
--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -528,7 +528,15 @@ and ``hash`` pair used to detect drift, and the generated ``targets``::
 
 Use ``mate skills:list`` for an overview, and ``mate skills:validate`` to check the generated folders
 against that record: it reports hand-edited content, missing folders, and sources that moved on since
-the last install. ``mate skills:prune`` removes leftover ``mate-*`` folders.
+the last install. It also looks at the installed content itself: it warns when a Markdown link points
+at a file that is not part of the skill, and suggests a better description when it is too short or
+never says when the skill applies, because that description is all an agent has when it decides
+whether to load the skill. Those description findings are suggestions, not warnings: they are printed
+but never change the exit code, not even with ``--strict``. ``mate skills:prune`` removes leftover
+``mate-*`` folders.
+
+To see what an install would do before it does it, run ``mate skills:install --dry-run``: the same
+reconciler runs and reports what it would install, rebuild or remove, but nothing is written.
 
 The core package itself ships a ``system-information`` skill describing how to inspect the PHP
 runtime and installed package versions via the ``server-info`` tool.
@@ -551,16 +559,18 @@ Commands
 ``mate skills:install``
     Install the Agent Skills shipped by your enabled extensions so your coding agent can use
     them. This runs automatically as part of ``mate discover``; use it for an explicit re-sync.
-    See `Skills`_.
+    Pass ``--dry-run`` to see what a run would install, rebuild or remove without writing
+    anything. See `Skills`_.
 
 ``mate skills:list``
     List declared and installed skills with their enabled, mode, state and status information.
     Read-only diagnostic. See `Skills`_.
 
 ``mate skills:validate``
-    Check the generated skill folders against the state recorded in ``mate/extensions.php``. Exits
-    with a non-zero status when a skill is broken; pass ``--strict`` to fail on warnings too.
-    Read-only. See `Skills`_.
+    Check the generated skill folders against the state recorded in ``mate/extensions.php``, and the
+    installed content itself for dead links and descriptions an agent cannot act on. Exits with a
+    non-zero status when a skill is broken; pass ``--strict`` to fail on warnings too. Suggestions
+    about a description never affect the exit code. Read-only. See `Skills`_.
 
 ``mate skills:prune``
     Remove generated ``mate-*`` folders that no longer belong to any skill. Pass ``--dry-run`` to

--- a/src/mate/AGENTS.md
+++ b/src/mate/AGENTS.md
@@ -45,8 +45,9 @@ cd ../../.. && vendor/bin/php-cs-fixer fix src/mate/
 bin/mate init                               # Initialize configuration
 bin/mate discover                           # Discover extensions (also installs extension skills)
 bin/mate skills:install                     # Install extension skills
+bin/mate skills:install --dry-run           # Report what an install would change
 bin/mate skills:list                        # List skills with mode, state and status
-bin/mate skills:validate                    # Check generated folders against recorded state
+bin/mate skills:validate                    # Check generated folders and content against recorded state
 bin/mate skills:prune                       # Remove leftover generated mate-* folders
 bin/mate skills:override mate-system-information  # Copy into mate/skills/ and own it
 bin/mate skills:reset mate-system-information     # Hand it back to Mate

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -11,6 +11,8 @@ CHANGELOG
  * Add `skills:validate` command: checks the generated folders against the recorded state and fails on hand-edited content, missing folders or a mispointed mirror (`--strict` also fails on warnings)
  * Add `skills:prune` command: removes generated `mate-*` folders that no longer belong to any skill (`--dry-run` to preview)
  * Add `skills:override` and `skills:reset` commands: take ownership of a skill by copying it into `mate/skills/<name>/`, and hand it back to Mate again
+ * Add `--dry-run` to `skills:install`, reporting what the run would install, rebuild or remove without writing anything
+ * Add content checks to `skills:validate`: a warning when SKILL.md links to a file that is not part of the installed skill (failing `--strict` like any other warning), and suggestions when a description is shorter than 40 characters or never says when the skill applies (printed only, never changing the exit code, not even with `--strict`)
 
 0.12
 ----

--- a/src/mate/src/Command/SkillsInstallCommand.php
+++ b/src/mate/src/Command/SkillsInstallCommand.php
@@ -16,6 +16,7 @@ use Symfony\AI\Mate\Skill\SkillManager;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -50,6 +51,7 @@ class SkillsInstallCommand extends Command
 
     protected function configure(): void
     {
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would change without writing anything');
         $this->setHelp(
             <<<'HELP'
 The <info>%command.name%</info> command rebuilds the generated skill folders
@@ -60,6 +62,10 @@ Both the intent it reads (<comment>enabled</comment>, <comment>mode</comment>) a
 records (<comment>state</comment>, <comment>source</comment>, hashes, targets) live in
 <comment>mate/extensions.php</comment>. The command is idempotent: running it repeatedly converges on
 the same result and never touches your overrides in <comment>mate/skills/</comment>.
+
+Pass <comment>--dry-run</comment> to see what a run would change. The same reconciler runs, it just
+writes nothing: no generated folder is touched and <comment>mate/extensions.php</comment> stays as it
+is.
 HELP
         );
     }
@@ -67,26 +73,36 @@ HELP
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+        $dryRun = true === $input->getOption('dry-run');
 
-        $this->render($io, $this->manager->reinstall());
+        $this->render($io, $this->manager->reinstall($dryRun), $dryRun);
 
         return Command::SUCCESS;
     }
 
-    private function render(SymfonyStyle $io, SkillInstallResult $result): void
+    private function render(SymfonyStyle $io, SkillInstallResult $result, bool $dryRun): void
     {
-        $io->title('Skill Installation');
+        $io->title($dryRun ? 'Skill Installation (dry run)' : 'Skill Installation');
 
         if ([] !== $result->installed) {
-            $io->success(\sprintf('Installed %d new skill%s: %s', \count($result->installed), 1 === \count($result->installed) ? '' : 's', implode(', ', $result->installed)));
+            $message = \sprintf('%s %d new skill%s: %s', $dryRun ? 'Would install' : 'Installed', \count($result->installed), 1 === \count($result->installed) ? '' : 's', implode(', ', $result->installed));
+            if ($dryRun) {
+                $io->text($message);
+            } else {
+                $io->success($message);
+            }
+        }
+
+        if ([] !== $result->updated) {
+            $io->text(\sprintf('%s %d skill%s: %s', $dryRun ? 'Would rebuild' : 'Rebuilt', \count($result->updated), 1 === \count($result->updated) ? '' : 's', implode(', ', $result->updated)));
         }
 
         if ([] !== $result->removed) {
-            $io->text(\sprintf('Removed %d skill%s: %s', \count($result->removed), 1 === \count($result->removed) ? '' : 's', implode(', ', $result->removed)));
+            $io->text(\sprintf('%s %d skill%s: %s', $dryRun ? 'Would remove' : 'Removed', \count($result->removed), 1 === \count($result->removed) ? '' : 's', implode(', ', $result->removed)));
         }
 
         foreach ($result->skipped as $name => $reason) {
-            $io->warning(\sprintf('Skipped %s: %s', $name, $reason));
+            $io->warning(\sprintf('%s %s: %s', $dryRun ? 'Would skip' : 'Skipped', $name, $reason));
         }
 
         foreach ($result->notices as $notice) {
@@ -94,11 +110,15 @@ HELP
         }
 
         if ([] === $result->active) {
-            $io->text('No skills are currently installed.');
+            $io->text($dryRun ? 'No skills would be installed.' : 'No skills are currently installed.');
 
             return;
         }
 
-        $io->text(\sprintf('%d skill%s installed: %s', \count($result->active), 1 === \count($result->active) ? '' : 's', implode(', ', $result->active)));
+        $io->text(\sprintf('%d skill%s %s: %s', \count($result->active), 1 === \count($result->active) ? '' : 's', $dryRun ? 'would be installed' : 'installed', implode(', ', $result->active)));
+
+        if ($dryRun && [] === $result->installed && [] === $result->updated && [] === $result->removed) {
+            $io->success('Nothing to do, the generated folders are up to date.');
+        }
     }
 }

--- a/src/mate/src/Command/SkillsValidateCommand.php
+++ b/src/mate/src/Command/SkillsValidateCommand.php
@@ -26,10 +26,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Checks the installed skills against the state recorded in mate/extensions.php.
  *
- * Read-only. Reports two kinds of finding: errors, where the generated folders no longer match what
- * was recorded (missing, hand-edited, mirror pointing elsewhere, disabled but still present), and
+ * Read-only. Reports three kinds of finding: errors, where the generated folders no longer match
+ * what was recorded (missing, hand-edited, mirror pointing elsewhere, disabled but still present);
  * warnings, where reality has legitimately moved on (source changed since the last install, a skill
- * declared but never installed, a mirror copied because symlinks are unavailable).
+ * declared but never installed, a mirror copied because symlinks are unavailable); and suggestions
+ * about the authored content, which are printed but never affect the exit code, not even under
+ * --strict, because they are heuristics a correct skill may miss.
  *
  * @author Johannes Wachter <johannes@sulu.io>
  */
@@ -65,7 +67,8 @@ The <info>%command.name%</info> command compares the generated skill folders aga
 recorded in <comment>mate/extensions.php</comment>.
 
 It exits with <comment>1</comment> when any error is found, and with <comment>--strict</comment> also
-when any warning is found. Most findings are fixed by running
+when any warning is found. Suggestions about the authored content are printed but never change the
+exit code. Most findings are fixed by running
 <info>mate skills:install</info> or <info>mate skills:prune</info>.
 HELP
         );
@@ -142,7 +145,11 @@ HELP
             foreach ($status->issues as $issue) {
                 $io->text(\sprintf(
                     '%s %s',
-                    'error' === $issue['level'] ? '<fg=red>ERROR</>' : '<fg=yellow>WARNING</>',
+                    match ($issue['level']) {
+                        'error' => '<fg=red>ERROR</>',
+                        'warning' => '<fg=yellow>WARNING</>',
+                        'suggestion' => '<fg=cyan>SUGGESTION</>',
+                    },
                     $issue['message'],
                 ));
             }

--- a/src/mate/src/Skill/Model/DiscoveredSkill.php
+++ b/src/mate/src/Skill/Model/DiscoveredSkill.php
@@ -17,6 +17,8 @@ namespace Symfony\AI\Mate\Skill\Model;
  * The {@see $source} path is always the declared source (e.g. "vendor/acme/pkg/skills/my-skill"),
  * regardless of whether the skill is later built from an override copy in mate/skills/.
  *
+ * @internal
+ *
  * @author Johannes Wachter <johannes@sulu.io>
  */
 final class DiscoveredSkill

--- a/src/mate/src/Skill/Model/SkillInstallResult.php
+++ b/src/mate/src/Skill/Model/SkillInstallResult.php
@@ -14,12 +14,15 @@ namespace Symfony\AI\Mate\Skill\Model;
 /**
  * Outcome of a single {@see \Symfony\AI\Mate\Skill\SkillInstaller::install()} run.
  *
+ * @internal
+ *
  * @author Johannes Wachter <johannes@sulu.io>
  */
 final class SkillInstallResult
 {
     /**
      * @param list<string>                                   $installed newly installed skills (not installed before this run)
+     * @param list<string>                                   $updated   skills that were already installed and got rebuilt
      * @param list<string>                                   $removed   installed names pruned from the generated folders
      * @param array<string, string>                          $skipped   installed name => reason for skills that could not be built
      * @param list<string>                                   $active    installed names present in the generated folders after the run
@@ -28,6 +31,7 @@ final class SkillInstallResult
      */
     public function __construct(
         public readonly array $installed,
+        public readonly array $updated,
         public readonly array $removed,
         public readonly array $skipped,
         public readonly array $active,

--- a/src/mate/src/Skill/Model/SkillStatus.php
+++ b/src/mate/src/Skill/Model/SkillStatus.php
@@ -17,7 +17,13 @@ namespace Symfony\AI\Mate\Skill\Model;
  * Shared by "skills:list" (which renders the columns) and "skills:validate" (which renders the
  * issues and turns them into an exit code).
  *
- * @phpstan-type SkillIssue array{level: 'warning'|'error', message: string}
+ * An issue carries the weight it should have on that exit code: an "error" always fails, a
+ * "warning" fails under --strict, and a "suggestion" is advice about the authored content that
+ * never fails a run, because it is a heuristic a correct skill may legitimately not satisfy.
+ *
+ * @phpstan-type SkillIssue array{level: 'suggestion'|'warning'|'error', message: string}
+ *
+ * @internal
  *
  * @author Johannes Wachter <johannes@sulu.io>
  */

--- a/src/mate/src/Skill/SkillInstaller.php
+++ b/src/mate/src/Skill/SkillInstaller.php
@@ -53,9 +53,15 @@ final class SkillInstaller
     }
 
     /**
+     * Reconciles the generated folders with source and intent.
+     *
+     * With $dryRun the run reports the same outcome without touching the filesystem or
+     * mate/extensions.php, so "what would change" is answered by the reconciler itself instead of a
+     * second code path that can drift from it.
+     *
      * @param list<DiscoveredSkill> $skills
      */
-    public function install(array $skills): SkillInstallResult
+    public function install(array $skills, bool $dryRun = false): SkillInstallResult
     {
         $config = $this->repository->read();
 
@@ -64,11 +70,12 @@ final class SkillInstaller
             $discovered[$skill->package][$skill->originalName] = $skill;
         }
 
-        $vanished = $this->dropVanished($config, $discovered);
+        $vanished = $this->dropVanished($config, $discovered, $dryRun);
         $config = $vanished['config'];
         $removed = $vanished['removed'];
 
         $installed = [];
+        $updated = [];
         $skipped = [];
         $notices = [];
         $states = [];
@@ -81,7 +88,7 @@ final class SkillInstaller
             $enabled = $config[$skill->package]['enabled'] && $state['enabled'];
 
             if (!$enabled) {
-                if ($this->removeTargets($skill->installedName, $state['targets'] ?? [])) {
+                if ($this->removeTargets($skill->installedName, $state['targets'] ?? [], $dryRun)) {
                     $removed[] = $skill->installedName;
                 }
 
@@ -115,7 +122,7 @@ final class SkillInstaller
 
             $wasInstalled = isset($state['state']) && 'disabled' !== $state['state'];
 
-            $build = $this->buildSkill($skill, $sourceDir, $override, $state);
+            $build = $this->buildSkill($skill, $sourceDir, $override, $state, $dryRun);
             if (null !== $build['notice']) {
                 $notices[] = $build['notice'];
             }
@@ -127,17 +134,21 @@ final class SkillInstaller
 
             if (!$wasInstalled) {
                 $installed[] = $skill->installedName;
+            } elseif ($build['changed']) {
+                $updated[] = $skill->installedName;
             }
         }
 
-        $this->repository->write($config);
+        if (!$dryRun) {
+            $this->repository->write($config);
+        }
 
-        $removed = array_merge($removed, $this->pruneStrays(false));
+        $removed = array_merge($removed, $this->pruneStrays($dryRun));
         $removed = array_values(array_unique($removed));
         sort($removed);
         sort($active);
 
-        return new SkillInstallResult($installed, $removed, $skipped, $active, $notices, $states);
+        return new SkillInstallResult($installed, $updated, $removed, $skipped, $active, $notices, $states);
     }
 
     /**
@@ -226,7 +237,7 @@ final class SkillInstaller
      *
      * @return array{config: ExtensionConfigMap, removed: list<string>}
      */
-    private function dropVanished(array $config, array $discovered): array
+    private function dropVanished(array $config, array $discovered, bool $dryRun): array
     {
         $removed = [];
         foreach ($config as $package => $entry) {
@@ -235,7 +246,7 @@ final class SkillInstaller
                     continue;
                 }
 
-                if ($this->removeTargets('mate-'.$name, $state['targets'] ?? [])) {
+                if ($this->removeTargets('mate-'.$name, $state['targets'] ?? [], $dryRun)) {
                     $removed[] = 'mate-'.$name;
                 }
 
@@ -274,9 +285,10 @@ final class SkillInstaller
      * @return array{
      *     facts: array{state: 'managed'|'override', source: string, source_hash: string|null, hash: string|null, targets: list<string>},
      *     notice: string|null,
+     *     changed: bool,
      * }
      */
-    private function buildSkill(DiscoveredSkill $skill, string $sourceDir, bool $override, array $previous): array
+    private function buildSkill(DiscoveredSkill $skill, string $sourceDir, bool $override, array $previous, bool $dryRun): array
     {
         $agentsTarget = $this->rootDir.'/'.self::AGENTS_SKILLS_DIR.'/'.$skill->installedName;
         $claudeTarget = $this->rootDir.'/'.self::CLAUDE_SKILLS_DIR.'/'.$skill->installedName;
@@ -297,7 +309,13 @@ final class SkillInstaller
         if ($this->isUpToDate($previous, $sourceHash, $agentsTarget, $skill->installedName)) {
             $facts['hash'] = $previous['hash'] ?? null;
 
-            return ['facts' => $facts, 'notice' => null];
+            return ['facts' => $facts, 'notice' => null, 'changed' => false];
+        }
+
+        if ($dryRun) {
+            $facts['hash'] = $previous['hash'] ?? null;
+
+            return ['facts' => $facts, 'notice' => null, 'changed' => true];
         }
 
         $this->filesystem->remove($agentsTarget);
@@ -311,7 +329,7 @@ final class SkillInstaller
 
         $facts['hash'] = $this->hasher->hash($agentsTarget);
 
-        return ['facts' => $facts, 'notice' => $notice];
+        return ['facts' => $facts, 'notice' => $notice, 'changed' => true];
     }
 
     /**
@@ -347,7 +365,7 @@ final class SkillInstaller
     /**
      * @param list<string> $recordedTargets
      */
-    private function removeTargets(string $installedName, array $recordedTargets): bool
+    private function removeTargets(string $installedName, array $recordedTargets, bool $dryRun): bool
     {
         $targets = $recordedTargets;
         $targets[] = self::AGENTS_SKILLS_DIR.'/'.$installedName;
@@ -360,7 +378,9 @@ final class SkillInstaller
                 $anyRemoved = true;
             }
 
-            $this->filesystem->remove($path);
+            if (!$dryRun) {
+                $this->filesystem->remove($path);
+            }
         }
 
         return $anyRemoved;

--- a/src/mate/src/Skill/SkillManager.php
+++ b/src/mate/src/Skill/SkillManager.php
@@ -34,6 +34,19 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class SkillManager
 {
+    /**
+     * Below this, a description cannot carry both what the skill does and when it applies.
+     */
+    private const MIN_DESCRIPTION_LENGTH = 40;
+
+    /**
+     * Words a description uses to name the situation it applies to.
+     *
+     * Deliberately generous: the check is a nudge, not a gate, so "Use this for deploying" passes
+     * on the same footing as "Use when deploying".
+     */
+    private const USAGE_CUE_PATTERN = '/\b(when|whenever|if|before|after|while|during|unless|once)\b|\buse (this|it)\b/i';
+
     public function __construct(
         private string $rootDir,
         private ComposerExtensionDiscovery $extensionDiscovery,
@@ -57,9 +70,9 @@ final class SkillManager
         return $this->skillDiscovery->discover($extensions);
     }
 
-    public function reinstall(): SkillInstallResult
+    public function reinstall(bool $dryRun = false): SkillInstallResult
     {
-        return $this->installer->install($this->discover());
+        return $this->installer->install($this->discover(), $dryRun);
     }
 
     /**
@@ -359,6 +372,78 @@ final class SkillManager
             $issues[] = ['level' => 'error', 'message' => \sprintf('Installed SKILL.md does not declare "name: %s".', $installedName)];
         }
 
+        return array_merge(
+            $issues,
+            $this->collectDescriptionIssues($frontmatter['description'] ?? ''),
+            $this->collectReferenceIssues($agentsTarget, $content),
+        );
+    }
+
+    /**
+     * Checks the description an agent decides from, before it ever opens the skill.
+     *
+     * Both findings are suggestions, and deliberately never fail a run: a description that never
+     * says when the skill applies makes the agent guess, but length and wording are heuristics
+     * tuned for English prose, and a correct description can miss both and still read well.
+     *
+     * @return list<SkillIssue>
+     */
+    private function collectDescriptionIssues(string $description): array
+    {
+        if ('' === $description) {
+            return [];
+        }
+
+        $issues = [];
+
+        if (mb_strlen($description) < self::MIN_DESCRIPTION_LENGTH) {
+            $issues[] = ['level' => 'suggestion', 'message' => \sprintf('Description is only %d characters long; an agent picks the skill from it alone.', mb_strlen($description))];
+        }
+
+        if (1 !== preg_match(self::USAGE_CUE_PATTERN, $description)) {
+            $issues[] = ['level' => 'suggestion', 'message' => 'Description does not say when to use the skill; name the situation it applies to, as in "Use when the tests fail" or "Use this for deploying".'];
+        }
+
+        return $issues;
+    }
+
+    /**
+     * Checks that the files SKILL.md links to came along into the installed folder.
+     *
+     * A skill folder is self-contained by design, so a relative link that resolves to nothing is a
+     * dead end for the agent following it. Only inline Markdown links are inspected: a path
+     * mentioned in prose is as likely to name a file in the user's project as one in the skill.
+     *
+     * @return list<SkillIssue>
+     */
+    private function collectReferenceIssues(string $agentsTarget, string $content): array
+    {
+        preg_match_all('/\[[^\]]*\]\(([^)\s]+)\)/', $content, $matches);
+
+        /** @var list<string> $missing */
+        $missing = [];
+        foreach ($matches[1] as $target) {
+            $path = explode('#', explode('?', trim($target, '<>'))[0])[0];
+            if ('' === $path) {
+                continue;
+            }
+
+            // Anything addressable on its own: URLs, mail links, and paths anchored at the project root.
+            if (str_starts_with($path, '/') || 1 === preg_match('#^[a-z][a-z0-9+.-]*:#i', $path)) {
+                continue;
+            }
+
+            $path = rawurldecode($path);
+            if (!file_exists($agentsTarget.'/'.$path) && !\in_array($path, $missing, true)) {
+                $missing[] = $path;
+            }
+        }
+
+        $issues = [];
+        foreach ($missing as $path) {
+            $issues[] = ['level' => 'warning', 'message' => \sprintf('SKILL.md links to "%s", which is not part of the installed skill.', $path)];
+        }
+
         return $issues;
     }
 
@@ -383,8 +468,11 @@ final class SkillManager
             return 'not installed';
         }
 
-        if ([] !== $issues) {
-            return 'stale';
+        // Suggestions are advice about the authored content, not drift, so they leave a skill "ok".
+        foreach ($issues as $issue) {
+            if ('warning' === $issue['level']) {
+                return 'stale';
+            }
         }
 
         return 'ok';

--- a/src/mate/tests/Command/SkillsInstallCommandTest.php
+++ b/src/mate/tests/Command/SkillsInstallCommandTest.php
@@ -73,10 +73,54 @@ final class SkillsInstallCommandTest extends TestCase
         $this->assertStringContainsString('1 skill installed', $output);
     }
 
+    public function testDryRunReportsTheNewSkillWithoutWritingAnything()
+    {
+        $this->createPackageWithSkill();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['--dry-run' => true]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertDirectoryDoesNotExist($this->rootDir.'/.agents/skills/mate-system-information');
+        $this->assertFileDoesNotExist((new SkillStateRepository($this->rootDir))->path());
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('dry run', $output);
+        $this->assertStringContainsString('Would install 1 new skill', $output);
+        $this->assertStringContainsString('mate-system-information', $output);
+    }
+
+    public function testDryRunReportsAChangedSourceAsARebuild()
+    {
+        $this->createPackageWithSkill();
+        (new CommandTester($this->command()))->execute([]);
+
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.', 'UPDATED UPSTREAM');
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['--dry-run' => true]);
+
+        $this->assertStringContainsString('Would rebuild 1 skill', $tester->getDisplay());
+        $this->assertStringNotContainsString('UPDATED UPSTREAM', file_get_contents($this->rootDir.'/.agents/skills/mate-system-information/SKILL.md') ?: '');
+    }
+
+    public function testDryRunOnAnUpToDateProjectReportsNothingToDo()
+    {
+        $this->createPackageWithSkill();
+        (new CommandTester($this->command()))->execute([]);
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['--dry-run' => true]);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Nothing to do', $output);
+        $this->assertStringNotContainsString('Would install', $output);
+    }
+
     private function createPackageWithSkill(): void
     {
         $this->createInstalledPackage($this->rootDir);
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
     }
 
     private function command(): SkillsInstallCommand

--- a/src/mate/tests/Command/SkillsListCommandTest.php
+++ b/src/mate/tests/Command/SkillsListCommandTest.php
@@ -114,7 +114,7 @@ final class SkillsListCommandTest extends TestCase
     private function createPackageWithSkill(): void
     {
         $this->createInstalledPackage($this->rootDir);
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
     }
 
     private function command(): SkillsListCommand

--- a/src/mate/tests/Command/SkillsPruneCommandTest.php
+++ b/src/mate/tests/Command/SkillsPruneCommandTest.php
@@ -91,7 +91,7 @@ final class SkillsPruneCommandTest extends TestCase
     private function installFixture(): void
     {
         $this->createInstalledPackage($this->rootDir);
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
         $this->createManager($this->rootDir)->reinstall();
     }
 

--- a/src/mate/tests/Command/SkillsValidateCommandTest.php
+++ b/src/mate/tests/Command/SkillsValidateCommandTest.php
@@ -117,7 +117,7 @@ final class SkillsValidateCommandTest extends TestCase
     public function testWarnsWhenTheSourceChangedSinceTheLastInstall()
     {
         $this->installFixture();
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.', 'UPDATED UPSTREAM');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.', 'UPDATED UPSTREAM');
 
         $tester = new CommandTester($this->command());
         $tester->execute([]);
@@ -130,7 +130,7 @@ final class SkillsValidateCommandTest extends TestCase
     public function testStrictTurnsWarningsIntoFailures()
     {
         $this->installFixture();
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.', 'UPDATED UPSTREAM');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.', 'UPDATED UPSTREAM');
 
         $tester = new CommandTester($this->command());
         $tester->execute(['--strict' => true]);
@@ -188,10 +188,97 @@ final class SkillsValidateCommandTest extends TestCase
         $this->assertNotSame([], $decoded['skills'][0]['issues']);
     }
 
-    private function installFixture(): void
+    public function testWarnsAboutALinkThatIsNotPartOfTheSkill()
+    {
+        $this->createInstalledPackage($this->rootDir);
+        $this->createSkill(
+            $this->rootDir.'/vendor/vendor/pkg-a/skills',
+            'system-information',
+            'Inspect the runtime environment when diagnosing a version-specific problem.',
+            'See [the checklist](references/checklist.md) and [the docs](https://symfony.com).',
+        );
+        $this->createManager($this->rootDir)->reinstall();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['--strict' => true]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('links to "references/checklist.md"', $output);
+        $this->assertStringNotContainsString('symfony.com', $output);
+    }
+
+    public function testAcceptsALinkToAFileShippedWithTheSkill()
+    {
+        $this->createInstalledPackage($this->rootDir);
+        $skillDir = $this->rootDir.'/vendor/vendor/pkg-a/skills/system-information';
+        $this->createSkill(
+            $this->rootDir.'/vendor/vendor/pkg-a/skills',
+            'system-information',
+            'Inspect the runtime environment when diagnosing a version-specific problem.',
+            'See [the checklist](references/checklist.md).',
+        );
+        mkdir($skillDir.'/references', 0777, true);
+        file_put_contents($skillDir.'/references/checklist.md', "# Checklist\n");
+        $this->createManager($this->rootDir)->reinstall();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['--strict' => true]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    public function testSuggestsABetterDescriptionThatCannotTriggerTheSkill()
     {
         $this->createInstalledPackage($this->rootDir);
         $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createManager($this->rootDir)->reinstall();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('SUGGESTION', $output);
+        $this->assertStringContainsString('Description is only 12 characters long', $output);
+        $this->assertStringContainsString('does not say when to use the skill', $output);
+    }
+
+    public function testStrictDoesNotFailOnDescriptionSuggestions()
+    {
+        $this->createInstalledPackage($this->rootDir);
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createManager($this->rootDir)->reinstall();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['--strict' => true, '--format' => 'json']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        $decoded = json_decode($tester->getDisplay(), true);
+        $this->assertIsArray($decoded);
+        $this->assertTrue($decoded['valid']);
+        $this->assertSame('ok', $decoded['skills'][0]['status']);
+        $this->assertSame('suggestion', $decoded['skills'][0]['issues'][0]['level']);
+    }
+
+    public function testAcceptsADescriptionThatNamesTheSituationWithoutATriggerWord()
+    {
+        $this->createInstalledPackage($this->rootDir);
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Use this for deploying the application to production.');
+        $this->createManager($this->rootDir)->reinstall();
+
+        $tester = new CommandTester($this->command());
+        $tester->execute(['--strict' => true]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringNotContainsString('SUGGESTION', $tester->getDisplay());
+    }
+
+    private function installFixture(): void
+    {
+        $this->createInstalledPackage($this->rootDir);
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
         $this->createManager($this->rootDir)->reinstall();
     }
 

--- a/src/mate/tests/Skill/SkillDiscoveryTest.php
+++ b/src/mate/tests/Skill/SkillDiscoveryTest.php
@@ -39,8 +39,8 @@ final class SkillDiscoveryTest extends TestCase
 
     public function testDiscoversPackageAndRootSkills()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
-        $this->createSkill($this->rootDir.'/mate/skills', 'project-notes', 'Project notes.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
+        $this->createSkill($this->rootDir.'/mate/skills', 'project-notes', 'Read the project notes when starting work in this repository.');
 
         $skills = $this->discovery()->discover([
             'vendor/pkg-a' => ['dirs' => [], 'includes' => [], 'skills' => ['vendor/vendor/pkg-a/skills']],
@@ -103,8 +103,8 @@ final class SkillDiscoveryTest extends TestCase
 
     public function testThrowsOnInstalledNameCollisionBetweenPackages()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'From A.');
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-b/skills', 'system-information', 'From B.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect package A when diagnosing a version-specific problem.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-b/skills', 'system-information', 'Inspect package B when diagnosing a version-specific problem.');
 
         $this->expectException(SkillCollisionException::class);
         $this->expectExceptionMessage('mate-system-information');

--- a/src/mate/tests/Skill/SkillInstallerTest.php
+++ b/src/mate/tests/Skill/SkillInstallerTest.php
@@ -46,7 +46,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testManagedSkillIsCopiedAndRecordsFacts()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
 
         $result = $this->installer()->install($this->discover());
 
@@ -75,7 +75,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testFrontmatterNameIsRewrittenToInstalledName()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
 
         $this->installer()->install($this->discover());
 
@@ -91,7 +91,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testReinstallIsIdempotent()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
 
         $this->installer()->install($this->discover());
         $afterFirst = file_get_contents($this->rootDir.'/mate/extensions.php');
@@ -106,7 +106,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testHandEditedTargetIsRebuilt()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.', 'ORIGINAL');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.', 'ORIGINAL');
         $this->installer()->install($this->discover());
 
         $installedFile = $this->rootDir.'/.agents/skills/mate-system-information/SKILL.md';
@@ -123,11 +123,11 @@ final class SkillInstallerTest extends TestCase
     public function testSourceChangeTriggersRebuild()
     {
         $skillsDir = $this->rootDir.'/vendor/vendor/pkg-a/skills';
-        $this->createSkill($skillsDir, 'system-information', 'System info.', 'FIRST');
+        $this->createSkill($skillsDir, 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.', 'FIRST');
         $this->installer()->install($this->discover());
         $firstHash = $this->state('vendor/pkg-a', 'system-information')['source_hash'];
 
-        $this->createSkill($skillsDir, 'system-information', 'System info.', 'SECOND');
+        $this->createSkill($skillsDir, 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.', 'SECOND');
         $this->installer()->install($this->discover());
 
         $content = file_get_contents($this->rootDir.'/.agents/skills/mate-system-information/SKILL.md');
@@ -138,7 +138,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testClaudeMirrorFallsBackToCopyWhenLinkerFails()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
 
         $result = $this->installer(new FailingLinker())->install($this->discover());
 
@@ -152,7 +152,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testMirrorPointingElsewhereIsRelinked()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
         $this->installer()->install($this->discover());
 
         mkdir($this->rootDir.'/elsewhere', 0777, true);
@@ -167,7 +167,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testVanishedSkillIsAutoPruned()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
         $this->installer()->install($this->discover());
 
         $this->removeDirectory($this->rootDir.'/vendor/vendor/pkg-a');
@@ -185,7 +185,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testDisabledSkillRemovesTargetsAndRecordsDisabledState()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
         $this->installer()->install($this->discover());
 
         (new SkillStateRepository($this->rootDir))->setEnabled('vendor/pkg-a', 'system-information', false);
@@ -204,7 +204,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testDisabledExtensionKeepsSkillOutOfGeneratedFolders()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
         (new SkillStateRepository($this->rootDir))->write(['vendor/pkg-a' => ['enabled' => false]]);
 
         $result = $this->installer()->install($this->discover());
@@ -215,8 +215,8 @@ final class SkillInstallerTest extends TestCase
 
     public function testOverrideBuildsFromUserCopyAndLeavesItUntouched()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Vendor body.', 'VENDOR CONTENT');
-        $this->createSkill($this->rootDir.'/mate/skills', 'system-information', 'Overridden.', 'OVERRIDE CONTENT');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the vendor skill when diagnosing a version-specific problem.', 'VENDOR CONTENT');
+        $this->createSkill($this->rootDir.'/mate/skills', 'system-information', 'Inspect the overridden skill when diagnosing a version-specific problem.', 'OVERRIDE CONTENT');
         (new SkillStateRepository($this->rootDir))->setMode('vendor/pkg-a', 'system-information', 'override');
 
         $result = $this->installer()->install($this->discover());
@@ -241,7 +241,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testOverrideWithMissingUserCopyIsSkipped()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Vendor body.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the vendor skill when diagnosing a version-specific problem.');
         (new SkillStateRepository($this->rootDir))->setMode('vendor/pkg-a', 'system-information', 'override');
 
         $result = $this->installer()->install($this->discover());
@@ -252,7 +252,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testGitignoreIsLeftAlone()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
         file_put_contents($this->rootDir.'/.gitignore', "/vendor/\n");
 
         $this->installer()->install($this->discover());
@@ -263,7 +263,7 @@ final class SkillInstallerTest extends TestCase
 
     public function testStraysArePrunedOnInstall()
     {
-        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'System info.');
+        $this->createSkill($this->rootDir.'/vendor/vendor/pkg-a/skills', 'system-information', 'Inspect the runtime environment when diagnosing a version-specific problem.');
         mkdir($this->rootDir.'/.agents/skills/mate-left-over', 0777, true);
         mkdir($this->rootDir.'/.agents/skills/my-own-skill', 0777, true);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Two gaps left over from #2370. Independent of #2433 and #2434.

`skills:install --dry-run` answers "what would this change" before it changes it. The same reconciler runs, it just writes nothing: no generated folder is touched and `mate/extensions.php` stays as it is. The result now also carries the skills that were rebuilt, not only the newly installed ones, so a real run reports the same groups the dry run does.

```terminal
$ vendor/bin/mate skills:install --dry-run
Would install 1 new skill: mate-symfony-profiler
Would rebuild 1 skill: mate-system-information
```

`skills:validate` so far only compared the generated folders against the record, which says nothing about whether the installed skill is any good. Two content checks are added, both warnings, so they show up under `--strict` and in CI without breaking a normal run: a Markdown link to a file that is not part of the installed skill, and a description that is very short or never says when the skill applies. That description is all an agent has when it decides whether to load the skill.
