### PR TITLE
[Platform] Pass the response_format instance to ResponseFormatFactoryInterface::create()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,30 @@
+UPGRADE FROM 0.13 to 0.14
+=========================
+
+Platform
+--------
+
+ * `StructuredOutput\ResponseFormatFactoryInterface::create()` now receives `class-string|object` instead of
+   `class-string`. When `response_format` is an existing object instance, the factory is handed that very
+   instance, so the schema can be derived from its runtime state and not only from its class. Implementations
+   must widen the parameter type:
+
+   ```diff
+    final class MyResponseFormatFactory implements ResponseFormatFactoryInterface
+    {
+   -    public function create(string $responseClass): array
+   +    public function create(string|object $response): array
+        {
+   +        $responseClass = \is_object($response) ? $response::class : $response;
+   +
+            // ...
+        }
+    }
+   ```
+
+   The shipped `StructuredOutput\ResponseFormatFactory` is unchanged in behavior: it still describes
+   `$response::class` when given an object.
+
 UPGRADE FROM 0.12 to 0.13
 =========================
 
@@ -178,27 +205,6 @@ Mate
 
 Platform
 --------
-
- * `StructuredOutput\ResponseFormatFactoryInterface::create()` now receives `class-string|object` instead of
-   `class-string`. When `response_format` is an existing object instance, the factory is handed that very
-   instance, so the schema can be derived from its runtime state and not only from its class. Implementations
-   must widen the parameter type:
-
-   ```diff
-    final class MyResponseFormatFactory implements ResponseFormatFactoryInterface
-    {
-   -    public function create(string $responseClass): array
-   +    public function create(string|object $response): array
-        {
-   +        $responseClass = \is_object($response) ? $response::class : $response;
-   +
-            // ...
-        }
-    }
-   ```
-
-   The shipped `StructuredOutput\ResponseFormatFactory` is unchanged in behavior: it still describes
-   `$response::class` when given an object.
 
  * The Gemini and VertexAI bridges now yield a single `ToolCallComplete` delta at the end of a stream,
    carrying all function calls of the response, instead of one `ToolCallComplete` per streamed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -179,6 +179,27 @@ Mate
 Platform
 --------
 
+ * `StructuredOutput\ResponseFormatFactoryInterface::create()` now receives `class-string|object` instead of
+   `class-string`. When `response_format` is an existing object instance, the factory is handed that very
+   instance, so the schema can be derived from its runtime state and not only from its class. Implementations
+   must widen the parameter type:
+
+   ```diff
+    final class MyResponseFormatFactory implements ResponseFormatFactoryInterface
+    {
+   -    public function create(string $responseClass): array
+   +    public function create(string|object $response): array
+        {
+   +        $responseClass = \is_object($response) ? $response::class : $response;
+   +
+            // ...
+        }
+    }
+   ```
+
+   The shipped `StructuredOutput\ResponseFormatFactory` is unchanged in behavior: it still describes
+   `$response::class` when given an object.
+
  * The Gemini and VertexAI bridges now yield a single `ToolCallComplete` delta at the end of a stream,
    carrying all function calls of the response, instead of one `ToolCallComplete` per streamed
    `functionCall` part. Consumers collecting tool calls across several deltas can rely on the single

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -1283,6 +1283,48 @@ serialization groups::
         'response_format' => $product,
     ]);
 
