### PR TITLE
[CI] Let the lowest job resolve the Symfony floor the packages declare

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -135,6 +135,10 @@ jobs:
     # all constraints and pick the highest of every package's floor, never exercising the lowest
     # bound a single package declares. So each package is installed on its own -- but grouped a few
     # per job and run in parallel by .github/run-lowest.sh, instead of one job per package.
+    #
+    # For the same reason this job sets no SYMFONY_REQUIRE. Packages declare "^7.3|^8.0", so pinning
+    # it to >=7.4 here left the 7.3 floor untested while we kept advertising it. Do not re-add it
+    # without raising those constraints first.
     lowest:
         name: Unit / Lowest / ${{ matrix.shard.name }}
         runs-on: ubuntu-latest
@@ -156,7 +160,6 @@ jobs:
                         find: "find src/mate/src/Bridge -mindepth 2 -maxdepth 2 -name phpunit.xml.dist"
 
         env:
-            SYMFONY_REQUIRE: '>=7.4'
             SYMFONY_DEPRECATIONS_HELPER: weak
 
         steps:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2481
| License       | MIT

As decided in #2481: keep `^7.3` and actually test it.

The lowest job pinned `SYMFONY_REQUIRE` to `>=7.4` while 177 constraints in the tree say `^7.3|^8.0`, so `--prefer-lowest` resolved 7.4.0 and the floor we advertise was never installed by any job. The pin is gone. The comment above the job records why, so it does not come back without the constraints moving first.

That gap is where #2480 came from. The `symfony/http-client` versions without `symfony/polyfill-php83` are 7.3.0 to 7.3.2, exactly the range no job reached, which is why three packages could call a PHP 8.3 function under `php: ">=8.2"` unnoticed.

This job is the one place that installs each package on its own, so it is also the only one that can see a missing per-package dependency at all. Expect it to surface more than it did yesterday; that is the point of the change, and whatever it finds is real.
