### PR TITLE
[MCP Bundle] Publish the registry's changes to the configured notification bus

### DIFF
--- a/src/mcp-bundle/composer.json
+++ b/src/mcp-bundle/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "mcp/sdk": "^0.8",
+        "mcp/sdk": "^0.8.1",
         "php-http/discovery": "^1.20",
         "symfony/config": "^7.3|^8.0",
         "symfony/console": "^7.3|^8.0",

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -39,6 +39,7 @@ use Mcp\Server\Session\Psr16SessionStore;
 use Mcp\Server\Subscription\InMemoryNotificationBus;
 use Mcp\Server\Subscription\NotificationBusInterface;
 use Mcp\Server\Subscription\Psr16NotificationBus;
+use Mcp\Server\Subscription\PublishingEventDispatcher;
 use Mcp\Server\Wire\CachePolicy;
 use Symfony\AI\McpBundle\App\McpAppRenderer;
 use Symfony\AI\McpBundle\Attribute\AsMcpApp;
@@ -358,7 +359,7 @@ final class McpBundle extends AbstractBundle
         $sessionId = $this->configureSessionStore($name, $server['session'], $container);
 
         $container->register($registryId, Registry::class)
-            ->setArguments([new Reference('event_dispatcher'), new Reference('logger')])
+            ->setArguments([$this->registryDispatcher($name, $server['subscriptions']), new Reference('logger')])
             ->addTag('monolog.logger', ['channel' => 'mcp']);
 
         $container->register($builderId, Builder::class)
@@ -489,7 +490,7 @@ final class McpBundle extends AbstractBundle
             $builder->addMethodCall('setCachePolicy', [$policy]);
         }
 
