### PR TITLE
[Chat][Platform] Declare the PHP 8.3 polyfill where json_validate() is used

### DIFF
--- a/src/chat/src/Bridge/Pogocache/composer.json
+++ b/src/chat/src/Bridge/Pogocache/composer.json
@@ -28,6 +28,7 @@
         "php": ">=8.2",
         "symfony/ai-chat": "^0.13",
         "symfony/http-client": "^7.3|^8.0",
+        "symfony/polyfill-php83": "^1.32",
         "symfony/serializer": "^7.3|^8.0"
     },
     "require-dev": {

--- a/src/platform/src/Bridge/Bedrock/Tests/Anthropic/ClaudeModelClientTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/Anthropic/ClaudeModelClientTest.php
@@ -48,7 +48,7 @@ final class ClaudeModelClientTest extends TestCase
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('us.anthropic.claude-sonnet-4-6', $arg->getModelId());
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 return true;
             }))
@@ -143,7 +143,7 @@ final class ClaudeModelClientTest extends TestCase
             ->with($this->callback(function ($arg) {
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 $body = json_decode($arg->getBody(), true);
                 $this->assertArrayNotHasKey('model', $body);
@@ -165,7 +165,7 @@ final class ClaudeModelClientTest extends TestCase
             ->with($this->callback(function ($arg) {
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 $body = json_decode($arg->getBody(), true);
                 $this->assertSame('bedrock-'.self::VERSION, $body['anthropic_version']);
@@ -187,7 +187,7 @@ final class ClaudeModelClientTest extends TestCase
             ->with($this->callback(function ($arg) {
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 $body = json_decode($arg->getBody(), true);
                 $this->assertSame(['type' => 'auto'], $body['tool_choice']);
@@ -237,7 +237,7 @@ final class ClaudeModelClientTest extends TestCase
             ->with($this->callback(function ($arg) {
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 $body = json_decode($arg->getBody(), true);
                 $this->assertArrayHasKey('output_config', $body);

--- a/src/platform/src/Bridge/Bedrock/Tests/Nova/NovaModelClientTest.php
+++ b/src/platform/src/Bridge/Bedrock/Tests/Nova/NovaModelClientTest.php
@@ -46,7 +46,7 @@ final class NovaModelClientTest extends TestCase
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('us.amazon.nova-pro-v1:0', $arg->getModelId());
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 return true;
             }))
@@ -65,7 +65,7 @@ final class NovaModelClientTest extends TestCase
             ->with($this->callback(function ($arg) {
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 $body = json_decode($arg->getBody(), true);
                 $this->assertArrayNotHasKey('model', $body);
@@ -87,7 +87,7 @@ final class NovaModelClientTest extends TestCase
             ->with($this->callback(function ($arg) {
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 $body = json_decode($arg->getBody(), true);
                 $this->assertSame(['tools' => ['Tool']], $body['toolConfig']);
@@ -113,7 +113,7 @@ final class NovaModelClientTest extends TestCase
             ->with($this->callback(function ($arg) {
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 $body = json_decode($arg->getBody(), true);
                 $this->assertArrayHasKey('inferenceConfig', $body);
@@ -140,7 +140,7 @@ final class NovaModelClientTest extends TestCase
             ->with($this->callback(function ($arg) {
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 $body = json_decode($arg->getBody(), true);
                 $this->assertArrayHasKey('inferenceConfig', $body);
@@ -167,7 +167,7 @@ final class NovaModelClientTest extends TestCase
             ->with($this->callback(function ($arg) {
                 $this->assertInstanceOf(InvokeModelRequest::class, $arg);
                 $this->assertSame('application/json', $arg->getContentType());
-                $this->assertTrue(json_validate($arg->getBody()));
+                $this->assertJson($arg->getBody());
 
                 $body = json_decode($arg->getBody(), true);
                 $this->assertArrayHasKey('inferenceConfig', $body);

--- a/src/platform/src/Bridge/Gemini/composer.json
+++ b/src/platform/src/Bridge/Gemini/composer.json
@@ -27,7 +27,8 @@
     "require": {
         "php": ">=8.2",
         "symfony/ai-platform": "^0.13",
-        "symfony/http-client": "^7.3|^8.0"
+        "symfony/http-client": "^7.3|^8.0",
+        "symfony/polyfill-php83": "^1.32"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",

--- a/src/platform/src/Bridge/VertexAi/composer.json
+++ b/src/platform/src/Bridge/VertexAi/composer.json
@@ -29,7 +29,8 @@
         "php": ">=8.2",
         "symfony/ai-gemini-platform": "^0.13",
         "symfony/ai-platform": "^0.13",
-        "symfony/http-client": "^7.3|^8.0"
+        "symfony/http-client": "^7.3|^8.0",
+        "symfony/polyfill-php83": "^1.32"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

The Gemini, Vertex AI and Pogocache packages call `json_validate()`, which is PHP 8.3, while declaring `php: ">=8.2"`. Nothing breaks today only because `symfony/http-client` requires `symfony/polyfill-php83` from v7.3.3 on, and all three require http-client. A resolution that lands on http-client 7.3.0, 7.3.1 or 7.3.2 on PHP 8.2 gets a fatal error instead. They now declare the polyfill themselves, the way `symfony/ai-store` already does for the same function in the Redis store.

The Bedrock tests used `json_validate()` to assert a request body and now use PHPUnit's `assertJson()`, which drops the version dependency rather than moving it.

Worth knowing for whoever looks at this next: the reason nothing flagged it is that PHPStan runs without a `phpVersion`, so it assumes the 8.5 it runs on and treats every post-8.2 function as available. Pinning the declared floor does not work today: any `phpVersion` setting makes PHPStan fall back to its version stubs, which have no `Pdo\Sqlite` at all, so the Sqlite store bridge and `examples/rag/sqlite-vec.php` light up with `class.notFound` even though the class exists on 8.4 and 8.5. A user stub does not help, PHPStan will not invent an internal class for a version. So the gap stays open for now.
