### PR TITLE
[Agent] Forward Progress updates from delegated executions in MultiAg…

### DIFF
--- a/ai.symfony.com/templates/cookbook/content/multi-agent-orchestration.html
+++ b/ai.symfony.com/templates/cookbook/content/multi-agent-orchestration.html
@@ -316,6 +316,99 @@ the <code translate="no" class="notranslate">MultiAgent</code> constructor to se
 </div>
 </div>
 <div class="section">
+<h2 id="step-7-show-which-agent-answers">
+    Step 7: Show Which Agent Answers
+    
+</h2>
+<p>Routing is invisible from the outside: the caller asks a question and gets an answer, with no clue
+which specialist produced it. Iterating the multi-agent instead of reading its result lets you show
+that, because the delegated agents report their own steps into the very same execution. The routing
+itself arrives as a <code translate="no" class="notranslate">Progress</code> update of the <code translate="no" class="notranslate">handoff</code> stage, carrying the orchestrator's
+<a href="https://github.com/symfony/ai/blob/main/src/agent/src/MultiAgent/Handoff/Decision.php" class="reference external" title="Symfony\AI\Agent\MultiAgent\Handoff\Decision" rel="external noopener noreferrer" target="_blank">Decision</a> as payload:</p>
+<div translate="no" class="highlight-php notranslate">
+    <table class="highlighttable">
+        <tbody>
+            <tr>
+                <td class="linenos">
+                    <div class="linenodiv">
+                        <pre>1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26</pre>
+                    </div>
+                </td>
+                <td class="code">
+                    <div class="highlight">
+                        <pre class="hljs php"><span class="hljs-keyword">use</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">AI</span>\<span class="hljs-title">Agent</span>\<span class="hljs-title">Execution</span>\<span class="hljs-title">Update</span>\<span class="hljs-title">Progress</span>;
+<span class="hljs-keyword">use</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">AI</span>\<span class="hljs-title">Agent</span>\<span class="hljs-title">Execution</span>\<span class="hljs-title">Update</span>\<span class="hljs-title">Result</span>;
+<span class="hljs-keyword">use</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">AI</span>\<span class="hljs-title">Agent</span>\<span class="hljs-title">MultiAgent</span>\<span class="hljs-title">Handoff</span>\<span class="hljs-title">Decision</span>;
+
+<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>messages</span> = <span class="hljs-keyword">new</span> <span class="hljs-title invoke__">MessageBag</span>(
+    Message::<span class="hljs-title invoke__">ofUser</span>(<span class="hljs-string">'I get a "Call to undefined method" error in my controller.'</span>),
+);
+
+<span class="hljs-keyword">foreach</span> (<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>multiAgent</span>-&gt;<span class="hljs-title invoke__">call</span>(<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>messages</span>) <span class="hljs-keyword">as</span> <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>update</span>) {
+    <span class="hljs-keyword">if</span> (<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>update</span> <span class="hljs-keyword">instanceof</span> Progress &amp;&amp; <span class="hljs-string">'handoff'</span> === <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>update</span>-&gt;<span class="hljs-title invoke__">getStage</span>()) {
+        <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>decision</span> = <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>update</span>-&gt;<span class="hljs-title invoke__">getPayload</span>();
+        \<span class="hljs-title invoke__">assert</span>(<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>decision</span> instanceof Decision);
+
+        <span class="hljs-keyword">echo</span> <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>update</span>-&gt;<span class="hljs-title invoke__">getMessage</span>().<span class="hljs-string">' Reason: '</span>.<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>decision</span>-&gt;<span class="hljs-title invoke__">getReasoning</span>().\<span class="hljs-keyword">PHP_EOL</span>;
+
+        <span class="hljs-keyword">continue</span>;
+    }
+
+    <span class="hljs-keyword">if</span> (<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>update</span> <span class="hljs-keyword">instanceof</span> Progress) {
+        <span class="hljs-keyword">echo</span> <span class="hljs-string">'  '</span>.<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>update</span>-&gt;<span class="hljs-title invoke__">getMessage</span>().\<span class="hljs-keyword">PHP_EOL</span>; <span class="hljs-comment">// the specialist's own model requests and tool calls</span>
+    }
+
+    <span class="hljs-keyword">if</span> (<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>update</span> <span class="hljs-keyword">instanceof</span> Result) {
+        <span class="hljs-keyword">echo</span> <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>update</span>-&gt;<span class="hljs-title invoke__">getResult</span>()-&gt;<span class="hljs-title invoke__">getContent</span>().\<span class="hljs-keyword">PHP_EOL</span>;
+    }
+}</pre>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+<p>The message names the agent that actually runs, while the decision explains why the orchestrator
+picked it - the two differ when the orchestrator selects an agent that no handoff defines, in which
+case the fallback answers instead. See the
+<a href="https://github.com/symfony/ai/blob/main/examples/multi-agent/orchestrator-iterable.php" class="reference external" rel="external noopener noreferrer" target="_blank">orchestrator-iterable.php</a>
+example for a runnable version of this loop.</p>
+<div class="admonition admonition-note ">
+    <p class="admonition-title">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
+                <span>Note</span>
+    </p><p>The orchestrator's own routing round is machinery, not answer: its <code translate="no" class="notranslate">model_request</code> and
+<code translate="no" class="notranslate">tool_call</code> updates are forwarded so you can show that a decision is being made, but the
+deltas that spell out the <code translate="no" class="notranslate">Decision</code> are not. With the <code translate="no" class="notranslate">stream</code> option, the <code translate="no" class="notranslate">delta</code>
+updates you receive are therefore only those of the agent that answers.</p>
+</div>
+</div>
+<div class="section">
 <h2 id="learn-more">
     Learn More
     

