### PR TITLE
[Mate] Show tool arguments in tools:list, point tools:call errors at tools:inspect

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.14
+----
+
+ * Add an `Arguments` column to `tools:list`'s table output, and stop truncating tool descriptions to 50 characters, so a tool's parameters and full description are visible without a separate `tools:inspect` call
+ * Add a `tools:inspect <tool-name>` hint to `tools:call`'s error output when a parameter name is unknown or a required one is missing
+
 0.13
 ----
 

--- a/src/mate/src/Command/ToolsCallCommand.php
+++ b/src/mate/src/Command/ToolsCallCommand.php
@@ -174,6 +174,16 @@ HELP
 
         try {
             $result = $this->invoker->invoke($tool, $params);
+        } catch (InvalidArgumentException $e) {
+            // A wrong or missing parameter name is a guess the caller can correct right away;
+            // point at the command that shows the full schema instead of leaving it a guess.
+            $io->error(\sprintf('Error: %s', $e->getMessage()));
+            $io->note(\sprintf('Use "%s tools:inspect %s" to see this tool\'s parameters.', $_SERVER['PHP_SELF'] ?? 'vendor/bin/mate', $toolName));
+            if ($verbose) {
+                $io->text($e->getTraceAsString());
+            }
+
+            return Command::FAILURE;
         } catch (\Throwable $e) {
             $io->error(\sprintf('Error: %s', $e->getMessage()));
             if ($verbose) {

--- a/src/mate/src/Command/ToolsListCommand.php
+++ b/src/mate/src/Command/ToolsListCommand.php
@@ -215,12 +215,13 @@ HELP
         }
 
         $table = new Table($io);
-        $table->setHeaders(['Tool Name', 'Description', 'Handler', 'Extension']);
+        $table->setHeaders(['Tool Name', 'Description', 'Arguments', 'Handler', 'Extension']);
 
         foreach ($tools as $toolName => $toolData) {
             $table->addRow([
                 $toolName,
-                $this->truncate($toolData['description'] ?? '', 50),
+                $toolData['description'] ?? '',
+                $this->formatArguments($toolData['input_schema']),
                 $toolData['handler'],
                 $toolData['extension'],
             ]);
@@ -250,12 +251,40 @@ HELP
         ];
     }
 
-    private function truncate(string $text, int $length): string
+    /**
+     * Renders the schema's parameter names as a compact summary, required ones first and
+     * unmarked, optional ones trailing with a `?` (e.g. `query, path?, limit?`), so the
+     * table conveys the call shape without forcing a separate `tools:inspect`.
+     *
+     * @param array<string, mixed>|null $inputSchema
+     */
+    private function formatArguments(?array $inputSchema): string
     {
-        if (\strlen($text) <= $length) {
-            return $text;
+        if (null === $inputSchema) {
+            return '';
         }
 
-        return substr($text, 0, $length - 3).'...';
+        $properties = $inputSchema['properties'] ?? [];
+        if (!\is_array($properties) || [] === $properties) {
+            return '';
+        }
+
+        $required = $inputSchema['required'] ?? [];
+        \assert(\is_array($required));
+
+        $required = array_flip($required);
+        $optional = [];
+        $names = [];
+
+        foreach (array_keys($properties) as $name) {
+            \assert(\is_string($name));
+            if (isset($required[$name])) {
+                $names[] = $name;
+            } else {
+                $optional[] = $name.'?';
+            }
+        }
+
+        return implode(', ', [...$names, ...$optional]);
     }
 }

--- a/src/mate/tests/Command/ToolsCallCommandTest.php
+++ b/src/mate/tests/Command/ToolsCallCommandTest.php
@@ -191,6 +191,25 @@ final class ToolsCallCommandTest extends TestCase
     }
 
     /**
+     * A wrong or missing parameter name is a guess the caller can correct right away, if it
+     * knows where the schema is; point at tools:inspect instead of leaving it a guess.
+     */
+    public function testUnknownParameterPointsAtToolsInspect()
+    {
+        $output = $this->runViaArgv(['sample-add', '--a=1', '--nope=2', '--format=json']);
+
+        $this->assertStringContainsString('tools:inspect sample-add', $output);
+    }
+
+    public function testMissingRequiredParameterPointsAtToolsInspect()
+    {
+        $output = $this->runViaArgv(['sample-add', '--format=json']);
+
+        $this->assertStringContainsString('Missing required argument "a"', $output);
+        $this->assertStringContainsString('tools:inspect sample-add', $output);
+    }
+
+    /**
      * `--silent` suppresses all output, so treating it as a tool parameter turned a rejected
      * unknown argument into a run that printed nothing and failed.
      */

--- a/src/mate/tests/Command/ToolsListCommandTest.php
+++ b/src/mate/tests/Command/ToolsListCommandTest.php
@@ -162,6 +162,24 @@ final class ToolsListCommandTest extends TestCase
         $this->assertStringContainsString('Extension', $output);
     }
 
+    public function testTableOutputShowsRequiredAndOptionalArguments()
+    {
+        $rootDir = __DIR__.'/../..';
+        $extensions = [
+            '_custom' => ['dirs' => ['tests/Command/Fixtures'], 'includes' => []],
+        ];
+
+        $command = $this->createCommand($rootDir, $extensions);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--filter' => 'sample-add', '--format' => 'table']);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Arguments', $output);
+        $this->assertStringContainsString('a, b?, negate?', $output);
+    }
+
     public function testExecuteWithToonFormatFailsWhenToonIsNotAvailable()
     {
         $rootDir = __DIR__.'/../..';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | n/a
| License       | MIT

`tools:list` already collected each tool's `input_schema`, but its table output dropped it and truncated the description to 50 characters. The table now shows an `Arguments` column (required names first, optional ones marked with `?`), and the description column is no longer truncated, so a tool's shape is visible without a separate `tools:inspect` call.

`tools:call` already reports unknown or missing parameter names via `ArgumentCaster`'s existing message; that part was not broken. A parameter error now additionally points at `tools:inspect <tool-name>`.

Measured against an external benchmark (a `monolog-search` scenario, 240 runs total across the batch): no movement in that scenario's error rate, for two independent reasons. `tools:list` was never called in that flow, so the new column had no path to the agent. And the observed failures were all missing-required-argument errors that `ArgumentCaster`'s message already named correctly, with 100% self-correction on retry even before this change. Noting that here rather than overselling it: this is a plausible hygiene improvement for flows that do read `tools:list` or a `tools:call` error, not a fix validated to move a measured number.
