### PR TITLE
[Mate] Make monolog-search's term parameter optional

### DIFF
--- a/demo/mate/AGENT_INSTRUCTIONS.md
+++ b/demo/mate/AGENT_INSTRUCTIONS.md
@@ -40,6 +40,7 @@ Use these Mate tools (via `vendor/bin/mate tools:call ...`) instead of raw shell
 | `tail -f var/log/dev.log`         | `monolog-tail`                                   |
 | `grep "error" var/log/*.log`      | `monolog-search` with term "error"               |
 | `grep -E "pattern" var/log/*.log` | `monolog-search` with term "pattern", regex: true |
+| `grep -l ERROR var/log/*.log`     | `monolog-search` with level: "ERROR" and no term |
 
 #### Benefits
 

--- a/docs/components/mate.rst
+++ b/docs/components/mate.rst
@@ -518,7 +518,7 @@ Monolog Bridge
 
 The Monolog bridge (``symfony/ai-monolog-mate-extension``) provides log search and analysis tools:
 
-* ``monolog-search`` - Search log entries by text term with optional filters (supports ``regex`` parameter for regex patterns and ``level`` filter)
+* ``monolog-search`` - Search log entries by an optional text term (supports ``regex`` parameter for regex patterns), plus filters like ``level``, ``channel``, ``from`` and ``to``; omit the term to filter without a text match
 * ``monolog-context-search`` - Search logs by context field value
 * ``monolog-tail`` - Get the last N log entries
 * ``monolog-list-files`` - List available log files

--- a/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
+++ b/src/mate/src/Bridge/Monolog/Capability/LogSearchTool.php
@@ -15,6 +15,7 @@ use Symfony\AI\Mate\Attribute\MateTool;
 use Symfony\AI\Mate\Bridge\Monolog\Model\SearchCriteria;
 use Symfony\AI\Mate\Bridge\Monolog\Service\LogReader;
 use Symfony\AI\Mate\Encoding\ResponseEncoder;
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
 
 /**
  * Tools for searching and analyzing Monolog log files.
@@ -29,7 +30,7 @@ final class LogSearchTool
     }
 
     /**
-     * @param string      $term          Text to search for in log messages, or a regex pattern when $regex is true
+     * @param string|null $term          Text to search for in log messages, or a regex pattern when $regex is true; omit to filter by level/channel/date only
      * @param bool        $regex         When true, treat $term as a regular expression pattern
      * @param string|null $level         Filter by log level: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY
      * @param string|null $channel       Filter by Monolog channel name (e.g. app, security, doctrine)
@@ -39,9 +40,9 @@ final class LogSearchTool
      * @param int         $limit         Maximum number of entries to return
      * @param string|null $kernelContext Filter by kernel context (e.g. the APP_ID of a multi-kernel application), only relevant when multiple log directories are configured
      */
