### PR TITLE
[Examples] Add copywriter and art director reviewer loop

### DIFF
--- a/ai.symfony.com/templates/cookbook/content/generator-reviewer-loop.html
+++ b/ai.symfony.com/templates/cookbook/content/generator-reviewer-loop.html
@@ -672,7 +672,8 @@ independent judgment as well as saving cost</li>
     
 </h2>
 <ul>
-    <li><a href="/cookbook/multi-agent-orchestration" class="reference internal">Multi-Agent Orchestration</a> - Route questions to specialist agents instead of reviewing output</li>
+    <li><a href="https://github.com/symfony/ai/blob/main/examples/agent/reviewer-loop.php" class="reference external" rel="external noopener noreferrer" target="_blank">Reviewer Loop Example</a> - A runnable copywriter and art director loop in a single file</li>
+<li><a href="/cookbook/multi-agent-orchestration" class="reference internal">Multi-Agent Orchestration</a> - Route questions to specialist agents instead of reviewing output</li>
 <li><a href="https://symfony.com/doc/current/ai/components/agent.html" class="reference internal">Symfony AI - Agent Component</a> - Processors, memory, and advanced agent patterns</li>
 <li><a href="https://symfony.com/doc/current/ai/components/platform.html" class="reference internal">Symfony AI - Platform Component</a> - Structured output and platform configuration reference</li>
 </ul>

--- a/docs/cookbook/generator-reviewer-loop.rst
+++ b/docs/cookbook/generator-reviewer-loop.rst
@@ -333,6 +333,7 @@ Best Practices
 Learn More
 ----------
 
+* `Reviewer Loop Example <https://github.com/symfony/ai/blob/main/examples/agent/reviewer-loop.php>`_ - A runnable copywriter and art director loop in a single file
 * :doc:`multi-agent-orchestration` - Route questions to specialist agents instead of reviewing output
 * :doc:`../components/agent` - Processors, memory, and advanced agent patterns
 * :doc:`../components/platform` - Structured output and platform configuration reference

--- a/examples/agent/reviewer-loop.php
+++ b/examples/agent/reviewer-loop.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\AI\Agent\Agent;
+use Symfony\AI\Platform\Bridge\OpenAi\Factory;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+$platform = Factory::createPlatform(env('OPENAI_API_KEY'), http_client());
+
+$copywriter = new Agent($platform, 'gpt-5-mini', name: 'copywriter');
+$artDirector = new Agent($platform, 'gpt-5-mini', name: 'art-director');
+
+// Both agents work on the same conversation, but each keeps its own view of it: what the other
+// one says arrives as a user message, what it said itself stays an assistant message.
+$copywriterMessages = new MessageBag(
+    Message::forSystem(<<<PROMPT
+        You are a copywriter with ten years of experience and are known for brevity and a dry humor.
+        You are laser focused on the goal at hand: refining a single slogan of at most eight words
+        until it is the best it can be. Consider the art director's suggestions when refining it, and
+        reply with the slogan only - no explanation, no alternatives, no chit chat.
+        PROMPT),
+    Message::ofUser('Write a slogan for this concept: maps made out of egg cartons.'),
+);
+
+$artDirectorMessages = new MessageBag(
+    Message::forSystem(<<<PROMPT
+        You are an art director who has opinions about copywriting born of a love for David Ogilvy.
+        Decide whether the slogan you are given is acceptable to print: short, memorable and on
+        concept is enough, do not chase perfection. If it is acceptable, reply with exactly
+        "APPROVED". If it is not, reply with a single sentence of concrete advice on how to refine
+        it - never write the copy yourself.
+        PROMPT),
+);
+
+$maxRounds = 4;
+$approved = false;
+$slogan = '';
+
+for ($round = 1; $round <= $maxRounds; ++$round) {
+    $slogan = $copywriter->call($copywriterMessages)->asText();
+    $copywriterMessages = $copywriterMessages->with(Message::ofAssistant($slogan));
+    $artDirectorMessages = $artDirectorMessages->with(Message::ofUser($slogan));
+
+    output()->writeln(sprintf('<info>Round %d, copywriter:</info> %s', $round, $slogan));
+
+    $verdict = $artDirector->call($artDirectorMessages)->asText();
+    $artDirectorMessages = $artDirectorMessages->with(Message::ofAssistant($verdict));
+
+    // The reviewer decides when the loop is done, the round cap only keeps it from running forever
+    $approved = str_contains(strtoupper($verdict), 'APPROVED');
+    if ($approved) {
+        break;
+    }
+
+    output()->writeln(sprintf('<comment>Round %d, art director:</comment> %s', $round, $verdict));
+
+    $copywriterMessages = $copywriterMessages->with(Message::ofUser($verdict));
+}
+
+output()->writeln('');
+
+if ($approved) {
+    output()->writeln(sprintf('<info>Approved in round %d:</info> %s', $round, $slogan));
+} else {
+    output()->writeln(sprintf('<comment>Still not approved after %d rounds, last version:</comment> %s', $maxRounds, $slogan));
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Docs?         | yes
| Issues        | -
| License       | MIT

Adds `examples/agent/reviewer-loop.php`, a slim single-file variant of the classic Semantic Kernel copywriter/art-director group chat: two agents, each with its own view of the same conversation, the reviewer decides when the loop terminates (`APPROVED`), a round cap only guards against running forever.

Complements the recently merged generator/reviewer cookbook recipe, which now links to it from "Learn More" (website fragments regenerated).

<img width="1254" height="284" alt="image" src="https://github.com/user-attachments/assets/38d3b3ed-2aa9-44f9-904b-3bd5b9fc2d41" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qdzad5xgvsjc7hXa7ypfqh