### PR TITLE
[MCP Bundle] Make #[Target('<client>')] resolve to the named client

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -136,6 +136,29 @@ MCP Bundle
    as more than one server enables the STDIO transport — one process can serve only one of them.
    `debug:mcp` gained a `--server` option to restrict its output to a single server.
 
+ * A configured MCP client is autowired under its own name, not under `<name>Client`. Rename the
+   argument to match:
+
+   ```diff
+    public function __construct(
+   -    private McpClientInterface $researchClient,
+   +    private McpClientInterface $research,
+    ) {
+    }
+   ```
+
+   The same alias backs `#[Target('research')]`, which is the form the bundle's documentation shows and
+   the one to use when the argument is named for its role rather than for the client:
+
+   ```php
+   public function __construct(
+       #[Target('research')] private McpClientInterface $client,
+   ) {
+   }
+   ```
+
+   A single configured client also answers a plain `McpClientInterface` type hint, unchanged.
+
 Mate
 ----
 

--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -14,6 +14,8 @@ CHANGELOG
  * Add `Symfony\AI\McpBundle\Client\McpClientInterface` (service `mcp.client.<name>`) and
    `Symfony\AI\McpBundle\Client\ServerConnectionInterface` (service `mcp.client.<name>.server.<server>`),
    which own the connection lifecycle: connecting on first use and disconnecting on kernel reset
+ * Add an argument alias per configured client, so `#[Target('<name>')] McpClientInterface $client`
+   injects the `mcp.client.<name>` service
  * Add `--clients` and `--client` options to `debug:mcp`, which now covers both sides of the bundle:
    the configured servers and what the configured clients reach
  * Add a `--server` option to `debug:mcp` and a server argument to `mcp:server`

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -167,7 +167,7 @@ final class McpBundle extends AbstractBundle
                 ->setArguments([$clientName, new Reference($locatorId)])
                 ->addTag('mcp.client', ['name' => $clientName]);
 
-            $container->registerAliasForArgument('mcp.client.'.$clientName, McpClientInterface::class, $clientName.' client');
+            $container->registerAliasForArgument('mcp.client.'.$clientName, McpClientInterface::class, $clientName);
 
             $clientReferences[$clientName] = new Reference('mcp.client.'.$clientName);
         }

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleClientTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleClientTest.php
@@ -211,7 +211,8 @@ final class McpBundleClientTest extends TestCase
             'research' => ['servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']]],
         ]));
 
-        $this->assertSame('mcp.client.research', (string) $container->getAlias(McpClientInterface::class.' $researchClient'));
+        $this->assertSame('mcp.client.research', (string) $container->getAlias(McpClientInterface::class.' $research'));
+        $this->assertFalse($container->hasAlias(McpClientInterface::class.' $researchClient'));
         // A single client also answers a plain McpClientInterface type hint.
         $this->assertSame('mcp.client.research', (string) $container->getAlias(McpClientInterface::class));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The documentation injects a client by name:

```php
public function __construct(
    #[Target('research')] private McpClientInterface $client,
) {
}
```

That fails at compile time with *"no such target exists"*: `McpBundle::loadExtension()` registered the argument alias as `'research client'`, which `registerAliasForArgument()` camel-cases into `McpClientInterface $researchClient` — `#[Target('research')]` looks for `$research`, which was never registered.

This registers the bare name instead, the way the AI Bundle aliases platforms (`PlatformInterface $openai`), agents (`AgentInterface $support`) and stores — so the documented `#[Target('research')]` and plain `McpClientInterface $research` both resolve. The `'research client'` spelling is dropped: it was introduced with multi-client support (#2412) and is unreleased, so there is nothing to keep compatible with.

`testClientIsAliasedForArgument()` now asserts the bare name and the absence of the suffixed alias.
