### PR TITLE
[Mate] Keep non-ASCII characters intact when init rewrites composer.json

### DIFF
--- a/src/mate/src/Command/InitCommand.php
+++ b/src/mate/src/Command/InitCommand.php
@@ -353,7 +353,7 @@ class InitCommand extends Command
         if ($modified) {
             file_put_contents(
                 $composerJsonPath,
-                json_encode($composerJson, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES)."\n"
+                json_encode($composerJson, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)."\n"
             );
             $actions[] = ['✓', 'Updated', 'composer.json'];
         }

--- a/src/mate/tests/Command/InitCommandTest.php
+++ b/src/mate/tests/Command/InitCommandTest.php
@@ -453,6 +453,26 @@ final class InitCommandTest extends TestCase
         $this->assertFalse($composerJson['extra']['ai-mate']['extension']);
     }
 
+    public function testPreservesNonAsciiCharactersInComposerJson()
+    {
+        file_put_contents($this->tempDir.'/composer.json', json_encode([
+            'name' => 'test/package',
+            'authors' => [['name' => 'Michał Pysiak']],
+        ], \JSON_UNESCAPED_UNICODE));
+
+        $command = $this->createCommand();
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        $composerContent = file_get_contents($this->tempDir.'/composer.json');
+        $this->assertIsString($composerContent);
+        $this->assertStringContainsString('Michał Pysiak', $composerContent);
+        $this->assertStringNotContainsString('\\u', $composerContent);
+    }
+
     public function testScaffoldsSensitiveFilesWithSecurePermissions()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | -
| License       | MIT

`mate init` rewrites the project's `composer.json` to add the `extra.ai-mate` block and the `Mate\` autoloader. It re-encodes the whole file with `JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES`, so every non-ASCII character already present in the file comes out as a `\uXXXX` escape. An author entry such as `Michał Pysiak` becomes `Micha\u0142 Pysiak` after `init`; the same happens to any non-English `description`, author name or keyword.

Adding `JSON_UNESCAPED_UNICODE` keeps those characters as written, which matches what Composer itself does when it writes `composer.json`.

Includes a regression test: a `composer.json` with a non-ASCII author name keeps it after `init`, with no `\u` escapes in the output.