--- a/docs/cookbook/multi-agent-orchestration.rst
+++ b/docs/cookbook/multi-agent-orchestration.rst
@@ -142,6 +142,55 @@ the question and routes it to the appropriate specialist automatically::
     so the orchestrator can route to any number of domains. For debugging, pass a PSR-3 logger to
     the ``MultiAgent`` constructor to see which agent handles each request.
 
+Step 7: Show Which Agent Answers
+--------------------------------
+
+Routing is invisible from the outside: the caller asks a question and gets an answer, with no clue
+which specialist produced it. Iterating the multi-agent instead of reading its result lets you show
+that, because the delegated agents report their own steps into the very same execution. The routing
+itself arrives as a ``Progress`` update of the ``handoff`` stage, carrying the orchestrator's
+:class:`Symfony\\AI\\Agent\\MultiAgent\\Handoff\\Decision` as payload::
+
+    use Symfony\AI\Agent\Execution\Update\Progress;
+    use Symfony\AI\Agent\Execution\Update\Result;
+    use Symfony\AI\Agent\MultiAgent\Handoff\Decision;
+
+    $messages = new MessageBag(
+        Message::ofUser('I get a "Call to undefined method" error in my controller.'),
+    );
+
+    foreach ($multiAgent->call($messages) as $update) {
+        if ($update instanceof Progress && 'handoff' === $update->getStage()) {
+            $decision = $update->getPayload();
+            \assert($decision instanceof Decision);
+
+            echo $update->getMessage().' Reason: '.$decision->getReasoning().\PHP_EOL;
+
+            continue;
+        }
+
+        if ($update instanceof Progress) {
+            echo '  '.$update->getMessage().\PHP_EOL; // the specialist's own model requests and tool calls
+        }
+
+        if ($update instanceof Result) {
+            echo $update->getResult()->getContent().\PHP_EOL;
+        }
+    }
+
+The message names the agent that actually runs, while the decision explains why the orchestrator
+picked it - the two differ when the orchestrator selects an agent that no handoff defines, in which
+case the fallback answers instead. See the
+`orchestrator-iterable.php <https://github.com/symfony/ai/blob/main/examples/multi-agent/orchestrator-iterable.php>`_
+example for a runnable version of this loop.
+
+.. note::
+
+    The orchestrator's own routing round is machinery, not answer: its ``model_request`` and
+    ``tool_call`` updates are forwarded so you can show that a decision is being made, but the
+    deltas that spell out the ``Decision`` are not. With the ``stream`` option, the ``delta``
+    updates you receive are therefore only those of the agent that answers.
+
 Learn More
 ----------
 

