### PR TITLE
[Mate] Wrap monolog-list-files and monolog-list-channels in the untrusted-data envelope

### DIFF
--- a/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
+++ b/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
@@ -149,7 +149,7 @@ final class LogSearchTool
             $result[] = $entry;
         }
 
-        return ResponseEncoder::encode(['files' => $result]);
+        return ResponseEncoder::encodeUntrusted(['files' => $result]);
     }
 
     /**
@@ -158,7 +158,7 @@ final class LogSearchTool
     #[MateTool(name: 'monolog-list-channels', title: 'List Log Channels', description: 'List all unique Monolog channel names found across log files (e.g. app, security, doctrine).')]
     public function listChannels(?string $kernelContext = null): string
     {
-        return ResponseEncoder::encode(['channels' => $this->reader->getUniqueChannels($kernelContext)]);
+        return ResponseEncoder::encodeUntrusted(['channels' => $this->reader->getUniqueChannels($kernelContext)]);
     }
 
     /**

--- a/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
@@ -172,7 +172,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testListFiles()
     {
-        $result = Toon::decode($this->tool->listFiles());
+        $result = $this->decodeUntrusted($this->tool->listFiles());
 
         $this->assertArrayHasKey('files', $result);
         $this->assertNotEmpty($result['files']);
@@ -187,7 +187,7 @@ final class LogSearchToolTest extends TestCase
 
     public function testListChannels()
     {
-        $result = Toon::decode($this->tool->listChannels());
+        $result = $this->decodeUntrusted($this->tool->listChannels());
 
         $this->assertArrayHasKey('channels', $result);
         $this->assertNotEmpty($result['channels']);
@@ -277,7 +277,7 @@ final class LogSearchToolTest extends TestCase
     {
         $tool = $this->createMultiKernelTool();
 
-        $result = Toon::decode($tool->listFiles(kernelContext: 'admin'));
+        $result = $this->decodeUntrusted($tool->listFiles(kernelContext: 'admin'));
 
         $this->assertCount(2, $result['files']);
         foreach ($result['files'] as $file) {
@@ -289,7 +289,7 @@ final class LogSearchToolTest extends TestCase
     {
         $tool = $this->createMultiKernelTool();
 
-        $result = Toon::decode($tool->listChannels('admin'));
+        $result = $this->decodeUntrusted($tool->listChannels('admin'));
 
         $this->assertContains('test', $result['channels']);
         $this->assertNotContains('security', $result['channels']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | none
| License       | MIT

`ResponseEncoder::encodeUntrusted()` was applied to `monolog-tail` and `monolog-search` but not to
`monolog-list-files` and `monolog-list-channels`, which read the same directory in the same class.
Both now use it too.

A security marker that covers half a class cannot be relied on. Nothing released ever returned the
bare shape, so this is a plain bug fix within the unreleased `0.13` work.
