### PR TITLE
[Examples] Unwrap the execution when replaying the assistant turn

### DIFF
--- a/examples/anthropic/server-tools-code-execution-roundtrip.php
+++ b/examples/anthropic/server-tools-code-execution-roundtrip.php
@@ -31,8 +31,8 @@ $messages = new MessageBag(
     Message::ofUser('Compute the 10th Fibonacci number using a short Python snippet.'),
 );
 
-$result = $agent->call($messages, ['tools' => $tools]);
-$messages->add($assistant = Message::ofAssistant($result));
+$execution = $agent->call($messages, ['tools' => $tools]);
+$messages->add($assistant = Message::ofAssistant($execution->getResult()));
 
 output()->writeln('<info>====== Turn 1 ======</info>');
 foreach ($assistant->getContent() as $part) {
@@ -49,5 +49,5 @@ echo \PHP_EOL;
 
 output()->writeln('<info>====== Turn 2 ======</info>');
 $messages->add(Message::ofUser('What number did your snippet print? Answer with the number only.'));
-$result = $agent->call($messages, ['tools' => $tools]);
-output()->writeln('<comment>Assistant:</comment> '.$result->asText());
+$execution = $agent->call($messages, ['tools' => $tools]);
+output()->writeln('<comment>Assistant:</comment> '.$execution->asText());

--- a/examples/anthropic/toolcall-roundtrip.php
+++ b/examples/anthropic/toolcall-roundtrip.php
@@ -29,18 +29,18 @@ $messages = new MessageBag(
 
 // plain chat
 $messages->add(Message::ofUser('What is the capital of France?'));
-$result = $agent->call($messages);
-echo 'Turn 1: '.$result->asText().\PHP_EOL;
-$messages->add(Message::ofAssistant($result));
+$execution = $agent->call($messages);
+echo 'Turn 1: '.$execution->asText().\PHP_EOL;
+$messages->add(Message::ofAssistant($execution->getResult()));
 
 // tool call
 $messages->add(Message::ofUser('What time is it right now?'));
-$result = $agent->call($messages);
-echo 'Turn 2: '.$result->asText().\PHP_EOL;
-$messages->add(Message::ofAssistant($result));
+$execution = $agent->call($messages);
+echo 'Turn 2: '.$execution->asText().\PHP_EOL;
+$messages->add(Message::ofAssistant($execution->getResult()));
 
 // another chat - the previous assistant turn (tool call + final answer) must be replayed via the
 // Anthropic AssistantMessageNormalizer, including any tool_use / tool_result / thinking blocks.
 $messages->add(Message::ofUser('What was the first question I asked you?'));
-$result = $agent->call($messages);
-echo 'Turn 3: '.$result->asText().\PHP_EOL;
+$execution = $agent->call($messages);
+echo 'Turn 3: '.$execution->asText().\PHP_EOL;

--- a/examples/gemini/server-tools-code-execution-roundtrip.php
+++ b/examples/gemini/server-tools-code-execution-roundtrip.php
@@ -31,8 +31,8 @@ $messages = new MessageBag(
     Message::ofUser('Compute the 10th Fibonacci number using a short Python snippet.'),
 );
 
-$result = $agent->call($messages, $options);
-$messages->add($assistant = Message::ofAssistant($result));
+$execution = $agent->call($messages, $options);
+$messages->add($assistant = Message::ofAssistant($execution->getResult()));
 
 output()->writeln('<info>====== Turn 1 ======</info>');
 foreach ($assistant->getContent() as $part) {
@@ -49,5 +49,5 @@ echo \PHP_EOL;
 
 output()->writeln('<info>====== Turn 2 ======</info>');
 $messages->add(Message::ofUser('What number did your snippet print? Answer with the number only.'));
-$result = $agent->call($messages, $options);
-output()->writeln('<comment>Assistant:</comment> '.$result->asText());
+$execution = $agent->call($messages, $options);
+output()->writeln('<comment>Assistant:</comment> '.$execution->asText());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Three roundtrip examples still passed the lazy `Execution` itself into `Message::ofAssistant()`, which has no mapping for it and throws `Unsupported assistant message part of type "Symfony\AI\Agent\Execution\Execution"`.

Aligned them with the documented pattern used by the rest of the corpus: `Message::ofAssistant($execution->getResult())`.

All three verified live against the Anthropic and Gemini APIs.