--- a/examples/multi-agent/orchestrator-iterable.php
+++ b/examples/multi-agent/orchestrator-iterable.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Execution\Update\Progress;
+use Symfony\AI\Agent\Execution\Update\Result;
+use Symfony\AI\Agent\InputProcessor\SystemPromptInputProcessor;
+use Symfony\AI\Agent\MultiAgent\Handoff;
+use Symfony\AI\Agent\MultiAgent\Handoff\Decision;
+use Symfony\AI\Agent\MultiAgent\MultiAgent;
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\StructuredOutput\PlatformSubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$dispatcher = new EventDispatcher();
+$dispatcher->addSubscriber(new PlatformSubscriber());
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client(), eventDispatcher: $dispatcher);
+
+$orchestrator = new Agent(
+    $platform,
+    'gpt-5-mini',
+    [new SystemPromptInputProcessor('You are an intelligent agent orchestrator that routes user questions to specialized agents.')],
+);
+
+$technical = new Agent(
+    $platform,
+    'gpt-4o-mini?max_output_tokens=150', // set max_output_tokens here to be faster and cheaper
+    [new SystemPromptInputProcessor('You are a technical support specialist. Help users resolve bugs, problems, and technical errors.')],
+    name: 'technical',
+);
+
+$fallback = new Agent(
+    $platform,
+    'gpt-5-mini',
+    [new SystemPromptInputProcessor('You are a helpful general assistant. Assist users with any questions or tasks they may have. You should never ever answer technical question.')],
+    name: 'fallback',
+);
+
+$multiAgent = new MultiAgent(
+    orchestrator: $orchestrator,
+    handoffs: [
+        new Handoff(to: $technical, when: ['bug', 'problem', 'technical', 'error']),
+    ],
+    fallback: $fallback,
+);
+
+$question = 'I get this error in my php code: "Call to undefined method App\Controller\UserController::getName()" - this is my line of code: $user->getName() where $user is an instance of User entity.';
+echo "Question: $question".\PHP_EOL.\PHP_EOL;
+
+// iterating the multi-agent reports the routing decision and the steps of the agent it delegates to
+foreach ($multiAgent->call(new MessageBag(Message::ofUser($question))) as $update) {
+    if ($update instanceof Progress && 'handoff' === $update->getStage()) {
+        $decision = $update->getPayload();
+        assert($decision instanceof Decision);
+
+        echo '>> '.$update->getMessage().' Reason: '.$decision->getReasoning().\PHP_EOL;
+
+        continue;
+    }
+
+    if ($update instanceof Progress) {
+        // the orchestrator's routing round reports here as well, before the handoff
+        echo '   '.$update->getMessage().\PHP_EOL;
+    }
+
+    if ($update instanceof Result) {
+        echo \PHP_EOL.'Answer: '.substr($update->getResult()->getContent(), 0, 300).'...'.\PHP_EOL;
+    }
+}

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ----
 
  * Add `Execution::cancel()` to stop an active execution and cancel its active HTTP response
+ * `MultiAgent` and `SpeechAgent` now forward the `Progress` updates of the executions they delegate to, and `MultiAgent` reports its routing as a `Progress` update of the `handoff` stage carrying the orchestrator's `MultiAgent\Handoff\Decision` as payload
 
 0.13
 ----

