### PR TITLE
[Store] Introduce VectorDocumentInterface

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,13 @@
 UPGRADE FROM 0.13 to 0.14
 =========================
 
+Agent
+-----
+
+ * `Bridge\SimilaritySearch\SimilaritySearch::getUsedDocuments()` returns
+   `Store\Document\VectorDocumentInterface[]` instead of `Store\Document\VectorDocument[]`, following the
+   retriever it reads from. Code narrowing the returned documents to the concrete class has to widen.
+
 Platform
 --------
 
@@ -45,6 +52,26 @@ Store
    instead of the final `Platform\Vector\Vector` class. Passing a `Vector` is unchanged. This is what
    makes a "more like this" query possible without a cast: the vector of a document returned by a store
    can now be fed straight back into a query.
+
+ * Stores are now typed against `Document\VectorDocumentInterface` rather than the final
+   `Document\VectorDocument` class, so that a store can hand back a document carrying more than an
+   id, a vector and metadata - the entity it was built from, for instance. `VectorDocument` implements
+   the new interface, so passing one is unchanged, but a custom store has to widen its signature:
+
+   ```diff
+   -public function add(VectorDocument|array $documents): void
+   +public function add(VectorDocumentInterface|array $documents): void
+    {
+   -    if ($documents instanceof VectorDocument) {
+   +    if ($documents instanceof VectorDocumentInterface) {
+            $documents = [$documents];
+        }
+        // ...
+    }
+   ```
+
+   The same applies to anything typed on the documents a store returns: `RetrieverInterface`,
+   `Reranker\RerankerInterface` and `VectorizerInterface` now speak in terms of the interface too.
 
 UPGRADE FROM 0.12 to 0.13
 =========================

--- a/docs/components/store.rst
+++ b/docs/components/store.rst
@@ -241,13 +241,13 @@ for adding, removing and querying vectorized documents in the store.
 
 This leads to a store implementing the following methods::
 