+By default the schema sent to the model is derived from the class of the instance,
+so it describes every property the class allows. When the schema should depend on
+what the instance currently holds, implement
+:class:`Symfony\\AI\\Platform\\StructuredOutput\\ResponseFormatFactoryInterface`:
+``create()`` receives the very same instance that is passed as ``response_format``,
+and a class-string when there is none::
+
+    use Symfony\AI\Platform\Contract\JsonSchema\Factory;
+    use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactoryInterface;
+
+    final class MissingPropertiesResponseFormatFactory implements ResponseFormatFactoryInterface
+    {
+        public function __construct(
+            private readonly Factory $schemaFactory = new Factory(),
+        ) {
+        }
+
+        public function create(string|object $response): array
+        {
+            $responseClass = \is_object($response) ? $response::class : $response;
+            $schema = $this->schemaFactory->buildProperties($responseClass);
+
+            // Ask only for what this very instance is still missing
+            if (\is_object($response)) {
+                foreach (array_keys($schema['properties']) as $property) {
+                    if (null !== $response->{$property}) {
+                        unset($schema['properties'][$property]);
+                    }
+                }
+
+                $schema['required'] = array_keys($schema['properties']);
+            }
+
+            return [
+                'type' => 'json_schema',
+                'json_schema' => ['name' => 'city', 'schema' => $schema, 'strict' => true],
+            ];
+        }
+    }
+
+    $dispatcher->addSubscriber(new PlatformSubscriber(new MissingPropertiesResponseFormatFactory()));
+
 Scoping the Schema to Serializer Groups
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.13
 ----
 
+ * [BC BREAK] Widen `StructuredOutput\ResponseFormatFactoryInterface::create()` to accept `class-string|object`, so a factory receives the very instance passed as `response_format` and can derive a schema from its runtime state instead of only from its class
  * [BC BREAK] Add `ListenerInterface::onError()` and `Result\Stream\ErrorEvent`, dispatched when draining a `StreamResult` throws, so a listener can finalize on a failed stream where `onComplete()` never fires; `AbstractStreamListener` provides a no-op default
  * Add `Test\Replay\CassetteHttpClient` and `Test\Replay\HttpCassette` to record real HTTP responses (when the cassette file is missing) and replay them offline through the real bridge pipeline (Contract, `ModelClient`, `ResultConverter`) in tests, including raw Server-Sent Event streams; binary response bodies (images, audio, ...) are elided to a metadata stub (content type, byte size) and replayed as a small placeholder body
  * `TemplateRendererListener` now renders templates without `template_vars`; consequently, an expression referencing an absent variable now throws instead of reaching the normalizer as an empty object

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -1,10 +1,14 @@
 CHANGELOG
 =========
 
-0.13
+0.14
 ----
 
  * [BC BREAK] Widen `StructuredOutput\ResponseFormatFactoryInterface::create()` to accept `class-string|object`, so a factory receives the very instance passed as `response_format` and can derive a schema from its runtime state instead of only from its class
+
+0.13
+----
+
  * [BC BREAK] Add `ListenerInterface::onError()` and `Result\Stream\ErrorEvent`, dispatched when draining a `StreamResult` throws, so a listener can finalize on a failed stream where `onComplete()` never fires; `AbstractStreamListener` provides a no-op default
  * Add `Test\Replay\CassetteHttpClient` and `Test\Replay\HttpCassette` to record real HTTP responses (when the cassette file is missing) and replay them offline through the real bridge pipeline (Contract, `ModelClient`, `ResultConverter`) in tests, including raw Server-Sent Event streams; binary response bodies (images, audio, ...) are elided to a metadata stub (content type, byte size) and replayed as a small placeholder body
  * `TemplateRendererListener` now renders templates without `template_vars`; consequently, an expression referencing an absent variable now throws instead of reaching the normalizer as an empty object

--- a/src/platform/src/StructuredOutput/PlatformSubscriber.php
+++ b/src/platform/src/StructuredOutput/PlatformSubscriber.php
@@ -84,7 +84,8 @@ final class PlatformSubscriber implements EventSubscriberInterface
 
         $this->outputType = $className;
 
-        $options[self::RESPONSE_FORMAT] = $this->responseFormatFactory->create($className);
+        // Pass the instance itself when there is one, so a factory can derive a schema from its runtime state
+        $options[self::RESPONSE_FORMAT] = $this->responseFormatFactory->create($responseFormat);
 
         $event->setOptions($options);
     }