-    #[MateTool(name: 'monolog-search', title: 'Log Search', description: 'Search log entries by text or regex pattern. Supports filtering by log level, channel, environment, and date range. Use empty string for term to match all entries when using filters only. When multiple kernel contexts are configured, entries carry a kernel_context field and can be narrowed with the kernelContext parameter.')]
+    #[MateTool(name: 'monolog-search', title: 'Log Search', description: 'Search log entries by text or regex pattern. Supports filtering by log level, channel, environment, and date range. Omit term to match all entries when filtering by level/channel/date only. When multiple kernel contexts are configured, entries carry a kernel_context field and can be narrowed with the kernelContext parameter.')]
     public function search(
-        string $term,
+        ?string $term = null,
         bool $regex = false,
         ?string $level = null,
         ?string $channel = null,
@@ -52,6 +53,10 @@ final class LogSearchTool
         ?string $kernelContext = null,
     ): string {
         if ($regex) {
+            if (null === $term) {
+                throw new InvalidArgumentException('The "term" parameter is required when "regex" is true.');
+            }
+
             $pattern = $term;
             if (!str_starts_with($pattern, '/') && !str_starts_with($pattern, '#')) {
                 $pattern = '/'.$pattern.'/i';
@@ -67,7 +72,7 @@ final class LogSearchTool
             );
         } else {
             $criteria = new SearchCriteria(
-                term: $term,
+                term: '' === $term ? null : $term,
                 level: $level,
                 channel: $channel,
                 from: $this->parseDate($from),

--- a/src/mate/src/Bridge/Monolog/INSTRUCTIONS.md
+++ b/src/mate/src/Bridge/Monolog/INSTRUCTIONS.md
@@ -7,6 +7,7 @@ Use these Mate tools (via `vendor/bin/mate tools:call ...`) instead of raw shell
 | `tail -f var/log/dev.log`         | `monolog-tail`                                   |
 | `grep "error" var/log/*.log`      | `monolog-search` with term "error"               |
 | `grep -E "pattern" var/log/*.log` | `monolog-search` with term "pattern", regex: true |
+| `grep -l ERROR var/log/*.log`     | `monolog-search` with level: "ERROR" and no term |
 
 ### Benefits
 

--- a/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
+++ b/src/mate/src/Bridge/Monolog/Tests/Capability/LogSearchToolTest.php
@@ -17,7 +17,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Mate\Bridge\Monolog\Capability\LogSearchTool;
 use Symfony\AI\Mate\Bridge\Monolog\Service\LogParser;
 use Symfony\AI\Mate\Bridge\Monolog\Service\LogReader;
+use Symfony\AI\Mate\Discovery\DocBlockParser;
+use Symfony\AI\Mate\Discovery\SchemaGenerator;
 use Symfony\AI\Mate\Encoding\ResponseEncoder;
+use Symfony\AI\Mate\Exception\InvalidArgumentException;
 
 /**
  * @author Johannes Wachter <johannes@sulu.io>
@@ -307,12 +310,71 @@ final class LogSearchToolTest extends TestCase
         }
     }
 
+    public function testSearchWithoutTermFiltersByLevelOnly()
+    {
+        // Regression test: an ERROR-level entry whose message never contains the literal
+        // word "error" must still be found when filtering by level alone, without a term.
+        $result = $this->decodeUntrusted($this->createTermOptionalTool()->search(level: 'ERROR'));
+
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertCount(1, $result['entries']);
+        $this->assertSame('ERROR', $result['entries'][0]['level']);
+        $this->assertStringContainsString('No route found', $result['entries'][0]['message']);
+    }
+
+    public function testSearchWithoutTermFiltersByChannelOnly()
+    {
+        $result = $this->decodeUntrusted($this->createTermOptionalTool()->search(channel: 'security'));
+
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertCount(1, $result['entries']);
+        $this->assertSame('security', $result['entries'][0]['channel']);
+    }
+
+    public function testSearchWithoutTermReturnsAllEntriesWithinBounds()
+    {
+        $result = $this->decodeUntrusted($this->createTermOptionalTool()->search());
+
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertCount(3, $result['entries']);
+    }
+
+    public function testSearchWithTermStillFiltersByText()
+    {
+        $result = $this->decodeUntrusted($this->createTermOptionalTool()->search('Deprecated'));
+
+        $this->assertArrayHasKey('entries', $result);
+        $this->assertCount(1, $result['entries']);
+        $this->assertStringContainsString('Deprecated function called', $result['entries'][0]['message']);
+    }
+
+    public function testSearchRegexWithoutTermThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->createTermOptionalTool()->search(regex: true);
+    }
+
+    public function testSearchSchemaDoesNotRequireTerm()
+    {
+        $method = new \ReflectionMethod(LogSearchTool::class, 'search');
+        $schema = (new SchemaGenerator(new DocBlockParser()))->generate($method);
+
+        $this->assertNotContains('term', $schema['required'] ?? []);
+        $this->assertSame(['null', 'string'], $schema['properties']['term']['type']);
+    }
+
     private function createMultiKernelTool(): LogSearchTool
     {
         return new LogSearchTool(new LogReader(new LogParser(), [
             'website' => $this->fixturesDir,
             'admin' => $this->fixturesDir.'/logs',
         ]));
+    }
+
+    private function createTermOptionalTool(): LogSearchTool
+    {
+        return new LogSearchTool(new LogReader(new LogParser(), $this->fixturesDir.'/term-optional'));
     }
 
     /**

--- a/src/mate/src/Bridge/Monolog/Tests/Fixtures/term-optional/app.log
+++ b/src/mate/src/Bridge/Monolog/Tests/Fixtures/term-optional/app.log
@@ -1,0 +1,3 @@
+[2024-01-15 09:00:00] app.INFO: Application booted [] []
+[2024-01-15 09:01:00] app.ERROR: Uncaught PHP Exception: No route found for "GET /missing" [] []
+[2024-01-15 09:02:00] security.WARNING: Deprecated function called [] []

--- a/src/mate/src/Bridge/Monolog/skills/symfony-log-investigation/SKILL.md
+++ b/src/mate/src/Bridge/Monolog/skills/symfony-log-investigation/SKILL.md
@@ -10,7 +10,7 @@ Reads Monolog files through Mate's CLI. Entries come back as `{datetime, channel
 - `monolog-list-files` (opt `environment`): what log files exist, newest first.
 - `monolog-list-channels`: distinct channel names (`app`, `security`, `doctrine`, ...). Reads every file, so it is the slow one; skip it if you already know the channel.
 - `monolog-tail` (`limit`, `level`, `environment`, `channel`): most recent entries. Reads ONLY the single newest file.
-- `monolog-search` (`term`, `regex`, `level`, `channel`, `environment`, `from`, `to`, `limit`): searches across all files. Empty `term` with filters set = filter-only.
+- `monolog-search` (`term`, `regex`, `level`, `channel`, `environment`, `from`, `to`, `limit`): searches across all files. `term` is optional; omit it (or pass an empty string) to filter by `level`/`channel`/`from`/`to` only, e.g. "just show me the errors".
 - `monolog-context-search` (`key`, `value`, `level`, `environment`, `limit`): matches a structured context field. No channel or date filter here.
 
 These commands accept `--format`: `json` to parse the result, `toon` (when `helgesverre/toon` is installed) for the smallest context footprint. A wide search returns many entries, so narrow with filters and a `limit` before widening the output format.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Docs?         | yes
| Issues        | Found while hand-testing `monolog-search` against the demo app
| License       | MIT

`monolog-search`'s `term` was required, so filtering purely by level, channel or date, e.g. "just show me the errors" (`--level=ERROR`), failed outright. The documented workaround (pass an empty string) still ran the text-match code path, so a real `ERROR` entry could be missed if its message didn't literally contain the word "error".

`$term` is now `?string $term = null` and drops out of the generated schema's required list. When it's omitted or empty, `null` is passed to `SearchCriteria` so the text-match check is skipped entirely instead of matching against an empty string. `regex: true` without `term` now throws a clear `InvalidArgumentException` instead of failing on a missing required argument. Docs and skill files updated to describe `term` as optional. `CHANGELOG.md` is untouched since required-to-optional is additive, not a BC break.

