### PR TITLE
[Platform] Add token usage to streamed Codex results

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -25,6 +25,7 @@
         "symfony/ai-clock-tool": "^0.13",
         "symfony/ai-cloudflare-message-store": "^0.13",
         "symfony/ai-cloudflare-store": "^0.13",
+        "symfony/ai-codex-platform": "^0.13",
         "symfony/ai-cohere-platform": "^0.13",
         "symfony/ai-decart-platform": "^0.13",
         "symfony/ai-deep-seek-platform": "^0.13",

--- a/src/platform/src/Bridge/Codex/CHANGELOG.md
+++ b/src/platform/src/Bridge/Codex/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.14
+----
+
+ * Add token usage to streamed results, extracted from the `turn.completed` event
+
 0.9
 ---
 

--- a/src/platform/src/Bridge/Codex/ResultConverter.php
+++ b/src/platform/src/Bridge/Codex/ResultConverter.php
@@ -22,6 +22,7 @@ use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCall;
 use Symfony\AI\Platform\Result\ToolCallResult;
 use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
 use Symfony\AI\Platform\TokenUsage\TokenUsageExtractorInterface;
 
 /**
@@ -91,6 +92,14 @@ final class ResultConverter implements ResultConverterInterface
                 && isset($data['item']['text'])
             ) {
                 yield new TextDelta($data['item']['text']);
+            }
+
+            if ('turn.completed' === $type && isset($data['usage'])) {
+                yield new TokenUsage(
+                    promptTokens: $data['usage']['input_tokens'] ?? null,
+                    completionTokens: $data['usage']['output_tokens'] ?? null,
+                    cachedTokens: $data['usage']['cached_input_tokens'] ?? null,
+                );
             }
         }
     }

--- a/src/platform/src/Bridge/Codex/Tests/ResultConverterTest.php
+++ b/src/platform/src/Bridge/Codex/Tests/ResultConverterTest.php
@@ -23,6 +23,7 @@ use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\StreamResult;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\AI\Platform\Result\ToolCallResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
 
 /**
  * @author Johannes Wachter <johannes@sulu.io>
@@ -149,9 +150,12 @@ final class ResultConverterTest extends TestCase
             $chunks[] = $chunk;
         }
 
-        $this->assertCount(1, $chunks);
+        $this->assertCount(2, $chunks);
         $this->assertInstanceOf(TextDelta::class, $chunks[0]);
         $this->assertSame('Hello', $chunks[0]->getText());
+        $this->assertInstanceOf(TokenUsage::class, $chunks[1]);
+        $this->assertSame(10, $chunks[1]->getPromptTokens());
+        $this->assertSame(5, $chunks[1]->getCompletionTokens());
     }
 
     public function testConvertStreamingYieldsMultipleAgentMessages()
@@ -174,11 +178,14 @@ final class ResultConverterTest extends TestCase
             $chunks[] = $chunk;
         }
 
-        $this->assertCount(2, $chunks);
+        $this->assertCount(3, $chunks);
         $this->assertInstanceOf(TextDelta::class, $chunks[0]);
         $this->assertSame('First part.', $chunks[0]->getText());
         $this->assertInstanceOf(TextDelta::class, $chunks[1]);
         $this->assertSame('Second part.', $chunks[1]->getText());
+        $this->assertInstanceOf(TokenUsage::class, $chunks[2]);
+        $this->assertSame(50, $chunks[2]->getPromptTokens());
+        $this->assertSame(20, $chunks[2]->getCompletionTokens());
     }
 
     public function testConvertStreamingIgnoresNonAgentEvents()
@@ -203,9 +210,10 @@ final class ResultConverterTest extends TestCase
             $chunks[] = $chunk;
         }
 
-        $this->assertCount(1, $chunks);
+        $this->assertCount(2, $chunks);
         $this->assertInstanceOf(TextDelta::class, $chunks[0]);
         $this->assertSame('Hello', $chunks[0]->getText());
+        $this->assertInstanceOf(TokenUsage::class, $chunks[1]);
     }
 
     public function testGetTokenUsageExtractor()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | n/a
| License       | MIT

The Codex stream converter only yielded text deltas and dropped the usage data from the `turn.completed` event, so `examples/codex/stream.php` printed no token usage at all despite asking for it. It now yields a `TokenUsage` delta, which the platform's existing `TokenUsage\StreamListener` promotes to result metadata, the same way the Ollama bridge does.

The second commit hunk adds the missing `symfony/ai-codex-platform` requirement to `examples/composer.json`. The Codex examples only ran locally because `./link` symlinks the whole platform package, so the namespace resolved by accident; a clean install (what CI does) would never install the bridge.

All four `examples/codex/*.php` run green against the real Codex CLI.
