### PR TITLE
[Platform] Unwrap a JSON code fence before decoding structured output

### DIFF
--- a/src/platform/src/StructuredOutput/ResultConverter.php
+++ b/src/platform/src/StructuredOutput/ResultConverter.php
@@ -80,6 +80,8 @@ final class ResultConverter implements ResultConverterInterface
 
     private function convertTextToObject(TextResult $textResult, RawResultInterface $result): ObjectResult
     {
+        $content = $this->unwrapCodeFence($textResult->getContent());
+
         try {
             $context = [];
             if (null !== $this->objectToPopulate) {
@@ -87,9 +89,9 @@ final class ResultConverter implements ResultConverterInterface
             }
 
             $structure = null === $this->outputType
-                ? json_decode($textResult->getContent(), true, flags: \JSON_THROW_ON_ERROR)
+                ? json_decode($content, true, flags: \JSON_THROW_ON_ERROR)
                 : $this->serializer->deserialize(
-                    $textResult->getContent(),
+                    $content,
                     $this->outputType,
                     'json',
                     $context
@@ -111,6 +113,22 @@ final class ResultConverter implements ResultConverterInterface
         }
 
         return $objectResult;
+    }
+
+    /**
+     * Models without native structured output often answer with their JSON inside a Markdown code
+     * fence. Unwrapping is limited to a fence whose body parses as JSON, so a text answer that
+     * merely contains a fence is handed to the decoder unchanged and still fails as before.
+     */
+    private function unwrapCodeFence(string $content): string
+    {
+        if (1 !== preg_match('/^\s*```(?:json)?\s*(.*?)\s*```\s*$/is', $content, $matches)) {
+            return $content;
+        }
+
+        json_decode($matches[1]);
+
+        return \JSON_ERROR_NONE === json_last_error() ? $matches[1] : $content;
     }
 
     private function convertMultiPart(MultiPartResult $multiPart, RawResultInterface $result): MultiPartResult

--- a/src/platform/tests/StructuredOutput/ResultConverterTest.php
+++ b/src/platform/tests/StructuredOutput/ResultConverterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\AI\Platform\Tests\StructuredOutput;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Exception\RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\Result\ChoiceResult;
@@ -53,6 +54,50 @@ final class ResultConverterTest extends TestCase
         $this->assertInstanceOf(ObjectResult::class, $result);
         $this->assertInstanceOf(SomeStructure::class, $result->getContent());
         $this->assertSame('data', $result->getContent()->some);
+    }
+
+    public function testConvertUnwrapsJsonCodeFence()
+    {
+        $innerConverter = new PlainConverter(new TextResult("```json\n{\"key\": \"value\"}\n```"));
+        $converter = new ResultConverter($innerConverter, new Serializer());
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(ObjectResult::class, $result);
+        $this->assertSame(['key' => 'value'], $result->getContent());
+    }
+
+    public function testConvertUnwrapsBareCodeFenceWithOutputType()
+    {
+        $innerConverter = new PlainConverter(new TextResult("```\n{\"some\": \"data\"}\n```"));
+        $converter = new ResultConverter($innerConverter, new Serializer(), SomeStructure::class);
+
+        $result = $converter->convert(new InMemoryRawResult());
+
+        $this->assertInstanceOf(SomeStructure::class, $result->getContent());
+        $this->assertSame('data', $result->getContent()->some);
+    }
+
+    public function testConvertLeavesCodeFenceWithoutJsonBodyUntouched()
+    {
+        $innerConverter = new PlainConverter(new TextResult("```json\nnot json at all\n```"));
+        $converter = new ResultConverter($innerConverter, new Serializer());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot json decode the content.');
+
+        $converter->convert(new InMemoryRawResult());
+    }
+
+    public function testConvertDoesNotUnwrapACodeFenceSurroundedByProse()
+    {
+        $innerConverter = new PlainConverter(new TextResult("Here you go:\n```json\n{\"key\": \"value\"}\n```"));
+        $converter = new ResultConverter($innerConverter, new Serializer());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot json decode the content.');
+
+        $converter->convert(new InMemoryRawResult());
     }
 
     public function testConvertWithObjectToPopulate()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

Replaces #2114. Models without native structured output often answer with their JSON inside a Markdown code fence, and `StructuredOutput\ResultConverter` handed that string straight to the decoder, so the call failed with `Cannot json decode the content.` even though the payload itself was correct.

The converter now unwraps the fence before decoding, but only when the fenced body parses as JSON on its own, so a text answer that merely contains a fence is passed through unchanged and fails exactly as before. A fence surrounded by prose is deliberately not unwrapped either; there is a test pinning that boundary, so widening it stays a conscious decision.

#2114 solved the same problem with a normalizer chain on `ResultEvent`. That approach also stripped Unicode format characters from every result by default, which corrupts bidi text, Indic ligatures and emoji sequences, and its subscriber resolved the deferred result eagerly, which suppresses `ResultConvertedEvent` and `ResultErrorEvent` for every call. Doing the unwrapping where the decode happens avoids both.
