### PR TITLE
[Store] Accept any VectorInterface in vector queries

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,11 @@ Store
    options (`chunk_size`, `platform_options`, and whatever else the caller passed). Loaders ignoring
    unknown options - which the interface asks for - are unaffected.
 
+ * `Query\VectorQuery` and `Query\HybridQuery` accept and return `Platform\Vector\VectorInterface`
+   instead of the final `Platform\Vector\Vector` class. Passing a `Vector` is unchanged. This is what
+   makes a "more like this" query possible without a cast: the vector of a document returned by a store
+   can now be fed straight back into a query.
+
 UPGRADE FROM 0.12 to 0.13
 =========================
 

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ----
 
  * `Indexer\SourceIndexer` now passes its options to the loader as well as to the document processor
+ * [BC BREAK] Accept and return `Platform\Vector\VectorInterface` in `Query\VectorQuery` and `Query\HybridQuery` instead of the final `Platform\Vector\Vector` class
+
 
 0.11
 ----

--- a/src/store/src/Distance/DistanceCalculator.php
+++ b/src/store/src/Distance/DistanceCalculator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Store\Distance;
 
-use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Document\VectorDocument;
 
 /**
@@ -34,7 +34,7 @@ final class DistanceCalculator
      *
      * @return VectorDocument[]
      */
