### PR TITLE
[MCP Bundle] Add runtime filtering for tools/list

### DIFF
--- a/docs/bundles/mcp-bundle.rst
+++ b/docs/bundles/mcp-bundle.rst
@@ -243,6 +243,43 @@ Access control is plain Symfony security — the routes have distinct, stable pa
         access_control:
             - { path: ^/mcp/editors, roles: ROLE_EDITOR }
 
+When clients on the same server have different permissions, a filter can hide tools they cannot use
+from ``tools/list``. The filter runs for every list request, so it can consult the current security
+context::
+
+    use Mcp\Schema\Tool;
+    use Symfony\AI\McpBundle\Server\ToolListFilterInterface;
+    use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+    final class ToolListFilter implements ToolListFilterInterface
+    {
+        public function __construct(
+            private AuthorizationCheckerInterface $authorizationChecker,
+        ) {
+        }
+
+        public function isVisible(Tool $tool): bool
+        {
+            return $this->authorizationChecker->isGranted('MCP_TOOL_VIEW', $tool);
+        }
+    }
+
+Point the server at the filter service:
+
+.. code-block:: yaml
+
+    # config/packages/mcp.yaml
+    mcp:
+        servers:
+            default:
+                tool_list_filter: 'App\Mcp\ToolListFilter'
+
+.. caution::
+
+    Filtering ``tools/list`` controls discovery only. Clients can still call a hidden tool by name, so
+    enforce the same authorization when handling tool calls. Keep caller-specific list responses on the
+    default ``private`` cache scope.
+
 Each server gets its own registry, session store and HTTP route (named ``_mcp_endpoint_<name>``), and its
 own services under ``mcp.server.<name>.*``. Autowire a specific server with ``Mcp\Server $editorsServer``.
 
@@ -929,6 +966,7 @@ Configuration
                       sizes: ['64x64'] # Sizes of the icon
                 website_url: 'https://example.com' # Website URL advertised to clients
                 pagination_limit: 50 # Maximum number of items returned per list request (default: 50)
+                tool_list_filter: 'App\Mcp\ToolListFilter' # Optional ToolListFilterInterface service
                 instructions: | # Instructions describing server purpose and usage context (for LLMs)
                     This server provides time management capabilities for developers.
 

--- a/src/mcp-bundle/CHANGELOG.md
+++ b/src/mcp-bundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.14
+----
+
+ * Add `servers.<name>.tool_list_filter` for request-time filtering of tools advertised by `tools/list`
+
 0.13
 ----
 