-        if ('none' !== $server['subscriptions']['bus']) {
+        if (self::publishesNotifications($server['subscriptions'])) {
             $builder
                 ->addMethodCall('setNotificationBus', [$this->notificationBus($name, $server['subscriptions'], $container)])
                 ->addMethodCall('setSubscriptionLifetime', [$server['subscriptions']['lifetime']]);
@@ -504,11 +505,51 @@ final class McpBundle extends AbstractBundle
     }
 
     /**
+     * One predicate for both halves, so the registry and the protocol cannot disagree about
+     * whether there is a bus.
+     *
+     * @param array{bus: string, cache_pool: string, lifetime: float} $subscriptions
+     */
+    private static function publishesNotifications(array $subscriptions): bool
+    {
+        return 'none' !== $subscriptions['bus'];
+    }
+
+    private static function notificationBusId(string $name): string
+    {
+        return \sprintf('mcp.server.%s.notification_bus', $name);
+    }
+
+    /**
+     * The dispatcher a server's registry announces its changes to.
+     *
+     * The SDK wraps the dispatcher in a {@see PublishingEventDispatcher} itself, but only around a
+     * registry it builds, and this bundle always supplies one — so without this the configured bus
+     * is read by every stream and written to by nothing.
+     *
+     * Per server, because the registries are per server.
+     *
+     * @param array{bus: string, cache_pool: string, lifetime: float} $subscriptions
+     */
+    private function registryDispatcher(string $name, array $subscriptions): Reference|Definition
+    {
+        if (!self::publishesNotifications($subscriptions)) {
+            return new Reference('event_dispatcher');
+        }
+
+        // By id: the bus is registered after this, and a forward reference resolves fine.
+        return new Definition(PublishingEventDispatcher::class, [
+            new Reference(self::notificationBusId($name)),
+            new Reference('event_dispatcher'),
+        ]);
+    }
+
+    /**
      * @param array{bus: string, cache_pool: string, lifetime: float} $subscriptions
      */
     private function notificationBus(string $name, array $subscriptions, ContainerBuilder $container): Reference
     {
-        $id = \sprintf('mcp.server.%s.notification_bus', $name);
+        $id = self::notificationBusId($name);
 
         if ('memory' === $subscriptions['bus']) {
             $container->register($id, InMemoryNotificationBus::class);
@@ -527,8 +568,8 @@ final class McpBundle extends AbstractBundle
                 ->addTag('monolog.logger', ['channel' => 'mcp']);
         }
 
-        // The SDK publishes registry changes itself; everything else — "notifications/resources/updated"
-        // above all — is the application calling publish(), so the bus has to be reachable.
+        // registryDispatcher() publishes the registry's own changes; everything else is the
+        // application calling publish(), so the bus has to be reachable.
         $container->registerAliasForArgument($id, NotificationBusInterface::class, $name.' notification bus');
 
         return new Reference($id);

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -30,6 +30,7 @@ use Mcp\Server\Stateless\StatelessProtocol;
 use Mcp\Server\Subscription\InMemoryNotificationBus;
 use Mcp\Server\Subscription\NotificationBusInterface;
 use Mcp\Server\Subscription\Psr16NotificationBus;
+use Mcp\Server\Subscription\PublishingEventDispatcher;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -750,6 +751,53 @@ class McpBundleTest extends TestCase
         // to surface as an unknown service rather than as a silently working cache.
         $this->assertSame('app.my_psr16', (string) $container->getDefinition('mcp.server.default.notification_bus')->getArgument('$cache'));
         $this->assertFalse($container->hasDefinition('app.my_psr16'));
+    }
+
+    public function testTheRegistryPublishesItsChangesToTheConfiguredBus()
+    {
+        $container = $this->buildContainer($this->config([
+            'modern' => ['subscriptions' => ['bus' => 'memory']],
+        ]));
+
+        $dispatcher = $container->getDefinition('mcp.server.modern.registry')->getArgument(0);
+
+        $this->assertInstanceOf(Definition::class, $dispatcher);
+        $this->assertSame(PublishingEventDispatcher::class, $dispatcher->getClass());
+        $this->assertSame('event_dispatcher', (string) $dispatcher->getArgument(1));
+    }
+
+    public function testTheRegistryPublishesToTheSameBusTheProtocolReads()
+    {
+        $container = $this->buildContainer($this->config([
+            'modern' => ['subscriptions' => ['bus' => 'memory']],
+        ]));
+
+        $published = (string) $container->getDefinition('mcp.server.modern.registry')->getArgument(0)->getArgument(0);
+        $read = $this->callsNamed($container, 'setNotificationBus', 'modern');
+
+        $this->assertCount(1, $read);
+        $this->assertSame('mcp.server.modern.notification_bus', $published);
+        $this->assertSame($published, (string) $read[0][1][0]);
+    }
+
+    public function testEachServerPublishesToItsOwnBus()
+    {
+        $container = $this->buildContainer($this->config([
+            'first' => ['subscriptions' => ['bus' => 'memory']],
+            'second' => ['subscriptions' => ['bus' => 'memory']],
+        ]));
+
+        $this->assertNotSame(
+            (string) $container->getDefinition('mcp.server.first.registry')->getArgument(0)->getArgument(0),
+            (string) $container->getDefinition('mcp.server.second.registry')->getArgument(0)->getArgument(0),
+        );
+    }
+
+    public function testTheRegistryUsesThePlainDispatcherWithoutSubscriptions()
+    {
+        $container = $this->buildContainer($this->config(['modern' => []]));
+
+        $this->assertSame('event_dispatcher', (string) $container->getDefinition('mcp.server.modern.registry')->getArgument(0));
     }
 
     public function testNoBusIsRegisteredWhenSubscriptionsAreOff()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

`subscriptions:` configures a notification bus, and the 2026-07-28 protocol reads it: every `subscriptions/listen` stream polls it for the list-changed notifications it agreed to carry. Nothing ever writes to it.

The SDK wires the publishing half itself — `Builder` wraps the event dispatcher in a `PublishingEventDispatcher` when a bus is configured. But it can only wrap a registry it constructs, and this bundle always supplies one (`mcp.server.<name>.registry`, built with Symfony's `event_dispatcher`), so the wrapping never happens. The two halves are each individually right and never meet.

From a client that is worse than an error: the stream opens, the acknowledgment names the types the server agreed to carry, keep-alives arrive for the configured lifetime, and it closes gracefully having carried nothing — whatever changed on the server.

Gives the registry the publishing dispatcher where it is registered, which is the only place the bundle knows both it and the bus. Per server, because the registries are per server.

Requires **mcp/sdk 0.8.1**. Below that the SDK loads a supplied registry without its `loading` guard (modelcontextprotocol/php-sdk#490), so publishing from the registry also publishes every element the load registers — this patch would turn an inert bus into a noisy one.

Found by a demo application that drives its own MCP servers with its own MCP client over a real transport ([chr-hertel/mcp-demo](https://github.com/chr-hertel/mcp-demo)).
