### PR TITLE
[Mate] Unify the Monolog bridge's result-limit parameter to `limit`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -341,6 +341,14 @@ Mate
    Symfony CLI, an unpinned Mate started on the host reads the host's runtime and reports on
    something that is not the application under test.
 
+ * The Monolog bridge's `monolog-tail` tool takes a `limit` parameter instead of `lines`, matching
+   `monolog-search` and `monolog-context-search`:
+
+   ```diff
+   -vendor/bin/mate tools:call monolog-tail --lines=50
+   +vendor/bin/mate tools:call monolog-tail --limit=50
+   ```
+
 Platform
 --------
 

--- a/demo/.agents/skills/mate-symfony-log-investigation/SKILL.md
+++ b/demo/.agents/skills/mate-symfony-log-investigation/SKILL.md
@@ -9,7 +9,7 @@ Reads Monolog files through Mate's CLI. Entries come back as `{datetime, channel
 
 - `monolog-list-files` (opt `environment`): what log files exist, newest first.
 - `monolog-list-channels`: distinct channel names (`app`, `security`, `doctrine`, ...). Reads every file, so it is the slow one; skip it if you already know the channel.
-- `monolog-tail` (`lines`, `level`, `environment`, `channel`): most recent entries. Reads ONLY the single newest file.
+- `monolog-tail` (`limit`, `level`, `environment`, `channel`): most recent entries. Reads ONLY the single newest file.
 - `monolog-search` (`term`, `regex`, `level`, `channel`, `environment`, `from`, `to`, `limit`): searches across all files. Empty `term` with filters set = filter-only.
 - `monolog-context-search` (`key`, `value`, `level`, `environment`, `limit`): matches a structured context field. No channel or date filter here.
 
