### PR TITLE
[Agent] Add Human-in-the-Loop tool approval and resumable checkpoints

### DIFF
--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -664,6 +664,51 @@ The sources can be fetched from the metadata of the result after the agent execu
 
 See `Anthropic Toolbox Example`_ for a complete example using sources with Wikipedia tool.
 
+Human-in-the-Loop (HITL) & Tool Approval
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For sensitive operations (such as executing payments, modifying database records, or sending emails), you can require human confirmation before a tool is executed using the :class:`Symfony\\AI\\Agent\\Approval\\Attribute\\RequiresApproval` attribute::
+
+    use Symfony\AI\Agent\Approval\Attribute\RequiresApproval;
+    use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+
+    #[AsTool('transfer_funds', 'Transfers money from user account to recipient')]
+    #[RequiresApproval(prompt: 'Confirm transfer of ${amount} to account #{toAccount}', roles: ['ROLE_FINANCE_ADMIN'])]
+    final class PaymentTool
+    {
+        public function __invoke(string $toAccount, float $amount): string
+        {
+            // Execute transfer
+            return sprintf('Transferred $%0.2f to %s', $amount, $toAccount);
+        }
+    }
+
+When an agent encounters a tool that requires approval, execution is suspended and returns an instance of :class:`Symfony\\AI\\Agent\\Approval\\ApprovalPendingResult`::
+
+    use Symfony\AI\Agent\Approval\ApprovalDecision;
+    use Symfony\AI\Agent\Approval\ApprovalManager;
+    use Symfony\AI\Agent\Approval\ApprovalPendingResult;
+    use Symfony\AI\Agent\Approval\Checkpoint\CheckpointSigner;
+    use Symfony\AI\Agent\Approval\Checkpoint\InMemoryCheckpointStore;
+
+    $store = new InMemoryCheckpointStore();
+    $signer = new CheckpointSigner($secret);
+    $approvalManager = new ApprovalManager([], $store, $signer);
+
+    $agent = new Agent($platform, $model, toolbox: $toolbox, approvalManager: $approvalManager);
+
+    $result = $agent->call('Transfer $500 to ACC-99')->getResult();
+
+    if ($result instanceof ApprovalPendingResult) {
+        $checkpoint = $result->getCheckpoint();
+        $token = $result->getToken(); // Secure, cryptographically signed token
+
+        // Later (e.g. from an HTTP Controller, webhook, or CLI command):
+        $finalResult = $agent->resume($token, ApprovalDecision::approve());
+        // Or reject with feedback:
+        // $finalResult = $agent->resume($token, ApprovalDecision::reject('Payment limit exceeded'));
+    }
+
 Tool Filtering
 ~~~~~~~~~~~~~~
 

--- a/examples/agent/human-in-the-loop.php
+++ b/examples/agent/human-in-the-loop.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\ApprovalManager;
+use Symfony\AI\Agent\Approval\ApprovalPendingResult;
+use Symfony\AI\Agent\Approval\Attribute\RequiresApproval;
+use Symfony\AI\Agent\Approval\Checkpoint\CheckpointSigner;
+use Symfony\AI\Agent\Approval\Checkpoint\InMemoryCheckpointStore;
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+#[AsTool('transfer_funds', 'Transfers money from the user account to a destination IBAN')]
+#[RequiresApproval(prompt: 'Transfer ${amount} to account #{iban}', roles: ['ROLE_FINANCE_ADMIN'])]
+final class PaymentService
+{
+    public function __invoke(string $iban, float $amount): string
+    {
+        return sprintf('Successfully wired $%0.2f to account %s. Transaction ID: TX-%d', $amount, $iban, random_int(10000, 99999));
+    }
+}
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+$store = new InMemoryCheckpointStore();
+$signer = new CheckpointSigner('app-secret-demo-key');
+$approvalManager = new ApprovalManager([], $store, $signer);
+
+$toolbox = new Toolbox([new PaymentService()], logger: logger());
+$agent = new Agent($platform, 'gpt-4o-mini', toolbox: $toolbox, approvalManager: $approvalManager);
+
+$messages = new MessageBag(
+    Message::forSystem('You are an AI financial assistant. Help the user initiate money transfers safely.'),
+    Message::ofUser('Please transfer $250.00 to IBAN DE89370400440532013000'),
+);
+
+output()->writeln('<info>1. Initiating transfer request...</info>');
+$result = $agent->call($messages)->getResult();
+
+if ($result instanceof ApprovalPendingResult) {
+    output()->writeln('<comment>2. Execution paused for Human Approval!</comment>');
+    output()->writeln(sprintf('   Prompt: %s', $result->getPrompt()));
+    output()->writeln(sprintf('   Roles required: %s', implode(', ', $result->getRoles())));
+    output()->writeln(sprintf('   Checkpoint ID: %s', $result->getCheckpoint()->getId()));
+    output()->writeln(sprintf('   Signed Token: %s', substr($result->getToken() ?? '', 0, 40).'...'));
+
+    output()->writeln('<info>3. Human Admin approves the transfer with positive feedback...</info>');
+    $finalResult = $agent->resume($result->getCheckpoint(), ApprovalDecision::approve('Approved by CFO'));
+
+    output()->writeln('<info>4. Final Agent Response:</info>');
+    output()->writeln($finalResult->getContent());
+} else {
+    output()->writeln($result->getContent());
+}

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+0.14
+----
+
+ * Add `#[RequiresApproval]` attribute, `ApprovalManager`, `ApprovalPolicyInterface`, and `ApprovalPendingResult` for Human-in-the-Loop (HITL) tool execution
+ * Add `ExecutionCheckpoint`, `CheckpointStoreInterface`, `InMemoryCheckpointStore`, `CheckpointSignerInterface`, and `CheckpointSigner` for state suspension and durable resumption
+ * Add `AgentInterface::resume()` and `Agent::resume()` to resume suspended agent runs with `ApprovalDecision` (approve, reject, modify)
+ * Add `ToolApprovalRequestedEvent` and `ToolApprovalResolvedEvent`
+
 0.13
 ----
 

--- a/src/agent/src/Agent.php
+++ b/src/agent/src/Agent.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\ApprovalManagerInterface;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
 use Symfony\AI\Agent\Exception\InvalidArgumentException;
 use Symfony\AI\Agent\Exception\RuntimeException;
 use Symfony\AI\Agent\Execution\Execution;
@@ -28,6 +31,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
+ * @author Saiful Islam <saif012@gmail.com>
  */
 final class Agent implements AgentInterface
 {
@@ -52,6 +56,7 @@ final class Agent implements AgentInterface
         bool $excludeToolMessages = false,
         bool $includeSources = false,
         ?EventDispatcherInterface $eventDispatcher = null,
+        ?ApprovalManagerInterface $approvalManager = null,
     ) {
         if (null === $toolExecutor && $toolbox instanceof ToolboxInterface) {
             $toolExecutor = new SequentialToolExecutor($toolbox);
@@ -65,6 +70,7 @@ final class Agent implements AgentInterface
             $excludeToolMessages,
             $includeSources,
             $eventDispatcher,
+            approvalManager: $approvalManager,
         );
     }
 
@@ -141,5 +147,28 @@ final class Agent implements AgentInterface
         };
 
         return new Execution($factory, true === ($options['stream'] ?? false));
+    }
+
+    public function resume(ExecutionCheckpoint|string $checkpoint, ApprovalDecision $decision): ResultInterface
+    {
+        $result = $this->runner->resume($this, $checkpoint, $decision);
+
+        $messages = $checkpoint instanceof ExecutionCheckpoint ? $checkpoint->getMessages() : new MessageBag();
+        $options = $checkpoint instanceof ExecutionCheckpoint ? $checkpoint->getOptions() : [];
+
+        $output = new Output($this->getModel(), $result, $messages, $options);
+        foreach ($this->outputProcessors as $outputProcessor) {
+            if (!$outputProcessor instanceof OutputProcessorInterface) {
+                throw new InvalidArgumentException(\sprintf('Output processor "%s" must implement "%s".', $outputProcessor::class, OutputProcessorInterface::class));
+            }
+
+            if ($outputProcessor instanceof AgentAwareInterface) {
+                $outputProcessor->setAgent($this);
+            }
+
+            $outputProcessor->processOutput($output);
+        }
+
+        return $output->getResult();
     }
 }

