### PR TITLE
[MCP Bundle] Support the 2026-07-28 revision on the existing endpoint

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -213,6 +213,34 @@ MCP Bundle
 
    A single configured client also answers a plain `McpClientInterface` type hint, unchanged.
 
+ * **Every HTTP server now also serves the 2026-07-28 revision**, on the endpoint it already had. The
+   SDK builds a dispatcher per era and the transport routes each request, so no configuration turns
+   this on — and an existing server gets it by upgrading. That revision removed server-initiated
+   requests, so a tool, prompt or resource handler calling `$gateway->sample()` or
+   `$gateway->listRoots()` now fails for clients speaking it ("This protocol revision has no
+   server-initiated requests"), while continuing to work for handshake-era clients on the same
+   endpoint. Take what those handlers need through tool arguments, resource URIs or server
+   configuration instead, or guard the calls with `$gateway->supportsSampling()` /
+   `$gateway->supportsRoots()`.
+
+   Until the handlers are ready, list only handshake-era revisions to refuse the modern era outright:
+
+   ```yaml
+   # config/packages/mcp.yaml
+   mcp:
+       servers:
+           api:
+               protocol_versions: ['2025-11-25'] # handshake era only
+               registry: '*'
+   ```
+
+   Elicitation survived, as a multi round-trip request: `$gateway->elicit()` keeps working unchanged.
+   A handler that elicits *more than once* now needs `servers.<name>.request_state.key` (at least 32
+   bytes), because without a session the answers to the earlier asks travel through the client and are
+   signed. Roots, sampling and MCP logging are deprecated by the same revision (SEP-2577), and
+   `mcp/sdk` 0.8 triggers a deprecation for each configured handler — including the one behind
+   `clients.<name>.forward_server_logs`, which defaults to `true`.
+
 Mate
 ----
 

--- a/docs/bundles/mcp-bundle.rst
+++ b/docs/bundles/mcp-bundle.rst
@@ -600,6 +600,168 @@ This wraps the configured Symfony session handler (e.g. Redis, database, filesys
 your application uses for HTTP sessions) with a JSON envelope for application-level TTL.
 Expired sessions are cleaned up lazily on read.
 
+The Modern Era
+..............
+
+The 2026-07-28 revision drops the ``initialize`` handshake and the session that went with it: every
+request describes itself, so any worker can answer any request, and no long-running connection is
+needed.
+
+Both eras are served **on the same endpoint**, with nothing to configure. The SDK builds a dispatcher
+per era, and the HTTP transport classifies every request before anything else looks at it: an envelope
+claiming a modern revision goes to the modern dispatcher, the ``initialize`` handshake and its
+session's later requests go to the other. A client picks nothing.
+
+STDIO carries the handshake era alone — it has no per-request envelope to classify — so a server
+configured for both transports simply serves the modern era over HTTP only.
+
+By default the HTTP endpoint supports every revision the SDK supports and negotiates with the client.
+Narrow the supported revisions through ``protocol_versions``:
+
+.. code-block:: yaml
+
+    # config/packages/mcp.yaml
+    mcp:
+        servers:
+            api:
+                protocol_versions: ['2025-11-25', '2026-07-28']
+                http:
+                    path: /mcp
+                registry: '*'
+
+Each era takes what belongs to it. The modern revisions listed become the only ones that leg answers
+for; listing none of them refuses the modern era, leaving the handshake one alone. A handshake-era
+revision pins the handshake to exactly that one — the SDK either negotiates over everything it knows
+or is pinned to a single revision, so narrowing that era to a subset is rejected when the container is
+compiled.
+
+The options below tune the modern-era leg. They are inert for handshake-era clients, which keep being
+served exactly as before. The converse does not hold: the modern leg is on for every server, including
+one written before the revision existed, and it drops things the handshake era offers.
+
+.. caution::
+
+    **The 2026-07-28 revision has no server-initiated requests.** Sampling and roots were removed with
+    it, so a handler calling ``$gateway->sample()`` or ``$gateway->listRoots()`` fails for a
+    2026-07-28 client — *"This protocol revision has no server-initiated requests: sampling and roots
+    were removed with it, so take what you need through tool arguments, resource URIs or server
+    configuration instead"* — while the same handler keeps working for handshake-era clients on the
+    same endpoint. Both calls are also deprecated as of ``mcp/sdk`` 0.8 (SEP-2577), as is
+    ``$gateway->log()``.
+
+    Take what such a handler needs through tool arguments, resource URIs or server configuration
+    instead, or guard the call with ``$gateway->supportsSampling()`` / ``$gateway->supportsRoots()``,
+    which report what the client of the current request declared. Elicitation is the one ask that
+    survived, as a multi round-trip request; see *Request State* below.
+
+    Until the handlers are ready, ``protocol_versions`` is the opt-out: list only handshake-era
+    revisions and the server refuses the modern era altogether.
+
+    .. code-block:: yaml
+
+        # config/packages/mcp.yaml
+        mcp:
+            servers:
+                api:
+                    protocol_versions: ['2025-11-25'] # handshake era only, no modern leg
+                    registry: '*'
+
+Request State
+^^^^^^^^^^^^^
+
+A handler that needs another round trip has nowhere to keep its progress once sessions are gone, so
+the state travels through the client and is signed to keep it honest:
+
+.. code-block:: yaml
+
+    mcp:
+        servers:
+            api:
+                request_state:
+                    key: '%env(MCP_REQUEST_STATE_KEY)%'
+                    ttl: 600 # seconds a minted state stays valid
+
+The key must be at least 32 bytes — below that the signature protecting the state is forgeable, so a
+shorter literal is refused when the container is compiled, and the SDK refuses one arriving from an
+env variable at runtime. **The same value must reach every process that might serve the retry**: a
+per-worker random key makes the follow-up request fail signature validation.
+
+Two kinds of handler need it. One returns an ``InputRequiredResult`` itself. The other simply calls
+``$gateway->elicit()``: on the modern leg the ask ends the request and the client re-sends the whole
+call with the answer, so a handler that asks more than once has to carry the earlier answers to the
+next round, and carrying them is what needs the key. A handler that asks exactly once never mints
+state and works without one. Missing the key, the ask is answered with a JSON-RPC internal error and
+the reason is logged on the ``mcp`` channel.
+
+Cache Hints
+^^^^^^^^^^^
+
+Without a session the client caches instead, and the revision expects the server to say for how long.
+``ttl_ms: 0`` (the default) refuses caching:
+
+.. code-block:: yaml
+
+    mcp:
+        servers:
+            api:
+                cache:
+                    ttl_ms: 5000
+                    scope: private # or "public"
+                    methods:
+                        'tools/list': { ttl_ms: 60000, scope: public }
+                        'resources/read': { ttl_ms: 1000 }
+
+Use ``public`` only for answers that do not vary by caller — anything shaped by the current user must
+stay ``private``.
+
+Subscriptions
+^^^^^^^^^^^^^
+
+``subscriptions/listen`` replaces the held-open HTTP GET stream. Delivery needs a bus, and the choice
+depends on your runtime:
+
+.. code-block:: yaml
+
+    mcp:
+        servers:
+            api:
+                subscriptions:
+                    bus: cache # none (default), memory, or cache
+                    cache_pool: 'cache.mcp.notifications'
+                    lifetime: 30.0 # seconds before the server closes a stream gracefully
+
+Under PHP-FPM the process publishing a notification is not the one holding the stream, so ``memory``
+cannot reach it — use ``cache``. ``memory`` suits a single-process runtime; ``lifetime: 0`` holds the
+stream until the client or the runtime ends it.
+
+``cache.mcp.notifications`` is auto-created as a PSR-16 wrapper around ``cache.app`` when you leave it
+at its default, exactly as the session store is. Each server namespaces its own keys inside that pool,
+so two servers can share it without reading each other's notifications.
+
+Only registry changes — the four ``list_changed`` notifications — are published for you. Everything
+else, ``notifications/resources/updated`` above all, is your application publishing it. Inject the
+server's bus to do that::
+
+    use Mcp\Schema\Notification\ResourceUpdatedNotification;
+    use Mcp\Server\Subscription\NotificationBusInterface;
+
+    class DocumentSaver
+    {
+        public function __construct(
+            private NotificationBusInterface $apiNotificationBus,
+        ) {
+        }
+
+        public function save(Document $document): void
+        {
+            // ...
+            $this->apiNotificationBus->publish(new ResourceUpdatedNotification($document->uri()));
+        }
+    }
+
+The argument name follows the server name, as ``$defaultNotificationBus`` for a server called
+``default``; the service id is ``mcp.server.<name>.notification_bus``.
+
 Act as Client
 ~~~~~~~~~~~~~
 
@@ -706,22 +868,44 @@ Failures surface as bundle exceptions naming the client and server:
 The HTTP transport uses the application's PSR-18 client (``psr18.http_client``, provided by
 ``symfony/http-client``) unless the ``http_client`` option points at another service.
 