--- a/src/platform/src/StructuredOutput/ResponseFormatFactory.php
+++ b/src/platform/src/StructuredOutput/ResponseFormatFactory.php
@@ -25,8 +25,10 @@ final class ResponseFormatFactory implements ResponseFormatFactoryInterface
     ) {
     }
 
-    public function create(string $responseClass): array
+    public function create(string|object $response): array
     {
+        $responseClass = \is_object($response) ? $response::class : $response;
+
         return [
             'type' => 'json_schema',
             'json_schema' => [

--- a/src/platform/src/StructuredOutput/ResponseFormatFactoryInterface.php
+++ b/src/platform/src/StructuredOutput/ResponseFormatFactoryInterface.php
@@ -17,7 +17,8 @@ namespace Symfony\AI\Platform\StructuredOutput;
 interface ResponseFormatFactoryInterface
 {
     /**
-     * @param class-string $responseClass
+     * @param class-string|object $response The class to describe, or the very same instance the result will be
+     *                                      populated on, allowing the schema to depend on its runtime state
      *
      * @return array{
      *     type: 'json_schema',
@@ -28,5 +29,5 @@ interface ResponseFormatFactoryInterface
      *     }
      * }
      */
-    public function create(string $responseClass): array;
+    public function create(string|object $response): array;
 }

--- a/src/platform/tests/StructuredOutput/ConfigurableResponseFormatFactory.php
+++ b/src/platform/tests/StructuredOutput/ConfigurableResponseFormatFactory.php
@@ -23,7 +23,7 @@ final readonly class ConfigurableResponseFormatFactory implements ResponseFormat
     ) {
     }
 
-    public function create(string $responseClass): array
+    public function create(string|object $response): array
     {
         return $this->responseFormat;
     }

--- a/src/platform/tests/StructuredOutput/ConfigurableResponseFormatFactory.php
+++ b/src/platform/tests/StructuredOutput/ConfigurableResponseFormatFactory.php
@@ -13,13 +13,13 @@ namespace Symfony\AI\Platform\Tests\StructuredOutput;
 
 use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactoryInterface;
 
-final readonly class ConfigurableResponseFormatFactory implements ResponseFormatFactoryInterface
+final class ConfigurableResponseFormatFactory implements ResponseFormatFactoryInterface
 {
     /**
      * @param array<mixed> $responseFormat
      */
     public function __construct(
-        private array $responseFormat = [],
+        private readonly array $responseFormat = [],
     ) {
     }
 

--- a/src/platform/tests/StructuredOutput/MissingPropertiesResponseFormatFactory.php
+++ b/src/platform/tests/StructuredOutput/MissingPropertiesResponseFormatFactory.php
@@ -18,7 +18,7 @@ use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactoryInterface;
  * only the properties still holding null are described, so two instances of the same class with
  * different values filled in produce different schemas.
  */
-final readonly class MissingPropertiesResponseFormatFactory implements ResponseFormatFactoryInterface
+final class MissingPropertiesResponseFormatFactory implements ResponseFormatFactoryInterface
 {
     public function create(string|object $response): array
     {

--- a/src/platform/tests/StructuredOutput/MissingPropertiesResponseFormatFactory.php
+++ b/src/platform/tests/StructuredOutput/MissingPropertiesResponseFormatFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\StructuredOutput;
+
+use Symfony\AI\Platform\StructuredOutput\ResponseFormatFactoryInterface;
+
+/**
+ * Test double for a factory deriving the schema from the runtime state of the instance to populate:
+ * only the properties still holding null are described, so two instances of the same class with
+ * different values filled in produce different schemas.
+ */
+final readonly class MissingPropertiesResponseFormatFactory implements ResponseFormatFactoryInterface
+{
+    public function create(string|object $response): array
+    {
+        $reflection = new \ReflectionClass($response);
+
+        $properties = [];
+        foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+            if (\is_object($response) && null !== $property->getValue($response)) {
+                continue;
+            }
+
+            $properties[$property->getName()] = ['type' => 'string'];
+        }
+
+        return [
+            'type' => 'json_schema',
+            'json_schema' => [
+                'name' => $reflection->getShortName(),
+                'schema' => [
+                    'type' => 'object',
+                    'properties' => $properties,
+                    'required' => array_keys($properties),
+                    'additionalProperties' => false,
+                ],
+                'strict' => true,
+            ],
+        ];
+    }
+}

--- a/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
+++ b/src/platform/tests/StructuredOutput/PlatformSubscriberTest.php
@@ -298,6 +298,45 @@ final class PlatformSubscriberTest extends TestCase
         $this->assertSame(['response_format' => ['some' => 'format']], $event->getOptions());
     }
 
+    public function testResponseFormatFactoryReceivesTheInstanceToPopulate()
+    {
+        $processor = new PlatformSubscriber(new MissingPropertiesResponseFormatFactory());
+        $model = new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]);
+
+        $berlin = new City(name: 'Berlin', country: 'Germany');
+        $event = new InvocationEvent($model, new MessageBag(), ['response_format' => $berlin]);
+        $processor->processInput($event);
+
+        $paris = new City(name: 'Paris');
+        $secondEvent = new InvocationEvent($model, new MessageBag(), ['response_format' => $paris]);
+        $processor->processInput($secondEvent);
+
+        // Both instances are of the same class, but only the properties they are still missing are described
+        $this->assertSame(
+            ['population', 'mayor'],
+            $event->getOptions()['response_format']['json_schema']['schema']['required'],
+        );
+        $this->assertSame(
+            ['population', 'country', 'mayor'],
+            $secondEvent->getOptions()['response_format']['json_schema']['schema']['required'],
+        );
+    }
+
+    public function testResponseFormatFactoryReceivesTheClassNameWithoutInstance()
+    {
+        $processor = new PlatformSubscriber(new MissingPropertiesResponseFormatFactory());
+        $event = new InvocationEvent(new Model('gpt-4', [Capability::OUTPUT_STRUCTURED]), new MessageBag(), [
+            'response_format' => City::class,
+        ]);
+
+        $processor->processInput($event);
+
+        $this->assertSame(
+            ['name', 'population', 'country', 'mayor'],
+            $event->getOptions()['response_format']['json_schema']['schema']['required'],
+        );
+    }
+
     public function testProcessOutputWithObjectInstance()
     {
         $processor = new PlatformSubscriber(new ConfigurableResponseFormatFactory(['some' => 'format']));

--- a/src/platform/tests/StructuredOutput/ResponseFormatFactoryTest.php
+++ b/src/platform/tests/StructuredOutput/ResponseFormatFactoryTest.php
@@ -51,4 +51,11 @@ final class ResponseFormatFactoryTest extends TestCase
             ],
         ], (new ResponseFormatFactory())->create($class));
     }