--- a/src/agent/src/AgentInterface.php
+++ b/src/agent/src/AgentInterface.php
@@ -11,13 +11,17 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
 use Symfony\AI\Agent\Exception\ExceptionInterface;
 use Symfony\AI\Agent\Execution\Execution;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Result\ResultInterface;
 
 /**
  * @author Denis Zunke <denis.zunke@gmail.com>
+ * @author Saiful Islam <saif012@gmail.com>
  */
 interface AgentInterface
 {
@@ -33,6 +37,15 @@ interface AgentInterface
      * @throws ExceptionInterface When the agent encounters an error (e.g., unsupported model capabilities, invalid arguments, network failures, or processor errors)
      */
     public function call(string|MessageBag|UserMessage $input, array $options = []): Execution;
+
+    /**
+     * Resumes an agent run that was suspended pending human tool approval.
+     *
+     * @param ExecutionCheckpoint|string $checkpoint Checkpoint object, ID, or cryptographically signed token
+     *
+     * @throws ExceptionInterface When resumption fails, checkpoint is invalid, or checkpoint has expired
+     */
+    public function resume(ExecutionCheckpoint|string $checkpoint, ApprovalDecision $decision): ResultInterface;
 
     /**
      * Get the agent's name, which can be used for debugging or multi-agent configuration.

--- a/src/agent/src/Approval/ApprovalDecision.php
+++ b/src/agent/src/Approval/ApprovalDecision.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval;
+
+/**
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class ApprovalDecision
+{
+    /**
+     * @param array<string, mixed>|null $modifiedArguments
+     */
+    public function __construct(
+        private readonly ApprovalDecisionType $type,
+        private readonly ?string $feedback = null,
+        private readonly ?array $modifiedArguments = null,
+    ) {
+    }
+
+    public static function approve(?string $feedback = null): self
+    {
+        return new self(ApprovalDecisionType::Approved, $feedback);
+    }
+
+    public static function reject(?string $reason = null): self
+    {
+        return new self(ApprovalDecisionType::Rejected, $reason);
+    }
+
+    /**
+     * @param array<string, mixed> $modifiedArguments
+     */
+    public static function modify(array $modifiedArguments, ?string $feedback = null): self
+    {
+        return new self(ApprovalDecisionType::Modified, $feedback, $modifiedArguments);
+    }
+
+    public function getType(): ApprovalDecisionType
+    {
+        return $this->type;
+    }
+
+    public function isApproved(): bool
+    {
+        return ApprovalDecisionType::Approved === $this->type;
+    }
+
+    public function isRejected(): bool
+    {
+        return ApprovalDecisionType::Rejected === $this->type;
+    }
+
+    public function isModified(): bool
+    {
+        return ApprovalDecisionType::Modified === $this->type;
+    }
+
+    public function getFeedback(): ?string
+    {
+        return $this->feedback;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getModifiedArguments(): ?array
+    {
+        return $this->modifiedArguments;
+    }
+}

--- a/src/agent/src/Approval/ApprovalDecisionType.php
+++ b/src/agent/src/Approval/ApprovalDecisionType.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval;
+
+/**
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+enum ApprovalDecisionType: string
+{
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+    case Modified = 'modified';
+}

--- a/src/agent/src/Approval/ApprovalManager.php
+++ b/src/agent/src/Approval/ApprovalManager.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval;
+
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Approval\Attribute\RequiresApproval;
+use Symfony\AI\Agent\Approval\Checkpoint\CheckpointSignerInterface;
+use Symfony\AI\Agent\Approval\Checkpoint\CheckpointStoreInterface;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\Tool;
+
+/**
+ * Default implementation of ApprovalManagerInterface.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class ApprovalManager implements ApprovalManagerInterface
+{
+    /**
+     * @param iterable<ApprovalPolicyInterface> $policies
+     */
+    public function __construct(
+        private readonly iterable $policies = [],
+        private readonly ?CheckpointStoreInterface $checkpointStore = null,
+        private readonly ?CheckpointSignerInterface $signer = null,
+    ) {
+    }
+
+    public function requiresApproval(Tool $tool, ToolCall $toolCall, ?AgentInterface $agent = null): bool
+    {
+        $requirement = $this->getApprovalRequirement($tool);
+
+        if (null !== $requirement) {
+            if (null !== $requirement->policy) {
+                foreach ($this->policies as $policy) {
+                    if ($policy instanceof $requirement->policy) {
+                        return $policy->requiresApproval($tool, $toolCall, $agent);
+                    }
+                }
+            }
+
+            foreach ($this->policies as $policy) {
+                if ($policy->requiresApproval($tool, $toolCall, $agent)) {
+                    return true;
+                }
+            }
+
+            return true;
+        }
+
+        foreach ($this->policies as $policy) {
+            if ($policy->requiresApproval($tool, $toolCall, $agent)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getApprovalRequirement(Tool $tool): ?RequiresApproval
+    {
+        $requirement = $tool->getMetadataValue('requires_approval');
+
+        return $requirement instanceof RequiresApproval ? $requirement : null;
+    }
+
+    public function formatPrompt(Tool $tool, ToolCall $toolCall): ?string
+    {
+        $requirement = $this->getApprovalRequirement($tool);
+        if (null === $requirement || null === $requirement->prompt) {
+            return null;
+        }
+
+        $prompt = $requirement->prompt;
+        $arguments = $toolCall->getArguments();
+
+        foreach ($arguments as $key => $value) {
+            $stringVal = \is_scalar($value) ? (string) $value : json_encode($value, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+            $prompt = str_replace('#{'.$key.'}', (string) $stringVal, $prompt);
+            $prompt = str_replace('${'.$key.'}', (string) $stringVal, $prompt);
+            $prompt = str_replace('{'.$key.'}', (string) $stringVal, $prompt);
+        }
+
+        return $prompt;
+    }
+
+    public function getCheckpointStore(): ?CheckpointStoreInterface
+    {
+        return $this->checkpointStore;
+    }
+
+    public function getSigner(): ?CheckpointSignerInterface
+    {
+        return $this->signer;
+    }
+}

--- a/src/agent/src/Approval/ApprovalManagerInterface.php
+++ b/src/agent/src/Approval/ApprovalManagerInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval;
+
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Approval\Attribute\RequiresApproval;
+use Symfony\AI\Agent\Approval\Checkpoint\CheckpointSignerInterface;
+use Symfony\AI\Agent\Approval\Checkpoint\CheckpointStoreInterface;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\Tool;
+
+/**
+ * Manages tool approval evaluations, policies, checkpoint stores and signers.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+interface ApprovalManagerInterface
+{
+    /**
+     * Determines whether a specific tool call requires human approval.
+     */
+    public function requiresApproval(Tool $tool, ToolCall $toolCall, ?AgentInterface $agent = null): bool;
+
+    /**
+     * Extracts the RequiresApproval attribute metadata from a tool definition, if present.
+     */
+    public function getApprovalRequirement(Tool $tool): ?RequiresApproval;
+
+    /**
+     * Formats the human-readable approval prompt for the tool call.
+     */
+    public function formatPrompt(Tool $tool, ToolCall $toolCall): ?string;
+
+    /**
+     * Returns the configured checkpoint store, if any.
+     */
+    public function getCheckpointStore(): ?CheckpointStoreInterface;
+
+    /**
+     * Returns the configured checkpoint signer, if any.
+     */
+    public function getSigner(): ?CheckpointSignerInterface;
+}

--- a/src/agent/src/Approval/ApprovalPendingResult.php
+++ b/src/agent/src/Approval/ApprovalPendingResult.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval;
+
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
+use Symfony\AI\Platform\Result\BaseResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\Tool;
+
+/**
+ * Result returned when an agent suspends execution because a tool call requires human confirmation.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class ApprovalPendingResult extends BaseResult
+{
+    /**
+     * @param string[] $roles
+     */
+    public function __construct(
+        private readonly ExecutionCheckpoint $checkpoint,
+        private readonly ToolCall $toolCall,
+        private readonly Tool $tool,
+        private readonly ?string $token = null,
+        private readonly ?string $prompt = null,
+        private readonly array $roles = [],
+    ) {
+    }
+
+    public function getContent(): string
+    {
+        return $this->prompt ?? \sprintf('Approval required for tool "%s" with arguments: %s', $this->toolCall->getName(), json_encode($this->toolCall->getArguments(), \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE));
+    }
+
+    public function getCheckpoint(): ExecutionCheckpoint
+    {
+        return $this->checkpoint;
+    }
+
+    public function getToolCall(): ToolCall
+    {
+        return $this->toolCall;
+    }
+
+    public function getTool(): Tool
+    {
+        return $this->tool;
+    }
+
+    public function getToken(): ?string
+    {
+        return $this->token;
+    }
+
+    public function getPrompt(): ?string
+    {
+        return $this->prompt;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+}

--- a/src/agent/src/Approval/ApprovalPolicyInterface.php
+++ b/src/agent/src/Approval/ApprovalPolicyInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval;
+
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\Tool;
+
+/**
+ * Strategy interface for dynamically deciding whether a tool call requires human approval.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+interface ApprovalPolicyInterface
+{
+    /**
+     * Determines whether the given tool call needs human approval.
+     */
+    public function requiresApproval(Tool $tool, ToolCall $toolCall, AgentInterface $agent): bool;
+}

--- a/src/agent/src/Approval/Attribute/RequiresApproval.php
+++ b/src/agent/src/Approval/Attribute/RequiresApproval.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Attribute;
+
+use Symfony\AI\Agent\Approval\ApprovalPolicyInterface;
+
+/**
+ * Marks a tool or tool method as requiring human approval before execution.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class RequiresApproval
+{
+    /**
+     * @param string|null                                $prompt   A human-readable prompt or template explaining what requires approval
+     * @param string[]                                   $roles    Security roles authorized to approve this tool execution
+     * @param class-string<ApprovalPolicyInterface>|null $policy   Custom policy class to evaluate whether approval is needed
+     * @param array<string, mixed>                       $metadata Arbitrary custom data attached to the approval requirement
+     */
+    public function __construct(
+        public readonly ?string $prompt = null,
+        public readonly array $roles = [],
+        public readonly ?string $policy = null,
+        public readonly array $metadata = [],
+    ) {
+    }
+}

--- a/src/agent/src/Approval/Checkpoint/CheckpointSigner.php
+++ b/src/agent/src/Approval/Checkpoint/CheckpointSigner.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Checkpoint;
+
+use Symfony\AI\Agent\Approval\Exception\CheckpointExpiredException;
+use Symfony\AI\Agent\Approval\Exception\InvalidCheckpointException;
+
+/**
+ * HMAC-SHA256 implementation of CheckpointSignerInterface.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class CheckpointSigner implements CheckpointSignerInterface
+{
+    public function __construct(
+        #[\SensitiveParameter]
+        private readonly string $secret,
+        private readonly ExecutionCheckpointSerializer $serializer = new ExecutionCheckpointSerializer(),
+    ) {
+    }
+
+    public function sign(string $payload): string
+    {
+        return hash_hmac('sha256', $payload, $this->secret);
+    }
+
+    public function verify(string $payload, string $signature): bool
+    {
+        return hash_equals($this->sign($payload), $signature);
+    }
+
+    public function encode(ExecutionCheckpoint $checkpoint): string
+    {
+        $json = $this->serializer->toJson($checkpoint);
+        $encodedPayload = rtrim(strtr(base64_encode($json), '+/', '-_'), '=');
+        $rawSignature = hash_hmac('sha256', $encodedPayload, $this->secret, true);
+        $encodedSignature = rtrim(strtr(base64_encode($rawSignature), '+/', '-_'), '=');
+
+        return \sprintf('%s.%s', $encodedPayload, $encodedSignature);
+    }
+
+    public function decode(string $token): ExecutionCheckpoint
+    {
+        $parts = explode('.', $token);
+        if (2 !== \count($parts)) {
+            throw InvalidCheckpointException::signatureMismatch();
+        }
+
+        [$encodedPayload, $encodedSignature] = $parts;
+
+        $rawSignature = hash_hmac('sha256', $encodedPayload, $this->secret, true);
+        $expectedSignature = rtrim(strtr(base64_encode($rawSignature), '+/', '-_'), '=');
+
+        if (!hash_equals($expectedSignature, $encodedSignature)) {
+            throw InvalidCheckpointException::signatureMismatch();
+        }
+
+        $decodedJson = base64_decode(strtr($encodedPayload, '-_', '+/'), true);
+        if (false === $decodedJson) {
+            throw InvalidCheckpointException::unreadable('Failed to base64 decode token payload.');
+        }
+
+        $checkpoint = $this->serializer->fromJson($decodedJson);
+
+        if ($checkpoint->isExpired()) {
+            throw CheckpointExpiredException::forCheckpoint($checkpoint->getId());
+        }
+
+        return $checkpoint;
+    }
+}

--- a/src/agent/src/Approval/Checkpoint/CheckpointSignerInterface.php
+++ b/src/agent/src/Approval/Checkpoint/CheckpointSignerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Checkpoint;
+
+/**
+ * Signs, verifies, encodes and decodes execution checkpoints for tamper-proof transport.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+interface CheckpointSignerInterface
+{
+    /**
+     * Generates a cryptographic signature for the given payload.
+     */
+    public function sign(string $payload): string;
+
+    /**
+     * Verifies that the payload matches the cryptographic signature.
+     */
+    public function verify(string $payload, string $signature): bool;
+
+    /**
+     * Serializes, signs, and encodes an ExecutionCheckpoint into a secure URL-safe token.
+     */
+    public function encode(ExecutionCheckpoint $checkpoint): string;
+
+    /**
+     * Decodes and verifies a secure token back into an ExecutionCheckpoint.
+     */
+    public function decode(string $token): ExecutionCheckpoint;
+}