@@ -18,7 +18,7 @@ These commands accept `--format`: `json` to parse the result, `toon` (when `helg
 ## Workflow
 
 1. Orient: `vendor/bin/mate tools:call monolog-list-files`. Confirm the environment you care about is present and recently modified.
-2. Latest state: `vendor/bin/mate tools:call monolog-tail --level=error --lines=50`. Good for "what just broke", nothing else.
+2. Latest state: `vendor/bin/mate tools:call monolog-tail --level=error --limit=50`. Good for "what just broke", nothing else.
 3. Narrow with search:
    - `vendor/bin/mate tools:call monolog-search --term="Timeout" --level=error`
    - Time-box it: `--from="-1 hour"`, `--from=2026-07-01 --to=2026-07-02`. Any PHP-parseable date works.

--- a/src/mate/skills/symfony-log-investigation/SKILL.md
+++ b/src/mate/skills/symfony-log-investigation/SKILL.md
@@ -9,7 +9,7 @@ Reads Monolog files through Mate's CLI. Entries come back as `{datetime, channel
 
 - `monolog-list-files` (opt `environment`): what log files exist, newest first.
 - `monolog-list-channels`: distinct channel names (`app`, `security`, `doctrine`, ...). Reads every file, so it is the slow one; skip it if you already know the channel.
-- `monolog-tail` (`lines`, `level`, `environment`, `channel`): most recent entries. Reads ONLY the single newest file.
+- `monolog-tail` (`limit`, `level`, `environment`, `channel`): most recent entries. Reads ONLY the single newest file.
 - `monolog-search` (`term`, `regex`, `level`, `channel`, `environment`, `from`, `to`, `limit`): searches across all files. Empty `term` with filters set = filter-only.
 - `monolog-context-search` (`key`, `value`, `level`, `environment`, `limit`): matches a structured context field. No channel or date filter here.
 
@@ -18,7 +18,7 @@ These commands accept `--format`: `json` to parse the result, `toon` (when `helg
 ## Workflow
 
 1. Orient: `vendor/bin/mate tools:call monolog-list-files`. Confirm the environment you care about is present and recently modified.
-2. Latest state: `vendor/bin/mate tools:call monolog-tail --level=error --lines=50`. Good for "what just broke", nothing else.
+2. Latest state: `vendor/bin/mate tools:call monolog-tail --level=error --limit=50`. Good for "what just broke", nothing else.
 3. Narrow with search:
    - `vendor/bin/mate tools:call monolog-search --term="Timeout" --level=error`
    - Time-box it: `--from="-1 hour"`, `--from=2026-07-01 --to=2026-07-02`. Any PHP-parseable date works.

--- a/src/mate/src/Bridge/Monolog/CHANGELOG.md
+++ b/src/mate/src/Bridge/Monolog/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Mark the entries returned by `monolog-search`, `monolog-context-search` and `monolog-tail` as untrusted data, since log messages and their context are frequently controlled by end users
  * Allow `ai_mate_monolog.log_dir` to be a map of context name to log directory. Log entries and files then carry a `kernel_context` field, and `monolog-search`, `monolog-context-search`, `monolog-tail`, `monolog-list-files` and `monolog-list-channels` accept an optional `kernelContext` filter parameter
+ * Rename `monolog-tail`'s `lines` parameter to `limit`, matching `monolog-search` and `monolog-context-search` and the `limit` convention used by every other result-capping tool in Mate
 
 0.7
 ---

--- a/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
+++ b/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
@@ -107,16 +107,16 @@ final class LogSearchTool
     }
 
     /**
-     * @param int         $lines         Number of most recent log entries to return
+     * @param int         $limit         Number of most recent log entries to return
      * @param string|null $level         Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
      * @param string|null $environment   Filter by Symfony environment (e.g. dev, prod, test)
      * @param string|null $channel       Filter by Monolog channel name (e.g. app, security, doctrine)
      * @param string|null $kernelContext Filter by kernel context (e.g. the APP_ID of a multi-kernel application), only relevant when multiple log directories are configured
      */
     #[MateTool(name: 'monolog-tail', title: 'Log Tail', description: 'Get the most recent log entries. Reads from the end of log files, optionally filtered by level, environment, and channel. When multiple kernel contexts are configured, the most recent entries of every context are merged.')]
-    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null, ?string $channel = null, ?string $kernelContext = null): string
+    public function tail(int $limit = 50, ?string $level = null, ?string $environment = null, ?string $channel = null, ?string $kernelContext = null): string
     {
-        $entries = $this->reader->tail($lines, $level, $environment, $channel, $kernelContext);
+        $entries = $this->reader->tail($limit, $level, $environment, $channel, $kernelContext);
 
         return ResponseEncoder::encodeUntrusted(['entries' => array_values(array_map(static fn ($entry) => $entry->toArray(), $entries))]);
     }

--- a/src/mate/src/Bridge/Monolog/Service/LogReader.php
+++ b/src/mate/src/Bridge/Monolog/Service/LogReader.php
@@ -152,7 +152,7 @@ final class LogReader
      *
      * @return LogEntry[]
      */
-    public function tail(int $lines = 50, ?string $level = null, ?string $environment = null, ?string $channel = null, ?string $kernelContext = null): array
+    public function tail(int $limit = 50, ?string $level = null, ?string $environment = null, ?string $channel = null, ?string $kernelContext = null): array
     {
         $entriesPerContext = [];
 
@@ -171,7 +171,7 @@ final class LogReader
                 continue;
             }
 
-            $entriesPerContext[] = $this->tailFromFile($file, $lines, $level, $channel);
+            $entriesPerContext[] = $this->tailFromFile($file, $limit, $level, $channel);
         }
 
         if ([] === $entriesPerContext) {
@@ -185,7 +185,7 @@ final class LogReader
         $entries = array_merge(...$entriesPerContext);
         usort($entries, static fn (LogEntry $a, LogEntry $b) => $a->getDatetime() <=> $b->getDatetime());
 
-        return \array_slice($entries, -$lines);
+        return \array_slice($entries, -$limit);
     }
 
     /**
@@ -218,7 +218,7 @@ final class LogReader
     /**
      * @return LogEntry[]
      */
-    private function tailFromFile(string $file, int $lines, ?string $level = null, ?string $channel = null): array
+    private function tailFromFile(string $file, int $limit, ?string $level = null, ?string $channel = null): array
     {
         $handle = fopen($file, 'r');
         if (false === $handle) {
@@ -235,14 +235,14 @@ final class LogReader
                 ++$lineNumber;
                 $buffer[] = ['line' => $line, 'number' => $lineNumber];
 
-                // Keep buffer size at 2x the requested lines to account for filtered entries
-                if (\count($buffer) > $lines * 2) {
+                // Keep buffer size at 2x the requested limit to account for filtered entries
+                if (\count($buffer) > $limit * 2) {
                     array_shift($buffer);
                 }
             }
 
             $entries = [];
-            for ($i = \count($buffer) - 1; $i >= 0 && \count($entries) < $lines; --$i) {
+            for ($i = \count($buffer) - 1; $i >= 0 && \count($entries) < $limit; --$i) {
                 $entry = $this->parser->parse($buffer[$i]['line'], $relativePath, $buffer[$i]['number'], $fileContext);
                 if (null === $entry) {
                     continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | none
| License       | MIT

`monolog-tail` took `lines` while `monolog-search` and `monolog-context-search` took `limit`, for
the same "how many results" meaning. Since `tools:list` does not show parameter names, getting it
right on the first try needs a `tools:inspect` round-trip per tool.

All three take `limit` now. This renames a tool parameter, so it is a BC break: documented in
`UPGRADE.md`.