-Sampling and Elicitation
-........................
+Server-initiated Requests
+.........................
 
-A remote server can ask the client to run a completion (*sampling*) or to prompt the user
-(*elicitation*). Point the matching option at a service implementing the SDK's callback interface; the
-capability is advertised only when a handler backs it:
+A remote server can ask the client to run a completion (*sampling*), to prompt the user
+(*elicitation*), or for the filesystem roots it may work in (*roots*). Point the matching option at a
+service implementing the SDK's callback interface; each capability is advertised only when a handler
+backs it, because advertising one without a handler earns a "method not found" from the client:
 
 .. code-block:: yaml
 
     mcp:
         clients:
             research:
+                roots: 'App\Mcp\RootsHandler'            # Mcp\Client\Handler\Request\RootsCallbackInterface
                 sampling: 'App\Mcp\SamplingHandler'      # Mcp\Client\Handler\Request\SamplingCallbackInterface
                 elicitation: 'App\Mcp\ElicitationHandler' # Mcp\Client\Handler\Request\ElicitationCallbackInterface
+                capabilities:
+                    roots_list_changed: true
                 servers:
                     github: { transport: http, url: 'https://api.githubcopilot.com/mcp/' }
+
+When the set of roots changes, tell the server with ``$connection->sendRootsListChanged()``.
+
+.. caution::
+
+    Roots, sampling and MCP logging are deprecated as of protocol revision 2026-07-28 (SEP-2577), with
+    2027-07-28 as the earliest removal. ``mcp/sdk`` 0.8 triggers a deprecation when the handler behind
+    each of them is instantiated, so an application still using them sees one per configured handler.
+    Because ``forward_server_logs`` defaults to ``true``, a client emits the logging one without opting
+    into anything; set it to ``false`` to configure no logging handler at all. The replacements are the
+    ones the revision names: directories through tool arguments or resource URIs rather than roots, an
+    LLM provider's API directly rather than sampling, and stderr or OpenTelemetry rather than MCP
+    logging. Elicitation is not deprecated.
+
+Besides the tool, prompt and resource calls, a connection also exposes
+``$connection->complete($ref, $argument)`` to complete one argument of a prompt or resource template,
+and ``$connection->getProtocolVersion()`` for the revision negotiated with that server (``null`` until
+the first request opens the connection).
 
 Logging notifications received from remote servers are written to the ``mcp`` logger channel; set
 ``forward_server_logs: false`` to drop them.
@@ -758,7 +942,27 @@ Configuration
                     path: /mcp # HTTP endpoint path (default: /mcp/<name>)
                     allowed_hosts: ['example.com'] # DNS rebinding allowlist; false disables the protection
 
-                session:
+                # Revisions this server answers for, in either era. Unset (the default) inherits
+                # the SDK's own support. Listing no modern revision refuses the modern era; a
+                # handshake-era revision pins the handshake to it.
+                protocol_versions: ['2025-11-25', '2026-07-28']
+
+                request_state: # Signs the state a multi-round-trip answer carries through the client
+                    key: '%env(MCP_REQUEST_STATE_KEY)%' # Required when a handler asks for more input; 32 bytes minimum
+                    ttl: 600 # Seconds a minted state stays valid (default: 600)
+
+                cache: # Cache hints the modern-era leg puts on its answers
+                    ttl_ms: 0 # Default freshness in milliseconds; 0 (default) refuses caching
+                    scope: private # 'private' (default) or 'public'
+                    methods: # Per-method overrides
+                        'tools/list': { ttl_ms: 60000, scope: public }
+
+                subscriptions: # Delivery for "subscriptions/listen" streams
+                    bus: none # 'none' (default), 'memory' or 'cache'
+                    cache_pool: 'cache.mcp.notifications' # PSR-16 service for the 'cache' bus
+                    lifetime: 30.0 # Seconds a stream is held; 0 means until the client or runtime ends it
+
+                session: # The handshake era's sessions; the modern era has none
                     store: file # 'file', 'memory', 'cache' or 'framework' (default: file)
                     directory: '%kernel.cache_dir%/mcp-sessions/default' # File store (default: cache_dir/mcp-sessions/<name>)
                     cache_pool: 'cache.mcp.sessions' # Cache pool service for the cache store (PSR-16)
@@ -784,8 +988,8 @@ Configuration
                     description: null
                 protocol_version: null # MCP protocol version to negotiate (default: the SDK default)
                 capabilities:
-                    roots: false # Advertise the "roots" capability
-                    roots_list_changed: false
+                    roots_list_changed: false # The "roots" capability itself follows the handler below
+                roots: null # Service id implementing RootsCallbackInterface; enables the capability
                 sampling: null # Service id implementing SamplingCallbackInterface; enables the capability
                 elicitation: null # Service id implementing ElicitationCallbackInterface; enables the capability
                 forward_server_logs: true # Write logging notifications to the "mcp" channel

--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -20,6 +20,16 @@ CHANGELOG
  * Add `--clients` and `--client` options to `debug:mcp`, which now covers both sides of the bundle:
    the configured servers and what the configured clients reach
  * Add a `--server` option to `debug:mcp` and a server argument to `mcp:server`
+ * Add support for the 2026-07-28 revision, served on the same endpoint as the handshake era: the SDK
+   classifies each request and routes it to the lifecycle it belongs to
+ * Add `servers.<name>.protocol_versions` narrowing the revisions a server answers for; left unset it
+   inherits the SDK's own support in both eras
+ * Add `servers.<name>.request_state` to sign the state a multi-round-trip answer carries through the client
+ * Add `servers.<name>.cache` for the cache hints the modern-era leg puts on its answers, with per-method overrides
+ * Add `servers.<name>.subscriptions` configuring delivery for `subscriptions/listen` streams
+ * Add the `clients.<name>.roots` option pointing at a `RootsCallbackInterface` service, replacing the
+   `capabilities.roots` flag, and add `getProtocolVersion()` and `sendRootsListChanged()` on
+   `ServerConnectionInterface`
 
 0.12
 ----

