### PR TITLE
[Agent] Keep server tools passed in the tools option

### DIFF
--- a/src/agent/src/Execution/Runner.php
+++ b/src/agent/src/Execution/Runner.php
@@ -232,22 +232,21 @@ final class Runner
             return $options;
         }
 
-        // only filter tool map if a list of strings is provided as option
-        if (isset($options['tools']) && \is_array($options['tools']) && $this->isFlatStringArray($options['tools'])) {
-            $toolMap = array_values(array_filter($toolMap, static fn (Tool $tool): bool => \in_array($tool->getName(), $options['tools'], true)));
+        $serverTools = [];
+
+        if (isset($options['tools']) && \is_array($options['tools'])) {
+            $names = array_values(array_filter($options['tools'], static fn (mixed $tool): bool => \is_string($tool)));
+            $serverTools = array_values(array_filter($options['tools'], static fn (mixed $tool): bool => \is_array($tool)));
+
+            // only filter tool map if tool names are provided as option, an empty option exposes no tool at all
+            if ([] !== $names || [] === $options['tools']) {
+                $toolMap = array_values(array_filter($toolMap, static fn (Tool $tool): bool => \in_array($tool->getName(), $names, true)));
+            }
         }
 
-        $options['tools'] = $toolMap;
+        $options['tools'] = [...$toolMap, ...$serverTools];
 
         return $options;
-    }
-
-    /**
-     * @param array<mixed> $tools
-     */
-    private function isFlatStringArray(array $tools): bool
-    {
-        return array_reduce($tools, static fn (bool $carry, mixed $item): bool => $carry && \is_string($item), true);
     }
 
     private function extractToolCallResult(ResultInterface $result): ?ToolCallResult

--- a/src/agent/tests/Execution/RunnerTest.php
+++ b/src/agent/tests/Execution/RunnerTest.php
@@ -85,6 +85,46 @@ final class RunnerTest extends TestCase
         $this->assertSame(['tools' => [$tool2]], $options);
     }
 
+    public function testAnEmptyToolsOptionExposesNoRegisteredTool()
+    {
+        $toolbox = $this->createStub(ToolboxInterface::class);
+        $tool1 = new Tool(new ExecutionReference('ClassTool1', 'method1'), 'tool1', 'description1', null);
+        $tool2 = new Tool(new ExecutionReference('ClassTool2', 'method1'), 'tool2', 'description2', null);
+        $toolbox->method('getTools')->willReturn([$tool1, $tool2]);
+
+        $options = $this->captureOptions($toolbox, ['tools' => []]);
+
+        $this->assertSame(['tools' => []], $options);
+    }
+
+    public function testServerToolsInTheToolsOptionAreKeptNextToRegisteredTools()
+    {
+        $toolbox = $this->createStub(ToolboxInterface::class);
+        $tool1 = new Tool(new ExecutionReference('ClassTool1', 'method1'), 'tool1', 'description1', null);
+        $tool2 = new Tool(new ExecutionReference('ClassTool2', 'method1'), 'tool2', 'description2', null);
+        $toolbox->method('getTools')->willReturn([$tool1, $tool2]);
+
+        $serverTool = ['type' => 'web_fetch_20260318', 'name' => 'web_fetch'];
+
+        $options = $this->captureOptions($toolbox, ['tools' => [$serverTool]]);
+
+        $this->assertSame(['tools' => [$tool1, $tool2, $serverTool]], $options);
+    }
+
+    public function testServerToolsAreKeptWhileRegisteredToolsGetFilteredByName()
+    {
+        $toolbox = $this->createStub(ToolboxInterface::class);
+        $tool1 = new Tool(new ExecutionReference('ClassTool1', 'method1'), 'tool1', 'description1', null);
+        $tool2 = new Tool(new ExecutionReference('ClassTool2', 'method1'), 'tool2', 'description2', null);
+        $toolbox->method('getTools')->willReturn([$tool1, $tool2]);
+
+        $serverTool = ['type' => 'web_fetch_20260318', 'name' => 'web_fetch'];
+
+        $options = $this->captureOptions($toolbox, ['tools' => ['tool2', $serverTool]]);
+
+        $this->assertSame(['tools' => [$tool2, $serverTool]], $options);
+    }
+
     public function testToolCallMessagesEndUpInTheCallersMessageBag()
     {
         $toolCall = new ToolCall('id1', 'tool1', ['arg1' => 'value1']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Fix #2485
| License       | MIT

When a toolbox is registered, `Runner::exposeTools()` replaces the whole `tools` option with the toolbox tool map, so provider-side server tools passed by the caller (`['type' => 'web_fetch_20260318', 'name' => 'web_fetch']`) never reach the API.

The option now keeps both: string entries still filter the toolbox by tool name, everything else is appended after the resulting tool map.
