### PR TITLE
[Store] Pass indexer options to the loader

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,6 +32,15 @@ Platform
    +protected function convertStreamUsage(array $usage, ?string $model = null): TokenUsage
    ```
 
+Store
+-----
+
+ * `Indexer\SourceIndexer` passes its options on to the loader, not only to the document processor,
+   so that a source can be narrowed at runtime. A `Document\LoaderInterface` implementation that
+   previously only ever saw options passed to `load()` directly now also receives the indexing
+   options (`chunk_size`, `platform_options`, and whatever else the caller passed). Loaders ignoring
+   unknown options - which the interface asks for - are unaffected.
+
 UPGRADE FROM 0.12 to 0.13
 =========================
 

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.14
+----
+
+ * `Indexer\SourceIndexer` now passes its options to the loader as well as to the document processor
+
 0.11
 ----
 

--- a/src/store/src/Indexer/SourceIndexer.php
+++ b/src/store/src/Indexer/SourceIndexer.php
@@ -29,12 +29,13 @@ final class SourceIndexer implements IndexerInterface
     }
 
     /**
-     * @param string|iterable<string>|null $input Source identifier (file path, URL, etc.), iterable of sources, or null for source-independent loaders
+     * @param string|iterable<string>|null $input   Source identifier (file path, URL, etc.), iterable of sources, or null for source-independent loaders
+     * @param array<string, mixed>         $options passed to the loader as well as to the processor, so a source can be narrowed at runtime
      */
     public function index(string|iterable|object|null $input = null, array $options = []): void
     {
         if (null === $input) {
-            $this->processor->process($this->loader->load(), $options);
+            $this->processor->process($this->loader->load(null, $options), $options);
 
             return;
         }
@@ -45,12 +46,12 @@ final class SourceIndexer implements IndexerInterface
 
         $sources = \is_string($input) ? [$input] : $input;
 
-        $documents = (function () use ($sources) {
+        $documents = (function () use ($sources, $options) {
             foreach ($sources as $source) {
                 if (!\is_string($source)) {
                     throw new InvalidArgumentException(\sprintf('SourceIndexer expects sources to be strings, got "%s".', get_debug_type($source)));
                 }
-                yield from $this->loader->load($source);
+                yield from $this->loader->load($source, $options);
             }
         })();
 

--- a/src/store/tests/Indexer/SourceIndexerTest.php
+++ b/src/store/tests/Indexer/SourceIndexerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Result\VectorResult;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Loader\InMemoryLoader;
+use Symfony\AI\Store\Document\LoaderInterface;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\TextDocument;
 use Symfony\AI\Store\Document\VectorDocument;
@@ -117,6 +118,44 @@ final class SourceIndexerTest extends TestCase
         $this->assertCount(4, $store->documents);
     }
 
+    public function testIndexPassesOptionsToTheLoader()
+    {
+        $loader = new OptionRecordingLoader();
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(), 'text-embedding-3-small');
+        $indexer = new SourceIndexer($loader, new DocumentProcessor($vectorizer, new TestStore()));
+
+        $indexer->index('source', ['criteria' => ['published' => true]]);
+
+        // The loader is what turns a source into documents, so narrowing which documents an
+        // indexing run covers has to reach it, not only the processor behind it.
+        $this->assertSame([['source', ['criteria' => ['published' => true]]]], $loader->calls);
+    }
+
+    public function testIndexPassesOptionsToASourceIndependentLoader()
+    {
+        $loader = new OptionRecordingLoader();
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(), 'text-embedding-3-small');
+        $indexer = new SourceIndexer($loader, new DocumentProcessor($vectorizer, new TestStore()));
+
+        $indexer->index(null, ['criteria' => ['published' => true]]);
+
+        $this->assertSame([[null, ['criteria' => ['published' => true]]]], $loader->calls);
+    }
+
+    public function testIndexPassesOptionsToEverySourceOfABatch()
+    {
+        $loader = new OptionRecordingLoader();
+        $vectorizer = new Vectorizer(PlatformTestHandler::createPlatform(), 'text-embedding-3-small');
+        $indexer = new SourceIndexer($loader, new DocumentProcessor($vectorizer, new TestStore()));
+
+        $indexer->index(['first', 'second'], ['criteria' => ['published' => true]]);
+
+        $this->assertSame([
+            ['first', ['criteria' => ['published' => true]]],
+            ['second', ['criteria' => ['published' => true]]],
+        ], $loader->calls);
+    }
+
     public function testIndexThrowsExceptionForObjectInput()
     {
         $loader = new InMemoryLoader([]);
@@ -143,5 +182,23 @@ final class SourceIndexerTest extends TestCase
         $this->expectExceptionMessage('SourceIndexer expects sources to be strings');
 
         $indexer->index([new TextDocument(Uuid::v4()->toString(), 'Test content')]); /* @phpstan-ignore argument.type */
+    }
+}
+
+/**
+ * Records how it was called, so the options an indexer hands down can be asserted on.
+ */
+final class OptionRecordingLoader implements LoaderInterface
+{
+    /**
+     * @var list<array{string|null, array<string, mixed>}>
+     */
+    public array $calls = [];
+
+    public function load(?string $source = null, array $options = []): iterable
+    {
+        $this->calls[] = [$source, $options];
+
+        return [];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

> Slice 1 of 5, splitting up a Doctrine store that keeps vectors on the entity's own table. Independent of the rest — nothing stacked on top of it is needed to review or merge this.

`SourceIndexer` hands its options to the document processor but not to the loader that produced the documents in the first place. Which documents a run covers is therefore fixed when the loader is constructed, and an indexer cannot narrow a source per run — "only the published ones", "only what changed since yesterday" — even though `LoaderInterface::load()` already takes options for exactly that.

```diff
-yield from $this->loader->load($source);
+yield from $this->loader->load($source, $options);
```

## Compatibility

Loaders that ignore options they do not know — which the interface already asks of them — are unaffected. Loaders that read options now also see the indexing options (`chunk_size`, `platform_options`, anything else the caller passed) alongside their own.

## Tests

Three cases added to `SourceIndexerTest`, covering a single source, a source-independent loader (`null`), and a batch of sources — the last because the options have to reach *every* source, not just the first.