-    use Symfony\AI\Store\Document\VectorDocument;
+    use Symfony\AI\Store\Document\VectorDocumentInterface;
     use Symfony\AI\Store\Query\QueryInterface;
     use Symfony\AI\Store\StoreInterface;
 
     class MyStore implements StoreInterface
     {
-        public function add(VectorDocument|array $documents): void
+        public function add(VectorDocumentInterface|array $documents): void
         {
             // Implementation to add a document to the store
         }

--- a/docs/components/store/local.rst
+++ b/docs/components/store/local.rst
@@ -86,16 +86,16 @@ Metadata Filtering
 
 Both stores support filtering search results based on document metadata using a callable::
 
-    use Symfony\AI\Store\Document\VectorDocument;
+    use Symfony\AI\Store\Document\VectorDocumentInterface;
 
     $results = $store->query($vectorQuery, [
-        'filter' => fn(VectorDocument $doc) => $doc->getMetadata()['category'] === 'products',
+        'filter' => fn(VectorDocumentInterface $doc) => $doc->getMetadata()['category'] === 'products',
     ]);
 
 You can combine multiple conditions::
 
     $results = $store->query($vectorQuery, [
-        'filter' => fn(VectorDocument $doc) =>
+        'filter' => fn(VectorDocumentInterface $doc) =>
             $doc->getMetadata()['price'] <= 100
             && $doc->getMetadata()['stock'] > 0
             && $doc->getMetadata()['enabled'] === true,
@@ -105,7 +105,7 @@ You can combine multiple conditions::
 Filter nested metadata::
 
     $results = $store->query($vectorQuery, [
-        'filter' => fn(VectorDocument $doc) =>
+        'filter' => fn(VectorDocumentInterface $doc) =>
             $doc->getMetadata()['options']['size'] === 'S'
             && $doc->getMetadata()['options']['color'] === 'blue',
     ]);
@@ -114,7 +114,7 @@ Use array functions for complex filtering::
 
     $allowedBrands = ['Nike', 'Adidas', 'Puma'];
     $results = $store->query($vectorQuery, [
-        'filter' => fn(VectorDocument $doc) =>
+        'filter' => fn(VectorDocumentInterface $doc) =>
             \in_array($doc->getMetadata()['brand'] ?? '', $allowedBrands, true),
     ]);
 
@@ -134,5 +134,5 @@ Example combining both options::
 
     $results = $store->query($vectorQuery, [
         'maxItems' => 5,
-        'filter' => fn(VectorDocument $doc) => $doc->getMetadata()['active'] === true,
+        'filter' => fn(VectorDocumentInterface $doc) => $doc->getMetadata()['active'] === true,
     ]);

--- a/docs/components/store/sqlite.rst
+++ b/docs/components/store/sqlite.rst
@@ -91,10 +91,10 @@ Metadata Filtering
 
 The SQLite store supports filtering search results based on document metadata using a callable::
 
-    use Symfony\AI\Store\Document\VectorDocument;
+    use Symfony\AI\Store\Document\VectorDocumentInterface;
 
     $results = $store->query($vectorQuery, [
-        'filter' => fn(VectorDocument $doc) => $doc->getMetadata()['category'] === 'products',
+        'filter' => fn(VectorDocumentInterface $doc) => $doc->getMetadata()['category'] === 'products',
     ]);
 
 Query Options
@@ -109,7 +109,7 @@ Example combining both options::
 
     $results = $store->query($vectorQuery, [
         'maxItems' => 5,
-        'filter' => fn(VectorDocument $doc) => $doc->getMetadata()['active'] === true,
+        'filter' => fn(VectorDocumentInterface $doc) => $doc->getMetadata()['active'] === true,
     ]);
 
 VecStore (sqlite-vec)

--- a/examples/document/vectorizing-text-documents.php
+++ b/examples/document/vectorizing-text-documents.php
@@ -11,7 +11,7 @@
 
 use Symfony\AI\Platform\Bridge\OpenAi\Factory;
 use Symfony\AI\Store\Document\TextDocument;
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Document\Vectorizer;
 use Symfony\Component\Uid\Uuid;
 
@@ -28,4 +28,4 @@ $textDocuments = [
 $vectorizer = new Vectorizer($platform, 'text-embedding-3-large');
 $vectorDocuments = $vectorizer->vectorize($textDocuments);
 
-dump(array_map(static fn (VectorDocument $document) => $document->getVector()->getDimensions(), $vectorDocuments));
+dump(array_map(static fn (VectorDocumentInterface $document) => $document->getVector()->getDimensions(), $vectorDocuments));

--- a/src/agent/CHANGELOG.md
+++ b/src/agent/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `Execution::cancel()` to stop an active execution and cancel its active HTTP response
  * `MultiAgent` and `SpeechAgent` now forward the `Progress` updates of the executions they delegate to, and `MultiAgent` reports its routing as a `Progress` update of the `handoff` stage carrying the orchestrator's `MultiAgent\Handoff\Decision` as payload
+ * [BC BREAK] `Bridge\SimilaritySearch\SimilaritySearch::getUsedDocuments()` returns `Store\Document\VectorDocumentInterface[]` instead of `Store\Document\VectorDocument[]`, following the retriever it reads from
 
 0.13
 ----

--- a/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
+++ b/src/agent/src/Bridge/SimilaritySearch/SimilaritySearch.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Agent\Bridge\SimilaritySearch;
 
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\RetrieverInterface;
 
 /**
@@ -22,7 +22,7 @@ use Symfony\AI\Store\RetrieverInterface;
 final class SimilaritySearch
 {
     /**
-     * @var VectorDocument[]
+     * @var VectorDocumentInterface[]
      */
     private array $usedDocuments = [];
 
@@ -52,7 +52,7 @@ final class SimilaritySearch
     }
 
     /**
-     * @return VectorDocument[]
+     * @return VectorDocumentInterface[]
      */
     public function getUsedDocuments(): array
     {

--- a/src/store/CHANGELOG.md
+++ b/src/store/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * `Indexer\SourceIndexer` now passes its options to the loader as well as to the document processor
  * [BC BREAK] Accept and return `Platform\Vector\VectorInterface` in `Query\VectorQuery` and `Query\HybridQuery` instead of the final `Platform\Vector\Vector` class
+ * [BC BREAK] Type stores, retrievers, rerankers and vectorizers against the new `Document\VectorDocumentInterface` instead of the final `Document\VectorDocument` class
+
 
 
 0.11

--- a/src/store/src/Bridge/AzureSearch/SearchStore.php
+++ b/src/store/src/Bridge/AzureSearch/SearchStore.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -42,14 +43,14 @@ final class SearchStore implements StoreInterface
     ) {
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
         $this->request('index', [
-            'value' => array_map(fn (VectorDocument $document): array => array_merge([
+            'value' => array_map(fn (VectorDocumentInterface $document): array => array_merge([
                 'id' => $document->getId(),
                 $this->vectorFieldName => $document->getVector()->getData(),
             ], $document->getMetadata()->getArrayCopy()), $documents),
@@ -201,7 +202,7 @@ final class SearchStore implements StoreInterface
     /**
      * @param array<string, mixed> $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         return new VectorDocument(
             id: $data['id'],

--- a/src/store/src/Bridge/Cache/Store.php
+++ b/src/store/src/Bridge/Cache/Store.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Distance\DistanceCalculator;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -51,15 +52,15 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->cache->get($this->cacheKey, static fn (): array => []);
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
         $existingVectors = $this->cache->get($this->cacheKey, static fn (): array => []);
 
-        $newVectors = array_map(static fn (VectorDocument $document): array => [
+        $newVectors = array_map(static fn (VectorDocumentInterface $document): array => [
             'id' => $document->getId(),
             'vector' => $document->getVector()->getData(),
             'metadata' => $document->getMetadata()->getArrayCopy(),
@@ -132,7 +133,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool
+     *     filter?: callable(VectorDocumentInterface): bool
      * } $options If maxItems is provided, only the top N results will be returned.
      *            If filter is provided, only documents matching the filter will be considered.
      */
@@ -154,10 +155,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryVector(VectorQuery $query, array $options): iterable
     {
@@ -167,7 +168,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             return;
         }
 
-        $vectorDocuments = array_map(static fn (array $document): VectorDocument => new VectorDocument(
+        $vectorDocuments = array_map(static fn (array $document): VectorDocumentInterface => new VectorDocument(
             id: $document['id'],
             vector: new Vector($document['vector']),
             metadata: new Metadata($document['metadata']),
@@ -183,10 +184,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryText(TextQuery $query, array $options): iterable
     {
@@ -196,7 +197,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             return;
         }
 
-        $vectorDocuments = array_map(static fn (array $document): VectorDocument => new VectorDocument(
+        $vectorDocuments = array_map(static fn (array $document): VectorDocumentInterface => new VectorDocument(
             id: $document['id'],
             vector: new Vector($document['vector']),
             metadata: new Metadata($document['metadata']),
@@ -206,7 +207,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             $vectorDocuments = array_values(array_filter($vectorDocuments, $options['filter']));
         }
 
-        $filteredDocuments = array_filter($vectorDocuments, static function (VectorDocument $doc) use ($query): bool {
+        $filteredDocuments = array_filter($vectorDocuments, static function (VectorDocumentInterface $doc) use ($query): bool {
             $text = strtolower($doc->getMetadata()->getText() ?? '');
 
             foreach ($query->getTexts() as $searchText) {
@@ -234,10 +235,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryHybrid(HybridQuery $query, array $options): iterable
     {

--- a/src/store/src/Bridge/Cache/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Cache/Tests/StoreTest.php
@@ -18,6 +18,7 @@ use Symfony\AI\Store\Distance\DistanceCalculator;
 use Symfony\AI\Store\Distance\DistanceStrategy;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\Query\HybridQuery;
@@ -180,7 +181,7 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc): bool => 'products' === $doc->getMetadata()['category'],
+            'filter' => static fn (VectorDocumentInterface $doc): bool => 'products' === $doc->getMetadata()['category'],
         ]));
 
         $this->assertCount(2, $result);
@@ -199,7 +200,7 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc): bool => 'products' === $doc->getMetadata()['category'],
+            'filter' => static fn (VectorDocumentInterface $doc): bool => 'products' === $doc->getMetadata()['category'],
             'maxItems' => 2,
         ]));
 
@@ -218,7 +219,7 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc): bool => $doc->getMetadata()['price'] <= 150 && $doc->getMetadata()['stock'] > 0,
+            'filter' => static fn (VectorDocumentInterface $doc): bool => $doc->getMetadata()['price'] <= 150 && $doc->getMetadata()['stock'] > 0,
         ]));
 
         $this->assertCount(2, $result);
@@ -234,7 +235,7 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc): bool => 'S' === $doc->getMetadata()['options']['size'],
+            'filter' => static fn (VectorDocumentInterface $doc): bool => 'S' === $doc->getMetadata()['options']['size'],
         ]));
 
         $this->assertCount(2, $result);
@@ -253,7 +254,7 @@ final class StoreTest extends TestCase
 
         $allowedBrands = ['Nike', 'Adidas', 'Puma'];
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc): bool => \in_array($doc->getMetadata()['brand'] ?? '', $allowedBrands, true),
+            'filter' => static fn (VectorDocumentInterface $doc): bool => \in_array($doc->getMetadata()['brand'] ?? '', $allowedBrands, true),
         ]));
 
         $this->assertCount(2, $result);
@@ -282,7 +283,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
-        $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->getId(), $result);
+        $remainingIds = array_map(static fn (VectorDocumentInterface $doc) => $doc->getId(), $result);
         $this->assertNotContains($id2->toRfc4122(), $remainingIds);
         $this->assertContains($id1->toRfc4122(), $remainingIds);
         $this->assertContains($id3->toRfc4122(), $remainingIds);
@@ -313,7 +314,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
-        $remainingIds = array_map(static fn (VectorDocument $doc) => $doc->getId(), $result);
+        $remainingIds = array_map(static fn (VectorDocumentInterface $doc) => $doc->getId(), $result);
         $this->assertNotContains($id2->toRfc4122(), $remainingIds);
         $this->assertNotContains($id4->toRfc4122(), $remainingIds);
         $this->assertContains($id1->toRfc4122(), $remainingIds);
@@ -468,7 +469,7 @@ final class StoreTest extends TestCase
         $this->assertGreaterThanOrEqual(2, \count($result));
 
         // Check that space-related documents are in results
-        $texts = array_map(static fn (VectorDocument $doc) => $doc->getMetadata()->getText(), $result);
+        $texts = array_map(static fn (VectorDocumentInterface $doc) => $doc->getMetadata()->getText(), $result);
         $this->assertContains('deep space mission', $texts);
     }
 

