### PR TITLE
[Platform] Make DeferredResult and RawHttpResult safe to dump()/dd()

### DIFF
--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -65,7 +65,13 @@ final class DeferredResult
      * conversion or otherwise touch $rawResult. That property is already safe to dump on its own, see
      * {@see RawHttpResult::__debugInfo()}, which is what keeps a plain dump() or dd() of a DeferredResult safe.
      *
-     * @return array<string, mixed>
+     * $options is a constructor-injected, always-initialized array and never holds $rawResult or anything
+     * derived from it. $metadata starts out empty and, once conversion succeeds, only ever holds what a
+     * ResultConverter or a stream listener explicitly added to it (e.g. token usage) — not the raw response
+     * itself. Reading $conversionFailure's message does not touch its (potentially deep) stack trace. None
+     * of the four can therefore drive the underlying HTTP stream forward as a side effect of dumping.
+     *
+     * @return array{state: 'pending'|'converted'|'failed', options: array<string, mixed>, metadata: array<string, mixed>, error: string|null}
      */
     public function __debugInfo(): array
     {
@@ -75,6 +81,9 @@ final class DeferredResult
                 $this->isConverted => 'converted',
                 default => 'pending',
             },
+            'options' => $this->options,
+            'metadata' => $this->getMetadata()->all(),
+            'error' => $this->conversionFailure?->getMessage(),
         ];
     }
 