--- a/src/agent/src/Approval/Checkpoint/CheckpointStoreInterface.php
+++ b/src/agent/src/Approval/Checkpoint/CheckpointStoreInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Checkpoint;
+
+/**
+ * Storage contract for persisting and retrieving execution checkpoints.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+interface CheckpointStoreInterface
+{
+    /**
+     * Persists an execution checkpoint.
+     */
+    public function save(ExecutionCheckpoint $checkpoint): void;
+
+    /**
+     * Retrieves an execution checkpoint by its ID.
+     */
+    public function get(string $id): ?ExecutionCheckpoint;
+
+    /**
+     * Removes an execution checkpoint.
+     */
+    public function remove(string $id): void;
+
+    /**
+     * Returns all active (non-expired) checkpoints.
+     *
+     * @return ExecutionCheckpoint[]
+     */
+    public function all(): array;
+}

--- a/src/agent/src/Approval/Checkpoint/ExecutionCheckpoint.php
+++ b/src/agent/src/Approval/Checkpoint/ExecutionCheckpoint.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Checkpoint;
+
+use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
+use Symfony\AI\Agent\Toolbox\ToolResult;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Immutable snapshot of agent execution state at the point of suspension for approval.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class ExecutionCheckpoint
+{
+    private readonly string $id;
+    private readonly \DateTimeImmutable $createdAt;
+
+    /**
+     * @param ToolCall[]           $pendingToolCalls
+     * @param ToolResult[]         $completedToolResults
+     * @param array<string, mixed> $options
+     */
+    public function __construct(
+        ?string $id = null,
+        private readonly string $agentName = 'agent',
+        private readonly string $model = '',
+        private readonly MessageBag $messages = new MessageBag(),
+        private readonly array $options = [],
+        private readonly array $pendingToolCalls = [],
+        private readonly array $completedToolResults = [],
+        private readonly int $iterations = 0,
+        private readonly ?SourceCollection $sources = null,
+        ?\DateTimeImmutable $createdAt = null,
+        private readonly ?\DateTimeImmutable $expiresAt = null,
+    ) {
+        $this->id = $id ?? (string) Uuid::v7();
+        $this->createdAt = $createdAt ?? new \DateTimeImmutable();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getAgentName(): string
+    {
+        return $this->agentName;
+    }
+
+    public function getModel(): string
+    {
+        return $this->model;
+    }
+
+    public function getMessages(): MessageBag
+    {
+        return $this->messages;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @return ToolCall[]
+     */
+    public function getPendingToolCalls(): array
+    {
+        return $this->pendingToolCalls;
+    }
+
+    /**
+     * @return ToolResult[]
+     */
+    public function getCompletedToolResults(): array
+    {
+        return $this->completedToolResults;
+    }
+
+    public function getIterations(): int
+    {
+        return $this->iterations;
+    }
+
+    public function getSources(): ?SourceCollection
+    {
+        return $this->sources;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getExpiresAt(): ?\DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function isExpired(?\DateTimeImmutable $now = null): bool
+    {
+        if (null === $this->expiresAt) {
+            return false;
+        }
+
+        $now ??= new \DateTimeImmutable();
+
+        return $now > $this->expiresAt;
+    }
+}

--- a/src/agent/src/Approval/Checkpoint/ExecutionCheckpointSerializer.php
+++ b/src/agent/src/Approval/Checkpoint/ExecutionCheckpointSerializer.php
@@ -1,0 +1,385 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Checkpoint;
+
+use Symfony\AI\Agent\Approval\Exception\InvalidCheckpointException;
+use Symfony\AI\Agent\Toolbox\Source\Source;
+use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
+use Symfony\AI\Agent\Toolbox\ToolResult;
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Audio;
+use Symfony\AI\Platform\Message\Content\Document;
+use Symfony\AI\Platform\Message\Content\Image;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\MessageInterface;
+use Symfony\AI\Platform\Message\SystemMessage;
+use Symfony\AI\Platform\Message\ToolCallMessage;
+use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Component\Uid\TimeBasedUidInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Serializes and deserializes ExecutionCheckpoint objects to and from JSON arrays.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class ExecutionCheckpointSerializer
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(ExecutionCheckpoint $checkpoint): array
+    {
+        $messagesData = [];
+        foreach ($checkpoint->getMessages() as $message) {
+            $messagesData[] = $this->serializeMessage($message);
+        }
+
+        $pendingCallsData = [];
+        foreach ($checkpoint->getPendingToolCalls() as $toolCall) {
+            $pendingCallsData[] = $this->serializeToolCall($toolCall);
+        }
+
+        $completedResultsData = [];
+        foreach ($checkpoint->getCompletedToolResults() as $toolResult) {
+            $completedResultsData[] = $this->serializeToolResult($toolResult);
+        }
+
+        $sourcesData = null;
+        if (null !== $checkpoint->getSources()) {
+            $sourcesData = [];
+            foreach ($checkpoint->getSources()->all() as $source) {
+                $sourcesData[] = [
+                    'name' => $source->getName(),
+                    'reference' => $source->getReference(),
+                    'content' => $source->getContent(),
+                ];
+            }
+        }
+
+        return [
+            'id' => $checkpoint->getId(),
+            'agentName' => $checkpoint->getAgentName(),
+            'model' => $checkpoint->getModel(),
+            'messages' => $messagesData,
+            'options' => $checkpoint->getOptions(),
+            'pendingToolCalls' => $pendingCallsData,
+            'completedToolResults' => $completedResultsData,
+            'iterations' => $checkpoint->getIterations(),
+            'sources' => $sourcesData,
+            'createdAt' => $checkpoint->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            'expiresAt' => $checkpoint->getExpiresAt()?->format(\DateTimeInterface::ATOM),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function fromArray(array $data): ExecutionCheckpoint
+    {
+        if (!isset($data['id'], $data['messages'])) {
+            throw InvalidCheckpointException::unreadable('Missing required fields "id" or "messages".');
+        }
+
+        $messages = [];
+        foreach ($data['messages'] as $messageData) {
+            $messages[] = $this->deserializeMessage($messageData);
+        }
+
+        $messageBag = new MessageBag(...$messages);
+
+        $pendingCalls = [];
+        foreach ($data['pendingToolCalls'] ?? [] as $callData) {
+            $pendingCalls[] = $this->deserializeToolCall($callData);
+        }
+
+        $completedResults = [];
+        foreach ($data['completedToolResults'] ?? [] as $resultData) {
+            $completedResults[] = $this->deserializeToolResult($resultData);
+        }
+
+        $sources = null;
+        if (isset($data['sources']) && \is_array($data['sources'])) {
+            $sourceObjects = [];
+            foreach ($data['sources'] as $src) {
+                $sourceObjects[] = new Source(
+                    $src['name'] ?? '',
+                    $src['reference'] ?? '',
+                    $src['content'] ?? '',
+                );
+            }
+            $sources = new SourceCollection($sourceObjects);
+        }
+
+        $createdAt = isset($data['createdAt']) ? new \DateTimeImmutable($data['createdAt']) : new \DateTimeImmutable();
+        $expiresAt = isset($data['expiresAt']) ? new \DateTimeImmutable($data['expiresAt']) : null;
+
+        return new ExecutionCheckpoint(
+            id: $data['id'],
+            agentName: $data['agentName'] ?? 'agent',
+            model: $data['model'] ?? '',
+            messages: $messageBag,
+            options: $data['options'] ?? [],
+            pendingToolCalls: $pendingCalls,
+            completedToolResults: $completedResults,
+            iterations: (int) ($data['iterations'] ?? 0),
+            sources: $sources,
+            createdAt: $createdAt,
+            expiresAt: $expiresAt,
+        );
+    }
+
+    public function toJson(ExecutionCheckpoint $checkpoint): string
+    {
+        return json_encode($this->toArray($checkpoint), \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+    }
+
+    public function fromJson(string $json): ExecutionCheckpoint
+    {
+        try {
+            $data = json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw InvalidCheckpointException::unreadable($e->getMessage());
+        }
+
+        if (!\is_array($data)) {
+            throw InvalidCheckpointException::unreadable('JSON does not decode into an array.');
+        }
+
+        return $this->fromArray($data);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeMessage(MessageInterface $message): array
+    {
+        $type = $message::class;
+        $id = (string) $message->getId();
+        $metadata = $message->getMetadata()->all();
+
+        if ($message instanceof SystemMessage) {
+            return [
+                'type' => 'system',
+                'id' => $id,
+                'content' => (string) $message->getContent(),
+                'metadata' => $metadata,
+            ];
+        }
+
+        if ($message instanceof UserMessage) {
+            $parts = [];
+            foreach ($message->getContent() as $part) {
+                if ($part instanceof Text) {
+                    $parts[] = ['type' => 'text', 'text' => $part->getText()];
+                } elseif ($part instanceof Image) {
+                    $parts[] = ['type' => 'image', 'data' => $part->asBase64(), 'mimeType' => $part->getFormat()];
+                } elseif ($part instanceof Audio) {
+                    $parts[] = ['type' => 'audio', 'data' => $part->asBase64(), 'format' => $part->getFormat()];
+                } elseif ($part instanceof Document) {
+                    $parts[] = ['type' => 'document', 'data' => $part->asBase64(), 'mimeType' => $part->getFormat()];
+                }
+            }
+
+            return [
+                'type' => 'user',
+                'id' => $id,
+                'parts' => $parts,
+                'metadata' => $metadata,
+            ];
+        }
+
+        if ($message instanceof AssistantMessage) {
+            $parts = [];
+            foreach ($message->getContent() as $part) {
+                if ($part instanceof Text) {
+                    $parts[] = ['type' => 'text', 'text' => $part->getText()];
+                } elseif ($part instanceof Thinking) {
+                    $parts[] = ['type' => 'thinking', 'thought' => $part->getContent()];
+                } elseif ($part instanceof ToolCall) {
+                    $parts[] = ['type' => 'tool_call', 'tool_call' => $this->serializeToolCall($part)];
+                }
+            }
+
+            return [
+                'type' => 'assistant',
+                'id' => $id,
+                'parts' => $parts,
+                'metadata' => $metadata,
+            ];
+        }
+
+        if ($message instanceof ToolCallMessage) {
+            $parts = [];
+            foreach ($message->getContent() as $part) {
+                if ($part instanceof Text) {
+                    $parts[] = ['type' => 'text', 'text' => $part->getText()];
+                }
+            }
+
+            return [
+                'type' => 'tool_call_message',
+                'id' => $id,
+                'tool_call' => $this->serializeToolCall($message->getToolCall()),
+                'parts' => $parts,
+                'metadata' => $metadata,
+            ];
+        }
+
+        return [
+            'type' => $type,
+            'id' => $id,
+            'metadata' => $metadata,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function deserializeMessage(array $data): MessageInterface
+    {
+        $type = $data['type'] ?? 'user';
+        $uuid = isset($data['id']) ? Uuid::fromString($data['id']) : Uuid::v7();
+
+        $message = match ($type) {
+            'system' => new SystemMessage($data['content'] ?? ''),
+            'user' => $this->deserializeUserMessage($data),
+            'assistant' => $this->deserializeAssistantMessage($data),
+            'tool_call_message' => $this->deserializeToolCallMessage($data),
+            default => Message::ofUser($data['content'] ?? ''),
+        };
+
+        if ($uuid instanceof TimeBasedUidInterface) {
+            $message = $message->withId($uuid);
+        }
+        if (isset($data['metadata']) && \is_array($data['metadata'])) {
+            $message->getMetadata()->set($data['metadata']);
+        }
+
+        return $message;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function deserializeUserMessage(array $data): UserMessage
+    {
+        $contents = [];
+        foreach ($data['parts'] ?? [] as $part) {
+            $partType = $part['type'] ?? 'text';
+            if ('text' === $partType) {
+                $contents[] = new Text($part['text'] ?? '');
+            } elseif ('image' === $partType && isset($part['data'])) {
+                $contents[] = new Image(base64_decode($part['data']), $part['mimeType'] ?? 'image/png');
+            } elseif ('audio' === $partType && isset($part['data'])) {
+                $contents[] = new Audio(base64_decode($part['data']), $part['format'] ?? 'audio/mp3');
+            } elseif ('document' === $partType && isset($part['data'])) {
+                $contents[] = new Document(base64_decode($part['data']), $part['mimeType'] ?? 'application/pdf');
+            }
+        }
+
+        if ([] === $contents && isset($data['content'])) {
+            $contents[] = new Text($data['content']);
+        }
+
+        return new UserMessage(...$contents);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function deserializeAssistantMessage(array $data): AssistantMessage
+    {
+        $contents = [];
+        foreach ($data['parts'] ?? [] as $part) {
+            $partType = $part['type'] ?? 'text';
+            if ('text' === $partType) {
+                $contents[] = new Text($part['text'] ?? '');
+            } elseif ('thinking' === $partType) {
+                $contents[] = new Thinking($part['thought'] ?? '');
+            } elseif ('tool_call' === $partType && isset($part['tool_call'])) {
+                $contents[] = $this->deserializeToolCall($part['tool_call']);
+            }
+        }
+
+        return new AssistantMessage(...$contents);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function deserializeToolCallMessage(array $data): ToolCallMessage
+    {
+        $toolCall = $this->deserializeToolCall($data['tool_call'] ?? []);
+        $contents = [];
+        foreach ($data['parts'] ?? [] as $part) {
+            if ('text' === ($part['type'] ?? 'text')) {
+                $contents[] = new Text($part['text'] ?? '');
+            }
+        }
+
+        if ([] === $contents && isset($data['content'])) {
+            $contents[] = new Text($data['content']);
+        }
+
+        return new ToolCallMessage($toolCall, ...$contents);
+    }
+
+    /**
+     * @return array{id: ?string, name: string, arguments: array<string, mixed>}
+     */
+    private function serializeToolCall(ToolCall $toolCall): array
+    {
+        return [
+            'id' => $toolCall->getId(),
+            'name' => $toolCall->getName(),
+            'arguments' => $toolCall->getArguments(),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function deserializeToolCall(array $data): ToolCall
+    {
+        return new ToolCall(
+            $data['id'] ?? null,
+            $data['name'] ?? '',
+            $data['arguments'] ?? [],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeToolResult(ToolResult $toolResult): array
+    {
+        return [
+            'toolCall' => $this->serializeToolCall($toolResult->getToolCall()),
+            'result' => $toolResult->getResult(),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function deserializeToolResult(array $data): ToolResult
+    {
+        $toolCall = $this->deserializeToolCall($data['toolCall'] ?? []);
+
+        return new ToolResult($toolCall, $data['result'] ?? null);
+    }
+}

--- a/src/agent/src/Approval/Checkpoint/InMemoryCheckpointStore.php
+++ b/src/agent/src/Approval/Checkpoint/InMemoryCheckpointStore.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Checkpoint;
+
+/**
+ * In-memory storage for execution checkpoints, primarily used for testing and stateless runs.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class InMemoryCheckpointStore implements CheckpointStoreInterface
+{
+    /**
+     * @var array<string, ExecutionCheckpoint>
+     */
+    private array $checkpoints = [];
+
+    public function save(ExecutionCheckpoint $checkpoint): void
+    {
+        $this->checkpoints[$checkpoint->getId()] = $checkpoint;
+    }
+
+    public function get(string $id): ?ExecutionCheckpoint
+    {
+        $checkpoint = $this->checkpoints[$id] ?? null;
+        if (null === $checkpoint) {
+            return null;
+        }
+
+        if ($checkpoint->isExpired()) {
+            unset($this->checkpoints[$id]);
+
+            return null;
+        }
+
+        return $checkpoint;
+    }
+
+    public function remove(string $id): void
+    {
+        unset($this->checkpoints[$id]);
+    }
+
+    /**
+     * @return ExecutionCheckpoint[]
+     */
+    public function all(): array
+    {
+        $active = [];
+        foreach ($this->checkpoints as $id => $checkpoint) {
+            if ($checkpoint->isExpired()) {
+                unset($this->checkpoints[$id]);
+                continue;
+            }
+
+            $active[] = $checkpoint;
+        }
+
+        return $active;
+    }
+}

--- a/src/agent/src/Approval/Event/ToolApprovalRequestedEvent.php
+++ b/src/agent/src/Approval/Event/ToolApprovalRequestedEvent.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Event;
+
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\Tool;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Dispatched when an agent suspends execution because a tool call requires human approval.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class ToolApprovalRequestedEvent extends Event
+{
+    private ?ApprovalDecision $decision = null;
+
+    /**
+     * @param string[] $roles
+     */
+    public function __construct(
+        private readonly ExecutionCheckpoint $checkpoint,
+        private readonly ToolCall $toolCall,
+        private readonly Tool $tool,
+        private readonly ?AgentInterface $agent = null,
+        private readonly ?string $prompt = null,
+        private readonly array $roles = [],
+    ) {
+    }
+
+    public function getCheckpoint(): ExecutionCheckpoint
+    {
+        return $this->checkpoint;
+    }
+
+    public function getToolCall(): ToolCall
+    {
+        return $this->toolCall;
+    }
+
+    public function getTool(): Tool
+    {
+        return $this->tool;
+    }
+
+    public function getAgent(): ?AgentInterface
+    {
+        return $this->agent;
+    }
+
+    public function getPrompt(): ?string
+    {
+        return $this->prompt;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    public function decide(ApprovalDecision $decision): void
+    {
+        $this->decision = $decision;
+    }
+
+    public function hasDecision(): bool
+    {
+        return null !== $this->decision;
+    }
+
+    public function getDecision(): ?ApprovalDecision
+    {
+        return $this->decision;
+    }
+}

--- a/src/agent/src/Approval/Event/ToolApprovalResolvedEvent.php
+++ b/src/agent/src/Approval/Event/ToolApprovalResolvedEvent.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Event;
+
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\Tool;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Dispatched when a pending tool approval decision is provided and execution resumes.
+ *
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class ToolApprovalResolvedEvent extends Event
+{
+    public function __construct(
+        private readonly ExecutionCheckpoint $checkpoint,
+        private readonly ToolCall $toolCall,
+        private readonly Tool $tool,
+        private readonly ?AgentInterface $agent = null,
+        private readonly ?ApprovalDecision $decision = null,
+    ) {
+    }
+
+    public function getCheckpoint(): ExecutionCheckpoint
+    {
+        return $this->checkpoint;
+    }
+
+    public function getToolCall(): ToolCall
+    {
+        return $this->toolCall;
+    }
+
+    public function getTool(): Tool
+    {
+        return $this->tool;
+    }
+
+    public function getAgent(): ?AgentInterface
+    {
+        return $this->agent;
+    }
+
+    public function getDecision(): ?ApprovalDecision
+    {
+        return $this->decision;
+    }
+}

--- a/src/agent/src/Approval/Exception/CheckpointExpiredException.php
+++ b/src/agent/src/Approval/Exception/CheckpointExpiredException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Exception;
+
+/**
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class CheckpointExpiredException extends ToolApprovalException
+{
+    public static function forCheckpoint(string $checkpointId): self
+    {
+        return new self(\sprintf('Execution checkpoint "%s" has expired.', $checkpointId));
+    }
+}

--- a/src/agent/src/Approval/Exception/ExceptionInterface.php
+++ b/src/agent/src/Approval/Exception/ExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Exception;
+
+use Symfony\AI\Agent\Exception\ExceptionInterface as AgentExceptionInterface;
+
+/**
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+interface ExceptionInterface extends AgentExceptionInterface
+{
+}

--- a/src/agent/src/Approval/Exception/InvalidCheckpointException.php
+++ b/src/agent/src/Approval/Exception/InvalidCheckpointException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Exception;
+
+/**
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+final class InvalidCheckpointException extends ToolApprovalException
+{
+    public static function signatureMismatch(): self
+    {
+        return new self('The execution checkpoint signature is invalid or has been tampered with.');
+    }
+
+    public static function unreadable(string $reason): self
+    {
+        return new self(\sprintf('The execution checkpoint is unreadable: "%s".', $reason));
+    }
+}

--- a/src/agent/src/Approval/Exception/ToolApprovalException.php
+++ b/src/agent/src/Approval/Exception/ToolApprovalException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Approval\Exception;
+
+use Symfony\AI\Agent\Exception\RuntimeException;
+
+/**
+ * @author Saiful Islam <saif012@gmail.com>
+ */
+class ToolApprovalException extends RuntimeException implements ExceptionInterface
+{
+}

--- a/src/agent/src/Execution/Runner.php
+++ b/src/agent/src/Execution/Runner.php
@@ -11,6 +11,16 @@
 
 namespace Symfony\AI\Agent\Execution;
 
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\ApprovalManagerInterface;
+use Symfony\AI\Agent\Approval\ApprovalPendingResult;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
+use Symfony\AI\Agent\Approval\Event\ToolApprovalRequestedEvent;
+use Symfony\AI\Agent\Approval\Event\ToolApprovalResolvedEvent;
+use Symfony\AI\Agent\Approval\Exception\CheckpointExpiredException;
+use Symfony\AI\Agent\Approval\Exception\InvalidCheckpointException;
+use Symfony\AI\Agent\Exception\LogicException;
 use Symfony\AI\Agent\Exception\MaxIterationsExceededException;
 use Symfony\AI\Agent\Execution\Update\Progress;
 use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
@@ -18,6 +28,7 @@ use Symfony\AI\Agent\Toolbox\Event\ToolCallsExecuted;
 use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
 use Symfony\AI\Agent\Toolbox\ToolExecutorInterface;
+use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Agent\Toolbox\ToolResultConverter;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\Text;
@@ -34,9 +45,11 @@ use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
+use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\StructuredOutput\Streaming\PartialObjectStreamListener;
 use Symfony\AI\Platform\Tool\Tool;
+use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -47,6 +60,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  * are consumed here as well, so a streamed tool call is just another round of that same loop.
  *
  * @author Christopher Hertel <mail@christopher-hertel.de>
+ * @author Saiful Islam <saif012@gmail.com>
  *
  * @internal
  */
@@ -61,6 +75,7 @@ final class Runner
         private readonly bool $includeSources = false,
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
         private readonly ToolResultConverter $resultConverter = new ToolResultConverter(),
+        private readonly ?ApprovalManagerInterface $approvalManager = null,
     ) {
     }
 
@@ -101,7 +116,59 @@ final class Runner
             }
 
             $toolCalls = array_values($toolCallResult->getContent());
-            $toolResults = yield from $this->toolExecutor->execute($toolCalls);
+
+            if (null !== $this->approvalManager && null !== $this->toolbox) {
+                $toolDefinitions = $this->toolbox->getTools();
+                $toolMap = [];
+                foreach ($toolDefinitions as $def) {
+                    $toolMap[$def->getName()] = $def;
+                }
+
+                $toolResults = [];
+                foreach ($toolCalls as $index => $toolCall) {
+                    $toolDef = $toolMap[$toolCall->getName()] ?? null;
+                    if (null !== $toolDef && $this->approvalManager->requiresApproval($toolDef, $toolCall)) {
+                        $checkpoint = new ExecutionCheckpoint(
+                            id: (string) Uuid::v7(),
+                            agentName: $options['agent_name'] ?? 'agent',
+                            model: $model,
+                            messages: $messages,
+                            options: $options,
+                            pendingToolCalls: array_values(\array_slice($toolCalls, $index)),
+                            completedToolResults: $toolResults,
+                            iterations: $iterations,
+                            sources: $this->includeSources ? $sources : null,
+                        );
+
+                        $prompt = $this->approvalManager->formatPrompt($toolDef, $toolCall);
+                        $roles = $this->approvalManager->getApprovalRequirement($toolDef)->roles ?? [];
+
+                        $approvalEvent = new ToolApprovalRequestedEvent($checkpoint, $toolCall, $toolDef, null, $prompt, $roles);
+                        $this->eventDispatcher?->dispatch($approvalEvent);
+
+                        if ($approvalEvent->hasDecision()) {
+                            $decision = $approvalEvent->getDecision();
+                            $toolResults[] = $this->executeDecision($toolCall, $decision);
+                            continue;
+                        }
+
+                        $this->approvalManager->getCheckpointStore()?->save($checkpoint);
+                        $token = $this->approvalManager->getSigner()?->encode($checkpoint);
+
+                        $pendingResult = new ApprovalPendingResult($checkpoint, $toolCall, $toolDef, $token, $prompt, $roles);
+                        yield new ResultUpdate($pendingResult);
+
+                        return;
+                    }
+
+                    $results = yield from $this->toolExecutor->execute([$toolCall]);
+                    foreach ($results as $res) {
+                        $toolResults[] = $res;
+                    }
+                }
+            } else {
+                $toolResults = yield from $this->toolExecutor->execute($toolCalls);
+            }
 
             $messages->add($assistantMessage ?? Message::ofAssistant($result));
             foreach ($toolResults as $i => $toolResult) {
@@ -129,6 +196,114 @@ final class Runner
         }
 
         yield new ResultUpdate($result);
+    }
+
+    /**
+     * Resumes execution of a previously suspended agent call after receiving an approval decision.
+     */
+    public function resume(
+        AgentInterface $agent,
+        ExecutionCheckpoint|string $checkpoint,
+        ApprovalDecision $decision,
+    ): ResultInterface {
+        if (\is_string($checkpoint)) {
+            $checkpoint = $this->resolveCheckpoint($checkpoint);
+        }
+
+        if ($checkpoint->isExpired()) {
+            throw CheckpointExpiredException::forCheckpoint($checkpoint->getId());
+        }
+
+        $pendingToolCalls = $checkpoint->getPendingToolCalls();
+        if ([] === $pendingToolCalls) {
+            return $agent->call($checkpoint->getMessages(), $checkpoint->getOptions())->getResult();
+        }
+
+        $currentToolCall = array_shift($pendingToolCalls);
+        $toolDef = null;
+        if (null !== $this->toolbox) {
+            foreach ($this->toolbox->getTools() as $def) {
+                if ($def->getName() === $currentToolCall->getName()) {
+                    $toolDef = $def;
+                    break;
+                }
+            }
+        }
+
+        if (null !== $toolDef) {
+            $this->eventDispatcher?->dispatch(new ToolApprovalResolvedEvent($checkpoint, $currentToolCall, $toolDef, $agent, $decision));
+        }
+
+        $toolResult = $this->executeDecision($currentToolCall, $decision);
+        $toolResults = [...$checkpoint->getCompletedToolResults(), $toolResult];
+
+        $messages = $checkpoint->getMessages();
+        $options = $checkpoint->getOptions();
+
+        // Check if more pending tool calls exist in this turn
+        if ([] !== $pendingToolCalls && null !== $this->approvalManager && null !== $this->toolbox) {
+            $toolDefinitions = $this->toolbox->getTools();
+            $toolMap = [];
+            foreach ($toolDefinitions as $def) {
+                $toolMap[$def->getName()] = $def;
+            }
+
+            foreach ($pendingToolCalls as $index => $toolCall) {
+                $pendingToolDef = $toolMap[$toolCall->getName()] ?? null;
+                if (null !== $pendingToolDef && $this->approvalManager->requiresApproval($pendingToolDef, $toolCall, $agent)) {
+                    $nextCheckpoint = new ExecutionCheckpoint(
+                        id: (string) Uuid::v7(),
+                        agentName: $checkpoint->getAgentName(),
+                        model: $checkpoint->getModel(),
+                        messages: $messages,
+                        options: $options,
+                        pendingToolCalls: array_values(\array_slice($pendingToolCalls, $index)),
+                        completedToolResults: $toolResults,
+                        iterations: $checkpoint->getIterations(),
+                        sources: $checkpoint->getSources(),
+                    );
+
+                    $prompt = $this->approvalManager->formatPrompt($pendingToolDef, $toolCall);
+                    $roles = $this->approvalManager->getApprovalRequirement($pendingToolDef)->roles ?? [];
+
+                    $approvalEvent = new ToolApprovalRequestedEvent($nextCheckpoint, $toolCall, $pendingToolDef, $agent, $prompt, $roles);
+                    $this->eventDispatcher?->dispatch($approvalEvent);
+
+                    if ($approvalEvent->hasDecision()) {
+                        $nextDecision = $approvalEvent->getDecision();
+                        $toolResults[] = $this->executeDecision($toolCall, $nextDecision);
+                        continue;
+                    }
+
+                    $this->approvalManager->getCheckpointStore()?->save($nextCheckpoint);
+                    $this->approvalManager->getCheckpointStore()?->remove($checkpoint->getId());
+
+                    $token = $this->approvalManager->getSigner()?->encode($nextCheckpoint);
+
+                    return new ApprovalPendingResult($nextCheckpoint, $toolCall, $pendingToolDef, $token, $prompt, $roles);
+                }
+
+                $toolResults[] = $this->toolbox->execute($toolCall);
+            }
+        }
+
+        // All tool calls for this turn are resolved
+        $allToolCalls = [];
+        foreach ($toolResults as $res) {
+            $allToolCalls[] = $res->getToolCall();
+        }
+
+        $messages->add(Message::ofAssistant(...$allToolCalls));
+        foreach ($toolResults as $res) {
+            $messages->add(Message::ofToolCall($res->getToolCall(), $this->resultConverter->convert($res)));
+        }
+
+        $this->approvalManager?->getCheckpointStore()?->remove($checkpoint->getId());
+
+        $event = new ToolCallsExecuted($toolResults);
+        $this->eventDispatcher?->dispatch($event);
+
+        return $event->hasResult() ? $event->getResult() : $agent->call($messages, $options)->getResult();
     }
 
     /**
@@ -261,5 +436,44 @@ final class Runner
         }
 
         return null;
+    }
+
+    private function executeDecision(ToolCall $toolCall, ApprovalDecision $decision): ToolResult
+    {
+        if ($decision->isRejected()) {
+            $feedback = $decision->getFeedback() ?? 'Tool execution was denied by human reviewer.';
+
+            return new ToolResult($toolCall, $feedback);
+        }
+
+        if ($decision->isModified() && null !== $decision->getModifiedArguments()) {
+            $toolCall = new ToolCall($toolCall->getId(), $toolCall->getName(), $decision->getModifiedArguments());
+        }
+
+        if (null === $this->toolbox) {
+            throw new LogicException('Cannot execute tool call without a configured toolbox.');
+        }
+
+        return $this->toolbox->execute($toolCall);
+    }
+
+    private function resolveCheckpoint(string $checkpoint): ExecutionCheckpoint
+    {
+        if (null !== $this->approvalManager?->getSigner()) {
+            try {
+                return $this->approvalManager->getSigner()->decode($checkpoint);
+            } catch (\Throwable) {
+                // Fallback to store lookup if token decoding failed
+            }
+        }
+
+        if (null !== $this->approvalManager?->getCheckpointStore()) {
+            $found = $this->approvalManager->getCheckpointStore()->get($checkpoint);
+            if (null !== $found) {
+                return $found;
+            }
+        }
+
+        throw InvalidCheckpointException::unreadable(\sprintf('Checkpoint "%s" could not be resolved from token or store.', $checkpoint));
     }
 }

--- a/src/agent/src/MockAgent.php
+++ b/src/agent/src/MockAgent.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
 use Symfony\AI\Agent\Exception\LogicException;
 use Symfony\AI\Agent\Exception\OutOfBoundsException;
 use Symfony\AI\Agent\Exception\RuntimeException;
@@ -20,6 +22,7 @@ use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
@@ -267,6 +270,14 @@ final class MockAgent implements AgentInterface
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function resume(ExecutionCheckpoint|string $checkpoint, ApprovalDecision $decision): ResultInterface
+    {
+        $messages = $checkpoint instanceof ExecutionCheckpoint ? $checkpoint->getMessages() : new MessageBag();
+        $options = $checkpoint instanceof ExecutionCheckpoint ? $checkpoint->getOptions() : [];
+
+        return $this->call($messages, $options);
     }
 
     private function extractText(MessageBag $messages): string

--- a/src/agent/src/MultiAgent/MultiAgent.php
+++ b/src/agent/src/MultiAgent/MultiAgent.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Agent\MultiAgent;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
 use Symfony\AI\Agent\Exception\ExceptionInterface;
 use Symfony\AI\Agent\Exception\InvalidArgumentException;
 use Symfony\AI\Agent\Exception\RuntimeException;
@@ -24,6 +26,7 @@ use Symfony\AI\Agent\MultiAgent\Handoff\Decision;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Result\ResultInterface;
 
 /**
  * A multi-agent system that coordinates multiple specialized agents.
@@ -135,6 +138,23 @@ final class MultiAgent implements AgentInterface
             // Call the selected agent with the original user question
             yield new ResultUpdate($targetAgent->call(new MessageBag($userMessage), $options)->getResult());
         });
+    }
+
+    public function resume(ExecutionCheckpoint|string $checkpoint, ApprovalDecision $decision): ResultInterface
+    {
+        if ($checkpoint instanceof ExecutionCheckpoint) {
+            foreach ($this->handoffs as $handoff) {
+                if ($handoff->getTo()->getName() === $checkpoint->getAgentName()) {
+                    return $handoff->getTo()->resume($checkpoint, $decision);
+                }
+            }
+
+            if ($this->fallback->getName() === $checkpoint->getAgentName()) {
+                return $this->fallback->resume($checkpoint, $decision);
+            }
+        }
+
+        return $this->orchestrator->resume($checkpoint, $decision);
     }
 
     private function buildAgentSelectionPrompt(string $userQuestion): string

--- a/src/agent/src/SpeechAgent.php
+++ b/src/agent/src/SpeechAgent.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\ApprovalPendingResult;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
 use Symfony\AI\Agent\Execution\Execution;
 use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
 use Symfony\AI\Agent\Speech\SpeechConfiguration;
@@ -21,9 +24,11 @@ use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\Role;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
 
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ * @author Saiful Islam <saif012@gmail.com>
  */
 final class SpeechAgent implements AgentInterface
 {
@@ -62,6 +67,33 @@ final class SpeechAgent implements AgentInterface
 
             yield new ResultUpdate($speechResult->getResult());
         });
+    }
+
+    public function resume(ExecutionCheckpoint|string $checkpoint, ApprovalDecision $decision): ResultInterface
+    {
+        $result = $this->agent->resume($checkpoint, $decision);
+
+        if (!$this->textToSpeechPlatform instanceof PlatformInterface) {
+            return $result;
+        }
+
+        if (!$this->configuration->supportsTextToSpeech()) {
+            return $result;
+        }
+
+        if ($result instanceof ApprovalPendingResult) {
+            return $result;
+        }
+
+        $speechResult = $this->textToSpeechPlatform->invoke(
+            $this->configuration->getTextToSpeechModel(),
+            $result->getContent(),
+            $this->configuration->getTextToSpeechOptions(),
+        );
+
+        $speechResult->getMetadata()->add('text', $result->getContent());
+
+        return $speechResult->getResult();
     }
 
     public function getName(): string

--- a/src/agent/src/Toolbox/ToolFactory/ReflectionToolFactory.php
+++ b/src/agent/src/Toolbox/ToolFactory/ReflectionToolFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Agent\Toolbox\ToolFactory;
 
+use Symfony\AI\Agent\Approval\Attribute\RequiresApproval;
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 use Symfony\AI\Agent\Toolbox\Exception\ToolConfigurationException;
 use Symfony\AI\Agent\Toolbox\Exception\ToolException;
@@ -46,16 +47,32 @@ final class ReflectionToolFactory implements ToolFactoryInterface
             throw ToolException::missingAttribute($className);
         }
 
+        $classApprovalAttributes = $reflectionClass->getAttributes(RequiresApproval::class);
+
         foreach ($attributes as $attribute) {
             $asTool = $attribute->newInstance();
 
             try {
+                $metadata = $asTool->metadata;
+
+                $approvalAttributes = $classApprovalAttributes;
+                if ($reflectionClass->hasMethod($asTool->method)) {
+                    $methodApprovalAttributes = $reflectionClass->getMethod($asTool->method)->getAttributes(RequiresApproval::class);
+                    if ([] !== $methodApprovalAttributes) {
+                        $approvalAttributes = $methodApprovalAttributes;
+                    }
+                }
+
+                if ([] !== $approvalAttributes && !isset($metadata['requires_approval'])) {
+                    $metadata['requires_approval'] = $approvalAttributes[0]->newInstance();
+                }
+
                 yield new Tool(
                     new ExecutionReference($className, $asTool->method),
                     $asTool->name,
                     $asTool->description,
                     $this->factory->buildParameters($className, $asTool->method),
-                    $asTool->metadata,
+                    $metadata,
                 );
             } catch (\ReflectionException $e) {
                 throw ToolConfigurationException::invalidMethod($className, $asTool->method, $e);

--- a/src/agent/src/TraceableAgent.php
+++ b/src/agent/src/TraceableAgent.php
@@ -11,18 +11,22 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
 use Symfony\AI\Agent\Execution\Execution;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Clock\MonotonicClock;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
+ * @author Saiful Islam <saif012@gmail.com>
  *
  * @phpstan-type AgentData array{
- *     input: string|MessageBag|UserMessage,
+ *     input: string|MessageBag|UserMessage|ExecutionCheckpoint,
  *     options: array<string, mixed>,
  *     called_at: \DateTimeImmutable,
  * }
@@ -49,6 +53,17 @@ final class TraceableAgent implements AgentInterface, ResetInterface
         ];
 
         return $this->agent->call($input, $options);
+    }
+
+    public function resume(ExecutionCheckpoint|string $checkpoint, ApprovalDecision $decision): ResultInterface
+    {
+        $this->calls[] = [
+            'input' => $checkpoint,
+            'options' => ['decision' => $decision],
+            'called_at' => $this->clock->now(),
+        ];
+
+        return $this->agent->resume($checkpoint, $decision);
     }
 
     public function getName(): string

--- a/src/agent/tests/Approval/AgentApprovalTest.php
+++ b/src/agent/tests/Approval/AgentApprovalTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Approval;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\ApprovalManager;
+use Symfony\AI\Agent\Approval\ApprovalPendingResult;
+use Symfony\AI\Agent\Approval\Attribute\RequiresApproval;
+use Symfony\AI\Agent\Approval\Checkpoint\CheckpointSigner;
+use Symfony\AI\Agent\Approval\Checkpoint\InMemoryCheckpointStore;
+use Symfony\AI\Agent\Approval\Event\ToolApprovalRequestedEvent;
+use Symfony\AI\Agent\Approval\Event\ToolApprovalResolvedEvent;
+use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\Test\InMemoryPlatform;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+#[AsTool(name: 'transfer_money', description: 'Transfers money to an account', method: 'transfer')]
+#[RequiresApproval(prompt: 'Transfer ${amount} to account #{toAccount}', roles: ['ROLE_FINANCE_ADMIN'])]
+class BankService
+{
+    /**
+     * @var array<array{toAccount: string, amount: float}>
+     */
+    public array $transfers = [];
+
+    public function transfer(string $toAccount, float $amount): string
+    {
+        $this->transfers[] = ['toAccount' => $toAccount, 'amount' => $amount];
+
+        return \sprintf('Successfully transferred $%s to %s', $amount, $toAccount);
+    }
+}
+
+final class AgentApprovalTest extends TestCase
+{
+    public function testAgentSuspendsExecutionWhenToolRequiresApproval()
+    {
+        $bankService = new BankService();
+        $toolbox = new Toolbox([$bankService]);
+        $store = new InMemoryCheckpointStore();
+        $signer = new CheckpointSigner('test-secret');
+        $approvalManager = new ApprovalManager([], $store, $signer);
+        $eventDispatcher = new EventDispatcher();
+
+        $requestedEvents = [];
+        $eventDispatcher->addListener(ToolApprovalRequestedEvent::class, static function (ToolApprovalRequestedEvent $e) use (&$requestedEvents) {
+            $requestedEvents[] = $e;
+        });
+
+        $platform = new InMemoryPlatform(static function ($model, MessageBag $messages) {
+            if ($messages->isLastMessageFrom(\Symfony\AI\Platform\Message\Role::User)) {
+                return new ToolCallResult([
+                    new ToolCall('call_transfer_1', 'transfer_money', ['toAccount' => 'ACC-99', 'amount' => 500.0]),
+                ]);
+            }
+
+            return new TextResult('Transfer completed!');
+        });
+
+        $agent = new Agent(
+            platform: $platform,
+            model: 'gpt-4o',
+            name: 'finance-agent',
+            toolbox: $toolbox,
+            eventDispatcher: $eventDispatcher,
+            approvalManager: $approvalManager,
+        );
+
+        $result = $agent->call('Please send $500 to ACC-99')->getResult();
+
+        $this->assertInstanceOf(ApprovalPendingResult::class, $result);
+        $this->assertSame('transfer_money', $result->getToolCall()->getName());
+        $this->assertSame('Transfer 500 to account ACC-99', $result->getPrompt());
+        $this->assertSame(['ROLE_FINANCE_ADMIN'], $result->getRoles());
+        $this->assertNotNull($result->getToken());
+
+        $this->assertCount(1, $requestedEvents);
+        $this->assertCount(0, $bankService->transfers);
+        $this->assertNotNull($store->get($result->getCheckpoint()->getId()));
+
+        // Now resume with Approval
+        $resolvedEvents = [];
+        $eventDispatcher->addListener(ToolApprovalResolvedEvent::class, static function (ToolApprovalResolvedEvent $e) use (&$resolvedEvents) {
+            $resolvedEvents[] = $e;
+        });
+
+        $resumeResult = $agent->resume($result->getToken(), ApprovalDecision::approve());
+
+        $this->assertInstanceOf(TextResult::class, $resumeResult);
+        $this->assertSame('Transfer completed!', $resumeResult->getContent());
+        $this->assertCount(1, $bankService->transfers);
+        $this->assertSame('ACC-99', $bankService->transfers[0]['toAccount']);
+        $this->assertSame(500.0, $bankService->transfers[0]['amount']);
+        $this->assertCount(1, $resolvedEvents);
+        $this->assertNull($store->get($result->getCheckpoint()->getId()));
+    }
+
+    public function testAgentResumesWithRejection()
+    {
+        $bankService = new BankService();
+        $toolbox = new Toolbox([$bankService]);
+        $store = new InMemoryCheckpointStore();
+        $signer = new CheckpointSigner('test-secret');
+        $approvalManager = new ApprovalManager([], $store, $signer);
+
+        $platform = new InMemoryPlatform(static function ($model, MessageBag $messages) {
+            if ($messages->isLastMessageFrom(\Symfony\AI\Platform\Message\Role::User)) {
+                return new ToolCallResult([
+                    new ToolCall('call_transfer_1', 'transfer_money', ['toAccount' => 'ACC-99', 'amount' => 500.0]),
+                ]);
+            }
+
+            return new TextResult('I understand the transfer was rejected.');
+        });
+
+        $agent = new Agent(
+            platform: $platform,
+            model: 'gpt-4o',
+            toolbox: $toolbox,
+            approvalManager: $approvalManager,
+        );
+
+        $pendingResult = $agent->call('Send $500')->getResult();
+        $this->assertInstanceOf(ApprovalPendingResult::class, $pendingResult);
+
+        $finalResult = $agent->resume($pendingResult->getCheckpoint(), ApprovalDecision::reject('Account not verified'));
+
+        $this->assertInstanceOf(TextResult::class, $finalResult);
+        $this->assertSame('I understand the transfer was rejected.', $finalResult->getContent());
+        $this->assertCount(0, $bankService->transfers);
+    }
+
+    public function testAgentResumesWithModifiedArguments()
+    {
+        $bankService = new BankService();
+        $toolbox = new Toolbox([$bankService]);
+        $store = new InMemoryCheckpointStore();
+        $signer = new CheckpointSigner('test-secret');
+        $approvalManager = new ApprovalManager([], $store, $signer);
+
+        $platform = new InMemoryPlatform(static function ($model, MessageBag $messages) {
+            if ($messages->isLastMessageFrom(\Symfony\AI\Platform\Message\Role::User)) {
+                return new ToolCallResult([
+                    new ToolCall('call_transfer_1', 'transfer_money', ['toAccount' => 'ACC-99', 'amount' => 500.0]),
+                ]);
+            }
+
+            return new TextResult('Transfer done with modified amount.');
+        });
+
+        $agent = new Agent(
+            platform: $platform,
+            model: 'gpt-4o',
+            toolbox: $toolbox,
+            approvalManager: $approvalManager,
+        );
+
+        $pendingResult = $agent->call('Send $500')->getResult();
+        $this->assertInstanceOf(ApprovalPendingResult::class, $pendingResult);
+
+        $finalResult = $agent->resume($pendingResult->getToken(), ApprovalDecision::modify(['toAccount' => 'ACC-99', 'amount' => 100.0]));
+
+        $this->assertInstanceOf(TextResult::class, $finalResult);
+        $this->assertCount(1, $bankService->transfers);
+        $this->assertSame(100.0, $bankService->transfers[0]['amount']);
+    }
+
+    public function testEventListenerImmediateSynchronousDecision()
+    {
+        $bankService = new BankService();
+        $toolbox = new Toolbox([$bankService]);
+        $approvalManager = new ApprovalManager();
+        $eventDispatcher = new EventDispatcher();
+
+        // Event listener auto-approves synchronously
+        $eventDispatcher->addListener(ToolApprovalRequestedEvent::class, static function (ToolApprovalRequestedEvent $e) {
+            $e->decide(ApprovalDecision::approve('Auto approved by security rule'));
+        });
+
+        $platform = new InMemoryPlatform(static function ($model, MessageBag $messages) {
+            if ($messages->isLastMessageFrom(\Symfony\AI\Platform\Message\Role::User)) {
+                return new ToolCallResult([
+                    new ToolCall('call_transfer_1', 'transfer_money', ['toAccount' => 'ACC-99', 'amount' => 500.0]),
+                ]);
+            }
+
+            return new TextResult('Finished directly.');
+        });
+
+        $agent = new Agent(
+            platform: $platform,
+            model: 'gpt-4o',
+            toolbox: $toolbox,
+            eventDispatcher: $eventDispatcher,
+            approvalManager: $approvalManager,
+        );
+
+        $result = $agent->call('Send $500')->getResult();
+
+        $this->assertInstanceOf(TextResult::class, $result);
+        $this->assertSame('Finished directly.', $result->getContent());
+        $this->assertCount(1, $bankService->transfers);
+    }
+}

--- a/src/agent/tests/Approval/ApprovalDecisionTest.php
+++ b/src/agent/tests/Approval/ApprovalDecisionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Approval;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Approval\ApprovalDecision;
+use Symfony\AI\Agent\Approval\ApprovalDecisionType;
+
+final class ApprovalDecisionTest extends TestCase
+{
+    public function testApproveFactory()
+    {
+        $decision = ApprovalDecision::approve('LGTM');
+
+        $this->assertSame(ApprovalDecisionType::Approved, $decision->getType());
+        $this->assertTrue($decision->isApproved());
+        $this->assertFalse($decision->isRejected());
+        $this->assertFalse($decision->isModified());
+        $this->assertSame('LGTM', $decision->getFeedback());
+        $this->assertNull($decision->getModifiedArguments());
+    }
+
+    public function testRejectFactory()
+    {
+        $decision = ApprovalDecision::reject('Amount too large');
+
+        $this->assertSame(ApprovalDecisionType::Rejected, $decision->getType());
+        $this->assertFalse($decision->isApproved());
+        $this->assertTrue($decision->isRejected());
+        $this->assertFalse($decision->isModified());
+        $this->assertSame('Amount too large', $decision->getFeedback());
+        $this->assertNull($decision->getModifiedArguments());
+    }
+
+    public function testModifyFactory()
+    {
+        $decision = ApprovalDecision::modify(['amount' => 50], 'Capped at 50');
+
+        $this->assertSame(ApprovalDecisionType::Modified, $decision->getType());
+        $this->assertFalse($decision->isApproved());
+        $this->assertFalse($decision->isRejected());
+        $this->assertTrue($decision->isModified());
+        $this->assertSame('Capped at 50', $decision->getFeedback());
+        $this->assertSame(['amount' => 50], $decision->getModifiedArguments());
+    }
+}

--- a/src/agent/tests/Approval/ApprovalManagerTest.php
+++ b/src/agent/tests/Approval/ApprovalManagerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Approval;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Approval\ApprovalManager;
+use Symfony\AI\Agent\Approval\ApprovalPolicyInterface;
+use Symfony\AI\Agent\Approval\Attribute\RequiresApproval;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Tool\ExecutionReference;
+use Symfony\AI\Platform\Tool\Tool;
+
+final class ApprovalManagerTest extends TestCase
+{
+    public function testRequiresApprovalFromAttribute()
+    {
+        $tool = new Tool(
+            new ExecutionReference('App\\Service', 'action'),
+            'sensitive_action',
+            'Performs a sensitive action',
+            null,
+            ['requires_approval' => new RequiresApproval(prompt: 'Confirm action with ID #{id}')],
+        );
+
+        $toolCall = new ToolCall('call_1', 'sensitive_action', ['id' => 42]);
+        $agent = $this->createStub(AgentInterface::class);
+
+        $manager = new ApprovalManager();
+        $this->assertTrue($manager->requiresApproval($tool, $toolCall, $agent));
+        $this->assertSame('Confirm action with ID 42', $manager->formatPrompt($tool, $toolCall));
+    }
+
+    public function testRequiresApprovalFromDynamicPolicy()
+    {
+        $policy = new class implements ApprovalPolicyInterface {
+            public function requiresApproval(Tool $tool, ToolCall $toolCall, AgentInterface $agent): bool
+            {
+                $amount = (float) ($toolCall->getArguments()['amount'] ?? 0);
+
+                return $amount > 100.0;
+            }
+        };
+
+        $tool = new Tool(
+            new ExecutionReference('App\\PaymentService', 'pay'),
+            'pay',
+            'Process payment',
+        );
+
+        $smallPayment = new ToolCall('call_1', 'pay', ['amount' => 50.0]);
+        $largePayment = new ToolCall('call_2', 'pay', ['amount' => 500.0]);
+        $agent = $this->createStub(AgentInterface::class);
+
+        $manager = new ApprovalManager([$policy]);
+        $this->assertFalse($manager->requiresApproval($tool, $smallPayment, $agent));
+        $this->assertTrue($manager->requiresApproval($tool, $largePayment, $agent));
+    }
+}

--- a/src/agent/tests/Approval/Checkpoint/CheckpointSignerTest.php
+++ b/src/agent/tests/Approval/Checkpoint/CheckpointSignerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Approval\Checkpoint;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Approval\Checkpoint\CheckpointSigner;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
+use Symfony\AI\Agent\Approval\Exception\CheckpointExpiredException;
+use Symfony\AI\Agent\Approval\Exception\InvalidCheckpointException;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+final class CheckpointSignerTest extends TestCase
+{
+    public function testEncodeAndDecodeValidToken()
+    {
+        $signer = new CheckpointSigner('test-secret-key');
+
+        $checkpoint = new ExecutionCheckpoint(
+            id: 'checkpoint-abc',
+            agentName: 'test-agent',
+            model: 'gpt-4o',
+            messages: new MessageBag(Message::ofUser('Hello')),
+            expiresAt: new \DateTimeImmutable('+1 hour'),
+        );
+
+        $token = $signer->encode($checkpoint);
+        $this->assertIsString($token);
+        $this->assertStringContainsString('.', $token);
+
+        $decoded = $signer->decode($token);
+        $this->assertSame('checkpoint-abc', $decoded->getId());
+        $this->assertSame('test-agent', $decoded->getAgentName());
+        $this->assertSame('gpt-4o', $decoded->getModel());
+    }
+
+    public function testDecodeTamperedTokenThrowsException()
+    {
+        $signer = new CheckpointSigner('test-secret-key');
+
+        $checkpoint = new ExecutionCheckpoint(
+            id: 'checkpoint-abc',
+            agentName: 'test-agent',
+            model: 'gpt-4o',
+            messages: new MessageBag(Message::ofUser('Hello')),
+        );
+
+        $token = $signer->encode($checkpoint);
+        $tamperedToken = substr_replace($token, 'X', 10, 1);
+
+        $this->expectException(InvalidCheckpointException::class);
+        $signer->decode($tamperedToken);
+    }
+
+    public function testDecodeWithWrongSecretThrowsException()
+    {
+        $signer1 = new CheckpointSigner('secret-1');
+        $signer2 = new CheckpointSigner('secret-2');
+
+        $checkpoint = new ExecutionCheckpoint(
+            id: 'checkpoint-abc',
+            agentName: 'test-agent',
+            model: 'gpt-4o',
+            messages: new MessageBag(Message::ofUser('Hello')),
+        );
+
+        $token = $signer1->encode($checkpoint);
+
+        $this->expectException(InvalidCheckpointException::class);
+        $signer2->decode($token);
+    }
+
+    public function testDecodeExpiredTokenThrowsException()
+    {
+        $signer = new CheckpointSigner('test-secret-key');
+
+        $checkpoint = new ExecutionCheckpoint(
+            id: 'checkpoint-expired',
+            agentName: 'test-agent',
+            model: 'gpt-4o',
+            messages: new MessageBag(Message::ofUser('Hello')),
+            expiresAt: new \DateTimeImmutable('-10 minutes'),
+        );
+
+        $token = $signer->encode($checkpoint);
+
+        $this->expectException(CheckpointExpiredException::class);
+        $signer->decode($token);
+    }
+}

--- a/src/agent/tests/Approval/Checkpoint/ExecutionCheckpointSerializerTest.php
+++ b/src/agent/tests/Approval/Checkpoint/ExecutionCheckpointSerializerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Approval\Checkpoint;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpointSerializer;
+use Symfony\AI\Agent\Toolbox\Source\Source;
+use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
+use Symfony\AI\Agent\Toolbox\ToolResult;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\ToolCall;
+
+final class ExecutionCheckpointSerializerTest extends TestCase
+{
+    public function testSerializationRoundTrip()
+    {
+        $messages = new MessageBag(
+            Message::forSystem('System prompt'),
+            Message::ofUser('Please transfer $100 to Alice'),
+            Message::ofAssistant(new ToolCall('call_1', 'check_balance', ['user' => 'Alice'])),
+            Message::ofToolCall(new ToolCall('call_1', 'check_balance', ['user' => 'Alice']), 'Balance is $500'),
+        );
+
+        $pendingToolCalls = [
+            new ToolCall('call_2', 'transfer_funds', ['to' => 'Alice', 'amount' => 100]),
+        ];
+
+        $completedResults = [
+            new ToolResult(new ToolCall('call_1', 'check_balance', ['user' => 'Alice']), 'Balance is $500'),
+        ];
+
+        $sources = new SourceCollection([
+            new Source('bank_api', 'https://api.bank.com', 'account data'),
+        ]);
+
+        $checkpoint = new ExecutionCheckpoint(
+            id: 'checkpoint-123',
+            agentName: 'finance-agent',
+            model: 'gpt-4o',
+            messages: $messages,
+            options: ['temperature' => 0.5],
+            pendingToolCalls: $pendingToolCalls,
+            completedToolResults: $completedResults,
+            iterations: 2,
+            sources: $sources,
+            createdAt: new \DateTimeImmutable('2026-08-28 10:00:00'),
+            expiresAt: new \DateTimeImmutable('2026-08-29 10:00:00'),
+        );
+
+        $serializer = new ExecutionCheckpointSerializer();
+        $json = $serializer->toJson($checkpoint);
+        $restored = $serializer->fromJson($json);
+
+        $this->assertSame('checkpoint-123', $restored->getId());
+        $this->assertSame('finance-agent', $restored->getAgentName());
+        $this->assertSame('gpt-4o', $restored->getModel());
+        $this->assertSame(['temperature' => 0.5], $restored->getOptions());
+        $this->assertSame(2, $restored->getIterations());
+        $this->assertCount(4, $restored->getMessages());
+        $this->assertCount(1, $restored->getPendingToolCalls());
+        $this->assertSame('transfer_funds', $restored->getPendingToolCalls()[0]->getName());
+        $this->assertSame(['to' => 'Alice', 'amount' => 100], $restored->getPendingToolCalls()[0]->getArguments());
+        $this->assertCount(1, $restored->getCompletedToolResults());
+        $this->assertNotNull($restored->getSources());
+        $this->assertCount(1, $restored->getSources()->all());
+        $this->assertSame('bank_api', $restored->getSources()->all()[0]->getName());
+        $this->assertFalse($restored->isExpired(new \DateTimeImmutable('2026-08-28 12:00:00')));
+        $this->assertTrue($restored->isExpired(new \DateTimeImmutable('2026-08-30 12:00:00')));
+    }
+}

--- a/src/agent/tests/Approval/Checkpoint/InMemoryCheckpointStoreTest.php
+++ b/src/agent/tests/Approval/Checkpoint/InMemoryCheckpointStoreTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Approval\Checkpoint;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Approval\Checkpoint\ExecutionCheckpoint;
+use Symfony\AI\Agent\Approval\Checkpoint\InMemoryCheckpointStore;
+
+final class InMemoryCheckpointStoreTest extends TestCase
+{
+    public function testSaveAndGet()
+    {
+        $store = new InMemoryCheckpointStore();
+
+        $checkpoint = new ExecutionCheckpoint(
+            id: 'cp-1',
+            agentName: 'agent-1',
+            expiresAt: new \DateTimeImmutable('+1 hour'),
+        );
+
+        $store->save($checkpoint);
+
+        $this->assertSame($checkpoint, $store->get('cp-1'));
+        $this->assertNull($store->get('unknown'));
+        $this->assertCount(1, $store->all());
+    }
+
+    public function testExpiredCheckpointIsIgnoredAndRemoved()
+    {
+        $store = new InMemoryCheckpointStore();
+
+        $expired = new ExecutionCheckpoint(
+            id: 'cp-expired',
+            agentName: 'agent-1',
+            expiresAt: new \DateTimeImmutable('-10 seconds'),
+        );
+
+        $store->save($expired);
+
+        $this->assertNull($store->get('cp-expired'));
+        $this->assertCount(0, $store->all());
+    }
+
+    public function testRemove()
+    {
+        $store = new InMemoryCheckpointStore();
+
+        $checkpoint = new ExecutionCheckpoint(id: 'cp-1');
+        $store->save($checkpoint);
+        $this->assertNotNull($store->get('cp-1'));
+
+        $store->remove('cp-1');
+        $this->assertNull($store->get('cp-1'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | 
| License       | MIT

### Description

Introduces **Human-in-the-Loop (HITL)** capabilities and **Resumable State Checkpointing** for autonomous agents in `symfony/ai-agent`.

In enterprise applications, agents should not execute sensitive actions (payments, database mutations, sending emails, external mutations) without explicit human confirmation.

### Summary of Changes

1. **`#[RequiresApproval]` Attribute & Dynamic Policies (`ApprovalPolicyInterface`)**:
   - Declaratively require human approval for tools with customizable prompt templates and authorized roles.
   - Dynamic policy evaluation via `ApprovalPolicyInterface` (e.g. threshold-based approvals).

2. **Durable State Suspension & Checkpoints (`ExecutionCheckpoint`, `CheckpointSigner`)**:
   - Suspends agent execution into an immutable `ExecutionCheckpoint` and returns an `ApprovalPendingResult`.
   - Generates tamper-proof HMAC-SHA256 tokens for transport over HTTP requests, webhooks, or emails.
   - Storage abstraction via `CheckpointStoreInterface` and `InMemoryCheckpointStore`.

3. **Agent Resumption Engine (`$agent->resume()`)**:
   - Resume execution with `ApprovalDecision::approve()`, `ApprovalDecision::reject($reason)` (which feeds rejection feedback to the LLM for self-correction), or `ApprovalDecision::modify($args)`.
   - Contract added to `AgentInterface`, `Agent`, `MockAgent`, `MultiAgent`, `SpeechAgent`, and `TraceableAgent`.

4. **Documentation & Examples**:
   - Component guide in `docs/components/agent.rst`.
   - Standalone runnable example in `examples/agent/human_in_the_loop.php`.

*(Note: The AI Bundle integration and CLI commands `ai:agent:list-pending` / `ai:agent:approve` are prepared on `feature/ai-bundle-approval-commands` and will follow in a dedicated PR once this core component PR is reviewed and merged).*