### PR TITLE
[Examples] Read agent answers through the typed result accessors

### DIFF
--- a/examples/agent/execution-iterable.php
+++ b/examples/agent/execution-iterable.php
@@ -32,7 +32,9 @@ $agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('What date and time is it? Answer in one sentence.'));
 
 // call() returns a lazy execution: every step the agent takes is yielded as an update
-foreach ($agent->call($messages, ['stream' => true]) as $update) {
+$execution = $agent->call($messages, ['stream' => true]);
+
+foreach ($execution as $update) {
     if ($update instanceof Progress) {
         echo match ($update->getStage()) {
             // the answer is streamed token by token
@@ -43,6 +45,6 @@ foreach ($agent->call($messages, ['stream' => true]) as $update) {
     }
 
     if ($update instanceof Result) {
-        echo \PHP_EOL.\PHP_EOL.'Final result: '.$update->getResult()->getContent().\PHP_EOL;
+        echo \PHP_EOL.\PHP_EOL.'Final result: '.$execution->asText().\PHP_EOL;
     }
 }

--- a/examples/agent/toolcall-limit.php
+++ b/examples/agent/toolcall-limit.php
@@ -43,7 +43,7 @@ $messages = new MessageBag(
 );
 
 try {
-    $result = $agent->call($messages)->getResult();
+    $answer = $agent->call($messages)->asText();
 } catch (MaxIterationsExceededException $e) {
     echo $e->getMessage().\PHP_EOL;
 
@@ -51,6 +51,6 @@ try {
 }
 
 output()->writeln('<error>Expected the tool call limit to stop the agent, but it returned a result.</error>');
-echo $result->getContent().\PHP_EOL;
+echo $answer.\PHP_EOL;
 
 exit(1);

--- a/examples/agent/toolcall-nested-objects.php
+++ b/examples/agent/toolcall-nested-objects.php
@@ -61,5 +61,5 @@ foreach ($platforms as $model => $platform) {
 
     $result = $agent->call($messages);
 
-    echo $result->getContent().\PHP_EOL;
+    echo $result->asText().\PHP_EOL;
 }

--- a/examples/agent/toolcall-polymorphic-interface.php
+++ b/examples/agent/toolcall-polymorphic-interface.php
@@ -44,7 +44,7 @@ foreach ($platforms as $model => $platform) {
 
     $result = $agent->call($messages);
 
-    echo $userMsg." : \n".$result->getContent().\PHP_EOL.\PHP_EOL;
+    echo $userMsg." : \n".$result->asText().\PHP_EOL.\PHP_EOL;
 
     $userMsg = 'Search for purchase contract number PC-67890 with subsidiary Acme Corp';
     $messages = new MessageBag(
@@ -54,7 +54,7 @@ foreach ($platforms as $model => $platform) {
 
     $result = $agent->call($messages);
 
-    echo $userMsg." : \n".$result->getContent().\PHP_EOL;
+    echo $userMsg." : \n".$result->asText().\PHP_EOL;
 }
 
 // Tool that uses polymorphic interface as parameter

--- a/examples/aimlapi/toolcall.php
+++ b/examples/aimlapi/toolcall.php
@@ -27,4 +27,4 @@ $agent = new Agent($platform, 'google/gemini-2.5-flash', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('Who is the current chancellor of Germany?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/anthropic/server-tools-code-execution-roundtrip.php
+++ b/examples/anthropic/server-tools-code-execution-roundtrip.php
@@ -50,4 +50,4 @@ echo \PHP_EOL;
 output()->writeln('<info>====== Turn 2 ======</info>');
 $messages->add(Message::ofUser('What number did your snippet print? Answer with the number only.'));
 $result = $agent->call($messages, ['tools' => $tools]);
-output()->writeln('<comment>Assistant:</comment> '.$result->getContent());
+output()->writeln('<comment>Assistant:</comment> '.$result->asText());

--- a/examples/anthropic/structured-output-clock.php
+++ b/examples/anthropic/structured-output-clock.php
@@ -48,4 +48,4 @@ $result = $agent->call($messages, ['response_format' => [
     ],
 ]]);
 
-dump($result->getContent());
+dump($result->asObject());

--- a/examples/anthropic/toolcall-parallel.php
+++ b/examples/anthropic/toolcall-parallel.php
@@ -30,7 +30,7 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL.\PHP_EOL;
+echo $result->asText().\PHP_EOL.\PHP_EOL;
 
 // Claude requests all three cities in a single turn, so the tool runs three times.
 echo 'Tool executed for: '.implode(', ', $temperature->calledFor).\PHP_EOL;

--- a/examples/anthropic/toolcall-roundtrip.php
+++ b/examples/anthropic/toolcall-roundtrip.php
@@ -30,17 +30,17 @@ $messages = new MessageBag(
 // plain chat
 $messages->add(Message::ofUser('What is the capital of France?'));
 $result = $agent->call($messages);
-echo 'Turn 1: '.$result->getContent().\PHP_EOL;
+echo 'Turn 1: '.$result->asText().\PHP_EOL;
 $messages->add(Message::ofAssistant($result));
 
 // tool call
 $messages->add(Message::ofUser('What time is it right now?'));
 $result = $agent->call($messages);
-echo 'Turn 2: '.$result->getContent().\PHP_EOL;
+echo 'Turn 2: '.$result->asText().\PHP_EOL;
 $messages->add(Message::ofAssistant($result));
 
 // another chat - the previous assistant turn (tool call + final answer) must be replayed via the
 // Anthropic AssistantMessageNormalizer, including any tool_use / tool_result / thinking blocks.
 $messages->add(Message::ofUser('What was the first question I asked you?'));
 $result = $agent->call($messages);
-echo 'Turn 3: '.$result->getContent().\PHP_EOL;
+echo 'Turn 3: '.$result->asText().\PHP_EOL;

--- a/examples/anthropic/toolcall.php
+++ b/examples/anthropic/toolcall.php
@@ -28,6 +28,6 @@ $agent = new Agent($platform, 'claude-sonnet-4-5-20250929', toolbox: $toolbox, i
 $messages = new MessageBag(Message::ofUser('Who is the current chancellor of Germany?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL.\PHP_EOL;
+echo $result->asText().\PHP_EOL.\PHP_EOL;
 
 print_sources($result->getMetadata()->get('sources'));

--- a/examples/bedrock/toolcall-claude.php
+++ b/examples/bedrock/toolcall-claude.php
@@ -33,4 +33,4 @@ $agent = new Agent($platform, 'claude-sonnet-4-5-20250929', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('Who is the current chancellor of Germany?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/bedrock/toolcall-nova.php
+++ b/examples/bedrock/toolcall-nova.php
@@ -35,4 +35,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -142,6 +142,18 @@ function logger(): LoggerInterface
     };
 }
 
+/**
+ * Whether the example writes to an interactive terminal.
+ *
+ * Live re-rendering with escape sequences like a clear screen only works there: when the
+ * output is captured - by the example runner, a pipe or a replay golden - those sequences
+ * would garble it, so examples fall back to printing the final state once.
+ */
+function is_interactive(): bool
+{
+    return defined('STDOUT') && stream_isatty(\STDOUT);
+}
+
 function output(): ConsoleOutput
 {
     $verbosity = match ($_SERVER['argv'][1] ?? null) {

--- a/examples/cerebras/toolcall.php
+++ b/examples/cerebras/toolcall.php
@@ -26,4 +26,4 @@ $agent = new Agent($platform, 'gpt-oss-120b', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('How many days until next Christmas?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/cohere/toolcall.php
+++ b/examples/cohere/toolcall.php
@@ -26,6 +26,6 @@ $agent = new Agent($platform, 'command-a-03-2025', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('What time is it?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;
 
 print_token_usage($result->getMetadata()->get('token_usage'));

--- a/examples/deepseek/structured-output-clock.php
+++ b/examples/deepseek/structured-output-clock.php
@@ -52,4 +52,4 @@ $result = $agent->call($messages, ['response_format' => [
     ],
 ]]);
 
-dump($result->getContent());
+dump($result->asObject());

--- a/examples/deepseek/toolcall.php
+++ b/examples/deepseek/toolcall.php
@@ -27,4 +27,4 @@ $agent = new Agent($platform, 'deepseek-chat', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('How many days until next Christmas?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/dockermodelrunner/chat.php
+++ b/examples/dockermodelrunner/chat.php
@@ -24,4 +24,4 @@ $messages = new MessageBag(
     Message::ofUser('What is the Symfony framework?'),
 );
 $result = $agent->call($messages);
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/dockermodelrunner/toolcall.php
+++ b/examples/dockermodelrunner/toolcall.php
@@ -27,4 +27,4 @@ $agent = new Agent($platform, 'ai/gemma3n', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('Who is the actual Prime Minister of France?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/gemini/server-tools-code-execution-roundtrip.php
+++ b/examples/gemini/server-tools-code-execution-roundtrip.php
@@ -50,4 +50,4 @@ echo \PHP_EOL;
 output()->writeln('<info>====== Turn 2 ======</info>');
 $messages->add(Message::ofUser('What number did your snippet print? Answer with the number only.'));
 $result = $agent->call($messages, $options);
-output()->writeln('<comment>Assistant:</comment> '.$result->getContent());
+output()->writeln('<comment>Assistant:</comment> '.$result->asText());

--- a/examples/gemini/server-tools-google-maps.php
+++ b/examples/gemini/server-tools-google-maps.php
@@ -33,4 +33,4 @@ $result = $agent->call($messages, [
     ],
 ]);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/gemini/server-tools.php
+++ b/examples/gemini/server-tools.php
@@ -33,4 +33,4 @@ $result = $agent->call($messages, [
     'temperature' => 1.0,
 ]);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/gemini/structured-output-clock.php
+++ b/examples/gemini/structured-output-clock.php
@@ -48,4 +48,4 @@ $result = $agent->call($messages, ['response_format' => [
     ],
 ]]);
 
-dump($result->getContent());
+dump($result->asObject());

--- a/examples/gemini/subagents.php
+++ b/examples/gemini/subagents.php
@@ -59,4 +59,4 @@ $agent = new Agent($platform, 'gemini-2.5-flash', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('I drove 150 kilometers. How many miles is that? Also, what is 150 divided by 8?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/gemini/toolcall-list-result.php
+++ b/examples/gemini/toolcall-list-result.php
@@ -41,4 +41,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/gemini/toolcall.php
+++ b/examples/gemini/toolcall.php
@@ -26,4 +26,4 @@ $agent = new Agent($platform, 'gemini-2.5-flash', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('What time is it?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/memory/mariadb.php
+++ b/examples/memory/mariadb.php
@@ -69,4 +69,4 @@ $agent = new Agent($platform, 'gpt-5-mini', [$memoryProcessor]);
 $messages = new MessageBag(Message::ofUser('Have we discussed about my friend John in the past? If yes, what did we talk about?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/memory/static.php
+++ b/examples/memory/static.php
@@ -34,4 +34,4 @@ $agent = new Agent($platform, 'gpt-5-mini', [$systemPromptProcessor, $memoryProc
 $messages = new MessageBag(Message::ofUser('What do we do today?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/misc/agent-with-cache.php
+++ b/examples/misc/agent-with-cache.php
@@ -33,7 +33,7 @@ $result = $agent->call($messages, [
 
 assert($result->getMetadata()->has('cached'));
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;
 
 // Thanks to the cache adapter and the "prompt_cache_key" key, this call will not trigger any network call
 
@@ -43,4 +43,4 @@ $secondResult = $agent->call($messages, [
 
 assert($secondResult->getMetadata()->has('cached'));
 
-echo $secondResult->getContent().\PHP_EOL;
+echo $secondResult->asText().\PHP_EOL;

--- a/examples/misc/agent-with-external-cache.php
+++ b/examples/misc/agent-with-external-cache.php
@@ -35,7 +35,7 @@ $result = $agent->call($messages, [
 
 assert($result->getMetadata()->has('cached'));
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;
 
 // Thanks to the cache adapter and the "prompt_cache_key" key, this call will not trigger any network call
 
@@ -45,4 +45,4 @@ $secondResult = $agent->call($messages, [
 
 assert($secondResult->getMetadata()->has('cached'));
 
-echo $secondResult->getContent().\PHP_EOL;
+echo $secondResult->asText().\PHP_EOL;

--- a/examples/misc/chat-system-prompt.php
+++ b/examples/misc/chat-system-prompt.php
@@ -25,4 +25,4 @@ $agent = new Agent($platform, 'gpt-5-mini', [$processor]);
 $messages = new MessageBag(Message::ofUser('What is the meaning of life?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/misc/prompt-json-file.php
+++ b/examples/misc/prompt-json-file.php
@@ -28,4 +28,4 @@ $agent = new Agent($platform, 'gpt-5-mini', [$systemPromptProcessor]);
 $messages = new MessageBag(Message::ofUser('Review this code: function add($a, $b) { return $a + $b; }'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/misc/prompt-text-file.php
+++ b/examples/misc/prompt-text-file.php
@@ -28,4 +28,4 @@ $agent = new Agent($platform, 'gpt-5-mini', [$systemPromptProcessor]);
 $messages = new MessageBag(Message::ofUser('Can you explain what dependency injection is?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/mistral/toolcall.php
+++ b/examples/mistral/toolcall.php
@@ -26,4 +26,4 @@ $agent = new Agent($platform, 'mistral-large-latest', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('What time is it?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/multi-agent/orchestrator.php
+++ b/examples/multi-agent/orchestrator.php
@@ -62,11 +62,11 @@ $technicalQuestion = 'I get this error in my php code: "Call to undefined method
 echo "Question: $technicalQuestion\n\n";
 $messages = new MessageBag(Message::ofUser($technicalQuestion));
 $result = $multiAgent->call($messages);
-echo 'Answer: '.substr($result->getContent(), 0, 300).'...'.\PHP_EOL.\PHP_EOL;
+echo 'Answer: '.substr($result->asText(), 0, 300).'...'.\PHP_EOL.\PHP_EOL;
 
 echo "=== General Question ===\n";
 $generalQuestion = 'Can you give me a lasagne recipe?';
 echo "Question: $generalQuestion\n\n";
 $messages = new MessageBag(Message::ofUser($generalQuestion));
 $result = $multiAgent->call($messages);
-echo 'Answer: '.substr($result->getContent(), 0, 300).'...'.\PHP_EOL;
+echo 'Answer: '.substr($result->asText(), 0, 300).'...'.\PHP_EOL;

--- a/examples/ollama/rag.php
+++ b/examples/ollama/rag.php
@@ -57,4 +57,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/ollama/toolcall.php
+++ b/examples/ollama/toolcall.php
@@ -26,4 +26,4 @@ $agent = new Agent($platform, env('OLLAMA_LLM'), toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('What time is it?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/openai/structured-output-clock.php
+++ b/examples/openai/structured-output-clock.php
@@ -48,4 +48,4 @@ $result = $agent->call($messages, ['response_format' => [
     ],
 ]]);
 
-dump($result->getContent());
+dump($result->asObject());

--- a/examples/openai/subagents.php
+++ b/examples/openai/subagents.php
@@ -59,4 +59,4 @@ $agent = new Agent($platform, 'gpt-4o-mini', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('I drove 150 kilometers. How many miles is that? Also, what is 150 divided by 8?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/openai/toolcall.php
+++ b/examples/openai/toolcall.php
@@ -27,4 +27,4 @@ $agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('Please summarize this video for me: https://www.youtube.com/watch?v=6uXW-ulpj0s'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/ovh/toolcall.php
+++ b/examples/ovh/toolcall.php
@@ -27,4 +27,4 @@ $agent = new Agent($platform, 'gpt-oss-120b', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('Please summarize this video for me: https://www.youtube.com/watch?v=6uXW-ulpj0s'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/platform/partial-json-stream.php
+++ b/examples/platform/partial-json-stream.php
@@ -56,25 +56,49 @@ $deferred = $platform->invoke('gpt-4o-mini', $messages, [
 ]);
 
 // Each snapshot is the largest valid JSON value recovered so far: the name
-// appears first, then ingredients trickle in one by one, then the steps. We
-// re-render the whole recipe card on every snapshot so the terminal shows it
-// filling up live instead of dumping the final payload at once.
+// appears first, then ingredients trickle in one by one, then the steps. On an
+// interactive terminal we re-render the whole recipe card on every snapshot so it
+// shows up filling live; when the output is captured - by the example runner or a
+// pipe - the clear-screen escape sequences would garble it, so the card is printed
+// once at the end instead.
+$live = is_interactive();
+$snapshots = 0;
+$latest = null;
+
+/**
+ * @param array{name?: string|null, ingredients?: list<string>, steps?: list<string>} $recipe
+ */
+$render = static function (array $recipe): void {
+    echo '🍕 '.($recipe['name'] ?? '…')."\n\n";
+
+    echo "Ingredients\n-----------\n";
+    foreach ($recipe['ingredients'] ?? [] as $ingredient) {
+        echo '  • '.$ingredient."\n";
+    }
+
+    echo "\nSteps\n-----\n";
+    foreach ($recipe['steps'] ?? [] as $index => $step) {
+        echo sprintf("  %d. %s\n", $index + 1, $step);
+    }
+};
+
 foreach ($deferred->asPartialJsonStream() as $snapshot) {
     if (!is_array($snapshot)) {
         continue;
     }
 
+    ++$snapshots;
+    $latest = $snapshot;
+
+    if (!$live) {
+        continue;
+    }
+
     echo "\033[2J\033[H"; // clear screen and move the cursor to the top-left
+    $render($snapshot);
+}
 
-    echo '🍕 '.($snapshot['name'] ?? '…')."\n\n";
-
-    echo "Ingredients\n-----------\n";
-    foreach ($snapshot['ingredients'] ?? [] as $ingredient) {
-        echo '  • '.$ingredient."\n";
-    }
-
-    echo "\nSteps\n-----\n";
-    foreach ($snapshot['steps'] ?? [] as $index => $step) {
-        echo sprintf("  %d. %s\n", $index + 1, $step);
-    }
+if (!$live && null !== $latest) {
+    echo sprintf("Recovered %d partial snapshots, the last one being:\n\n", $snapshots);
+    $render($latest);
 }

--- a/examples/platform/streaming-structured-output.php
+++ b/examples/platform/streaming-structured-output.php
@@ -34,13 +34,16 @@ $result = $platform->invoke('gpt-4o-mini', $messages, [
 ]);
 
 // Each streamed snapshot is a progressively populated Recipe instance: the name
-// appears first, then ingredients trickle in one by one, then the steps. We
-// re-render the whole recipe card on every snapshot so the terminal shows it
-// filling up live instead of dumping the final object at once.
-foreach ($result->asStreamedObject() as $recipe) {
-    /** @var Recipe $recipe */
-    echo "\033[2J\033[H"; // clear screen and move the cursor to the top-left
+// appears first, then ingredients trickle in one by one, then the steps. On an
+// interactive terminal we re-render the whole recipe card on every snapshot so it
+// shows up filling live; when the output is captured - by the example runner or a
+// pipe - the clear-screen escape sequences would garble it, so the card is printed
+// once at the end instead.
+$live = is_interactive();
+$snapshots = 0;
+$latest = null;
 
+$render = static function (Recipe $recipe): void {
     echo '🍕 '.($recipe->name ?? '…')."\n\n";
 
     echo "Ingredients\n-----------\n";
@@ -52,4 +55,22 @@ foreach ($result->asStreamedObject() as $recipe) {
     foreach ($recipe->steps as $index => $step) {
         echo sprintf("  %d. %s\n", $index + 1, $step);
     }
+};
+
+foreach ($result->asStreamedObject() as $recipe) {
+    /* @var Recipe $recipe */
+    ++$snapshots;
+    $latest = $recipe;
+
+    if (!$live) {
+        continue;
+    }
+
+    echo "\033[2J\033[H"; // clear screen and move the cursor to the top-left
+    $render($recipe);
+}
+
+if (!$live && null !== $latest) {
+    echo sprintf("Received %d streamed snapshots, the last one being:\n\n", $snapshots);
+    $render($latest);
 }

--- a/examples/rag/agentic-search.php
+++ b/examples/rag/agentic-search.php
@@ -173,7 +173,7 @@ echo "--- Agent Search Process ---\n\n";
 $messages = new MessageBag(Message::ofUser($question));
 $result = $agent->call($messages);
 
-echo $result->getContent()."\n\n";
+echo $result->asText()."\n\n";
 
 // 5. Show the final working set
 echo "--- Final Working Set ---\n";

--- a/examples/rag/azuresearch.php
+++ b/examples/rag/azuresearch.php
@@ -63,4 +63,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/cache.php
+++ b/examples/rag/cache.php
@@ -58,4 +58,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/chromadb.php
+++ b/examples/rag/chromadb.php
@@ -65,4 +65,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/clickhouse.php
+++ b/examples/rag/clickhouse.php
@@ -65,4 +65,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/cloudflare.php
+++ b/examples/rag/cloudflare.php
@@ -65,4 +65,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/elasticsearch.php
+++ b/examples/rag/elasticsearch.php
@@ -64,4 +64,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/in-memory.php
+++ b/examples/rag/in-memory.php
@@ -57,4 +57,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/manticore.php
+++ b/examples/rag/manticore.php
@@ -65,4 +65,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/mariadb-gemini.php
+++ b/examples/rag/mariadb-gemini.php
@@ -67,4 +67,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/mariadb-openai.php
+++ b/examples/rag/mariadb-openai.php
@@ -66,4 +66,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/meilisearch.php
+++ b/examples/rag/meilisearch.php
@@ -65,4 +65,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/milvus.php
+++ b/examples/rag/milvus.php
@@ -66,4 +66,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/mongodb.php
+++ b/examples/rag/mongodb.php
@@ -67,4 +67,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/neo4j.php
+++ b/examples/rag/neo4j.php
@@ -68,4 +68,4 @@ $messages = new MessageBag(
 );
 $response = $agent->call($messages);
 
-echo $response->getContent().\PHP_EOL;
+echo $response->asText().\PHP_EOL;

--- a/examples/rag/opensearch.php
+++ b/examples/rag/opensearch.php
@@ -64,4 +64,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/pinecone.php
+++ b/examples/rag/pinecone.php
@@ -58,4 +58,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/postgres.php
+++ b/examples/rag/postgres.php
@@ -65,4 +65,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/qdrant.php
+++ b/examples/rag/qdrant.php
@@ -60,4 +60,4 @@ $messages = new MessageBag(
 );
 $response = $agent->call($messages);
 
-echo $response->getContent().\PHP_EOL;
+echo $response->asText().\PHP_EOL;

--- a/examples/rag/redis.php
+++ b/examples/rag/redis.php
@@ -67,6 +67,6 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;
 
 $store->drop();

--- a/examples/rag/sqlite-vec.php
+++ b/examples/rag/sqlite-vec.php
@@ -73,4 +73,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/sqlite.php
+++ b/examples/rag/sqlite.php
@@ -63,4 +63,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/supabase.php
+++ b/examples/rag/supabase.php
@@ -65,4 +65,4 @@ $messages = new MessageBag(
 
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/surrealdb.php
+++ b/examples/rag/surrealdb.php
@@ -68,4 +68,4 @@ $messages = new MessageBag(
 );
 $response = $agent->call($messages);
 
-echo $response->getContent().\PHP_EOL;
+echo $response->asText().\PHP_EOL;

--- a/examples/rag/typesense.php
+++ b/examples/rag/typesense.php
@@ -65,4 +65,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/vektor.php
+++ b/examples/rag/vektor.php
@@ -60,4 +60,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/rag/weaviate.php
+++ b/examples/rag/weaviate.php
@@ -60,4 +60,4 @@ $messages = new MessageBag(
 );
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/scaleway/responses-toolcall.php
+++ b/examples/scaleway/responses-toolcall.php
@@ -32,4 +32,4 @@ $agent = new Agent($platform, 'gpt-oss-120b', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('What date and time is it right now?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/scaleway/toolcall.php
+++ b/examples/scaleway/toolcall.php
@@ -27,4 +27,4 @@ $agent = new Agent($platform, 'gpt-oss-120b', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('Please summarize this video for me: https://www.youtube.com/watch?v=6uXW-ulpj0s'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/speech/agent-openai-speech-stt.php
+++ b/examples/speech/agent-openai-speech-stt.php
@@ -30,4 +30,4 @@ $answer = $speechAgent->call(new MessageBag(
     Message::ofUser(Audio::fromFile(dirname(__DIR__, 2).'/fixtures/audio.mp3'))
 ));
 
-echo $answer->getContent().\PHP_EOL;
+echo $answer->asText().\PHP_EOL;

--- a/examples/toolbox/clock.php
+++ b/examples/toolbox/clock.php
@@ -29,4 +29,4 @@ $agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('What date and time is it?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/toolbox/firecrawl-crawl.php
+++ b/examples/toolbox/firecrawl-crawl.php
@@ -33,4 +33,4 @@ $agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('Crawl the following URL: https://symfony.com/doc/current/setup.html then resume it in less than 200 words.'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/toolbox/firecrawl-map.php
+++ b/examples/toolbox/firecrawl-map.php
@@ -33,4 +33,4 @@ $agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('Retrieve all the links from https://symfony.com then list only the ones related to the Messenger component.'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/toolbox/firecrawl-scrape.php
+++ b/examples/toolbox/firecrawl-scrape.php
@@ -33,4 +33,4 @@ $agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('Scrape the following URL: https://symfony.com/doc/current/setup.html then resume it in less than 200 words.'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/toolbox/mapbox-geocode.php
+++ b/examples/toolbox/mapbox-geocode.php
@@ -27,4 +27,4 @@ $agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('What are the coordinates of Brandenburg Gate in Berlin?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/toolbox/mapbox-reverse-geocode.php
+++ b/examples/toolbox/mapbox-reverse-geocode.php
@@ -27,4 +27,4 @@ $agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('What address is at coordinates longitude -73.985131, latitude 40.758895?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/toolbox/ollama-web-search.php
+++ b/examples/toolbox/ollama-web-search.php
@@ -26,4 +26,4 @@ $agent = new Agent($platform, env('OLLAMA_LLM'), toolbox: $toolbox);
 
 $result = $agent->call(new MessageBag(Message::ofUser('What is Ollama?')));
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/toolbox/ollama-webpage-fetch.php
+++ b/examples/toolbox/ollama-webpage-fetch.php
@@ -26,4 +26,4 @@ $agent = new Agent($platform, env('OLLAMA_LLM'), toolbox: $toolbox);
 
 $result = $agent->call(new MessageBag(Message::ofUser('Retrieve the content of the ollama.com homepage')));
 
-echo $result->getContent().\PHP_EOL.\PHP_EOL;
+echo $result->asText().\PHP_EOL.\PHP_EOL;

--- a/examples/toolbox/schema-provider.php
+++ b/examples/toolbox/schema-provider.php
@@ -71,4 +71,4 @@ $agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('Search for closed issues'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/toolbox/tavily.php
+++ b/examples/toolbox/tavily.php
@@ -35,6 +35,6 @@ $prompt = <<<PROMPT
 
 $result = $agent->call(new MessageBag(Message::ofUser($prompt)));
 
-echo $result->getContent().\PHP_EOL.\PHP_EOL;
+echo $result->asText().\PHP_EOL.\PHP_EOL;
 
 print_sources($result->getMetadata()->get('sources'));

--- a/examples/toolbox/validation.php
+++ b/examples/toolbox/validation.php
@@ -65,10 +65,10 @@ $agent = new Agent($platform, 'gpt-5-mini', toolbox: $toolbox, eventDispatcher: 
 $messages = new MessageBag(Message::ofUser('Look up the order with reference "ORD-2026-0042", shipping to Berlin, DE.'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;
 
 // The LLM is instructed to use a malformed reference on purpose, to show the #[Schema] pattern being enforced.
 $messages = new MessageBag(Message::ofUser('Look up the order using exactly this reference, unmodified: "not-a-valid-reference", shipping to Berlin, DE.'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/toolbox/weather-event.php
+++ b/examples/toolbox/weather-event.php
@@ -40,4 +40,4 @@ $eventDispatcher->addListener(ToolCallsExecuted::class, static function (ToolCal
 $messages = new MessageBag(Message::ofUser('How is the weather currently in Berlin?'));
 $result = $agent->call($messages);
 
-dump($result->getContent());
+dump($result->asObject());

--- a/examples/vertexai/server-tools-google-maps.php
+++ b/examples/vertexai/server-tools-google-maps.php
@@ -33,4 +33,4 @@ $result = $agent->call($messages, [
     ],
 ]);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;

--- a/examples/vertexai/structured-output-clock.php
+++ b/examples/vertexai/structured-output-clock.php
@@ -48,4 +48,4 @@ $result = $agent->call($messages, ['response_format' => [
     ],
 ]]);
 
-dump($result->getContent());
+dump($result->asObject());

--- a/examples/vertexai/toolcall.php
+++ b/examples/vertexai/toolcall.php
@@ -26,4 +26,4 @@ $agent = new Agent($platform, 'gemini-2.5-flash-lite', toolbox: $toolbox);
 $messages = new MessageBag(Message::ofUser('What time is it?'));
 $result = $agent->call($messages);
 
-echo $result->getContent().\PHP_EOL;
+echo $result->asText().\PHP_EOL;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Follow-up to #2436: reasoning models answer with a `MultiPartResult` of a thinking and a text part, so `getContent()` hands back the parts array and the examples printed `Array` instead of the answer.

* `asText()` for every non-streamed agent answer echoed as a string
* `asObject()` for the structured output examples
* `agent/toolcall-limit.php` and `agent/execution-iterable.php` needed a small reshape to reach a typed accessor

Streamed examples keep `getContent()`, which delegates to `asStream()`.