--- a/src/store/src/Bridge/ChromaDb/Store.php
+++ b/src/store/src/Bridge/ChromaDb/Store.php
@@ -18,6 +18,7 @@ use Codewithkyrian\ChromaDB\Responses\QueryItemsResponse;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -60,9 +61,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -172,7 +173,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{where?: array<string, string>, whereDocument?: array<string, mixed>, include?: array<string>, limit?: positive-int} $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryVector(VectorQuery $query, array $options): iterable
     {
@@ -193,7 +194,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{where?: array<string, string>, whereDocument?: array<string, mixed>, include?: array<string>, limit?: positive-int} $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryText(TextQuery $query, array $options): iterable
     {
@@ -227,7 +228,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function transformResponse(QueryItemsResponse $queryResponse): iterable
     {

--- a/src/store/src/Bridge/ClickHouse/Store.php
+++ b/src/store/src/Bridge/ClickHouse/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -55,9 +56,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->execute('POST', 'DROP TABLE IF EXISTS {{ table }}');
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -141,7 +142,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @return array<string, mixed>
      */
-    protected function formatVectorDocument(VectorDocument $document): array
+    protected function formatVectorDocument(VectorDocumentInterface $document): array
     {
         return [
             'id' => $document->getId(),

--- a/src/store/src/Bridge/Cloudflare/Store.php
+++ b/src/store/src/Bridge/Cloudflare/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -59,9 +60,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->request('DELETE', \sprintf('vectorize/v2/indexes/%s', $this->index));
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -229,7 +230,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @return array<string, mixed>
      */
-    private function convertToIndexableArray(VectorDocument $document): array
+    private function convertToIndexableArray(VectorDocumentInterface $document): array
     {
         return [
             'id' => $document->getId(),
@@ -241,7 +242,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array<mixed> $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         $id = $data['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
         if (!\is_string($id) && !\is_int($id)) {

--- a/src/store/src/Bridge/Elasticsearch/Store.php
+++ b/src/store/src/Bridge/Elasticsearch/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -75,20 +76,20 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->request('DELETE', $this->indexName);
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
-        $documentToIndex = fn (VectorDocument $document): array => [
+        $documentToIndex = fn (VectorDocumentInterface $document): array => [
             'index' => [
                 '_index' => $this->indexName,
                 '_id' => $document->getId(),
             ],
         ];
 
-        $documentToPayload = fn (VectorDocument $document): array => [
+        $documentToPayload = fn (VectorDocumentInterface $document): array => [
             $this->vectorsField => $document->getVector()->getData(),
             'metadata' => json_encode($document->getMetadata()->getArrayCopy()),
         ];
@@ -203,7 +204,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     '_score': float,
      * } $document
      */
-    private function convertToVectorDocument(array $document): VectorDocument
+    private function convertToVectorDocument(array $document): VectorDocumentInterface
     {
         $id = $document['_id'] ?? throw new InvalidArgumentException('Missing "_id" field in the document data.');
 

--- a/src/store/src/Bridge/ManticoreSearch/Store.php
+++ b/src/store/src/Bridge/ManticoreSearch/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -68,14 +69,14 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @throws \Random\RandomException {@see random_int()}
      */
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
         $payload = array_map(
-            fn (VectorDocument $document): array => [
+            fn (VectorDocumentInterface $document): array => [
                 'insert' => [
                     'table' => $this->table,
                     'id' => random_int(0, \PHP_INT_MAX),
@@ -199,7 +200,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     _source: array<string, mixed>,
      * } $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         $payload = $data['_source'];
 

--- a/src/store/src/Bridge/MariaDb/Store.php
+++ b/src/store/src/Bridge/MariaDb/Store.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Exception as DBALException;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -105,9 +106,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         return self::fromPdo($pdo, $tableName, $indexName, $vectorFieldName, $distance);
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 

--- a/src/store/src/Bridge/Meilisearch/Store.php
+++ b/src/store/src/Bridge/Meilisearch/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -71,9 +72,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -164,7 +165,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @return array<string, mixed>
      */
-    private function convertToIndexableArray(VectorDocument $document): array
+    private function convertToIndexableArray(VectorDocumentInterface $document): array
     {
         return array_merge([
             'id' => $document->getId(),
@@ -180,7 +181,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array<string, mixed> $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         $id = $data['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
         $vector = !\array_key_exists($this->vectorFieldName, $data) || null === $data[$this->vectorFieldName]

--- a/src/store/src/Bridge/Milvus/Store.php
+++ b/src/store/src/Bridge/Milvus/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -101,9 +102,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -205,7 +206,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @return array<string, mixed>
      */
-    private function convertToIndexableArray(VectorDocument $document): array
+    private function convertToIndexableArray(VectorDocumentInterface $document): array
     {
         return [
             'id' => $document->getId(),
@@ -217,7 +218,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array<string, mixed> $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         $id = $data['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
 

--- a/src/store/src/Bridge/MongoDb/Store.php
+++ b/src/store/src/Bridge/MongoDb/Store.php
@@ -19,6 +19,7 @@ use Psr\Log\NullLogger;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -112,9 +113,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->getCollection()->drop();
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 

--- a/src/store/src/Bridge/Neo4j/Store.php
+++ b/src/store/src/Bridge/Neo4j/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -56,9 +57,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -189,7 +190,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array<string|int, mixed> $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         $payload = $data[0];
 

--- a/src/store/src/Bridge/OpenSearch/Store.php
+++ b/src/store/src/Bridge/OpenSearch/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -80,20 +81,20 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->request('DELETE', $this->indexName);
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
-        $documentToIndex = fn (VectorDocument $document): array => [
+        $documentToIndex = fn (VectorDocumentInterface $document): array => [
             'index' => [
                 '_index' => $this->indexName,
                 '_id' => $document->getId(),
             ],
         ];
 
-        $documentToPayload = fn (VectorDocument $document): array => [
+        $documentToPayload = fn (VectorDocumentInterface $document): array => [
             $this->vectorsField => $document->getVector()->getData(),
             'metadata' => json_encode($document->getMetadata()->getArrayCopy()),
         ];
@@ -206,7 +207,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     '_score': float,
      * } $document
      */
-    private function convertToVectorDocument(array $document): VectorDocument
+    private function convertToVectorDocument(array $document): VectorDocumentInterface
     {
         $id = $document['_id'] ?? throw new InvalidArgumentException('Missing "_id" field in the document data.');
 

--- a/src/store/src/Bridge/Pinecone/Store.php
+++ b/src/store/src/Bridge/Pinecone/Store.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -66,9 +67,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
             );
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 

--- a/src/store/src/Bridge/Postgres/Store.php
+++ b/src/store/src/Bridge/Postgres/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\Query\HybridQuery;
@@ -83,9 +84,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->connection->exec(\sprintf('DROP TABLE IF EXISTS "%s"', $this->tableName));
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -160,7 +161,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{limit?: positive-int, maxScore?: float, where?: string, params?: array<string, mixed>} $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryVector(VectorQuery $query, array $options): iterable
     {
@@ -219,7 +220,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{limit?: positive-int} $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryText(TextQuery $query, array $options): iterable
     {
@@ -274,7 +275,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{limit?: positive-int, maxScore?: float} $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryHybrid(HybridQuery $query, array $options): iterable
     {

--- a/src/store/src/Bridge/Qdrant/Store.php
+++ b/src/store/src/Bridge/Qdrant/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -57,9 +58,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -67,7 +68,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             'PUT',
             \sprintf('collections/%s/points', $this->collectionName),
             [
-                'points' => array_map(static fn (VectorDocument $document): array => [
+                'points' => array_map(static fn (VectorDocumentInterface $document): array => [
                     'id' => $document->getId(),
                     'vector' => $document->getVector()->getData(),
                     'payload' => $document->getMetadata()->getArrayCopy(),
@@ -174,7 +175,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array<string, mixed> $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         $id = $data['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
 

--- a/src/store/src/Bridge/Redis/Store.php
+++ b/src/store/src/Bridge/Redis/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Platform\Vector\VectorInterface;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -80,9 +81,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         }
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -162,7 +163,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{limit?: positive-int, maxScore?: float, where?: string} $options
      *
-     * @return VectorDocument[]
+     * @return VectorDocumentInterface[]
      */
     public function query(QueryInterface $query, array $options = []): iterable
     {

--- a/src/store/src/Bridge/S3Vectors/Store.php
+++ b/src/store/src/Bridge/S3Vectors/Store.php
@@ -19,6 +19,7 @@ use AsyncAws\S3Vectors\ValueObject\VectorDataMemberFloat32;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -118,9 +119,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         return VectorQuery::class === $queryClass;
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 

--- a/src/store/src/Bridge/Sqlite/Store.php
+++ b/src/store/src/Bridge/Sqlite/Store.php
@@ -16,6 +16,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Distance\DistanceCalculator;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -81,9 +82,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->connection->exec(\sprintf('DROP TABLE IF EXISTS %s', $this->tableName));
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -204,7 +205,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      */
     public function query(QueryInterface $query, array $options = []): iterable
@@ -220,10 +221,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryVector(VectorQuery $query, array $options): iterable
     {
@@ -243,10 +244,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryText(TextQuery $query, array $options): iterable
     {
@@ -337,10 +338,10 @@ final class Store implements ManagedStoreInterface, StoreInterface
      * @param array{
      *     maxItems?: positive-int,
      *     rrfCandidatePoolSize?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryHybrid(HybridQuery $query, array $options): iterable
     {
@@ -370,7 +371,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
             $subOptions,
         ));
 
-        /** @var array<string, array{doc: VectorDocument, score: float}> $scores */
+        /** @var array<string, array{doc: VectorDocumentInterface, score: float}> $scores */
         $scores = [];
 
         foreach ($vectorResults as $rank => $doc) {
@@ -411,7 +412,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     }
 
     /**
-     * @return VectorDocument[]
+     * @return VectorDocumentInterface[]
      */
     private function loadAllDocuments(): array
     {

--- a/src/store/src/Bridge/Sqlite/Tests/StoreTest.php
+++ b/src/store/src/Bridge/Sqlite/Tests/StoreTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Bridge\Sqlite\Store;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\Query\HybridQuery;
@@ -255,7 +256,7 @@ final class StoreTest extends TestCase
 
         $results = iterator_to_array($store->query(
             new VectorQuery(new Vector([1.0, 0.0, 0.0])),
-            ['filter' => static fn (VectorDocument $doc): bool => 'a' === $doc->getMetadata()['category']],
+            ['filter' => static fn (VectorDocumentInterface $doc): bool => 'a' === $doc->getMetadata()['category']],
         ));
 
         $this->assertCount(2, $results);
@@ -356,7 +357,7 @@ final class StoreTest extends TestCase
 
         $this->assertNotEmpty($results);
 
-        $foundIds = array_map(static fn (VectorDocument $doc): string|int => $doc->getId(), $results);
+        $foundIds = array_map(static fn (VectorDocumentInterface $doc): string|int => $doc->getId(), $results);
 
         // Should find doc-1 (vector match) and/or doc-3 (text match)
         $this->assertTrue(
@@ -416,7 +417,7 @@ final class StoreTest extends TestCase
         // Both documents must appear and have non-null scores
         $this->assertCount(2, $results);
 
-        $ids = array_map(static fn (VectorDocument $doc): string|int => $doc->getId(), $results);
+        $ids = array_map(static fn (VectorDocumentInterface $doc): string|int => $doc->getId(), $results);
         $this->assertContains('doc-vector', $ids);
         $this->assertContains('doc-text', $ids);
 
@@ -548,7 +549,7 @@ final class StoreTest extends TestCase
 
         $results = iterator_to_array($store->query(
             new HybridQuery(new Vector([1.0, 0.0, 0.0]), ['keyword'], 0.5),
-            ['filter' => static fn (VectorDocument $doc): bool => 'a' === $doc->getMetadata()['category']],
+            ['filter' => static fn (VectorDocumentInterface $doc): bool => 'a' === $doc->getMetadata()['category']],
         ));
 
         $this->assertCount(1, $results);

--- a/src/store/src/Bridge/Sqlite/Tests/VecStoreTest.php
+++ b/src/store/src/Bridge/Sqlite/Tests/VecStoreTest.php
@@ -18,6 +18,7 @@ use Symfony\AI\Store\Bridge\Sqlite\Distance;
 use Symfony\AI\Store\Bridge\Sqlite\VecStore;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\Query\HybridQuery;
@@ -270,7 +271,7 @@ final class VecStoreTest extends TestCase
 
         $results = iterator_to_array($store->query(
             new VectorQuery(new Vector([1.0, 0.0, 0.0])),
-            ['filter' => static fn (VectorDocument $doc): bool => 'a' === $doc->getMetadata()['category']],
+            ['filter' => static fn (VectorDocumentInterface $doc): bool => 'a' === $doc->getMetadata()['category']],
         ));
 
         $this->assertCount(2, $results);
@@ -360,7 +361,7 @@ final class VecStoreTest extends TestCase
 
         $this->assertNotEmpty($results);
 
-        $foundIds = array_map(static fn (VectorDocument $doc): string|int => $doc->getId(), $results);
+        $foundIds = array_map(static fn (VectorDocumentInterface $doc): string|int => $doc->getId(), $results);
 
         $this->assertContains('doc-1', $foundIds, 'RRF should include the top vector match');
         $this->assertContains('doc-3', $foundIds, 'RRF should include the top text match');
@@ -372,7 +373,7 @@ final class VecStoreTest extends TestCase
         }
 
         // Results should be sorted by RRF score descending
-        $scores = array_map(static fn (VectorDocument $doc): float => $doc->getScore(), $results);
+        $scores = array_map(static fn (VectorDocumentInterface $doc): float => $doc->getScore(), $results);
         $sortedScores = $scores;
         rsort($sortedScores);
         $this->assertSame($sortedScores, $scores, 'Results should be sorted by RRF score descending');
@@ -438,7 +439,7 @@ final class VecStoreTest extends TestCase
 
         $this->assertCount(2, $results);
 
-        $ids = array_map(static fn (VectorDocument $doc): string|int => $doc->getId(), $results);
+        $ids = array_map(static fn (VectorDocumentInterface $doc): string|int => $doc->getId(), $results);
         $this->assertContains('doc-vector', $ids);
         $this->assertContains('doc-text', $ids);
 

--- a/src/store/src/Bridge/Sqlite/VecStore.php
+++ b/src/store/src/Bridge/Sqlite/VecStore.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Connection;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -106,9 +107,9 @@ final class VecStore implements ManagedStoreInterface, StoreInterface
         $this->connection->exec(\sprintf('DROP TABLE IF EXISTS %s', $this->tableName));
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -235,7 +236,7 @@ final class VecStore implements ManagedStoreInterface, StoreInterface
      * @param array{
      *     maxItems?: positive-int,
      *     rrfCandidatePoolSize?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      */
     public function query(QueryInterface $query, array $options = []): iterable
@@ -251,10 +252,10 @@ final class VecStore implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryVector(VectorQuery $query, array $options): iterable
     {
@@ -305,10 +306,10 @@ final class VecStore implements ManagedStoreInterface, StoreInterface
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryText(TextQuery $query, array $options): iterable
     {
@@ -378,10 +379,10 @@ final class VecStore implements ManagedStoreInterface, StoreInterface
      * @param array{
      *     maxItems?: positive-int,
      *     rrfCandidatePoolSize?: positive-int,
-     *     filter?: callable(VectorDocument): bool,
+     *     filter?: callable(VectorDocumentInterface): bool,
      * } $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryHybrid(HybridQuery $query, array $options): iterable
     {
@@ -407,7 +408,7 @@ final class VecStore implements ManagedStoreInterface, StoreInterface
             $subOptions,
         ));
 
-        /** @var array<string, array{doc: VectorDocument, score: float}> $scores */
+        /** @var array<string, array{doc: VectorDocumentInterface, score: float}> $scores */
         $scores = [];
 
         foreach ($vectorResults as $rank => $doc) {

--- a/src/store/src/Bridge/Supabase/Store.php
+++ b/src/store/src/Bridge/Supabase/Store.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Store\Bridge\Supabase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -57,9 +58,9 @@ final class Store implements StoreInterface
         $this->endpoint = rtrim($endpoint, '/');
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 

--- a/src/store/src/Bridge/SurrealDb/Store.php
+++ b/src/store/src/Bridge/SurrealDb/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -55,9 +56,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ));
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -192,7 +193,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @return array<string, mixed>
      */
-    private function convertToIndexableArray(VectorDocument $document): array
+    private function convertToIndexableArray(VectorDocumentInterface $document): array
     {
         return [
             'id' => $document->getId(),
@@ -206,7 +207,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array<mixed> $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         $rawMetadata = $data['_metadata'] ?? null;
         if (!\is_array($rawMetadata)) {

--- a/src/store/src/Bridge/Typesense/Store.php
+++ b/src/store/src/Bridge/Typesense/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -63,9 +64,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -182,7 +183,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @return array<string, mixed>
      */
-    private function convertToIndexableArray(VectorDocument $document): array
+    private function convertToIndexableArray(VectorDocumentInterface $document): array
     {
         return [
             'id' => $document->getId(),
@@ -194,7 +195,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array<mixed> $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         $document = $data['document'] ?? throw new InvalidArgumentException('Missing "document" field in the document data.');
         if (!\is_array($document)) {

--- a/src/store/src/Bridge/Vektor/Store.php
+++ b/src/store/src/Bridge/Vektor/Store.php
@@ -19,6 +19,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -71,9 +72,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         $this->filesystem->remove($this->storagePath.'/vektor');
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -142,7 +143,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
      *     metadata: mixed[],
      * } $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         $id = $data['id'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
 

--- a/src/store/src/Bridge/Weaviate/Store.php
+++ b/src/store/src/Bridge/Weaviate/Store.php
@@ -15,6 +15,7 @@ use Symfony\AI\Platform\Vector\NullVector;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\RuntimeException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
@@ -50,9 +51,9 @@ final class Store implements ManagedStoreInterface, StoreInterface
         ]);
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -179,7 +180,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @return array<string, mixed>
      */
-    private function convertToIndexableArray(VectorDocument $document): array
+    private function convertToIndexableArray(VectorDocumentInterface $document): array
     {
         return [
             'class' => $this->collection,
@@ -196,7 +197,7 @@ final class Store implements ManagedStoreInterface, StoreInterface
     /**
      * @param array<string, mixed> $data
      */
-    private function convertToVectorDocument(array $data): VectorDocument
+    private function convertToVectorDocument(array $data): VectorDocumentInterface
     {
         $id = $data['uuid'] ?? throw new InvalidArgumentException('Missing "id" field in the document data.');
 

--- a/src/store/src/CombinedStore.php
+++ b/src/store/src/CombinedStore.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Store;
 
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\Query\HybridQuery;
 use Symfony\AI\Store\Query\QueryInterface;
@@ -35,7 +35,7 @@ final class CombinedStore implements StoreInterface
     ) {
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
         $this->vectorStore->add($documents);
 
@@ -93,7 +93,7 @@ final class CombinedStore implements StoreInterface
     /**
      * @param array<string, mixed> $options
      *
-     * @return list<VectorDocument>
+     * @return list<VectorDocumentInterface>
      */
     private function hybridQuery(HybridQuery $query, array $options): array
     {
@@ -109,17 +109,17 @@ final class CombinedStore implements StoreInterface
     }
 
     /**
-     * @param list<VectorDocument> $list1
-     * @param list<VectorDocument> $list2
+     * @param list<VectorDocumentInterface> $list1
+     * @param list<VectorDocumentInterface> $list2
      *
-     * @return list<VectorDocument>
+     * @return list<VectorDocumentInterface>
      */
     private function reciprocalRankFusion(array $list1, array $list2): array
     {
         /** @var array<string, float> $scores */
         $scores = [];
 
-        /** @var array<string, VectorDocument> $documentsById */
+        /** @var array<string, VectorDocumentInterface> $documentsById */
         $documentsById = [];
 
         foreach ($list1 as $rank => $document) {

--- a/src/store/src/Distance/DistanceCalculator.php
+++ b/src/store/src/Distance/DistanceCalculator.php
@@ -12,7 +12,7 @@
 namespace Symfony\AI\Store\Distance;
 
 use Symfony\AI\Platform\Vector\VectorInterface;
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 
 /**
  * @author Guillaume Loulier <personal@guillaumeloulier.fr>
@@ -29,10 +29,10 @@ final class DistanceCalculator
     }
 
     /**
-     * @param VectorDocument[] $documents
-     * @param ?int             $maxItems  If maxItems is provided, only the top N results will be returned
+     * @param VectorDocumentInterface[] $documents
+     * @param ?int                      $maxItems  If maxItems is provided, only the top N results will be returned
      *
-     * @return VectorDocument[]
+     * @return VectorDocumentInterface[]
      */
     public function calculate(array $documents, VectorInterface $vector, ?int $maxItems = null): array
     {
@@ -44,16 +44,16 @@ final class DistanceCalculator
     }
 
     /**
-     * @param VectorDocument[] $documents
+     * @param VectorDocumentInterface[] $documents
      *
-     * @return VectorDocument[]
+     * @return VectorDocumentInterface[]
      */
     private function calculateAgainstAll(array $documents, VectorInterface $vector, ?int $maxItems): array
     {
         $strategy = $this->resolveStrategy();
 
         $currentEmbeddings = array_map(
-            static fn (VectorDocument $vectorDocument): array => [
+            static fn (VectorDocumentInterface $vectorDocument): array => [
                 'distance' => $strategy($vectorDocument, $vector),
                 'document' => $vectorDocument,
             ],
@@ -70,7 +70,7 @@ final class DistanceCalculator
         }
 
         return array_map(
-            static fn (array $embedding): VectorDocument => $embedding['document']->withScore($embedding['distance']),
+            static fn (array $embedding): VectorDocumentInterface => $embedding['document']->withScore($embedding['distance']),
             $currentEmbeddings,
         );
     }
@@ -78,21 +78,21 @@ final class DistanceCalculator
     /**
      * Processes documents in chunks of {@see self::$batchSize}, keeping only the top $maxItems candidates after each chunk.
      *
-     * @param VectorDocument[] $documents
-     * @param positive-int     $maxItems
+     * @param VectorDocumentInterface[] $documents
+     * @param positive-int              $maxItems
      *
-     * @return VectorDocument[]
+     * @return VectorDocumentInterface[]
      */
     private function calculateBatched(array $documents, VectorInterface $vector, int $maxItems): array
     {
         $strategy = $this->resolveStrategy();
 
-        /** @var array<int, array{distance: float, document: VectorDocument}> $candidates */
+        /** @var array<int, array{distance: float, document: VectorDocumentInterface}> $candidates */
         $candidates = [];
 
         foreach (array_chunk($documents, $this->batchSize) as $batch) {
             $batchResults = array_map(
-                static fn (VectorDocument $vectorDocument): array => [
+                static fn (VectorDocumentInterface $vectorDocument): array => [
                     'distance' => $strategy($vectorDocument, $vector),
                     'document' => $vectorDocument,
                 ],
@@ -115,13 +115,13 @@ final class DistanceCalculator
         }
 
         return array_map(
-            static fn (array $embedding): VectorDocument => $embedding['document']->withScore($embedding['distance']),
+            static fn (array $embedding): VectorDocumentInterface => $embedding['document']->withScore($embedding['distance']),
             $candidates,
         );
     }
 
     /**
-     * @return \Closure(VectorDocument, VectorInterface): float
+     * @return \Closure(VectorDocumentInterface, VectorInterface): float
      */
     private function resolveStrategy(): \Closure
     {
@@ -134,12 +134,12 @@ final class DistanceCalculator
         };
     }
 
-    private function cosineDistance(VectorDocument $embedding, VectorInterface $against): float
+    private function cosineDistance(VectorDocumentInterface $embedding, VectorInterface $against): float
     {
         return 1 - $this->cosineSimilarity($embedding, $against);
     }
 
-    private function cosineSimilarity(VectorDocument $embedding, VectorInterface $against): float
+    private function cosineSimilarity(VectorDocumentInterface $embedding, VectorInterface $against): float
     {
         $currentEmbeddingVectors = $embedding->getVector()->getData();
 
@@ -162,14 +162,14 @@ final class DistanceCalculator
         return fdiv($dotProduct, $currentEmbeddingLength * $againstLength);
     }
 
-    private function angularDistance(VectorDocument $embedding, VectorInterface $against): float
+    private function angularDistance(VectorDocumentInterface $embedding, VectorInterface $against): float
     {
         $cosineSimilarity = $this->cosineSimilarity($embedding, $against);
 
         return fdiv(acos($cosineSimilarity), \M_PI);
     }
 
-    private function euclideanDistance(VectorDocument $embedding, VectorInterface $against): float
+    private function euclideanDistance(VectorDocumentInterface $embedding, VectorInterface $against): float
     {
         return sqrt(array_sum(array_map(
             static fn (float $a, float $b): float => ($a - $b) ** 2,
@@ -178,7 +178,7 @@ final class DistanceCalculator
         )));
     }
 
-    private function manhattanDistance(VectorDocument $embedding, VectorInterface $against): float
+    private function manhattanDistance(VectorDocumentInterface $embedding, VectorInterface $against): float
     {
         return array_sum(array_map(
             static fn (float $a, float $b): float => abs($a - $b),
@@ -187,7 +187,7 @@ final class DistanceCalculator
         ));
     }
 
-    private function chebyshevDistance(VectorDocument $embedding, VectorInterface $against): float
+    private function chebyshevDistance(VectorDocumentInterface $embedding, VectorInterface $against): float
     {
         $embeddingsAsPower = array_map(
             static fn (float $currentValue, float $againstValue): float => abs($currentValue - $againstValue),

--- a/src/store/src/Document/VectorDocument.php
+++ b/src/store/src/Document/VectorDocument.php
@@ -16,7 +16,7 @@ use Symfony\AI\Platform\Vector\VectorInterface;
 /**
  * @author Christopher Hertel <mail@christopher-hertel.de>
  */
-final class VectorDocument
+final class VectorDocument implements VectorDocumentInterface
 {
     public function __construct(
         private readonly int|string $id,

--- a/src/store/src/Document/VectorDocumentInterface.php
+++ b/src/store/src/Document/VectorDocumentInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Store\Document;
+
+use Symfony\AI\Platform\Vector\VectorInterface;
+
+/**
+ * A document that carries a vector, as stored in and returned by a StoreInterface.
+ *
+ * Implement this interface to let a store hand back richer objects than the shipped VectorDocument,
+ * for example a document that keeps a reference to the domain object it was created from.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+interface VectorDocumentInterface
+{
+    public function getId(): int|string;
+
+    public function getVector(): VectorInterface;
+
+    public function getMetadata(): Metadata;
+
+    /**
+     * The distance to the queried vector, if this document was returned by a similarity query.
+     */
+    public function getScore(): ?float;
+
+    /**
+     * Returns a new instance with the given score.
+     */
+    public function withScore(float $score): self;
+}

--- a/src/store/src/Document/Vectorizer.php
+++ b/src/store/src/Document/Vectorizer.php
@@ -28,7 +28,7 @@ final class Vectorizer implements VectorizerInterface
     ) {
     }
 
-    public function vectorize(string|\Stringable|EmbeddableDocumentInterface|array $values, array $options = []): Vector|VectorDocument|array
+    public function vectorize(string|\Stringable|EmbeddableDocumentInterface|array $values, array $options = []): Vector|VectorDocumentInterface|array
     {
         if (\is_string($values) || $values instanceof \Stringable) {
             return $this->vectorizeString($values, $options);
@@ -99,7 +99,7 @@ final class Vectorizer implements VectorizerInterface
      *
      * @throws ExceptionInterface
      */
-    private function vectorizeEmbeddableDocument(EmbeddableDocumentInterface $document, array $options = []): VectorDocument
+    private function vectorizeEmbeddableDocument(EmbeddableDocumentInterface $document, array $options = []): VectorDocumentInterface
     {
         $this->logger->debug('Vectorizing embeddable document', ['document_id' => $document->getId()]);
         $result = $this->platform->invoke($this->model, $document->getContent(), $options);
@@ -145,7 +145,7 @@ final class Vectorizer implements VectorizerInterface
      * @param array<EmbeddableDocumentInterface> $documents
      * @param array<string, mixed>               $options
      *
-     * @return array<VectorDocument>
+     * @return array<VectorDocumentInterface>
      */
     private function vectorizeEmbeddableDocuments(array $documents, array $options = []): array
     {

--- a/src/store/src/Document/VectorizerInterface.php
+++ b/src/store/src/Document/VectorizerInterface.php
@@ -26,15 +26,15 @@ interface VectorizerInterface
      * @param string|\Stringable|EmbeddableDocumentInterface|array<string|\Stringable>|array<EmbeddableDocumentInterface> $values  The values to vectorize
      * @param array<string, mixed>                                                                                        $options Options to pass to the underlying platform
      *
-     * @return Vector|VectorDocument|array<Vector>|array<VectorDocument>
+     * @return Vector|VectorDocumentInterface|array<Vector>|array<VectorDocumentInterface>
      *
      * @phpstan-return (
      *     $values is string|\Stringable ? Vector : (
-     *         $values is EmbeddableDocumentInterface ? VectorDocument : (
-     *             $values is array<string|\Stringable> ? array<Vector> : array<VectorDocument>
+     *         $values is EmbeddableDocumentInterface ? VectorDocumentInterface : (
+     *             $values is array<string|\Stringable> ? array<Vector> : array<VectorDocumentInterface>
      *         )
      *     )
      * )
      */
-    public function vectorize(string|\Stringable|EmbeddableDocumentInterface|array $values, array $options = []): Vector|VectorDocument|array;
+    public function vectorize(string|\Stringable|EmbeddableDocumentInterface|array $values, array $options = []): Vector|VectorDocumentInterface|array;
 }

--- a/src/store/src/Event/PostQueryEvent.php
+++ b/src/store/src/Event/PostQueryEvent.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Store\Event;
 
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -24,8 +24,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 final class PostQueryEvent extends Event
 {
     /**
-     * @param iterable<VectorDocument> $documents
-     * @param array<string, mixed>     $options
+     * @param iterable<VectorDocumentInterface> $documents
+     * @param array<string, mixed>              $options
      */
     public function __construct(
         private readonly string $query,
@@ -40,7 +40,7 @@ final class PostQueryEvent extends Event
     }
 
     /**
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     public function getDocuments(): iterable
     {
@@ -48,7 +48,7 @@ final class PostQueryEvent extends Event
     }
 
     /**
-     * @param iterable<VectorDocument> $documents
+     * @param iterable<VectorDocumentInterface> $documents
      */
     public function setDocuments(iterable $documents): void
     {

--- a/src/store/src/InMemory/Store.php
+++ b/src/store/src/InMemory/Store.php
@@ -13,6 +13,7 @@ namespace Symfony\AI\Store\InMemory;
 
 use Symfony\AI\Store\Distance\DistanceCalculator;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\ManagedStoreInterface;
@@ -29,7 +30,7 @@ use Symfony\Contracts\Service\ResetInterface;
 final class Store implements ManagedStoreInterface, StoreInterface, ResetInterface
 {
     /**
-     * @var VectorDocument[]
+     * @var VectorDocumentInterface[]
      */
     private array $documents = [];
 
@@ -47,9 +48,9 @@ final class Store implements ManagedStoreInterface, StoreInterface, ResetInterfa
         $this->drop();
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 
@@ -66,7 +67,7 @@ final class Store implements ManagedStoreInterface, StoreInterface, ResetInterfa
             $ids = [$ids];
         }
 
-        $this->documents = array_values(array_filter($this->documents, static function (VectorDocument $document) use ($ids): bool {
+        $this->documents = array_values(array_filter($this->documents, static function (VectorDocumentInterface $document) use ($ids): bool {
             return !\in_array((string) $document->getId(), $ids, true);
         }));
     }
@@ -92,7 +93,7 @@ final class Store implements ManagedStoreInterface, StoreInterface, ResetInterfa
     /**
      * @param array{
      *     maxItems?: positive-int,
-     *     filter?: callable(VectorDocument): bool
+     *     filter?: callable(VectorDocumentInterface): bool
      * } $options If maxItems is provided, only the top N results will be returned.
      *            If filter is provided, only documents matching the filter will be considered.
      */
@@ -117,9 +118,9 @@ final class Store implements ManagedStoreInterface, StoreInterface, ResetInterfa
     }
 
     /**
-     * @param array{maxItems?: positive-int, filter?: callable(VectorDocument): bool} $options
+     * @param array{maxItems?: positive-int, filter?: callable(VectorDocumentInterface): bool} $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryVector(VectorQuery $query, array $options): iterable
     {
@@ -133,13 +134,13 @@ final class Store implements ManagedStoreInterface, StoreInterface, ResetInterfa
     }
 
     /**
-     * @param array{maxItems?: positive-int, filter?: callable(VectorDocument): bool} $options
+     * @param array{maxItems?: positive-int, filter?: callable(VectorDocumentInterface): bool} $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryText(TextQuery $query, array $options): iterable
     {
-        $documents = array_filter($this->documents, static function (VectorDocument $doc) use ($query) {
+        $documents = array_filter($this->documents, static function (VectorDocumentInterface $doc) use ($query) {
             $text = strtolower($doc->getMetadata()->getText() ?? '');
 
             // OR logic: match if ANY of the search texts is found
@@ -161,9 +162,9 @@ final class Store implements ManagedStoreInterface, StoreInterface, ResetInterfa
     }
 
     /**
-     * @param array{maxItems?: positive-int, filter?: callable(VectorDocument): bool} $options
+     * @param array{maxItems?: positive-int, filter?: callable(VectorDocumentInterface): bool} $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function queryHybrid(HybridQuery $query, array $options): iterable
     {

--- a/src/store/src/Reranker/Reranker.php
+++ b/src/store/src/Reranker/Reranker.php
@@ -14,7 +14,7 @@ namespace Symfony\AI\Store\Reranker;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Platform\PlatformInterface;
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 
 /**
  * Platform-based reranker that delegates to PlatformInterface for cross-encoder scoring.
@@ -37,7 +37,7 @@ final class Reranker implements RerankerInterface
         }
 
         $texts = array_map(
-            static fn (VectorDocument $doc): string => $doc->getMetadata()->getText()
+            static fn (VectorDocumentInterface $doc): string => $doc->getMetadata()->getText()
                 ?? $doc->getMetadata()->getSource() ?? '',
             $documents,
         );

--- a/src/store/src/Reranker/RerankerInterface.php
+++ b/src/store/src/Reranker/RerankerInterface.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Store\Reranker;
 
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 
 /**
  * Reranks a list of retrieved documents using a cross-encoder model.
@@ -23,9 +23,9 @@ interface RerankerInterface
     /**
      * Rerank documents for the given query.
      *
-     * @param list<VectorDocument> $documents
+     * @param list<VectorDocumentInterface> $documents
      *
-     * @return list<VectorDocument> Reranked documents with updated scores, limited to $topK
+     * @return list<VectorDocumentInterface> Reranked documents with updated scores, limited to $topK
      */
     public function rerank(string $query, array $documents, int $topK = 5): array;
 }

--- a/src/store/src/Retriever.php
+++ b/src/store/src/Retriever.php
@@ -13,7 +13,7 @@ namespace Symfony\AI\Store;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Document\VectorizerInterface;
 use Symfony\AI\Store\Event\PostQueryEvent;
 use Symfony\AI\Store\Event\PreQueryEvent;
@@ -39,7 +39,7 @@ final class Retriever implements RetrieverInterface
     /**
      * @param array<string, mixed> $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     public function retrieve(string $query, array $options = []): iterable
     {
@@ -63,9 +63,9 @@ final class Retriever implements RetrieverInterface
     }
 
     /**
-     * @param iterable<VectorDocument> $documents
+     * @param iterable<VectorDocumentInterface> $documents
      *
-     * @return \Generator<VectorDocument>
+     * @return \Generator<VectorDocumentInterface>
      */
     private function yieldDocuments(iterable $documents): \Generator
     {
@@ -92,10 +92,10 @@ final class Retriever implements RetrieverInterface
     }
 
     /**
-     * @param iterable<VectorDocument> $documents
-     * @param array<string, mixed>     $options
+     * @param iterable<VectorDocumentInterface> $documents
+     * @param array<string, mixed>              $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      */
     private function dispatchPostQuery(string $query, iterable $documents, array $options): iterable
     {

--- a/src/store/src/RetrieverInterface.php
+++ b/src/store/src/RetrieverInterface.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Store;
 
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 
 /**
  * Retrieves documents from a vector store based on a query string.
@@ -29,7 +29,7 @@ interface RetrieverInterface
      * @param string               $query   The search query to vectorize and use for similarity search
      * @param array<string, mixed> $options Options to pass to the store query (e.g., limit, filters)
      *
-     * @return iterable<VectorDocument> The retrieved documents with similarity scores
+     * @return iterable<VectorDocumentInterface> The retrieved documents with similarity scores
      */
     public function retrieve(string $query, array $options = []): iterable;
 }

--- a/src/store/src/StoreInterface.php
+++ b/src/store/src/StoreInterface.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Store;
 
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\Query\QueryInterface;
 
@@ -23,9 +23,9 @@ interface StoreInterface
     /**
      * Adds documents to the store, so they can be queried afterwards.
      *
-     * @param VectorDocument|VectorDocument[] $documents
+     * @param VectorDocumentInterface|VectorDocumentInterface[] $documents
      */
-    public function add(VectorDocument|array $documents): void;
+    public function add(VectorDocumentInterface|array $documents): void;
 
     /**
      * Removes the documents with the given ids from the store.
@@ -47,7 +47,7 @@ interface StoreInterface
      *
      * @param array<string, mixed> $options
      *
-     * @return iterable<VectorDocument>
+     * @return iterable<VectorDocumentInterface>
      *
      * @throws UnsupportedQueryTypeException if query type not supported
      */

--- a/src/store/src/TraceableStore.php
+++ b/src/store/src/TraceableStore.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Store;
 
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Query\QueryInterface;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Clock\MonotonicClock;
@@ -22,7 +22,7 @@ use Symfony\Contracts\Service\ResetInterface;
  *
  * @phpstan-type StoreData array{
  *     method: string,
- *     documents?: VectorDocument|VectorDocument[],
+ *     documents?: VectorDocumentInterface|VectorDocumentInterface[],
  *     query?: QueryInterface,
  *     ids?: string[]|string,
  *     options?: array<string, mixed>,
@@ -54,7 +54,7 @@ final class TraceableStore implements StoreInterface, ManagedStoreInterface, Res
         return $this->store;
     }
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
         $this->calls[] = [
             'method' => 'add',

--- a/src/store/tests/Distance/DistanceCalculatorTest.php
+++ b/src/store/tests/Distance/DistanceCalculatorTest.php
@@ -19,6 +19,7 @@ use Symfony\AI\Store\Distance\DistanceCalculator;
 use Symfony\AI\Store\Distance\DistanceStrategy;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\Component\Uid\Uuid;
 
 final class DistanceCalculatorTest extends TestCase
@@ -321,8 +322,8 @@ final class DistanceCalculatorTest extends TestCase
         $fullResult = $fullCalculator->calculate($documents, $queryVector, 3);
         $batchedResult = $batchedCalculator->calculate($documents, $queryVector, 3);
 
-        $fullIds = array_map(static fn (VectorDocument $doc): string => $doc->getMetadata()['id'], $fullResult);
-        $batchedIds = array_map(static fn (VectorDocument $doc): string => $doc->getMetadata()['id'], $batchedResult);
+        $fullIds = array_map(static fn (VectorDocumentInterface $doc): string => $doc->getMetadata()['id'], $fullResult);
+        $batchedIds = array_map(static fn (VectorDocumentInterface $doc): string => $doc->getMetadata()['id'], $batchedResult);
 
         $this->assertSame($fullIds, $batchedIds);
         $this->assertCount(3, $batchedResult);
@@ -347,7 +348,7 @@ final class DistanceCalculatorTest extends TestCase
 
         $this->assertCount(2, $result);
 
-        $ids = array_map(static fn (VectorDocument $doc): string => $doc->getMetadata()['id'], $result);
+        $ids = array_map(static fn (VectorDocumentInterface $doc): string => $doc->getMetadata()['id'], $result);
         $this->assertSame(['0', '1'], $ids);
     }
 

--- a/src/store/tests/Double/TestStore.php
+++ b/src/store/tests/Double/TestStore.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\AI\Store\Tests\Double;
 
-use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\UnsupportedFeatureException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\Query\QueryInterface;
@@ -21,15 +21,15 @@ use Symfony\AI\Store\StoreInterface;
 final class TestStore implements StoreInterface
 {
     /**
-     * @var VectorDocument[]
+     * @var VectorDocumentInterface[]
      */
     public array $documents = [];
 
     public int $addCalls = 0;
 
-    public function add(VectorDocument|array $documents): void
+    public function add(VectorDocumentInterface|array $documents): void
     {
-        if ($documents instanceof VectorDocument) {
+        if ($documents instanceof VectorDocumentInterface) {
             $documents = [$documents];
         }
 

--- a/src/store/tests/InMemory/StoreTest.php
+++ b/src/store/tests/InMemory/StoreTest.php
@@ -17,6 +17,7 @@ use Symfony\AI\Store\Distance\DistanceCalculator;
 use Symfony\AI\Store\Distance\DistanceStrategy;
 use Symfony\AI\Store\Document\Metadata;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\Exception\InvalidArgumentException;
 use Symfony\AI\Store\Exception\UnsupportedQueryTypeException;
 use Symfony\AI\Store\InMemory\Store;
@@ -179,7 +180,7 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc) => 'products' === $doc->getMetadata()['category'],
+            'filter' => static fn (VectorDocumentInterface $doc) => 'products' === $doc->getMetadata()['category'],
         ]));
 
         $this->assertCount(2, $result);
@@ -198,7 +199,7 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc) => 'products' === $doc->getMetadata()['category'],
+            'filter' => static fn (VectorDocumentInterface $doc) => 'products' === $doc->getMetadata()['category'],
             'maxItems' => 2,
         ]));
 
@@ -217,7 +218,7 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc) => $doc->getMetadata()['price'] <= 150 && $doc->getMetadata()['stock'] > 0,
+            'filter' => static fn (VectorDocumentInterface $doc) => $doc->getMetadata()['price'] <= 150 && $doc->getMetadata()['stock'] > 0,
         ]));
 
         $this->assertCount(2, $result);
@@ -233,7 +234,7 @@ final class StoreTest extends TestCase
         ]);
 
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc) => 'S' === $doc->getMetadata()['options']['size'],
+            'filter' => static fn (VectorDocumentInterface $doc) => 'S' === $doc->getMetadata()['options']['size'],
         ]));
 
         $this->assertCount(2, $result);
@@ -252,7 +253,7 @@ final class StoreTest extends TestCase
 
         $allowedBrands = ['Nike', 'Adidas', 'Puma'];
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6])), [
-            'filter' => static fn (VectorDocument $doc) => \in_array($doc->getMetadata()['brand'] ?? '', $allowedBrands, true),
+            'filter' => static fn (VectorDocumentInterface $doc) => \in_array($doc->getMetadata()['brand'] ?? '', $allowedBrands, true),
         ]));
 
         $this->assertCount(2, $result);
@@ -279,7 +280,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
-        $ids = array_map(static fn (VectorDocument $doc) => (string) $doc->getId(), $result);
+        $ids = array_map(static fn (VectorDocumentInterface $doc) => (string) $doc->getId(), $result);
         $this->assertContains((string) $id1, $ids);
         $this->assertContains((string) $id3, $ids);
         $this->assertNotContains((string) $id2, $ids);
@@ -308,7 +309,7 @@ final class StoreTest extends TestCase
         $result = iterator_to_array($store->query(new VectorQuery(new Vector([0.0, 0.1, 0.6]))));
         $this->assertCount(2, $result);
 
-        $ids = array_map(static fn (VectorDocument $doc) => (string) $doc->getId(), $result);
+        $ids = array_map(static fn (VectorDocumentInterface $doc) => (string) $doc->getId(), $result);
         $this->assertContains((string) $id2, $ids);
         $this->assertContains((string) $id4, $ids);
         $this->assertNotContains((string) $id1, $ids);
@@ -431,7 +432,7 @@ final class StoreTest extends TestCase
         $this->assertGreaterThanOrEqual(2, \count($result));
 
         // Check that space-related documents are in results
-        $texts = array_map(static fn (VectorDocument $doc) => $doc->getMetadata()->getText(), $result);
+        $texts = array_map(static fn (VectorDocumentInterface $doc) => $doc->getMetadata()->getText(), $result);
         $this->assertContains('deep space mission', $texts);
     }
 

--- a/src/store/tests/TraceableStoreTest.php
+++ b/src/store/tests/TraceableStoreTest.php
@@ -14,6 +14,7 @@ namespace Symfony\AI\Store\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\Vector\Vector;
 use Symfony\AI\Store\Document\VectorDocument;
+use Symfony\AI\Store\Document\VectorDocumentInterface;
 use Symfony\AI\Store\InMemory\Store;
 use Symfony\AI\Store\ManagedStoreInterface;
 use Symfony\AI\Store\Query\QueryInterface;
@@ -122,7 +123,7 @@ final class TraceableStoreTest extends TestCase
             {
             }
 
-            public function add(VectorDocument|array $documents): void
+            public function add(VectorDocumentInterface|array $documents): void
             {
             }
 
@@ -181,7 +182,7 @@ final class TraceableStoreTest extends TestCase
                 $this->dropOptions = $options;
             }
 
-            public function add(VectorDocument|array $documents): void
+            public function add(VectorDocumentInterface|array $documents): void
             {
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

> Slice 3 of 5, splitting up a Doctrine store that keeps vectors on the entity's own table. Stacked on #2494.

`StoreInterface` is typed on the final `VectorDocument` class, which fixes what a store may hand back to an id, a vector and metadata. A store that knows more about a hit than that — the entity it stands for, the file it came from — has no way to say so, and every caller is left resolving the id back to whatever it meant.

`VectorDocument` implements the new interface and stays the default. The stores, the retriever, the rerankers and the vectorizers speak in terms of the interface instead.

## Reviewing this

45 files, but only a handful carry a decision. **25 of them are the same mechanical widening repeated across the bridges** — none of them looks at more than `getId()`, `getVector()`, `getMetadata()` and `getScore()`, all of which are on the interface:

```diff
-public function add(VectorDocument|array $documents): void
+public function add(VectorDocumentInterface|array $documents): void
 {
-    if ($documents instanceof VectorDocument) {
+    if ($documents instanceof VectorDocumentInterface) {
```

The rest is `Document/VectorDocumentInterface.php` itself plus the same widening in the component's own types.

## Compatibility

A custom store has to widen its `add()` signature — a parameter widening, so implementations stay compatible in both directions once changed. Passing and reading `VectorDocument` is unchanged.

## Why now

On its own this buys extensibility rather than a feature; what uses it is the Doctrine store at the top of this stack, which returns entities. Splitting it out so the rename can be reviewed as a rename.
