### PR TITLE
[Agent] Add execution cancellation example

### DIFF
--- a/docs/components/agent.rst
+++ b/docs/components/agent.rst
@@ -147,7 +147,9 @@ the stream without producing a final result::
 
 Cancellation is idempotent, propagates to the agents a ``MultiAgent`` or ``SpeechAgent`` delegates to, and makes
 ``getResult()`` throw a :class:`Symfony\\AI\\Agent\\Exception\\RuntimeException` instead of returning a partial
-answer.
+answer. See the
+`execution-cancellation.php <https://github.com/symfony/ai/blob/main/examples/agent/execution-cancellation.php>`_
+example.
 
 Once the stream is drained, the execution resolves to the assembled answer like a non-streamed one: ``getResult()``
 returns the final result, and a streamed structured output ends with the object, so ``asObject()`` works on it as

--- a/examples/agent/execution-cancellation.php
+++ b/examples/agent/execution-cancellation.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Agent\Exception\RuntimeException;
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+if (!function_exists('pcntl_signal')) {
+    echo 'This example requires the pcntl extension.'.\PHP_EOL;
+
+    exit(1);
+}
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+$agent = new Agent($platform, 'gpt-5-mini');
+
+$messages = new MessageBag(Message::ofUser('Tell me a long story about a lighthouse keeper.'));
+
+$execution = $agent->call($messages, ['stream' => true]);
+
+// Enable async signal handling and register a signal handler for SIGINT (Ctrl+C)
+pcntl_async_signals(true);
+pcntl_signal(\SIGINT, static fn () => $execution->cancel());
+
+$characters = 0;
+foreach ($execution->asTextStream() as $delta) {
+    echo $delta->getText();
+
+    // Cancel the execution if the total number of characters exceeds 200
+    if (($characters += strlen($delta->getText())) > 200) {
+        $execution->cancel();
+    }
+}
+
+echo \PHP_EOL.\PHP_EOL.'>> Canceled after '.$characters.' characters.'.\PHP_EOL;
+
+try {
+    $execution->getResult();
+} catch (RuntimeException $e) {
+    echo '>> '.$e->getMessage().\PHP_EOL;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | n/a
| License       | MIT

Adds `examples/agent/execution-cancellation.php` for the cancellation feature from #2471:

* cancels a streamed execution from a `SIGINT` handler and from within the consumption loop
* shows `getResult()` throwing instead of returning a partial answer
* links the example from the cancellation section in `docs/components/agent.rst`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzwwE4uQ6KbrtgLRx5V7ew