### PR TITLE
[Examples][Platform] Fix structured output arrays, CLI errors and stream deltas

### DIFF
--- a/docs/components/platform.rst
+++ b/docs/components/platform.rst
@@ -1254,7 +1254,7 @@ top this example uses the feature through the agent to leverage tool calling::
         ],
     ]]);
 
-    dump($result->getContent()); // returns an array
+    dump($result->asObject()); // returns an array
 
 Populating Existing Object Instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/cohere/toolcall-stream.php
+++ b/examples/cohere/toolcall-stream.php
@@ -15,6 +15,7 @@ use Symfony\AI\Agent\Toolbox\Toolbox;
 use Symfony\AI\Platform\Bridge\Cohere\Factory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 
 require_once dirname(__DIR__).'/bootstrap.php';
 
@@ -28,8 +29,10 @@ $result = $agent->call($messages, [
     'stream' => true,
 ]);
 
-foreach ($result->getContent() as $word) {
-    echo $word;
+foreach ($result->getContent() as $delta) {
+    if ($delta instanceof TextDelta) {
+        echo $delta;
+    }
 }
 
 echo \PHP_EOL;

--- a/examples/elevenlabs/speech-to-text-srt.php
+++ b/examples/elevenlabs/speech-to-text-srt.php
@@ -10,6 +10,7 @@
  */
 
 use Symfony\AI\Platform\Bridge\ElevenLabs\Factory;
+use Symfony\AI\Platform\Bridge\ElevenLabs\Result\Transcript;
 use Symfony\AI\Platform\Message\Content\Audio;
 
 require_once dirname(__DIR__).'/bootstrap.php';
@@ -31,4 +32,8 @@ $result = $platform->invoke(
     ],
 );
 
-echo $result->asObject()->asSubRipText().\PHP_EOL;
+$transcript = $result->asObject();
+
+if ($transcript instanceof Transcript) {
+    echo $transcript->asSubRipText().\PHP_EOL;
+}

--- a/examples/toolbox/confirmation.php
+++ b/examples/toolbox/confirmation.php
@@ -16,6 +16,7 @@ use Symfony\AI\Agent\Toolbox\Toolbox;
 use Symfony\AI\Platform\Bridge\OpenAi\Factory;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
