### PR TITLE
[Agent] Add execution cancellation

### DIFF
--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -132,6 +132,23 @@ text deltas and ``asStreamedObject()`` the progressively populated object of a s
         echo $delta->getText();
     }
 
+A running execution can be canceled, for example from a signal handler when the user aborts a console command, or
+when a chat user hits "stop". Canceling aborts the active HTTP response, so the model stops generating, and ends
+the stream without producing a final result::
+
+    $execution = $agent->call('Tell me a story.', ['stream' => true]);
+
+    pcntl_async_signals(true);
+    pcntl_signal(\SIGINT, static fn () => $execution->cancel());
+
+    foreach ($execution->asTextStream() as $delta) {
+        echo $delta->getText();
+    }
+
+Cancellation is idempotent, propagates to the agents a ``MultiAgent`` or ``SpeechAgent`` delegates to, and makes
+``getResult()`` throw a :class:`Symfony\\AI\\Agent\\Exception\\RuntimeException` instead of returning a partial
+answer.
+
 Once the stream is drained, the execution resolves to the assembled answer like a non-streamed one: ``getResult()``
 returns the final result, and a streamed structured output ends with the object, so ``asObject()`` works on it as
 well.

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.14
+----
+
+ * Add `Execution::cancel()` to stop an active execution and cancel its active HTTP response
+
 0.13
 ----
 

--- a/src/agent/src/Agent.php
+++ b/src/agent/src/Agent.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Agent;
 
 use Symfony\AI\Agent\Exception\InvalidArgumentException;
 use Symfony\AI\Agent\Exception\RuntimeException;
+use Symfony\AI\Agent\Execution\Cancellation;
 use Symfony\AI\Agent\Execution\Execution;
 use Symfony\AI\Agent\Execution\Runner;
 use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
