### PR TITLE
[Chat] Fix flaky MongoDB message store save test

### DIFF
--- a/src/chat/src/Bridge/MongoDb/Tests/MessageStoreTest.php
+++ b/src/chat/src/Bridge/MongoDb/Tests/MessageStoreTest.php
@@ -68,16 +68,43 @@ final class MessageStoreTest extends TestCase
 
         $this->assertArrayHasKey('_id', $payload);
 
+        $documents = null;
+
         $collection = $this->createMock(Collection::class);
-        $collection->expects($this->once())->method('insertMany')->with([
-            $payload,
-        ]);
+        $collection->expects($this->once())->method('insertMany')->with($this->callback(
+            /**
+             * @param list<array<string, mixed>> $insertedDocuments
+             */
+            static function (array $insertedDocuments) use (&$documents): bool {
+                $documents = $insertedDocuments;
+
+                return true;
+            },
+        ));
 
         $client = $this->createMock(Client::class);
         $client->expects($this->once())->method('getCollection')->willReturn($collection);
 
         $messageStore = new MessageStore($client, 'foo', 'bar', $serializer);
+
+        $before = (new \DateTimeImmutable())->getTimestamp();
         $messageStore->save($bag);
+        $after = (new \DateTimeImmutable())->getTimestamp();
+
+        $this->assertIsArray($documents);
+        $this->assertCount(1, $documents);
+
+        $document = $documents[0];
+
+        // The normalizer stamps "addedAt" on every call, so it cannot equal the expectation built above.
+        $this->assertArrayHasKey('addedAt', $document);
+        $this->assertIsInt($document['addedAt']);
+        $this->assertGreaterThanOrEqual($before, $document['addedAt']);
+        $this->assertLessThanOrEqual($after, $document['addedAt']);
+
+        unset($document['addedAt'], $payload['addedAt']);
+
+        $this->assertSame($payload, $document);
     }
 
     public function testMessageStoreCanLoad()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

`MessageNormalizer::normalize()` stamps `addedAt` with the current timestamp on every call. `testMessageStoreCanSave` normalized the message once to build the expected document, and `save()` normalized it a second time, so the strict `->with([$payload])` comparison failed whenever a second boundary fell between the two calls.

Seen on CI:

```
Parameter 0 for invocation MongoDB\Collection::insertMany([...], []) does not match expected value.
-        'addedAt' => 1787518330
+        'addedAt' => 1787518331
```

The test now captures the inserted document, asserts its `addedAt` lies within the wall-clock window bracketing `save()`, and compares every remaining field verbatim. Coverage is unchanged for the stable fields and stronger for the timestamp, which previously was compared against a value that carried no meaning.

Injecting a clock into `MessageNormalizer` would also fix it, but that is a public API change to a class all chat bridges consume, purely for one test's determinism.

The other chat bridges do not share the race: they either feed a normalized payload in as mock response input for `load()`, use a hardcoded string, or round-trip through a real store.

Verified by forcing the second boundary with a busy-wait, which reproduces the CI failure on the old assertion and passes on the new one, plus 200 consecutive runs of the bridge suite with random test order and no failures.
