### PR TITLE
[Platform] Record the model name when TraceablePlatform is invoked with a Model

### DIFF
--- a/src/platform/src/TraceablePlatform.php
+++ b/src/platform/src/TraceablePlatform.php
@@ -59,7 +59,7 @@ final class TraceablePlatform implements PlatformInterface, ResetInterface
         }
 
         $this->calls[] = [
-            'model' => $model,
+            'model' => $model instanceof Model ? $model->getName() : $model,
             'input' => \is_object($input) ? clone $input : $input,
             'options' => $options,
             'result' => $deferredResult,

--- a/src/platform/tests/TraceablePlatformTest.php
+++ b/src/platform/tests/TraceablePlatformTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
@@ -41,5 +42,18 @@ final class TraceablePlatformTest extends TestCase
         $this->assertCount(0, $traceablePlatform->getCalls());
         $this->assertNotSame($oldCache, $traceablePlatform->getResultCache());
         $this->assertInstanceOf(\WeakMap::class, $traceablePlatform->getResultCache());
+    }
+
+    public function testInvokeWithModelInstanceRecordsModelName()
+    {
+        $platform = $this->createStub(PlatformInterface::class);
+        $traceablePlatform = new TraceablePlatform($platform);
+        $result = new TextResult('Assistant response');
+
+        $platform->method('invoke')->willReturn(new DeferredResult(new PlainConverter($result), $this->createStub(RawResultInterface::class)));
+
+        $traceablePlatform->invoke(new Model('gpt-4o'), 'Hello');
+
+        $this->assertSame('gpt-4o', $traceablePlatform->getCalls()[0]['model']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2472
| License       | MIT

`TraceablePlatform::invoke()` accepts `string|Model`, but stored the argument as-is, so `getCalls()` could return a `Model` object under the `model` key while the `PlatformCallData` phpstan-type (and the `CollectedPlatformCallData` copy in the profiler's data collector) promises a `string`. PHPStan trusts the docblock, so the mismatch only shows up at runtime, and `Model` has no `__toString()`, so the profiler template's `{{ call.model }}` breaks as soon as a call passes a model instance.

This normalizes the value at the point where the call is recorded, keeping the recorded `model` a plain string as both docblocks already state.