--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "mcp/sdk": "^0.7",
+        "mcp/sdk": "^0.8",
         "php-http/discovery": "^1.20",
         "symfony/config": "^7.3|^8.0",
         "symfony/console": "^7.3|^8.0",

--- a/src/mcp-bundle/config/options.php
+++ b/src/mcp-bundle/config/options.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Config\Definition\Configurator;
 
 use Mcp\Schema\Enum\ProtocolVersion;
+use Mcp\Server\Stateless\RequestStateCodec;
+use Symfony\AI\McpBundle\McpBundle;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
 return static function (DefinitionConfigurator $configurator): void {
@@ -134,13 +136,73 @@ return static function (DefinitionConfigurator $configurator): void {
                             ->end()
                         ->end()
 
+                        ->arrayNode('protocol_versions')
+                            ->info('Narrows the revisions this server answers for; left unset the SDK\'s own support stands. Each era takes what belongs to it: the modern revisions listed become the only ones that leg answers for, and listing none of them refuses the modern era. A handshake-era revision pins the handshake to exactly that one; listing none leaves it negotiating over every revision it knows, which the SDK offers no way to narrow further.')
+                            ->beforeNormalization()->ifString()->then(static fn (string $v): array => [$v])->end()
+                            ->enumPrototype()->values(array_column(ProtocolVersion::cases(), 'value'))->end()
+                            ->defaultValue([])
+                            ->validate()
+                                // setProtocolVersion() pins the handshake to one revision; the SDK has no way to
+                                // offer a subset of the others, so a list it cannot express is refused here.
+                                ->ifTrue(static fn (array $v): bool => \count(array_filter($v, static fn (string $r): bool => !ProtocolVersion::from($r)->isModern())) > 1)
+                                ->thenInvalid('The handshake era can be pinned to a single revision or left to negotiate, not narrowed to a subset, got %s.')
+                            ->end()
+                        ->end()
+
+                        ->arrayNode('request_state')
+                            ->addDefaultsIfNotSet()
+                            ->info('Signs the state a multi-round-trip answer carries through the client, which has no session to keep progress in. Required for a modern-era server whose handlers return an InputRequiredResult, and for one whose handlers call ClientGateway::elicit() more than once: the second ask has to carry the first answer to the next round.')
+                            ->children()
+                                ->stringNode('key')->cannotBeEmpty()->defaultNull()->info('HMAC key, at least 32 bytes. The same value must reach every process that might serve the retry.')
+                                    ->validate()
+                                        // Only a literal is measurable: a container parameter is resolved before
+                                        // this runs, and an env one has no value until runtime, so it is skipped
+                                        // rather than measured as the placeholder string it still is here.
+                                        ->ifTrue(static fn (?string $v): bool => null !== $v && 1 !== preg_match('/^%[^%]+%$/', $v) && \strlen($v) < RequestStateCodec::MINIMUM_KEY_BYTES)
+                                        ->thenInvalid(\sprintf('The "request_state.key" must be at least %d bytes: below that the signature protecting the carried state is forgeable, and the SDK refuses it.', RequestStateCodec::MINIMUM_KEY_BYTES))
+                                    ->end()
+                                ->end()
+                                ->integerNode('ttl')->min(1)->defaultValue(600)->info('Seconds a minted state stays valid.')->end()
+                            ->end()
+                        ->end()
+
+                        ->arrayNode('cache')
+                            ->addDefaultsIfNotSet()
+                            ->info('Cache hints the modern-era leg puts on its answers. The spec requires them on server/discover, the list methods and resources/read.')
+                            ->children()
+                                ->integerNode('ttl_ms')->min(0)->defaultValue(0)->info('Default freshness in milliseconds. 0 refuses caching.')->end()
+                                ->enumNode('scope')->values(['private', 'public'])->defaultValue('private')->end()
+                                ->arrayNode('methods')
+                                    ->info('Per-method overrides, e.g. "tools/list". Use "public" only for answers that do not vary by caller.')
+                                    ->normalizeKeys(false)
+                                    ->useAttributeAsKey('method')
+                                    ->arrayPrototype()
+                                        ->children()
+                                            ->integerNode('ttl_ms')->min(0)->isRequired()->end()
+                                            ->enumNode('scope')->values(['private', 'public'])->defaultValue('private')->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+
+                        ->arrayNode('subscriptions')
+                            ->addDefaultsIfNotSet()
+                            ->info('Delivery for "subscriptions/listen" streams, which replace the HTTP GET stream in 2026-07-28.')
+                            ->children()
+                                ->enumNode('bus')->values(['none', 'memory', 'cache'])->defaultValue('none')->end()
+                                ->stringNode('cache_pool')->defaultValue(McpBundle::DEFAULT_NOTIFICATION_CACHE_POOL)->info('PSR-16 service for the "cache" bus. Under PHP-FPM the publisher and the stream are different workers, so "memory" cannot reach them.')->end()
+                                ->floatNode('lifetime')->min(0)->defaultValue(30.0)->info('Seconds a stream is held before the server closes it gracefully. 0 means until the client or the runtime ends it.')->end()
+                            ->end()
+                        ->end()
+
                         ->arrayNode('session')
                             ->addDefaultsIfNotSet()
                             ->info('Session storage. Every server needs its own store: session ids are not namespaced by server, so a shared store makes a session minted on one server valid on the others.')
                             ->children()
                                 ->enumNode('store')->values(['file', 'memory', 'cache', 'framework'])->defaultValue('file')->end()
                                 ->stringNode('directory')->defaultNull()->info('Directory for the "file" store. Defaults to "%kernel.cache_dir%/mcp-sessions/<name>".')->end()
-                                ->stringNode('cache_pool')->defaultValue('cache.mcp.sessions')->info('PSR-16 cache service for the "cache" store.')->end()
+                                ->stringNode('cache_pool')->defaultValue(McpBundle::DEFAULT_SESSION_CACHE_POOL)->info('PSR-16 cache service for the "cache" store.')->end()
                                 ->stringNode('prefix')->defaultNull()->info('Key prefix for the "cache" and "framework" stores. Defaults to "mcp-<name>-".')->end()
                                 ->integerNode('ttl')->min(1)->defaultValue(3600)->end()
                             ->end()
@@ -175,12 +237,15 @@ return static function (DefinitionConfigurator $configurator): void {
                             ->defaultNull()
                         ->end()
                         ->arrayNode('capabilities')
-                            ->info('Client capabilities advertised during the handshake. "sampling" and "elicitation" are derived from the handlers configured below.')
+                            ->info('Client capabilities advertised during the handshake. "roots", "sampling" and "elicitation" are derived from the handlers configured below.')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->booleanNode('roots')->defaultFalse()->end()
                                 ->booleanNode('roots_list_changed')->defaultFalse()->end()
                             ->end()
+                        ->end()
+                        ->stringNode('roots')
+                            ->info('Service id implementing Mcp\Client\Handler\Request\RootsCallbackInterface. Answers the server\'s "roots/list" requests.')
+                            ->defaultNull()
                         ->end()
                         ->stringNode('sampling')
                             ->info('Service id implementing Mcp\Client\Handler\Request\SamplingCallbackInterface. Enables the "sampling" capability.')

--- a/src/mcp-bundle/src/Client/ServerConnection.php
+++ b/src/mcp-bundle/src/Client/ServerConnection.php
@@ -15,6 +15,7 @@ use Mcp\Client;
 use Mcp\Client\Transport\TransportInterface;
 use Mcp\Exception\ExceptionInterface as McpExceptionInterface;
 use Mcp\Schema\Enum\LoggingLevel;
+use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\Implementation;
 use Mcp\Schema\PromptReference;
 use Mcp\Schema\ResourceReference;
@@ -109,6 +110,13 @@ final class ServerConnection implements ServerConnectionInterface, ResetInterfac
         return $this->client->getServerInfo();
     }
 
+    public function getProtocolVersion(): ?ProtocolVersion
+    {
+        $this->connect();
+
+        return $this->client->getProtocolVersion();
+    }
+
     public function getInstructions(): ?string
     {
         $this->connect();
@@ -184,6 +192,11 @@ final class ServerConnection implements ServerConnectionInterface, ResetInterfac
     public function setLoggingLevel(LoggingLevel $level): void
     {
         $this->call('logging/setLevel', fn () => $this->client->setLoggingLevel($level));
+    }
+
+    public function sendRootsListChanged(): void
+    {
+        $this->call('notifications/roots/list_changed', fn () => $this->client->sendRootsListChanged());
     }
 
     /**

--- a/src/mcp-bundle/src/Client/ServerConnectionInterface.php
+++ b/src/mcp-bundle/src/Client/ServerConnectionInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\McpBundle\Client;
 
 use Mcp\Schema\Enum\LoggingLevel;
+use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\Implementation;
 use Mcp\Schema\Prompt;
 use Mcp\Schema\PromptReference;
@@ -56,6 +57,11 @@ interface ServerConnectionInterface
     public function disconnect(): void;
 
     public function getServerInfo(): ?Implementation;
+
+    /**
+     * The protocol revision negotiated with this server, or null before the first request.
+     */
+    public function getProtocolVersion(): ?ProtocolVersion;
 
     public function getInstructions(): ?string;
 
@@ -116,4 +122,9 @@ interface ServerConnectionInterface
     public function complete(PromptReference|ResourceReference $ref, array $argument): CompletionCompleteResult;
 
     public function setLoggingLevel(LoggingLevel $level): void;
+
+    /**
+     * Tell the server that this client's roots changed.
+     */
+    public function sendRootsListChanged(): void;
 }

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -21,10 +21,12 @@ use Mcp\Client as McpSdkClient;
 use Mcp\Client\Builder as McpSdkClientBuilder;
 use Mcp\Client\Handler\Notification\LoggingNotificationHandler;
 use Mcp\Client\Handler\Request\ElicitationRequestHandler;
+use Mcp\Client\Handler\Request\ListRootsRequestHandler;
 use Mcp\Client\Handler\Request\SamplingRequestHandler;
 use Mcp\Client\Transport\HttpTransport;
 use Mcp\Client\Transport\StdioTransport;
 use Mcp\Schema\ClientCapabilities;
+use Mcp\Schema\Enum\CacheScope;
 use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\Icon;
 use Mcp\Server;
@@ -34,6 +36,10 @@ use Mcp\Server\Handler\Request\RequestHandlerInterface;
 use Mcp\Server\Session\FileSessionStore;
 use Mcp\Server\Session\InMemorySessionStore;
 use Mcp\Server\Session\Psr16SessionStore;
+use Mcp\Server\Subscription\InMemoryNotificationBus;
+use Mcp\Server\Subscription\NotificationBusInterface;
+use Mcp\Server\Subscription\Psr16NotificationBus;
+use Mcp\Server\Wire\CachePolicy;
 use Symfony\AI\McpBundle\App\McpAppRenderer;
 use Symfony\AI\McpBundle\Attribute\AsMcpApp;
 use Symfony\AI\McpBundle\Client\McpClient;
@@ -75,6 +81,15 @@ final class McpBundle extends AbstractBundle
         'resource_templates' => 'mcp.resource_template',
         'apps' => 'mcp.app',
     ];
+
+    /**
+     * The PSR-16 pools the bundle creates on demand — see {@see self::registerPsr16Fallback()}.
+     *
+     * Named constants because the auto-registration only fires for the configured default: a
+     * default changed in config/options.php alone would silently stop creating the pool.
+     */
+    public const DEFAULT_SESSION_CACHE_POOL = 'cache.mcp.sessions';
+    public const DEFAULT_NOTIFICATION_CACHE_POOL = 'cache.mcp.notifications';
 
     public function configure(DefinitionConfigurator $definition): void
     {
@@ -231,9 +246,9 @@ final class McpBundle extends AbstractBundle
                 $client['client_info']['description'],
             ])
             ->addMethodCall('setCapabilities', [new Definition(ClientCapabilities::class, [
-                $client['capabilities']['roots'],
-                $client['capabilities']['roots_list_changed'],
                 // Advertised only when a handler backs them, otherwise the server gets "method not found".
+                null !== $client['roots'],
+                $client['capabilities']['roots_list_changed'],
                 null !== $client['sampling'],
                 null !== $client['elicitation'],
             ])])
