### PR TITLE
[Examples] Fix stale HuggingFace models in three examples

### DIFF
--- a/examples/huggingface/chat-completion.php
+++ b/examples/huggingface/chat-completion.php
@@ -10,16 +10,17 @@
  */
 
 use Symfony\AI\Platform\Bridge\HuggingFace\Factory;
+use Symfony\AI\Platform\Bridge\HuggingFace\Provider;
 use Symfony\AI\Platform\Bridge\HuggingFace\Task;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 
 require_once dirname(__DIR__).'/bootstrap.php';
 
-$platform = Factory::createPlatform(env('HUGGINGFACE_KEY'), httpClient: http_client());
+$platform = Factory::createPlatform(env('HUGGINGFACE_KEY'), Provider::NSCALE, http_client());
 
 $messages = new MessageBag(Message::ofUser('Hello, how are you doing today?'));
-$result = $platform->invoke('HuggingFaceH4/zephyr-7b-beta', $messages, [
+$result = $platform->invoke('meta-llama/Llama-3.1-8B-Instruct', $messages, [
     'task' => Task::CHAT_COMPLETION,
 ]);
 

--- a/examples/huggingface/text-to-image.php
+++ b/examples/huggingface/text-to-image.php
@@ -16,7 +16,7 @@ require_once dirname(__DIR__).'/bootstrap.php';
 
 $platform = Factory::createPlatform(env('HUGGINGFACE_KEY'), httpClient: http_client());
 
-$result = $platform->invoke('black-forest-labs/FLUX.1-schnell', 'Astronaut riding a horse', [
+$result = $platform->invoke('stabilityai/stable-diffusion-3-medium-diffusers', 'Astronaut riding a horse', [
     'task' => Task::TEXT_TO_IMAGE,
 ]);
 

--- a/examples/huggingface/translation.php
+++ b/examples/huggingface/translation.php
@@ -18,8 +18,8 @@ $platform = Factory::createPlatform(env('HUGGINGFACE_KEY'), httpClient: http_cli
 
 $result = $platform->invoke('facebook/mbart-large-50-many-to-many-mmt', 'Меня зовут Вольфганг и я живу в Берлине', [
     'task' => Task::TRANSLATION,
-    'src_lang' => 'ru',
-    'tgt_lang' => 'en',
+    'src_lang' => 'ru_RU',
+    'tgt_lang' => 'en_XX',
 ]);
 
 echo $result->asText().\PHP_EOL;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

I ran all 19 HuggingFace examples against the live Inference API. 14 worked, 5 failed. This PR fixes the three that are fixable by changing the example.

`chat-completion.php` and `text-to-image.php` pointed at models that HuggingFace no longer serves on the default `hf-inference` provider, failing with a 400 and a 410. `hf-inference` does not serve any chat model anymore, so chat completion now uses `meta-llama/Llama-3.1-8B-Instruct` on `nscale`. For text to image, `stabilityai/stable-diffusion-3-medium-diffusers` is the only model `hf-inference` still offers.

`translation.php` exited 0 but printed `en I'm a golfer and I live in Berlin` instead of `My name is Wolfgang and I live in Berlin`. mBART-50 needs full locale codes; with the short `ru`/`en` it silently mistranslates. With `ru_RU`/`en_XX` the output is correct.

All three were verified against the live API after the change.

## The other two failures, and one more

These cannot be fixed by picking another model, so I left them alone:

* `audio-classification.php` and `image-to-text.php` fail with `Model not supported by provider hf-inference`. The HuggingFace model API returns **zero** models with any live inference provider for these two pipelines, so the tasks are gone from Inference Providers entirely. The examples should probably be dropped, or `image-to-text` rewritten to `image-text-to-text`, which has plenty of models.
* `text-generation.php` fails with a 410. `hf-inference` serves no `text-generation` model, and third-party providers expose raw completion through the OpenAI-compatible `/v1/completions` route. `ModelClient::getUrl()` special-cases only `chat-completion` and builds `/{provider}/models/{model}` for everything else, which the router rejects with a 400. I confirmed `POST /featherless-ai/v1/completions` works for `google/gemma-2-2b` while the bridge's URL does not, so this needs a bridge change rather than an example change.

Worth noting that `.github/workflows/run-examples.yaml` only runs `./runner openai`, which is why this drift went unnoticed.