+
+    public function testCreateWithObjectFallsBackToItsClass()
+    {
+        $factory = new ResponseFormatFactory();
+
+        $this->assertSame($factory->create(User::class), $factory->create(new User()));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

### Problem

`response_format` accepts an existing object instance, and the Platform uses it as the
serializer's `object_to_populate` so the model's answer is written onto that very
instance (`Populating Existing Object Instances` in the Platform docs).

The schema half of that feature never sees the object.
`ResponseFormatFactoryInterface::create()` takes only a `class-string`, and
`PlatformSubscriber` passes `$responseFormat::class` to it. So the JSON schema is always
the open-ended shape the *class* allows, never the shape the *instance* actually needs.

That makes the instance mode half-implemented. Any schema that depends on runtime state
is impossible to express:

* only asking the model for the properties the instance is still missing, instead of
  re-asking for everything and hoping the merge is a no-op;
* a recursive tree object where the schema should describe exactly the nodes that exist
  (their count, their concrete types), not the unbounded shape of the class.

Today the only escape is to decorate the factory service and smuggle the instance in
through side-channel state on the decorator, which is exactly the sort of thing the
framework should make unnecessary.

### Reproduction

```php
final class City
{
    public function __construct(
        public ?string $name = null,
        public ?int $population = null,
        public ?string $country = null,
    ) {
    }
}

final class MissingPropertiesResponseFormatFactory implements ResponseFormatFactoryInterface
{
    public function create(string $responseClass): array
    {
        // $responseClass is City::class — for every instance, always.
        // There is no way to know that this particular City already has a name.
    }
}

$dispatcher->addSubscriber(new PlatformSubscriber(new MissingPropertiesResponseFormatFactory()));

$platform->invoke($model, $messages, ['response_format' => new City(name: 'Berlin')]);
$platform->invoke($model, $messages, ['response_format' => new City()]);
// Both invocations send the identical schema.
```

### Fix

Widen the interface parameter to `class-string|object` and hand the instance through
from `PlatformSubscriber`:

```php
public function create(string|object $response): array;
```

`PlatformSubscriber` already has the original option value in scope, so the change is
one line — it passes `$responseFormat` (the object when there is one, the class-string
otherwise) instead of the derived `$className`. The object-to-populate path is untouched.

The shipped `ResponseFormatFactory` is unchanged in behavior: given an object it
resolves `$response::class` and describes the class exactly as before.

### BC impact

`BC Break` label + `UPGRADE.md` entry. Callers are unaffected (a `class-string` is still
a valid argument); **implementors** of `ResponseFormatFactoryInterface` must widen the
parameter type, otherwise PHP raises a declaration-compatibility fatal error:

```diff
 final class MyResponseFormatFactory implements ResponseFormatFactoryInterface
 {
-    public function create(string $responseClass): array
+    public function create(string|object $response): array
     {
+        $responseClass = \is_object($response) ? $response::class : $response;
+
         // ...
     }
 }
```

In this repository the only implementations are `ResponseFormatFactory` and a test
double, both updated here. `ai-bundle` registers the factory as a service and aliases
the interface; no signature coupling, nothing to change there.

### Alternatives considered

**(a) Widen the parameter — `create(string|object $response)`.** What this PR does.
Mirrors how the `response_format` option itself is typed, keeps the argument
self-documenting and statically checkable, and the "is it an instance?" question is
answered by `\is_object()` rather than by an array key that may or may not be present.

**(b) Keep `create(string $responseClass)`, add `array $context = []` with the instance
under a documented key.** Attractive because `Contract\JsonSchema\Factory::buildProperties()`
already takes a `$context` array (`serializer_groups`), so a factory could forward the
context straight down to the describers. Rejected because: it is equally a break for
implementors (an implementation missing the second parameter is also a fatal declaration
error), it makes the instance a stringly-typed, optional, undiscoverable payload, and it
invites the context array to become a grab bag. The extensibility it buys is not needed
for the concrete problem here — and if a describer-facing context is wanted later, it can
be added as a *third* concern on top of (a) without re-litigating the instance.

**(c) Add a separate `createForInstance(object $response)` method.** Avoids touching the
existing signature but still breaks every implementor (a new interface method), and
leaves two methods that must be kept in sync for what is one concept.

**(d) Do nothing; document decorating the factory.** This is the status quo, and it only
works by keeping mutable per-invocation state on a service, which is not safe to
recommend.

### Follow-up (deliberately not in this PR)

A fully useful instance mode also wants the instance to reach
`Contract\JsonSchema\Provider\SchemaProviderInterface::getSchemaFragment()`. Today
`SchemaAttributeDescriber` calls it as `getSchemaFragment($attribute->context)` — the
static array from `#[Schema(context: ...)]` — and the `ObjectSubject`/`PropertySubject`
travelling through the describer chain carries a reflector and a describer context but no
runtime subject. So a `#[Schema(provider: ...)]` fragment still cannot depend on the
instance being populated, even with this PR. Reworking the describer chain to carry the
instance is a larger change with its own design questions (does the subject own it? does
it ride in the describer context? what happens for nested objects?), so it is better
argued separately.