@@ -93,7 +94,8 @@ final class Agent implements AgentInterface
      */
     public function call(string|MessageBag|UserMessage $input, array $options = []): Execution
     {
-        $factory = function () use ($input, $options): \Generator {
+        $cancellation = new Cancellation();
+        $factory = function () use ($input, $options, $cancellation): \Generator {
             $request = new Input($this->getModel(), InputNormalizer::toMessageBag($input), $options);
             foreach ($this->inputProcessors as $inputProcessor) {
                 if (!$inputProcessor instanceof InputProcessorInterface) {
@@ -112,7 +114,7 @@ final class Agent implements AgentInterface
             $processedOptions = $request->getOptions();
 
             $result = null;
-            foreach ($this->runner->run($model, $messages, $processedOptions) as $update) {
+            foreach ($this->runner->run($model, $messages, $processedOptions, $cancellation) as $update) {
                 if ($update instanceof ResultUpdate) {
                     $result = $update->getResult();
 
@@ -120,6 +122,10 @@ final class Agent implements AgentInterface
                 }
 
                 yield $update;
+            }
+
+            if ($cancellation->isRequested()) {
+                return;
             }
 
             \assert($result instanceof ResultInterface);
@@ -140,6 +146,6 @@ final class Agent implements AgentInterface
             yield new ResultUpdate($output->getResult());
         };
 
-        return new Execution($factory, true === ($options['stream'] ?? false));
+        return new Execution($factory, true === ($options['stream'] ?? false), $cancellation);
     }
 }

--- a/src/agent/src/Execution/Cancellation.php
+++ b/src/agent/src/Execution/Cancellation.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Execution;
+
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\RawResultInterface;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @internal
+ */
+final class Cancellation
+{
+    private bool $requested = false;
+
+    private ?\Closure $onCancel = null;
+
+    public function request(): void
+    {
+        if ($this->requested) {
+            return;
+        }
+
+        $this->requested = true;
+
+        if (null !== $this->onCancel) {
+            ($this->onCancel)();
+        }
+    }
+
+    public function activate(RawResultInterface $result): void
+    {
+        if (!$result instanceof RawHttpResult) {
+            return;
+        }
+
+        $this->watch($result->getObject()->cancel(...));
+    }
+
+    /**
+     * Forwards a cancellation request to the execution of a delegated agent.
+     */
+    public function forward(Execution $execution): Execution
+    {
+        $this->watch($execution->cancel(...));
+
+        return $execution;
+    }
+
+    public function deactivate(): void
+    {
+        $this->onCancel = null;
+    }
+
+    public function isRequested(): bool
+    {
+        return $this->requested;
+    }
+
+    private function watch(\Closure $onCancel): void
+    {
+        $this->onCancel = $onCancel;
+
+        if ($this->requested) {
+            $onCancel();
+        }
+    }
+}

--- a/src/agent/src/Execution/Execution.php
+++ b/src/agent/src/Execution/Execution.php
@@ -59,9 +59,15 @@ final class Execution implements \IteratorAggregate, ResultInterface
 
     private bool $consumed = false;
 
+    private bool $canceled = false;
+
+    private bool $finished = false;
+
     private ?ResultInterface $result = null;
 
     private readonly Metadata $metadata;
+
+    private readonly Cancellation $cancellation;
 
     /**
      * @param \Closure(): \Generator<int, UpdateInterface, mixed, void> $factory
@@ -70,8 +76,10 @@ final class Execution implements \IteratorAggregate, ResultInterface
     public function __construct(
         private readonly \Closure $factory,
         private readonly bool $streamed = false,
+        ?Cancellation $cancellation = null,
     ) {
         $this->metadata = new Metadata();
+        $this->cancellation = $cancellation ?? new Cancellation();
     }
 
     /**
@@ -103,6 +111,19 @@ final class Execution implements \IteratorAggregate, ResultInterface
     }
 
     /**
+     * Cancels the execution and its active HTTP response.
+     */
+    public function cancel(): void
+    {
+        if ($this->canceled || $this->finished || null !== $this->result) {
+            return;
+        }
+
+        $this->canceled = true;
+        $this->cancellation->request();
+    }
+
+    /**
      * Drives the execution to completion and returns the final result.
      */
     public function getResult(): ResultInterface
@@ -111,10 +132,18 @@ final class Execution implements \IteratorAggregate, ResultInterface
             return $this->result;
         }
 
+        if ($this->consumed && $this->canceled) {
+            throw new RuntimeException('The agent execution was canceled.');
+        }
+
         foreach ($this->consume() as $update) {
             if ($update instanceof Result) {
                 return $update->getResult();
             }
+        }
+
+        if ($this->canceled) {
+            throw new RuntimeException('The agent execution was canceled.');
         }
 
         throw new RuntimeException('The agent execution finished without producing a result.');
@@ -186,24 +215,47 @@ final class Execution implements \IteratorAggregate, ResultInterface
 
         $this->consumed = true;
 
-        foreach (($this->factory)() as $update) {
-            if ($update instanceof Result) {
-                // the final result carries the metadata aggregated over all rounds, e.g. token usage
-                $this->result = $update->getResult();
-                $this->metadata->merge($update->getResult()->getMetadata());
+        if ($this->canceled) {
+            $this->finished = true;
 
-                foreach ($this->resultCallbacks as $callback) {
-                    $callback($update);
+            return;
+        }
+
+        try {
+            foreach (($this->factory)() as $update) {
+                if ($this->canceled) {
+                    break;
+                }
+
+                if ($update instanceof Result) {
+                    // the final result carries the metadata aggregated over all rounds, e.g. token usage
+                    $this->result = $update->getResult();
+                    $this->metadata->merge($update->getResult()->getMetadata());
+
+                    foreach ($this->resultCallbacks as $callback) {
+                        $callback($update);
+                    }
+                }
+
+                if ($update instanceof Progress) {
+                    foreach ($this->progressCallbacks as $callback) {
+                        $callback($update);
+                    }
+                }
+
+                yield $update;
+
+                // @phpstan-ignore if.alwaysFalse (cancellation can happen while the generator is suspended)
+                if ($this->canceled) {
+                    break;
                 }
             }
-
-            if ($update instanceof Progress) {
-                foreach ($this->progressCallbacks as $callback) {
-                    $callback($update);
-                }
+        } catch (\Throwable $exception) {
+            if (!$this->canceled) {
+                throw $exception;
             }
-
-            yield $update;
+        } finally {
+            $this->finished = true;
         }
     }
 }

--- a/src/agent/src/Execution/Runner.php
+++ b/src/agent/src/Execution/Runner.php
@@ -69,7 +69,7 @@ final class Runner
      *
      * @return \Generator<int, UpdateInterface, mixed, void>
      */
-    public function run(string $model, MessageBag $messages, array $options): \Generator
+    public function run(string $model, MessageBag $messages, array $options, ?Cancellation $cancellation = null): \Generator
     {
         $options = $this->exposeTools($options);
         $messages = $this->excludeToolMessages ? clone $messages : $messages;
@@ -81,11 +81,31 @@ final class Runner
         while (true) {
             yield new Progress('model_request', 'Invoking model.', $model);
 
-            $result = $this->platform->invoke($model, $messages, $options)->getResult();
+            $deferredResult = $this->platform->invoke($model, $messages, $options);
+            $cancellation?->activate($deferredResult->getRawResult());
 
-            $assistantMessage = null;
-            if ($result instanceof StreamResult) {
-                [$result, $assistantMessage] = yield from $this->consumeStream($result);
+            try {
+                if ($cancellation?->isRequested()) {
+                    return;
+                }
+
+                $result = $deferredResult->getResult();
+
+                $assistantMessage = null;
+                if ($result instanceof StreamResult) {
+                    $streamedResult = yield from $this->consumeStream($result, $cancellation);
+                    if (null === $streamedResult) {
+                        return;
+                    }
+
+                    [$result, $assistantMessage] = $streamedResult;
+                }
+            } finally {
+                $cancellation?->deactivate();
+            }
+
+            if ($cancellation?->isRequested()) {
+                return;
             }
 
             $toolCallResult = $this->extractToolCallResult($result);
@@ -137,9 +157,9 @@ final class Runner
      * The stream is drained completely even after a tool call was seen, since its metadata (e.g. token
      * usage) is only complete once the underlying generator is exhausted.
      *
-     * @return \Generator<int, UpdateInterface, mixed, array{ResultInterface, AssistantMessage}>
+     * @return \Generator<int, UpdateInterface, mixed, array{ResultInterface, AssistantMessage}|null>
      */
-    private function consumeStream(StreamResult $stream): \Generator
+    private function consumeStream(StreamResult $stream, ?Cancellation $cancellation): \Generator
     {
         $text = '';
         $toolCalls = [];
@@ -161,6 +181,14 @@ final class Runner
             }
 
             yield new Progress('delta', 'Received a streamed delta.', $delta);
+
+            if ($cancellation?->isRequested()) {
+                return null;
+            }
+        }
+
+        if ($cancellation?->isRequested()) {
+            return null;
         }
 
         $turn = $stream->getAssistantMessage();

--- a/src/agent/src/MultiAgent/MultiAgent.php
+++ b/src/agent/src/MultiAgent/MultiAgent.php
@@ -17,6 +17,7 @@ use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Agent\Exception\ExceptionInterface;
 use Symfony\AI\Agent\Exception\InvalidArgumentException;
 use Symfony\AI\Agent\Exception\RuntimeException;
+use Symfony\AI\Agent\Execution\Cancellation;
 use Symfony\AI\Agent\Execution\Execution;
 use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
 use Symfony\AI\Agent\InputNormalizer;
@@ -67,7 +68,9 @@ final class MultiAgent implements AgentInterface
      */
     public function call(string|MessageBag|UserMessage $input, array $options = []): Execution
     {
-        return new Execution(function () use ($input, $options): \Generator {
+        $cancellation = new Cancellation();
+
+        return new Execution(function () use ($input, $options, $cancellation): \Generator {
             $messages = InputNormalizer::toMessageBag($input);
             $userMessages = $messages->withoutSystemMessage();
 
@@ -85,14 +88,14 @@ final class MultiAgent implements AgentInterface
 
             $agentSelectionPrompt = $this->buildAgentSelectionPrompt($userText);
 
-            $decision = $this->orchestrator->call(new MessageBag(Message::ofUser($agentSelectionPrompt)), array_merge($options, [
+            $decision = $cancellation->forward($this->orchestrator->call(new MessageBag(Message::ofUser($agentSelectionPrompt)), array_merge($options, [
                 'response_format' => Decision::class,
-            ]))->getContent();
+            ])))->getContent();
 
             if (!$decision instanceof Decision) {
                 $this->logger->debug('MultiAgent: Failed to get decision, falling back to orchestrator');
 
-                yield new ResultUpdate($this->orchestrator->call($messages, $options)->getResult());
+                yield new ResultUpdate($cancellation->forward($this->orchestrator->call($messages, $options))->getResult());
 
                 return;
             }
@@ -105,7 +108,7 @@ final class MultiAgent implements AgentInterface
             if (!$decision->hasAgent()) {
                 $this->logger->debug('MultiAgent: Using fallback agent', ['reason' => 'no_agent_selected']);
 
-                yield new ResultUpdate($this->fallback->call($messages, $options)->getResult());
+                yield new ResultUpdate($cancellation->forward($this->fallback->call($messages, $options))->getResult());
 
                 return;
             }
@@ -125,7 +128,7 @@ final class MultiAgent implements AgentInterface
                     'reason' => 'agent_not_found',
                 ]);
 
-                yield new ResultUpdate($this->fallback->call($messages, $options)->getResult());
+                yield new ResultUpdate($cancellation->forward($this->fallback->call($messages, $options))->getResult());
 
                 return;
             }
@@ -133,8 +136,8 @@ final class MultiAgent implements AgentInterface
             $this->logger->debug('MultiAgent: Delegating to agent', ['agent_name' => $decision->getAgentName()]);
 
             // Call the selected agent with the original user question
-            yield new ResultUpdate($targetAgent->call(new MessageBag($userMessage), $options)->getResult());
-        });
+            yield new ResultUpdate($cancellation->forward($targetAgent->call(new MessageBag($userMessage), $options))->getResult());
+        }, cancellation: $cancellation);
     }
 
     private function buildAgentSelectionPrompt(string $userQuestion): string

--- a/src/agent/src/SpeechAgent.php
+++ b/src/agent/src/SpeechAgent.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Execution\Cancellation;
 use Symfony\AI\Agent\Execution\Execution;
 use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
 use Symfony\AI\Agent\Speech\SpeechConfiguration;
@@ -37,14 +38,16 @@ final class SpeechAgent implements AgentInterface
 
     public function call(string|MessageBag|UserMessage $input, array $options = []): Execution
     {
-        return new Execution(function () use ($input, $options): \Generator {
+        $cancellation = new Cancellation();
+
+        return new Execution(function () use ($input, $options, $cancellation): \Generator {
             $messages = InputNormalizer::toMessageBag($input);
 
             if ($this->configuration->supportsSpeechToText() && $this->speechToTextPlatform instanceof PlatformInterface) {
-                $messages = $this->transcribe($messages, $options);
+                $messages = $this->transcribe($messages, $options, $cancellation);
             }
 
-            $result = $this->agent->call($messages, $options)->getResult();
+            $result = $cancellation->forward($this->agent->call($messages, $options))->getResult();
 
             if (!$this->textToSpeechPlatform instanceof PlatformInterface || !$this->configuration->supportsTextToSpeech()) {
                 yield new ResultUpdate($result);
@@ -57,11 +60,12 @@ final class SpeechAgent implements AgentInterface
                 $result->getContent(),
                 $this->configuration->getTextToSpeechOptions(),
             );
+            $cancellation->activate($speechResult->getRawResult());
 
             $speechResult->getMetadata()->add('text', $result->getContent());
 
             yield new ResultUpdate($speechResult->getResult());
-        });
+        }, cancellation: $cancellation);
     }
 
     public function getName(): string
@@ -72,7 +76,7 @@ final class SpeechAgent implements AgentInterface
     /**
      * @param array<string, mixed> $options
      */
-    private function transcribe(MessageBag $messages, array $options): MessageBag
+    private function transcribe(MessageBag $messages, array $options, Cancellation $cancellation): MessageBag
     {
         try {
             $latestUserMessage = $messages->latestAs(Role::User);
@@ -98,6 +102,7 @@ final class SpeechAgent implements AgentInterface
                 ...$options,
             ],
         );
+        $cancellation->activate($result->getRawResult());
 
         $text = new Text($result->asText());
         $messages->replace($latestUserMessage->getId(), Message::ofUser($text));

--- a/src/agent/tests/AgentTest.php
+++ b/src/agent/tests/AgentTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Agent\AgentAwareInterface;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Agent\Exception\InvalidArgumentException;
 use Symfony\AI\Agent\Exception\MaxIterationsExceededException;
+use Symfony\AI\Agent\Exception\RuntimeException;
 use Symfony\AI\Agent\Input;
 use Symfony\AI\Agent\InputProcessorInterface;
 use Symfony\AI\Agent\Output;
@@ -33,13 +34,17 @@ use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\RawResultInterface;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\Test\InMemoryPlatform;
 use Symfony\AI\Platform\Tool\ExecutionReference;
 use Symfony\AI\Platform\Tool\Tool;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class AgentTest extends TestCase
 {
@@ -261,6 +266,42 @@ final class AgentTest extends TestCase
         $actualResult = $agent->call($messages, $options)->getResult();
 
         $this->assertSame($result, $actualResult);
+    }
+
+    public function testCancelStopsTheActiveStreamAndCancelsItsHttpResponse()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())->method('cancel');
+
+        $stream = new StreamResult((static function (): \Generator {
+            yield new TextDelta('First');
+            yield new TextDelta('Second');
+        })());
+
+        $platform = $this->createStub(PlatformInterface::class);
+        $platform->method('invoke')->willReturn(new DeferredResult(
+            new PlainConverter($stream),
+            new RawHttpResult($response),
+            ['stream' => true],
+        ));
+
+        $execution = (new Agent($platform, 'gpt-4'))->call('Hello', ['stream' => true]);
+        $deltas = [];
+
+        foreach ($execution->asStream() as $delta) {
+            $this->assertInstanceOf(TextDelta::class, $delta);
+            $deltas[] = $delta->getText();
+            $execution->cancel();
+            $execution->cancel();
+        }
+
+        $execution->cancel();
+
+        $this->assertSame(['First'], $deltas);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The agent execution was canceled.');
+
+        $execution->getResult();
     }
 
     public function testConstructorAcceptsTraversableProcessors()

--- a/src/agent/tests/Execution/CancellationTest.php
+++ b/src/agent/tests/Execution/CancellationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Execution;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Exception\RuntimeException;
+use Symfony\AI\Agent\Execution\Cancellation;
+use Symfony\AI\Agent\Execution\Execution;
+use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\RawHttpResult;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class CancellationTest extends TestCase
+{
+    public function testRequestCancelsTheActiveResponseOnce()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())->method('cancel');
+
+        $cancellation = new Cancellation();
+        $cancellation->activate(new RawHttpResult($response));
+
+        $this->assertFalse($cancellation->isRequested());
+
+        $cancellation->request();
+        $cancellation->request();
+
+        $this->assertTrue($cancellation->isRequested());
+    }
+
+    public function testActivateCancelsImmediatelyWhenAlreadyRequested()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())->method('cancel');
+
+        $cancellation = new Cancellation();
+        $cancellation->request();
+        $cancellation->activate(new RawHttpResult($response));
+    }
+
+    public function testActivateIgnoresNonHttpRawResults()
+    {
+        $cancellation = new Cancellation();
+        $cancellation->activate(new InMemoryRawResult());
+        $cancellation->request();
+
+        $this->assertTrue($cancellation->isRequested());
+    }
+
+    public function testDeactivateReleasesTheActiveResponse()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->never())->method('cancel');
+
+        $cancellation = new Cancellation();
+        $cancellation->activate(new RawHttpResult($response));
+        $cancellation->deactivate();
+        $cancellation->request();
+    }
+
+    public function testRequestCancelsTheForwardedExecution()
+    {
+        $execution = new Execution(static function (): \Generator {
+            yield new ResultUpdate(new TextResult('Done'));
+        });
+
+        $cancellation = new Cancellation();
+
+        $this->assertSame($execution, $cancellation->forward($execution));
+
+        $cancellation->request();
+
+        $this->assertSame([], iterator_to_array($execution, false));
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The agent execution was canceled.');
+
+        $execution->getResult();
+    }
+
+    public function testForwardCancelsImmediatelyWhenAlreadyRequested()
+    {
+        $cancellation = new Cancellation();
+        $cancellation->request();
+
+        $execution = new Execution(static function (): \Generator {
+            yield new ResultUpdate(new TextResult('Done'));
+        });
+        $cancellation->forward($execution);
+
+        $this->assertSame([], iterator_to_array($execution, false));
+    }
+}