@@ -39,8 +40,10 @@ $messages = new MessageBag(Message::ofUser('First, list the files in this folder
 
 $result = $agent->call($messages, ['stream' => true]);
 
-foreach ($result->getContent() as $chunk) {
-    echo $chunk;
+foreach ($result->getContent() as $delta) {
+    if ($delta instanceof TextDelta) {
+        echo $delta;
+    }
 }
 
 echo \PHP_EOL;

--- a/src/platform/src/Bridge/ClaudeCode/RawProcessResult.php
+++ b/src/platform/src/Bridge/ClaudeCode/RawProcessResult.php
@@ -40,7 +40,7 @@ final class RawProcessResult implements RawResultInterface
         $this->process->wait();
 
         if (!$this->process->isSuccessful()) {
-            throw new RuntimeException(\sprintf('Claude Code CLI process failed: "%s"', $this->process->getErrorOutput()));
+            throw $this->createFailureException();
         }
 
         $output = $this->process->getOutput();
@@ -131,13 +131,57 @@ final class RawProcessResult implements RawResultInterface
         }
 
         if (!$this->process->isSuccessful()) {
-            throw new RuntimeException(\sprintf('Claude Code CLI process failed: "%s"', $this->process->getErrorOutput()));
+            throw $this->createFailureException();
         }
     }
 
     public function getObject(): Process
     {
         return $this->process;
+    }
+
+    /**
+     * The CLI reports why it stopped in the final `type=result` event on stdout, while
+     * stderr often only carries unrelated warnings, e.g. about the active auth source.
+     */
+    private function createFailureException(): RuntimeException
+    {
+        $reason = $this->extractResultError() ?? trim($this->process->getErrorOutput());
+
+        if ('' === $reason) {
+            $reason = \sprintf('exit code %d', $this->process->getExitCode() ?? -1);
+        }
+
+        return new RuntimeException(\sprintf('Claude Code CLI process failed: "%s"', $reason));
+    }
+
+    private function extractResultError(): ?string
+    {
+        foreach (array_reverse(explode(\PHP_EOL, $this->process->getOutput())) as $line) {
+            $line = trim($line);
+
+            if ('' === $line) {
+                continue;
+            }
+
+            $decoded = json_decode($line, true);
+
+            if (!\is_array($decoded) || 'result' !== ($decoded['type'] ?? null)) {
+                continue;
+            }
+
+            $errors = \is_array($decoded['errors'] ?? null) ? array_filter($decoded['errors'], 'is_string') : [];
+
+            if ([] !== $errors) {
+                return implode(', ', $errors);
+            }
+
+            $subtype = $decoded['subtype'] ?? null;
+
+            return \is_string($subtype) && '' !== $subtype ? $subtype : null;
+        }
+
+        return null;
     }
 
     /**

--- a/src/platform/src/Bridge/ClaudeCode/Tests/RawProcessResultTest.php
+++ b/src/platform/src/Bridge/ClaudeCode/Tests/RawProcessResultTest.php
@@ -108,6 +108,78 @@ final class RawProcessResultTest extends TestCase
         $rawResult->getData();
     }
 
+    public function testGetDataFailureReportsCliErrorInsteadOfUnrelatedStderr()
+    {
+        $jsonOutput = json_encode([
+            'type' => 'result',
+            'subtype' => 'error_max_turns',
+            'is_error' => true,
+            'errors' => ['Reached maximum number of turns (1)'],
+        ]);
+
+        $phpCode = \sprintf('fwrite(STDERR, "warning: connectors are disabled"); echo %s; exit(1);', escapeshellarg($jsonOutput));
+        $process = new Process(['php', '-r', $phpCode]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Claude Code CLI process failed: "Reached maximum number of turns (1)"');
+
+        $rawResult->getData();
+    }
+
+    public function testGetDataFailureFallsBackToResultSubtype()
+    {
+        $jsonOutput = json_encode(['type' => 'result', 'subtype' => 'error_during_execution', 'is_error' => true]);
+
+        $phpCode = \sprintf('echo %s; exit(1);', escapeshellarg($jsonOutput));
+        $process = new Process(['php', '-r', $phpCode]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Claude Code CLI process failed: "error_during_execution"');
+
+        $rawResult->getData();
+    }
+
+    public function testGetDataFailureFallsBackToExitCodeWithoutAnyOutput()
+    {
+        $process = new Process(['php', '-r', 'exit(3);']);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Claude Code CLI process failed: "exit code 3"');
+
+        $rawResult->getData();
+    }
+
+    public function testGetDataStreamFailureReportsCliError()
+    {
+        $jsonOutput = json_encode([
+            'type' => 'result',
+            'subtype' => 'error_max_turns',
+            'is_error' => true,
+            'errors' => ['Reached maximum number of turns (2)'],
+        ]);
+
+        $phpCode = \sprintf('fwrite(STDERR, "warning: connectors are disabled"); echo %s.PHP_EOL; exit(1);', escapeshellarg($jsonOutput));
+        $process = new Process(['php', '-r', $phpCode]);
+        $process->start();
+
+        $rawResult = new RawProcessResult($process);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Claude Code CLI process failed: "Reached maximum number of turns (2)"');
+
+        foreach ($rawResult->getDataStream() as $data) {
+        }
+    }
+
     public function testGetDataStreamYieldsJsonLines()
     {
         $lines = [

--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -152,9 +152,11 @@ final class DeferredResult
     }
 
     /**
+     * @return object|array<string, mixed>
+     *
      * @throws ExceptionInterface
      */
-    public function asObject(): object
+    public function asObject(): object|array
     {
         $result = $this->getResult();
 

--- a/src/platform/src/Result/TypedResultTrait.php
+++ b/src/platform/src/Result/TypedResultTrait.php
@@ -39,9 +39,14 @@ trait TypedResultTrait
     }
 
     /**
+     * A `response_format` given as a plain JSON schema has no class to deserialize into,
+     * so the structured output stays the decoded array.
+     *
+     * @return object|array<string, mixed>
+     *
      * @throws ExceptionInterface
      */
-    public function asObject(): object
+    public function asObject(): object|array
     {
         return $this->as(ObjectResult::class)->getContent();
     }

--- a/src/platform/tests/Test/Recording/RecordingProviderTest.php
+++ b/src/platform/tests/Test/Recording/RecordingProviderTest.php
@@ -99,6 +99,7 @@ final class RecordingProviderTest extends TestCase
 
         $object = $this->replay()->invoke('any-model', 'q')->asObject();
 
+        $this->assertIsObject($object);
         $this->assertSame(42, $object->answer);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

Three small fixes:

* `asObject()` declared `object` but returns the decoded array when `response_format` is a plain JSON schema (no class to deserialize into) — return type widened to `object|array`, docs updated.
* `RawProcessResult` reported the Claude Code CLI failure from stderr, which often only carries unrelated warnings (e.g. about the active auth source). It now reads the reason from the final `type=result` event on stdout, falling back to stderr and then the exit code.
* `cohere/toolcall-stream.php` and `toolbox/confirmation.php` echoed every stream delta instead of only `TextDelta`s.