### PR TITLE
[Platform] Keep forward slashes unescaped in tool call arguments

### DIFF
--- a/src/platform/src/Bridge/OpenResponses/Contract/ToolCallNormalizer.php
+++ b/src/platform/src/Bridge/OpenResponses/Contract/ToolCallNormalizer.php
@@ -31,7 +31,7 @@ final class ToolCallNormalizer extends ModelContractNormalizer
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
         return [
-            'arguments' => json_encode($data->getArguments() ?: new \stdClass()),
+            'arguments' => json_encode($data->getArguments() ?: new \stdClass(), \JSON_UNESCAPED_SLASHES),
             'call_id' => $data->getId(),
             'name' => $data->getName(),
             'type' => 'function_call',

--- a/src/platform/src/Contract/Normalizer/Result/ToolCallNormalizer.php
+++ b/src/platform/src/Contract/Normalizer/Result/ToolCallNormalizer.php
@@ -50,7 +50,7 @@ final class ToolCallNormalizer implements NormalizerInterface
             'type' => 'function',
             'function' => [
                 'name' => $data->getName(),
-                'arguments' => json_encode($data->getArguments() ?: new \stdClass()),
+                'arguments' => json_encode($data->getArguments() ?: new \stdClass(), \JSON_UNESCAPED_SLASHES),
             ],
         ];
     }

--- a/src/platform/tests/Bridge/OpenResponses/Contract/ToolCallNormalizerTest.php
+++ b/src/platform/tests/Bridge/OpenResponses/Contract/ToolCallNormalizerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Bridge\OpenResponses\Contract;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Bridge\OpenResponses\Contract\ToolCallNormalizer;
+use Symfony\AI\Platform\Bridge\OpenResponses\ResponsesModel;
+use Symfony\AI\Platform\Contract;
+use Symfony\AI\Platform\Result\ToolCall;
+
+final class ToolCallNormalizerTest extends TestCase
+{
+    private ToolCallNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new ToolCallNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $context = [Contract::CONTEXT_MODEL => new ResponsesModel('gpt-4o')];
+
+        $this->assertTrue($this->normalizer->supportsNormalization(new ToolCall('id', 'function'), null, $context));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass(), null, $context));
+    }
+
+    public function testNormalize()
+    {
+        $toolCall = new ToolCall('call_123', 'get_weather', ['location' => 'Paris']);
+
+        $this->assertSame([
+            'arguments' => '{"location":"Paris"}',
+            'call_id' => 'call_123',
+            'name' => 'get_weather',
+            'type' => 'function_call',
+        ], $this->normalizer->normalize($toolCall));
+    }
+
+    public function testNormalizeKeepsForwardSlashesUnescaped()
+    {
+        $toolCall = new ToolCall('call_123', 'query_assets', ['path' => '/de/shop']);
+
+        $normalized = $this->normalizer->normalize($toolCall);
+
+        $this->assertSame('{"path":"/de/shop"}', $normalized['arguments']);
+    }
+}

--- a/src/platform/tests/Contract/Normalizer/Result/ToolCallNormalizerTest.php
+++ b/src/platform/tests/Contract/Normalizer/Result/ToolCallNormalizerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Platform\Tests\Contract\Normalizer\Result;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Contract\Normalizer\Result\ToolCallNormalizer;
+use Symfony\AI\Platform\Result\ToolCall;
+
+final class ToolCallNormalizerTest extends TestCase
+{
+    private ToolCallNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new ToolCallNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new ToolCall('id', 'function')));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testGetSupportedTypes()
+    {
+        $this->assertSame([ToolCall::class => true], $this->normalizer->getSupportedTypes(null));
+    }
+
+    public function testNormalize()
+    {
+        $toolCall = new ToolCall('tool_call_123', 'get_weather', ['location' => 'Paris']);
+
+        $this->assertSame([
+            'id' => 'tool_call_123',
+            'type' => 'function',
+            'function' => [
+                'name' => 'get_weather',
+                'arguments' => '{"location":"Paris"}',
+            ],
+        ], $this->normalizer->normalize($toolCall));
+    }
+
+    public function testNormalizeKeepsForwardSlashesUnescaped()
+    {
+        $toolCall = new ToolCall('tool_call_123', 'query_assets', ['path' => '/de/shop']);
+
+        $normalized = $this->normalizer->normalize($toolCall);
+
+        $this->assertSame('{"path":"/de/shop"}', $normalized['function']['arguments']);
+    }
+
+    public function testNormalizeWithoutArguments()
+    {
+        $normalized = $this->normalizer->normalize(new ToolCall('tool_call_123', 'now'));
+
+        $this->assertSame('{}', $normalized['function']['arguments']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | no
| Issues        | Related to #1973 and #2087
| License       | MIT


`ToolCallNormalizer` encodes a tool call's arguments with `json_encode()` and no flags. PHP escapes forward slashes by default, so `/de/shop` is written as `\/de\/shop`. That is valid JSON, and any decoder returns the original string.

The problem is that these arguments are not only sent to the provider. They also come back to the model as the text of its own previous call, and the model reads that text instead of decoding it. It sees a backslash, assumes the value contains one, and escapes it on the next attempt. The next call then arrives with a real backslash in the path.

This only happens after a failed call, because that is when the previous call is part of the history.

```php
$payload = OpenAiContract::create()->createRequestPayload(new Gpt('gpt-5-mini'), new MessageBag(
    Message::ofUser('find them'),
    Message::ofAssistant(new ToolCall('call_1', 'query_assets',
        ['filters' => ['path' => ['startsWith' => '/de/shop/']]])),
));

// before: arguments === '{"filters":{"path":{"startsWith":"\/de\/shop\/"}}}'
// after:  arguments === '{"filters":{"path":{"startsWith":"/de/shop/"}}}'
```

#2087 asked how much impact this has: For model names the answer depends on the backend, because a router compares the string. For tool call arguments the reader is the model itself, so every provider is affected.

The fix is the same line in the two normalizers that encode arguments. The Ollama normalizer passes the array through and needs no change. Neither class had tests, so I added them.