--- a/src/platform/src/Result/DeferredResult.php
+++ b/src/platform/src/Result/DeferredResult.php
@@ -58,6 +58,27 @@ final class DeferredResult
     }
 
     /**
+     * Adds an at-a-glance conversion-state summary to dumps, on top of the normal properties.
+     *
+     * The underlying HTTP response is not read here, directly or indirectly: $isConverted and
+     * $conversionFailure are plain, always-initialized properties, so computing "state" cannot trigger a
+     * conversion or otherwise touch $rawResult. That property is already safe to dump on its own, see
+     * {@see RawHttpResult::__debugInfo()}, which is what keeps a plain dump() or dd() of a DeferredResult safe.
+     *
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array
+    {
+        return [
+            'state' => match (true) {
+                null !== $this->conversionFailure => 'failed',
+                $this->isConverted => 'converted',
+                default => 'pending',
+            },
+        ];
+    }
+
+    /**
      * Registers a callback invoked with the converted result once conversion succeeds.
      *
      * The callback may return a replacement result, which is then used as the converted result

--- a/src/platform/src/Result/RawHttpResult.php
+++ b/src/platform/src/Result/RawHttpResult.php
@@ -26,6 +26,29 @@ final class RawHttpResult implements RawResultInterface
     ) {
     }
 
+    /**
+     * Replaces the wrapped response with a safe summary in dumps.
+     *
+     * The response is typically a Symfony HttpClient {@see \Symfony\Component\HttpClient\Response\AsyncResponse}
+     * (every HTTP-based bridge streams through {@see \Symfony\Component\HttpClient\EventSourceHttpClient}), which
+     * has no dedicated VarDumper caster and keeps its network stream alive until it is explicitly consumed. Letting
+     * a dumper reflect into its internals can drive that stream forward outside of the client's own bookkeeping, so
+     * dump() and dd() must never see its live state.
+     *
+     * The array keys reuse PHP's own mangled-property-name format ("\0Class\0property") on purpose: it is the only
+     * way for __debugInfo() to *replace* a specific property's value for both var_dump() and VarDumper's dump(),
+     * rather than adding a same-named entry next to the original one.
+     *
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array
+    {
+        return [
+            "\0".self::class."\0response" => \sprintf('%s (hidden from dumps to avoid consuming the underlying HTTP stream)', $this->response::class),
+            "\0".self::class."\0httpStream" => $this->httpStream,
+        ];
+    }
+
     public function getData(): array
     {
         return $this->response->toArray(false);

--- a/src/platform/tests/Result/DeferredResultTest.php
+++ b/src/platform/tests/Result/DeferredResultTest.php
@@ -469,6 +469,48 @@ final class DeferredResultTest extends TestCase
         $this->assertSame(3500000, $city->population);
     }
 
+    public function testDebugInfoReportsPendingStateWithoutConverting()
+    {
+        $resultConverter = $this->createMock(ResultConverterInterface::class);
+        $resultConverter->expects($this->never())->method('convert');
+
+        $deferredResult = new DeferredResult($resultConverter, new InMemoryRawResult());
+
+        $debugInfo = $deferredResult->__debugInfo();
+
+        $this->assertSame('pending', $debugInfo['state']);
+    }
+
+    public function testDebugInfoReportsConvertedStateAfterGetResult()
+    {
+        $deferredResult = new DeferredResult(new PlainConverter(new TextResult('hi')), new InMemoryRawResult());
+        $deferredResult->getResult();
+
+        $debugInfo = $deferredResult->__debugInfo();
+
+        $this->assertSame('converted', $debugInfo['state']);
+    }
+
+    public function testDebugInfoReportsFailedStateAfterConversionFailure()
+    {
+        $rawHttpResult = new RawHttpResult($this->createStub(SymfonyHttpResponse::class));
+
+        $resultConverter = $this->createStub(ResultConverterInterface::class);
+        $resultConverter->method('convert')->willThrowException(new RateLimitExceededException());
+
+        $deferredResult = new DeferredResult($resultConverter, $rawHttpResult);
+
+        try {
+            $deferredResult->getResult();
+            $this->fail('Expected RateLimitExceededException.');
+        } catch (RateLimitExceededException) {
+        }
+
+        $debugInfo = $deferredResult->__debugInfo();
+
+        $this->assertSame('failed', $debugInfo['state']);
+    }
+
     public function testAsObjectFinishesStreamAfterExceptionDuringIteration()
     {
         $stream = new StreamResult((static function () {

--- a/src/platform/tests/Result/DeferredResultTest.php
+++ b/src/platform/tests/Result/DeferredResultTest.php
@@ -511,6 +511,67 @@ final class DeferredResultTest extends TestCase
         $this->assertSame('failed', $debugInfo['state']);
     }
 
+    public function testDebugInfoIncludesOptionsWithoutConverting()
+    {
+        $resultConverter = $this->createMock(ResultConverterInterface::class);
+        $resultConverter->expects($this->never())->method('convert');
+
+        $options = ['temperature' => 0.7, 'model' => 'gpt-5'];
+        $deferredResult = new DeferredResult($resultConverter, new InMemoryRawResult(), $options);
+
+        $debugInfo = $deferredResult->__debugInfo();
+
+        $this->assertSame($options, $debugInfo['options']);
+    }
+
+    public function testDebugInfoReportsEmptyMetadataAndNullErrorWhilePending()
+    {
+        $resultConverter = $this->createMock(ResultConverterInterface::class);
+        $resultConverter->expects($this->never())->method('convert');
+
+        $deferredResult = new DeferredResult($resultConverter, new InMemoryRawResult());
+
+        $debugInfo = $deferredResult->__debugInfo();
+
+        $this->assertSame([], $debugInfo['metadata']);
+        $this->assertNull($debugInfo['error']);
+    }
+
+    public function testDebugInfoIncludesMetadataAfterGetResult()
+    {
+        $result = new TextResult('Hello World');
+        $result->getMetadata()->add('foo', 'bar');
+        $converter = new PlainConverter($result);
+
+        $deferredResult = new DeferredResult($converter, new InMemoryRawResult());
+        $deferredResult->getResult();
+
+        $debugInfo = $deferredResult->__debugInfo();
+
+        $this->assertSame('bar', $debugInfo['metadata']['foo']);
+    }
+
+    public function testDebugInfoIncludesErrorMessageAfterConversionFailure()
+    {
+        $rawHttpResult = new RawHttpResult($this->createStub(SymfonyHttpResponse::class));
+        $exception = new RateLimitExceededException(null, 'Provider is throttling requests.');
+
+        $resultConverter = $this->createStub(ResultConverterInterface::class);
+        $resultConverter->method('convert')->willThrowException($exception);
+
+        $deferredResult = new DeferredResult($resultConverter, $rawHttpResult);
+
+        try {
+            $deferredResult->getResult();
+            $this->fail('Expected RateLimitExceededException.');
+        } catch (RateLimitExceededException) {
+        }
+
+        $debugInfo = $deferredResult->__debugInfo();
+
+        $this->assertSame($exception->getMessage(), $debugInfo['error']);
+    }
+
     public function testAsObjectFinishesStreamAfterExceptionDuringIteration()
     {
         $stream = new StreamResult((static function () {

--- a/src/platform/tests/Result/RawHttpResultTest.php
+++ b/src/platform/tests/Result/RawHttpResultTest.php
@@ -95,4 +95,67 @@ final class RawHttpResultTest extends TestCase
 
         $this->assertSame([], $results);
     }
+
+    public function testDebugInfoDoesNotCallAnyMethodOnTheResponse()
+    {
+        $response = new class implements ResponseInterface {
+            public function getStatusCode(): int
+            {
+                throw new \LogicException(__METHOD__.'() must not be called when dumping.');
+            }
+
+            /**
+             * @return array<string, list<string>>
+             */
+            public function getHeaders(bool $throw = true): array
+            {
+                throw new \LogicException(__METHOD__.'() must not be called when dumping.');
+            }
+
+            public function getContent(bool $throw = true): string
+            {
+                throw new \LogicException(__METHOD__.'() must not be called when dumping.');
+            }
+
+            /**
+             * @return array<string, mixed>
+             */
+            public function toArray(bool $throw = true): array
+            {
+                throw new \LogicException(__METHOD__.'() must not be called when dumping.');
+            }
+
+            public function cancel(): void
+            {
+                throw new \LogicException(__METHOD__.'() must not be called when dumping.');
+            }
+
+            public function getInfo(?string $type = null): mixed
+            {
+                throw new \LogicException(__METHOD__.'() must not be called when dumping.');
+            }
+        };
+
+        $rawResult = new RawHttpResult($response);
+
+        // Would throw if __debugInfo() called any method on the still-live, not-yet-consumed response.
+        $debugInfo = $rawResult->__debugInfo();
+
+        $this->assertIsString($debugInfo["\0Symfony\\AI\\Platform\\Result\\RawHttpResult\0response"]);
+        $this->assertStringContainsString($response::class, $debugInfo["\0Symfony\\AI\\Platform\\Result\\RawHttpResult\0response"]);
+    }
+
+    public function testDebugInfoKeepsHttpStreamVisible()
+    {
+        $response = new MockResponse('{}');
+        $httpClient = new MockHttpClient([$response]);
+        $actualResponse = $httpClient->request('GET', 'https://example.com');
+        $httpStream = new SseStream();
+
+        $rawResult = new RawHttpResult($actualResponse, $httpStream);
+
+        $debugInfo = $rawResult->__debugInfo();
+
+        $this->assertSame($httpStream, $debugInfo["\0Symfony\\AI\\Platform\\Result\\RawHttpResult\0httpStream"]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Contributes to #2280
| License       | MIT

Every HTTP-based `ModelClient` wraps its injected client with
`EventSourceHttpClient` (needed to decode SSE streaming responses), so the
response held by `RawHttpResult` is always a Symfony HttpClient
`AsyncResponse`, itself wrapping a `TraceableResponse` whenever HTTP client
profiling is enabled, which is the default in a full-stack app's dev
environment. Neither class has a dedicated VarDumper caster, and both keep
their network stream alive until it is explicitly consumed.

`dump()`'ing or `dd()`'ing a `DeferredResult` right after
`PlatformInterface::invoke()`, before the result is ever read, therefore
reflects into that live, not-yet-consumed response instead of a safe
snapshot: closures bound to the response, its HTTP client and its internal
chunk-accounting state all get expanded, and poking at that state from
outside the client's own bookkeeping is exactly what the
`AsyncResponse`/`TraceableResponse` pair is not designed to tolerate.

This PR adds `__debugInfo()` to `RawHttpResult` so it never exposes the live
response in a dump, replacing it with a short, static summary of its type
instead of letting the dumper walk into its internals. It also adds
`__debugInfo()` to `DeferredResult` so a dump surfaces the conversion state
(`pending`, `converted` or `failed`) at a glance, without ever calling
`getResult()` itself, so inspecting a pending result cannot trigger a
conversion as a side effect.

Tests assert that `__debugInfo()` never calls any method on the wrapped
response, that the `httpStream` property stays visible, and that
`DeferredResult`'s reported state matches pending/converted/failed without
triggering a conversion.

No `CHANGELOG.md`/`UPGRADE.md` changes, since this is a bug fix only.
