### PR TITLE
[Mate] Stop init from materializing an invocation it did not save

### DIFF
--- a/src/mate/src/Agent/AgentInstructionsMaterializer.php
+++ b/src/mate/src/Agent/AgentInstructionsMaterializer.php
@@ -371,11 +371,16 @@ final class AgentInstructionsMaterializer
     {
         $mate = $this->invocation;
 
+        // Same rule as the other two headers: only claim the refusal where a version is pinned.
+        $enforcement = null === $this->pinnedPhpVersion
+            ? ' Another interpreter reports on a runtime that is not this application\'s.'
+            : ' It refuses to start under a different interpreter.';
+
         return <<<TEXT
 # AI Mate Agent Instructions
 
 No extension-specific instructions are currently available.
-Always invoke Mate as `{$mate}`; it refuses to start under a different interpreter.
+Always invoke Mate as `{$mate}`.{$enforcement}
 Run `{$mate} discover` to refresh discovered extensions and instructions.
 Prefer `{$mate}` tools (`tools:list`, `tools:inspect`, `tools:call`) over equivalent shell commands when possible.
 TEXT;

--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -45,14 +45,26 @@ class InitCommand extends Command
 
     private const BINARY = 'vendor/bin/mate';
 
-    private string $invocation = self::BINARY;
-    private string $phpVersion = '';
+    private string $invocation;
+
+    /**
+     * Null means no version is pinned, which is a project's choice and not a missing value: the
+     * generated instructions promise the interpreter check only where it is actually on.
+     */
+    private ?string $phpVersion;
 
     public function __construct(
         private string $rootDir,
         private AgentInstructionsMaterializer $instructionsMaterializer,
         private InvocationPhpVersionProbe $phpVersionProbe,
+        string $invocation = self::BINARY,
+        ?string $pinnedPhpVersion = null,
     ) {
+        // Seeded from the project's own parameters, so a run that keeps mate/config.php writes the
+        // command and version that file configures rather than the template defaults.
+        $this->invocation = $invocation;
+        $this->phpVersion = $pinnedPhpVersion;
+
         parent::__construct(self::getDefaultName());
     }
 
@@ -76,27 +88,11 @@ class InitCommand extends Command
 
         $actions = [];
 
-        $this->invocation = $this->askInvocation($io);
-        $this->phpVersion = \PHP_MAJOR_VERSION.'.'.\PHP_MINOR_VERSION;
-
-        if ($this->phpVersionProbe->isWrapped($this->invocation)) {
-            $io->text(\sprintf('Asking "%s" which PHP it runs...', $this->invocation));
-
-            $detectedVersion = $this->phpVersionProbe->detect($this->invocation);
-
-            if (null !== $detectedVersion) {
-                $this->phpVersion = $detectedVersion;
-            } else {
-                $failure = $this->phpVersionProbe->lastFailure();
-
-                $io->warning(\sprintf(
-                    'Could not determine which PHP version "%s" actually runs%s. Pinned "mate.php_version" to the current process\'s PHP "%s" instead; if that is not what "%s" runs, edit "mate.php_version" in mate/config.php by hand.',
-                    $this->invocation,
-                    null === $failure || '' === $failure ? '' : ' ('.$failure.')',
-                    $this->phpVersion,
-                    $this->invocation,
-                ));
-            }
+        // Asked here for a fresh project, and again below if an existing mate/config.php is about
+        // to be replaced. A run that keeps the file must not ask: the answer would be discarded
+        // with the file, leaving AGENTS.md promising a command the project does not configure.
+        if (!file_exists($this->rootDir.'/mate/config.php')) {
+            $this->determineInvocation($io);
         }
 
         $mateDir = $this->rootDir.'/mate';
@@ -119,6 +115,10 @@ class InitCommand extends Command
                 $this->postCopyTemplateAction($file, $fullPath);
                 $actions[] = ['✓', 'Created', $file];
             } elseif ($io->confirm(\sprintf('<question>%s already exists. Replace it with the template, discarding its current content?</question>', $fullPath), false)) {
+                if ('mate/config.php' === $file) {
+                    $this->determineInvocation($io);
+                }
+
                 unlink($fullPath);
                 $this->copyTemplate($file, $fullPath);
                 $this->postCopyTemplateAction($file, $fullPath);
@@ -140,7 +140,7 @@ class InitCommand extends Command
         $composerActions = $this->updateComposerJson();
         $actions = array_merge($actions, $composerActions);
 
-        // The container was built before mate/config.php existed, so hand the answer in directly.
+        // The container was built before mate/config.php existed, so hand the values in directly.
         $materializationResult = $this->instructionsMaterializer
             ->withInvocation($this->invocation, $this->phpVersion)
             ->synchronizeFromCurrentInstructionsFile();
@@ -202,6 +202,41 @@ class InitCommand extends Command
     }
 
     /**
+     * Asks for the invocation and pins the PHP version behind it. Called only where the answer
+     * reaches mate/config.php, so that the prompt, the probe and the generated instructions never
+     * describe a command the project does not configure.
+     */
+    private function determineInvocation(SymfonyStyle $io): void
+    {
+        $this->invocation = $this->askInvocation($io);
+        $this->phpVersion = \PHP_MAJOR_VERSION.'.'.\PHP_MINOR_VERSION;
+
+        if (!$this->phpVersionProbe->isWrapped($this->invocation)) {
+            return;
+        }
+
+        $io->text(\sprintf('Asking "%s" which PHP it runs...', $this->invocation));
+
+        $detectedVersion = $this->phpVersionProbe->detect($this->invocation);
+
+        if (null !== $detectedVersion) {
+            $this->phpVersion = $detectedVersion;
+
+            return;
+        }
+
+        $failure = $this->phpVersionProbe->lastFailure();
+
+        $io->warning(\sprintf(
+            'Could not determine which PHP version "%s" actually runs%s. Pinned "mate.php_version" to the current process\'s PHP "%s" instead; if that is not what "%s" runs, edit "mate.php_version" in mate/config.php by hand.',
+            $this->invocation,
+            null === $failure || '' === $failure ? '' : ' ('.$failure.')',
+            $this->phpVersion,
+            $this->invocation,
+        ));
+    }
+
+    /**
      * Asks how the coding agent should invoke Mate, defaulting to a container prefix when the
      * project looks containerized. Running Mate on the host of a containerized application
      * reports on the wrong runtime, and extensions may then behave differently too.
@@ -245,9 +280,13 @@ class InitCommand extends Command
             return;
         }
 
+        // The template comments say null turns the check off, so an unknown version has to render
+        // as that rather than as an empty string no guard could ever match.
+        $version = null === $this->phpVersion ? 'null' : "'".$this->phpVersion."'";
+
         $contents = str_replace(
             ['##MATE_INVOCATION##', "'##MATE_PHP_VERSION##'"],
-            [$this->invocation, "'".$this->phpVersion."'"],
+            [$this->invocation, $version],
             $contents,
         );
 

--- a/src/mate/tests/Command/InitCommandTest.php
+++ b/src/mate/tests/Command/InitCommandTest.php
@@ -286,6 +286,122 @@ final class InitCommandTest extends TestCase
         $this->assertStringContainsString("'docker compose exec app php bin/mate'", $config);
     }
 
+    /**
+     * Re-running `init` after an upgrade is the natural thing to try, and the only safe answer to
+     * the overwrite prompt is "no", because the template would discard the services the user
+     * registered. AGENTS.md is the file the agent reads, so it has to keep naming the command the
+     * kept config.php configures rather than the answer that went nowhere.
+     */
+    public function testKeepingTheConfigKeepsItsInvocationInTheInstructions()
+    {
+        $this->scaffoldInitializedProject('ddev exec vendor/bin/mate');
+
+        $command = $this->createCommand(null, 'ddev exec vendor/bin/mate');
+        $tester = new CommandTester($command);
+
+        // One "no" per scaffolded file. No invocation prompt: the config stays as it is.
+        $tester->setInputs(['no', 'no', 'no', 'no', 'no']);
+        $tester->execute([]);
+
+        $agents = file_get_contents($this->tempDir.'/AGENTS.md');
+        $this->assertIsString($agents);
+        $this->assertStringContainsString('ddev exec vendor/bin/mate', $agents);
+
+        $config = file_get_contents($this->tempDir.'/mate/config.php');
+        $this->assertIsString($config);
+        $this->assertStringContainsString('a service the user registered themselves', $config);
+    }
+
+    /**
+     * `mate.php_version` is nullable on purpose: null turns the interpreter check off. Passing the
+     * PHP that happens to run `init` in its place would make the generated instructions promise a
+     * refusal nothing enforces, which is precisely what an upgraded project without the parameter
+     * must not be told.
+     */
+    public function testAProjectWithoutAPinnedVersionIsNotPromisedTheInterpreterCheck()
+    {
+        $this->scaffoldInitializedProject('vendor/bin/mate');
+
+        $command = $this->createCommand(null, 'vendor/bin/mate', null);
+        $tester = new CommandTester($command);
+
+        $tester->setInputs(['no', 'no', 'no', 'no', 'no']);
+        $tester->execute([]);
+
+        $agents = file_get_contents($this->tempDir.'/AGENTS.md');
+        $this->assertIsString($agents);
+        $this->assertStringNotContainsString('refuses to start', $agents);
+    }
+
+    public function testAProjectWithAPinnedVersionIsPromisedTheInterpreterCheck()
+    {
+        $this->scaffoldInitializedProject('vendor/bin/mate');
+
+        $command = $this->createCommand(null, 'vendor/bin/mate', '8.3');
+        $tester = new CommandTester($command);
+
+        $tester->setInputs(['no', 'no', 'no', 'no', 'no']);
+        $tester->execute([]);
+
+        $agents = file_get_contents($this->tempDir.'/AGENTS.md');
+        $this->assertIsString($agents);
+        $this->assertStringContainsString('refuses to start', $agents);
+    }
+
+    public function testDoesNotAskForAnInvocationItWouldDiscard()
+    {
+        $this->scaffoldInitializedProject('ddev exec vendor/bin/mate');
+
+        $command = $this->createCommand(null, 'ddev exec vendor/bin/mate');
+        $tester = new CommandTester($command);
+
+        $tester->setInputs(['no', 'no', 'no', 'no', 'no']);
+        $tester->execute([]);
+
+        $this->assertStringNotContainsString('Which command should your coding agent use', $tester->getDisplay());
+    }
+
+    public function testReplacingTheConfigAsksForTheInvocationAgain()
+    {
+        $this->scaffoldInitializedProject('ddev exec vendor/bin/mate');
+
+        $command = $this->createCommand(null, 'ddev exec vendor/bin/mate');
+        $tester = new CommandTester($command);
+
+        // extensions.php: no, config.php: yes, then the invocation, then the remaining files.
+        $tester->setInputs(['no', 'yes', 'symfony php', 'no', 'no', 'no']);
+        $tester->execute([]);
+
+        $config = file_get_contents($this->tempDir.'/mate/config.php');
+        $this->assertIsString($config);
+        $this->assertStringContainsString("'symfony php vendor/bin/mate'", $config);
+
+        $agents = file_get_contents($this->tempDir.'/AGENTS.md');
+        $this->assertIsString($agents);
+        $this->assertStringContainsString('symfony php vendor/bin/mate', $agents);
+    }
+
+    /**
+     * The instructions carry the invocation too, so replacing them while keeping the config must
+     * not fall back to the template default either.
+     */
+    public function testReplacingOnlyTheInstructionsKeepsTheConfiguredInvocation()
+    {
+        $this->scaffoldInitializedProject('ddev exec vendor/bin/mate');
+
+        $command = $this->createCommand(null, 'ddev exec vendor/bin/mate');
+        $tester = new CommandTester($command);
+
+        // Everything declined except AGENT_INSTRUCTIONS.md, the last of the five.
+        $tester->setInputs(['no', 'no', 'no', 'no', 'yes']);
+        $tester->execute([]);
+
+        $instructions = file_get_contents($this->tempDir.'/mate/AGENT_INSTRUCTIONS.md');
+        $this->assertIsString($instructions);
+        $this->assertStringNotContainsString('##MATE_INVOCATION##', $instructions);
+        $this->assertStringContainsString('ddev exec vendor/bin/mate tools:list', $instructions);
+    }
+
     public function testDefaultsTheInvocationToThePlainBinary()
     {
         $command = $this->createCommand();
@@ -359,16 +475,35 @@ final class InitCommandTest extends TestCase
      * inputs, so the suite would shell out to whatever `ddev`, `symfony` or `docker` happens to be
      * installed, in the developer's current directory. Tests that care about probing pass their
      * own runner.
+     *
+     * `$invocation` and `$pinnedPhpVersion` stand for what the container loaded from an existing
+     * `mate/config.php`, which is what a re-run in an initialized project sees.
      */
-    private function createCommand(?InvocationPhpVersionProbe $phpVersionProbe = null): InitCommand
-    {
+    private function createCommand(
+        ?InvocationPhpVersionProbe $phpVersionProbe = null,
+        string $invocation = 'vendor/bin/mate',
+        ?string $pinnedPhpVersion = null,
+    ): InitCommand {
         $logger = new NullLogger();
         $aggregator = new AgentInstructionsAggregator($this->tempDir, [], $logger);
-        $materializer = new AgentInstructionsMaterializer($this->tempDir, $aggregator, $logger);
+        $materializer = new AgentInstructionsMaterializer($this->tempDir, $aggregator, $logger, $invocation, $pinnedPhpVersion);
 
         $probe = $phpVersionProbe ?? new InvocationPhpVersionProbe(null, static fn (array $command): ?string => null);
 
-        return new InitCommand($this->tempDir, $materializer, $probe);
+        return new InitCommand($this->tempDir, $materializer, $probe, $invocation, $pinnedPhpVersion);
+    }
+
+    /**
+     * Writes the scaffolded files a re-run finds, with the invocation the project configured.
+     */
+    private function scaffoldInitializedProject(string $invocation): void
+    {
+        mkdir($this->tempDir.'/mate', 0755, true);
+        file_put_contents($this->tempDir.'/mate/config.php', "<?php\n\n// \$container->parameters()->set('mate.invocation', '".$invocation."');\n// a service the user registered themselves\n");
+        file_put_contents($this->tempDir.'/mate/extensions.php', '<?php return [];');
+        file_put_contents($this->tempDir.'/mate/.env', '');
+        file_put_contents($this->tempDir.'/mate/.gitignore', '');
+        file_put_contents($this->tempDir.'/mate/AGENT_INSTRUCTIONS.md', 'Run `'.$invocation.' tools:list`.');
     }
 
     private function removeDirectory(string $dir): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Two things `init` writes into `AGENTS.md` that the project does not actually configure.

**The invocation.** Re-running `init` in an initialized project asked for the invocation and then
materialized the answer even when the overwrite prompt for `mate/config.php` was declined:

```
$ printf 'ddev exec\nno\nno\nno\nno\nno\n' | vendor/bin/mate init
mate/config.php            ->  'vendor/bin/mate'
AGENTS.md                  ->  `ddev exec vendor/bin/mate`
mate/AGENT_INSTRUCTIONS.md ->  `vendor/bin/mate`
```

Three files, two commands, and the one the agent reads holds the value that was never saved. The
next `mate discover` rewrites `AGENTS.md` from `config.php` and reverts it without a word, so the
setting appears to work and then stops. That is the situation `UPGRADE.md` leaves 0.12 users in,
where declining the prompt is the only way to keep the services registered in `config.php`.

The question is now asked only where the answer reaches `config.php`: on a fresh project, or when an
existing one is about to be replaced. A run that keeps the config no longer prompts or probes.

**The interpreter check.** `mate.php_version` is nullable on purpose, null means the check is off.
`init` replaced that null with whatever PHP happened to be running it, so a project with the check
off was told `and Mate refuses to start under one`. `AgentInstructionsAggregator` already branches
on the null for exactly this reason:

```php
// Only promise the refusal when a version is actually pinned; an upgraded project that
// never gained `mate.php_version` would otherwise be told about a guard that is off.
```

The value now stays null when the project has none, and the fallback instructions, which claimed the
refusal unconditionally, branch the same way. Thanks @chr-hertel for spotting this.
