### PR TITLE
[Agent][Chat][Platform] Replay the assistant turn as the provider produced it

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -64,6 +64,9 @@ Agent
    Code relying on the `StreamResult` type specifically — `instanceof StreamResult`, `addListener()` — must be
    reworked to consume the execution instead (as the `Chat` component's `stream()` now does).
 
+ * A tool-calling round adds one assistant message per turn — text, thinking blocks and tool calls
+   together — instead of splitting it. Code asserting on the message bag's shape needs updating.
+
 AI Bundle
 ---------
 
@@ -91,6 +94,9 @@ Chat
    streamed deltas and persists the assistant message, including the result metadata, once the stream is complete.
    Since `AgentInterface::call()` no longer returns a `StreamResult` (see the Agent section), there is no stream to
    attach the listener to anymore.
+
+ * `Chat::stream()` persists the assistant turn whole — a `Thinking` part now survives where plain text
+   was stored. Code reading persisted history must expect structured content.
 
 MCP Bundle
 ----------

--- a/demo/src/Document/Chat.php
+++ b/demo/src/Document/Chat.php
@@ -14,7 +14,6 @@ namespace App\Document;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
-use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -64,7 +63,7 @@ final class Chat
         $messages = new MessageBag(
             Message::forSystem($system),
             Message::ofUser($url),
-            Message::ofAssistant($execution->asText()),
+            Message::ofAssistant($execution->getResult()),
         );
 
         $this->reset();
@@ -76,11 +75,9 @@ final class Chat
         $messages = $this->loadMessages();
 
         $messages->add(Message::ofUser($message));
-        $result = $this->agent->call($messages)->getResult();
+        $execution = $this->agent->call($messages);
 
-        \assert($result instanceof TextResult);
-
-        $messages->add(Message::ofAssistant($result->getContent()));
+        $messages->add(Message::ofAssistant($execution->getResult()));
 
         $this->saveMessages($messages);
     }

--- a/demo/src/YouTube/Chat.php
+++ b/demo/src/YouTube/Chat.php
@@ -63,7 +63,7 @@ final class Chat
         $messages->add(Message::ofUser($message));
         $execution = $this->agent->call($messages);
 
-        $messages->add(Message::ofAssistant($execution->asText()));
+        $messages->add(Message::ofAssistant($execution->getResult()));
 
         $this->saveMessages($messages);
     }

--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -176,6 +176,20 @@ Tool calling can be enabled by passing a toolbox to the agent::
 
     $agent = new Agent($platform, $model, toolbox: $toolbox);
 
+When the model calls a tool, the agent runs the tool loop and appends the exchange to the
+message bag: the assistant turn the provider produced - its text, thinking blocks and tool
+calls as one message - followed by the tool results.
+
+Carry the final answer into the next turn by passing the result itself to
+:method:`Symfony\\AI\\Platform\\Message\\Message::ofAssistant`, which keeps the thinking
+blocks and signatures providers validate when the conversation is replayed::
+
+    $execution = $agent->call($messages);
+
+    $messages->add(Message::ofAssistant($execution->getResult()));
+
+Streamed results work the same way, see :doc:`the Platform component </components/platform>`.
+
 Custom tools can basically be any class, but must configure by the :class:`Symfony\\AI\\Agent\\Toolbox\\Attribute\\AsTool` attribute::
 
     use Symfony\AI\Agent\Toolbox\Attribute\AsTool;

--- a/docs/components/chat.rst
+++ b/docs/components/chat.rst
@@ -65,6 +65,9 @@ Once the stream is fully consumed, the assistant message is automatically
 persisted to the message store along with the user message. This means the
 conversation history is kept up-to-date without any additional code.
 
+The persisted message is the assistant turn as the provider produced it, thinking blocks
+and signatures included, so the stored conversation can be replayed on a later turn.
+
 .. note::
 
     Due to implementations limitations, using streaming with :class:`Symfony\\AI\\Chat\\Bridge\\Session\\MessageStore` is *not* recommended.

