### PR TITLE
[Platform] Add provider identity to ResultConvertedEvent and ResultErrorEvent

### DIFF
--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add a `server_tools` option to the Anthropic `ModelClient`, mapping `web_search` and `code_execution` to their versioned Anthropic tool spec, mirroring the Gemini and Vertex AI bridges' name-to-params map shape; unmapped tool names throw instead of being silently forwarded, and the raw `tools` option remains the escape hatch for anything not mapped. The Anthropic `ResultConverter` now merges the `server_tool_use`/`web_search_tool_result` pair of a web search into a single `Result\WebSearchResult` carrying query, id and status, instead of dropping the blocks (or throwing when a response carries only web-search blocks)
  * [BC BREAK] Add `TokenUsage\TokenUsageInterface::getModel()`, reporting the model a provider says consumed the tokens, so a run mixing models (a chat model and an embeddings one, say) can be priced per call; `TokenUsageAggregation::getModel()` answers only when every usage it sums up agrees on a model, and `null` otherwise. `Test\Recording\ResultSerializer` records and replays it alongside the token counts, and a cassette recorded before the field existed still replays
+ * Add the serving provider to `ResultConvertedEvent` and `ResultErrorEvent`, so listeners can attribute a resolved result to the provider that produced it (e.g. to release held capacity)
 
 0.13
 ----

--- a/src/platform/src/Event/ResultConvertedEvent.php
+++ b/src/platform/src/Event/ResultConvertedEvent.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Event;
 
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ProviderInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
@@ -35,7 +36,13 @@ final class ResultConvertedEvent extends Event
         private ResultInterface $result,
         private readonly array $options = [],
         private readonly array|string|object $input = [],
+        private readonly ?ProviderInterface $provider = null,
     ) {
+    }
+
+    public function getProvider(): ?ProviderInterface
+    {
+        return $this->provider;
     }
 
     public function getModel(): Model

--- a/src/platform/src/Event/ResultErrorEvent.php
+++ b/src/platform/src/Event/ResultErrorEvent.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Event;
 
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ProviderInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -34,7 +35,13 @@ final class ResultErrorEvent extends Event
         private readonly \Throwable $error,
         private readonly array $options = [],
         private readonly array|string|object $input = [],
+        private readonly ?ProviderInterface $provider = null,
     ) {
+    }
+
+    public function getProvider(): ?ProviderInterface
+    {
+        return $this->provider;
     }
 
     public function getModel(): Model

--- a/src/platform/src/Provider.php
+++ b/src/platform/src/Provider.php
@@ -118,13 +118,13 @@ final class Provider implements ProviderInterface
 
         if (null !== $this->eventDispatcher) {
             $deferredResult->onConvert(function (ResultInterface $result) use ($model, $options, $input): ResultInterface {
-                $event = new ResultConvertedEvent($model, $result, $options, $input);
+                $event = new ResultConvertedEvent($model, $result, $options, $input, $this);
                 $this->eventDispatcher->dispatch($event);
 
                 return $event->getResult();
             });
             $deferredResult->onError(function (\Throwable $error) use ($model, $options, $input): void {
-                $this->eventDispatcher->dispatch(new ResultErrorEvent($model, $error, $options, $input));
+                $this->eventDispatcher->dispatch(new ResultErrorEvent($model, $error, $options, $input, $this));
             });
         }
 

--- a/src/platform/tests/Event/ResultConvertedEventTest.php
+++ b/src/platform/tests/Event/ResultConvertedEventTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Event\ResultConvertedEvent;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ProviderInterface;
 use Symfony\AI\Platform\Result\TextResult;
 
 final class ResultConvertedEventTest extends TestCase
@@ -24,13 +25,15 @@ final class ResultConvertedEventTest extends TestCase
         $model = new Model('test-model', [Capability::OUTPUT_TEXT]);
         $result = new TextResult('Hello');
         $options = ['temperature' => 0.7];
