### PR TITLE
[MCP Bundle] Fix invalid null values in the docs reference config

### DIFF
--- a/docs/bundles/mcp-bundle.rst
+++ b/docs/bundles/mcp-bundle.rst
@@ -986,7 +986,7 @@ Configuration
                     name: 'acme-research' # (default: the configuration key)
                     version: '1.0.0'
                     description: null
-                protocol_version: null # MCP protocol version to negotiate (default: the SDK default)
+                # protocol_version: '2026-07-28' # MCP protocol version to negotiate (default: the SDK default)
                 capabilities:
                     roots_list_changed: false # The "roots" capability itself follows the handler below
                 roots: null # Service id implementing RootsCallbackInterface; enables the capability
@@ -1006,7 +1006,7 @@ Configuration
                         headers:
                             Authorization: 'Bearer %env(GITHUB_MCP_TOKEN)%'
                         http_client: null # Service id of a PSR-18 client (default: psr18.http_client)
-                        max_sse_buffer_bytes: null # Bytes buffered per SSE event (default: the SDK value)
+                        # max_sse_buffer_bytes: 1048576 # Bytes buffered per SSE event (default: the SDK value)
                         request_timeout: 300 # Overrides the client-level value
 
                     filesystem:
@@ -1017,7 +1017,7 @@ Configuration
                         env: # Environment variables for the child process
                             LOG_LEVEL: 'debug'
                         inherit_env: true # Merge "env" over the current environment instead of replacing it
-                        max_buffer_size: null # Bytes buffered per line (default: the SDK value)
+                        # max_buffer_size: 1048576 # Bytes buffered per line (default: the SDK value)
 
 Logging Configuration
 ---------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

The annotated reference configuration in `docs/bundles/mcp-bundle.rst` showed `null` for three options whose nodes reject it, so copy-pasting the block fails config validation:

* `clients.*.protocol_version` — enum node, `null` is not a permissible value
* `clients.*.servers.*.max_sse_buffer_bytes` — integer node
* `clients.*.servers.*.max_buffer_size` — integer node

All three use `defaultNull()`, which only applies when the key is absent, so they are now shown commented out with an example value and the documented default kept intact.