--- a/src/agent/tests/Execution/ExecutionTest.php
+++ b/src/agent/tests/Execution/ExecutionTest.php
@@ -151,6 +151,63 @@ final class ExecutionTest extends TestCase
         iterator_to_array($execution);
     }
 
+    public function testItCanBeCanceledBeforeConsumption()
+    {
+        $runs = 0;
+        $execution = new Execution(static function () use (&$runs): \Generator {
+            ++$runs;
+
+            yield new ResultUpdate(new TextResult('Done'));
+        });
+
+        $execution->cancel();
+        $execution->cancel();
+
+        $this->assertSame([], iterator_to_array($execution, false));
+        $this->assertSame(0, $runs);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The agent execution was canceled.');
+
+        $execution->getResult();
+    }
+
+    public function testCancellationStopsAnActiveStreamWithoutProducingAResult()
+    {
+        $execution = new Execution(static function (): \Generator {
+            yield new Progress('delta', 'Received a streamed delta.', new TextDelta('First'));
+            yield new Progress('delta', 'Received a streamed delta.', new TextDelta('Second'));
+            yield new ResultUpdate(new TextResult('FirstSecond'));
+        }, streamed: true);
+
+        $deltas = [];
+        foreach ($execution->asStream() as $delta) {
+            $this->assertInstanceOf(TextDelta::class, $delta);
+            $deltas[] = $delta->getText();
+            $execution->cancel();
+        }
+
+        $this->assertSame(['First'], $deltas);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The agent execution was canceled.');
+
+        $execution->getResult();
+    }
+
+    public function testCancelAfterCompletionKeepsTheResult()
+    {
+        $result = new TextResult('Done');
+        $execution = new Execution(static function () use ($result): \Generator {
+            yield new ResultUpdate($result);
+        });
+
+        $this->assertSame($result, $execution->getResult());
+
+        $execution->cancel();
+        $execution->cancel();
+
+        $this->assertSame($result, $execution->getResult());
+    }
+
     public function testItActsAsTheResultItProduces()
     {
         $execution = new Execution(static function (): \Generator {

--- a/src/agent/tests/Fixtures/SuspendingConverter.php
+++ b/src/agent/tests/Fixtures/SuspendingConverter.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Agent\Tests\Fixtures;
+
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\Result\RawResultInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
+
+/**
+ * Suspends the current fiber during conversion, so a test can cancel an execution while its HTTP call is in flight.
+ */
+final class SuspendingConverter implements ResultConverterInterface
+{
+    public function supports(Model $model): bool
+    {
+        return true;
+    }
+
+    public function convert(RawResultInterface $result, array $options = []): ResultInterface
+    {
+        \Fiber::suspend();
+
+        return new TextResult('Full answer');
+    }
+
+    public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
+    {
+        return null;
+    }
+}

--- a/src/agent/tests/MultiAgent/MultiAgentTest.php
+++ b/src/agent/tests/MultiAgent/MultiAgentTest.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Agent\Tests\MultiAgent;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Agent\Exception\InvalidArgumentException;
 use Symfony\AI\Agent\Exception\RuntimeException;
@@ -22,13 +23,18 @@ use Symfony\AI\Agent\MockAgent;
 use Symfony\AI\Agent\MultiAgent\Handoff;
 use Symfony\AI\Agent\MultiAgent\Handoff\Decision;
 use Symfony\AI\Agent\MultiAgent\MultiAgent;
+use Symfony\AI\Agent\Tests\Fixtures\SuspendingConverter;
 use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\SystemMessage;
 use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
@@ -375,6 +381,31 @@ class MultiAgentTest extends TestCase
         $messages = new MessageBag(Message::ofUser('Question'));
 
         $multiAgent->call($messages)->getResult();
+    }
+
+    public function testCancelPropagatesToTheOrchestratorExecution()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())->method('cancel');
+
+        $platform = $this->createStub(PlatformInterface::class);
+        $platform->method('invoke')->willReturn(new DeferredResult(new SuspendingConverter(), new RawHttpResult($response)));
+
+        $orchestrator = new Agent($platform, 'gpt-4');
+        $handoff = new Handoff(new MockAgent(name: 'technical'), ['technical']);
+
+        $multiAgent = new MultiAgent($orchestrator, [$handoff], new MockAgent(name: 'fallback'));
+        $execution = $multiAgent->call(new MessageBag(Message::ofUser('Question')));
+
+        $fiber = new \Fiber(static fn (): ResultInterface => $execution->getResult());
+        $fiber->start();
+
+        $execution->cancel();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The agent execution was canceled.');
+
+        $fiber->resume();
     }
 
     private function execution(ResultInterface $result): Execution

