### PR TITLE
[Platform] Reset structured output state on every invocation

### DIFF
--- a/src/platform/src/StructuredOutput/PlatformSubscriber.php
+++ b/src/platform/src/StructuredOutput/PlatformSubscriber.php
@@ -28,7 +28,7 @@ final class PlatformSubscriber implements EventSubscriberInterface
 {
     public const RESPONSE_FORMAT = 'response_format';
 
-    private string $outputType;
+    private ?string $outputType = null;
 
     private ?object $objectToPopulate = null;
 
@@ -54,6 +54,8 @@ final class PlatformSubscriber implements EventSubscriberInterface
      */
     public function processInput(InvocationEvent $event): void
     {
+        $this->reset();
+
         $options = $event->getOptions();
 
         if (!isset($options[self::RESPONSE_FORMAT])) {
@@ -67,7 +69,6 @@ final class PlatformSubscriber implements EventSubscriberInterface
             $className = $responseFormat::class;
         } elseif (\is_string($responseFormat)) {
             if (class_exists($responseFormat)) {
-                $this->objectToPopulate = null;
                 $className = $responseFormat;
             } elseif (str_contains($responseFormat, '\\')) {
                 throw new InvalidArgumentException(\sprintf('The response format class "%s" does not exist.', $responseFormat));
@@ -101,13 +102,18 @@ final class PlatformSubscriber implements EventSubscriberInterface
         $converter = new ResultConverter(
             $deferred->getResultConverter(),
             $this->serializer,
-            $this->outputType ?? null,
+            $this->outputType,
             $this->objectToPopulate
         );
 
         $event->setDeferredResult(new DeferredResult($converter, $deferred->getRawResult(), $options));
 
-        // Reset object to populate for next invocation
+        $this->reset();
+    }
+
+    private function reset(): void
+    {
+        $this->outputType = null;
         $this->objectToPopulate = null;
     }
 }

--- a/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
+++ b/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
@@ -339,6 +339,7 @@ final class PlatformSubscriberTest extends TestCase
 
         $processor->processResult($resultEvent);
 
+        /** @var City $result */
         $result = $resultEvent->getDeferredResult()->asObject();
         $this->assertSame($city, $result);
         $this->assertSame('Berlin', $result->name);
@@ -409,7 +410,7 @@ final class PlatformSubscriberTest extends TestCase
         $this->assertSame(['response_format' => 'url'], $event->getOptions());
     }
 
-    public function testObjectToPopulateIsResetAfterProcessResult()
+    public function testObjectToPopulateIsNotReusedForFollowingInvocation()
     {
         $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));
 
@@ -476,5 +477,122 @@ final class PlatformSubscriberTest extends TestCase
         $this->assertSame(3500000, $city1->population);
         $this->assertSame('Paris', $city2->name);
         $this->assertSame(2161000, $city2->population);
