### PR TITLE
[Store][ChromaDb] Use default ChromaDB query limit

### DIFF
--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -33,6 +33,7 @@ use Symfony\AI\Store\StoreInterface;
 final class Store implements ManagedStoreInterface, StoreInterface
 {
     private const BATCH_SIZE = 1000;
+    private const DEFAULT_QUERY_LIMIT = 10;
 
     public function __construct(
         private readonly Client $client,
@@ -180,7 +181,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $collection = $this->client->getOrCreateCollection($this->collectionName);
         $queryResponse = $collection->query(
             queryEmbeddings: [$query->getVector()->getData()],
-            nResults: $options['limit'] ?? 4,
+            nResults: $options['limit'] ?? self::DEFAULT_QUERY_LIMIT,
             where: $options['where'] ?? null,
             whereDocument: $options['whereDocument'] ?? null,
             include: $include,
@@ -201,7 +202,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $collection = $this->client->getOrCreateCollection($this->collectionName, embeddingFunction: $this->embeddingFunction);
         $queryResponse = $collection->query(
             queryTexts: $query->getTexts(),
-            nResults: $options['limit'] ?? 4,
+            nResults: $options['limit'] ?? self::DEFAULT_QUERY_LIMIT,
             where: $options['where'] ?? null,
             whereDocument: $options['whereDocument'] ?? null,
             include: $include,

--- a/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
+++ b/src/store/src/Bridge/ChromaDb/Tests/StoreTest.php
@@ -31,6 +31,9 @@ use Symfony\Component\Uid\Uuid;
 
 final class StoreTest extends TestCase
 {
+    private const DEFAULT_QUERY_LIMIT = 10;
+    private const CUSTOM_QUERY_LIMIT = 6;
+
     /**
      * @param array<VectorDocument>       $documents
      * @param array<string>               $expectedIds
@@ -166,7 +169,7 @@ final class StoreTest extends TestCase
             ->with(
                 [[0.15, 0.25, 0.35]],  // queryEmbeddings
                 null,                  // queryTexts
-                4,                     // nResults
+                self::DEFAULT_QUERY_LIMIT, // nResults
                 null,                  // where
                 null,                  // whereDocument
                 null                   // include
@@ -180,6 +183,46 @@ final class StoreTest extends TestCase
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
         $this->assertSame([0.1, 0.2, 0.3], $documents[0]->getVector()->getData());
         $this->assertSame(['title' => 'Doc 1'], $documents[0]->getMetadata()->getArrayCopy());
+    }
+
+    public function testQueryWithConfiguredLimitOption()
+    {
+        $queryVector = new Vector([0.15, 0.25, 0.35]);
+        $queryResponse = new QueryItemsResponse(
+            ids: [['01234567-89ab-cdef-0123-456789abcdef']],
+            embeddings: [[[0.1, 0.2, 0.3]]],
+            metadatas: [[['title' => 'Doc 1']]],
+            documents: null,
+            data: null,
+            uris: null,
+            distances: null
+        );
+
+        $collection = $this->createMock(Collection::class);
+        $client = $this->createMock(Client::class);
+
+        $client->expects($this->once())
+            ->method('getOrCreateCollection')
+            ->with('test-collection')
+            ->willReturn($collection);
+
+        $collection->expects($this->once())
+            ->method('query')
+            ->with(
+                [[0.15, 0.25, 0.35]],  // queryEmbeddings
+                null,                  // queryTexts
+                self::CUSTOM_QUERY_LIMIT, // nResults
+                null,                  // where
+                null,                  // whereDocument
+                null                   // include
+            )
+            ->willReturn($queryResponse);
+
+        $store = StoreFactory::create($client, 'test-collection');
+        $documents = iterator_to_array($store->query(new VectorQuery($queryVector), ['limit' => self::CUSTOM_QUERY_LIMIT]));
+
+        $this->assertCount(1, $documents);
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', (string) $documents[0]->getId());
     }
 
     public function testQueryWithWhereFilter()
@@ -210,7 +253,7 @@ final class StoreTest extends TestCase
             ->with(
                 [[0.15, 0.25, 0.35]],  // queryEmbeddings
                 null,                  // queryTexts
-                4,                     // nResults
+                self::DEFAULT_QUERY_LIMIT, // nResults
                 ['category' => 'technology'],  // where
                 null,                  // whereDocument
                 null                   // include
@@ -253,7 +296,7 @@ final class StoreTest extends TestCase
             ->with(
                 [[0.15, 0.25, 0.35]],  // queryEmbeddings
                 null,                  // queryTexts
-                4,                     // nResults
+                self::DEFAULT_QUERY_LIMIT, // nResults
                 null,                  // where
                 ['$contains' => 'machine learning'],  // whereDocument
                 null                   // include
@@ -297,7 +340,7 @@ final class StoreTest extends TestCase
             ->with(
                 [[0.15, 0.25, 0.35]],  // queryEmbeddings
                 null,                  // queryTexts
-                4,                     // nResults
+                self::DEFAULT_QUERY_LIMIT, // nResults
                 ['category' => 'AI', 'status' => 'published'],  // where
                 ['$contains' => 'neural networks'],  // whereDocument
                 null                   // include
@@ -343,7 +386,7 @@ final class StoreTest extends TestCase
             ->with(
                 [[0.15, 0.25, 0.35]],  // queryEmbeddings
                 null,                  // queryTexts
-                4,                     // nResults
+                self::DEFAULT_QUERY_LIMIT, // nResults
                 ['category' => 'nonexistent'],  // where
                 null,                  // whereDocument
                 null                   // include
@@ -457,7 +500,7 @@ final class StoreTest extends TestCase
             ->with(
                 [[0.1, 0.2, 0.3]],     // queryEmbeddings
                 null,                  // queryTexts
-                4,                     // nResults
+                self::DEFAULT_QUERY_LIMIT, // nResults
                 $expectedWhere,        // where
                 $expectedWhereDocument,// whereDocument
                 null                   // include
@@ -842,7 +885,7 @@ final class StoreTest extends TestCase
             ->with(
                 null,                          // queryEmbeddings
                 ['search for this text'],      // queryTexts
-                4,                             // nResults
+                self::DEFAULT_QUERY_LIMIT,     // nResults
                 null,                          // where
                 null,                          // whereDocument
                 null                           // include


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #812
| License       | MIT

ChromaDB queries currently fall back to 4 results when no `limit` option is passed. The underlying ChromaDB PHP client default is 10, and the bridge already exposes `limit` for callers that need a custom value.

This changes the default query limit to 10 for vector and text queries while keeping explicit `limit` handling intact.

Tests:

```text
RED: php vendor/bin/phpunit --filter "testQueryWithoutFilters|testQueryWithConfiguredLimitOption|testQueryWithTextQuery" --no-coverage
FAILURES! Tests: 4, Assertions: 23, Failures: 2.
Failed asserting that 4 matches expected 10.
```

```text
GREEN: ./run-ci.sh
OK (36 tests, 244 assertions)
[OK] No errors
OK (36 tests, 244 assertions)
```

`./run-ci.sh` covers the ChromaDB bridge unit suite, PHPStan, and coverage text. The integration group was excluded because it requires a live ChromaDB service; the same environment-only failure was present before this patch.