+        $provider = $this->createStub(ProviderInterface::class);
 
-        $event = new ResultConvertedEvent($model, $result, $options, 'Hello?');
+        $event = new ResultConvertedEvent($model, $result, $options, 'Hello?', $provider);
 
         $this->assertSame($model, $event->getModel());
         $this->assertSame($result, $event->getResult());
         $this->assertSame($options, $event->getOptions());
         $this->assertSame('Hello?', $event->getInput());
+        $this->assertSame($provider, $event->getProvider());
     }
 
     public function testSetResultOverridesResolvedResult()
@@ -41,5 +44,13 @@ final class ResultConvertedEventTest extends TestCase
         $event->setResult($newResult);
 
         $this->assertSame($newResult, $event->getResult());
+    }
+
+    public function testProviderIsOptional()
+    {
+        $model = new Model('test-model', [Capability::OUTPUT_TEXT]);
+        $result = new TextResult('Hello');
+
+        $this->assertNull((new ResultConvertedEvent($model, $result))->getProvider());
     }
 }

--- a/src/platform/tests/Event/ResultErrorEventTest.php
+++ b/src/platform/tests/Event/ResultErrorEventTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Capability;
 use Symfony\AI\Platform\Event\ResultErrorEvent;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ProviderInterface;
 
 final class ResultErrorEventTest extends TestCase
 {
@@ -24,12 +25,22 @@ final class ResultErrorEventTest extends TestCase
         $model = new Model('test-model', [Capability::OUTPUT_TEXT]);
         $error = new RuntimeException('conversion failed');
         $options = ['temperature' => 0.7];
+        $provider = $this->createStub(ProviderInterface::class);
 
-        $event = new ResultErrorEvent($model, $error, $options, 'Hello?');
+        $event = new ResultErrorEvent($model, $error, $options, 'Hello?', $provider);
 
         $this->assertSame($model, $event->getModel());
         $this->assertSame($error, $event->getError());
         $this->assertSame($options, $event->getOptions());
         $this->assertSame('Hello?', $event->getInput());
+        $this->assertSame($provider, $event->getProvider());
+    }
+
+    public function testProviderIsOptional()
+    {
+        $model = new Model('test-model', [Capability::OUTPUT_TEXT]);
+        $error = new RuntimeException('conversion failed');
+
+        $this->assertNull((new ResultErrorEvent($model, $error))->getProvider());
     }
 }

--- a/src/platform/tests/ProviderTest.php
+++ b/src/platform/tests/ProviderTest.php
@@ -253,6 +253,7 @@ final class ProviderTest extends TestCase
         $this->assertCount(3, $dispatchedEvents);
         $this->assertInstanceOf(ResultConvertedEvent::class, $dispatchedEvents[2]);
         $this->assertSame($textResult, $dispatchedEvents[2]->getResult());
+        $this->assertSame($provider, $dispatchedEvents[2]->getProvider());
     }
 
     public function testInvokeDispatchesResultErrorEventOnConversionFailure()
@@ -293,6 +294,7 @@ final class ProviderTest extends TestCase
 
         $this->assertInstanceOf(ResultErrorEvent::class, $dispatchedEvents[2]);
         $this->assertSame($exception, $dispatchedEvents[2]->getError());
+        $this->assertSame($provider, $dispatchedEvents[2]->getProvider());
     }
 
     public function testGetModelCatalog()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no 
| License       | MIT

A Platform can hold several providers, but a listener on `ResultConvertedEvent` / `ResultErrorEvent` can't tell which provider actually served the request.

This adds an optional `?ProviderInterface $provider` to both events (with a `getProvider(): ?ProviderInterface` getter), and `Provider` now passes itself when dispatching them.

I need this to rework #1452: capacity is acquired when routing picks a provider and a listener on these events releases it when a result resolves. This will only work if the event says which provider's capacity to release.

