### PR TITLE
[Mate] Add the missing .gitattributes to the two Mate packages

### DIFF
--- a/src/mate/.gitattributes
+++ b/src/mate/.gitattributes
@@ -1,0 +1,8 @@
+/.github export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpstan.dist.neon export-ignore
+phpunit.xml.dist export-ignore
+CLAUDE.md export-ignore
+AGENTS.md export-ignore

--- a/src/mate/composer-plugin/.gitattributes
+++ b/src/mate/composer-plugin/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

`symfony/ai-mate` and `symfony/ai-mate-composer-plugin` are the only two of the 91 packages in
this repo without a `.gitattributes`, so their dist tarballs ship `tests/`, `phpunit.xml.dist`,
`phpstan.dist.neon`, the split repo's `.github/` and the contributor `AGENTS.md`/`CLAUDE.md` into
every user's `vendor/`.

Copied from `src/agent/.gitattributes`, plus the bridges' form for the plugin. Verified with
`git archive`: the dist now contains only `bin`, `resources`, `skills`, `src`, `composer.json`,
`INSTRUCTIONS.md`, `README.md`, `CHANGELOG.md` and `LICENSE`.
