### PR TITLE
[MCP Bundle] Forward completion/complete to the server

### DIFF
--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -14,8 +14,9 @@ CHANGELOG
  * Add `Symfony\AI\McpBundle\Client\McpClientInterface` (service `mcp.client.<name>`) and
    `Symfony\AI\McpBundle\Client\ServerConnectionInterface` (service `mcp.client.<name>.server.<server>`),
    which own the connection lifecycle: connecting on first use and disconnecting on kernel reset
- * Add an argument alias per configured client, so `#[Target('<name>')] McpClientInterface $client`
-   injects the `mcp.client.<name>` service
+ * Drop `client` suffix on alias for argument injection of `McpClientInterface`
+ * Add `Symfony\AI\McpBundle\Client\ServerConnectionInterface::complete()`, forwarding `completion/complete`
+   so a client can ask a remote server to complete a prompt or resource-template argument
  * Add `--clients` and `--client` options to `debug:mcp`, which now covers both sides of the bundle:
    the configured servers and what the configured clients reach
  * Add a `--server` option to `debug:mcp` and a server argument to `mcp:server`

--- a/src/mcp-bundle/src/Client/ServerConnection.php
+++ b/src/mcp-bundle/src/Client/ServerConnection.php
@@ -16,7 +16,10 @@ use Mcp\Client\Transport\TransportInterface;
 use Mcp\Exception\ExceptionInterface as McpExceptionInterface;
 use Mcp\Schema\Enum\LoggingLevel;
 use Mcp\Schema\Implementation;
+use Mcp\Schema\PromptReference;
+use Mcp\Schema\ResourceReference;
 use Mcp\Schema\Result\CallToolResult;
+use Mcp\Schema\Result\CompletionCompleteResult;
 use Mcp\Schema\Result\GetPromptResult;
 use Mcp\Schema\Result\ListPromptsResult;
 use Mcp\Schema\Result\ListResourcesResult;
@@ -171,6 +174,11 @@ final class ServerConnection implements ServerConnectionInterface, ResetInterfac
     public function getPrompt(string $name, array $arguments = [], ?callable $onProgress = null): GetPromptResult
     {
         return $this->call('prompts/get', fn (): GetPromptResult => $this->client->getPrompt($name, $arguments, $onProgress));
+    }
+
+    public function complete(PromptReference|ResourceReference $ref, array $argument): CompletionCompleteResult
+    {
+        return $this->call('completion/complete', fn (): CompletionCompleteResult => $this->client->complete($ref, $argument));
     }
 
     public function setLoggingLevel(LoggingLevel $level): void

--- a/src/mcp-bundle/src/Client/ServerConnectionInterface.php
+++ b/src/mcp-bundle/src/Client/ServerConnectionInterface.php
@@ -14,9 +14,12 @@ namespace Symfony\AI\McpBundle\Client;
 use Mcp\Schema\Enum\LoggingLevel;
 use Mcp\Schema\Implementation;
 use Mcp\Schema\Prompt;
+use Mcp\Schema\PromptReference;
 use Mcp\Schema\ResourceDefinition;
+use Mcp\Schema\ResourceReference;
 use Mcp\Schema\ResourceTemplate;
 use Mcp\Schema\Result\CallToolResult;
+use Mcp\Schema\Result\CompletionCompleteResult;
 use Mcp\Schema\Result\GetPromptResult;
 use Mcp\Schema\Result\ListPromptsResult;
 use Mcp\Schema\Result\ListResourcesResult;
@@ -104,6 +107,13 @@ interface ServerConnectionInterface
      * @param (callable(float $progress, ?float $total, ?string $message): void)|null $onProgress
      */
     public function getPrompt(string $name, array $arguments = [], ?callable $onProgress = null): GetPromptResult;
+
+    /**
+     * Ask the server to complete one argument of a prompt or resource template.
+     *
+     * @param array{name: string, value: string} $argument
+     */
+    public function complete(PromptReference|ResourceReference $ref, array $argument): CompletionCompleteResult;
 
     public function setLoggingLevel(LoggingLevel $level): void;
 }

--- a/src/mcp-bundle/tests/Client/ServerConnectionTest.php
+++ b/src/mcp-bundle/tests/Client/ServerConnectionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\McpBundle\Tests\Client;
 
 use Mcp\Client;
+use Mcp\Schema\PromptReference;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpBundle\Client\ServerConnection;
 use Symfony\AI\McpBundle\Exception\ConnectionException;
@@ -158,6 +159,20 @@ final class ServerConnectionTest extends TestCase
         $connection->reset();
 
         $this->assertFalse($connection->isConnected());
+    }
+
+    public function testCompleteForwardsTheReferenceAndArgument()
+    {
+        $transport = new InMemoryTransport(['completion/complete' => [
+            ['completion' => ['values' => ['berlin'], 'total' => 1, 'hasMore' => false]],
+        ]]);
+        $connection = $this->createConnection($transport);
+
+        $result = $connection->complete(new PromptReference('venue'), ['name' => 'city', 'value' => 'ber']);
+
+        $call = end($transport->sent);
+        $this->assertSame('completion/complete', $call['method']);
+        $this->assertSame(['berlin'], $result->values);
     }
 
     public function testNamesAreExposed()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

`ServerConnectionInterface` wraps the SDK client's request surface — `callTool()`, `readResource()`, `getPrompt()`, `listTools()` and so on — but not `complete()`. An application using the bundle therefore could not reach argument completion at all without reaching past the abstraction to the raw `Mcp\Client`, which is the one thing the connection exists to avoid.

It is also the client-side counterpart of something the bundle already supports on the server side: `#[CompletionProvider]` makes a server answer `completion/complete`, and until now a bundle-configured client had no way to ask.

```php
public function __construct(
    #[Target('research')] private McpClientInterface $client,
) {
}

public function citiesStartingWith(string $prefix): array
{
    return $this->client->getServer('venues')
        ->complete(new PromptReference('venue'), ['name' => 'city', 'value' => $prefix])
        ->values;
}
```

Wrapped in the same error translation as the rest of the surface, so a transport failure surfaces as the bundle's `RemoteCallException` naming the operation rather than an SDK exception. `ServerConnectionTest` covers the forwarded call.

Two neighbouring methods — `getProtocolVersion()` and `sendRootsListChanged()` — are deliberately **not** in this PR: both need `Mcp\Client` methods that do not exist in `mcp/sdk` `^0.7`, the constraint this bundle currently requires. They make sense once that constraint moves.

Found while building a demo application against the bundle: the server answered `completion/complete` and the bundle's own client could not ask the question.