### PR TITLE
[MCP Bundle] Let request_state.key come from an environment variable

### DIFF
--- a/src/mcp-bundle/config/options.php
+++ b/src/mcp-bundle/config/options.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Config\Definition\Configurator;
 
 use Mcp\Schema\Enum\ProtocolVersion;
-use Mcp\Server\Stateless\RequestStateCodec;
 use Symfony\AI\McpBundle\McpBundle;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
@@ -153,15 +152,7 @@ return static function (DefinitionConfigurator $configurator): void {
                             ->addDefaultsIfNotSet()
                             ->info('Signs the state a multi-round-trip answer carries through the client, which has no session to keep progress in. Required for a modern-era server whose handlers return an InputRequiredResult, and for one whose handlers call ClientGateway::elicit() more than once: the second ask has to carry the first answer to the next round.')
                             ->children()
-                                ->stringNode('key')->cannotBeEmpty()->defaultNull()->info('HMAC key, at least 32 bytes. The same value must reach every process that might serve the retry.')
-                                    ->validate()
-                                        // Only a literal is measurable: a container parameter is resolved before
-                                        // this runs, and an env one has no value until runtime, so it is skipped
-                                        // rather than measured as the placeholder string it still is here.
-                                        ->ifTrue(static fn (?string $v): bool => null !== $v && 1 !== preg_match('/^%[^%]+%$/', $v) && \strlen($v) < RequestStateCodec::MINIMUM_KEY_BYTES)
-                                        ->thenInvalid(\sprintf('The "request_state.key" must be at least %d bytes: below that the signature protecting the carried state is forgeable, and the SDK refuses it.', RequestStateCodec::MINIMUM_KEY_BYTES))
-                                    ->end()
-                                ->end()
+                                ->stringNode('key')->defaultNull()->info('HMAC key, at least 32 bytes. The same value must reach every process that might serve the retry.')->end()
                                 ->integerNode('ttl')->min(1)->defaultValue(600)->info('Seconds a minted state stays valid.')->end()
                             ->end()
                         ->end()

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -36,6 +36,7 @@ use Mcp\Server\Handler\Request\RequestHandlerInterface;
 use Mcp\Server\Session\FileSessionStore;
 use Mcp\Server\Session\InMemorySessionStore;
 use Mcp\Server\Session\Psr16SessionStore;
+use Mcp\Server\Stateless\RequestStateCodec;
 use Mcp\Server\Subscription\InMemoryNotificationBus;
 use Mcp\Server\Subscription\NotificationBusInterface;
 use Mcp\Server\Subscription\Psr16NotificationBus;
@@ -469,8 +470,12 @@ final class McpBundle extends AbstractBundle
     {
         $builder = $container->getDefinition($builderId);
 
-        if (null !== $server['request_state']['key']) {
-            $builder->addMethodCall('setRequestState', [$server['request_state']['key'], $server['request_state']['ttl']]);
+        if (null !== $key = $server['request_state']['key']) {
+            if (1 !== preg_match('/^%[^%]+%$/', $container->resolveEnvPlaceholders($key)) && \strlen($key) < RequestStateCodec::MINIMUM_KEY_BYTES) {
+                throw new LogicException(\sprintf('The "request_state.key" of server "%s" must be at least %d bytes, got %d: below that the signature protecting the carried state is forgeable, and the SDK refuses it.', $name, RequestStateCodec::MINIMUM_KEY_BYTES, \strlen($key)));
+            }
+
+            $builder->addMethodCall('setRequestState', [$key, $server['request_state']['ttl']]);
         }
 
         // "private, immediately stale" is what the SDK does without a policy, so only a

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -43,8 +43,11 @@ use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass;
+use Symfony\Component\DependencyInjection\Compiler\ValidateEnvPlaceholdersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -636,7 +639,7 @@ class McpBundleTest extends TestCase
 
     public function testAShortRequestStateKeyIsRejectedWhenTheContainerIsCompiled()
     {
-        $this->expectException(InvalidConfigurationException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessageMatches('/must be at least 32 bytes/');
 
         $this->buildContainer($this->config(['modern' => ['request_state' => ['key' => 'too-short']]]));
@@ -645,9 +648,8 @@ class McpBundleTest extends TestCase
     public function testAnEnvPlaceholderKeyIsNotMeasured()
     {
         // Its length is unknowable at compile time, so the check must not turn a valid config
-        // into an error. Symfony also skips validation while handling a registered placeholder,
-        // but that only happens once the container's env machinery has run — the guard is what
-        // makes the rule hold everywhere, including here.
+        // into an error. Here the reference is still written as it was configured; the test below
+        // covers the other shape it takes, once a kernel's env machinery has registered it.
         $container = $this->buildContainer($this->config([
             'modern' => ['request_state' => ['key' => '%env(MCP_REQUEST_STATE_KEY)%']],
         ]));
@@ -656,6 +658,35 @@ class McpBundleTest extends TestCase
             [['%env(MCP_REQUEST_STATE_KEY)%', 600]],
             array_column($this->callsNamed($container, 'setRequestState', 'modern'), 1),
         );
+    }
+
+    public function testAnEnvPlaceholderKeySurvivesTheRealCompilationPath()
+    {
+        // The test above builds the container by hand, so the config component never learns it is
+        // handling a placeholder and the node's validator is simply reached and skipped. A kernel
+        // runs ValidateEnvPlaceholdersPass, which re-processes the configuration with the
+        // placeholder registered — and there cannotBeEmpty() on a validated node refuses every env
+        // variable outright, before the validator gets a say.
+        $container = new ContainerBuilder(new EnvPlaceholderParameterBag());
+        $container->setParameter('kernel.debug', true);
+        $container->setParameter('kernel.environment', 'test');
+        $container->setParameter('kernel.build_dir', 'public');
+        $container->setParameter('kernel.project_dir', '/path/to/project');
+
+        $container->registerExtension((new McpBundle())->getContainerExtension());
+        $container->prependExtensionConfig('mcp', $this->config([
+            'modern' => ['request_state' => ['key' => '%env(MCP_REQUEST_STATE_KEY)%']],
+        ])['mcp']);
+
+        (new MergeExtensionConfigurationPass(['mcp']))->process($container);
+        (new ValidateEnvPlaceholdersPass())->process($container);
+
+        // The placeholder has been swapped for the unique id the parameter bag resolves at
+        // runtime, so what is asserted is that the key arrived at all and still names the variable.
+        $calls = array_column($this->callsNamed($container, 'setRequestState', 'modern'), 1);
+        $this->assertCount(1, $calls);
+        $this->assertStringContainsString('MCP_REQUEST_STATE_KEY', $calls[0][0]);
+        $this->assertSame(600, $calls[0][1]);
     }
 
     public function testCacheHintsAreBuiltAsAPolicy()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

`request_state.key` signs the state a multi-round-trip answer carries through the client. It is an HMAC secret, and `docs/bundles/mcp-bundle.rst` shows it arriving the way a Symfony secret does:

```yaml
request_state:
    key: '%env(MCP_REQUEST_STATE_KEY)%'
```

That configuration cannot be compiled. `cache:clear` fails with:

> The path `mcp.servers.modern.request_state.key` cannot contain an environment variable when empty values are not allowed by definition and are validated.

`VariableNode::finalizeValue()` refuses a registered env placeholder outright on any node that is both `cannotBeEmpty()` and carries a `->validate()`, before the validator runs at all. So the only expressible way to set the key was to inline the secret in a committed file — for the one option in the bundle that is explicitly a secret.

### Why dropping `cannotBeEmpty()` is not the fix

`ValidateEnvPlaceholdersPass` re-processes the whole configuration with the placeholder **substituted for a sample value**, so the length check then measures `''` and refuses that instead. The guard the check already carries — a regex for `%…%` — cannot match at that point, because the placeholder is gone by the time the validator sees it.

A config-tree validator is structurally unable to tell a short literal from an env reference, which is exactly the distinction this check exists to make.

### The fix

The check moves to `McpBundle::configureModernEra()`, where `resolveEnvPlaceholders()` turns a registered placeholder back into `%env(NAME)%` and a reference written in the configuration is still in that form anyway. What is left to measure is exactly the literals, which is what the documentation promises.

Behaviour is otherwise unchanged: a short literal key is still refused when the container is built. It becomes the bundle's own `LogicException` rather than an `InvalidConfigurationException`, in line with the other compile-time refusals in `McpBundle` (duplicate HTTP paths, shared session stores). Not a BC break — every configuration that compiled before compiles now, and the option is unreleased.

### Tests

`testAnEnvPlaceholderKeyIsNotMeasured` passes today because it builds the container by hand, and a container built by hand never registers the placeholder — which is why the bug shipped with a test that looks like it covers it. Its new sibling runs `MergeExtensionConfigurationPass` and `ValidateEnvPlaceholdersPass`, the path a kernel takes and the only one where the bug exists. Reverting the fix turns it red.

Found by [chr-hertel/mcp-demo](https://github.com/chr-hertel/mcp-demo), which configures the key from the environment because the same value has to reach every process that might serve the retry.