--- a/src/mcp-bundle/config/options.php
+++ b/src/mcp-bundle/config/options.php
@@ -110,6 +110,10 @@ return static function (DefinitionConfigurator $configurator): void {
                         ->end()
                         ->stringNode('website_url')->defaultNull()->end()
                         ->integerNode('pagination_limit')->min(1)->defaultValue(50)->end()
+                        ->stringNode('tool_list_filter')
+                            ->defaultNull()
+                            ->info('Service implementing ToolListFilterInterface to control tools/list visibility. Tool calls must be authorized separately.')
+                        ->end()
                         ->stringNode('instructions')->defaultNull()->end()
 
                         ->arrayNode('transports')

--- a/src/mcp-bundle/src/McpBundle.php
+++ b/src/mcp-bundle/src/McpBundle.php
@@ -58,6 +58,7 @@ use Symfony\AI\McpBundle\Exception\LogicException;
 use Symfony\AI\McpBundle\Http\MiddlewareFactory;
 use Symfony\AI\McpBundle\Profiler\DataCollector;
 use Symfony\AI\McpBundle\Routing\RouteLoader;
+use Symfony\AI\McpBundle\Server\Handler\Request\FilteredListToolsHandler;
 use Symfony\AI\McpBundle\Session\FrameworkSessionStore;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -363,7 +364,7 @@ final class McpBundle extends AbstractBundle
             ->setArguments([$this->registryDispatcher($name, $server['subscriptions']), new Reference('logger')])
             ->addTag('monolog.logger', ['channel' => 'mcp']);
 
-        $container->register($builderId, Builder::class)
+        $builderDefinition = $container->register($builderId, Builder::class)
             ->setFactory([Server::class, 'builder'])
             ->addMethodCall('setServerInfo', [
                 $server['name'] ?? $name,
@@ -376,7 +377,17 @@ final class McpBundle extends AbstractBundle
             ->addMethodCall('setInstructions', [$server['instructions']])
             ->addMethodCall('setEventDispatcher', [new Reference('event_dispatcher')])
             ->addMethodCall('setRegistry', [new Reference($registryId)])
-            ->addMethodCall('setSession', [new Reference($sessionId)])
+            ->addMethodCall('setSession', [new Reference($sessionId)]);
+
+        if (null !== $server['tool_list_filter']) {
+            $builderDefinition->addMethodCall('addRequestHandler', [new Definition(FilteredListToolsHandler::class, [
+                new Reference($registryId),
+                new Reference($server['tool_list_filter']),
+                $server['pagination_limit'],
+            ])]);
+        }
+
+        $builderDefinition
             ->addMethodCall('addRequestHandlers', [new TaggedIteratorArgument('mcp.request_handler')])
             ->addMethodCall('addNotificationHandlers', [new TaggedIteratorArgument('mcp.notification_handler')])
             ->addMethodCall('addLoaders', [new TaggedIteratorArgument('mcp.loader')])

--- a/src/mcp-bundle/src/Server/Handler/Request/FilteredListToolsHandler.php
+++ b/src/mcp-bundle/src/Server/Handler/Request/FilteredListToolsHandler.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Server\Handler\Request;
+
+use Mcp\Capability\RegistryInterface;
+use Mcp\Exception\InvalidCursorException;
+use Mcp\Schema\JsonRpc\Request;
+use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Request\ListToolsRequest;
+use Mcp\Schema\Result\ListToolsResult;
+use Mcp\Schema\Tool;
+use Mcp\Server\Handler\Request\RequestHandlerInterface;
+use Mcp\Server\Session\SessionInterface;
+use Symfony\AI\McpBundle\Server\ToolListFilterInterface;
+
+/**
+ * @implements RequestHandlerInterface<ListToolsResult>
+ *
+ * @author Ousama Ben Younes <2910651+ousamabenyounes@users.noreply.github.com>
+ */
+final class FilteredListToolsHandler implements RequestHandlerInterface
+{
+    private const DEFAULT_PAGE_SIZE = 20;
+
+    public function __construct(
+        private readonly RegistryInterface $registry,
+        private readonly ToolListFilterInterface $filter,
+        private readonly int $pageSize = self::DEFAULT_PAGE_SIZE,
+    ) {
+    }
+
+    public function supports(Request $request): bool
+    {
+        return $request instanceof ListToolsRequest;
+    }
+
+    /**
+     * @return Response<ListToolsResult>
+     *
+     * @throws InvalidCursorException When the cursor is invalid
+     */
+    public function handle(Request $request, SessionInterface $session): Response
+    {
+        \assert($request instanceof ListToolsRequest);
+
+        $tools = array_values(array_filter(
+            $this->registry->getTools()->references,
+            fn (Tool $tool): bool => $this->filter->isVisible($tool),
+        ));
+        [$tools, $nextCursor] = $this->paginate($tools, $request->cursor);
+
+        return new Response(
+            $request->getId(),
+            new ListToolsResult($tools, $nextCursor),
+        );
+    }
+
+    /**
+     * @param list<Tool> $tools
+     *
+     * @return array{list<Tool>, ?string}
+     */
+    private function paginate(array $tools, ?string $cursor): array
+    {
+        $offset = 0;
+        if (null !== $cursor) {
+            $decodedCursor = base64_decode($cursor, true);
+            if (false === $decodedCursor || !is_numeric($decodedCursor)) {
+                throw new InvalidCursorException($cursor);
+            }
+
+            $offset = (int) $decodedCursor;
+            if ($offset < 0 || $offset > \count($tools)) {
+                throw new InvalidCursorException($cursor);
+            }
+        }
+
+        $nextOffset = $offset + $this->pageSize;
+        $nextCursor = $nextOffset < \count($tools) ? base64_encode((string) $nextOffset) : null;
+
+        return [\array_slice($tools, $offset, $this->pageSize), $nextCursor];
+    }
+}

--- a/src/mcp-bundle/src/Server/ToolListFilterInterface.php
+++ b/src/mcp-bundle/src/Server/ToolListFilterInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Server;
+
+use Mcp\Schema\Tool;
+
+/**
+ * Decides which tools are advertised to the current client.
+ *
+ * This controls discovery through tools/list only. Implementations must enforce authorization
+ * separately when a tool is called.
+ *
+ * @author Ousama Ben Younes <2910651+ousamabenyounes@users.noreply.github.com>
+ */
+interface ToolListFilterInterface
+{
+    public function isVisible(Tool $tool): bool;
+}

--- a/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
+++ b/src/mcp-bundle/tests/DependencyInjection/McpBundleTest.php
@@ -39,6 +39,7 @@ use Symfony\AI\McpBundle\Attribute\AsMcpApp;
 use Symfony\AI\McpBundle\Controller\McpController;
 use Symfony\AI\McpBundle\Exception\LogicException;
 use Symfony\AI\McpBundle\McpBundle;
+use Symfony\AI\McpBundle\Server\Handler\Request\FilteredListToolsHandler;
 use Symfony\AI\McpBundle\Session\FrameworkSessionStore;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -104,6 +105,25 @@ class McpBundleTest extends TestCase
 
         $this->assertSame([25], $this->callsNamed($container, 'setPaginationLimit')[0][1]);
         $this->assertSame(['This server provides weather and calendar tools'], $this->callsNamed($container, 'setInstructions')[0][1]);
+    }
+
+    public function testToolListFilterIsConfiguredPerServer()
+    {
+        $container = $this->buildContainer($this->config([
+            'public' => ['tool_list_filter' => 'app.public_tool_filter', 'pagination_limit' => 25],
+            'internal' => [],
+        ]));
+
+        $calls = $this->callsNamed($container, 'addRequestHandler', 'public');
+        $this->assertCount(1, $calls);
+        $this->assertInstanceOf(Definition::class, $calls[0][1][0]);
+        $this->assertSame(FilteredListToolsHandler::class, $calls[0][1][0]->getClass());
+        $this->assertEquals([
+            new Reference('mcp.server.public.registry'),
+            new Reference('app.public_tool_filter'),
+            25,
+        ], $calls[0][1][0]->getArguments());
+        $this->assertSame([], $this->callsNamed($container, 'addRequestHandler', 'internal'));
     }
 
     public function testIconsDefaultToNullInsteadOfAnEmptyList()

--- a/src/mcp-bundle/tests/Server/Handler/Request/FilteredListToolsHandlerTest.php
+++ b/src/mcp-bundle/tests/Server/Handler/Request/FilteredListToolsHandlerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\McpBundle\Tests\Server\Handler\Request;
+
+use Mcp\Capability\Registry;
+use Mcp\Exception\InvalidCursorException;
+use Mcp\Schema\Request\ListToolsRequest;
+use Mcp\Schema\Request\PingRequest;
+use Mcp\Schema\Tool;
+use Mcp\Server\Session\SessionInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\Server\Handler\Request\FilteredListToolsHandler;
+use Symfony\AI\McpBundle\Server\ToolListFilterInterface;
+
+class FilteredListToolsHandlerTest extends TestCase
+{
+    private const ALLOWED_TOOL_ONE = 'allowed-one';
+    private const ALLOWED_TOOL_TWO = 'allowed-two';
+    private const HIDDEN_TOOL = 'hidden';
+
+    public function testFiltersBeforePaginatingWithoutRemovingToolsFromTheRegistry()
+    {
+        $registry = new Registry();
+        $registry->registerTool($this->createTool(self::ALLOWED_TOOL_ONE), static fn () => null);
+        $registry->registerTool($this->createTool(self::HIDDEN_TOOL), static fn () => null);
+        $registry->registerTool($this->createTool(self::ALLOWED_TOOL_TWO), static fn () => null);
+
+        $filter = new class(self::HIDDEN_TOOL) implements ToolListFilterInterface {
+            public function __construct(private readonly string $hiddenTool)
+            {
+            }
+
+            public function isVisible(Tool $tool): bool
+            {
+                return $this->hiddenTool !== $tool->name;
+            }
+        };
+        $handler = new FilteredListToolsHandler($registry, $filter, 1);
+        $session = $this->createStub(SessionInterface::class);
+
+        $firstPage = $handler->handle((new ListToolsRequest())->withId(1), $session)->result;
+        $this->assertSame([self::ALLOWED_TOOL_ONE], array_column($firstPage->tools, 'name'));
+        $this->assertSame(base64_encode('1'), $firstPage->nextCursor);
+
+        $secondPage = $handler->handle((new ListToolsRequest($firstPage->nextCursor))->withId(2), $session)->result;
+        $this->assertSame([self::ALLOWED_TOOL_TWO], array_column($secondPage->tools, 'name'));
+        $this->assertNull($secondPage->nextCursor);
+
+        $this->assertSame(self::HIDDEN_TOOL, $registry->getTool(self::HIDDEN_TOOL)->tool->name);
+    }
+
+    public function testSupportsOnlyListToolsRequests()
+    {
+        $handler = $this->createHandler();
+
+        $this->assertTrue($handler->supports(new ListToolsRequest()));
+        $this->assertFalse($handler->supports(new PingRequest()));
+    }
+
+    #[DataProvider('provideInvalidCursors')]
+    public function testRejectsAnInvalidCursor(string $cursor)
+    {
+        $handler = $this->createHandler();
+
+        $this->expectException(InvalidCursorException::class);
+
+        $handler->handle(
+            (new ListToolsRequest($cursor))->withId(1),
+            $this->createStub(SessionInterface::class),
+        );
+    }
+
+    public static function provideInvalidCursors(): iterable
+    {
+        yield 'not base64' => ['not-a-cursor'];
+        yield 'negative offset' => [base64_encode('-1')];
+        yield 'offset past the end' => [base64_encode('1')];
+    }
+
+    private function createHandler(): FilteredListToolsHandler
+    {
+        return new FilteredListToolsHandler(
+            new Registry(),
+            new class implements ToolListFilterInterface {
+                public function isVisible(Tool $tool): bool
+                {
+                    return true;
+                }
+            },
+        );
+    }
+
+    private function createTool(string $name): Tool
+    {
+        return new Tool($name, null, ['type' => 'object', 'properties' => [], 'required' => null], null, null);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | Fix #1623
| License       | MIT

This adds per-server, request-time filtering for MCP `tools/list` responses.

Applications can configure a `ToolListFilterInterface` service to decide which
tools are advertised to the current caller. Filtering happens before pagination,
while the registry remains unchanged so callers can enforce invocation
authorization separately.

The default behavior is unchanged when no filter is configured.

Full local validation suite:

- regression tests were RED before the implementation and GREEN afterward;
- MCP Bundle suite: 203 tests, 604 assertions (baseline: 197 tests, 589 assertions);
- PHPStan and Composer validation pass;
- all 32 changed executable lines are covered;
- RST validation and the full documentation build pass.