@@ -244,10 +259,12 @@ final class McpBundle extends AbstractBundle
             ->addTag('monolog.logger', ['channel' => 'mcp']);
 
         if (null !== $client['protocol_version']) {
-            $definition->addMethodCall('setProtocolVersion', [
-                (new Definition(ProtocolVersion::class))
-                    ->setFactory([ProtocolVersion::class, 'from'])
-                    ->setArguments([$client['protocol_version']]),
+            $definition->addMethodCall('setProtocolVersion', [$this->protocolVersion($client['protocol_version'])]);
+        }
+
+        if (null !== $client['roots']) {
+            $definition->addMethodCall('addRequestHandler', [
+                new Definition(ListRootsRequestHandler::class, [new Reference($client['roots']), $logger]),
             ]);
         }
 
@@ -365,6 +382,9 @@ final class McpBundle extends AbstractBundle
             ->addTag('mcp.server.builder', ['server' => $name])
             ->addTag('monolog.logger', ['channel' => 'mcp']);
 
+        $this->configureProtocolVersions($server['protocol_versions'], $builderId, $container);
+        $this->configureModernEra($name, $server, $builderId, $container);
+
         $container->register('mcp.server.'.$name, Server::class)
             ->setFactory([new Reference($builderId), 'build']);
 
@@ -390,6 +410,144 @@ final class McpBundle extends AbstractBundle
             ->setPublic(true)
             ->addTag('controller.service_arguments')
             ->addTag('monolog.logger', ['channel' => 'mcp']);
+    }
+
+    /**
+     * Narrows the revisions the server answers for, in either era.
+     *
+     * Left unset the SDK's own support stands: the handshake negotiates over every
+     * handshake-era revision, and the modern leg answers for every modern one.
+     *
+     * @param list<string> $versions
+     */
+    private function configureProtocolVersions(array $versions, string $builderId, ContainerBuilder $container): void
+    {
+        if ([] === $versions) {
+            return;
+        }
+
+        $builder = $container->getDefinition($builderId);
+        $modern = array_values(array_filter($versions, static fn (string $version): bool => ProtocolVersion::from($version)->isModern()));
+        $handshake = array_values(array_filter($versions, static fn (string $version): bool => !ProtocolVersion::from($version)->isModern()));
+
+        if ([] === $modern) {
+            $builder->addMethodCall('withoutModernEra');
+        } else {
+            $builder->addMethodCall('setModernVersions', [array_map($this->protocolVersion(...), $modern)]);
+        }
+
+        // The handshake negotiates rather than declares, so the SDK pins it to one
+        // revision instead of taking a list. Config validation keeps it to one.
+        if ([] !== $handshake) {
+            $builder->addMethodCall('setProtocolVersion', [$this->protocolVersion($handshake[0])]);
+        }
+    }
+
+    private function protocolVersion(string $version): Definition
+    {
+        return (new Definition(ProtocolVersion::class))
+            ->setFactory([ProtocolVersion::class, 'from'])
+            ->setArguments([$version]);
+    }
+
+    /**
+     * The builder calls that only mean something to the modern-era (2026-07-28)
+     * leg: which revisions it answers for, multi-round-trip state, cache hints
+     * and subscription delivery.
+     *
+     * The two eras share one endpoint — the transport classifies each request and
+     * routes it — so none of this changes how a handshake-era client is served.
+     *
+     * @param array{
+     *     request_state: array{key: string|null, ttl: int},
+     *     cache: array{ttl_ms: int, scope: string, methods: array<string, array{ttl_ms: int, scope: string}>},
+     *     subscriptions: array{bus: string, cache_pool: string, lifetime: float},
+     *     ...
+     * } $server
+     */
+    private function configureModernEra(string $name, array $server, string $builderId, ContainerBuilder $container): void
+    {
+        $builder = $container->getDefinition($builderId);
+
+        if (null !== $server['request_state']['key']) {
+            $builder->addMethodCall('setRequestState', [$server['request_state']['key'], $server['request_state']['ttl']]);
+        }
+
+        // "private, immediately stale" is what the SDK does without a policy, so only a
+        // configuration that departs from it is worth building one for.
+        if (0 !== $server['cache']['ttl_ms'] || 'private' !== $server['cache']['scope'] || [] !== $server['cache']['methods']) {
+            $policy = (new Definition(CachePolicy::class))
+                ->setFactory([CachePolicy::class, 'default'])
+                ->setArguments([$server['cache']['ttl_ms'], $this->cacheScope($server['cache']['scope'])]);
+
+            foreach ($server['cache']['methods'] as $method => $override) {
+                $policy = (new Definition(CachePolicy::class))
+                    ->setFactory([$policy, 'withMethod'])
+                    ->setArguments([$method, $override['ttl_ms'], $this->cacheScope($override['scope'])]);
+            }
+
+            $builder->addMethodCall('setCachePolicy', [$policy]);
+        }
+
+        if ('none' !== $server['subscriptions']['bus']) {
+            $builder
+                ->addMethodCall('setNotificationBus', [$this->notificationBus($name, $server['subscriptions'], $container)])
+                ->addMethodCall('setSubscriptionLifetime', [$server['subscriptions']['lifetime']]);
+        }
+    }
+
+    private function cacheScope(string $scope): Definition
+    {
+        return (new Definition(CacheScope::class))
+            ->setFactory([CacheScope::class, 'from'])
+            ->setArguments([$scope]);
+    }
+
+    /**
+     * @param array{bus: string, cache_pool: string, lifetime: float} $subscriptions
+     */
+    private function notificationBus(string $name, array $subscriptions, ContainerBuilder $container): Reference
+    {
+        $id = \sprintf('mcp.server.%s.notification_bus', $name);
+
+        if ('memory' === $subscriptions['bus']) {
+            $container->register($id, InMemoryNotificationBus::class);
+        } else {
+            $this->registerPsr16Fallback($subscriptions['cache_pool'], self::DEFAULT_NOTIFICATION_CACHE_POOL, $container);
+
+            $container->register($id, Psr16NotificationBus::class)
+                ->setArguments([
+                    '$cache' => new Reference($subscriptions['cache_pool']),
+                    // Namespaced per server: two servers left on the default pool would otherwise
+                    // share one cursor, so each would read the other's notifications and their
+                    // publishes would overwrite each other under the same sequence number.
+                    '$prefix' => \sprintf('mcp-%s-notifications.', $name),
+                    '$logger' => new Reference('logger'),
+                ])
+                ->addTag('monolog.logger', ['channel' => 'mcp']);
+        }
+
+        // The SDK publishes registry changes itself; everything else — "notifications/resources/updated"
+        // above all — is the application calling publish(), so the bus has to be reachable.
+        $container->registerAliasForArgument($id, NotificationBusInterface::class, $name.' notification bus');
+
+        return new Reference($id);
+    }
+
+    /**
+     * Creates a default PSR-16 pool as a wrapper around cache.app, so the common case
+     * needs no services.yaml entry.
+     *
+     * Only ever for the configured default: any other id is the application's own service,
+     * and inventing one would hide a typo behind a working-looking cache.
+     */
+    private function registerPsr16Fallback(string $id, string $default, ContainerBuilder $container): void
+    {
+        if ($id !== $default || $container->hasDefinition($id) || $container->hasAlias($id)) {
+            return;
+        }
+
+        $container->register($id, Psr16Cache::class)->setArguments([new Reference('cache.app')]);
     }
 
     /**
@@ -605,16 +763,10 @@ final class McpBundle extends AbstractBundle
         }
 
         if ('cache' === $session['store']) {
-            $cachePoolId = $session['cache_pool'];
-
-            // Create the default cache pool as a PSR-16 wrapper around cache.app if it doesn't exist
-            if ('cache.mcp.sessions' === $cachePoolId && !$container->hasDefinition($cachePoolId) && !$container->hasAlias($cachePoolId)) {
-                $container->register($cachePoolId, Psr16Cache::class)
-                    ->setArguments([new Reference('cache.app')]);
-            }
+            $this->registerPsr16Fallback($session['cache_pool'], self::DEFAULT_SESSION_CACHE_POOL, $container);
 
             $container->register($id, Psr16SessionStore::class)
-                ->setArguments([new Reference($cachePoolId), $prefix, $session['ttl']]);
+                ->setArguments([new Reference($session['cache_pool']), $prefix, $session['ttl']]);
 
             return $id;
         }

--- a/src/mcp-bundle/tests/Client/ServerConnectionTest.php
+++ b/src/mcp-bundle/tests/Client/ServerConnectionTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\AI\McpBundle\Tests\Client;
 
 use Mcp\Client;
+use Mcp\Schema\ClientCapabilities;
+use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\PromptReference;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\McpBundle\Client\ServerConnection;
@@ -173,6 +175,39 @@ final class ServerConnectionTest extends TestCase
         $call = end($transport->sent);
         $this->assertSame('completion/complete', $call['method']);
         $this->assertSame(['berlin'], $result->values);
+    }
+
+    public function testProtocolVersionComesFromTheHandshake()
+    {
+        $connection = $this->createConnection(new InMemoryTransport());
+
+        $this->assertSame(ProtocolVersion::V2025_11_25, $connection->getProtocolVersion());
+    }
+
+    public function testRootsListChangedIsSentAsANotification()
+    {
+        $transport = new InMemoryTransport();
+        $client = Client::builder()->setCapabilities(new ClientCapabilities(roots: true, rootsListChanged: true))->build();
+        $connection = new ServerConnection('research', 'github', $client, $transport);
+
+        $connection->sendRootsListChanged();
+
+        $call = end($transport->sent);
+        $this->assertSame('notifications/roots/list_changed', $call['method']);
+        // A notification carries no id, so nothing waits for an answer that will never come.
+        $this->assertArrayNotHasKey('id', $call);
+    }
+
+    public function testRootsListChangedWithoutTheCapabilityFailsLikeAnyOtherCall()
+    {
+        // The bundle advertises "roots.listChanged" only when a roots provider is configured,
+        // so the SDK's refusal has to arrive as a bundle exception naming the operation.
+        $connection = $this->createConnection(new InMemoryTransport());
+
+        $this->expectException(RemoteCallException::class);
+        $this->expectExceptionMessage('The "notifications/roots/list_changed" request of MCP client "research" to server "github" failed:');
+
+        $connection->sendRootsListChanged();
     }
 
     public function testNamesAreExposed()

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleClientTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleClientTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\McpBundle\Tests\DependencyInjection;
 use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\Psr18ClientDiscovery;
 use Mcp\Client as McpSdkClient;
+use Mcp\Client\Handler\Request\ListRootsRequestHandler;
 use Mcp\Client\Transport\HttpTransport;
 use Mcp\Client\Transport\StdioTransport;
 use Mcp\Schema\ClientCapabilities;
@@ -162,9 +163,9 @@ final class McpBundleClientTest extends TestCase
         $container = $this->buildContainer($this->config([
             'plain' => ['servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']]],
             'rich' => [
+                'roots' => 'app.roots',
                 'sampling' => 'app.sampling',
                 'elicitation' => 'app.elicitation',
-                'capabilities' => ['roots' => true],
                 'servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']],
             ],
         ]));
@@ -177,7 +178,30 @@ final class McpBundleClientTest extends TestCase
 
         $rich = $this->callsNamed($container, 'rich', 'github', 'setCapabilities')[0][1][0];
         $this->assertSame([true, false, true, true], $rich->getArguments());
-        $this->assertCount(2, $this->callsNamed($container, 'rich', 'github', 'addRequestHandler'));
+        $this->assertCount(3, $this->callsNamed($container, 'rich', 'github', 'addRequestHandler'));
+    }
+
+    public function testTheRootsHandlerIsRegisteredWithTheConfiguredService()
+    {
+        $container = $this->buildContainer($this->config([
+            'research' => [
+                'roots' => 'app.roots',
+                'servers' => ['github' => ['transport' => 'http', 'url' => 'https://example.com/mcp']],
+            ],
+        ]));
+
+        $handlers = $this->callsNamed($container, 'research', 'github', 'addRequestHandler');
+        $this->assertCount(1, $handlers);
+
+        $handler = $handlers[0][1][0];
+        $this->assertInstanceOf(Definition::class, $handler);
+        $this->assertSame(ListRootsRequestHandler::class, $handler->getClass());
+        $this->assertSame('app.roots', (string) $handler->getArgument(0));
+
+        // The capability is advertised because a handler backs it, not because
+        // a boolean said so.
+        $capabilities = $this->callsNamed($container, 'research', 'github', 'setCapabilities')[0][1][0];
+        $this->assertSame([true, false, false, false], $capabilities->getArguments());
     }
 
     public function testServerLogsAreForwardedByDefault()

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -15,18 +15,27 @@ use Mcp\Capability\Attribute\McpPrompt;
 use Mcp\Capability\Attribute\McpResource;
 use Mcp\Capability\Attribute\McpResourceTemplate;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Registry;
 use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Schema\Icon;
 use Mcp\Server;
 use Mcp\Server\Handler\Notification\NotificationHandlerInterface;
 use Mcp\Server\Handler\Request\RequestHandlerInterface;
+use Mcp\Server\Protocol;
 use Mcp\Server\Session\FileSessionStore;
 use Mcp\Server\Session\InMemorySessionStore;
 use Mcp\Server\Session\Psr16SessionStore;
+use Mcp\Server\Stateless\RequestStateCodec;
+use Mcp\Server\Stateless\StatelessProtocol;
+use Mcp\Server\Subscription\InMemoryNotificationBus;
+use Mcp\Server\Subscription\NotificationBusInterface;
+use Mcp\Server\Subscription\Psr16NotificationBus;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use Symfony\AI\McpBundle\App\McpAppRenderer;
 use Symfony\AI\McpBundle\Attribute\AsMcpApp;
+use Symfony\AI\McpBundle\Controller\McpController;
 use Symfony\AI\McpBundle\Exception\LogicException;
 use Symfony\AI\McpBundle\McpBundle;
 use Symfony\AI\McpBundle\Session\FrameworkSessionStore;
@@ -36,6 +45,8 @@ use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class McpBundleTest extends TestCase
 {
@@ -525,6 +536,231 @@ class McpBundleTest extends TestCase
         $this->assertTrue($container->hasDefinition(McpAppRenderer::SERVICE_ID));
     }
 
+    public function testBothErasAreServedByOneServerOnOneEndpoint()
+    {
+        $container = $this->buildContainer($this->config(['default' => []]));
+
+        // The SDK hands the transport a dispatcher per era, and the transport routes
+        // each request; there is no second server, controller or route to configure.
+        $definition = $container->getDefinition('mcp.server.default');
+        $this->assertSame(Server::class, $definition->getClass());
+        $this->assertSame('mcp.server.default.builder', (string) $definition->getFactory()[0]);
+        $this->assertSame('build', $definition->getFactory()[1]);
+        $this->assertSame(McpController::class, $container->getDefinition('mcp.server.default.controller')->getClass());
+        $this->assertSame(
+            [['name' => 'default', 'path' => '/mcp/default', 'controller' => 'mcp.server.default.controller::handle']],
+            $container->getDefinition('mcp.server.route_loader')->getArgument(0),
+        );
+
+        // Which legs are live is the SDK's answer to the builder calls rather than something
+        // the definition shows, so the built server is what settles it: a handshake-era
+        // protocol (hence the session) and a modern-era one, on the same object.
+        $server = $this->buildServer($container, 'default');
+        $this->assertInstanceOf(Protocol::class, $this->legOf($server, 'protocol'));
+        $this->assertInstanceOf(StatelessProtocol::class, $this->legOf($server, 'statelessProtocol'));
+    }
+
+    public function testTheSdkSupportIsInheritedWhenNoRevisionIsListed()
+    {
+        $container = $this->buildContainer($this->config(['default' => []]));
+
+        foreach (['setModernVersions', 'withoutModernEra', 'setProtocolVersion'] as $call) {
+            $this->assertSame([], $this->callsNamed($container, $call), $call);
+        }
+    }
+
+    public function testListingModernRevisionsNarrowsTheModernLeg()
+    {
+        $container = $this->buildContainer($this->config([
+            'modern' => ['protocol_versions' => ['2026-07-28']],
+        ]));
+
+        $versions = $this->callsNamed($container, 'setModernVersions', 'modern')[0][1][0];
+        $this->assertCount(1, $versions);
+        $this->assertSame(['2026-07-28'], $versions[0]->getArguments());
+
+        // Nothing is pinned: the handshake keeps negotiating over every revision it knows.
+        $this->assertSame([], $this->callsNamed($container, 'setProtocolVersion', 'modern'));
+    }
+
+    public function testListingOnlyHandshakeRevisionsPinsItAndRefusesTheModernEra()
+    {
+        $container = $this->buildContainer($this->config([
+            'legacy' => ['protocol_versions' => ['2025-11-25']],
+        ]));
+
+        $pinned = $this->callsNamed($container, 'setProtocolVersion', 'legacy')[0][1][0];
+        $this->assertSame(['2025-11-25'], $pinned->getArguments());
+
+        $this->assertSame([[]], array_column($this->callsNamed($container, 'withoutModernEra', 'legacy'), 1));
+        $this->assertSame([], $this->callsNamed($container, 'setModernVersions', 'legacy'));
+
+        // The contrast that gives testBothErasAreServedByOneServerOnOneEndpoint its meaning:
+        // the built server then carries no modern-era dispatcher at all.
+        $this->assertNull($this->legOf($this->buildServer($container, 'legacy'), 'statelessProtocol'));
+    }
+
+    public function testBothErasCanBeNarrowedAtOnce()
+    {
+        $container = $this->buildContainer($this->config([
+            'both' => ['protocol_versions' => ['2025-11-25', '2026-07-28']],
+        ]));
+
+        $this->assertSame(['2025-11-25'], $this->callsNamed($container, 'setProtocolVersion', 'both')[0][1][0]->getArguments());
+        $this->assertSame(['2026-07-28'], $this->callsNamed($container, 'setModernVersions', 'both')[0][1][0][0]->getArguments());
+    }
+
+    public function testNarrowingTheHandshakeEraToASubsetIsRejected()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches('/pinned to a single revision/');
+
+        $this->buildContainer($this->config([
+            'legacy' => ['protocol_versions' => ['2025-06-18', '2025-11-25']],
+        ]));
+    }
+
+    public function testRequestStateIsConfiguredForMultiRoundTripAnswers()
+    {
+        // What bin2hex(random_bytes(32)) gives you. Asserted against the SDK's own minimum so the
+        // fixture cannot drift back into a key the codec would refuse at runtime.
+        $key = '4f8a1c05b7e2d93610fa8c4b2e57d0913a6ecb4728f105d3c9b60a7e8412fd56';
+        $this->assertGreaterThanOrEqual(RequestStateCodec::MINIMUM_KEY_BYTES, \strlen($key));
+
+        $container = $this->buildContainer($this->config([
+            'modern' => ['request_state' => ['key' => $key, 'ttl' => 90]],
+        ]));
+
+        $this->assertSame([[$key, 90]], array_column($this->callsNamed($container, 'setRequestState', 'modern'), 1));
+    }
+
+    public function testAShortRequestStateKeyIsRejectedWhenTheContainerIsCompiled()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches('/must be at least 32 bytes/');
+
+        $this->buildContainer($this->config(['modern' => ['request_state' => ['key' => 'too-short']]]));
+    }
+
+    public function testAnEnvPlaceholderKeyIsNotMeasured()
+    {
+        // Its length is unknowable at compile time, so the check must not turn a valid config
+        // into an error. Symfony also skips validation while handling a registered placeholder,
+        // but that only happens once the container's env machinery has run — the guard is what
+        // makes the rule hold everywhere, including here.
+        $container = $this->buildContainer($this->config([
+            'modern' => ['request_state' => ['key' => '%env(MCP_REQUEST_STATE_KEY)%']],
+        ]));
+
+        $this->assertSame(
+            [['%env(MCP_REQUEST_STATE_KEY)%', 600]],
+            array_column($this->callsNamed($container, 'setRequestState', 'modern'), 1),
+        );
+    }
+
+    public function testCacheHintsAreBuiltAsAPolicy()
+    {
+        $container = $this->buildContainer($this->config([
+            'modern' => [
+                'cache' => ['ttl_ms' => 30000, 'methods' => ['tools/list' => ['ttl_ms' => 3600000, 'scope' => 'public']]],
+            ],
+        ]));
+
+        $calls = $this->callsNamed($container, 'setCachePolicy', 'modern');
+        $this->assertCount(1, $calls);
+
+        // The override wraps the default, so the outermost call is withMethod().
+        $policy = $calls[0][1][0];
+        $this->assertSame('withMethod', $policy->getFactory()[1]);
+        $this->assertSame('tools/list', $policy->getArgument(0));
+        $this->assertSame(3600000, $policy->getArgument(1));
+    }
+
+    public function testSubscriptionsAreOptOut()
+    {
+        $container = $this->buildContainer($this->config(['modern' => []]));
+
+        $this->assertSame([], $this->callsNamed($container, 'setNotificationBus', 'modern'));
+    }
+
+    public function testSubscriptionsAreWiredWhenAskedFor()
+    {
+        $container = $this->buildContainer($this->config([
+            'modern' => [
+                'subscriptions' => ['bus' => 'memory', 'lifetime' => 5.0],
+            ],
+        ]));
+
+        $this->assertSame([5.0], $this->callsNamed($container, 'setSubscriptionLifetime', 'modern')[0][1]);
+        $this->assertSame(InMemoryNotificationBus::class, $container->getDefinition('mcp.server.modern.notification_bus')->getClass());
+    }
+
+    public function testTheBusIsAutowirableSoTheApplicationCanPublishToIt()
+    {
+        $container = $this->buildContainer($this->config([
+            'modern' => ['subscriptions' => ['bus' => 'memory']],
+        ]));
+
+        // Registry changes publish themselves; everything else is the application calling
+        // publish(), which it cannot do without a way to inject the bus.
+        $this->assertSame(
+            'mcp.server.modern.notification_bus',
+            (string) $container->getAlias(NotificationBusInterface::class.' $modernNotificationBus'),
+        );
+    }
+
+    public function testTheCacheBusNamespacesItsKeysPerServer()
+    {
+        $container = $this->buildContainer($this->config([
+            'first' => ['subscriptions' => ['bus' => 'cache']],
+            'second' => ['subscriptions' => ['bus' => 'cache']],
+        ]));
+
+        $arguments = [];
+        foreach (['first', 'second'] as $name) {
+            $definition = $container->getDefinition(\sprintf('mcp.server.%s.notification_bus', $name));
+            $this->assertSame(Psr16NotificationBus::class, $definition->getClass());
+            $arguments[$name] = $definition->getArguments();
+
+            $this->assertSame('cache.mcp.notifications', (string) $arguments[$name]['$cache']);
+            $this->assertSame('logger', (string) $arguments[$name]['$logger']);
+        }
+
+        // Both servers sit on the same default pool, so only the key prefix keeps one server's
+        // notifications — and its cursor — out of the other's listen streams.
+        $this->assertSame('mcp-first-notifications.', $arguments['first']['$prefix']);
+        $this->assertSame('mcp-second-notifications.', $arguments['second']['$prefix']);
+    }
+
+    public function testTheDefaultNotificationPoolIsCreatedButACustomOneIsNot()
+    {
+        $container = $this->buildContainer($this->config([
+            'default' => ['subscriptions' => ['bus' => 'cache']],
+        ]));
+
+        $pool = $container->getDefinition('cache.mcp.notifications');
+        $this->assertSame(Psr16Cache::class, $pool->getClass());
+        $this->assertSame('cache.app', (string) $pool->getArgument(0));
+
+        $container = $this->buildContainer($this->config([
+            'default' => ['subscriptions' => ['bus' => 'cache', 'cache_pool' => 'app.my_psr16']],
+        ]));
+
+        // An application-provided pool is referenced as configured, never invented: a typo has
+        // to surface as an unknown service rather than as a silently working cache.
+        $this->assertSame('app.my_psr16', (string) $container->getDefinition('mcp.server.default.notification_bus')->getArgument('$cache'));
+        $this->assertFalse($container->hasDefinition('app.my_psr16'));
+    }
+
+    public function testNoBusIsRegisteredWhenSubscriptionsAreOff()
+    {
+        $container = $this->buildContainer($this->config(['default' => []]));
+
+        $this->assertFalse($container->hasDefinition('mcp.server.default.notification_bus'));
+        $this->assertSame([], $this->callsNamed($container, 'setNotificationBus'));
+        $this->assertSame([], $this->callsNamed($container, 'setSubscriptionLifetime'));
+    }
+
     /**
      * Builds an "mcp" configuration from partial server definitions, defaulting each server to
      * exposing every tool so the "at least one element list" validation is satisfied.
@@ -551,6 +787,87 @@ class McpBundleTest extends TestCase
             $container->getDefinition('mcp.server.'.$server.'.builder')->getMethodCalls(),
             static fn (array $call): bool => $call[0] === $method,
         ));
+    }
+
+    /**
+     * Instantiates the SDK server the container describes, so an assertion can reach what the
+     * builder calls actually produced rather than restating the calls themselves.
+     *
+     * References are stood in for and tagged iterators come out empty: which eras a server
+     * carries does not depend on the registered elements.
+     */
+    private function buildServer(ContainerBuilder $container, string $name): Server
+    {
+        $dispatcher = new EventDispatcher();
+        $services = [
+            'event_dispatcher' => $dispatcher,
+            'logger' => new NullLogger(),
+            \sprintf('mcp.server.%s.registry', $name) => new Registry($dispatcher),
+            \sprintf('mcp.server.%s.session.store', $name) => new InMemorySessionStore(),
+        ];
+
+        $builder = Server::builder();
+        foreach ($container->getDefinition(\sprintf('mcp.server.%s.builder', $name))->getMethodCalls() as $call) {
+            \call_user_func_array([$builder, $call[0]], $this->resolveArguments($call[1], $services));
+        }
+
+        return $builder->build();
+    }
+
+    /**
+     * @param array<array-key, mixed> $arguments
+     * @param array<string, object>   $services
+     *
+     * @return array<array-key, mixed>
+     */
+    private function resolveArguments(array $arguments, array $services): array
+    {
+        return array_map(fn (mixed $argument): mixed => $this->resolveArgument($argument, $services), $arguments);
+    }
+
+    /**
+     * @param array<string, object> $services
+     */
+    private function resolveArgument(mixed $argument, array $services): mixed
+    {
+        if ($argument instanceof Reference) {
+            return $services[(string) $argument];
+        }
+
+        if ($argument instanceof TaggedIteratorArgument) {
+            return [];
+        }
+
+        if (\is_array($argument)) {
+            return $this->resolveArguments($argument, $services);
+        }
+
+        if (!$argument instanceof Definition) {
+            return $argument;
+        }
+
+        $arguments = $this->resolveArguments($argument->getArguments(), $services);
+        $factory = $argument->getFactory();
+
+        if (null === $factory) {
+            $class = $argument->getClass();
+            $this->assertNotNull($class);
+
+            return new $class(...$arguments);
+        }
+
+        $this->assertIsCallable($factory);
+
+        return \call_user_func_array($factory, $arguments);
+    }
+
+    /**
+     * The eras are private state of the SDK's server, and deliberately so: nothing but a test
+     * has business asking which dispatchers a built server carries.
+     */
+    private function legOf(Server $server, string $property): mixed
+    {
+        return (new \ReflectionProperty(Server::class, $property))->getValue($server);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

Adds support for the 2026-07-28 revision — no `initialize` handshake, no session, every request
self-describing — **on the endpoint that is already there**.

`mcp/sdk` 0.8 builds a dispatcher per era and lets the HTTP transport classify each request before
anything else looks at it: an envelope claiming a modern revision goes to the modern dispatcher, the
handshake and its session's later requests go to the other. `Builder::build()` already carries both
legs and `McpController` already runs a `StreamableHttpTransport`, so there is no second controller,
no second route and no per-server mode to pick. STDIO carries the handshake era alone, having no
per-request envelope to classify.

What is left to configure is the modern leg itself.

```yaml
mcp:
    servers:
        api:
            protocol_versions: ['2025-11-25', '2026-07-28']
            http: { path: /mcp }
            registry: '*'
```

- **`protocol_versions`** — narrows the revisions the server answers for. Left unset it inherits the
  SDK's own support in both eras. Each era takes what belongs to it: the modern revisions listed become
  the only ones that leg answers for (`setModernVersions()`), listing none refuses the era
  (`withoutModernEra()`), and a handshake-era revision pins the handshake to it
  (`setProtocolVersion()`). The SDK either negotiates over everything or pins to one revision, so
  narrowing the handshake era to a subset is rejected at compile time.
- **`request_state`** — a handler asking for another round trip has no session to keep progress in, so
  the state travels through the client HMAC-signed. The key must reach every process that might serve
  the retry.
- **`cache`** — cache hints (`ttl_ms`, `private`/`public` scope, per-method overrides). `0` refuses
  caching.
- **`subscriptions`** — delivery for `subscriptions/listen`, which replaces the held-open GET stream.
  Under PHP-FPM the publisher is a different worker from the stream, so `memory` cannot reach it.

### Also

- `clients.<name>.roots` now points at a `RootsCallbackInterface` service instead of being a boolean
  capability flag, and connections gain `getProtocolVersion()` and `sendRootsListChanged()`.

### Notes

- Replaces #2414, which was written against an SDK branch where a stateless endpoint was a separate
  thing to mount, and could not go green before `mcp/sdk` 0.8 was released.
- **Why the `BC Break` label:** since the SDK's default answers for every modern revision, existing
  endpoints start accepting 2026-07-28 requests once the constraint moves to `^0.8`, with no config
  change. That revision removed server-initiated requests, so a handler calling `$gateway->sample()`
  or `$gateway->listRoots()` fails for clients speaking it while continuing to work for handshake-era
  clients on the same endpoint. `UPGRADE.md` covers it; listing only handshake-era revisions under
  `protocol_versions` is the opt-out, and `supportsSampling()` / `supportsRoots()` guard a handler
  that wants to serve both.
- Roots, sampling and MCP logging are deprecated by the same revision (SEP-2577, earliest removal
  2027-07-28) and `mcp/sdk` 0.8 triggers a deprecation per configured handler — including the one
  behind `clients.<name>.forward_server_logs`, which defaults to `true`. Documented, not changed.
- The tasks extension (SEP-2663) is left out: 0.8.0 ships the extension framework but no tasks
  implementation. Worth a follow-up once it lands.

190 tests / 575 assertions, PHPStan and CS clean against `mcp/sdk` v0.8.0.