--- a/src/agent/src/Execution/Update/Progress.php
+++ b/src/agent/src/Execution/Update/Progress.php
@@ -24,7 +24,7 @@ final class Progress implements UpdateInterface
     /**
      * @param non-empty-string $stage   machine-readable stage, e.g. "model_request", "tool_call", "delta"
      * @param string           $message human-readable description
-     * @param mixed            $payload stage-specific payload (e.g. the ToolCall, a streamed delta, ...)
+     * @param mixed            $payload stage-specific payload (e.g. the ToolCall, a streamed delta, the handoff Decision, ...)
      */
     public function __construct(
         private readonly string $stage,

--- a/src/agent/src/MultiAgent/Handoff/Decision.php
+++ b/src/agent/src/MultiAgent/Handoff/Decision.php
@@ -15,8 +15,6 @@ namespace Symfony\AI\Agent\MultiAgent\Handoff;
  * Represents the orchestrator's decision on which agent should handle a request.
  *
  * @author Oskar Stark <oskarstark@googlemail.com>
- *
- * @internal
  */
 final class Decision
 {

--- a/src/agent/src/MultiAgent/MultiAgent.php
+++ b/src/agent/src/MultiAgent/MultiAgent.php
@@ -19,12 +19,14 @@ use Symfony\AI\Agent\Exception\InvalidArgumentException;
 use Symfony\AI\Agent\Exception\RuntimeException;
 use Symfony\AI\Agent\Execution\Cancellation;
 use Symfony\AI\Agent\Execution\Execution;
+use Symfony\AI\Agent\Execution\Update\Progress;
 use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
 use Symfony\AI\Agent\InputNormalizer;
 use Symfony\AI\Agent\MultiAgent\Handoff\Decision;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\UserMessage;
+use Symfony\AI\Platform\Result\ResultInterface;
 
 /**
  * A multi-agent system that coordinates multiple specialized agents.
@@ -88,14 +90,25 @@ final class MultiAgent implements AgentInterface
 
             $agentSelectionPrompt = $this->buildAgentSelectionPrompt($userText);
 
-            $decision = $cancellation->forward($this->orchestrator->call(new MessageBag(Message::ofUser($agentSelectionPrompt)), array_merge($options, [
-                'response_format' => Decision::class,
-            ])))->getContent();
+            // the selection round is internal machinery: its deltas spell out the Decision, not the answer
+            $selection = yield from $this->delegate(
+                $this->orchestrator,
+                new MessageBag(Message::ofUser($agentSelectionPrompt)),
+                array_merge($options, ['response_format' => Decision::class]),
+                $cancellation,
+                false,
+            );
+
+            if (null === $selection) {
+                return;
+            }
+
+            $decision = $selection->getContent();
 
             if (!$decision instanceof Decision) {
                 $this->logger->debug('MultiAgent: Failed to get decision, falling back to orchestrator');
 
-                yield new ResultUpdate($cancellation->forward($this->orchestrator->call($messages, $options))->getResult());
+                yield from $this->answerWith($this->orchestrator, $messages, $options, $cancellation);
 
                 return;
             }
@@ -108,7 +121,9 @@ final class MultiAgent implements AgentInterface
             if (!$decision->hasAgent()) {
                 $this->logger->debug('MultiAgent: Using fallback agent', ['reason' => 'no_agent_selected']);
 
-                yield new ResultUpdate($cancellation->forward($this->fallback->call($messages, $options))->getResult());
+                yield new Progress('handoff', \sprintf('Routing to fallback agent "%s".', $this->fallback->getName()), $decision);
+
+                yield from $this->answerWith($this->fallback, $messages, $options, $cancellation);
 
                 return;
             }
@@ -128,16 +143,77 @@ final class MultiAgent implements AgentInterface
                     'reason' => 'agent_not_found',
                 ]);
 
-                yield new ResultUpdate($cancellation->forward($this->fallback->call($messages, $options))->getResult());
+                yield new Progress('handoff', \sprintf('Routing to fallback agent "%s".', $this->fallback->getName()), $decision);
+
+                yield from $this->answerWith($this->fallback, $messages, $options, $cancellation);
 
                 return;
             }
 
             $this->logger->debug('MultiAgent: Delegating to agent', ['agent_name' => $decision->getAgentName()]);
 
+            yield new Progress('handoff', \sprintf('Routing to agent "%s".', $targetAgent->getName()), $decision);
+
             // Call the selected agent with the original user question
-            yield new ResultUpdate($cancellation->forward($targetAgent->call(new MessageBag($userMessage), $options))->getResult());
+            yield from $this->answerWith($targetAgent, new MessageBag($userMessage), $options, $cancellation);
         }, cancellation: $cancellation);
+    }
+
+    /**
+     * Runs a delegated agent and yields its result, unless the execution was canceled.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return \Generator<int, Progress|ResultUpdate, mixed, void>
+     */
+    private function answerWith(AgentInterface $agent, MessageBag $messages, array $options, Cancellation $cancellation): \Generator
+    {
+        $result = yield from $this->delegate($agent, $messages, $options, $cancellation);
+
+        if (null !== $result) {
+            yield new ResultUpdate($result);
+        }
+    }
+
+    /**
+     * Runs a delegated agent, forwarding its progress into this execution and returning the result it produced.
+     *
+     * @param array<string, mixed> $options
+     * @param bool                 $forwardDeltas whether the delegated deltas are part of this agent's answer
+     *
+     * @return \Generator<int, Progress, mixed, ResultInterface|null> the result, or null when the execution was canceled
+     */
+    private function delegate(AgentInterface $agent, MessageBag $messages, array $options, Cancellation $cancellation, bool $forwardDeltas = true): \Generator
+    {
+        $result = null;
+
+        foreach ($cancellation->forward($agent->call($messages, $options)) as $update) {
+            if ($update instanceof ResultUpdate) {
+                $result = $update->getResult();
+
+                continue;
+            }
+
+            if (!$update instanceof Progress) {
+                continue;
+            }
+
+            if (!$forwardDeltas && 'delta' === $update->getStage()) {
+                continue;
+            }
+
+            yield $update;
+        }
+
+        if ($cancellation->isRequested()) {
+            return null;
+        }
+
+        if (!$result instanceof ResultInterface) {
+            throw new RuntimeException(\sprintf('The agent "%s" finished without producing a result.', $agent->getName()));
+        }
+
+        return $result;
     }
 
     private function buildAgentSelectionPrompt(string $userQuestion): string

--- a/src/agent/src/SpeechAgent.php
+++ b/src/agent/src/SpeechAgent.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\AI\Agent;
 
+use Symfony\AI\Agent\Exception\RuntimeException;
 use Symfony\AI\Agent\Execution\Cancellation;
 use Symfony\AI\Agent\Execution\Execution;
+use Symfony\AI\Agent\Execution\Update\Progress;
 use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
 use Symfony\AI\Agent\Speech\SpeechConfiguration;
 use Symfony\AI\Platform\Exception\InvalidArgumentException;
@@ -22,6 +24,7 @@ use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\Role;
 use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\ResultInterface;
 
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
@@ -47,7 +50,26 @@ final class SpeechAgent implements AgentInterface
                 $messages = $this->transcribe($messages, $options, $cancellation);
             }
 
-            $result = $cancellation->forward($this->agent->call($messages, $options))->getResult();
+            $result = null;
+            foreach ($cancellation->forward($this->agent->call($messages, $options)) as $update) {
+                if ($update instanceof ResultUpdate) {
+                    $result = $update->getResult();
+
+                    continue;
+                }
+
+                if ($update instanceof Progress) {
+                    yield $update;
+                }
+            }
+
+            if ($cancellation->isRequested()) {
+                return;
+            }
+
+            if (!$result instanceof ResultInterface) {
+                throw new RuntimeException(\sprintf('The agent "%s" finished without producing a result.', $this->agent->getName()));
+            }
 
             if (!$this->textToSpeechPlatform instanceof PlatformInterface || !$this->configuration->supportsTextToSpeech()) {
                 yield new ResultUpdate($result);

--- a/src/agent/tests/MultiAgent/MultiAgentTest.php
+++ b/src/agent/tests/MultiAgent/MultiAgentTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\AI\Agent\Tests\MultiAgent;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\Agent;
@@ -18,6 +19,7 @@ use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Agent\Exception\InvalidArgumentException;
 use Symfony\AI\Agent\Exception\RuntimeException;
 use Symfony\AI\Agent\Execution\Execution;
+use Symfony\AI\Agent\Execution\Update\Progress;
 use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
 use Symfony\AI\Agent\MockAgent;
 use Symfony\AI\Agent\MultiAgent\Handoff;
@@ -33,6 +35,7 @@ use Symfony\AI\Platform\PlatformInterface;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\RawHttpResult;
 use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
 use Symfony\AI\Platform\Result\TextResult;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -406,6 +409,143 @@ class MultiAgentTest extends TestCase
         $this->expectExceptionMessage('The agent execution was canceled.');
 
         $fiber->resume();
+    }
+
+    public function testCallForwardsProgressUpdatesAndEmitsHandoff()
+    {
+        $decision = new Decision('technical', 'This is a technical question');
+
+        $orchestratorResult = $this->createMock(ResultInterface::class);
+        $orchestratorResult->method('getContent')->willReturn($decision);
+
+        $orchestrator = $this->createMock(AgentInterface::class);
+        $orchestrator->method('getName')->willReturn('orchestrator');
+        $orchestrator->method('call')->willReturn(new Execution(static function () use ($orchestratorResult): \Generator {
+            yield new Progress('model_request', 'Invoking orchestrator model.');
+            yield new ResultUpdate($orchestratorResult);
+        }));
+
+        $technicalAgent = $this->createMock(AgentInterface::class);
+        $technicalAgent->method('getName')->willReturn('technical');
+        $technicalAgent->method('call')->willReturn(new Execution(static function (): \Generator {
+            yield new Progress('tool_call', 'Executing tool.');
+            yield new Progress('delta', 'Streaming answer.');
+            yield new ResultUpdate(new TextResult('Technical response'));
+        }));
+
+        $fallback = $this->createMock(AgentInterface::class);
+        $fallback->method('getName')->willReturn('fallback');
+
+        $handoff = new Handoff($technicalAgent, ['technical']);
+        $multiAgent = new MultiAgent($orchestrator, [$handoff], $fallback);
+
+        $updates = iterator_to_array($multiAgent->call(new MessageBag(Message::ofUser('Help with code'))));
+
+        $this->assertCount(5, $updates);
+
+        // 1. Orchestrator progress
+        $this->assertInstanceOf(Progress::class, $updates[0]);
+        $this->assertSame('model_request', $updates[0]->getStage());
+        $this->assertSame('Invoking orchestrator model.', $updates[0]->getMessage());
+
+        // 2. MultiAgent handoff progress
+        $this->assertInstanceOf(Progress::class, $updates[1]);
+        $this->assertSame('handoff', $updates[1]->getStage());
+        $this->assertSame('Routing to agent "technical".', $updates[1]->getMessage());
+        $this->assertSame($decision, $updates[1]->getPayload());
+
+        // 3. Technical agent tool call progress
+        $this->assertInstanceOf(Progress::class, $updates[2]);
+        $this->assertSame('tool_call', $updates[2]->getStage());
+
+        // 4. Technical agent delta progress
+        $this->assertInstanceOf(Progress::class, $updates[3]);
+        $this->assertSame('delta', $updates[3]->getStage());
+
+        // 5. Final result update
+        $this->assertInstanceOf(ResultUpdate::class, $updates[4]);
+        $this->assertSame('Technical response', $updates[4]->getResult()->getContent());
+    }
+
+    public function testCallDropsTheOrchestratorDeltasButForwardsTheAnsweringOnes()
+    {
+        $decision = new Decision('technical', 'This is a technical question');
+
+        $orchestratorResult = $this->createMock(ResultInterface::class);
+        $orchestratorResult->method('getContent')->willReturn($decision);
+
+        $orchestrator = $this->createMock(AgentInterface::class);
+        $orchestrator->method('getName')->willReturn('orchestrator');
+        $orchestrator->method('call')->willReturn(new Execution(static function () use ($orchestratorResult): \Generator {
+            yield new Progress('model_request', 'Invoking orchestrator model.');
+            // the routing round spells out the Decision, which is no part of the answer
+            yield new Progress('delta', 'Received a streamed delta.', new TextDelta('{"agentName":"tech'));
+            yield new Progress('delta', 'Received a streamed delta.', new TextDelta('nical"}'));
+            yield new ResultUpdate($orchestratorResult);
+        }));
+
+        $technicalAgent = $this->createMock(AgentInterface::class);
+        $technicalAgent->method('getName')->willReturn('technical');
+        $technicalAgent->method('call')->willReturn(new Execution(static function (): \Generator {
+            yield new Progress('delta', 'Received a streamed delta.', new TextDelta('Hello '));
+            yield new Progress('delta', 'Received a streamed delta.', new TextDelta('world'));
+            yield new ResultUpdate(new TextResult('Hello world'));
+        }));
+
+        $fallback = $this->createMock(AgentInterface::class);
+        $fallback->method('getName')->willReturn('fallback');
+
+        $handoff = new Handoff($technicalAgent, ['technical']);
+        $multiAgent = new MultiAgent($orchestrator, [$handoff], $fallback);
+
+        $answer = '';
+        foreach ($multiAgent->call(new MessageBag(Message::ofUser('Help with code')), ['stream' => true]) as $update) {
+            if ($update instanceof Progress && 'delta' === $update->getStage() && $update->getPayload() instanceof TextDelta) {
+                $answer .= $update->getPayload()->getText();
+            }
+        }
+
+        $this->assertSame('Hello world', $answer);
+    }
+
+    #[DataProvider('provideFallbackDecisions')]
+    public function testCallEmitsHandoffCarryingTheDecisionWhenFallingBack(Decision $decision)
+    {
+        $orchestratorResult = $this->createMock(ResultInterface::class);
+        $orchestratorResult->method('getContent')->willReturn($decision);
+
+        $orchestrator = $this->createMock(AgentInterface::class);
+        $orchestrator->method('getName')->willReturn('orchestrator');
+        $orchestrator->method('call')->willReturn($this->execution($orchestratorResult));
+
+        $fallback = $this->createMock(AgentInterface::class);
+        $fallback->method('getName')->willReturn('fallback');
+        $fallback->method('call')->willReturn($this->execution(new TextResult('Fallback response')));
+
+        $handoff = new Handoff(new MockAgent(name: 'technical'), ['technical']);
+        $multiAgent = new MultiAgent($orchestrator, [$handoff], $fallback);
+
+        $updates = iterator_to_array($multiAgent->call(new MessageBag(Message::ofUser('Question'))));
+
+        $this->assertCount(2, $updates);
+
+        // The handoff names the agent that actually runs, while its payload carries the orchestrator's decision
+        $this->assertInstanceOf(Progress::class, $updates[0]);
+        $this->assertSame('handoff', $updates[0]->getStage());
+        $this->assertSame('Routing to fallback agent "fallback".', $updates[0]->getMessage());
+        $this->assertSame($decision, $updates[0]->getPayload());
+
+        $this->assertInstanceOf(ResultUpdate::class, $updates[1]);
+        $this->assertSame('Fallback response', $updates[1]->getResult()->getContent());
+    }
+
+    /**
+     * @return iterable<string, array{Decision}>
+     */
+    public static function provideFallbackDecisions(): iterable
+    {
+        yield 'no agent selected' => [new Decision('', 'No specific agent matches')];
+        yield 'agent not found' => [new Decision('nonexistent', 'Selected non-existent agent')];
     }
 
     private function execution(ResultInterface $result): Execution

--- a/src/agent/tests/SpeechAgentTest.php
+++ b/src/agent/tests/SpeechAgentTest.php
@@ -16,6 +16,7 @@ use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Agent\Exception\RuntimeException as AgentRuntimeException;
 use Symfony\AI\Agent\Execution\Execution;
+use Symfony\AI\Agent\Execution\Update\Progress;
 use Symfony\AI\Agent\Execution\Update\Result as ResultUpdate;
 use Symfony\AI\Agent\Speech\SpeechConfiguration;
 use Symfony\AI\Agent\SpeechAgent;
@@ -292,6 +293,30 @@ final class SpeechAgentTest extends TestCase
         $this->expectExceptionMessage('The agent execution was canceled.');
 
         $fiber->resume();
+    }
+
+    public function testCallForwardsProgressUpdatesFromInnerAgent()
+    {
+        $innerAgent = $this->createMock(AgentInterface::class);
+        $innerAgent->expects($this->once())
+            ->method('call')
+            ->willReturn(new Execution(static function (): \Generator {
+                yield new Progress('model_request', 'Invoking model.');
+                yield new Progress('delta', 'Received a streamed delta.');
+                yield new ResultUpdate(new TextResult('hello'));
+            }));
+
+        $agent = new SpeechAgent($innerAgent, new SpeechConfiguration());
+
+        $updates = iterator_to_array($agent->call(new MessageBag(Message::ofUser('Hello'))));
+
+        $this->assertCount(3, $updates);
+        $this->assertInstanceOf(Progress::class, $updates[0]);
+        $this->assertSame('model_request', $updates[0]->getStage());
+        $this->assertInstanceOf(Progress::class, $updates[1]);
+        $this->assertSame('delta', $updates[1]->getStage());
+        $this->assertInstanceOf(ResultUpdate::class, $updates[2]);
+        $this->assertSame('hello', $updates[2]->getResult()->getContent());
     }
 
     private function execution(ResultInterface $result): Execution


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #2444
| License       | MIT

### Description

Iterating a `MultiAgent` or `SpeechAgent` previously yielded no `Progress` updates because both
decorating agents eagerly resolved the delegated execution via `->getResult()`.

This PR fixes that by:

1. Forwarding the `Progress` updates of the delegated executions in both `MultiAgent` and
   `SpeechAgent` (model requests, tool calls, streamed deltas), with cancellation still propagating.
2. Emitting a `handoff` `Progress` stage on `MultiAgent` carrying the orchestrator's
   `Handoff\Decision` as payload, so consumers see which agent answers and why. `Decision` is
   therefore no longer `@internal`.

The orchestrator's own routing round is excluded from delta forwarding: those deltas spell out the
`Decision`, not the answer, and would otherwise leak into the `delta` stage that consumers render as
the answer.

Docs: a new step in the multi-agent cookbook recipe, with `examples/multi-agent/orchestrator-iterable.php`
as its runnable counterpart.