--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -904,6 +904,34 @@ so a result that contains a :class:`Symfony\\AI\\Platform\\Result\\ThinkingResul
 followed by a :class:`Symfony\\AI\\Platform\\Result\\TextResult` (and any tool
 calls) is replayed in the same order on the next turn.
 
+Replaying a Streamed Turn
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A streamed response carries the assistant turn as deltas.
+:method:`Symfony\\AI\\Platform\\Message\\Message::ofAssistant` accepts a streamed result
+just like a buffered one and returns the turn the provider produced - text, thinking
+blocks with their signatures, and tool calls, in order::
+
+    $result = $platform->invoke($model, $messages, ['stream' => true])->getResult();
+    \assert($result instanceof StreamResult);
+
+    foreach ($result->getContent() as $delta) {
+        echo $delta;
+    }
+
+    $messages->add(Message::ofAssistant($result));
+
+The turn is collected while the stream is read;
+:method:`Symfony\\AI\\Platform\\Result\\StreamResult::getAssistantMessage` returns it
+directly, draining a stream that was never iterated.
+:class:`Symfony\\AI\\Platform\\Result\\Stream\\AssistantMessageStreamListener` performs
+the reassembly and can be used on its own.
+
+.. caution::
+
+    Read the turn *after* the deltas, as above. A stream is read once, so asking for the
+    turn first drains it and the deltas never reach the loop that follows.
+
 Checking for Thinking Support
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/examples/agent/multi-turn-reasoning-mistral.php
+++ b/examples/agent/multi-turn-reasoning-mistral.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Bridge\Clock\Clock;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Mistral\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+// Mistral wants the reasoning trace back as a thinking chunk of the content list, and rejects the
+// `reasoning_content` of the OpenAI-compatible convention with a 422.
+$platform = Factory::createPlatform(env('MISTRAL_API_KEY'), http_client());
+
+$toolbox = new Toolbox([new Clock()], logger: logger());
+$agent = new Agent($platform, 'mistral-medium-2604', toolbox: $toolbox);
+
+$options = ['reasoning_effort' => 'high'];
+
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant.'),
+);
+
+$messages->add(Message::ofUser('What time is it right now?'));
+$execution = $agent->call($messages, $options);
+
+$assistant = Message::ofAssistant($execution->getResult());
+output()->writeln('<info>Turn 1:</info> '.$assistant->asText());
+$messages->add($assistant);
+
+$messages->add(Message::ofUser('What did I just ask you?'));
+$execution = $agent->call($messages, $options);
+
+$assistant = Message::ofAssistant($execution->getResult());
+output()->writeln('<info>Turn 2:</info> '.$assistant->asText());
+$messages->add($assistant);
+
+print_conversation_shape($messages);

--- a/examples/agent/multi-turn-reasoning-stateless.php
+++ b/examples/agent/multi-turn-reasoning-stateless.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Bridge\Clock\Clock;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+// With "store" => false the Responses API keeps its encrypted reasoning items across the tool call
+// only if the whole assistant turn comes back, carried as the signature of a Thinking part.
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+$toolbox = new Toolbox([new Clock()], logger: logger());
+$agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox);
+
+$options = [
+    'store' => false,
+    'include' => ['reasoning.encrypted_content'],
+    'reasoning' => ['effort' => 'low', 'summary' => 'auto'],
+];
+
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant.'),
+);
+
+$messages->add(Message::ofUser('What time is it right now?'));
+$execution = $agent->call($messages, $options);
+
+$assistant = Message::ofAssistant($execution->getResult());
+output()->writeln('<info>Turn 1:</info> '.$assistant->asText());
+$messages->add($assistant);
+
+$messages->add(Message::ofUser('What did I just ask you?'));
+$execution = $agent->call($messages, $options);
+
+$assistant = Message::ofAssistant($execution->getResult());
+output()->writeln('<info>Turn 2:</info> '.$assistant->asText());
+$messages->add($assistant);
+
+print_conversation_shape($messages);

--- a/examples/agent/multi-turn-thinking-stream.php
+++ b/examples/agent/multi-turn-thinking-stream.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Bridge\Clock\Clock;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Anthropic\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+// The streaming counterpart of multi-turn-thinking.php: a streamed round returns the same result a
+// buffered one does.
+$platform = Factory::createPlatform(env('ANTHROPIC_API_KEY'), httpClient: http_client());
+
+$toolbox = new Toolbox([new Clock()], logger: logger());
+$agent = new Agent($platform, 'claude-sonnet-4-5-20250929', toolbox: $toolbox);
+
+$options = [
+    'stream' => true,
+    'max_tokens' => 4000,
+    'thinking' => ['type' => 'enabled', 'budget_tokens' => 1024],
+];
+
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant.'),
+);
+
+$messages->add(Message::ofUser('What time is it right now?'));
+$execution = $agent->call($messages, $options);
+
+output()->write('<info>Turn 1:</info> ');
+foreach ($execution->asStream() as $delta) {
+    if ($delta instanceof TextDelta) {
+        output()->write($delta->getText());
+    }
+}
+output()->writeln('');
+
+$messages->add(Message::ofAssistant($execution->getResult()));
+
+$messages->add(Message::ofUser('What did I just ask you?'));
+$execution = $agent->call($messages, $options);
+
+output()->write('<info>Turn 2:</info> ');
+foreach ($execution->asStream() as $delta) {
+    if ($delta instanceof TextDelta) {
+        output()->write($delta->getText());
+    }
+}
+output()->writeln('');
+
+$messages->add(Message::ofAssistant($execution->getResult()));
+
+print_conversation_shape($messages);

--- a/examples/agent/multi-turn-thinking.php
+++ b/examples/agent/multi-turn-thinking.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Bridge\Clock\Clock;
+use Symfony\AI\Agent\Toolbox\Toolbox;
+use Symfony\AI\Platform\Bridge\Anthropic\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+// Anthropic answers turn 2 with a 400 unless the assistant turn comes back exactly as produced,
+// thinking signatures and ordering included.
+$platform = Factory::createPlatform(env('ANTHROPIC_API_KEY'), httpClient: http_client());
+
+$toolbox = new Toolbox([new Clock()], logger: logger());
+$agent = new Agent($platform, 'claude-sonnet-4-5-20250929', toolbox: $toolbox);
+
+$options = [
+    'max_tokens' => 4000,
+    'thinking' => ['type' => 'enabled', 'budget_tokens' => 1024],
+];
+
+$messages = new MessageBag(
+    Message::forSystem('You are a helpful assistant.'),
+);
+
+$messages->add(Message::ofUser('What time is it right now?'));
+$execution = $agent->call($messages, $options);
+
+$assistant = Message::ofAssistant($execution->getResult());
+output()->writeln('<info>Turn 1:</info> '.$assistant->asText());
+$messages->add($assistant);
+
+$messages->add(Message::ofUser('What did I just ask you?'));
+$execution = $agent->call($messages, $options);
+
+$assistant = Message::ofAssistant($execution->getResult());
+output()->writeln('<info>Turn 2:</info> '.$assistant->asText());
+$messages->add($assistant);
+
+print_conversation_shape($messages);

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -16,7 +16,14 @@ use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
 use Symfony\AI\Platform\Exception\ExceptionInterface as PlatformException;
 use Symfony\AI\Platform\FinishReason\FinishReason;
 use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\MessageInterface;
+use Symfony\AI\Platform\Message\ToolCallMessage;
 use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Test\Replay\CassetteHttpClient;
 use Symfony\AI\Platform\Test\Replay\HttpCassette;
 use Symfony\AI\Platform\TokenUsage\TokenUsageAggregation;
@@ -198,6 +205,52 @@ function print_token_usage(?TokenUsageInterface $tokenUsage): void
     if ($tokenUsage instanceof TokenUsageAggregation) {
         output()->writeln(sprintf('<comment>Aggregated token usage from %d calls.</comment>', $tokenUsage->count()));
     }
+}
+
+/**
+ * Renders what each message is made of rather than what it says, which keeps the recorded
+ * golden stable across re-records.
+ */
+function print_conversation_shape(MessageBag $messages): void
+{
+    $table = new Table(output());
+    $table->setHeaderTitle('Conversation Shape');
+    $table->setHeaders(['#', 'Role', 'Content parts']);
+
+    foreach ($messages->getMessages() as $index => $message) {
+        $table->addRow([$index, $message->getRole()->value, implode(' + ', describe_message_parts($message))]);
+    }
+
+    $table->render();
+}
+
+/**
+ * @return list<string>
+ */
+function describe_message_parts(MessageInterface $message): array
+{
+    if ($message instanceof ToolCallMessage) {
+        return [sprintf('ToolResult(%s)', $message->getToolCall()->getName())];
+    }
+
+    if (!$message instanceof AssistantMessage) {
+        return ['Text'];
+    }
+
+    $parts = [];
+    foreach ($message->getContent() as $part) {
+        $parts[] = match (true) {
+            $part instanceof Thinking => sprintf(
+                'Thinking(%s)',
+                null === $part->getSignature() ? '<error>unsigned</error>' : '<info>signed</info>',
+            ),
+            $part instanceof ToolCall => sprintf('ToolCall(%s)', $part->getName()),
+            $part instanceof Text => 'Text',
+            default => (new ReflectionClass($part))->getShortName(),
+        };
+    }
+
+    return [] === $parts ? ['<error>empty</error>'] : $parts;
 }
 
 function print_finish_reason(?FinishReason $finishReason): void

--- a/examples/gemini/toolcall-roundtrip.php
+++ b/examples/gemini/toolcall-roundtrip.php
@@ -30,18 +30,18 @@ $messages = new MessageBag(
 
 // plain chat
 $messages->add(Message::ofUser('What is the capital of France?'));
-$result = $agent->call($messages);
-echo 'Turn 1: '.$result->getContent().\PHP_EOL;
-$messages->add(Message::ofAssistant($result->getContent()));
+$execution = $agent->call($messages);
+echo 'Turn 1: '.$execution->asText().\PHP_EOL;
+$messages->add(Message::ofAssistant($execution->getResult()));
 
 // parallel tool calls – Clock returns a scalar string, EuropeanCapitalsTool returns a list
 // (the latter must be wrapped as a Protobuf Struct on the function_response leg)
 $messages->add(Message::ofUser('What time is it right now, and which European capitals do you know about via your tools?'));
-$result = $agent->call($messages);
-echo 'Turn 2: '.$result->getContent().\PHP_EOL;
-$messages->add(Message::ofAssistant($result->getContent()));
+$execution = $agent->call($messages);
+echo 'Turn 2: '.$execution->asText().\PHP_EOL;
+$messages->add(Message::ofAssistant($execution->getResult()));
 
 // another chat with tool results in MessageBag
 $messages->add(Message::ofUser('What was the first question I asked you?'));
-$result = $agent->call($messages);
-echo 'Turn 3: '.$result->getContent().\PHP_EOL;
+$execution = $agent->call($messages);
+echo 'Turn 3: '.$execution->asText().\PHP_EOL;

--- a/examples/tests/fixtures/agent/multi-turn-reasoning-mistral.json
+++ b/examples/tests/fixtures/agent/multi-turn-reasoning-mistral.json
@@ -1,0 +1,199 @@
+{
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.mistral.ai/v1/chat/completions",
+                "signature": "a418ad834619b9eadbefa26ab76452cf",
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "[redacted]"
+                    ]
+                },
+                "body": "{\"reasoning_effort\":\"high\",\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"clock\",\"description\":\"Provides the current date and time.\",\"parameters\":{\"type\":\"object\"}}}],\"messages\":[{\"role\":\"system\",\"content\":\"You are a helpful assistant.\"},{\"role\":\"user\",\"content\":\"What time is it right now?\"}],\"model\":\"mistral-medium-2604\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "x-max-retry-attempts-reached": [
+                        "false"
+                    ],
+                    "x-ratelimit-limit-tokens-minute": [
+                        "500000"
+                    ],
+                    "x-ratelimit-remaining-tokens-minute": [
+                        "498196"
+                    ],
+                    "x-ratelimit-tokens-query-cost": [
+                        "195"
+                    ],
+                    "x-ratelimit-limit-req-minute": [
+                        "1000"
+                    ],
+                    "x-ratelimit-remaining-req-minute": [
+                        "995"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "access-control-allow-origin": [
+                        "*"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15552000; includeSubDomains; preload"
+                    ],
+                    "x-content-type-options": [
+                        "nosniff"
+                    ],
+                    "set-cookie": [
+                        "[redacted]"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\"id\":\"be4001e216174d2b9d3a2de5d0c8c583\",\"created\":1788046765,\"model\":\"mistral-medium-2604\",\"usage\":{\"prompt_tokens\":70,\"total_tokens\":195,\"completion_tokens\":125,\"prompt_tokens_details\":{\"cached_tokens\":0},\"service_tier\":\"standard\"},\"object\":\"chat.completion\",\"choices\":[{\"index\":0,\"finish_reason\":\"tool_calls\",\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"id\":\"0AMsv2EWQ\",\"type\":\"function\",\"function\":{\"name\":\"clock\",\"arguments\":\"{}\"},\"index\":0}],\"content\":[{\"type\":\"thinking\",\"thinking\":[{\"type\":\"text\",\"text\":\"Okay, the user is asking for the current time. I need to figure out how to get that information. The available tool is \\\"clock\\\" which provides the current date and time. So I should call the clock function. The function parameters are a dictionary, but maybe it doesn't need any specific arguments. Let me check the function's description again. It says it provides the current date and time, so probably just calling it without any arguments is sufficient. So I'll make a tool call to clock with an empty dict as the arguments. Then the response will be the current time.\"}],\"closed\":true}]}}]}"
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.mistral.ai/v1/chat/completions",
+                "signature": "46a926fe94497746825a314542c3d67c",
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "[redacted]"
+                    ]
+                },
+                "body": "{\"reasoning_effort\":\"high\",\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"clock\",\"description\":\"Provides the current date and time.\",\"parameters\":{\"type\":\"object\"}}}],\"messages\":[{\"role\":\"system\",\"content\":\"You are a helpful assistant.\"},{\"role\":\"user\",\"content\":\"What time is it right now?\"},{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"id\":\"0AMsv2EWQ\",\"type\":\"function\",\"function\":{\"name\":\"clock\",\"arguments\":\"{}\"}}]},{\"role\":\"tool\",\"content\":\"Current date is 2026-08-29 (YYYY-MM-DD) and the time is 23:39:26 (HH:MM:SS).\",\"tool_call_id\":\"0AMsv2EWQ\"}],\"model\":\"mistral-medium-2604\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "x-max-retry-attempts-reached": [
+                        "false"
+                    ],
+                    "x-ratelimit-limit-tokens-minute": [
+                        "500000"
+                    ],
+                    "x-ratelimit-remaining-tokens-minute": [
+                        "497952"
+                    ],
+                    "x-ratelimit-tokens-query-cost": [
+                        "249"
+                    ],
+                    "x-ratelimit-limit-req-minute": [
+                        "1000"
+                    ],
+                    "x-ratelimit-remaining-req-minute": [
+                        "994"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "access-control-allow-origin": [
+                        "*"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15552000; includeSubDomains; preload"
+                    ],
+                    "x-content-type-options": [
+                        "nosniff"
+                    ],
+                    "set-cookie": [
+                        "[redacted]"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\"id\":\"e14c743cf3a14304bc63c9c481bc53ff\",\"created\":1788046766,\"model\":\"mistral-medium-2604\",\"usage\":{\"prompt_tokens\":116,\"total_tokens\":249,\"completion_tokens\":133,\"prompt_tokens_details\":{\"cached_tokens\":0},\"service_tier\":\"standard\"},\"object\":\"chat.completion\",\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"tool_calls\":null,\"content\":[{\"type\":\"thinking\",\"thinking\":[{\"type\":\"text\",\"text\":\"Okay, the user asked what time it is right now. I need to check the current time. The clock tool was called, and it provided the current date as 2026-08-29 and the time as 23:39:26. So the time is 23:39:26, which is 11:39 PM. I should just state the time clearly without any additional information.\"}],\"closed\":true},{\"type\":\"text\",\"text\":\"The current time is **23:39:26 (11:39:26 PM)** on August 29, 2026.\"}]}}]}"
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.mistral.ai/v1/chat/completions",
+                "signature": "8e37747d39a6f7954e1d28cb6dd1df7c",
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "accept": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "[redacted]"
+                    ]
+                },
+                "body": "{\"reasoning_effort\":\"high\",\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"clock\",\"description\":\"Provides the current date and time.\",\"parameters\":{\"type\":\"object\"}}}],\"messages\":[{\"role\":\"system\",\"content\":\"You are a helpful assistant.\"},{\"role\":\"user\",\"content\":\"What time is it right now?\"},{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"id\":\"0AMsv2EWQ\",\"type\":\"function\",\"function\":{\"name\":\"clock\",\"arguments\":\"{}\"}}]},{\"role\":\"tool\",\"content\":\"Current date is 2026-08-29 (YYYY-MM-DD) and the time is 23:39:26 (HH:MM:SS).\",\"tool_call_id\":\"0AMsv2EWQ\"},{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":[{\"type\":\"text\",\"text\":\"Okay, the user asked what time it is right now. I need to check the current time. The clock tool was called, and it provided the current date as 2026-08-29 and the time as 23:39:26. So the time is 23:39:26, which is 11:39 PM. I should just state the time clearly without any additional information.\"}]},{\"type\":\"text\",\"text\":\"The current time is **23:39:26 (11:39:26 PM)** on August 29, 2026.\"}]},{\"role\":\"user\",\"content\":\"What did I just ask you?\"}],\"model\":\"mistral-medium-2604\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "x-max-retry-attempts-reached": [
+                        "false"
+                    ],
+                    "x-ratelimit-limit-tokens-minute": [
+                        "500000"
+                    ],
+                    "x-ratelimit-remaining-tokens-minute": [
+                        "497630"
+                    ],
+                    "x-ratelimit-tokens-query-cost": [
+                        "327"
+                    ],
+                    "x-ratelimit-limit-req-minute": [
+                        "1000"
+                    ],
+                    "x-ratelimit-remaining-req-minute": [
+                        "993"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "access-control-allow-origin": [
+                        "*"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15552000; includeSubDomains; preload"
+                    ],
+                    "x-content-type-options": [
+                        "nosniff"
+                    ],
+                    "set-cookie": [
+                        "[redacted]"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\"id\":\"bbd836290bef4268aa6840133f7632b1\",\"created\":1788046767,\"model\":\"mistral-medium-2604\",\"usage\":{\"prompt_tokens\":258,\"total_tokens\":327,\"completion_tokens\":69,\"prompt_tokens_details\":{\"cached_tokens\":0},\"service_tier\":\"standard\"},\"object\":\"chat.completion\",\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"tool_calls\":null,\"content\":[{\"type\":\"thinking\",\"thinking\":[{\"type\":\"text\",\"text\":\"The user is asking what they just asked me. I need to recall the previous interaction. The last question was \\\"What time is it right now?\\\" which I answered with the current time. So the user's previous question was about the current time. I should confirm that.\"}],\"closed\":true},{\"type\":\"text\",\"text\":\"You asked, \\\"What time is it right now?\\\"\"}]}}]}"
+            }
+        }
+    ]
+}

--- a/examples/tests/fixtures/agent/multi-turn-reasoning-mistral.out
+++ b/examples/tests/fixtures/agent/multi-turn-reasoning-mistral.out
@@ -1,0 +1,13 @@
+Turn 1: The current time is **23:39:26 (11:39:26 PM)** on August 29, 2026.
+Turn 2: You asked, "What time is it right now?"
++---+------- Conversation Shape ------------+
+| # | Role      | Content parts             |
++---+-----------+---------------------------+
+| 0 | system    | Text                      |
+| 1 | user      | Text                      |
+| 2 | assistant | ToolCall(clock)           |
+| 3 | tool      | ToolResult(clock)         |
+| 4 | assistant | Thinking(unsigned) + Text |
+| 5 | user      | Text                      |
+| 6 | assistant | Thinking(unsigned) + Text |
++---+-----------+---------------------------+

--- a/examples/tests/fixtures/agent/multi-turn-reasoning-stateless.json
+++ b/examples/tests/fixtures/agent/multi-turn-reasoning-stateless.json
@@ -1,0 +1,223 @@
+{
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.openai.com/v1/responses",
+                "signature": "3c923515669b04576aa71ee082e8a623",
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "[redacted]"
+                    ]
+                },
+                "body": "{\"store\":false,\"include\":[\"reasoning.encrypted_content\"],\"reasoning\":{\"effort\":\"low\",\"summary\":\"auto\"},\"tools\":[{\"type\":\"function\",\"name\":\"clock\",\"description\":\"Provides the current date and time.\"}],\"model\":\"gpt-5-mini\",\"input\":[{\"role\":\"user\",\"content\":\"What time is it right now?\"}],\"instructions\":\"You are a helpful assistant.\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=31536000; includeSubDomains; preload"
+                    ],
+                    "x-content-type-options": [
+                        "nosniff"
+                    ],
+                    "access-control-expose-headers": [
+                        "X-Request-ID",
+                        "CF-Ray",
+                        "CF-Ray"
+                    ],
+                    "openai-organization": [
+                        "[redacted]"
+                    ],
+                    "openai-project": [
+                        "[redacted]"
+                    ],
+                    "openai-version": [
+                        "2020-10-01"
+                    ],
+                    "x-ratelimit-limit-requests": [
+                        "10000"
+                    ],
+                    "x-ratelimit-limit-tokens": [
+                        "10000000"
+                    ],
+                    "x-ratelimit-remaining-requests": [
+                        "9999"
+                    ],
+                    "x-ratelimit-remaining-tokens": [
+                        "10000000"
+                    ],
+                    "x-ratelimit-reset-requests": [
+                        "6ms"
+                    ],
+                    "x-ratelimit-reset-tokens": [
+                        "0s"
+                    ],
+                    "set-cookie": [
+                        "[redacted]"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\n  \"id\": \"resp_0c79059922ab3fc1016a921327718487d29d1b6e91b4bd955d\",\n  \"object\": \"response\",\n  \"created_at\": 1787958055,\n  \"status\": \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\": \"developer\"\n  },\n  \"completed_at\": 1787958057,\n  \"error\": null,\n  \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\": \"You are a helpful assistant.\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\": \"gpt-5-mini-2025-08-07\",\n  \"moderation\": null,\n  \"output\": [\n    {\n      \"id\": \"rs_0c79059922ab3fc1016a921327ffdc87d2bf5cd070d5e6e431\",\n      \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\": \"gAAAAABqkhMp2_h9avlZ61QNrdcs3Z2dEHV_92eniVQ4JR3Is-naDj8ZWCdds-8SbH08GeONMRQ30TYX2AfUIM2VaJBq41svZk3tXxATPzmiwgI_EX6HQk_SY86PxnSfytVFamXueRcIMQnIQYMj9x3jwi2kmkVlZg6jc3vqJTRwgncRGFOmpcDqgkC7dT-1feyRoLZTkPrgAbcC8tuiOen0pbD_DOkuhie-RixoUb-vFFqiDy5s6eDYOKTVk9N067HjFIDskbIIa9i1czHd990RVztU3OpQ-ZVBjba302qwusIVF5hR6UgQ76s7IBnik2-AwT4KWAuEv1Q0RetMD9Ew4dZEN4lv-RXkpSwx3YtTY-JMoHpLegCbMYHoi8XFH7aJmhDmqF6vWsrVSNbSVR0pRySC-kMCojKQbRMthzZKxBqm5OApVoVYLUSSof94YB4J44443lclRzAZ2gMYv340RnCCtqusPux8tDILvH2fxDCQZOPs3qdKrQA3TWNSD5sx5tAUB3Pj-rQ71Mzp8vzerEHBuiPZcVeixG9PCydWbO9QvBfy09VfRqFFbsmVO3P-5WP2xkLcS8tw5vrE0t2XEp7RkTUsOLIBHmw_ZqL0uqTsMxQZWGpqXt6tJcnCDhTy-Bav7BL6P140NRIeBGeptwI65M3JGQNisre-MD81ySA96pWYKE1cZjknBMY20j9gPsNtK3V_6j8JcUdvghgZoToxBpEWvDzfPygzW-APl5ugZIz7QVcgqS4jf79thjs53Po2D20csP2sSN0ca0IDWVjIIshvjCn7nMGWclwHQlsdUsl91d9Ge22V166LRcOwoKy36ElR-bYg6zl-NyNvLUXkoqG8gjVz7oXeNZ_GCccI7oN2xAclGmwmEhEnqi9Cz5s9SpjUCrZN50Y6Uf3IS7He86avqupdNLYMwmn74FswO0VTy-qQ_I9204HoEdRvcH_WPDMkHpCEpvHNbgbmc8jrWLuQOJ3bAUAbG9Gs1dhxk2K2f_2aJEvJFOGrzP13X0yh5Ug2WTOIx9U5NBnvDHj9W_ixEzcBnOj5UbUmuPhrHnmz2gMk573RTVEDiCQ2ah39yQ-qXdiWD9_dzNh9zDa0h8QZ2hQE8JL9hE9Yu2LGs3xdlVBe3Ec0aZjW2W4zZwpQDTBFPDZHqtBvNImKtagO4S8RvEMUPuaU0oIEiT4MO0l61AkMqiX78Zyzbb2U0mQELWHelSZsPjx00xuCzZ6LyXIih20Szlax96bcDUpGXRncb19nX3RF1z8JJKfJ05k8YsCbvUxGEu5Secy95hLRt95NA3RWyPr5OaHeDMYOyMEIbEyIgIuOtCvbQkoD3RPD9OejQ7qscMBspcEs8lAeYhg-Eg==\",\n      \"summary\": [\n        {\n          \"type\": \"summary_text\",\n          \"text\": \"**Getting current time**\\n\\nThe user is asking for the current time, which means I should use the clock tool to get that information. It feels straightforward to me, and since this task only requires one tool, using multi_tool_use isn't necessary here. I just need to make a direct call to the functions.clock, and I can provide the user with the specific time they\\u2019re looking for!\"\n        }\n      ]\n    },\n    {\n      \"id\": \"fc_0c79059922ab3fc1016a9213293c4887d28a03b138cf17bb46\",\n      \"type\": \"function_call\",\n      \"status\": \"completed\",\n      \"arguments\": \"{}\",\n      \"call_id\": \"call_DKuBCqaJGHTpZTdMW0BwV3tj\",\n      \"name\": \"clock\"\n    }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\": \"in_memory\",\n  \"reasoning\": {\n    \"context\": \"current_turn\",\n    \"effort\": \"low\",\n    \"mode\": \"standard\",\n    \"summary\": \"detailed\"\n  },\n  \"safety_identifier\": null,\n  \"service_tier\": \"default\",\n  \"store\": false,\n  \"temperature\": 1.0,\n  \"text\": {\n    \"format\": {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n  \"tool_usage\": {\n    \"image_gen\": {\n      \"input_tokens\": 0,\n      \"input_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\": 0,\n      \"output_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"total_tokens\": 0\n    },\n    \"web_search\": {\n      \"num_requests\": 0\n    }\n  },\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\": \"Provides the current date and time.\",\n      \"name\": \"clock\",\n      \"output_schema\": null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n        \"type\": \"object\",\n        \"properties\": {},\n        \"required\": []\n      },\n      \"strict\": true\n    }\n  ],\n  \"top_logprobs\": 0,\n  \"top_p\": 1.0,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n    \"input_tokens\": 53,\n    \"input_tokens_details\": {\n      \"cache_write_tokens\": 0,\n      \"cached_tokens\": 0\n    },\n    \"output_tokens\": 45,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\": 0\n    },\n    \"total_tokens\": 98\n  },\n  \"user\": null,\n  \"metadata\": {}\n}"
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.openai.com/v1/responses",
+                "signature": "55200ac95119ce13917d1486b277a5a3",
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "[redacted]"
+                    ]
+                },
+                "body": "{\"store\":false,\"include\":[\"reasoning.encrypted_content\"],\"reasoning\":{\"effort\":\"low\",\"summary\":\"auto\"},\"tools\":[{\"type\":\"function\",\"name\":\"clock\",\"description\":\"Provides the current date and time.\"}],\"model\":\"gpt-5-mini\",\"input\":[{\"role\":\"user\",\"content\":\"What time is it right now?\"},{\"id\":\"rs_0c79059922ab3fc1016a921327ffdc87d2bf5cd070d5e6e431\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqkhMp2_h9avlZ61QNrdcs3Z2dEHV_92eniVQ4JR3Is-naDj8ZWCdds-8SbH08GeONMRQ30TYX2AfUIM2VaJBq41svZk3tXxATPzmiwgI_EX6HQk_SY86PxnSfytVFamXueRcIMQnIQYMj9x3jwi2kmkVlZg6jc3vqJTRwgncRGFOmpcDqgkC7dT-1feyRoLZTkPrgAbcC8tuiOen0pbD_DOkuhie-RixoUb-vFFqiDy5s6eDYOKTVk9N067HjFIDskbIIa9i1czHd990RVztU3OpQ-ZVBjba302qwusIVF5hR6UgQ76s7IBnik2-AwT4KWAuEv1Q0RetMD9Ew4dZEN4lv-RXkpSwx3YtTY-JMoHpLegCbMYHoi8XFH7aJmhDmqF6vWsrVSNbSVR0pRySC-kMCojKQbRMthzZKxBqm5OApVoVYLUSSof94YB4J44443lclRzAZ2gMYv340RnCCtqusPux8tDILvH2fxDCQZOPs3qdKrQA3TWNSD5sx5tAUB3Pj-rQ71Mzp8vzerEHBuiPZcVeixG9PCydWbO9QvBfy09VfRqFFbsmVO3P-5WP2xkLcS8tw5vrE0t2XEp7RkTUsOLIBHmw_ZqL0uqTsMxQZWGpqXt6tJcnCDhTy-Bav7BL6P140NRIeBGeptwI65M3JGQNisre-MD81ySA96pWYKE1cZjknBMY20j9gPsNtK3V_6j8JcUdvghgZoToxBpEWvDzfPygzW-APl5ugZIz7QVcgqS4jf79thjs53Po2D20csP2sSN0ca0IDWVjIIshvjCn7nMGWclwHQlsdUsl91d9Ge22V166LRcOwoKy36ElR-bYg6zl-NyNvLUXkoqG8gjVz7oXeNZ_GCccI7oN2xAclGmwmEhEnqi9Cz5s9SpjUCrZN50Y6Uf3IS7He86avqupdNLYMwmn74FswO0VTy-qQ_I9204HoEdRvcH_WPDMkHpCEpvHNbgbmc8jrWLuQOJ3bAUAbG9Gs1dhxk2K2f_2aJEvJFOGrzP13X0yh5Ug2WTOIx9U5NBnvDHj9W_ixEzcBnOj5UbUmuPhrHnmz2gMk573RTVEDiCQ2ah39yQ-qXdiWD9_dzNh9zDa0h8QZ2hQE8JL9hE9Yu2LGs3xdlVBe3Ec0aZjW2W4zZwpQDTBFPDZHqtBvNImKtagO4S8RvEMUPuaU0oIEiT4MO0l61AkMqiX78Zyzbb2U0mQELWHelSZsPjx00xuCzZ6LyXIih20Szlax96bcDUpGXRncb19nX3RF1z8JJKfJ05k8YsCbvUxGEu5Secy95hLRt95NA3RWyPr5OaHeDMYOyMEIbEyIgIuOtCvbQkoD3RPD9OejQ7qscMBspcEs8lAeYhg-Eg==\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Getting current time**\\n\\nThe user is asking for the current time, which means I should use the clock tool to get that information. It feels straightforward to me, and since this task only requires one tool, using multi_tool_use isn\\u0027t necessary here. I just need to make a direct call to the functions.clock, and I can provide the user with the specific time they\\u2019re looking for!\"}]},{\"arguments\":\"{}\",\"call_id\":\"call_DKuBCqaJGHTpZTdMW0BwV3tj\",\"name\":\"clock\",\"type\":\"function_call\"},{\"type\":\"function_call_output\",\"call_id\":\"call_DKuBCqaJGHTpZTdMW0BwV3tj\",\"output\":\"Current date is 2026-08-28 (YYYY-MM-DD) and the time is 23:00:57 (HH:MM:SS).\"}],\"instructions\":\"You are a helpful assistant.\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=31536000; includeSubDomains; preload"
+                    ],
+                    "x-content-type-options": [
+                        "nosniff"
+                    ],
+                    "access-control-expose-headers": [
+                        "X-Request-ID",
+                        "CF-Ray",
+                        "CF-Ray"
+                    ],
+                    "openai-organization": [
+                        "[redacted]"
+                    ],
+                    "openai-project": [
+                        "[redacted]"
+                    ],
+                    "openai-version": [
+                        "2020-10-01"
+                    ],
+                    "x-ratelimit-limit-requests": [
+                        "10000"
+                    ],
+                    "x-ratelimit-limit-tokens": [
+                        "10000000"
+                    ],
+                    "x-ratelimit-remaining-requests": [
+                        "9999"
+                    ],
+                    "x-ratelimit-remaining-tokens": [
+                        "10000000"
+                    ],
+                    "x-ratelimit-reset-requests": [
+                        "6ms"
+                    ],
+                    "x-ratelimit-reset-tokens": [
+                        "0s"
+                    ],
+                    "set-cookie": [
+                        "[redacted]"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\n  \"id\": \"resp_0c79059922ab3fc1016a9213298c1887d2b76202b564e8ec3d\",\n  \"object\": \"response\",\n  \"created_at\": 1787958057,\n  \"status\": \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\": \"developer\"\n  },\n  \"completed_at\": 1787958058,\n  \"error\": null,\n  \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\": \"You are a helpful assistant.\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\": \"gpt-5-mini-2025-08-07\",\n  \"moderation\": null,\n  \"output\": [\n    {\n      \"id\": \"msg_0c79059922ab3fc1016a92132a485487d2a0860df78ee1ac04\",\n      \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\": [\n        {\n          \"type\": \"output_text\",\n          \"annotations\": [],\n          \"logprobs\": [],\n          \"text\": \"It's 23:00:57 on 2026-08-28 (local time).\"\n        }\n      ],\n      \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\": \"in_memory\",\n  \"reasoning\": {\n    \"context\": \"current_turn\",\n    \"effort\": \"low\",\n    \"mode\": \"standard\",\n    \"summary\": \"detailed\"\n  },\n  \"safety_identifier\": null,\n  \"service_tier\": \"default\",\n  \"store\": false,\n  \"temperature\": 1.0,\n  \"text\": {\n    \"format\": {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n  \"tool_usage\": {\n    \"image_gen\": {\n      \"input_tokens\": 0,\n      \"input_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\": 0,\n      \"output_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"total_tokens\": 0\n    },\n    \"web_search\": {\n      \"num_requests\": 0\n    }\n  },\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\": \"Provides the current date and time.\",\n      \"name\": \"clock\",\n      \"output_schema\": null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n        \"type\": \"object\",\n        \"properties\": {},\n        \"required\": []\n      },\n      \"strict\": true\n    }\n  ],\n  \"top_logprobs\": 0,\n  \"top_p\": 1.0,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n    \"input_tokens\": 137,\n    \"input_tokens_details\": {\n      \"cache_write_tokens\": 0,\n      \"cached_tokens\": 0\n    },\n    \"output_tokens\": 23,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\": 0\n    },\n    \"total_tokens\": 160\n  },\n  \"user\": null,\n  \"metadata\": {}\n}"
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.openai.com/v1/responses",
+                "signature": "5dcb33edd508860da27a0ef280fde4ee",
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "[redacted]"
+                    ]
+                },
+                "body": "{\"store\":false,\"include\":[\"reasoning.encrypted_content\"],\"reasoning\":{\"effort\":\"low\",\"summary\":\"auto\"},\"tools\":[{\"type\":\"function\",\"name\":\"clock\",\"description\":\"Provides the current date and time.\"}],\"model\":\"gpt-5-mini\",\"input\":[{\"role\":\"user\",\"content\":\"What time is it right now?\"},{\"id\":\"rs_0c79059922ab3fc1016a921327ffdc87d2bf5cd070d5e6e431\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqkhMp2_h9avlZ61QNrdcs3Z2dEHV_92eniVQ4JR3Is-naDj8ZWCdds-8SbH08GeONMRQ30TYX2AfUIM2VaJBq41svZk3tXxATPzmiwgI_EX6HQk_SY86PxnSfytVFamXueRcIMQnIQYMj9x3jwi2kmkVlZg6jc3vqJTRwgncRGFOmpcDqgkC7dT-1feyRoLZTkPrgAbcC8tuiOen0pbD_DOkuhie-RixoUb-vFFqiDy5s6eDYOKTVk9N067HjFIDskbIIa9i1czHd990RVztU3OpQ-ZVBjba302qwusIVF5hR6UgQ76s7IBnik2-AwT4KWAuEv1Q0RetMD9Ew4dZEN4lv-RXkpSwx3YtTY-JMoHpLegCbMYHoi8XFH7aJmhDmqF6vWsrVSNbSVR0pRySC-kMCojKQbRMthzZKxBqm5OApVoVYLUSSof94YB4J44443lclRzAZ2gMYv340RnCCtqusPux8tDILvH2fxDCQZOPs3qdKrQA3TWNSD5sx5tAUB3Pj-rQ71Mzp8vzerEHBuiPZcVeixG9PCydWbO9QvBfy09VfRqFFbsmVO3P-5WP2xkLcS8tw5vrE0t2XEp7RkTUsOLIBHmw_ZqL0uqTsMxQZWGpqXt6tJcnCDhTy-Bav7BL6P140NRIeBGeptwI65M3JGQNisre-MD81ySA96pWYKE1cZjknBMY20j9gPsNtK3V_6j8JcUdvghgZoToxBpEWvDzfPygzW-APl5ugZIz7QVcgqS4jf79thjs53Po2D20csP2sSN0ca0IDWVjIIshvjCn7nMGWclwHQlsdUsl91d9Ge22V166LRcOwoKy36ElR-bYg6zl-NyNvLUXkoqG8gjVz7oXeNZ_GCccI7oN2xAclGmwmEhEnqi9Cz5s9SpjUCrZN50Y6Uf3IS7He86avqupdNLYMwmn74FswO0VTy-qQ_I9204HoEdRvcH_WPDMkHpCEpvHNbgbmc8jrWLuQOJ3bAUAbG9Gs1dhxk2K2f_2aJEvJFOGrzP13X0yh5Ug2WTOIx9U5NBnvDHj9W_ixEzcBnOj5UbUmuPhrHnmz2gMk573RTVEDiCQ2ah39yQ-qXdiWD9_dzNh9zDa0h8QZ2hQE8JL9hE9Yu2LGs3xdlVBe3Ec0aZjW2W4zZwpQDTBFPDZHqtBvNImKtagO4S8RvEMUPuaU0oIEiT4MO0l61AkMqiX78Zyzbb2U0mQELWHelSZsPjx00xuCzZ6LyXIih20Szlax96bcDUpGXRncb19nX3RF1z8JJKfJ05k8YsCbvUxGEu5Secy95hLRt95NA3RWyPr5OaHeDMYOyMEIbEyIgIuOtCvbQkoD3RPD9OejQ7qscMBspcEs8lAeYhg-Eg==\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Getting current time**\\n\\nThe user is asking for the current time, which means I should use the clock tool to get that information. It feels straightforward to me, and since this task only requires one tool, using multi_tool_use isn\\u0027t necessary here. I just need to make a direct call to the functions.clock, and I can provide the user with the specific time they\\u2019re looking for!\"}]},{\"arguments\":\"{}\",\"call_id\":\"call_DKuBCqaJGHTpZTdMW0BwV3tj\",\"name\":\"clock\",\"type\":\"function_call\"},{\"type\":\"function_call_output\",\"call_id\":\"call_DKuBCqaJGHTpZTdMW0BwV3tj\",\"output\":\"Current date is 2026-08-28 (YYYY-MM-DD) and the time is 23:00:57 (HH:MM:SS).\"},{\"role\":\"assistant\",\"type\":\"message\",\"content\":\"It\\u0027s 23:00:57 on 2026-08-28 (local time).\"},{\"role\":\"user\",\"content\":\"What did I just ask you?\"}],\"instructions\":\"You are a helpful assistant.\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=31536000; includeSubDomains; preload"
+                    ],
+                    "x-content-type-options": [
+                        "nosniff"
+                    ],
+                    "access-control-expose-headers": [
+                        "X-Request-ID",
+                        "CF-Ray",
+                        "CF-Ray"
+                    ],
+                    "openai-organization": [
+                        "[redacted]"
+                    ],
+                    "openai-project": [
+                        "[redacted]"
+                    ],
+                    "openai-version": [
+                        "2020-10-01"
+                    ],
+                    "x-ratelimit-limit-requests": [
+                        "10000"
+                    ],
+                    "x-ratelimit-limit-tokens": [
+                        "10000000"
+                    ],
+                    "x-ratelimit-remaining-requests": [
+                        "9999"
+                    ],
+                    "x-ratelimit-remaining-tokens": [
+                        "10000000"
+                    ],
+                    "x-ratelimit-reset-requests": [
+                        "6ms"
+                    ],
+                    "x-ratelimit-reset-tokens": [
+                        "0s"
+                    ],
+                    "set-cookie": [
+                        "[redacted]"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\n  \"id\": \"resp_0c79059922ab3fc1016a92132ac88c87d28aea08a62167b74c\",\n  \"object\": \"response\",\n  \"created_at\": 1787958058,\n  \"status\": \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\": \"developer\"\n  },\n  \"completed_at\": 1787958060,\n  \"error\": null,\n  \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\": \"You are a helpful assistant.\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\": \"gpt-5-mini-2025-08-07\",\n  \"moderation\": null,\n  \"output\": [\n    {\n      \"id\": \"rs_0c79059922ab3fc1016a92132b7f6087d28b119d4d33f32dea\",\n      \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\": \"gAAAAABqkhMtq1ZVev8dHbpbnLjG_MbS8X-iJOqTgO4_PpgFfCQYNjR9IR955vw_XQRMeqJv2Nx8uHrDvBgRaFv3iiOtJJRxlnYRsY9jlJRY7uAQ3HfHjI9HNIgC_sghk6Vp9h8-1dGBN7WRs5YeGX3ZCN8DyIPFZfvRUm4o7Cal1BuXJUcFMoF4k5HDZczkOKlnkINSVgVmrR8QLk38T2S3UjfZf9-UBB45Xu3ef3yiOZYQQFO775aIN2grlxeawVVMs84PFPn8F-9bxSzYXWV25QYXWENibgCho6jU0nlQEfPIOeEHnOw7lThnTxUCok7XJzFZJLVr98_i_6RpfslcQLv4m8BpaUXUi5RXtv_EvDUIPqugOJTnk9IWqvGm2UZ2zVCy9QezZ_23m_mgiRnV6m0aKTqo-MYpn0Iq9A45-bCvtBJBEoDEIIzYIOmDgLImYi4r4ejflfqPyc7cE2RJul4hQsKDgQ80nMdYPVGit31RGXBjuHT8i2ghyDFToAlSLSKLTqIFe9wZRA4-VIowXEZ_Tar9U5cLtVtU0TpNky2CH8zUNXbYEpxu14g9RYHfr22bTnow-aEimOIp1A-k81T9fOqK2bELuwMfKPSaE81KxDjWtZAjeB7S2plLHgHY82YTlzFT46624vT7C7No1DjLJZBdMeozvaWnj03y-vqppI854OSnZ3FMja7VEwkfIuRI3TqzpLbYd75rqhUgiefNSrN6xK7R4usu3RUj-kTamdLquDKp3W8eyJkLTZnvz_LWpDaHaZfpouMWJw6cTd-vonUBYjlcgGCsQB9BWfwTrTaPeO_gHdKY9vbgw19Bh_lFkfemsEFkS6HSWQn7xDrtWSOAn7nljdrpXd4wvQ_z4KWnx-l2n0uhFdpoNU5WFy5qjHCgpeEoVaWmgodeYh1s80aRULGTwOQOE0IdbLhGhDPTWBEEUrMEdQMu4OvRjzVMwk2n_IKtRjP2vb37fVMLeZW6GnPM1aVUou2AOyXyefpjaJd_w0r88IYyw0p7XPzSfM3Bd7d8b_prGx4Dahb1PprYBfWgf2-jLcm-6ECWRH6-CgInf4YVn4NJfmV3v-DDf43EeNlKLfB1fbSsH8409uAfLSPsQReZzdNnMGlt42aGLfoKsCMWYZS_rdNujOhpIoiKnFhPHpaizuaAGa7Gkz86QgWdq3YfjzOUjc3XYZyNsFkJuwT2Z7cMyUrI7rdBR5z_TY6ZEPrryJ9w2RM6rsaaThpGq5RTEqHOSZJ4nt0JltzXidLvZTNtwWsqDM3FfZFZs09b0Euqywd8k-t4i91-fZZspjbEcIJiQpGVSjWA0JuHKSHhEB4ObM-fkHDMwRpgV68-n0SeUepl1351Z7fUJR71lc0D8MQR88Zl_f1Nfio=\",\n      \"summary\": [\n        {\n          \"type\": \"summary_text\",\n          \"text\": \"**Answering time inquiry**\\n\\nThe user asked, \\u201cWhat time is it right now?\\u201d I\\u2019ll make sure to respond succinctly, providing the current time accurately. Since it\\u2019s a straightforward question, I\\u2019ll ensure clarity in my answer, and no need to add extra details. Keeping it simple is best! I want to make sure the user gets the information they\\u2019re seeking without any confusion. Alright, let\\u2019s get that time for them!\"\n        }\n      ]\n    },\n    {\n      \"id\": \"msg_0c79059922ab3fc1016a92132ce82887d2ab962ba0f9f8e374\",\n      \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\": [\n        {\n          \"type\": \"output_text\",\n          \"annotations\": [],\n          \"logprobs\": [],\n          \"text\": \"You asked, \\\"What time is it right now?\\\"\"\n        }\n      ],\n      \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\": \"in_memory\",\n  \"reasoning\": {\n    \"context\": \"current_turn\",\n    \"effort\": \"low\",\n    \"mode\": \"standard\",\n    \"summary\": \"detailed\"\n  },\n  \"safety_identifier\": null,\n  \"service_tier\": \"default\",\n  \"store\": false,\n  \"temperature\": 1.0,\n  \"text\": {\n    \"format\": {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n  \"tool_usage\": {\n    \"image_gen\": {\n      \"input_tokens\": 0,\n      \"input_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\": 0,\n      \"output_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"total_tokens\": 0\n    },\n    \"web_search\": {\n      \"num_requests\": 0\n    }\n  },\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\": \"Provides the current date and time.\",\n      \"name\": \"clock\",\n      \"output_schema\": null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n        \"type\": \"object\",\n        \"properties\": {},\n        \"required\": []\n      },\n      \"strict\": true\n    }\n  ],\n  \"top_logprobs\": 0,\n  \"top_p\": 1.0,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n    \"input_tokens\": 141,\n    \"input_tokens_details\": {\n      \"cache_write_tokens\": 0,\n      \"cached_tokens\": 0\n    },\n    \"output_tokens\": 51,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\": 0\n    },\n    \"total_tokens\": 192\n  },\n  \"user\": null,\n  \"metadata\": {}\n}"
+            }
+        }
+    ]
+}

--- a/examples/tests/fixtures/agent/multi-turn-reasoning-stateless.out
+++ b/examples/tests/fixtures/agent/multi-turn-reasoning-stateless.out
@@ -1,0 +1,13 @@
+Turn 1: It's 23:00:57 on 2026-08-28 (local time).
+Turn 2: You asked, "What time is it right now?"
++---+-----------+ Conversation Shape ----------------+
+| # | Role      | Content parts                      |
++---+-----------+------------------------------------+
+| 0 | system    | Text                               |
+| 1 | user      | Text                               |
+| 2 | assistant | Thinking(signed) + ToolCall(clock) |
+| 3 | tool      | ToolResult(clock)                  |
+| 4 | assistant | Text                               |
+| 5 | user      | Text                               |
+| 6 | assistant | Thinking(signed) + Text            |
++---+-----------+------------------------------------+

--- a/examples/tests/fixtures/agent/multi-turn-thinking-stream.json
+++ b/examples/tests/fixtures/agent/multi-turn-thinking-stream.json
@@ -1,0 +1,298 @@
+{
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.anthropic.com/v1/messages",
+                "signature": "169b7b27619cfa7e3973128abfe88581",
+                "headers": {
+                    "x-api-key": [
+                        "[redacted]"
+                    ],
+                    "anthropic-version": [
+                        "2023-06-01"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "anthropic-beta": [
+                        "interleaved-thinking-2025-05-14"
+                    ]
+                },
+                "body": "{\"max_tokens\":4000,\"stream\":true,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"clock\",\"description\":\"Provides the current date and time.\",\"input_schema\":{\"type\":\"object\"},\"cache_control\":{\"type\":\"ephemeral\"}}],\"tool_choice\":{\"type\":\"auto\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What time is it right now?\",\"cache_control\":{\"type\":\"ephemeral\"}}]}],\"system\":[{\"type\":\"text\",\"text\":\"You are a helpful assistant.\",\"cache_control\":{\"type\":\"ephemeral\"}}],\"model\":\"claude-sonnet-4-5-20250929\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "text/event-stream; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "anthropic-ratelimit-input-tokens-limit": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-remaining": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-reset": [
+                        "2026-08-28T23:00:54Z"
+                    ],
+                    "anthropic-ratelimit-output-tokens-limit": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-remaining": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-reset": [
+                        "2026-08-28T23:00:54Z"
+                    ],
+                    "anthropic-ratelimit-requests-limit": [
+                        "5000"
+                    ],
+                    "anthropic-ratelimit-requests-remaining": [
+                        "4999"
+                    ],
+                    "anthropic-ratelimit-requests-reset": [
+                        "2026-08-28T23:00:54Z"
+                    ],
+                    "anthropic-ratelimit-tokens-limit": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-remaining": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-reset": [
+                        "2026-08-28T23:00:54Z"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=31536000; includeSubDomains; preload"
+                    ],
+                    "anthropic-organization-id": [
+                        "152d88d9-0d18-4cae-80c9-c425a5bf4e25"
+                    ],
+                    "anthropic-workspace-id": [
+                        "wrkspc_01Eo1YZvq8sNWFRAfhfjg7gS"
+                    ],
+                    "traceresponse": [
+                        "00-762e3642e5b91cafab7bd049ec0e1546-dd65e86f4863d542-01"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ],
+                    "vary": [
+                        "Accept-Encoding"
+                    ],
+                    "x-robots-tag": [
+                        "none"
+                    ],
+                    "content-security-policy": [
+                        "default-src 'none'; frame-ancestors 'none'"
+                    ]
+                },
+                "body_format": "sse",
+                "body": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_011CeVygbKrZxVBFnrYqLZg1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":729,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":5,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}         }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}            }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"The user is asking for\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" the current time. I have access to a clock function that can provide the current date and time. Let me use it.\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"EoQDCpsBCBEYAipAuZHKs82WEZdSpAtul9f5tA98Wa/oYcqMRTUZ4wyDozjaxoZxP69FsW+DlAsa0AKtyVEyDCZFE1EqSrTGHuKoIDIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBqKbI1AYSDL6c3HsLWSATj1EYhBoMbHQosEE22qsw3ma+IjAmuvAbCkYIC2fxTpgeazBj5bRNpbDcDrZh9IB2fgEjYp8Fjy77mJku1Ozma94R/JkqlQFzhyuWYstSqsRWxC2KKdXBweJbjiUkNmIHbERqgroK3w7bw0H0o17YuzD+rejoAn++1XsJLgC7ZFGJuRFevA6pZG/U51jzKMxNW/Emv4hrL/ruxZh9qhnLUWzlMrhTqu6u2K3LZU9BTExwAC2LofxbYCse05Cu1SzXjrd2E+EKAfP2utm6+QlLeYzPi1Lrq6/cfOtqjRgB\"}      }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0              }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01FX2eH86CmqTjwF1ymuTW8e\",\"name\":\"clock\",\"input\":{},\"caller\":{\"type\":\"direct\"}}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}           }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1           }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null},\"usage\":{\"input_tokens\":729,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":72,\"output_tokens_details\":{\"thinking_tokens\":35}}             }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"        }\n\n"
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.anthropic.com/v1/messages",
+                "signature": "4e488054976bbddba0871cab31a1b91a",
+                "headers": {
+                    "x-api-key": [
+                        "[redacted]"
+                    ],
+                    "anthropic-version": [
+                        "2023-06-01"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "anthropic-beta": [
+                        "interleaved-thinking-2025-05-14"
+                    ]
+                },
+                "body": "{\"max_tokens\":4000,\"stream\":true,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"clock\",\"description\":\"Provides the current date and time.\",\"input_schema\":{\"type\":\"object\"},\"cache_control\":{\"type\":\"ephemeral\"}}],\"tool_choice\":{\"type\":\"auto\"},\"messages\":[{\"role\":\"user\",\"content\":\"What time is it right now?\"},{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The user is asking for the current time. I have access to a clock function that can provide the current date and time. Let me use it.\",\"signature\":\"EoQDCpsBCBEYAipAuZHKs82WEZdSpAtul9f5tA98Wa\\/oYcqMRTUZ4wyDozjaxoZxP69FsW+DlAsa0AKtyVEyDCZFE1EqSrTGHuKoIDIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBqKbI1AYSDL6c3HsLWSATj1EYhBoMbHQosEE22qsw3ma+IjAmuvAbCkYIC2fxTpgeazBj5bRNpbDcDrZh9IB2fgEjYp8Fjy77mJku1Ozma94R\\/JkqlQFzhyuWYstSqsRWxC2KKdXBweJbjiUkNmIHbERqgroK3w7bw0H0o17YuzD+rejoAn++1XsJLgC7ZFGJuRFevA6pZG\\/U51jzKMxNW\\/Emv4hrL\\/ruxZh9qhnLUWzlMrhTqu6u2K3LZU9BTExwAC2LofxbYCse05Cu1SzXjrd2E+EKAfP2utm6+QlLeYzPi1Lrq6\\/cfOtqjRgB\"},{\"type\":\"tool_use\",\"id\":\"toolu_01FX2eH86CmqTjwF1ymuTW8e\",\"name\":\"clock\",\"input\":{}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01FX2eH86CmqTjwF1ymuTW8e\",\"content\":\"Current date is 2026-08-28 (YYYY-MM-DD) and the time is 23:00:56 (HH:MM:SS).\",\"cache_control\":{\"type\":\"ephemeral\"}}]}],\"system\":[{\"type\":\"text\",\"text\":\"You are a helpful assistant.\",\"cache_control\":{\"type\":\"ephemeral\"}}],\"model\":\"claude-sonnet-4-5-20250929\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "text/event-stream; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "anthropic-ratelimit-input-tokens-limit": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-remaining": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-reset": [
+                        "2026-08-28T23:00:57Z"
+                    ],
+                    "anthropic-ratelimit-output-tokens-limit": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-remaining": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-reset": [
+                        "2026-08-28T23:00:57Z"
+                    ],
+                    "anthropic-ratelimit-requests-limit": [
+                        "5000"
+                    ],
+                    "anthropic-ratelimit-requests-remaining": [
+                        "4999"
+                    ],
+                    "anthropic-ratelimit-requests-reset": [
+                        "2026-08-28T23:00:57Z"
+                    ],
+                    "anthropic-ratelimit-tokens-limit": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-remaining": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-reset": [
+                        "2026-08-28T23:00:57Z"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=31536000; includeSubDomains; preload"
+                    ],
+                    "anthropic-organization-id": [
+                        "152d88d9-0d18-4cae-80c9-c425a5bf4e25"
+                    ],
+                    "anthropic-workspace-id": [
+                        "wrkspc_01Eo1YZvq8sNWFRAfhfjg7gS"
+                    ],
+                    "traceresponse": [
+                        "00-294590a511dfef489fbe6c969de6094a-88527988ba3787a7-01"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ],
+                    "vary": [
+                        "Accept-Encoding"
+                    ],
+                    "x-robots-tag": [
+                        "none"
+                    ],
+                    "content-security-policy": [
+                        "default-src 'none'; frame-ancestors 'none'"
+                    ]
+                },
+                "body_format": "sse",
+                "body": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_011CeVygkci1ztm2eXXM19YN\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":858,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":4,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}          }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}     }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"The function returned that\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" the current date is August 28, 2026, and the time is 23:00:56 (11:00:56 PM). I should present this information clearly to the user.\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"Ep0DCpsBCBEYAipA8HiWDBGRplvA9HDF0oa3pvSwrjF4SOW96MmUcHiGIUzeU8pMECKNHxVCiohFVbJOA1OqWFTV4UCIXfn04chO7jIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBqqbI1AYSDLjmSt1g2DyT/SOKixoMoCwRs4ilHkA117uiIjDIiOIYw/78Lgy0WJAIHmNqiLjqBF2bHApIb4BNFYWQx+kXBOBVDJiaqeHukz1PyX0qrgGpm4UaonBLLN/z7DdOIMQ4JdQcnwqf2r+C6VeJER/0fFO3BaX9lT1a44Xtq3SlYXEHrw7gqMxqDQCk8u4+j/k5XUQxXL8PAOoUXE6EV2JBnm+L4FygejpPGAUgwd3ofV+2HWiFJ2qqXbl7kIsGCrXMXZsR9B0oyp/XbR6mfwYKNQXT5raOeQzNyrSgMwOeA38MuNvLOczOxRqdt/GyCVMqfjkRNjoiyWw28vCUXBgYAQ==\"}           }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0    }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"The current time is **23\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\":00:56** (11:00:56 PM) on August 28, 2026.\"}             }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1         }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null},\"usage\":{\"input_tokens\":858,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":86,\"output_tokens_details\":{\"thinking_tokens\":51}}              }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"             }\n\n"
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.anthropic.com/v1/messages",
+                "signature": "61bdee2547509f90cad0f628665b7c33",
+                "headers": {
+                    "x-api-key": [
+                        "[redacted]"
+                    ],
+                    "anthropic-version": [
+                        "2023-06-01"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "anthropic-beta": [
+                        "interleaved-thinking-2025-05-14"
+                    ]
+                },
+                "body": "{\"max_tokens\":4000,\"stream\":true,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"clock\",\"description\":\"Provides the current date and time.\",\"input_schema\":{\"type\":\"object\"},\"cache_control\":{\"type\":\"ephemeral\"}}],\"tool_choice\":{\"type\":\"auto\"},\"messages\":[{\"role\":\"user\",\"content\":\"What time is it right now?\"},{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The user is asking for the current time. I have access to a clock function that can provide the current date and time. Let me use it.\",\"signature\":\"EoQDCpsBCBEYAipAuZHKs82WEZdSpAtul9f5tA98Wa\\/oYcqMRTUZ4wyDozjaxoZxP69FsW+DlAsa0AKtyVEyDCZFE1EqSrTGHuKoIDIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBqKbI1AYSDL6c3HsLWSATj1EYhBoMbHQosEE22qsw3ma+IjAmuvAbCkYIC2fxTpgeazBj5bRNpbDcDrZh9IB2fgEjYp8Fjy77mJku1Ozma94R\\/JkqlQFzhyuWYstSqsRWxC2KKdXBweJbjiUkNmIHbERqgroK3w7bw0H0o17YuzD+rejoAn++1XsJLgC7ZFGJuRFevA6pZG\\/U51jzKMxNW\\/Emv4hrL\\/ruxZh9qhnLUWzlMrhTqu6u2K3LZU9BTExwAC2LofxbYCse05Cu1SzXjrd2E+EKAfP2utm6+QlLeYzPi1Lrq6\\/cfOtqjRgB\"},{\"type\":\"tool_use\",\"id\":\"toolu_01FX2eH86CmqTjwF1ymuTW8e\",\"name\":\"clock\",\"input\":{}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01FX2eH86CmqTjwF1ymuTW8e\",\"content\":\"Current date is 2026-08-28 (YYYY-MM-DD) and the time is 23:00:56 (HH:MM:SS).\"}]},{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The user is asking for the current time. I have access to a clock function that can provide the current date and time. Let me use it.\",\"signature\":\"EoQDCpsBCBEYAipAuZHKs82WEZdSpAtul9f5tA98Wa\\/oYcqMRTUZ4wyDozjaxoZxP69FsW+DlAsa0AKtyVEyDCZFE1EqSrTGHuKoIDIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBqKbI1AYSDL6c3HsLWSATj1EYhBoMbHQosEE22qsw3ma+IjAmuvAbCkYIC2fxTpgeazBj5bRNpbDcDrZh9IB2fgEjYp8Fjy77mJku1Ozma94R\\/JkqlQFzhyuWYstSqsRWxC2KKdXBweJbjiUkNmIHbERqgroK3w7bw0H0o17YuzD+rejoAn++1XsJLgC7ZFGJuRFevA6pZG\\/U51jzKMxNW\\/Emv4hrL\\/ruxZh9qhnLUWzlMrhTqu6u2K3LZU9BTExwAC2LofxbYCse05Cu1SzXjrd2E+EKAfP2utm6+QlLeYzPi1Lrq6\\/cfOtqjRgB\"},{\"type\":\"thinking\",\"thinking\":\"The function returned that the current date is August 28, 2026, and the time is 23:00:56 (11:00:56 PM). I should present this information clearly to the user.\",\"signature\":\"Ep0DCpsBCBEYAipA8HiWDBGRplvA9HDF0oa3pvSwrjF4SOW96MmUcHiGIUzeU8pMECKNHxVCiohFVbJOA1OqWFTV4UCIXfn04chO7jIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBqqbI1AYSDLjmSt1g2DyT\\/SOKixoMoCwRs4ilHkA117uiIjDIiOIYw\\/78Lgy0WJAIHmNqiLjqBF2bHApIb4BNFYWQx+kXBOBVDJiaqeHukz1PyX0qrgGpm4UaonBLLN\\/z7DdOIMQ4JdQcnwqf2r+C6VeJER\\/0fFO3BaX9lT1a44Xtq3SlYXEHrw7gqMxqDQCk8u4+j\\/k5XUQxXL8PAOoUXE6EV2JBnm+L4FygejpPGAUgwd3ofV+2HWiFJ2qqXbl7kIsGCrXMXZsR9B0oyp\\/XbR6mfwYKNQXT5raOeQzNyrSgMwOeA38MuNvLOczOxRqdt\\/GyCVMqfjkRNjoiyWw28vCUXBgYAQ==\"},{\"type\":\"text\",\"text\":\"The current time is **23:00:56** (11:00:56 PM) on August 28, 2026.\"}]},{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What did I just ask you?\",\"cache_control\":{\"type\":\"ephemeral\"}}]}],\"system\":[{\"type\":\"text\",\"text\":\"You are a helpful assistant.\",\"cache_control\":{\"type\":\"ephemeral\"}}],\"model\":\"claude-sonnet-4-5-20250929\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "text/event-stream; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "anthropic-ratelimit-input-tokens-limit": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-remaining": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-reset": [
+                        "2026-08-28T23:00:59Z"
+                    ],
+                    "anthropic-ratelimit-output-tokens-limit": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-remaining": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-reset": [
+                        "2026-08-28T23:00:59Z"
+                    ],
+                    "anthropic-ratelimit-requests-limit": [
+                        "5000"
+                    ],
+                    "anthropic-ratelimit-requests-remaining": [
+                        "4999"
+                    ],
+                    "anthropic-ratelimit-requests-reset": [
+                        "2026-08-28T23:00:59Z"
+                    ],
+                    "anthropic-ratelimit-tokens-limit": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-remaining": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-reset": [
+                        "2026-08-28T23:00:59Z"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=31536000; includeSubDomains; preload"
+                    ],
+                    "anthropic-organization-id": [
+                        "152d88d9-0d18-4cae-80c9-c425a5bf4e25"
+                    ],
+                    "anthropic-workspace-id": [
+                        "wrkspc_01Eo1YZvq8sNWFRAfhfjg7gS"
+                    ],
+                    "traceresponse": [
+                        "00-d3856dc614b2dff9a8ddfae65d501562-d40bb5d731d879f2-01"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ],
+                    "vary": [
+                        "Accept-Encoding"
+                    ],
+                    "x-robots-tag": [
+                        "none"
+                    ],
+                    "content-security-policy": [
+                        "default-src 'none'; frame-ancestors 'none'"
+                    ]
+                },
+                "body_format": "sse",
+                "body": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_011CeVygv6DQwyZg4xrYG6tU\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":856,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":5,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}             }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}   }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"The user is asking me\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" what they just asked me\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\". Looking\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" back at the conversation, their\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" previous question was \\\"What time is it right now?\\\"\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"EogDCpsBCBEYAipA2fWExWelS3zVeckP1ixF2/4uj+NXekQgYkAfLI3brv1fOMAKceUzfGEUNySl7xzBAOPRxGjjTR9dqBkFW8/91zIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBrabI1AYSDJi9vZQdMnj7q2mXKBoM1l3n3Ce6RTRsMVIDIjDBxswTP4VD9YG/mqIn/YEqMRswgPZRBYvnliF0BaCf078HNk31LvXBdP5yogThXbwqmQHBS3mRbQoB20dAVrSR3OfU+bEv6RDiTRCH3EhA3/kjLZl+0prv9rmMZR1oA6DaZ5AYzvJXVjJILEx5/dSH3vn0cqHOq2E4ehQsediVU6WsWEUPBqIiNemlJfmjrGzjtXXtdJ8lWm0Uriq8eL/TQS1QuI7OizaW+Ltm8S1UhukcFMxNGyAKxdwfsRpA/2X2ynexiZxjuXn3W28YAQ==\"}            }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0      }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"You just asked me \\\"What time is it right now?\\\"\"} }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1  }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null},\"usage\":{\"input_tokens\":856,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":52,\"output_tokens_details\":{\"thinking_tokens\":35}}        }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"    }\n\n"
+            }
+        }
+    ]
+}

--- a/examples/tests/fixtures/agent/multi-turn-thinking-stream.out
+++ b/examples/tests/fixtures/agent/multi-turn-thinking-stream.out
@@ -1,0 +1,13 @@
+Turn 1: The current time is **23:00:56** (11:00:56 PM) on August 28, 2026.
+Turn 2: You just asked me "What time is it right now?"
++---+-----------+ Conversation Shape ----------------+
+| # | Role      | Content parts                      |
++---+-----------+------------------------------------+
+| 0 | system    | Text                               |
+| 1 | user      | Text                               |
+| 2 | assistant | Thinking(signed) + ToolCall(clock) |
+| 3 | tool      | ToolResult(clock)                  |
+| 4 | assistant | Thinking(signed) + Text            |
+| 5 | user      | Text                               |
+| 6 | assistant | Thinking(signed) + Text            |
++---+-----------+------------------------------------+

--- a/examples/tests/fixtures/agent/multi-turn-thinking.json
+++ b/examples/tests/fixtures/agent/multi-turn-thinking.json
@@ -1,0 +1,289 @@
+{
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.anthropic.com/v1/messages",
+                "signature": "97ecb73c393938a31af17a893762acad",
+                "headers": {
+                    "x-api-key": [
+                        "[redacted]"
+                    ],
+                    "anthropic-version": [
+                        "2023-06-01"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "anthropic-beta": [
+                        "interleaved-thinking-2025-05-14"
+                    ]
+                },
+                "body": "{\"max_tokens\":4000,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"clock\",\"description\":\"Provides the current date and time.\",\"input_schema\":{\"type\":\"object\"},\"cache_control\":{\"type\":\"ephemeral\"}}],\"tool_choice\":{\"type\":\"auto\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What time is it right now?\",\"cache_control\":{\"type\":\"ephemeral\"}}]}],\"system\":[{\"type\":\"text\",\"text\":\"You are a helpful assistant.\",\"cache_control\":{\"type\":\"ephemeral\"}}],\"model\":\"claude-sonnet-4-5-20250929\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "anthropic-ratelimit-input-tokens-limit": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-remaining": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-reset": [
+                        "2026-08-28T23:00:56Z"
+                    ],
+                    "anthropic-ratelimit-output-tokens-limit": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-remaining": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-reset": [
+                        "2026-08-28T23:00:57Z"
+                    ],
+                    "anthropic-ratelimit-requests-limit": [
+                        "5000"
+                    ],
+                    "anthropic-ratelimit-requests-remaining": [
+                        "4999"
+                    ],
+                    "anthropic-ratelimit-requests-reset": [
+                        "2026-08-28T23:00:54Z"
+                    ],
+                    "anthropic-ratelimit-tokens-limit": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-remaining": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-reset": [
+                        "2026-08-28T23:00:56Z"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=31536000; includeSubDomains; preload"
+                    ],
+                    "anthropic-organization-id": [
+                        "152d88d9-0d18-4cae-80c9-c425a5bf4e25"
+                    ],
+                    "anthropic-workspace-id": [
+                        "wrkspc_01Eo1YZvq8sNWFRAfhfjg7gS"
+                    ],
+                    "traceresponse": [
+                        "00-5dd6fe2b4be6465c82db06c25c448f5d-c27d744e26fdd300-01"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "vary": [
+                        "Accept-Encoding"
+                    ],
+                    "content-security-policy": [
+                        "default-src 'none'; frame-ancestors 'none'"
+                    ],
+                    "x-robots-tag": [
+                        "none"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_011CeVygdGSA2DobmtNKT8oL\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The user is asking for the current time. I have access to a clock function that can provide this information. Let me call it.\",\"signature\":\"EvwCCpsBCBEYAipAseO3ISBFkLEkKGkboiJEhsL0hQoPI4xN+KUgyktTb0gjygbQH6s6EF4FZ7RfgPCHTEdVdWdAiFcQ7AlcvlDHeTIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBqabI1AYSDHTOZOdCMHeDSlh6OhoMAKjH68buSecYmYMyIjAkn0jFmpEIefCqKv83iqSDDDYcJZAvHJvvGtGdS/TgIgAOhRIm0MP4FYjTudfhZBYqjQG7krwko6HtNYkUi5K0i6f8BCRPoejL624+q2ZOmBHZ+xsQgBQLHpdYPi00SdeoDQ+b5tflbNxqr8IjCvg6EBuoCU/DjjXr7IOMI9/8zy4xLHvc+jbyt0V2TR7UTNHelv+hSODI225NpS5caPKxCOY/GnCL/OmDwVdnKmD4tfARfnLVSAgcYE/cDoXEUK0YAQ==\"},{\"type\":\"tool_use\",\"id\":\"toolu_012R7ErKzZ1gckpdkL7Hm2Y6\",\"name\":\"clock\",\"input\":{},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":729,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":69,\"output_tokens_details\":{\"thinking_tokens\":32},\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}"
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.anthropic.com/v1/messages",
+                "signature": "92e8f64cee3dd38853b56f2e16607af8",
+                "headers": {
+                    "x-api-key": [
+                        "[redacted]"
+                    ],
+                    "anthropic-version": [
+                        "2023-06-01"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "anthropic-beta": [
+                        "interleaved-thinking-2025-05-14"
+                    ]
+                },
+                "body": "{\"max_tokens\":4000,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"clock\",\"description\":\"Provides the current date and time.\",\"input_schema\":{\"type\":\"object\"},\"cache_control\":{\"type\":\"ephemeral\"}}],\"tool_choice\":{\"type\":\"auto\"},\"messages\":[{\"role\":\"user\",\"content\":\"What time is it right now?\"},{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The user is asking for the current time. I have access to a clock function that can provide this information. Let me call it.\",\"signature\":\"EvwCCpsBCBEYAipAseO3ISBFkLEkKGkboiJEhsL0hQoPI4xN+KUgyktTb0gjygbQH6s6EF4FZ7RfgPCHTEdVdWdAiFcQ7AlcvlDHeTIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBqabI1AYSDHTOZOdCMHeDSlh6OhoMAKjH68buSecYmYMyIjAkn0jFmpEIefCqKv83iqSDDDYcJZAvHJvvGtGdS\\/TgIgAOhRIm0MP4FYjTudfhZBYqjQG7krwko6HtNYkUi5K0i6f8BCRPoejL624+q2ZOmBHZ+xsQgBQLHpdYPi00SdeoDQ+b5tflbNxqr8IjCvg6EBuoCU\\/DjjXr7IOMI9\\/8zy4xLHvc+jbyt0V2TR7UTNHelv+hSODI225NpS5caPKxCOY\\/GnCL\\/OmDwVdnKmD4tfARfnLVSAgcYE\\/cDoXEUK0YAQ==\"},{\"type\":\"tool_use\",\"id\":\"toolu_012R7ErKzZ1gckpdkL7Hm2Y6\",\"name\":\"clock\",\"input\":{}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_012R7ErKzZ1gckpdkL7Hm2Y6\",\"content\":\"Current date is 2026-08-28 (YYYY-MM-DD) and the time is 23:00:57 (HH:MM:SS).\",\"cache_control\":{\"type\":\"ephemeral\"}}]}],\"system\":[{\"type\":\"text\",\"text\":\"You are a helpful assistant.\",\"cache_control\":{\"type\":\"ephemeral\"}}],\"model\":\"claude-sonnet-4-5-20250929\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "anthropic-ratelimit-input-tokens-limit": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-remaining": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-reset": [
+                        "2026-08-28T23:00:58Z"
+                    ],
+                    "anthropic-ratelimit-output-tokens-limit": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-remaining": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-reset": [
+                        "2026-08-28T23:00:59Z"
+                    ],
+                    "anthropic-ratelimit-requests-limit": [
+                        "5000"
+                    ],
+                    "anthropic-ratelimit-requests-remaining": [
+                        "4999"
+                    ],
+                    "anthropic-ratelimit-requests-reset": [
+                        "2026-08-28T23:00:57Z"
+                    ],
+                    "anthropic-ratelimit-tokens-limit": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-remaining": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-reset": [
+                        "2026-08-28T23:00:58Z"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=31536000; includeSubDomains; preload"
+                    ],
+                    "anthropic-organization-id": [
+                        "152d88d9-0d18-4cae-80c9-c425a5bf4e25"
+                    ],
+                    "anthropic-workspace-id": [
+                        "wrkspc_01Eo1YZvq8sNWFRAfhfjg7gS"
+                    ],
+                    "traceresponse": [
+                        "00-2ec019040a26f6300b472aef58cae96d-514adba2943ca6df-01"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "vary": [
+                        "Accept-Encoding"
+                    ],
+                    "content-security-policy": [
+                        "default-src 'none'; frame-ancestors 'none'"
+                    ],
+                    "x-robots-tag": [
+                        "none"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_011CeVygnNNs4uTjWE8oUGAw\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The clock function returned the current date and time. It's August 28, 2026, and the time is 23:00:57 (11:00:57 PM).\",\"signature\":\"EvMCCpsBCBEYAipAlLLeQi0yTF23HNO/No8XdFrHzuELDYCnsYaN86Towriw1c6UzU7RR8E6NH8e51mddWO0NweB9OMmvOF4odL5JTIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBq6bI1AYSDFMe4CM00/wohtyudhoMv2xFDYCA2en03ZtIIjAzEs7v7H7lkIAfIbzjcguGO2Agc4weU08lDOzpwfNOZQLOxUdKDMskZI7VrMmpe3YqhAEJlCVmVvpeJ7Qco6Ar736iIrKBbVIAdTWFoUA/BsZf2eDv7+92OMPcbK2udEso5kuruaeW6J2j1+s6LhIJkExvqdVzwIJj5bX6ZvxT/1GZ3xL7yQVf4RsfNGiHNwhGejPHZSEo0au57FBszoWryY1EIjyf5o5d6hhrGXHBcuIbKbxFX2AYAQ==\"},{\"type\":\"text\",\"text\":\"The current time is **23:00:57** (11:00:57 PM) on August 28, 2026.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":855,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":80,\"output_tokens_details\":{\"thinking_tokens\":46},\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}"
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.anthropic.com/v1/messages",
+                "signature": "1600499222da9694f5d1aab9b090105e",
+                "headers": {
+                    "x-api-key": [
+                        "[redacted]"
+                    ],
+                    "anthropic-version": [
+                        "2023-06-01"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "anthropic-beta": [
+                        "interleaved-thinking-2025-05-14"
+                    ]
+                },
+                "body": "{\"max_tokens\":4000,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"clock\",\"description\":\"Provides the current date and time.\",\"input_schema\":{\"type\":\"object\"},\"cache_control\":{\"type\":\"ephemeral\"}}],\"tool_choice\":{\"type\":\"auto\"},\"messages\":[{\"role\":\"user\",\"content\":\"What time is it right now?\"},{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The user is asking for the current time. I have access to a clock function that can provide this information. Let me call it.\",\"signature\":\"EvwCCpsBCBEYAipAseO3ISBFkLEkKGkboiJEhsL0hQoPI4xN+KUgyktTb0gjygbQH6s6EF4FZ7RfgPCHTEdVdWdAiFcQ7AlcvlDHeTIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBqabI1AYSDHTOZOdCMHeDSlh6OhoMAKjH68buSecYmYMyIjAkn0jFmpEIefCqKv83iqSDDDYcJZAvHJvvGtGdS\\/TgIgAOhRIm0MP4FYjTudfhZBYqjQG7krwko6HtNYkUi5K0i6f8BCRPoejL624+q2ZOmBHZ+xsQgBQLHpdYPi00SdeoDQ+b5tflbNxqr8IjCvg6EBuoCU\\/DjjXr7IOMI9\\/8zy4xLHvc+jbyt0V2TR7UTNHelv+hSODI225NpS5caPKxCOY\\/GnCL\\/OmDwVdnKmD4tfARfnLVSAgcYE\\/cDoXEUK0YAQ==\"},{\"type\":\"tool_use\",\"id\":\"toolu_012R7ErKzZ1gckpdkL7Hm2Y6\",\"name\":\"clock\",\"input\":{}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_012R7ErKzZ1gckpdkL7Hm2Y6\",\"content\":\"Current date is 2026-08-28 (YYYY-MM-DD) and the time is 23:00:57 (HH:MM:SS).\"}]},{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The clock function returned the current date and time. It\\u0027s August 28, 2026, and the time is 23:00:57 (11:00:57 PM).\",\"signature\":\"EvMCCpsBCBEYAipAlLLeQi0yTF23HNO\\/No8XdFrHzuELDYCnsYaN86Towriw1c6UzU7RR8E6NH8e51mddWO0NweB9OMmvOF4odL5JTIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBq6bI1AYSDFMe4CM00\\/wohtyudhoMv2xFDYCA2en03ZtIIjAzEs7v7H7lkIAfIbzjcguGO2Agc4weU08lDOzpwfNOZQLOxUdKDMskZI7VrMmpe3YqhAEJlCVmVvpeJ7Qco6Ar736iIrKBbVIAdTWFoUA\\/BsZf2eDv7+92OMPcbK2udEso5kuruaeW6J2j1+s6LhIJkExvqdVzwIJj5bX6ZvxT\\/1GZ3xL7yQVf4RsfNGiHNwhGejPHZSEo0au57FBszoWryY1EIjyf5o5d6hhrGXHBcuIbKbxFX2AYAQ==\"},{\"type\":\"text\",\"text\":\"The current time is **23:00:57** (11:00:57 PM) on August 28, 2026.\"}]},{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What did I just ask you?\",\"cache_control\":{\"type\":\"ephemeral\"}}]}],\"system\":[{\"type\":\"text\",\"text\":\"You are a helpful assistant.\",\"cache_control\":{\"type\":\"ephemeral\"}}],\"model\":\"claude-sonnet-4-5-20250929\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "anthropic-ratelimit-input-tokens-limit": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-remaining": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-reset": [
+                        "2026-08-28T23:01:00Z"
+                    ],
+                    "anthropic-ratelimit-output-tokens-limit": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-remaining": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-reset": [
+                        "2026-08-28T23:01:01Z"
+                    ],
+                    "anthropic-ratelimit-requests-limit": [
+                        "5000"
+                    ],
+                    "anthropic-ratelimit-requests-remaining": [
+                        "4999"
+                    ],
+                    "anthropic-ratelimit-requests-reset": [
+                        "2026-08-28T23:00:59Z"
+                    ],
+                    "anthropic-ratelimit-tokens-limit": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-remaining": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-reset": [
+                        "2026-08-28T23:01:00Z"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=31536000; includeSubDomains; preload"
+                    ],
+                    "anthropic-organization-id": [
+                        "152d88d9-0d18-4cae-80c9-c425a5bf4e25"
+                    ],
+                    "anthropic-workspace-id": [
+                        "wrkspc_01Eo1YZvq8sNWFRAfhfjg7gS"
+                    ],
+                    "traceresponse": [
+                        "00-325b7312cff9a3189c2092c80f250e27-0dac75a9337effa3-01"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "vary": [
+                        "Accept-Encoding"
+                    ],
+                    "content-security-policy": [
+                        "default-src 'none'; frame-ancestors 'none'"
+                    ],
+                    "x-robots-tag": [
+                        "none"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ]
+                },
+                "body_format": "json",
+                "body": "{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_011CeVygxgzJ8YQ2Yz3tnJrD\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The user is asking me to recall what they just asked me. Looking at the conversation history, their previous question was \\\"What time is it right now?\\\"\",\"signature\":\"EpUDCpsBCBEYAipA901XYhehLNNRiZ0tcJSGva0Vs2zf6kfnfMfD2abMHIawbTH0bQGgKSbFpHa7pT2lE0B501GYCvieYz7mEdQhijIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBrabI1AYSDP90NNDdYYH+7bD1zhoM347D2fI6objncS5aIjDQS15u0H/qts0uktibgwKii0ugJ9zxF6FRgNwMQ/Li4hAqWgOnXIwbMCfAKxbvWAwqpgH2de7dF7DoFlM9u0GoWc3f4jjNoygKLMHOuim7qT0UQcfWcKEOUR57e7Ea1G5dFDvYH+ac1Gj12nSL2k4M+dVNIPUZANtXUXw5V3BzFHNENJ9GaZ+ifyGgkuzixMnsh7wgZ50GhRMZHouXGL1E0w59uiUd/2j16f2TzM4y7j1/JhwMYkSgmccBn0LRBgZPZ9UbzzkxcLrgFramCOnJfSPM2UXJ08b+GAE=\"},{\"type\":\"text\",\"text\":\"You just asked me \\\"What time is it right now?\\\"\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":856,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":54,\"output_tokens_details\":{\"thinking_tokens\":37},\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}"
+            }
+        }
+    ]
+}

--- a/examples/tests/fixtures/agent/multi-turn-thinking.out
+++ b/examples/tests/fixtures/agent/multi-turn-thinking.out
@@ -1,0 +1,13 @@
+Turn 1: The current time is **23:00:57** (11:00:57 PM) on August 28, 2026.
+Turn 2: You just asked me "What time is it right now?"
++---+-----------+ Conversation Shape ----------------+
+| # | Role      | Content parts                      |
++---+-----------+------------------------------------+
+| 0 | system    | Text                               |
+| 1 | user      | Text                               |
+| 2 | assistant | Thinking(signed) + ToolCall(clock) |
+| 3 | tool      | ToolResult(clock)                  |
+| 4 | assistant | Thinking(signed) + Text            |
+| 5 | user      | Text                               |
+| 6 | assistant | Thinking(signed) + Text            |
++---+-----------+------------------------------------+

--- a/src/agent/src/Execution/Runner.php
+++ b/src/agent/src/Execution/Runner.php
@@ -19,6 +19,9 @@ use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
 use Symfony\AI\Agent\Toolbox\ToolExecutorInterface;
 use Symfony\AI\Agent\Toolbox\ToolResultConverter;
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Metadata\Metadata;
@@ -30,6 +33,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\StructuredOutput\Streaming\PartialObjectStreamListener;
 use Symfony\AI\Platform\Tool\Tool;
@@ -79,9 +83,9 @@ final class Runner
 
             $result = $this->platform->invoke($model, $messages, $options)->getResult();
 
-            $streamedText = '';
+            $assistantMessage = null;
             if ($result instanceof StreamResult) {
-                [$result, $streamedText] = yield from $this->consumeStream($result);
+                [$result, $assistantMessage] = yield from $this->consumeStream($result);
             }
 
             $toolCallResult = $this->extractToolCallResult($result);
@@ -96,14 +100,10 @@ final class Runner
                 throw new MaxIterationsExceededException($this->maxToolCalls);
             }
 
-            if ('' !== $streamedText) {
-                $messages->add(Message::ofAssistant($streamedText));
-            }
-
             $toolCalls = array_values($toolCallResult->getContent());
             $toolResults = yield from $this->toolExecutor->execute($toolCalls);
 
-            $messages->add(Message::ofAssistant(...$toolCalls));
+            $messages->add($assistantMessage ?? Message::ofAssistant($result));
             foreach ($toolResults as $i => $toolResult) {
                 $messages->add(Message::ofToolCall($toolCalls[$i], $this->resultConverter->convert($toolResult)));
 
@@ -137,7 +137,7 @@ final class Runner
      * The stream is drained completely even after a tool call was seen, since its metadata (e.g. token
      * usage) is only complete once the underlying generator is exhausted.
      *
-     * @return \Generator<int, UpdateInterface, mixed, array{ResultInterface, string}>
+     * @return \Generator<int, UpdateInterface, mixed, array{ResultInterface, AssistantMessage}>
      */
     private function consumeStream(StreamResult $stream): \Generator
     {
@@ -163,16 +163,46 @@ final class Runner
             yield new Progress('delta', 'Received a streamed delta.', $delta);
         }
 
+        $turn = $stream->getAssistantMessage();
+
         if ([] !== $toolCalls) {
             $result = new ToolCallResult($toolCalls);
         } else {
             // a streamed structured output round ends with the object assembled by the platform's listener
-            $result = $this->streamedObjectResult($stream) ?? new TextResult($text);
+            $result = $this->streamedObjectResult($stream) ?? $this->turnResult($turn, $text);
         }
 
         $result->getMetadata()->merge($stream->getMetadata());
 
-        return [$result, $text];
+        return [$result, $turn];
+    }
+
+    /**
+     * The streamed turn as the result the same round would have returned unstreamed, so a thinking
+     * block and its signature survive into the next turn.
+     */
+    private function turnResult(AssistantMessage $turn, string $text): ResultInterface
+    {
+        $parts = [];
+        foreach ($turn->getContent() as $content) {
+            if ($content instanceof Thinking) {
+                $parts[] = new ThinkingResult($content->getContent(), $content->getSignature());
+            }
+
+            if ($content instanceof Text) {
+                $parts[] = new TextResult($content->getText(), $content->getSignature());
+            }
+        }
+
+        if ([] === $parts) {
+            return new TextResult($text);
+        }
+
+        if (1 === \count($parts) && $parts[0] instanceof TextResult) {
+            return $parts[0];
+        }
+
+        return new MultiPartResult($parts);
     }
 
     private function streamedObjectResult(StreamResult $stream): ?ObjectResult

--- a/src/agent/tests/Execution/RunnerTest.php
+++ b/src/agent/tests/Execution/RunnerTest.php
@@ -23,16 +23,22 @@ use Symfony\AI\Agent\Toolbox\Source\SourceCollection;
 use Symfony\AI\Agent\Toolbox\ToolboxInterface;
 use Symfony\AI\Agent\Toolbox\ToolResult;
 use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\File;
+use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\ToolCallMessage;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingSignature;
 use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\StructuredOutput\Serializer;
@@ -134,6 +140,33 @@ final class RunnerTest extends TestCase
 
         $this->assertInstanceOf(TextResult::class, $actual);
         $this->assertSame('Final response', $actual->getContent());
+    }
+
+    public function testToolCallAlongsideBinaryOutputStillGetsExecuted()
+    {
+        $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);
+        $toolbox = $this->createMock(ToolboxInterface::class);
+        $toolbox
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn(new ToolResult($toolCall, 'Test response'));
+
+        // Gemini returns inlineData next to a functionCall, the Responses API an image_generation_call
+        $result = new MultiPartResult([
+            new BinaryResult('binary-image-bytes', 'image/png'),
+            new ToolCallResult([$toolCall]),
+        ]);
+
+        $messages = new MessageBag();
+        $platform = $this->platform($result, new TextResult('Final response'));
+        $actual = $this->drive($this->createRunner($platform, $toolbox), $messages);
+
+        $this->assertInstanceOf(TextResult::class, $actual);
+
+        $assistantMessage = $messages->getMessages()[0];
+        $this->assertInstanceOf(AssistantMessage::class, $assistantMessage);
+        $this->assertSame([$toolCall], $assistantMessage->getToolCalls());
+        $this->assertInstanceOf(File::class, $assistantMessage->getContent()[0]);
     }
 
     public function testMultiPartResultWithSeveralToolCallPartsExecutesAllOfThem()
@@ -343,12 +376,50 @@ final class RunnerTest extends TestCase
         $platform = $this->platform($stream, new TextResult('Final response'));
         $this->drive($this->createRunner($platform, $toolbox), $messages);
 
-        $textMessages = array_filter(
+        $assistantMessages = array_values(array_filter(
             $messages->getMessages(),
-            static fn ($message): bool => $message instanceof AssistantMessage && !$message->hasToolCalls(),
+            static fn ($message): bool => $message instanceof AssistantMessage,
+        ));
+
+        $this->assertCount(1, $assistantMessages);
+        $this->assertSame('Let me check that.', $assistantMessages[0]->asText());
+        $this->assertSame([$toolCall], $assistantMessages[0]->getToolCalls());
+        $this->assertEquals(
+            [new Text('Let me check that.'), $toolCall],
+            $assistantMessages[0]->getContent(),
         );
-        $this->assertCount(1, $textMessages);
-        $this->assertSame('Let me check that.', reset($textMessages)->asText());
+    }
+
+    public function testAStreamedRoundReturnsTheSameResultABufferedOneWould()
+    {
+        $stream = new StreamResult((static function () {
+            yield new ThinkingDelta('let me think');
+            yield new ThinkingSignature('sig-abc');
+            yield new TextDelta('It is 10:00.');
+        })());
+
+        $actual = $this->drive($this->createRunner($this->platform($stream), $this->createMock(ToolboxInterface::class)), new MessageBag());
+
+        // flattening the turn to its text drops the signature providers require on the next turn
+        $this->assertInstanceOf(MultiPartResult::class, $actual);
+        $this->assertEquals(
+            [new ThinkingResult('let me think', 'sig-abc'), new TextResult('It is 10:00.')],
+            $actual->getContent(),
+        );
+        $this->assertSame('It is 10:00.', $actual->asText());
+    }
+
+    public function testAStreamedRoundOfPlainTextStaysATextResult()
+    {
+        $stream = new StreamResult((static function () {
+            yield new TextDelta('It is ');
+            yield new TextDelta('10:00.');
+        })());
+
+        $actual = $this->drive($this->createRunner($this->platform($stream), $this->createMock(ToolboxInterface::class)), new MessageBag());
+
+        $this->assertInstanceOf(TextResult::class, $actual);
+        $this->assertSame('It is 10:00.', $actual->getContent());
     }
 
     public function testUsageMetadataGetsPropagatedInStreaming()

--- a/src/chat/src/Chat.php
+++ b/src/chat/src/Chat.php
@@ -16,7 +16,6 @@ use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
-use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
@@ -60,17 +59,9 @@ final class Chat implements ChatInterface
 
         $execution = $this->agent->call($messages, ['stream' => true]);
 
-        // the execution's deltas are the streamed answer; accumulate the text to persist it afterwards
-        $content = '';
-        foreach ($execution->asStream() as $delta) {
-            if ($delta instanceof TextDelta) {
-                $content .= $delta;
-            }
+        yield from $execution->asStream();
 
-            yield $delta;
-        }
-
-        $assistantMessage = Message::ofAssistant($content);
+        $assistantMessage = Message::ofAssistant($execution->getResult());
         $assistantMessage->getMetadata()->merge($execution->getMetadata());
         $messages->add($assistantMessage);
 

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -11,6 +11,8 @@ CHANGELOG
  * Add `TokenUsage\TokenUsageAggregation::getTokenUsages()` to read back the individual usages an aggregation sums up
  * Encode `Test\Recording\Cassette` with `JSON_THROW_ON_ERROR` and `JSON_PRESERVE_ZERO_FRACTION` and check the write, so a result holding a value JSON cannot represent (`NAN`, `INF`, invalid UTF-8) raises instead of truncating the cassette and destroying the interactions already recorded in it, and a recorded float with no fractional part no longer replays as an integer
  * Add `Test\Replay\AbstractBridgeReplayTestCase` for cassette-driven bridge replay tests, and make the `examples/` corpus a record/replay harness: `examples/runner --record` captures every HTTP interaction of an example into a committed cassette and refreshes the replay goldens, `ExamplesReplayTest` re-runs each recorded example offline through the full bridge pipeline in CI, without credentials, against those goldens
+ * Add `Result\Stream\AssistantMessageStreamListener`, which rebuilds the assistant turn - text, thinking blocks with their signatures, tool calls, in provider order - from a streamed response
+ * Accept a `StreamResult` in `Message::ofAssistant()` and add `StreamResult::getAssistantMessage()`, so a streamed turn is replayed like a buffered one, draining the stream if the caller has not read it
  * Add `Result\CustomToolCallResult` for `custom_tool_call` output items reported by provider-specific server-side tools (e.g. xAI's `x_search`), converted the same way as the other built-in tool call results instead of being surfaced as a `ToolCall` the application is expected to execute
 
 0.12

--- a/src/platform/src/Bridge/Anthropic/Tests/Fixtures/cassettes/streaming_thinking_tool_call.json
+++ b/src/platform/src/Bridge/Anthropic/Tests/Fixtures/cassettes/streaming_thinking_tool_call.json
@@ -1,0 +1,102 @@
+{
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "url": "https://api.anthropic.com/v1/messages",
+                "signature": "169b7b27619cfa7e3973128abfe88581",
+                "headers": {
+                    "x-api-key": [
+                        "[redacted]"
+                    ],
+                    "anthropic-version": [
+                        "2023-06-01"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "anthropic-beta": [
+                        "interleaved-thinking-2025-05-14"
+                    ]
+                },
+                "body": "{\"max_tokens\":4000,\"stream\":true,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"clock\",\"description\":\"Provides the current date and time.\",\"input_schema\":{\"type\":\"object\"},\"cache_control\":{\"type\":\"ephemeral\"}}],\"tool_choice\":{\"type\":\"auto\"},\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What time is it right now?\",\"cache_control\":{\"type\":\"ephemeral\"}}]}],\"system\":[{\"type\":\"text\",\"text\":\"You are a helpful assistant.\",\"cache_control\":{\"type\":\"ephemeral\"}}],\"model\":\"claude-sonnet-4-5-20250929\"}"
+            },
+            "response": {
+                "status": 200,
+                "headers": {
+                    "content-type": [
+                        "text/event-stream; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "anthropic-ratelimit-input-tokens-limit": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-remaining": [
+                        "5000000"
+                    ],
+                    "anthropic-ratelimit-input-tokens-reset": [
+                        "2026-08-28T23:00:54Z"
+                    ],
+                    "anthropic-ratelimit-output-tokens-limit": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-remaining": [
+                        "1000000"
+                    ],
+                    "anthropic-ratelimit-output-tokens-reset": [
+                        "2026-08-28T23:00:54Z"
+                    ],
+                    "anthropic-ratelimit-requests-limit": [
+                        "5000"
+                    ],
+                    "anthropic-ratelimit-requests-remaining": [
+                        "4999"
+                    ],
+                    "anthropic-ratelimit-requests-reset": [
+                        "2026-08-28T23:00:54Z"
+                    ],
+                    "anthropic-ratelimit-tokens-limit": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-remaining": [
+                        "6000000"
+                    ],
+                    "anthropic-ratelimit-tokens-reset": [
+                        "2026-08-28T23:00:54Z"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=31536000; includeSubDomains; preload"
+                    ],
+                    "anthropic-organization-id": [
+                        "152d88d9-0d18-4cae-80c9-c425a5bf4e25"
+                    ],
+                    "anthropic-workspace-id": [
+                        "wrkspc_01Eo1YZvq8sNWFRAfhfjg7gS"
+                    ],
+                    "traceresponse": [
+                        "00-762e3642e5b91cafab7bd049ec0e1546-dd65e86f4863d542-01"
+                    ],
+                    "server": [
+                        "cloudflare"
+                    ],
+                    "content-encoding": [
+                        "gzip"
+                    ],
+                    "vary": [
+                        "Accept-Encoding"
+                    ],
+                    "x-robots-tag": [
+                        "none"
+                    ],
+                    "content-security-policy": [
+                        "default-src 'none'; frame-ancestors 'none'"
+                    ]
+                },
+                "body_format": "sse",
+                "body": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_011CeVygbKrZxVBFnrYqLZg1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":729,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":5,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}         }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}            }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"The user is asking for\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" the current time. I have access to a clock function that can provide the current date and time. Let me use it.\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"EoQDCpsBCBEYAipAuZHKs82WEZdSpAtul9f5tA98Wa/oYcqMRTUZ4wyDozjaxoZxP69FsW+DlAsa0AKtyVEyDCZFE1EqSrTGHuKoIDIaY2xhdWRlLXNvbm5ldC00LTUtMjAyNTA5Mjk4AEIIdGhpbmtpbmdaJDE1MmQ4OGQ5LTBkMTgtNGNhZS04MGM5LWM0MjVhNWJmNGUyNagBqKbI1AYSDL6c3HsLWSATj1EYhBoMbHQosEE22qsw3ma+IjAmuvAbCkYIC2fxTpgeazBj5bRNpbDcDrZh9IB2fgEjYp8Fjy77mJku1Ozma94R/JkqlQFzhyuWYstSqsRWxC2KKdXBweJbjiUkNmIHbERqgroK3w7bw0H0o17YuzD+rejoAn++1XsJLgC7ZFGJuRFevA6pZG/U51jzKMxNW/Emv4hrL/ruxZh9qhnLUWzlMrhTqu6u2K3LZU9BTExwAC2LofxbYCse05Cu1SzXjrd2E+EKAfP2utm6+QlLeYzPi1Lrq6/cfOtqjRgB\"}      }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0              }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01FX2eH86CmqTjwF1ymuTW8e\",\"name\":\"clock\",\"input\":{},\"caller\":{\"type\":\"direct\"}}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}           }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1           }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null},\"usage\":{\"input_tokens\":729,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":72,\"output_tokens_details\":{\"thinking_tokens\":35}}             }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"        }\n\n"
+            }
+        }
+    ]
+}

--- a/src/platform/src/Bridge/Anthropic/Tests/ReplayTest.php
+++ b/src/platform/src/Bridge/Anthropic/Tests/ReplayTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Anthropic\Tests;
+
+use Symfony\AI\Platform\Bridge\Anthropic\Factory;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\AI\Platform\Test\Replay\AbstractBridgeReplayTestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Replays recorded Anthropic interactions through the real bridge pipeline.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ReplayTest extends AbstractBridgeReplayTestCase
+{
+    /**
+     * Pins the event vocabulary and ordering the provider emits, which synthetic deltas cannot.
+     */
+    public function testStreamedThinkingAndToolCallRebuildTheAssistantTurn()
+    {
+        $platform = $this->platformForCassette('streaming_thinking_tool_call');
+
+        $result = $platform->invoke(
+            'claude-sonnet-4-5-20250929',
+            new MessageBag(Message::ofUser('What time is it right now?')),
+            [
+                'stream' => true,
+                'max_tokens' => 4000,
+                'thinking' => ['type' => 'enabled', 'budget_tokens' => 1024],
+            ],
+        )->getResult();
+
+        $this->assertInstanceOf(StreamResult::class, $result);
+
+        $content = Message::ofAssistant($result)->getContent();
+
+        $this->assertCount(2, $content);
+
+        $this->assertInstanceOf(Thinking::class, $content[0]);
+        $this->assertNotSame('', $content[0]->getContent());
+        $this->assertNotNull($content[0]->getSignature(), 'the signature Anthropic validates is preserved');
+
+        $this->assertInstanceOf(ToolCall::class, $content[1]);
+        $this->assertSame('clock', $content[1]->getName());
+    }
+
+    protected function createPlatform(HttpClientInterface $httpClient): PlatformInterface
+    {
+        return Factory::createPlatform('test-api-key', httpClient: $httpClient);
+    }
+
+    protected function cassetteDirectory(): string
+    {
+        return __DIR__.'/Fixtures/cassettes';
+    }
+}

--- a/src/platform/src/Bridge/Cerebras/CHANGELOG.md
+++ b/src/platform/src/Bridge/Cerebras/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.13
+----
+
+ * Add a Cerebras assistant message normalizer that drops the `reasoning_content` of the shared contract, which Cerebras answers with a 400 `property 'messages.N.assistant.reasoning_content' is unsupported`; its streamed responses carry a reasoning trace, so a replayed turn reaches it
+
 0.11
 ----
 

--- a/src/platform/src/Bridge/Cerebras/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Cerebras/Contract/AssistantMessageNormalizer.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cerebras\Contract;
+
+use Symfony\AI\Platform\Contract\Normalizer\Message\AssistantMessageNormalizer as BaseAssistantMessageNormalizer;
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Drops the `reasoning_content` of the shared contract, which Cerebras answers with a 400
+ * "property 'messages.N.assistant.reasoning_content' is unsupported".
+ *
+ * Its streamed responses carry a reasoning trace, so a replayed turn reaches this. Cerebras has no
+ * shape of its own to put it in - a Mistral-style thinking chunk is rejected too - so the trace is
+ * dropped and the turn replays as text and tool calls.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class AssistantMessageNormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    private BaseAssistantMessageNormalizer $inner;
+
+    public function __construct()
+    {
+        $this->inner = new BaseAssistantMessageNormalizer();
+    }
+
+    public function setNormalizer(NormalizerInterface $normalizer): void
+    {
+        $this->inner->setNormalizer($normalizer);
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof AssistantMessage;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            AssistantMessage::class => true,
+        ];
+    }
+
+    /**
+     * @param AssistantMessage $data
+     *
+     * @return array{role: 'assistant', content: string|null, tool_calls?: array<array<string, mixed>>}
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        $array = $this->inner->normalize($data, $format, $context);
+
+        unset($array['reasoning_content']);
+
+        return $array;
+    }
+}

--- a/src/platform/src/Bridge/Cerebras/Factory.php
+++ b/src/platform/src/Bridge/Cerebras/Factory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Cerebras;
 
+use Symfony\AI\Platform\Bridge\Cerebras\Contract\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Bridge\Cerebras\Contract\ToolNormalizer;
 use Symfony\AI\Platform\Contract;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
@@ -48,6 +49,7 @@ final class Factory
             [new ResultConverter()],
             $modelCatalog,
             $contract ?? Contract::create([
+                new AssistantMessageNormalizer(),
                 new ToolNormalizer(),
             ]),
             $eventDispatcher,

--- a/src/platform/src/Bridge/Cerebras/Tests/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/Cerebras/Tests/Contract/AssistantMessageNormalizerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Cerebras\Tests\Contract;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Cerebras\Contract\AssistantMessageNormalizer;
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class AssistantMessageNormalizerTest extends TestCase
+{
+    public function testSupportsNormalization()
+    {
+        $normalizer = new AssistantMessageNormalizer();
+
+        $this->assertTrue($normalizer->supportsNormalization(Message::ofAssistant('Hello')));
+        $this->assertFalse($normalizer->supportsNormalization('not a message'));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame(
+            [AssistantMessage::class => true],
+            (new AssistantMessageNormalizer())->getSupportedTypes(null),
+        );
+    }
+
+    public function testThinkingIsDropped()
+    {
+        $message = Message::ofAssistant(new Thinking('Let me think.'), new Text('It is 10:00.'));
+
+        // Cerebras answers `reasoning_content` with a 400, and accepts no other shape for it
+        $this->assertSame(
+            ['role' => 'assistant', 'content' => 'It is 10:00.'],
+            (new AssistantMessageNormalizer())->normalize($message),
+        );
+    }
+
+    public function testToolCallsSurviveAlongsideTheDroppedThinking()
+    {
+        $inner = $this->createMock(NormalizerInterface::class);
+        $inner->method('normalize')->willReturn([['id' => 'call_1']]);
+
+        $normalizer = new AssistantMessageNormalizer();
+        $normalizer->setNormalizer($inner);
+
+        $actual = $normalizer->normalize(
+            Message::ofAssistant(new Thinking('Which tool?'), new ToolCall('call_1', 'clock')),
+        );
+
+        $this->assertArrayNotHasKey('reasoning_content', $actual);
+        $this->assertSame([['id' => 'call_1']], $actual['tool_calls']);
+    }
+}

--- a/src/platform/src/Bridge/Mistral/CHANGELOG.md
+++ b/src/platform/src/Bridge/Mistral/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.13
 ----
 
+ * Add a Mistral assistant message normalizer that replays a reasoning turn as a `thinking` chunk of the content list, the shape the API accepts and its result converter already reads, instead of the `reasoning_content` of the OpenAI-compatible convention, which Mistral rejects with a 422 `Extra inputs are not permitted`
  * Add a Mistral audio normalizer so `Content\Audio` can be used as a chat message part (audio understanding) with Voxtral models such as `voxtral-small-latest`
  * Add Voxtral speech-to-text support through the dedicated `/v1/audio/transcriptions` endpoint, exposing a `SpeechToText` model, model client, result converter and audio normalizer (opt-in via `new SpeechToText('voxtral-mini-latest')`)
 

--- a/src/platform/src/Bridge/Mistral/Contract/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/Mistral/Contract/AssistantMessageNormalizer.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Contract;
+
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Replays a reasoning turn the way Mistral asks for it, as a thinking chunk of the content list.
+ *
+ * The generic contract sends `reasoning_content`, which Mistral rejects with a 422
+ * "Extra inputs are not permitted". Its own shape is a content list of `thinking` and `text`
+ * chunks - the one {@see \Symfony\AI\Platform\Bridge\Mistral\Llm\ResultConverter} reads back -
+ * and the reasoning has to come along: "The model relies on the reasoning trace to maintain
+ * coherence across turns."
+ *
+ * @see https://docs.mistral.ai/capabilities/reasoning/
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class AssistantMessageNormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof AssistantMessage;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            AssistantMessage::class => true,
+        ];
+    }
+
+    /**
+     * @param AssistantMessage $data
+     *
+     * @return array{
+     *     role: 'assistant',
+     *     content: string|list<array{type: 'thinking', thinking: list<array{type: 'text', text: string}>}|array{type: 'text', text: string}>|null,
+     *     tool_calls?: array<array<string, mixed>>,
+     * }
+     */
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        /** @var list<array{type: 'thinking'|'text', text: string}> $chunks */
+        $chunks = [];
+        $toolCalls = [];
+        $hasThinking = false;
+
+        foreach ($data->getContent() as $part) {
+            if ($part instanceof ToolCall) {
+                $toolCalls[] = $part;
+
+                continue;
+            }
+
+            if ($part instanceof Text) {
+                self::append($chunks, 'text', $part->getText());
+
+                continue;
+            }
+
+            if ($part instanceof Thinking && self::append($chunks, 'thinking', $part->getContent())) {
+                $hasThinking = true;
+            }
+        }
+
+        $array = [
+            'role' => $data->getRole()->value,
+            // a turn without reasoning keeps the plain string every other Mistral model expects
+            'content' => $hasThinking ? self::chunks($chunks) : self::plainText($chunks),
+        ];
+
+        if ([] !== $toolCalls) {
+            $array['tool_calls'] = $this->normalizer->normalize($toolCalls, $format, $context);
+        }
+
+        return $array;
+    }
+
+    /**
+     * Merges into the previous chunk when it is of the same type; an empty block is not replayed.
+     *
+     * @param list<array{type: 'thinking'|'text', text: string}> $chunks
+     * @param 'thinking'|'text'                                  $type
+     */
+    private static function append(array &$chunks, string $type, string $text): bool
+    {
+        if ('' === $text) {
+            return false;
+        }
+
+        $last = array_key_last($chunks);
+
+        if (null !== $last && $type === $chunks[$last]['type']) {
+            $chunks[$last]['text'] .= $text;
+
+            return true;
+        }
+
+        $chunks[] = ['type' => $type, 'text' => $text];
+
+        return true;
+    }
+
+    /**
+     * @param list<array{type: 'thinking'|'text', text: string}> $chunks
+     *
+     * @return list<array{type: 'thinking', thinking: list<array{type: 'text', text: string}>}|array{type: 'text', text: string}>
+     */
+    private static function chunks(array $chunks): array
+    {
+        $content = [];
+
+        foreach ($chunks as $chunk) {
+            $content[] = 'thinking' === $chunk['type']
+                ? ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => $chunk['text']]]]
+                : ['type' => 'text', 'text' => $chunk['text']];
+        }
+
+        return $content;
+    }
+
+    /**
+     * @param list<array{type: 'thinking'|'text', text: string}> $chunks
+     */
+    private static function plainText(array $chunks): ?string
+    {
+        $text = '';
+
+        foreach ($chunks as $chunk) {
+            if ('text' === $chunk['type']) {
+                $text .= $chunk['text'];
+            }
+        }
+
+        return '' === $text ? null : $text;
+    }
+}

--- a/src/platform/src/Bridge/Mistral/Factory.php
+++ b/src/platform/src/Bridge/Mistral/Factory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Platform\Bridge\Mistral;
 
+use Symfony\AI\Platform\Bridge\Mistral\Contract\AssistantMessageNormalizer;
 use Symfony\AI\Platform\Bridge\Mistral\Contract\AudioNormalizer;
 use Symfony\AI\Platform\Bridge\Mistral\Contract\DocumentNormalizer;
 use Symfony\AI\Platform\Bridge\Mistral\Contract\DocumentUrlNormalizer;
@@ -52,6 +53,7 @@ final class Factory
             [new Embeddings\ResultConverter(), new Llm\ResultConverter(), new Ocr\ResultConverter(), new SpeechToText\ResultConverter()],
             $modelCatalog,
             $contract ?? Contract::create([
+                new AssistantMessageNormalizer(),
                 new ToolNormalizer(),
                 new DocumentNormalizer(),
                 new DocumentUrlNormalizer(),

--- a/src/platform/src/Bridge/Mistral/Tests/Contract/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/Mistral/Tests/Contract/AssistantMessageNormalizerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\Mistral\Tests\Contract;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\Mistral\Contract\AssistantMessageNormalizer;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class AssistantMessageNormalizerTest extends TestCase
+{
+    public function testSupportsNormalization()
+    {
+        $normalizer = new AssistantMessageNormalizer();
+
+        $this->assertTrue($normalizer->supportsNormalization(Message::ofAssistant('Hello')));
+        $this->assertFalse($normalizer->supportsNormalization('not a message'));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame(
+            [\Symfony\AI\Platform\Message\AssistantMessage::class => true],
+            (new AssistantMessageNormalizer())->getSupportedTypes(null),
+        );
+    }
+
+    public function testATurnWithoutThinkingKeepsPlainStringContent()
+    {
+        $normalizer = new AssistantMessageNormalizer();
+
+        $this->assertSame(
+            ['role' => 'assistant', 'content' => 'It is 10:00.'],
+            $normalizer->normalize(Message::ofAssistant('It is 10:00.')),
+        );
+    }
+
+    public function testThinkingIsReplayedAsAThinkChunk()
+    {
+        $normalizer = new AssistantMessageNormalizer();
+
+        $message = Message::ofAssistant(new Thinking('Let me check the clock.'), new Text('It is 10:00.'));
+
+        // Mistral rejects `reasoning_content` with a 422 and reads the reasoning back from the
+        // content list instead, which is also the shape its ResultConverter parses
+        $this->assertSame([
+            'role' => 'assistant',
+            'content' => [
+                ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'Let me check the clock.']]],
+                ['type' => 'text', 'text' => 'It is 10:00.'],
+            ],
+        ], $normalizer->normalize($message));
+    }
+
+    public function testThinkingWithoutTextOmitsTheTextChunk()
+    {
+        $normalizer = new AssistantMessageNormalizer();
+
+        $this->assertSame([
+            'role' => 'assistant',
+            'content' => [
+                ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'Still thinking.']]],
+            ],
+        ], $normalizer->normalize(Message::ofAssistant(new Thinking('Still thinking.'))));
+    }
+
+    public function testChunksKeepTheOrderTheModelProducedThemIn()
+    {
+        $normalizer = new AssistantMessageNormalizer();
+
+        $message = Message::ofAssistant(
+            new Text('Let me check. '),
+            new Thinking('The clock tool answers this.'),
+            new Text('It is 10:00.'),
+        );
+
+        $this->assertSame([
+            'role' => 'assistant',
+            'content' => [
+                ['type' => 'text', 'text' => 'Let me check. '],
+                ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'The clock tool answers this.']]],
+                ['type' => 'text', 'text' => 'It is 10:00.'],
+            ],
+        ], $normalizer->normalize($message));
+    }
+
+    public function testConsecutivePartsOfOneKindBecomeOneChunk()
+    {
+        $normalizer = new AssistantMessageNormalizer();
+
+        $message = Message::ofAssistant(
+            new Thinking('First. '),
+            new Thinking('Second.'),
+            new Text('It is '),
+            new Text('10:00.'),
+        );
+
+        $this->assertSame([
+            'role' => 'assistant',
+            'content' => [
+                ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'First. Second.']]],
+                ['type' => 'text', 'text' => 'It is 10:00.'],
+            ],
+        ], $normalizer->normalize($message));
+    }
+
+    public function testAnEmptyThinkingBlockIsNotReplayed()
+    {
+        $normalizer = new AssistantMessageNormalizer();
+
+        $this->assertSame(
+            ['role' => 'assistant', 'content' => 'It is 10:00.'],
+            $normalizer->normalize(Message::ofAssistant(new Thinking(''), new Text('It is 10:00.'))),
+        );
+    }
+
+    public function testToolCallsAreNormalizedAlongsideTheThinkChunk()
+    {
+        $toolCall = new ToolCall('call_1', 'clock');
+
+        $inner = $this->createMock(NormalizerInterface::class);
+        $inner->method('normalize')->willReturn([['id' => 'call_1']]);
+
+        $normalizer = new AssistantMessageNormalizer();
+        $normalizer->setNormalizer($inner);
+
+        $actual = $normalizer->normalize(Message::ofAssistant(new Thinking('Which tool?'), $toolCall));
+
+        $this->assertSame([
+            ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'Which tool?']]],
+        ], $actual['content']);
+        $this->assertSame([['id' => 'call_1']], $actual['tool_calls']);
+    }
+}

--- a/src/platform/src/Bridge/OpenResponses/Contract/Message/AssistantMessageNormalizer.php
+++ b/src/platform/src/Bridge/OpenResponses/Contract/Message/AssistantMessageNormalizer.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 
@@ -28,36 +29,54 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
     use NormalizerAwareTrait;
 
     /**
+     * Responses input is a flat list of output items, so text is buffered until a reasoning item or
+     * a tool call fixes the next position in that list.
+     *
      * @param AssistantMessage $data
      *
      * @return list<array<string, mixed>>
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        $reasoningItems = $this->extractReasoningItems($data);
-
-        if ($data->hasToolCalls()) {
-            /** @var list<array<string, mixed>> $toolCalls */
-            $toolCalls = $this->normalizer->normalize($data->getToolCalls(), $format, $context);
-
-            return array_merge($reasoningItems, $toolCalls);
-        }
-
+        $items = [];
         $text = '';
+
         foreach ($data->getContent() as $part) {
             if ($part instanceof Text) {
                 $text .= $part->getText();
+
+                continue;
+            }
+
+            if ($part instanceof Thinking) {
+                $item = $this->toReasoningItem($part);
+
+                if (null === $item) {
+                    continue;
+                }
+
+                $this->flushText($items, $text, $data);
+                $items[] = $item;
+
+                continue;
+            }
+
+            if ($part instanceof ToolCall) {
+                $this->flushText($items, $text, $data);
+
+                /** @var array<string, mixed> $toolCall */
+                $toolCall = $this->normalizer->normalize($part, $format, $context);
+                $items[] = $toolCall;
             }
         }
 
-        return [
-            ...$reasoningItems,
-            [
-                'role' => $data->getRole()->value,
-                'type' => 'message',
-                'content' => '' === $text ? null : $text,
-            ],
-        ];
+        $this->flushText($items, $text, $data);
+
+        if ([] === $items) {
+            $items[] = self::message($data, null);
+        }
+
+        return $items;
     }
 
     protected function supportedDataClass(): string
@@ -71,29 +90,56 @@ final class AssistantMessageNormalizer extends ModelContractNormalizer implement
     }
 
     /**
-     * @return list<array<string, mixed>>
+     * The signature carries the provider's original reasoning output item; the summary text alone
+     * is not accepted.
+     *
+     * @return array<string, mixed>|null
      */
-    private function extractReasoningItems(AssistantMessage $data): array
+    private function toReasoningItem(Thinking $part): ?array
     {
-        $items = [];
+        $signature = $part->getSignature();
 
-        foreach ($data->getContent() as $part) {
-            if (!$part instanceof Thinking || null === $part->getSignature()) {
-                continue;
-            }
-
-            try {
-                $item = json_decode($part->getSignature(), true, flags: \JSON_THROW_ON_ERROR);
-            } catch (\JsonException) {
-                // Signatures from other providers may be opaque strings
-                continue;
-            }
-
-            if (\is_array($item) && 'reasoning' === ($item['type'] ?? null)) {
-                $items[] = $item;
-            }
+        if (null === $signature) {
+            return null;
         }
 
-        return $items;
+        try {
+            $item = json_decode($signature, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            // signatures from other providers may be opaque strings
+            return null;
+        }
+
+        if (!\is_array($item) || 'reasoning' !== ($item['type'] ?? null)) {
+            return null;
+        }
+
+        /* @var array<string, mixed> $item */
+        return $item;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $items
+     */
+    private function flushText(array &$items, string &$text, AssistantMessage $data): void
+    {
+        if ('' === $text) {
+            return;
+        }
+
+        $items[] = self::message($data, $text);
+        $text = '';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function message(AssistantMessage $data, ?string $content): array
+    {
+        return [
+            'role' => $data->getRole()->value,
+            'type' => 'message',
+            'content' => $content,
+        ];
     }
 }

--- a/src/platform/src/Bridge/OpenResponses/Tests/AssistantReplayTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/AssistantReplayTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Bridge\OpenResponses\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\OpenResponses\Contract\OpenResponsesContract;
+use Symfony\AI\Platform\Bridge\OpenResponses\ResponsesModel;
+use Symfony\AI\Platform\Bridge\OpenResponses\ResultConverter;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\ToolCall;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+/**
+ * Asserts the shape of the request sent back on turn 2, which normalizing each message in
+ * isolation cannot prove.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class AssistantReplayTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $providerResponse
+     * @param array<string, mixed> $expectedReplayPayload
+     */
+    #[DataProvider('provideReplayScenarios')]
+    public function testRoundTrip(array $providerResponse, callable $bagBuilder, array $expectedReplayPayload)
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse($providerResponse));
+        $httpResponse = $httpClient->request('POST', 'https://api.openai.com/v1/responses');
+        $result = (new ResultConverter())->convert(new RawHttpResult($httpResponse));
+
+        $bag = $bagBuilder($result);
+        $payload = OpenResponsesContract::create()->createRequestPayload(new ResponsesModel('gpt-5'), $bag);
+
+        $this->assertEquals($expectedReplayPayload, $payload);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>, 1: callable, 2: array<string, mixed>}>
+     */
+    public static function provideReplayScenarios(): iterable
+    {
+        $reasoningItem = [
+            'type' => 'reasoning',
+            'id' => 'rs_1',
+            'summary' => [['type' => 'summary_text', 'text' => 'The user wants the time.']],
+            'encrypted_content' => 'gAAAAA-encrypted',
+        ];
+
+        yield 'text-only assistant turn' => [
+            [
+                'output' => [
+                    [
+                        'type' => 'message',
+                        'id' => 'msg_1',
+                        'role' => 'assistant',
+                        'content' => [['type' => 'output_text', 'text' => 'Hi there!']],
+                    ],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Hello'),
+                Message::ofAssistant($result),
+                Message::ofUser('Tell me more.'),
+            ),
+            ['input' => [
+                ['role' => 'user', 'content' => 'Hello'],
+                ['role' => 'assistant', 'type' => 'message', 'content' => 'Hi there!'],
+                ['role' => 'user', 'content' => 'Tell me more.'],
+            ]],
+        ];
+
+        yield 'reasoning item survives the round trip with its encrypted content' => [
+            [
+                'output' => [
+                    $reasoningItem,
+                    [
+                        'type' => 'message',
+                        'id' => 'msg_1',
+                        'role' => 'assistant',
+                        'content' => [['type' => 'output_text', 'text' => 'It is 10:00 AM.']],
+                    ],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What time is it?'),
+                Message::ofAssistant($result),
+                Message::ofUser('And in Paris?'),
+            ),
+            ['input' => [
+                ['role' => 'user', 'content' => 'What time is it?'],
+                $reasoningItem,
+                ['role' => 'assistant', 'type' => 'message', 'content' => 'It is 10:00 AM.'],
+                ['role' => 'user', 'content' => 'And in Paris?'],
+            ]],
+        ];
+
+        yield 'reasoning, text and a tool call replay in provider order' => [
+            [
+                'output' => [
+                    $reasoningItem,
+                    [
+                        'type' => 'message',
+                        'id' => 'msg_1',
+                        'role' => 'assistant',
+                        'content' => [['type' => 'output_text', 'text' => 'Let me check the clock.']],
+                    ],
+                    [
+                        'type' => 'function_call',
+                        'id' => 'fc_1',
+                        'call_id' => 'call_1',
+                        'name' => 'clock',
+                        'arguments' => '{}',
+                    ],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('What time is it?'),
+                Message::ofAssistant($result),
+                Message::ofToolCall(new ToolCall('call_1', 'clock', []), '10:00 AM'),
+            ),
+            ['input' => [
+                ['role' => 'user', 'content' => 'What time is it?'],
+                $reasoningItem,
+                ['role' => 'assistant', 'type' => 'message', 'content' => 'Let me check the clock.'],
+                [
+                    'type' => 'function_call',
+                    'call_id' => 'call_1',
+                    'name' => 'clock',
+                    'arguments' => '{}',
+                ],
+                [
+                    'type' => 'function_call_output',
+                    'call_id' => 'call_1',
+                    'output' => '10:00 AM',
+                ],
+            ]],
+        ];
+
+        yield 'encrypted reasoning without a summary is still replayed' => [
+            [
+                'output' => [
+                    [
+                        'type' => 'reasoning',
+                        'id' => 'rs_2',
+                        'summary' => [],
+                        'encrypted_content' => 'gAAAAA-opaque',
+                    ],
+                    [
+                        'type' => 'message',
+                        'id' => 'msg_1',
+                        'role' => 'assistant',
+                        'content' => [['type' => 'output_text', 'text' => 'Done.']],
+                    ],
+                ],
+            ],
+            static fn ($result) => new MessageBag(
+                Message::ofUser('Think hard.'),
+                Message::ofAssistant($result),
+                Message::ofUser('Again.'),
+            ),
+            ['input' => [
+                ['role' => 'user', 'content' => 'Think hard.'],
+                [
+                    'type' => 'reasoning',
+                    'id' => 'rs_2',
+                    'summary' => [],
+                    'encrypted_content' => 'gAAAAA-opaque',
+                ],
+                ['role' => 'assistant', 'type' => 'message', 'content' => 'Done.'],
+                ['role' => 'user', 'content' => 'Again.'],
+            ]],
+        ];
+    }
+}

--- a/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/AssistantMessageNormalizerTest.php
+++ b/src/platform/src/Bridge/OpenResponses/Tests/Contract/Message/AssistantMessageNormalizerTest.php
@@ -113,6 +113,81 @@ class AssistantMessageNormalizerTest extends TestCase
                 'content' => 'Foo',
             ]],
         ];
+
+        $normalizedToolCall = [
+            'arguments' => json_encode($toolCall->getArguments()),
+            'call_id' => $toolCall->getId(),
+            'name' => $toolCall->getName(),
+            'type' => 'function_call',
+        ];
+
+        yield 'text accompanying a tool call is replayed, not dropped' => [
+            Message::ofAssistant(new Text('Let me roll.'), $toolCall),
+            [
+                [
+                    'role' => 'assistant',
+                    'type' => 'message',
+                    'content' => 'Let me roll.',
+                ],
+                $normalizedToolCall,
+            ],
+        ];
+
+        yield 'text on both sides of a tool call keeps its positions' => [
+            Message::ofAssistant(new Text('Before. '), $toolCall, new Text('After.')),
+            [
+                [
+                    'role' => 'assistant',
+                    'type' => 'message',
+                    'content' => 'Before. ',
+                ],
+                $normalizedToolCall,
+                [
+                    'role' => 'assistant',
+                    'type' => 'message',
+                    'content' => 'After.',
+                ],
+            ],
+        ];
+
+        yield 'a reasoning item after text stays after it' => [
+            Message::ofAssistant(new Text('Thinking about it. '), new Thinking('Pondering.', json_encode($reasoningItem)), new Text('Done.')),
+            [
+                [
+                    'role' => 'assistant',
+                    'type' => 'message',
+                    'content' => 'Thinking about it. ',
+                ],
+                $reasoningItem,
+                [
+                    'role' => 'assistant',
+                    'type' => 'message',
+                    'content' => 'Done.',
+                ],
+            ],
+        ];
+
+        yield 'reasoning, text and a tool call in the order the model produced them' => [
+            Message::ofAssistant(new Thinking('Pondering.', json_encode($reasoningItem)), new Text('Let me roll.'), $toolCall),
+            [
+                $reasoningItem,
+                [
+                    'role' => 'assistant',
+                    'type' => 'message',
+                    'content' => 'Let me roll.',
+                ],
+                $normalizedToolCall,
+            ],
+        ];
+
+        yield 'an assistant turn with nothing replayable keeps the empty message' => [
+            Message::ofAssistant(new Thinking('Pondering.')),
+            [[
+                'role' => 'assistant',
+                'type' => 'message',
+                'content' => null,
+            ]],
+        ];
     }
 
     #[DataProvider('supportsNormalizationProvider')]

--- a/src/platform/src/Message/Message.php
+++ b/src/platform/src/Message/Message.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Message\Content\ComputerCall;
 use Symfony\AI\Platform\Message\Content\ContentInterface;
 use Symfony\AI\Platform\Message\Content\CustomToolCall;
 use Symfony\AI\Platform\Message\Content\ExecutableCode;
+use Symfony\AI\Platform\Message\Content\File;
 use Symfony\AI\Platform\Message\Content\FileSearch;
 use Symfony\AI\Platform\Message\Content\LocalShellCall;
 use Symfony\AI\Platform\Message\Content\McpApprovalRequest;
@@ -25,6 +26,7 @@ use Symfony\AI\Platform\Message\Content\McpListTools;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Content\Thinking;
 use Symfony\AI\Platform\Message\Content\WebSearch;
+use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\CodeExecutionResult;
 use Symfony\AI\Platform\Result\ComputerCallResult;
 use Symfony\AI\Platform\Result\CustomToolCallResult;
@@ -36,6 +38,7 @@ use Symfony\AI\Platform\Result\McpCallResult;
 use Symfony\AI\Platform\Result\McpListToolsResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -163,6 +166,17 @@ final class Message
 
         if ($part instanceof LocalShellCallResult) {
             return [new LocalShellCall($part->getContent(), $part->getCallId(), $part->getId(), $part->getStatus())];
+        }
+
+        // a model can return binary output next to its tool calls (Gemini inlineData, a Responses
+        // image_generation_call)
+        if ($part instanceof BinaryResult) {
+            return [new File($part->getContent(), $part->getMimeType() ?? 'application/octet-stream')];
+        }
+
+        // Drains the stream when the caller has not read it
+        if ($part instanceof StreamResult) {
+            return array_values($part->getAssistantMessage()->getContent());
         }
 
         if ($part instanceof MultiPartResult) {

--- a/src/platform/src/Result/Stream/AssistantMessageStreamListener.php
+++ b/src/platform/src/Result/Stream/AssistantMessageStreamListener.php
@@ -1,0 +1,252 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Result\Stream;
+
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Message\Content\ContentInterface;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingSignature;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+
+/**
+ * Rebuilds the assistant message a provider would have returned unstreamed, from its deltas.
+ *
+ * Attach it to a {@see \Symfony\AI\Platform\Result\StreamResult} and read
+ * {@see self::getAssistantMessage()} once the deltas of interest have been consumed.
+ *
+ * The delta vocabulary differs per bridge: not every bridge announces a thinking block before its
+ * first chunk or a tool call before its arguments, and the Responses API emits a reasoning item's
+ * signature only after the block has closed.
+ *
+ * A `ChoiceDelta` contributes nothing: it carries the deltas of several candidates, and one
+ * assistant turn cannot be reassembled from alternatives to it.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class AssistantMessageStreamListener extends AbstractStreamListener
+{
+    /**
+     * Parts in provider order; a null entry is a slot reserved by `ToolCallStart`.
+     *
+     * @var list<ContentInterface|null>
+     */
+    private array $content = [];
+
+    /**
+     * @var array<string, int>
+     */
+    private array $toolCallSlots = [];
+
+    private ?int $openThinking = null;
+
+    /**
+     * Most recent thinking block, for providers that emit its signature after it closed.
+     */
+    private ?int $lastThinking = null;
+
+    public function onStart(StartEvent $event): void
+    {
+        $this->reset();
+    }
+
+    public function onDelta(DeltaEvent $event): void
+    {
+        $delta = $event->getDelta();
+
+        // a replacement stream cannot be read here without consuming it; StreamResult collects
+        // those deltas as it yields them
+        if (!$delta instanceof DeltaInterface) {
+            return;
+        }
+
+        $this->accumulate($delta);
+    }
+
+    public function reset(): void
+    {
+        $this->content = [];
+        $this->toolCallSlots = [];
+        $this->openThinking = null;
+        $this->lastThinking = null;
+    }
+
+    /**
+     * Feeds a single delta in, for callers driving the reassembly themselves.
+     */
+    public function accumulate(DeltaInterface $delta): void
+    {
+        if ($delta instanceof TextDelta) {
+            $this->appendText($delta->getText());
+
+            return;
+        }
+
+        if ($delta instanceof ThinkingStart) {
+            $this->openThinking();
+
+            return;
+        }
+
+        if ($delta instanceof ThinkingDelta) {
+            $index = $this->openThinking ?? $this->openThinking();
+            $thinking = $this->thinkingAt($index);
+            $this->content[$index] = new Thinking($thinking->getContent().$delta->getThinking(), $thinking->getSignature());
+
+            return;
+        }
+
+        if ($delta instanceof ThinkingComplete) {
+            $index = $this->openThinking ?? $this->openThinking();
+            $thinking = $this->thinkingAt($index);
+            $this->content[$index] = new Thinking($delta->getThinking(), $delta->getSignature() ?? $thinking->getSignature());
+            $this->openThinking = null;
+            $this->lastThinking = $index;
+
+            return;
+        }
+
+        if ($delta instanceof ThinkingSignature) {
+            $this->applySignature($delta->getSignature());
+
+            return;
+        }
+
+        if ($delta instanceof ToolCallStart) {
+            $id = $delta->getId();
+
+            // an id that is empty or already announced cannot address a slot of its own
+            if ('' !== $id && !isset($this->toolCallSlots[$id])) {
+                $this->content[] = null;
+                $this->toolCallSlots[$id] = array_key_last($this->content);
+            }
+
+            $this->openThinking = null;
+
+            return;
+        }
+
+        if ($delta instanceof ToolCallComplete) {
+            foreach ($delta->getToolCalls() as $toolCall) {
+                $slot = $this->toolCallSlots[$toolCall->getId()] ?? null;
+
+                // a bridge that never announced the call still needs it replayed
+                if (null === $slot) {
+                    $this->content[] = $toolCall;
+                    continue;
+                }
+
+                $this->content[$slot] = $toolCall;
+                unset($this->toolCallSlots[$toolCall->getId()]);
+            }
+
+            $this->openThinking = null;
+        }
+    }
+
+    /**
+     * The assistant turn as reassembled so far.
+     */
+    public function getAssistantMessage(): AssistantMessage
+    {
+        $content = [];
+
+        foreach ($this->content as $part) {
+            // providers reject empty content blocks on replay
+            if (null === $part || $this->isEmpty($part)) {
+                continue;
+            }
+
+            $content[] = $part;
+        }
+
+        return new AssistantMessage(...$content);
+    }
+
+    private function appendText(string $text): void
+    {
+        if ('' === $text) {
+            return;
+        }
+
+        $this->openThinking = null;
+
+        $index = array_key_last($this->content);
+        $last = null === $index ? null : $this->content[$index];
+
+        if ($last instanceof Text) {
+            $this->content[$index] = new Text($last->getText().$text, $last->getSignature());
+
+            return;
+        }
+
+        $this->content[] = new Text($text);
+    }
+
+    /**
+     * The Responses API emits a reasoning item's signature after its block has closed, and emits one
+     * even when no summary was streamed, so a signature with no block to attach to is an item of its
+     * own rather than the opening of the next one.
+     */
+    private function applySignature(string $signature): void
+    {
+        $index = $this->openThinking;
+
+        if (null === $index) {
+            $index = $this->lastThinking;
+            $candidate = null === $index ? null : $this->content[$index];
+
+            if (!$candidate instanceof Thinking || null !== $candidate->getSignature()) {
+                $index = $this->openThinking();
+                $this->openThinking = null;
+            }
+        }
+
+        $thinking = $this->thinkingAt($index);
+        $this->content[$index] = new Thinking($thinking->getContent(), ($thinking->getSignature() ?? '').$signature);
+        $this->lastThinking = $index;
+    }
+
+    private function openThinking(): int
+    {
+        $this->content[] = new Thinking('');
+
+        return $this->openThinking = $this->lastThinking = array_key_last($this->content);
+    }
+
+    private function thinkingAt(int $index): Thinking
+    {
+        $thinking = $this->content[$index];
+        \assert($thinking instanceof Thinking);
+
+        return $thinking;
+    }
+
+    private function isEmpty(ContentInterface $part): bool
+    {
+        if ($part instanceof Thinking) {
+            return '' === $part->getContent() && null === $part->getSignature();
+        }
+
+        if ($part instanceof Text) {
+            return '' === $part->getText();
+        }
+
+        return false;
+    }
+}

--- a/src/platform/src/Result/Stream/DeltaEvent.php
+++ b/src/platform/src/Result/Stream/DeltaEvent.php
@@ -35,6 +35,8 @@ final class DeltaEvent extends Event
     }
 
     /**
+     * Replaces the delta about to be yielded.
+     *
      * @param DeltaInterface|\Generator<DeltaInterface> $delta
      */
     public function setDelta(DeltaInterface|\Generator $delta): void

--- a/src/platform/src/Result/StreamResult.php
+++ b/src/platform/src/Result/StreamResult.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\AI\Platform\Result;
 
+use Symfony\AI\Platform\Message\AssistantMessage;
+use Symfony\AI\Platform\Result\Stream\AssistantMessageStreamListener;
 use Symfony\AI\Platform\Result\Stream\CompleteEvent;
 use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
 use Symfony\AI\Platform\Result\Stream\DeltaEvent;
@@ -23,6 +25,22 @@ use Symfony\AI\Platform\Result\Stream\StartEvent;
  */
 final class StreamResult extends BaseResult
 {
+    private readonly AssistantMessageStreamListener $assistantMessage;
+
+    /**
+     * Weak on purpose: the generator holds the result, so a strong reference would make the pair
+     * a cycle and defer freeing the underlying HTTP response to the cycle collector.
+     *
+     * @var \WeakReference<\Generator<DeltaInterface>>|null
+     */
+    private ?\WeakReference $stream = null;
+
+    private bool $started = false;
+
+    private bool $finished = false;
+
+    private bool $consuming = false;
+
     /**
      * @param \Generator<DeltaInterface> $generator
      * @param ListenerInterface[]        $listeners
@@ -31,6 +49,35 @@ final class StreamResult extends BaseResult
         private readonly \Generator $generator,
         private array $listeners = [],
     ) {
+        $this->assistantMessage = new AssistantMessageStreamListener();
+    }
+
+    /**
+     * The assistant turn this stream carried, draining what the caller has not read.
+     *
+     * Two cases return the turn as collected so far rather than a complete one: reading it from
+     * inside the stream - a listener's onComplete(), say - because the generator cannot be resumed
+     * while its body is running, and reading it after a partial iteration whose generator is gone,
+     * because a fresh one would re-read the delta the abandoned one stopped on. Keep the generator
+     * in a variable to have an abandoned stream finished here.
+     *
+     * Do not call this from inside a loop over the stream: a suspended generator is indistinguishable
+     * from an abandoned one, so the rest of the turn is drained and the loop ends on the next delta.
+     * Attach an {@see AssistantMessageStreamListener} to read the turn mid-stream.
+     */
+    public function getAssistantMessage(): AssistantMessage
+    {
+        $stream = $this->stream?->get();
+
+        if (!$this->consuming && !$this->finished && (null !== $stream || !$this->started)) {
+            $stream ??= $this->consume();
+
+            while ($stream->valid()) {
+                $stream->next();
+            }
+        }
+
+        return $this->assistantMessage->getAssistantMessage();
     }
 
     public function addListener(ListenerInterface $listener): void
@@ -47,15 +94,41 @@ final class StreamResult extends BaseResult
     }
 
     /**
+     * The deltas, from where the last consumer left off: the stream is read once, so a generator
+     * taken after it finished yields nothing and two iterated in parallel split the deltas.
+     *
      * @return \Generator<DeltaInterface>
      */
     public function getContent(): \Generator
     {
-        $event = new StartEvent($this);
-        foreach ($this->listeners as $listener) {
-            $listener->onStart($event);
+        $stream = $this->consume();
+        $this->stream = \WeakReference::create($stream);
+
+        return $stream;
+    }
+
+    /**
+     * @return \Generator<DeltaInterface>
+     */
+    private function consume(): \Generator
+    {
+        if ($this->finished) {
+            return;
         }
-        $this->getMetadata()->merge($event->getMetadata());
+
+        $this->consuming = true;
+
+        // resuming an abandoned stream continues the turn it collected
+        if (!$this->started) {
+            $this->started = true;
+            $this->assistantMessage->reset();
+
+            $event = new StartEvent($this);
+            foreach ($this->listeners as $listener) {
+                $listener->onStart($event);
+            }
+            $this->getMetadata()->merge($event->getMetadata());
+        }
 
         try {
             foreach ($this->generator as $delta) {
@@ -69,12 +142,18 @@ final class StreamResult extends BaseResult
                     continue;
                 }
 
-                $delta = $event->getDelta();
+                $emitted = $event->getDelta();
 
-                if ($delta instanceof DeltaInterface) {
-                    yield $delta;
-                } else {
-                    yield from $delta;
+                foreach ($emitted instanceof DeltaInterface ? [$emitted] : $emitted as $inner) {
+                    $this->assistantMessage->accumulate($inner);
+
+                    // clear across the yield: suspended, the generator can be resumed and an
+                    // abandoned stream drained; resuming it while the body runs is fatal
+                    $this->consuming = false;
+
+                    yield $inner;
+
+                    $this->consuming = true;
                 }
             }
         } catch (\Throwable $e) {
@@ -86,6 +165,9 @@ final class StreamResult extends BaseResult
             }
             $this->getMetadata()->merge($event->getMetadata());
 
+            $this->finished = true;
+            $this->consuming = false;
+
             throw $e;
         }
 
@@ -94,5 +176,10 @@ final class StreamResult extends BaseResult
             $listener->onComplete($event);
         }
         $this->getMetadata()->merge($event->getMetadata());
+
+        $this->finished = true;
+
+        // cleared after the listeners: they run inside this generator and must not resume it
+        $this->consuming = false;
     }
 }

--- a/src/platform/tests/Message/MessageTest.php
+++ b/src/platform/tests/Message/MessageTest.php
@@ -18,6 +18,7 @@ use Symfony\AI\Platform\Message\Content\ComputerCall;
 use Symfony\AI\Platform\Message\Content\ContentInterface;
 use Symfony\AI\Platform\Message\Content\CustomToolCall;
 use Symfony\AI\Platform\Message\Content\ExecutableCode;
+use Symfony\AI\Platform\Message\Content\File;
 use Symfony\AI\Platform\Message\Content\FileSearch;
 use Symfony\AI\Platform\Message\Content\ImageUrl;
 use Symfony\AI\Platform\Message\Content\LocalShellCall;
@@ -39,6 +40,7 @@ use Symfony\AI\Platform\Result\McpApprovalRequestResult;
 use Symfony\AI\Platform\Result\McpCallResult;
 use Symfony\AI\Platform\Result\McpListToolsResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
+use Symfony\AI\Platform\Result\ObjectResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ThinkingResult;
 use Symfony\AI\Platform\Result\ToolCall;
@@ -223,9 +225,23 @@ final class MessageTest extends TestCase
         $this->assertInstanceOf(Text::class, $parts[8]);
     }
 
+    public function testCreateAssistantMessageFromBinaryResultKeepsItAsAFile()
+    {
+        $result = new MultiPartResult([
+            BinaryResult::fromBase64(base64_encode('binary'), 'image/png'),
+            new ToolCallResult([new ToolCall('id1', 'tool1')]),
+        ]);
+
+        $content = Message::ofAssistant($result)->getContent();
+
+        $this->assertInstanceOf(File::class, $content[0]);
+        $this->assertSame('image/png', $content[0]->getFormat());
+        $this->assertInstanceOf(ToolCall::class, $content[1]);
+    }
+
     public function testCreateAssistantMessageFromUnsupportedResultThrows()
     {
-        $result = BinaryResult::fromBase64(base64_encode('binary'), 'image/png');
+        $result = new ObjectResult(new \stdClass());
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf('Unsupported assistant message part of type "%s".', $result::class));
@@ -237,7 +253,7 @@ final class MessageTest extends TestCase
     {
         $result = new MultiPartResult([
             new TextResult('Visible answer.'),
-            BinaryResult::fromBase64(base64_encode('binary'), 'image/png'),
+            new ObjectResult(new \stdClass()),
         ]);
 
         $this->expectException(InvalidArgumentException::class);

--- a/src/platform/tests/Result/Stream/AssistantMessageStreamListenerTest.php
+++ b/src/platform/tests/Result/Stream/AssistantMessageStreamListenerTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Result\Stream;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Message\Content\ContentInterface;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Result\Stream\AbstractStreamListener;
+use Symfony\AI\Platform\Result\Stream\AssistantMessageStreamListener;
+use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\MetadataDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingSignature;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\DeltaEvent;
+use Symfony\AI\Platform\Result\StreamResult;
+use Symfony\AI\Platform\Result\ToolCall;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class AssistantMessageStreamListenerTest extends TestCase
+{
+    /**
+     * @param list<DeltaInterface>   $deltas
+     * @param list<ContentInterface> $expected
+     */
+    #[DataProvider('provideStreams')]
+    public function testItRebuildsTheAssistantTurn(array $deltas, array $expected)
+    {
+        $listener = new AssistantMessageStreamListener();
+
+        foreach ($deltas as $delta) {
+            $listener->accumulate($delta);
+        }
+
+        $this->assertEquals($expected, $listener->getAssistantMessage()->getContent());
+    }
+
+    /**
+     * @return iterable<string, array{0: list<DeltaInterface>, 1: list<ContentInterface>}>
+     */
+    public static function provideStreams(): iterable
+    {
+        $toolCall = new ToolCall('call_1', 'clock', []);
+        $other = new ToolCall('call_2', 'weather', ['city' => 'Paris']);
+
+        yield 'text is concatenated into a single part' => [
+            [new TextDelta('Hello '), new TextDelta('World')],
+            [new Text('Hello World')],
+        ];
+
+        yield 'empty text deltas carry no content' => [
+            [new TextDelta(''), new TextDelta('Hi'), new TextDelta('')],
+            [new Text('Hi')],
+        ];
+
+        yield 'anthropic thinking with an inline signature' => [
+            [
+                new ThinkingStart(),
+                new ThinkingDelta('Let me '),
+                new ThinkingDelta('think.'),
+                new ThinkingSignature('sig-abc'),
+                new ThinkingComplete('Let me think.', 'sig-abc'),
+                new TextDelta('The answer is 42.'),
+            ],
+            [new Thinking('Let me think.', 'sig-abc'), new Text('The answer is 42.')],
+        ];
+
+        yield 'signature arriving after the thinking block closed' => [
+            [
+                new ThinkingStart(),
+                new ThinkingDelta('Pondering.'),
+                new ThinkingComplete('Pondering.'),
+                new ThinkingSignature('{"type":"reasoning","id":"rs_1"}'),
+                new TextDelta('Done.'),
+            ],
+            [new Thinking('Pondering.', '{"type":"reasoning","id":"rs_1"}'), new Text('Done.')],
+        ];
+
+        yield 'signature without any thinking block' => [
+            [
+                new ThinkingSignature('{"type":"reasoning","id":"rs_1"}'),
+                new TextDelta('Answer.'),
+            ],
+            [new Thinking('', '{"type":"reasoning","id":"rs_1"}'), new Text('Answer.')],
+        ];
+
+        yield 'two reasoning items keep separate signatures' => [
+            [
+                new ThinkingSignature('{"type":"reasoning","id":"rs_1"}'),
+                new ThinkingSignature('{"type":"reasoning","id":"rs_2"}'),
+            ],
+            [
+                new Thinking('', '{"type":"reasoning","id":"rs_1"}'),
+                new Thinking('', '{"type":"reasoning","id":"rs_2"}'),
+            ],
+        ];
+
+        yield 'a thinking block opened but never filled is dropped' => [
+            [new ThinkingStart(), new TextDelta('Straight to it.')],
+            [new Text('Straight to it.')],
+        ];
+
+        yield 'announced tool call keeps its position' => [
+            [
+                new TextDelta('Before. '),
+                new ToolCallStart('call_1', 'clock'),
+                new TextDelta('After.'),
+                new ToolCallComplete([$toolCall]),
+            ],
+            [new Text('Before. '), $toolCall, new Text('After.')],
+        ];
+
+        yield 'unannounced tool calls are appended rather than dropped' => [
+            [new TextDelta('Checking.'), new ToolCallComplete([$toolCall])],
+            [new Text('Checking.'), $toolCall],
+        ];
+
+        yield 'a mix of announced and unannounced calls keeps both' => [
+            [
+                new ToolCallStart('call_1', 'clock'),
+                new TextDelta('and'),
+                new ToolCallComplete([$toolCall, $other]),
+            ],
+            [$toolCall, new Text('and'), $other],
+        ];
+
+        yield 'an announced call that never completes leaves no hole' => [
+            [
+                new TextDelta('Before. '),
+                new ToolCallStart('call_1', 'clock'),
+                new ToolCallComplete([$other]),
+            ],
+            [new Text('Before. '), $other],
+        ];
+
+        yield 'thinking, text and a tool call in provider order' => [
+            [
+                new ThinkingStart(),
+                new ThinkingDelta('I should check the clock.'),
+                new ThinkingSignature('sig-xyz'),
+                new ThinkingComplete('I should check the clock.', 'sig-xyz'),
+                new TextDelta('Let me check that.'),
+                new ToolCallStart('call_1', 'clock'),
+                new ToolCallComplete([$toolCall]),
+            ],
+            [
+                new Thinking('I should check the clock.', 'sig-xyz'),
+                new Text('Let me check that.'),
+                $toolCall,
+            ],
+        ];
+
+        yield 'two calls sharing an id are both kept' => [
+            [
+                new ToolCallStart('call_1', 'clock'),
+                new ToolCallStart('call_1', 'clock'),
+                new ToolCallComplete([$toolCall, new ToolCall('call_1', 'clock', ['tz' => 'UTC'])]),
+            ],
+            [$toolCall, new ToolCall('call_1', 'clock', ['tz' => 'UTC'])],
+        ];
+
+        yield 'a call announced without an id is still kept' => [
+            [
+                new TextDelta('Before. '),
+                new ToolCallStart('', 'clock'),
+                new ToolCallComplete([$toolCall]),
+            ],
+            [new Text('Before. '), $toolCall],
+        ];
+
+        yield 'unrelated deltas are ignored' => [
+            [new MetadataDelta('finish_reason', 'stop'), new TextDelta('Hi')],
+            [new Text('Hi')],
+        ];
+
+        yield 'a stream with nothing replayable yields an empty message' => [
+            [new ThinkingStart()],
+            [],
+        ];
+    }
+
+    public function testItResetsBetweenRuns()
+    {
+        $listener = new AssistantMessageStreamListener();
+        $listener->accumulate(new TextDelta('First run'));
+
+        $stream = new StreamResult((static function () {
+            yield new TextDelta('Second run');
+        })());
+        $stream->addListener($listener);
+
+        iterator_to_array($stream->getContent());
+
+        $this->assertEquals([new Text('Second run')], $listener->getAssistantMessage()->getContent());
+    }
+
+    public function testItReadsTheTurnWhileTheStreamIsStillRunning()
+    {
+        $listener = new AssistantMessageStreamListener();
+        $toolCall = new ToolCall('call_1', 'clock', []);
+
+        $stream = new StreamResult((static function () use ($toolCall) {
+            yield new TextDelta('Let me check.');
+            yield new ToolCallComplete([$toolCall]);
+            yield new TextDelta('Trailing.');
+        })());
+        $stream->addListener($listener);
+
+        $seen = null;
+        foreach ($stream->getContent() as $delta) {
+            if ($delta instanceof ToolCallComplete) {
+                // reading the turn mid-stream, before it has finished
+                $seen = $listener->getAssistantMessage()->getContent();
+            }
+        }
+
+        $this->assertEquals([new Text('Let me check.'), $toolCall], $seen);
+    }
+
+    public function testItIgnoresDeltasReplacedByAnotherListener()
+    {
+        $listener = new AssistantMessageStreamListener();
+
+        $stream = new StreamResult((static function () {
+            yield new TextDelta('Original');
+        })());
+        $stream->addListener(new class extends AbstractStreamListener {
+            public function onDelta(DeltaEvent $event): void
+            {
+                $event->setDelta((static function () {
+                    yield new TextDelta('Substituted');
+                })());
+            }
+        });
+        $stream->addListener($listener);
+
+        iterator_to_array($stream->getContent(), false);
+
+        $this->assertSame([], $listener->getAssistantMessage()->getContent());
+    }
+}

--- a/src/platform/tests/Result/StreamResultTest.php
+++ b/src/platform/tests/Result/StreamResultTest.php
@@ -12,10 +12,14 @@
 namespace Symfony\AI\Platform\Tests\Result;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Message\Content\Text;
+use Symfony\AI\Platform\Message\Content\Thinking;
+use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Result\Stream\AbstractStreamListener;
 use Symfony\AI\Platform\Result\Stream\CompleteEvent;
 use Symfony\AI\Platform\Result\Stream\Delta\DeltaInterface;
 use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ThinkingComplete;
 use Symfony\AI\Platform\Result\Stream\DeltaEvent;
 use Symfony\AI\Platform\Result\Stream\ErrorEvent;
 use Symfony\AI\Platform\Result\StreamResult;
@@ -39,6 +43,170 @@ final class StreamResultTest extends TestCase
         $this->assertSame('data1', $content[0]->getText());
         $this->assertInstanceOf(TextDelta::class, $content[1]);
         $this->assertSame('data2', $content[1]->getText());
+    }
+
+    public function testGetAssistantMessageReturnsTheDrainedTurn()
+    {
+        $result = new StreamResult((static function () {
+            yield new TextDelta('Hello ');
+            yield new ThinkingComplete('Pondering.', 'sig-abc');
+            yield new TextDelta('World');
+        })());
+
+        iterator_to_array($result->getContent());
+
+        $this->assertEquals(
+            [new Text('Hello '), new Thinking('Pondering.', 'sig-abc'), new Text('World')],
+            $result->getAssistantMessage()->getContent(),
+        );
+    }
+
+    public function testGetAssistantMessageDrainsAStreamNobodyRead()
+    {
+        $result = new StreamResult((static function () {
+            yield new TextDelta('Never ');
+            yield new TextDelta('iterated');
+        })());
+
+        $this->assertSame('Never iterated', $result->getAssistantMessage()->asText());
+    }
+
+    public function testOfAssistantAcceptsAStreamedResultLikeABufferedOne()
+    {
+        $result = new StreamResult((static function () {
+            yield new ThinkingComplete('Pondering.', 'sig-abc');
+            yield new TextDelta('The answer is 42.');
+        })());
+
+        $message = Message::ofAssistant($result);
+
+        $this->assertEquals(
+            [new Thinking('Pondering.', 'sig-abc'), new Text('The answer is 42.')],
+            $message->getContent(),
+        );
+    }
+
+    public function testGetAssistantMessageDrainsAStreamAbandonedMidIteration()
+    {
+        $result = new StreamResult((static function () {
+            yield new TextDelta('one ');
+            yield new TextDelta('two ');
+            yield new TextDelta('three');
+        })());
+
+        $stream = $result->getContent();
+        foreach ($stream as $delta) {
+            break;
+        }
+
+        $this->assertSame('one two three', $result->getAssistantMessage()->asText());
+        $this->assertSame('one two three', Message::ofAssistant($result)->asText());
+    }
+
+    public function testGetAssistantMessageReturnsThePartialTurnOfADiscardedStream()
+    {
+        $result = new StreamResult((static function () {
+            yield new TextDelta('one ');
+            yield new TextDelta('two ');
+        })());
+
+        // nothing holds the generator once the loop drops it, and a fresh one would re-read the
+        // delta this one stopped on
+        foreach ($result->getContent() as $delta) {
+            break;
+        }
+
+        $this->assertSame('one ', $result->getAssistantMessage()->asText());
+    }
+
+    public function testGetAssistantMessageReturnsThePartialTurnAfterTheStreamThrew()
+    {
+        $result = new StreamResult((static function () {
+            yield new TextDelta('one ');
+            yield new TextDelta('two ');
+
+            throw new \RuntimeException('upstream failed');
+        })());
+
+        try {
+            iterator_to_array($result->getContent());
+            $this->fail('the stream was expected to throw');
+        } catch (\RuntimeException) {
+        }
+
+        // a stream that threw cannot be resumed
+        $this->assertSame('one two ', $result->getAssistantMessage()->asText());
+    }
+
+    public function testADeltaRewrittenInPlaceDoesNotDiscardTheTurn()
+    {
+        $result = new StreamResult((static function () {
+            yield new TextDelta('My number is ');
+            yield new TextDelta('555-0100');
+            yield new TextDelta(', call me.');
+        })());
+
+        // a rewrite leaves the rest of the collected turn intact
+        $result->addListener(new class extends AbstractStreamListener {
+            public function onDelta(DeltaEvent $event): void
+            {
+                $delta = $event->getDelta();
+
+                if ($delta instanceof TextDelta && str_contains($delta->getText(), '555')) {
+                    $event->setDelta(new TextDelta('[redacted]'));
+                }
+            }
+        });
+
+        iterator_to_array($result->getContent());
+
+        $this->assertSame('My number is [redacted], call me.', $result->getAssistantMessage()->asText());
+    }
+
+    public function testADeltaReplacedByAStreamOfItsOwnDoesNotDiscardTheTurn()
+    {
+        $result = new StreamResult((static function () {
+            yield new TextDelta('{"name":');
+            yield new TextDelta('"Berlin"}');
+        })());
+
+        // what PartialObjectStreamListener does: the original delta is re-yielded alongside a snapshot
+        $result->addListener(new class extends AbstractStreamListener {
+            public function onDelta(DeltaEvent $event): void
+            {
+                $delta = $event->getDelta();
+
+                $event->setDelta((static function () use ($delta) {
+                    yield $delta;
+                })());
+            }
+        });
+
+        iterator_to_array($result->getContent(), false);
+
+        $this->assertSame('{"name":"Berlin"}', $result->getAssistantMessage()->asText());
+    }
+
+    public function testAListenerReadsTheTurnFromInsideTheStream()
+    {
+        $result = new StreamResult((static function () {
+            yield new TextDelta('Collected');
+        })());
+
+        $listener = new class extends AbstractStreamListener {
+            public ?string $seen = null;
+
+            public function onComplete(CompleteEvent $event): void
+            {
+                // runs inside the generator, so reading the turn must not resume it
+                $this->seen = $event->getResult()->getAssistantMessage()->asText();
+            }
+        };
+        $result->addListener($listener);
+
+        iterator_to_array($result->getContent());
+
+        $this->assertSame('Collected', $listener->seen);
     }
 
     public function testGetDelta()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | yes
| Issues        | n/a
| License       | MIT

Alternative proposal to #2390 — /cc @fabpot @wachterjohannes

The intent was broader than #2390: across Agent, Chat, the demo and the examples we usually
rebuild the assistant turn from its text (`Message::ofAssistant($result->asText())` and friends),
where providers expect us to hand back everything they gave us. Anthropic answers a rebuilt turn
with a 400, the Responses API needs its reasoning items back untouched when `store: false`, and
Gemini needs its thought signatures resent.

Summary:

* **Platform**: `Message::ofAssistant($result)` now takes a streamed result just like a buffered
  one, so replaying a turn no longer depends on how it arrived. `StreamResult` collects the turn as
  it is read (draining it if the caller never iterated), and the reassembly itself lives in the new
  `Result\Stream\AssistantMessageStreamListener` — in Platform, because the delta vocabulary is
  bridge knowledge. Thanks @wachterjohannes for that argument on #2390.
* **Agent**: a tool-calling round adds the turn the provider produced as one assistant message
  instead of the text and the tool calls as two, and a streamed round returns the result its
  buffered counterpart would — a thinking block survives as a `ThinkingResult` rather than being
  flattened to its text.
* **Chat**: `Chat::stream()` persists the turn whole, reading it off the execution's result
  instead of re-accumulating the text.
* **OpenResponses**: the normalizer emits output items in model order; it used to drop the
  assistant's text whenever the turn carried a tool call.
* **Mistral**: a reasoning turn is replayed as a `thinking` chunk of the content list — the
  shape the API accepts and `Llm\ResultConverter` already parses — instead of the generic
  contract's `reasoning_content`, which Mistral answers with a 422. The shared contract keeps
  emitting it for the endpoints #1855 added it for.
* **Cerebras**: the trace is dropped there instead — it rejects `reasoning_content` with a 400
  and accepts no shape of its own to put it in.
* Cleaned up the lossy call sites in `examples/` and `demo/`.

Tests: unit tests for the reassembler and `StreamResult`, an OpenResponses `AssistantReplayTest`,
an Anthropic bridge replay test over a recorded thinking+tool_use stream, and three new multi-turn
agent examples with committed cassettes. Their goldens are the proof —
`Thinking(signed) + ToolCall(clock)` in one assistant message, where `main` has just
`ToolCall(clock)`.

Rebased onto #2436, which removed both listeners this branch hooked into (`Toolbox\StreamListener`
and `ChatStreamListener`) and rewrote the tool loop, so the Agent and Chat sides were re-landed
against the lazy `Execution` rather than replayed.

Two caveats worth knowing while reading the diff:

* A `BinaryResult` next to a tool call now maps to a `File` part instead of throwing, so the turn
  is constructible — but no assistant message normalizer emits a `File` yet, so binary output still
  does not round-trip.
* `StreamResult::getAssistantMessage()` must not be called from inside a loop over the stream: a
  suspended generator is indistinguishable from an abandoned one, so the drain that finishes an
  abandoned stream runs and the loop ends on the next delta. Attach the listener to read the turn
  mid-stream.