+    }
+
+    public function testOutputTypeIsNotReusedForFollowingInvocationWithRawResponseFormat()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+
+        $invocationEvent1 = new InvocationEvent($model, new MessageBag(), ['response_format' => SomeStructure::class]);
+        $processor->processInput($invocationEvent1);
+
+        $converter1 = new PlainConverter(new TextResult('{"some": "data"}'));
+        $deferred1 = new DeferredResult($converter1, new InMemoryRawResult());
+        $resultEvent1 = new ResultEvent($model, $deferred1, $invocationEvent1->getOptions());
+        $processor->processResult($resultEvent1);
+
+        // A raw JSON schema is passed through untouched by processInput(), so no output type is set.
+        $rawResponseFormat = ['type' => 'json_schema', 'json_schema' => ['name' => 'city', 'schema' => ['type' => 'object']]];
+        $invocationEvent2 = new InvocationEvent($model, new MessageBag(), ['response_format' => $rawResponseFormat]);
+        $processor->processInput($invocationEvent2);
+
+        $this->assertSame(['response_format' => $rawResponseFormat], $invocationEvent2->getOptions());
+
+        $converter2 = new PlainConverter(new TextResult('{"name": "Paris"}'));
+        $deferred2 = new DeferredResult($converter2, new InMemoryRawResult());
+        $resultEvent2 = new ResultEvent($model, $deferred2, $invocationEvent2->getOptions());
+        $processor->processResult($resultEvent2);
+
+        $this->assertSame(['name' => 'Paris'], $resultEvent2->getDeferredResult()->getResult()->getContent());
+    }
+
+    public function testOutputTypeIsNotReusedForFollowingInvocationWithNonClassStringResponseFormat()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+
+        $invocationEvent1 = new InvocationEvent($model, new MessageBag(), ['response_format' => SomeStructure::class]);
+        $processor->processInput($invocationEvent1);
+
+        $converter1 = new PlainConverter(new TextResult('{"some": "data"}'));
+        $deferred1 = new DeferredResult($converter1, new InMemoryRawResult());
+        $resultEvent1 = new ResultEvent($model, $deferred1, $invocationEvent1->getOptions());
+        $processor->processResult($resultEvent1);
+
+        $invocationEvent2 = new InvocationEvent($model, new MessageBag(), ['response_format' => 'json_object']);
+        $processor->processInput($invocationEvent2);
+
+        $this->assertSame(['response_format' => 'json_object'], $invocationEvent2->getOptions());
+
+        $converter2 = new PlainConverter(new TextResult('{"name": "Paris"}'));
+        $deferred2 = new DeferredResult($converter2, new InMemoryRawResult());
+        $resultEvent2 = new ResultEvent($model, $deferred2, $invocationEvent2->getOptions());
+        $processor->processResult($resultEvent2);
+
+        $this->assertSame(['name' => 'Paris'], $resultEvent2->getDeferredResult()->getResult()->getContent());
+    }
+
+    public function testInvocationWithoutResultEventDoesNotLeakStateIntoFollowingInvocation()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+
+        // The provider call fails, so this invocation never reaches processResult().
+        $city = new City(name: 'Berlin');
+        $invocationEvent1 = new InvocationEvent($model, new MessageBag(), ['response_format' => $city]);
+        $processor->processInput($invocationEvent1);
+
+        $rawResponseFormat = ['type' => 'json_schema', 'json_schema' => ['name' => 'city', 'schema' => ['type' => 'object']]];
+        $invocationEvent2 = new InvocationEvent($model, new MessageBag(), ['response_format' => $rawResponseFormat]);
+        $processor->processInput($invocationEvent2);
+
+        $converter2 = new PlainConverter(new TextResult('{"name": "Paris", "population": 2161000}'));
+        $deferred2 = new DeferredResult($converter2, new InMemoryRawResult());
+        $resultEvent2 = new ResultEvent($model, $deferred2, $invocationEvent2->getOptions());
+        $processor->processResult($resultEvent2);
+
+        $this->assertSame(['name' => 'Paris', 'population' => 2161000], $resultEvent2->getDeferredResult()->getResult()->getContent());
+        $this->assertSame('Berlin', $city->name);
+        $this->assertNull($city->population);
+    }
+
+    public function testInvocationFailingInProcessInputDoesNotLeakStateIntoFollowingInvocation()
+    {
+        $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+
+        $invocationEvent1 = new InvocationEvent($model, new MessageBag(), ['response_format' => SomeStructure::class]);
+        $processor->processInput($invocationEvent1);
+
+        $converter1 = new PlainConverter(new TextResult('{"some": "data"}'));
+        $deferred1 = new DeferredResult($converter1, new InMemoryRawResult());
+        $resultEvent1 = new ResultEvent($model, $deferred1, $invocationEvent1->getOptions());
+        $processor->processResult($resultEvent1);
+
+        // processInput() stores the object to populate before it rejects the unsupported model.
+        $city = new City(name: 'Berlin');
+        $unsupportedModel = new Model('gpt-3');
+        $invocationEvent2 = new InvocationEvent($unsupportedModel, new MessageBag(), ['response_format' => $city]);
+
+        try {
+            $processor->processInput($invocationEvent2);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', MissingModelSupportException::class));
+        } catch (MissingModelSupportException) {
+        }
+
+        // A class, not a raw schema: the object to populate is only consulted once an output
+        // type is set, so a leaked one would be deserialized into here.
+        $invocationEvent3 = new InvocationEvent($model, new MessageBag(), ['response_format' => City::class]);
+        $processor->processInput($invocationEvent3);
+
+        $converter3 = new PlainConverter(new TextResult('{"name": "Paris", "population": 2161000}'));
+        $deferred3 = new DeferredResult($converter3, new InMemoryRawResult());
+        $resultEvent3 = new ResultEvent($model, $deferred3, $invocationEvent3->getOptions());
+        $processor->processResult($resultEvent3);
+
+        $this->assertNotSame($city, $resultEvent3->getDeferredResult()->asObject());
+        $this->assertSame('Berlin', $city->name);
+        $this->assertNull($city->population);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

`StructuredOutput\PlatformSubscriber` is registered as a shared service. It carries
the resolved output type and the object to populate as properties between
`processInput()` (`InvocationEvent`) and `processResult()` (`ResultEvent`).

`processResult()` cleared `$objectToPopulate` but never `$outputType`, and neither was
cleared when an invocation ended without reaching `processResult()`. The stale values
were then applied to a later, unrelated invocation.

### Reproduction

Two invocations through the same platform. The first uses a class as
`response_format`; the second passes a provider JSON schema directly, which
`processInput()` deliberately leaves untouched:

```php
$platform->invoke('gpt-4o-mini', $messages, [
    'response_format' => Weather::class,
]);

$result = $platform->invoke('gpt-4o-mini', $messages, [
    'response_format' => [
        'type' => 'json_schema',
        'json_schema' => ['name' => 'city', 'schema' => [/* ... */]],
    ],
]);

// expected: array decoded from the model's JSON
// actual:   a Weather instance, deserialized from the second call's content
$result->asObject();
```

`processInput()` has three paths that return without setting an output type. Two of
them leave `response_format` in the options, so `processResult()` does not take its
matching early return and uses whatever the previous call left behind:

* `response_format` is an array (a raw provider JSON schema), as above;
* `response_format` is a string that is not a class and contains no namespace
  separator (e.g. `'url'` for an image model, `'json_object'`).

Two further paths abort an invocation before `processResult()` runs, so its reset
never happened at all:

* `processInput()` throws `MissingModelSupportException` for a model without
  `Capability::OUTPUT_STRUCTURED`. Note it assigns `$objectToPopulate` *before* that
  check, so the caller's own object stays parked on the shared service;
* the provider call fails. `ResultEvent` is dispatched after `doInvoke()` in
  `Provider::invoke()`, so any API or network error skips the reset.

In the last two cases the leaked `$objectToPopulate` is not just read but **written
to**: the next invocation deserializes its content *into the previous caller's
object*, silently mutating it.

### Fix

Both properties are cleared at the start of `processInput()`. `InvocationEvent` is
dispatched unconditionally at the top of every `Provider::invoke()`, so this holds
regardless of how the preceding invocation ended — early return, exception, or
provider failure.

`$outputType` becomes `?string` with a `null` default, matching `$objectToPopulate`
and making the `?? null` at the call site unnecessary. The two now-dead resets (the
one inside the `class_exists()` branch and the one at the end of `processResult()`)
are removed, so there is a single place where this state is cleared.

Note that resetting at the *end* of `processResult()` instead — with a `finally` or a
reset method — would not be sufficient: it does not run at all for the two aborted-
invocation cases above.

### BC impact

None. Both properties are `private`, and the change only removes behaviour that was
already unintended. Code passing a class or an object as `response_format` is
unaffected; code passing a raw schema or a non-structured `response_format` now gets
the plain decoded JSON it always should have.

### Alternatives considered

**Reset at the end of `processResult()` (`finally` or an explicit reset method).**
Smaller and more local, but incomplete for the reasons above: a failed provider call
or a rejected model leaves the subscriber dirty.

**Stop keeping per-call state on the subscriber at all** — carry the resolved output
type and object to populate on something scoped to the invocation. This is the real
fix and I would like to do it as a follow-up, but it does not fit in a bug fix PR.
The only value that currently flows from `InvocationEvent` to `ResultEvent` is
`$options`, and `processInput()` replaces `$options['response_format']` with the
provider-shaped schema, which `Provider::invoke()` then passes straight to
`doInvoke()` and into the request body — so an output type stashed there would be
sent to the provider. Carrying it properly needs a per-invocation context bag shared
by the two events, which is an API addition worth discussing separately.

That follow-up matters beyond this bug: mutable per-call state on a shared service is
also wrong for long-running runtimes (Messenger workers, FrankenPHP, RoadRunner) and
makes any future nested or concurrent invocation unsafe. A listener on `ResultEvent`
that itself calls `$platform->invoke()` can already clobber the outer invocation's
state today. This PR bounds the damage to one invocation; it does not remove the
underlying design issue.