--- a/src/agent/tests/SpeechAgentTest.php
+++ b/src/agent/tests/SpeechAgentTest.php
@@ -12,11 +12,14 @@
 namespace Symfony\AI\Agent\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\AgentInterface;
+use Symfony\AI\Agent\Exception\RuntimeException as AgentRuntimeException;
 use Symfony\AI\Agent\Execution\Execution;
 use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
 use Symfony\AI\Agent\Speech\SpeechConfiguration;
 use Symfony\AI\Agent\SpeechAgent;
+use Symfony\AI\Agent\Tests\Fixtures\SuspendingConverter;
 use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Message\Content\Audio;
 use Symfony\AI\Platform\Message\Content\Text;
@@ -28,8 +31,10 @@ use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\BinaryResult;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\ResultInterface;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class SpeechAgentTest extends TestCase
 {
@@ -265,6 +270,28 @@ final class SpeechAgentTest extends TestCase
         $agent = new SpeechAgent($innerAgent, new SpeechConfiguration(), $platform, $platform);
 
         $this->assertSame('my-agent', $agent->getName());
+    }
+
+    public function testCancelPropagatesToTheDelegatedAgentExecution()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())->method('cancel');
+
+        $platform = $this->createStub(PlatformInterface::class);
+        $platform->method('invoke')->willReturn(new DeferredResult(new SuspendingConverter(), new RawHttpResult($response)));
+
+        $agent = new SpeechAgent(new Agent($platform, 'gpt-4'), new SpeechConfiguration());
+        $execution = $agent->call(new MessageBag(Message::ofUser('Hello')));
+
+        $fiber = new \Fiber(static fn (): ResultInterface => $execution->getResult());
+        $fiber->start();
+
+        $execution->cancel();
+
+        $this->expectException(AgentRuntimeException::class);
+        $this->expectExceptionMessage('The agent execution was canceled.');
+
+        $fiber->resume();
     }
 
     private function execution(ResultInterface $result): Execution


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Docs?         | yes <!-- required for new features -->
| Issues        | n/a
| License       | MIT

My main use case is when using fibers, but not mentioned in the docs as nothing does that in Symfony AI core. Signals is also a god use case, used in the docs.