-    public function calculate(array $documents, Vector $vector, ?int $maxItems = null): array
+    public function calculate(array $documents, VectorInterface $vector, ?int $maxItems = null): array
     {
         if (null !== $maxItems && $this->batchSize <= \count($documents)) {
             return $this->calculateBatched($documents, $vector, $maxItems);
@@ -48,7 +48,7 @@ final class DistanceCalculator
      *
      * @return VectorDocument[]
      */
-    private function calculateAgainstAll(array $documents, Vector $vector, ?int $maxItems): array
+    private function calculateAgainstAll(array $documents, VectorInterface $vector, ?int $maxItems): array
     {
         $strategy = $this->resolveStrategy();
 
@@ -83,7 +83,7 @@ final class DistanceCalculator
      *
      * @return VectorDocument[]
      */
-    private function calculateBatched(array $documents, Vector $vector, int $maxItems): array
+    private function calculateBatched(array $documents, VectorInterface $vector, int $maxItems): array
     {
         $strategy = $this->resolveStrategy();
 
@@ -121,7 +121,7 @@ final class DistanceCalculator
     }
 
     /**
-     * @return \Closure(VectorDocument, Vector): float
+     * @return \Closure(VectorDocument, VectorInterface): float
      */
     private function resolveStrategy(): \Closure
     {
@@ -134,12 +134,12 @@ final class DistanceCalculator
         };
     }
 
-    private function cosineDistance(VectorDocument $embedding, Vector $against): float
+    private function cosineDistance(VectorDocument $embedding, VectorInterface $against): float
     {
         return 1 - $this->cosineSimilarity($embedding, $against);
     }
 
-    private function cosineSimilarity(VectorDocument $embedding, Vector $against): float
+    private function cosineSimilarity(VectorDocument $embedding, VectorInterface $against): float
     {
         $currentEmbeddingVectors = $embedding->getVector()->getData();
 
@@ -162,14 +162,14 @@ final class DistanceCalculator
         return fdiv($dotProduct, $currentEmbeddingLength * $againstLength);
     }
 
-    private function angularDistance(VectorDocument $embedding, Vector $against): float
+    private function angularDistance(VectorDocument $embedding, VectorInterface $against): float
     {
         $cosineSimilarity = $this->cosineSimilarity($embedding, $against);
 
         return fdiv(acos($cosineSimilarity), \M_PI);
     }
 
-    private function euclideanDistance(VectorDocument $embedding, Vector $against): float
+    private function euclideanDistance(VectorDocument $embedding, VectorInterface $against): float
     {
         return sqrt(array_sum(array_map(
             static fn (float $a, float $b): float => ($a - $b) ** 2,
@@ -178,7 +178,7 @@ final class DistanceCalculator
         )));
     }
 
-    private function manhattanDistance(VectorDocument $embedding, Vector $against): float
+    private function manhattanDistance(VectorDocument $embedding, VectorInterface $against): float
     {
         return array_sum(array_map(
             static fn (float $a, float $b): float => abs($a - $b),
@@ -187,7 +187,7 @@ final class DistanceCalculator
         ));
     }
 
-    private function chebyshevDistance(VectorDocument $embedding, Vector $against): float
+    private function chebyshevDistance(VectorDocument $embedding, VectorInterface $against): float
     {
         $embeddingsAsPower = array_map(
             static fn (float $currentValue, float $againstValue): float => abs($currentValue - $againstValue),

--- a/src/store/src/Query/HybridQuery.php
+++ b/src/store/src/Query/HybridQuery.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Store\Query;
 
-use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 
 /**
@@ -28,7 +28,7 @@ final class HybridQuery implements QueryInterface
      * @param string|array<string> $text Single search text or array of texts (combined with OR logic)
      */
     public function __construct(
-        private readonly Vector $vector,
+        private readonly VectorInterface $vector,
         private readonly string|array $text,
         private readonly float $semanticRatio = 0.5,
     ) {
@@ -37,7 +37,7 @@ final class HybridQuery implements QueryInterface
         }
     }
 
-    public function getVector(): Vector
+    public function getVector(): VectorInterface
     {
         return $this->vector;
     }

--- a/src/store/src/Query/VectorQuery.php
+++ b/src/store/src/Query/VectorQuery.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Store\Query;
 
-use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Platform\Vector\VectorInterface;
 
 /**
  * Classic vector search query using semantic similarity.
@@ -21,11 +21,11 @@ use Symfony\AI\Platform\Vector\Vector;
 final class VectorQuery implements QueryInterface
 {
     public function __construct(
-        private readonly Vector $vector,
+        private readonly VectorInterface $vector,
     ) {
     }
 
-    public function getVector(): Vector
+    public function getVector(): VectorInterface
     {
         return $this->vector;
     }

--- a/src/store/tests/Query/VectorQueryTest.php
+++ b/src/store/tests/Query/VectorQueryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Tests\Query;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Vector\Vector;
+use Symfony\AI\Platform\Vector\VectorInterface;
+use Symfony\AI\Store\Query\HybridQuery;
+use Symfony\AI\Store\Query\VectorQuery;
+
+final class VectorQueryTest extends TestCase
+{
+    public function testCarriesTheVectorItWasBuiltWith()
+    {
+        $vector = new Vector([0.1, 0.2]);
+
+        $this->assertSame($vector, (new VectorQuery($vector))->getVector());
+    }
+
+    public function testAcceptsAnyVectorImplementation()
+    {
+        // A store hands back documents typed on VectorInterface. Without this, feeding the vector
+        // of such a document back into a query - a "more like this" search - needs a cast.
+        $vector = new CustomVector([0.1, 0.2]);
+
+        $this->assertSame($vector, (new VectorQuery($vector))->getVector());
+    }
+
+    public function testHybridQueryAcceptsAnyVectorImplementation()
+    {
+        $vector = new CustomVector([0.1, 0.2]);
+        $query = new HybridQuery($vector, ['reality', 'tv'], 0.7);
+
+        $this->assertSame($vector, $query->getVector());
+        $this->assertSame(['reality', 'tv'], $query->getTexts());
+    }
+}
+
+final class CustomVector implements VectorInterface
+{
+    /**
+     * @param list<float> $data
+     */
+    public function __construct(private readonly array $data)
+    {
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getDimensions(): int
+    {
+        return \count($this->data);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | no
| Issues        | -
| License       | MIT

> Slice 2 of 5, splitting up a Doctrine store that keeps vectors on the entity's own table. Stacked on #2493 only to keep the diffs clean — it depends on nothing in it.

`VectorQuery` and `HybridQuery` are typed on the final `Vector` class, while everything a store hands back exposes `VectorInterface`. Feeding the vector of a returned document back into a query — which is what a "more like this" search *is* — therefore needs a cast, for no reason: the queries only pass the vector on to a store, and every store already reads it through `getData()`.

```diff
-private readonly Vector $vector,
+private readonly VectorInterface $vector,
```

`DistanceCalculator` follows, being the one consumer that still narrowed to the concrete class. I checked every `getVector()` call site in the component and the bridges — all of them either call `getData()` or already accept `VectorInterface`.

## Compatibility

Passing a `Vector` is unchanged. Code that relied on `getVector()` returning the concrete class has to widen — hence the `[BC BREAK]` changelog entry.

## Tests

New `VectorQueryTest` covering both queries, with a `VectorInterface` implementation that is deliberately *not* a `Vector` — which is the case that could not be expressed before.
