### PR TITLE
[MCP Bundle] Resolve completion providers from the container

### DIFF
--- a/src/mcp-bundle/src/DependencyInjection/McpPass.php
+++ b/src/mcp-bundle/src/DependencyInjection/McpPass.php
@@ -189,9 +189,26 @@ final class McpPass implements CompilerPassInterface
         /** @var array<string, array<string, array{template: string, meta: array<string, mixed>|null}>> $appTemplates */
         $appTemplates = $container->hasParameter('mcp.servers.app_tool_templates') ? $container->getParameter('mcp.servers.app_tool_templates') : [];
 
+        // Resolved by class name at request time, so every server needs all of them.
+        $completionProviders = [];
+        foreach ($container->findTaggedServiceIds('mcp.completion_provider') as $serviceId => $tags) {
+            $definition = $container->getDefinition($serviceId);
+            if ($definition->isAbstract()) {
+                continue;
+            }
+
+            $class = $container->getParameterBag()->resolveValue($definition->getClass() ?? $serviceId);
+            $completionProviders[$class] = new Reference($serviceId);
+            $completionProviders[$serviceId] ??= new Reference($serviceId);
+        }
+
         foreach (array_keys($servers) as $server) {
             foreach ($appHandlers[$server] ?? [] as $key => $id) {
                 $serviceReferences[$server][$key] ??= new Reference($id);
+            }
+
+            foreach ($completionProviders as $key => $reference) {
+                $serviceReferences[$server][$key] ??= $reference;
             }
 
             if ([] === ($serviceReferences[$server] ?? [])) {

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -15,6 +15,7 @@ use Mcp\Capability\Attribute\McpPrompt;
 use Mcp\Capability\Attribute\McpResource;
 use Mcp\Capability\Attribute\McpResourceTemplate;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Completion\ProviderInterface as CompletionProviderInterface;
 use Mcp\Capability\Registry;
 use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Client as McpSdkClient;
@@ -91,6 +92,11 @@ final class McpBundle extends AbstractBundle
 
         $builder->registerForAutoconfiguration(LoaderInterface::class)
             ->addTag('mcp.loader');
+
+        // Resolved from the server's container at request time, so a provider can
+        // have constructor dependencies like any other service.
+        $builder->registerForAutoconfiguration(CompletionProviderInterface::class)
+            ->addTag('mcp.completion_provider');
 
         $builder->registerForAutoconfiguration(RequestHandlerInterface::class)
             ->addTag('mcp.request_handler');

--- a/src/mcp-bundle/tests/DependencyInjection/McpPassTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpPassTest.php
@@ -457,13 +457,22 @@ class UserTemplate
 
 class CityCompletionProvider implements CompletionProviderInterface
 {
-    public function __construct(private readonly string $unresolvable = 'needs the container')
+    /**
+     * A constructor argument is the whole point of the fixture: instantiated
+     * with `new`, this provider cannot be built at all.
+     *
+     * @param list<string> $cities
+     */
+    public function __construct(private readonly array $cities = ['berlin', 'brussels'])
     {
     }
 
     public function getCompletions(string $currentValue): array
     {
-        return ['berlin', 'brussels'];
+        return array_values(array_filter(
+            $this->cities,
+            static fn (string $city): bool => str_starts_with($city, $currentValue),
+        ));
     }
 }
 

--- a/src/mcp-bundle/tests/DependencyInjection/McpPassTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpPassTest.php
@@ -15,6 +15,7 @@ use Mcp\Capability\Attribute\McpPrompt;
 use Mcp\Capability\Attribute\McpResource;
 use Mcp\Capability\Attribute\McpResourceTemplate;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Completion\ProviderInterface as CompletionProviderInterface;
 use Mcp\Schema\Icon;
 use Mcp\Schema\ToolAnnotations;
 use PHPUnit\Framework\TestCase;
@@ -194,6 +195,27 @@ final class McpPassTest extends TestCase
         $reference = $services[TimeTool::class]->getValues()[0];
         $this->assertInstanceOf(Reference::class, $reference);
         $this->assertSame('app.time_tool', (string) $reference);
+    }
+
+    public function testCompletionProvidersJoinEveryServerLocator()
+    {
+        // Resolved by class name out of the server's container at request time.
+        $container = $this->containerWithBuilder(['default' => [], 'editors' => []]);
+        $container->setDefinition(TimeTool::class, (new Definition(TimeTool::class))->addTag('mcp.tool', ['method' => 'getCurrentTime']));
+        $container->setDefinition('app.completion', (new Definition(CityCompletionProvider::class))->addTag('mcp.completion_provider'));
+
+        (new McpPass())->process($container);
+
+        foreach (['default', 'editors'] as $server) {
+            $services = $this->locatorServices($container, $server);
+
+            $this->assertArrayHasKey(CityCompletionProvider::class, $services, $server);
+            $this->assertArrayHasKey('app.completion', $services, $server);
+
+            $reference = $services[CityCompletionProvider::class]->getValues()[0];
+            $this->assertInstanceOf(Reference::class, $reference);
+            $this->assertSame('app.completion', (string) $reference);
+        }
     }
 
     public function testThrowsWhenExplicitTagMethodDoesNotExist()
@@ -430,6 +452,18 @@ class UserTemplate
     public function read(string $id): string
     {
         return $id;
+    }
+}
+
+class CityCompletionProvider implements CompletionProviderInterface
+{
+    public function __construct(private readonly string $unresolvable = 'needs the container')
+    {
+    }
+
+    public function getCompletions(string $currentValue): array
+    {
+        return ['berlin', 'brussels'];
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

A completion provider with a constructor dependency always fails:

```php
final class CityCompletionProvider implements ProviderInterface
{
    public function __construct(private CityRepository $cities)
    {
    }

    public function getCompletions(string $currentValue, SessionInterface $session): array
    {
        return $this->cities->matching($currentValue);
    }
}
```

```php
#[McpTool(name: 'find_venue')]
public function findVenue(
    #[CompletionProvider(provider: CityCompletionProvider::class)] string $city,
): string {
}
```

Calling `completion/complete` returns *"Error while handling completion request"*.

The SDK resolves `provider:` at request time from the container the server was built with, and falls back to `new $provider()` when the container does not have it. The bundle hands each server a service locator built in `McpPass`, but it only holds element handlers — tools, prompts, resources and apps — so a provider is never in it. The fallback then instantiates it with no arguments and dies with an `ArgumentCountError`, which the SDK reports as the generic message above.

Providers with no constructor arguments work by accident, which is why this is easy to miss.

This autoconfigures every service implementing `Mcp\Capability\Completion\ProviderInterface` with an `mcp.completion_provider` tag and adds them to each server's locator, keyed by both class name and service id so either spelling of `provider:` resolves. `McpPassTest` covers the locator contents.

Found while building a demo application against the bundle: the provider worked as a plain class and broke the moment it needed a repository.