### PR TITLE
[Mate] Show constructor arguments in symfony-service-detail

### DIFF
--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * Add an `Arguments` column to `tools:list`'s table output, and stop truncating tool descriptions to 50 characters, so a tool's parameters and full description are visible without a separate `tools:inspect` call
  * Add a `tools:inspect <tool-name>` hint to `tools:call`'s error output when a parameter name is unknown or a required one is missing
- * Add constructor arguments to `symfony-service-detail`: the compiled container dump carries them but they were never read, so the services wired into a definition — the middleware list of a messenger bus, for one — were invisible. Parameter names come from reflecting the constructor or factory method; scalar values are redacted when the name looks like a secret, and also when the parameter cannot be identified at all
+ * Add constructor arguments to `symfony-service-detail`: the compiled container dump carries them but they were never read, so the services wired into a definition, such as the middleware list of a messenger bus, were invisible. Parameter names come from reflecting the constructor or factory method; scalar values are redacted when the name looks like a secret, and also when the parameter cannot be identified at all
 
 0.13
 ----

--- a/src/mate/CHANGELOG.md
+++ b/src/mate/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add an `Arguments` column to `tools:list`'s table output, and stop truncating tool descriptions to 50 characters, so a tool's parameters and full description are visible without a separate `tools:inspect` call
  * Add a `tools:inspect <tool-name>` hint to `tools:call`'s error output when a parameter name is unknown or a required one is missing
+ * Add constructor arguments to `symfony-service-detail`: the compiled container dump carries them but they were never read, so the services wired into a definition — the middleware list of a messenger bus, for one — were invisible. Parameter names come from reflecting the constructor or factory method; scalar values are redacted when the name looks like a secret, and also when the parameter cannot be identified at all
 
 0.13
 ----

--- a/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
@@ -16,6 +16,7 @@ use Symfony\AI\Mate\Bridge\Symfony\Exception\ContainerNotDumpedException;
 use Symfony\AI\Mate\Bridge\Symfony\Exception\ServiceNotFoundException;
 use Symfony\AI\Mate\Bridge\Symfony\Model\Container;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
+use Symfony\AI\Mate\Bridge\Symfony\Service\ServiceArgumentResolver;
 use Symfony\AI\Mate\Encoding\ResponseEncoder;
 
 /**
@@ -38,6 +39,8 @@ class ServiceTool
 
     private readonly bool $hasContexts;
 
+    private readonly ServiceArgumentResolver $argumentResolver;
+
     /**
      * @param string|array<string, string> $cacheDir A single cache directory, or a map of context name to cache
      *                                               directory for multi-kernel (APP_ID) applications
@@ -45,9 +48,11 @@ class ServiceTool
     public function __construct(
         string|array $cacheDir,
         private ContainerProvider $provider,
+        ?ServiceArgumentResolver $argumentResolver = null,
     ) {
         $this->hasContexts = \is_array($cacheDir);
         $this->cacheDirs = \is_string($cacheDir) ? [0 => $cacheDir] : $cacheDir;
+        $this->argumentResolver = $argumentResolver ?? new ServiceArgumentResolver();
     }
 
     /**
@@ -77,7 +82,7 @@ class ServiceTool
      * @param string      $id      The exact service ID to retrieve details for
      * @param string|null $context Filter by Symfony kernel context, only relevant when multiple cache directories are configured
      */
-    #[MateTool(name: 'symfony-service-detail', title: 'Symfony Service Detail', description: 'Get full details of a single Symfony DI container service by its exact ID, including class, tags, method calls, and constructor/factory information. When multiple kernel contexts are configured, the containers are searched in order and the result carries the context it was found in.')]
+    #[MateTool(name: 'symfony-service-detail', title: 'Symfony Service Detail', description: 'Get full details of a single Symfony DI container service by its exact ID, including class, tags, method calls, constructor arguments and factory information. Constructor arguments show which services are wired in — including the entries of a collection, such as the middleware list of a messenger bus. Scalar values are redacted when their parameter name looks like a secret, or when the parameter cannot be identified. When multiple kernel contexts are configured, the containers are searched in order and the result carries the context it was found in.')]
     public function getServiceDetail(string $id, ?string $context = null): string
     {
         $containers = $this->readContainers($context);
@@ -110,6 +115,7 @@ class ServiceTool
                 'class' => $service->getClass(),
                 'tags' => $tags,
                 'calls' => $service->getCalls(),
+                'arguments' => $this->argumentResolver->resolve($service->getConstructor(), $service->getArguments()),
             ];
 
             if (null !== $constructor) {

--- a/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
+++ b/src/mate/src/Bridge/Symfony/Capability/ServiceTool.php
@@ -82,7 +82,7 @@ class ServiceTool
      * @param string      $id      The exact service ID to retrieve details for
      * @param string|null $context Filter by Symfony kernel context, only relevant when multiple cache directories are configured
      */
-    #[MateTool(name: 'symfony-service-detail', title: 'Symfony Service Detail', description: 'Get full details of a single Symfony DI container service by its exact ID, including class, tags, method calls, constructor arguments and factory information. Constructor arguments show which services are wired in — including the entries of a collection, such as the middleware list of a messenger bus. Scalar values are redacted when their parameter name looks like a secret, or when the parameter cannot be identified. When multiple kernel contexts are configured, the containers are searched in order and the result carries the context it was found in.')]
+    #[MateTool(name: 'symfony-service-detail', title: 'Symfony Service Detail', description: 'Get full details of a single Symfony DI container service by its exact ID, including class, tags, method calls, constructor arguments and factory information. Constructor arguments show which services are wired in, including the entries of a collection, such as the middleware list of a messenger bus. Scalar values are redacted when their parameter name looks like a secret, or when the parameter cannot be identified. When multiple kernel contexts are configured, the containers are searched in order and the result carries the context it was found in.')]
     public function getServiceDetail(string $id, ?string $context = null): string
     {
         $containers = $this->readContainers($context);

--- a/src/mate/src/Bridge/Symfony/INSTRUCTIONS.md
+++ b/src/mate/src/Bridge/Symfony/INSTRUCTIONS.md
@@ -5,6 +5,7 @@
 | Instead of...                  | Use                |
 |--------------------------------|--------------------|
 | `bin/console debug:container`  | `symfony-services` |
+| `bin/console debug:container <id>` | `symfony-service-detail` |
 
 - Direct access to compiled container
 - Environment-aware (auto-detects dev/test/prod)
@@ -12,6 +13,11 @@
 - Multi-kernel aware: when several cache directories are configured (one per kernel context, e.g.
   per `APP_ID`), `symfony-services` groups the services by context, `symfony-service-detail`
   reports the context a service was found in, and both accept a `context` parameter
+- `symfony-service-detail` returns constructor arguments, so the services wired into a
+  definition are visible — including the entries of a collection, such as the middleware
+  list of a messenger bus
+- Scalar arguments are redacted when the parameter name looks like a secret, and when the
+  parameter cannot be identified; service references and collections never are
 
 ### Profiler Access
 

--- a/src/mate/src/Bridge/Symfony/INSTRUCTIONS.md
+++ b/src/mate/src/Bridge/Symfony/INSTRUCTIONS.md
@@ -14,7 +14,7 @@
   per `APP_ID`), `symfony-services` groups the services by context, `symfony-service-detail`
   reports the context a service was found in, and both accept a `context` parameter
 - `symfony-service-detail` returns constructor arguments, so the services wired into a
-  definition are visible — including the entries of a collection, such as the middleware
+  definition are visible, including the entries of a collection, such as the middleware
   list of a messenger bus
 - Scalar arguments are redacted when the parameter name looks like a secret, and when the
   parameter cannot be identified; service references and collections never are

--- a/src/mate/src/Bridge/Symfony/Model/ServiceDefinition.php
+++ b/src/mate/src/Bridge/Symfony/Model/ServiceDefinition.php
@@ -14,6 +14,8 @@ namespace Symfony\AI\Mate\Bridge\Symfony\Model;
 /**
  * @internal
  *
+ * @phpstan-type ParsedArgument array{key: string|null, type: 'service'|'collection'|'scalar', value: mixed, literal: bool}
+ *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 class ServiceDefinition
@@ -24,6 +26,8 @@ class ServiceDefinition
      * @param string[]                         $calls
      * @param ServiceTag[]                     $tags
      * @param array{0: string|null, 1: string} $constructor
+     * @param list<ParsedArgument>             $arguments   positional constructor/factory arguments, still unnamed and
+     *                                                      unredacted; ServiceArgumentResolver turns them into output
      */
     public function __construct(
         private readonly string $id,
@@ -32,6 +36,7 @@ class ServiceDefinition
         private readonly array $calls,
         private readonly array $tags,
         private readonly array $constructor,
+        private readonly array $arguments = [],
     ) {
     }
 
@@ -75,5 +80,18 @@ class ServiceDefinition
     public function getConstructor(): array
     {
         return $this->constructor;
+    }
+
+    /**
+     * The arguments as the container dump carries them: positional, in declaration order,
+     * with no parameter names — the XML does not record those. Pass them through
+     * {@see \Symfony\AI\Mate\Bridge\Symfony\Service\ServiceArgumentResolver} before
+     * showing them to anyone; scalars here are raw.
+     *
+     * @return list<ParsedArgument>
+     */
+    public function getArguments(): array
+    {
+        return $this->arguments;
     }
 }

--- a/src/mate/src/Bridge/Symfony/Model/ServiceDefinition.php
+++ b/src/mate/src/Bridge/Symfony/Model/ServiceDefinition.php
@@ -83,10 +83,8 @@ class ServiceDefinition
     }
 
     /**
-     * The arguments as the container dump carries them: positional, in declaration order,
-     * with no parameter names (the XML does not record those). Pass them through
-     * {@see \Symfony\AI\Mate\Bridge\Symfony\Service\ServiceArgumentResolver} before
-     * showing them to anyone; scalars here are raw.
+     * Positional, unnamed and unredacted. Pass through
+     * {@see \Symfony\AI\Mate\Bridge\Symfony\Service\ServiceArgumentResolver} first.
      *
      * @return list<ParsedArgument>
      */

--- a/src/mate/src/Bridge/Symfony/Model/ServiceDefinition.php
+++ b/src/mate/src/Bridge/Symfony/Model/ServiceDefinition.php
@@ -84,7 +84,7 @@ class ServiceDefinition
 
     /**
      * The arguments as the container dump carries them: positional, in declaration order,
-     * with no parameter names — the XML does not record those. Pass them through
+     * with no parameter names (the XML does not record those). Pass them through
      * {@see \Symfony\AI\Mate\Bridge\Symfony\Service\ServiceArgumentResolver} before
      * showing them to anyone; scalars here are raw.
      *

--- a/src/mate/src/Bridge/Symfony/Service/ContainerProvider.php
+++ b/src/mate/src/Bridge/Symfony/Service/ContainerProvider.php
@@ -21,10 +21,42 @@ use Symfony\AI\Mate\Bridge\Symfony\Model\ServiceTag;
 /**
  * This will parse an App_KernelDevDebugContainer.xml and return value objects.
  *
+ * @phpstan-import-type ParsedArgument from ServiceDefinition
+ *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 class ContainerProvider
 {
+    /**
+     * Argument node types the dumper writes for a reference to another service.
+     *
+     * @var list<string>
+     */
+    private const SERVICE_ARGUMENT_TYPES = ['service', 'service_closure'];
+
+    /**
+     * Argument node types that carry nested `<argument>` children rather than a value. A
+     * messenger bus keeps its middleware in an `iterator`, which is why this matters.
+     *
+     * @var list<string>
+     */
+    private const COLLECTION_ARGUMENT_TYPES = ['collection', 'iterator', 'service_locator'];
+
+    /**
+     * Argument node types that stand for "every service carrying this tag". They hold no
+     * value, only the tag name, and that name is wiring rather than data.
+     *
+     * @var list<string>
+     */
+    private const TAGGED_ARGUMENT_TYPES = ['tagged_iterator', 'tagged_locator'];
+
+    /**
+     * Argument node types whose text content is meant to stay a string, so it must not be
+     * coerced back into a bool, null or number.
+     *
+     * @var list<string>
+     */
+    private const STRING_ARGUMENT_TYPES = ['string', 'binary', 'constant', 'expression', 'abstract', 'env_closure'];
     /**
      * @var array<string, Container>
      */
@@ -95,6 +127,7 @@ class ContainerProvider
                     $calls,
                     $serviceTags,
                     $constructor,
+                    $this->parseArguments($def),
                 );
 
                 if (null === $service->getAlias()) {
@@ -118,10 +151,115 @@ class ContainerProvider
                 $services[$alias]->getCalls(),
                 $services[$alias]->getTags(),
                 $services[$alias]->getConstructor(),
+                $services[$alias]->getArguments(),
             );
         }
 
         return new Container($services);
+    }
+
+    /**
+     * Reads the direct `<argument>` children of a node.
+     *
+     * Symfony's XmlDumper writes constructor arguments here
+     * (`convertParameters($definition->getArguments(), 'argument')`), so the wiring is in
+     * the dump already — it was simply never read.
+     *
+     * @return list<ParsedArgument>
+     */
+    private function parseArguments(\SimpleXMLElement $node): array
+    {
+        $arguments = [];
+
+        foreach ($node->argument as $argument) {
+            /** @var \SimpleXMLElement $attrs */
+            $attrs = $argument->attributes();
+            $type = isset($attrs->type) ? (string) $attrs->type : null;
+            $key = isset($attrs->key) ? (string) $attrs->key : null;
+
+            if (null !== $type && \in_array($type, self::SERVICE_ARGUMENT_TYPES, true)) {
+                $arguments[] = [
+                    'key' => $key,
+                    'type' => 'service',
+                    'value' => $this->referencedService($argument, $attrs),
+                    'literal' => false,
+                ];
+
+                continue;
+            }
+
+            if (null !== $type && \in_array($type, self::COLLECTION_ARGUMENT_TYPES, true)) {
+                $arguments[] = [
+                    'key' => $key,
+                    'type' => 'collection',
+                    'value' => $this->parseArguments($argument),
+                    'literal' => false,
+                ];
+
+                continue;
+            }
+
+            if (null !== $type && \in_array($type, self::TAGGED_ARGUMENT_TYPES, true)) {
+                $arguments[] = [
+                    'key' => $key,
+                    'type' => 'scalar',
+                    'value' => \sprintf('all services tagged "%s"', isset($attrs->tag) ? (string) $attrs->tag : ''),
+                    'literal' => false,
+                ];
+
+                continue;
+            }
+
+            $arguments[] = [
+                'key' => $key,
+                'type' => 'scalar',
+                'value' => $this->castScalar((string) $argument, $type),
+                'literal' => true,
+            ];
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * A service argument normally carries the referenced id. An inline (anonymous)
+     * definition has no id, and then the nested `<service>` node's class is the only
+     * identity there is.
+     */
+    private function referencedService(\SimpleXMLElement $argument, \SimpleXMLElement $attrs): ?string
+    {
+        if (isset($attrs->id)) {
+            return self::cleanServiceId((string) $attrs->id);
+        }
+
+        if (isset($argument->service)) {
+            $inline = $argument->service->attributes();
+            if (isset($inline->class)) {
+                return (string) $inline->class;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The dumper writes `true`, `false`, `null` and numbers as bare text and marks anything
+     * that only looks like one with `type="string"`, so the original type is recoverable —
+     * and worth recovering, because `\"30\"` and `30` read differently to whoever is
+     * diagnosing the wiring.
+     */
+    private function castScalar(string $text, ?string $type): mixed
+    {
+        if (null !== $type && \in_array($type, self::STRING_ARGUMENT_TYPES, true)) {
+            return $text;
+        }
+
+        return match ($text) {
+            'true' => true,
+            'false' => false,
+            'null' => null,
+            default => is_numeric($text) ? $text + 0 : $text,
+        };
     }
 
     private function cleanServiceId(string $id): string

--- a/src/mate/src/Bridge/Symfony/Service/ContainerProvider.php
+++ b/src/mate/src/Bridge/Symfony/Service/ContainerProvider.php
@@ -163,7 +163,7 @@ class ContainerProvider
      *
      * Symfony's XmlDumper writes constructor arguments here
      * (`convertParameters($definition->getArguments(), 'argument')`), so the wiring is in
-     * the dump already — it was simply never read.
+     * the dump already: it was simply never read.
      *
      * @return list<ParsedArgument>
      */
@@ -244,9 +244,9 @@ class ContainerProvider
 
     /**
      * The dumper writes `true`, `false`, `null` and numbers as bare text and marks anything
-     * that only looks like one with `type="string"`, so the original type is recoverable —
-     * and worth recovering, because `\"30\"` and `30` read differently to whoever is
-     * diagnosing the wiring.
+     * that only looks like one with `type="string"`, so the original type is recoverable,
+     * and worth recovering: `\"30\"` and `30` read differently to whoever is diagnosing
+     * the wiring.
      */
     private function castScalar(string $text, ?string $type): mixed
     {

--- a/src/mate/src/Bridge/Symfony/Service/ContainerProvider.php
+++ b/src/mate/src/Bridge/Symfony/Service/ContainerProvider.php
@@ -28,35 +28,32 @@ use Symfony\AI\Mate\Bridge\Symfony\Model\ServiceTag;
 class ContainerProvider
 {
     /**
-     * Argument node types the dumper writes for a reference to another service.
-     *
      * @var list<string>
      */
     private const SERVICE_ARGUMENT_TYPES = ['service', 'service_closure'];
 
     /**
-     * Argument node types that carry nested `<argument>` children rather than a value. A
-     * messenger bus keeps its middleware in an `iterator`, which is why this matters.
+     * Carry nested `<argument>` children instead of a value (a messenger bus keeps its
+     * middleware in an `iterator`).
      *
      * @var list<string>
      */
     private const COLLECTION_ARGUMENT_TYPES = ['collection', 'iterator', 'service_locator'];
 
     /**
-     * Argument node types that stand for "every service carrying this tag". They hold no
-     * value, only the tag name, and that name is wiring rather than data.
+     * Hold no value, only a tag name: "every service carrying this tag".
      *
      * @var list<string>
      */
     private const TAGGED_ARGUMENT_TYPES = ['tagged_iterator', 'tagged_locator'];
 
     /**
-     * Argument node types whose text content is meant to stay a string, so it must not be
-     * coerced back into a bool, null or number.
+     * Must not be coerced back into a bool, null or number.
      *
      * @var list<string>
      */
     private const STRING_ARGUMENT_TYPES = ['string', 'binary', 'constant', 'expression', 'abstract', 'env_closure'];
+
     /**
      * @var array<string, Container>
      */
@@ -161,10 +158,6 @@ class ContainerProvider
     /**
      * Reads the direct `<argument>` children of a node.
      *
-     * Symfony's XmlDumper writes constructor arguments here
-     * (`convertParameters($definition->getArguments(), 'argument')`), so the wiring is in
-     * the dump already: it was simply never read.
-     *
      * @return list<ParsedArgument>
      */
     private function parseArguments(\SimpleXMLElement $node): array
@@ -222,9 +215,7 @@ class ContainerProvider
     }
 
     /**
-     * A service argument normally carries the referenced id. An inline (anonymous)
-     * definition has no id, and then the nested `<service>` node's class is the only
-     * identity there is.
+     * An inline (anonymous) definition has no id, so its class is the only identity there is.
      */
     private function referencedService(\SimpleXMLElement $argument, \SimpleXMLElement $attrs): ?string
     {
@@ -243,10 +234,8 @@ class ContainerProvider
     }
 
     /**
-     * The dumper writes `true`, `false`, `null` and numbers as bare text and marks anything
-     * that only looks like one with `type="string"`, so the original type is recoverable,
-     * and worth recovering: `\"30\"` and `30` read differently to whoever is diagnosing
-     * the wiring.
+     * The dumper marks a string that only looks like a bool/null/number with `type="string"`,
+     * so the original type is still recoverable here.
      */
     private function castScalar(string $text, ?string $type): mixed
     {

--- a/src/mate/src/Bridge/Symfony/Service/ServiceArgumentResolver.php
+++ b/src/mate/src/Bridge/Symfony/Service/ServiceArgumentResolver.php
@@ -1,0 +1,200 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Service;
+
+use Symfony\AI\Mate\Bridge\Symfony\Model\ServiceDefinition;
+
+/**
+ * Puts parameter names on the container's positional arguments, and redacts the scalars
+ * whose name says they carry a secret.
+ *
+ * The dump records positions, not names — `convertParameters()` never had them to write.
+ * The names live on the constructor (or factory method) signature, so they come from
+ * reflection, and a class that cannot be reflected leaves the position unidentified.
+ *
+ * When a position is unidentified, its scalar is redacted. That is the deliberate direction
+ * to fail in: a service ID is wiring and useless to an attacker, but a literal could be an
+ * API key, and "we could not tell" has to read as "do not show it". Structural arguments —
+ * service references, collections of them, tagged iterators — are never redacted, because
+ * they are the wiring the tool exists to reveal.
+ *
+ * @phpstan-import-type ParsedArgument from ServiceDefinition
+ *
+ * @phpstan-type ResolvedArgument array{name: string, type: 'service'|'collection'|'scalar', value: mixed}
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class ServiceArgumentResolver
+{
+    /**
+     * Case-insensitive substring match against the parameter name. Kept local on purpose:
+     * every formatter in this bridge carries its own list, and hoisting them into a shared
+     * utility is a separate change from this one.
+     *
+     * @var list<string>
+     */
+    private const SENSITIVE_PARAMETER_PATTERNS = [
+        'SECRET',
+        'KEY',
+        'PASSWORD',
+        'TOKEN',
+        'BEARER',
+        'AUTH',
+        'CREDENTIAL',
+        'PRIVATE',
+        'COOKIE',
+    ];
+
+    private const REDACTED = '***REDACTED***';
+
+    /**
+     * @param array{0: string|null, 1: string} $constructor class and method the arguments are passed to; a factory
+     *                                                      makes this the factory method rather than `__construct`
+     * @param list<ParsedArgument>             $arguments
+     *
+     * @return list<ResolvedArgument>
+     */
+    public function resolve(array $constructor, array $arguments): array
+    {
+        $names = $this->parameterNames($constructor, \count($arguments));
+
+        $resolved = [];
+        foreach ($arguments as $position => $argument) {
+            $name = $names[$position] ?? null;
+
+            $resolved[] = $this->resolveArgument(
+                $argument,
+                $name ?? \sprintf('#%d', $position),
+                null === $name || $this->isSensitive($name),
+            );
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param ParsedArgument $argument
+     *
+     * @return ResolvedArgument
+     */
+    private function resolveArgument(array $argument, string $name, bool $sensitive): array
+    {
+        if ('collection' === $argument['type']) {
+            /** @var list<ParsedArgument> $children */
+            $children = \is_array($argument['value']) ? $argument['value'] : [];
+
+            return [
+                'name' => $name,
+                'type' => 'collection',
+                'value' => $this->resolveCollection($children, $sensitive),
+            ];
+        }
+
+        // Only literals can leak. A service id, or the tag a tagged iterator collects, is
+        // exactly the information this tool exists to surface.
+        if ('scalar' === $argument['type'] && true === $argument['literal'] && $sensitive) {
+            return ['name' => $name, 'type' => 'scalar', 'value' => self::REDACTED];
+        }
+
+        return ['name' => $name, 'type' => $argument['type'], 'value' => $argument['value']];
+    }
+
+    /**
+     * Nested entries inherit the sensitivity of the parameter they sit under: once the
+     * enclosing parameter is a secret (or could not be identified), nothing inside it can
+     * be shown either. A keyed entry can additionally be sensitive on its own name.
+     *
+     * @param list<ParsedArgument> $children
+     *
+     * @return list<ResolvedArgument>
+     */
+    private function resolveCollection(array $children, bool $sensitive): array
+    {
+        $resolved = [];
+        foreach ($children as $index => $child) {
+            $key = $child['key'];
+
+            $resolved[] = $this->resolveArgument(
+                $child,
+                $key ?? \sprintf('#%d', $index),
+                $sensitive || (null !== $key && $this->isSensitive($key)),
+            );
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param array{0: string|null, 1: string} $constructor
+     *
+     * @return list<string>|null null when the signature cannot be read at all, which makes every position unidentified
+     */
+    private function parameterNames(array $constructor, int $argumentCount): ?array
+    {
+        [$class, $method] = $constructor;
+
+        // A factory declared as `<factory service="..." method="..."/>` carries no class, so
+        // there is nothing to reflect and every argument stays unidentified.
+        if (null === $class || '' === $class) {
+            return null;
+        }
+
+        try {
+            if (!class_exists($class)) {
+                return null;
+            }
+
+            $reflection = new \ReflectionClass($class);
+            $function = '__construct' === $method
+                ? $reflection->getConstructor()
+                : ($reflection->hasMethod($method) ? $reflection->getMethod($method) : null);
+
+            if (null === $function) {
+                return null;
+            }
+
+            $parameters = $function->getParameters();
+        } catch (\Throwable) {
+            // A class that exists but cannot be reflected (unloadable parent, broken
+            // autoloader) is the same situation as one that does not exist.
+            return null;
+        }
+
+        $names = [];
+        foreach ($parameters as $parameter) {
+            $names[] = $parameter->getName();
+        }
+
+        // Everything past a variadic parameter still belongs to it.
+        $last = end($parameters);
+        if (false !== $last && $last->isVariadic()) {
+            while (\count($names) < $argumentCount) {
+                $names[] = $last->getName();
+            }
+        }
+
+        return $names;
+    }
+
+    private function isSensitive(string $name): bool
+    {
+        $upper = strtoupper($name);
+
+        foreach (self::SENSITIVE_PARAMETER_PATTERNS as $pattern) {
+            if (str_contains($upper, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Service/ServiceArgumentResolver.php
+++ b/src/mate/src/Bridge/Symfony/Service/ServiceArgumentResolver.php
@@ -17,15 +17,12 @@ use Symfony\AI\Mate\Bridge\Symfony\Model\ServiceDefinition;
  * Puts parameter names on the container's positional arguments, and redacts the scalars
  * whose name says they carry a secret.
  *
- * The dump records positions, not names — `convertParameters()` never had them to write.
- * The names live on the constructor (or factory method) signature, so they come from
- * reflection, and a class that cannot be reflected leaves the position unidentified.
- *
- * When a position is unidentified, its scalar is redacted. That is the deliberate direction
- * to fail in: a service ID is wiring and useless to an attacker, but a literal could be an
- * API key, and "we could not tell" has to read as "do not show it". Structural arguments —
- * service references, collections of them, tagged iterators — are never redacted, because
- * they are the wiring the tool exists to reveal.
+ * The dump records positions, not names: `convertParameters()` never had them to write. The
+ * names come from reflecting the constructor (or factory method) signature, and a class that
+ * cannot be reflected leaves the position unidentified, which is redacted deliberately: "we
+ * could not tell" has to read as "do not show it". Structural arguments (service references,
+ * collections, tagged iterators) are never redacted, since they are the wiring the tool
+ * exists to reveal.
  *
  * @phpstan-import-type ParsedArgument from ServiceDefinition
  *

--- a/src/mate/src/Bridge/Symfony/Service/ServiceArgumentResolver.php
+++ b/src/mate/src/Bridge/Symfony/Service/ServiceArgumentResolver.php
@@ -14,15 +14,10 @@ namespace Symfony\AI\Mate\Bridge\Symfony\Service;
 use Symfony\AI\Mate\Bridge\Symfony\Model\ServiceDefinition;
 
 /**
- * Puts parameter names on the container's positional arguments, and redacts the scalars
- * whose name says they carry a secret.
- *
- * The dump records positions, not names: `convertParameters()` never had them to write. The
- * names come from reflecting the constructor (or factory method) signature, and a class that
- * cannot be reflected leaves the position unidentified, which is redacted deliberately: "we
- * could not tell" has to read as "do not show it". Structural arguments (service references,
- * collections, tagged iterators) are never redacted, since they are the wiring the tool
- * exists to reveal.
+ * Puts parameter names on the container's positional arguments (read from the dump by
+ * position only), and redacts scalars whose name looks like a secret or whose position
+ * could not be identified. Service references, collections and tagged iterators are never
+ * redacted: they are the wiring the tool exists to reveal.
  *
  * @phpstan-import-type ParsedArgument from ServiceDefinition
  *
@@ -33,9 +28,7 @@ use Symfony\AI\Mate\Bridge\Symfony\Model\ServiceDefinition;
 class ServiceArgumentResolver
 {
     /**
-     * Case-insensitive substring match against the parameter name. Kept local on purpose:
-     * every formatter in this bridge carries its own list, and hoisting them into a shared
-     * utility is a separate change from this one.
+     * Case-insensitive substring match against the parameter name.
      *
      * @var list<string>
      */
@@ -96,8 +89,7 @@ class ServiceArgumentResolver
             ];
         }
 
-        // Only literals can leak. A service id, or the tag a tagged iterator collects, is
-        // exactly the information this tool exists to surface.
+        // Only literals can leak; a service id is wiring, not a secret.
         if ('scalar' === $argument['type'] && true === $argument['literal'] && $sensitive) {
             return ['name' => $name, 'type' => 'scalar', 'value' => self::REDACTED];
         }
@@ -106,9 +98,8 @@ class ServiceArgumentResolver
     }
 
     /**
-     * Nested entries inherit the sensitivity of the parameter they sit under: once the
-     * enclosing parameter is a secret (or could not be identified), nothing inside it can
-     * be shown either. A keyed entry can additionally be sensitive on its own name.
+     * A nested entry inherits its enclosing parameter's sensitivity, and can additionally
+     * be sensitive on its own key.
      *
      * @param list<ParsedArgument> $children
      *
@@ -133,14 +124,13 @@ class ServiceArgumentResolver
     /**
      * @param array{0: string|null, 1: string} $constructor
      *
-     * @return list<string>|null null when the signature cannot be read at all, which makes every position unidentified
+     * @return list<string>|null null means every position is unidentified
      */
     private function parameterNames(array $constructor, int $argumentCount): ?array
     {
         [$class, $method] = $constructor;
 
-        // A factory declared as `<factory service="..." method="..."/>` carries no class, so
-        // there is nothing to reflect and every argument stays unidentified.
+        // A factory service (vs. a factory class) carries no class to reflect.
         if (null === $class || '' === $class) {
             return null;
         }
@@ -161,8 +151,6 @@ class ServiceArgumentResolver
 
             $parameters = $function->getParameters();
         } catch (\Throwable) {
-            // A class that exists but cannot be reflected (unloadable parent, broken
-            // autoloader) is the same situation as one that does not exist.
             return null;
         }
 

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolArgumentsTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolArgumentsTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Capability;
+
+use HelgeSverre\Toon\Toon;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Capability\ServiceTool;
+use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
+use Symfony\AI\Mate\Encoding\ResponseEncoder;
+
+/**
+ * `symfony-service-detail` end to end, over a container dumped by Symfony's own XmlDumper.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ServiceToolArgumentsTest extends TestCase
+{
+    private ServiceTool $tool;
+
+    protected function setUp(): void
+    {
+        $this->tool = new ServiceTool(
+            \dirname(__DIR__).'/Fixtures/container-arguments',
+            new ContainerProvider(),
+        );
+    }
+
+    /**
+     * The case this whole change exists for.
+     *
+     * Asking which middleware a messenger bus runs used to be unanswerable through Mate:
+     * `symfony-service-detail` returned id, class, tags and calls, and the middleware is in
+     * none of those — it is a constructor argument, which the tool did not read. Finding
+     * `doctrine_transaction` on the default bus meant leaving the tool and opening the
+     * dumped XML by hand.
+     */
+    public function testTheMiddlewareOfAMessengerBusIsVisible()
+    {
+        $detail = $this->decodeUntrusted($this->tool->getServiceDetail('messenger.bus.default'));
+
+        $this->assertCount(1, $detail['arguments']);
+        $this->assertSame('middlewareHandlers', $detail['arguments'][0]['name']);
+        $this->assertSame('collection', $detail['arguments'][0]['type']);
+
+        $middleware = array_column($detail['arguments'][0]['value'], 'value');
+
+        $this->assertContains(
+            'doctrine.orm.messenger.middleware_factory.transaction',
+            $middleware,
+            'The doctrine transaction middleware has to be findable on the bus that runs it.',
+        );
+        $this->assertSame([
+            'messenger.middleware.add_bus_name_stamp_middleware',
+            'messenger.middleware.reject_redelivered_message_middleware',
+            'messenger.middleware.dispatch_after_current_bus',
+            'doctrine.orm.messenger.middleware_factory.transaction',
+            'messenger.middleware.send_message',
+            'messenger.middleware.handle_message',
+        ], $middleware, 'Middleware order is the execution order, so it has to survive too.');
+    }
+
+    public function testConstructorArgumentsAreNamedAndTyped()
+    {
+        $arguments = $this->decodeUntrusted($this->tool->getServiceDetail('app.api_client'))['arguments'];
+
+        $this->assertSame(
+            ['httpClient', 'apiKey', 'timeoutSeconds', 'scopes', 'debug', 'region'],
+            array_column($arguments, 'name'),
+        );
+        $this->assertSame(
+            ['service', 'scalar', 'scalar', 'collection', 'scalar', 'scalar'],
+            array_column($arguments, 'type'),
+        );
+
+        $this->assertSame('http_client', $arguments[0]['value']);
+        $this->assertSame(30, $arguments[2]['value']);
+        $this->assertSame(['first', 'second'], array_column($arguments[3]['value'], 'value'));
+        $this->assertTrue($arguments[4]['value']);
+        $this->assertNull($arguments[5]['value']);
+    }
+
+    public function testASecretShapedParameterIsRedacted()
+    {
+        $arguments = $this->decodeUntrusted($this->tool->getServiceDetail('app.api_client'))['arguments'];
+
+        $this->assertSame('apiKey', $arguments[1]['name']);
+        $this->assertSame('***REDACTED***', $arguments[1]['value']);
+
+        $this->assertStringNotContainsString(
+            'sk-live-do-not-log-this',
+            $this->tool->getServiceDetail('app.api_client'),
+            'The raw secret must not survive anywhere in the encoded response.',
+        );
+    }
+
+    public function testAKeyedCollectionRedactsOnlyWhatItHasTo()
+    {
+        $arguments = $this->decodeUntrusted($this->tool->getServiceDetail('app.storage'))['arguments'];
+
+        $this->assertSame('connectionOptions', $arguments[0]['name']);
+        $this->assertSame(['host', 'password', 'port'], array_column($arguments[0]['value'], 'name'));
+        $this->assertSame(['db.internal', '***REDACTED***', 5432], array_column($arguments[0]['value'], 'value'));
+
+        $this->assertSame('plugins', $arguments[1]['name']);
+        $this->assertSame('all services tagged "app.plugin"', $arguments[1]['value']);
+    }
+
+    /**
+     * A service built by a factory service has no class in the dump to reflect, so nothing
+     * can be named — and an unnamed scalar is treated as a secret.
+     */
+    public function testAnUnreflectableServiceStillHidesItsScalars()
+    {
+        $arguments = $this->decodeUntrusted($this->tool->getServiceDetail('app.factory_made'))['arguments'];
+
+        $this->assertSame('#0', $arguments[0]['name']);
+        $this->assertSame('***REDACTED***', $arguments[0]['value']);
+
+        $this->assertSame('logger', $arguments[1]['value'], 'Wiring stays visible; only literals fail closed.');
+
+        $this->assertStringNotContainsString('production-database-dsn', $this->tool->getServiceDetail('app.factory_made'));
+    }
+
+    public function testAMissingClassAlsoFailsClosed()
+    {
+        $arguments = $this->decodeUntrusted($this->tool->getServiceDetail('app.missing_class'))['arguments'];
+
+        $this->assertSame('***REDACTED***', $arguments[0]['value']);
+    }
+
+    public function testAServiceWithoutArgumentsReportsAnEmptyList()
+    {
+        $detail = $this->decodeUntrusted($this->tool->getServiceDetail('app.plain'));
+
+        $this->assertArrayHasKey('arguments', $detail);
+        $this->assertSame([], $detail['arguments']);
+    }
+
+    /**
+     * The list tool is unchanged on purpose: arguments belong to the detail view, and
+     * resolving them for every service would mean reflecting the whole container.
+     */
+    public function testTheServiceListStillReturnsOnlyIdsAndClasses()
+    {
+        $services = $this->decodeUntrusted($this->tool->getServices('messenger'))['services'];
+
+        $this->assertSame(
+            ['messenger.bus.default' => 'Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service\MessageBus'],
+            $services,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeUntrusted(string $response): array
+    {
+        $decoded = Toon::decode($response);
+
+        $this->assertIsArray($decoded);
+        $this->assertSame(ResponseEncoder::UNTRUSTED_NOTICE, $decoded['_security_notice']);
+
+        return $decoded['untrusted_data'];
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolArgumentsTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolArgumentsTest.php
@@ -34,15 +34,6 @@ final class ServiceToolArgumentsTest extends TestCase
         );
     }
 
-    /**
-     * The case this whole change exists for.
-     *
-     * Asking which middleware a messenger bus runs used to be unanswerable through Mate:
-     * `symfony-service-detail` returned id, class, tags and calls, and the middleware is in
-     * none of those. It is a constructor argument, which the tool did not read. Finding
-     * `doctrine_transaction` on the default bus meant leaving the tool and opening the
-     * dumped XML by hand.
-     */
     public function testTheMiddlewareOfAMessengerBusIsVisible()
     {
         $detail = $this->decodeUntrusted($this->tool->getServiceDetail('messenger.bus.default'));

--- a/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolArgumentsTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Capability/ServiceToolArgumentsTest.php
@@ -39,7 +39,7 @@ final class ServiceToolArgumentsTest extends TestCase
      *
      * Asking which middleware a messenger bus runs used to be unanswerable through Mate:
      * `symfony-service-detail` returned id, class, tags and calls, and the middleware is in
-     * none of those — it is a constructor argument, which the tool did not read. Finding
+     * none of those. It is a constructor argument, which the tool did not read. Finding
      * `doctrine_transaction` on the default bus meant leaving the tool and opening the
      * dumped XML by hand.
      */
@@ -116,7 +116,7 @@ final class ServiceToolArgumentsTest extends TestCase
 
     /**
      * A service built by a factory service has no class in the dump to reflect, so nothing
-     * can be named — and an unnamed scalar is treated as a secret.
+     * can be named, and an unnamed scalar is treated as a secret.
      */
     public function testAnUnreflectableServiceStillHidesItsScalars()
     {

--- a/src/mate/src/Bridge/Symfony/Tests/Fixtures/Service/ApiClient.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Fixtures/Service/ApiClient.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class ApiClient
+{
+    /**
+     * @param list<string> $scopes
+     */
+    public function __construct(
+        public readonly ?object $httpClient = null,
+        public readonly string $apiKey = '',
+        public readonly int $timeoutSeconds = 0,
+        public readonly array $scopes = [],
+        public readonly bool $debug = false,
+        public readonly ?string $region = null,
+    ) {
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Fixtures/Service/MessageBus.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Fixtures/Service/MessageBus.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service;
+
+/**
+ * Mirrors the constructor of Symfony\\Component\\Messenger\\MessageBus, which the bridge does
+ * not depend on. The parameter name is what matters: it is the name the redaction rules see.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class MessageBus
+{
+    /**
+     * @param iterable<object> $middlewareHandlers
+     */
+    public function __construct(
+        public readonly iterable $middlewareHandlers = [],
+    ) {
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Fixtures/Service/Storage.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Fixtures/Service/Storage.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class Storage
+{
+    /**
+     * @param array<string, mixed> $connectionOptions
+     * @param iterable<object>     $plugins
+     */
+    public function __construct(
+        public readonly array $connectionOptions = [],
+        public readonly iterable $plugins = [],
+    ) {
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Fixtures/Service/Unreflectable.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Fixtures/Service/Unreflectable.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service;
+
+/**
+ * Built by a factory service in the fixture container, so the dump records no class to
+ * reflect and its parameter names stay unknown.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class Unreflectable
+{
+    /**
+     * @param array<string, mixed> $anything
+     */
+    public function __construct(
+        public readonly array $anything = [],
+    ) {
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Fixtures/container-arguments/App_KernelDevDebugContainer.xml
+++ b/src/mate/src/Bridge/Symfony/Tests/Fixtures/container-arguments/App_KernelDevDebugContainer.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
+    <service id="messenger.bus.default" class="Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service\MessageBus">
+      <argument type="iterator">
+        <argument type="service" id="messenger.middleware.add_bus_name_stamp_middleware"/>
+        <argument type="service" id="messenger.middleware.reject_redelivered_message_middleware"/>
+        <argument type="service" id="messenger.middleware.dispatch_after_current_bus"/>
+        <argument type="service" id="doctrine.orm.messenger.middleware_factory.transaction"/>
+        <argument type="service" id="messenger.middleware.send_message"/>
+        <argument type="service" id="messenger.middleware.handle_message"/>
+      </argument>
+    </service>
+    <service id="app.api_client" class="Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service\ApiClient">
+      <argument type="service" id="http_client"/>
+      <argument>sk-live-do-not-log-this</argument>
+      <argument>30</argument>
+      <argument type="collection">
+        <argument>first</argument>
+        <argument>second</argument>
+      </argument>
+      <argument>true</argument>
+      <argument>null</argument>
+    </service>
+    <service id="app.storage" class="Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service\Storage">
+      <argument type="collection">
+        <argument key="host">db.internal</argument>
+        <argument key="password">hunter2</argument>
+        <argument key="port">5432</argument>
+      </argument>
+      <argument type="tagged_iterator" tag="app.plugin"/>
+    </service>
+    <service id="app.factory_made" class="Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service\Unreflectable">
+      <argument>production-database-dsn</argument>
+      <argument type="service" id="logger"/>
+      <factory service="app.factory" method="create"/>
+    </service>
+    <service id="app.missing_class" class="App\Absolutely\NotThere">
+      <argument>some-literal</argument>
+    </service>
+    <service id="app.plain" class="Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service\MessageBus"/>
+  </services>
+</container>

--- a/src/mate/src/Bridge/Symfony/Tests/Service/ContainerProviderArgumentsTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Service/ContainerProviderArgumentsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
+
+/**
+ * The fixture container this reads is not hand-written: it was produced by Symfony's own
+ * XmlDumper (see the class docblock of ServiceArgumentResolver for why that matters). If
+ * the dumper ever changes the shape of an `<argument>` node, these tests fail against the
+ * real format rather than against an assumption about it.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ContainerProviderArgumentsTest extends TestCase
+{
+    private const FIXTURE = __DIR__.'/../Fixtures/container-arguments/App_KernelDevDebugContainer.xml';
+
+    public function testParsesAServiceReference()
+    {
+        $arguments = $this->argumentsOf('app.api_client');
+
+        $this->assertSame('service', $arguments[0]['type']);
+        $this->assertSame('http_client', $arguments[0]['value']);
+        $this->assertFalse($arguments[0]['literal']);
+    }
+
+    /**
+     * The messenger bus case: middleware arrives as `<argument type="iterator">` holding one
+     * service reference per middleware.
+     */
+    public function testParsesACollectionOfServiceReferences()
+    {
+        $arguments = $this->argumentsOf('messenger.bus.default');
+
+        $this->assertCount(1, $arguments);
+        $this->assertSame('collection', $arguments[0]['type']);
+
+        $this->assertSame([
+            'messenger.middleware.add_bus_name_stamp_middleware',
+            'messenger.middleware.reject_redelivered_message_middleware',
+            'messenger.middleware.dispatch_after_current_bus',
+            'doctrine.orm.messenger.middleware_factory.transaction',
+            'messenger.middleware.send_message',
+            'messenger.middleware.handle_message',
+        ], array_column($arguments[0]['value'], 'value'));
+    }
+
+    public function testParsesPlainScalarsWithTheirOriginalTypes()
+    {
+        $arguments = $this->argumentsOf('app.api_client');
+
+        $this->assertSame('sk-live-do-not-log-this', $arguments[1]['value']);
+        $this->assertSame(30, $arguments[2]['value'], 'A numeric argument should not come back as a string.');
+        $this->assertTrue($arguments[4]['value']);
+        $this->assertNull($arguments[5]['value']);
+
+        foreach ([1, 2, 4, 5] as $position) {
+            $this->assertSame('scalar', $arguments[$position]['type']);
+            $this->assertTrue($arguments[$position]['literal']);
+        }
+    }
+
+    public function testParsesAPlainCollectionOfScalars()
+    {
+        $arguments = $this->argumentsOf('app.api_client');
+
+        $this->assertSame('collection', $arguments[3]['type']);
+        $this->assertSame(['first', 'second'], array_column($arguments[3]['value'], 'value'));
+    }
+
+    public function testKeepsTheKeysOfAKeyedCollection()
+    {
+        $arguments = $this->argumentsOf('app.storage');
+
+        $this->assertSame(['host', 'password', 'port'], array_column($arguments[0]['value'], 'key'));
+        $this->assertSame(['db.internal', 'hunter2', 5432], array_column($arguments[0]['value'], 'value'));
+    }
+
+    /**
+     * A tagged iterator has no value of its own, only the tag it collects — which is wiring,
+     * so it is marked non-literal and never redacted later.
+     */
+    public function testParsesATaggedIterator()
+    {
+        $arguments = $this->argumentsOf('app.storage');
+
+        $this->assertSame('scalar', $arguments[1]['type']);
+        $this->assertSame('all services tagged "app.plugin"', $arguments[1]['value']);
+        $this->assertFalse($arguments[1]['literal']);
+    }
+
+    public function testAServiceWithoutArgumentsHasNone()
+    {
+        $this->assertSame([], $this->argumentsOf('app.plain'));
+    }
+
+    public function testNestedArgumentsAreNotCountedAtTheServiceLevel()
+    {
+        // The six middleware references are children of the iterator, not arguments of the
+        // bus, and SimpleXML would happily conflate the two if the parser asked for them
+        // recursively.
+        $this->assertCount(1, $this->argumentsOf('messenger.bus.default'));
+    }
+
+    /**
+     * @return list<array{key: string|null, type: string, value: mixed, literal: bool}>
+     */
+    private function argumentsOf(string $id): array
+    {
+        $services = (new ContainerProvider())->getContainer(self::FIXTURE)->getServices();
+
+        $this->assertArrayHasKey($id, $services);
+
+        return $services[$id]->getArguments();
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Service/ContainerProviderArgumentsTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Service/ContainerProviderArgumentsTest.php
@@ -15,10 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
 
 /**
- * The fixture container this reads is not hand-written: it was produced by Symfony's own
- * XmlDumper (see the class docblock of ServiceArgumentResolver for why that matters). If
- * the dumper ever changes the shape of an `<argument>` node, these tests fail against the
- * real format rather than against an assumption about it.
+ * Reads a fixture container produced by Symfony's own XmlDumper, not hand-written.
  *
  * @author Johannes Wachter <johannes@sulu.io>
  */
@@ -107,9 +104,7 @@ final class ContainerProviderArgumentsTest extends TestCase
 
     public function testNestedArgumentsAreNotCountedAtTheServiceLevel()
     {
-        // The six middleware references are children of the iterator, not arguments of the
-        // bus, and SimpleXML would happily conflate the two if the parser asked for them
-        // recursively.
+        // The six middleware references are children of the iterator, not of the bus.
         $this->assertCount(1, $this->argumentsOf('messenger.bus.default'));
     }
 

--- a/src/mate/src/Bridge/Symfony/Tests/Service/ContainerProviderArgumentsTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Service/ContainerProviderArgumentsTest.php
@@ -88,7 +88,7 @@ final class ContainerProviderArgumentsTest extends TestCase
     }
 
     /**
-     * A tagged iterator has no value of its own, only the tag it collects — which is wiring,
+     * A tagged iterator has no value of its own, only the tag it collects, which is wiring,
      * so it is marked non-literal and never redacted later.
      */
     public function testParsesATaggedIterator()

--- a/src/mate/src/Bridge/Symfony/Tests/Service/ServiceArgumentResolverTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Service/ServiceArgumentResolverTest.php
@@ -1,0 +1,295 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\AI\Mate\Bridge\Symfony\Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Mate\Bridge\Symfony\Service\ServiceArgumentResolver;
+use Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service\ApiClient;
+use Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service\MessageBus;
+use Symfony\AI\Mate\Bridge\Symfony\Tests\Fixtures\Service\Storage;
+
+/**
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ServiceArgumentResolverTest extends TestCase
+{
+    private ServiceArgumentResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ServiceArgumentResolver();
+    }
+
+    public function testNamesArgumentsFromTheConstructorSignature()
+    {
+        $resolved = $this->resolver->resolve([ApiClient::class, '__construct'], [
+            $this->service('http_client'),
+            $this->literal('sk-live'),
+            $this->literal(30),
+            $this->collection([$this->literal('first')]),
+            $this->literal(true),
+            $this->literal(null),
+        ]);
+
+        $this->assertSame(
+            ['httpClient', 'apiKey', 'timeoutSeconds', 'scopes', 'debug', 'region'],
+            array_column($resolved, 'name'),
+        );
+    }
+
+    /**
+     * @dataProvider sensitiveParameterNameProvider
+     */
+    public function testRedactsAScalarWhoseParameterNameLooksLikeASecret(string $parameterName)
+    {
+        $resolved = $this->resolveAgainstSignature([$parameterName], [$this->literal('the-real-value')]);
+
+        $this->assertSame('***REDACTED***', $resolved[0]['value']);
+        $this->assertSame($parameterName, $resolved[0]['name']);
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function sensitiveParameterNameProvider(): iterable
+    {
+        yield 'apiKey' => ['apiKey'];
+        yield 'password' => ['password'];
+        yield 'appSecret' => ['appSecret'];
+        yield 'accessToken' => ['accessToken'];
+        yield 'bearerValue' => ['bearerValue'];
+        yield 'authString' => ['authString'];
+        yield 'credentials' => ['credentials'];
+        yield 'privateKeyPath' => ['privateKeyPath'];
+        yield 'cookieName' => ['cookieName'];
+        yield 'uppercase spelling' => ['API_KEY'];
+    }
+
+    public function testKeepsAScalarWhoseParameterNameIsHarmless()
+    {
+        $resolved = $this->resolveAgainstSignature(['timeoutSeconds'], [$this->literal(30)]);
+
+        $this->assertSame(30, $resolved[0]['value']);
+    }
+
+    /**
+     * A service ID is wiring, not data. Redacting it would remove the only thing worth
+     * reading here, and it gives away nothing.
+     */
+    public function testNeverRedactsServiceReferencesEvenUnderASensitiveParameterName()
+    {
+        $resolved = $this->resolveAgainstSignature(['secretProvider'], [$this->service('app.vault')]);
+
+        $this->assertSame('app.vault', $resolved[0]['value']);
+    }
+
+    public function testKeepsTheServiceIdsOfACollection()
+    {
+        $resolved = $this->resolver->resolve([MessageBus::class, '__construct'], [
+            $this->collection([
+                $this->service('messenger.middleware.send_message'),
+                $this->service('doctrine.orm.messenger.middleware_factory.transaction'),
+            ]),
+        ]);
+
+        $this->assertSame('middlewareHandlers', $resolved[0]['name']);
+        $this->assertSame('collection', $resolved[0]['type']);
+        $this->assertSame(
+            ['messenger.middleware.send_message', 'doctrine.orm.messenger.middleware_factory.transaction'],
+            array_column($resolved[0]['value'], 'value'),
+        );
+    }
+
+    public function testRedactsOnlyTheSensitiveEntriesOfAKeyedCollection()
+    {
+        $resolved = $this->resolver->resolve([Storage::class, '__construct'], [
+            $this->collection([
+                $this->literal('db.internal', 'host'),
+                $this->literal('hunter2', 'password'),
+                $this->literal(5432, 'port'),
+            ]),
+            $this->tagged('app.plugin'),
+        ]);
+
+        $this->assertSame(['host', 'password', 'port'], array_column($resolved[0]['value'], 'name'));
+        $this->assertSame(['db.internal', '***REDACTED***', 5432], array_column($resolved[0]['value'], 'value'));
+    }
+
+    /**
+     * A collection sitting under a sensitive parameter has to go entirely, keys or not —
+     * otherwise `$credentials = ['user' => ..., 'pass' => ...]` leaks through the entry
+     * whose own key looks innocent.
+     */
+    public function testRedactsEveryLiteralInsideASensitiveCollection()
+    {
+        $resolved = $this->resolveAgainstSignature(['credentials'], [
+            $this->collection([
+                $this->literal('admin', 'user'),
+                $this->literal('hunter2', 'pass'),
+            ]),
+        ]);
+
+        $this->assertSame(['***REDACTED***', '***REDACTED***'], array_column($resolved[0]['value'], 'value'));
+    }
+
+    public function testNeverRedactsATaggedIterator()
+    {
+        $resolved = $this->resolveAgainstSignature(['authHandlers'], [$this->tagged('security.authenticator')]);
+
+        $this->assertSame('all services tagged "security.authenticator"', $resolved[0]['value']);
+    }
+
+    /**
+     * Fail closed: no signature to read means no way to tell a DSN from a timeout, and the
+     * safe reading of "we do not know" is "do not show it".
+     */
+    public function testRedactsScalarsWhenTheClassCannotBeReflected()
+    {
+        $resolved = $this->resolver->resolve(['App\Absolutely\NotThere', '__construct'], [
+            $this->literal('production-database-dsn'),
+            $this->service('logger'),
+        ]);
+
+        $this->assertSame('#0', $resolved[0]['name']);
+        $this->assertSame('***REDACTED***', $resolved[0]['value']);
+
+        // The wiring still shows, because that is the part that was never in danger.
+        $this->assertSame('logger', $resolved[1]['value']);
+    }
+
+    public function testRedactsScalarsWhenAFactoryLeavesNoClassToReflect()
+    {
+        $resolved = $this->resolver->resolve(['', 'create'], [$this->literal('production-database-dsn')]);
+
+        $this->assertSame('***REDACTED***', $resolved[0]['value']);
+    }
+
+    public function testRedactsScalarsWhenThereIsNoClassAtAll()
+    {
+        $resolved = $this->resolver->resolve([null, '__construct'], [$this->literal('anything')]);
+
+        $this->assertSame('***REDACTED***', $resolved[0]['value']);
+    }
+
+    public function testRedactsScalarsWhenTheFactoryMethodDoesNotExist()
+    {
+        $resolved = $this->resolver->resolve([ApiClient::class, 'noSuchFactoryMethod'], [$this->literal('anything')]);
+
+        $this->assertSame('***REDACTED***', $resolved[0]['value']);
+    }
+
+    /**
+     * More arguments than parameters means the extras are unidentified — unless the
+     * signature ends in a variadic, which owns all of them.
+     */
+    public function testRedactsArgumentsBeyondTheEndOfTheSignature()
+    {
+        $resolved = $this->resolver->resolve([Storage::class, '__construct'], [
+            $this->collection([]),
+            $this->tagged('app.plugin'),
+            $this->literal('unexpected-extra'),
+        ]);
+
+        $this->assertSame('#2', $resolved[2]['name']);
+        $this->assertSame('***REDACTED***', $resolved[2]['value']);
+    }
+
+    public function testNamesVariadicArgumentsAfterTheVariadicParameter()
+    {
+        $resolved = $this->resolver->resolve([VariadicFixture::class, '__construct'], [
+            $this->literal('first'),
+            $this->literal('a'),
+            $this->literal('b'),
+        ]);
+
+        $this->assertSame(['label', 'extras', 'extras'], array_column($resolved, 'name'));
+        $this->assertSame(['first', 'a', 'b'], array_column($resolved, 'value'));
+    }
+
+    public function testNoArgumentsResolveToNothing()
+    {
+        $this->assertSame([], $this->resolver->resolve([MessageBus::class, '__construct'], []));
+    }
+
+    /**
+     * Builds an anonymous class with the given parameter names so a redaction rule can be
+     * checked without a fixture class per case.
+     *
+     * @param list<string>                                                             $parameterNames
+     * @param list<array{key: string|null, type: string, value: mixed, literal: bool}> $arguments
+     *
+     * @return list<array{name: string, type: string, value: mixed}>
+     */
+    private function resolveAgainstSignature(array $parameterNames, array $arguments): array
+    {
+        $signature = implode(', ', array_map(static fn (string $name): string => '$'.$name, $parameterNames));
+        $class = 'MateArgumentSignature_'.md5($signature);
+
+        if (!class_exists($class, false)) {
+            eval(\sprintf('class %s { public function __construct(%s) {} }', $class, $signature));
+        }
+
+        return $this->resolver->resolve([$class, '__construct'], $arguments);
+    }
+
+    /**
+     * @return array{key: string|null, type: string, value: mixed, literal: bool}
+     */
+    private function service(string $id, ?string $key = null): array
+    {
+        return ['key' => $key, 'type' => 'service', 'value' => $id, 'literal' => false];
+    }
+
+    /**
+     * @param list<array{key: string|null, type: string, value: mixed, literal: bool}> $children
+     *
+     * @return array{key: string|null, type: string, value: mixed, literal: bool}
+     */
+    private function collection(array $children, ?string $key = null): array
+    {
+        return ['key' => $key, 'type' => 'collection', 'value' => $children, 'literal' => false];
+    }
+
+    /**
+     * @return array{key: string|null, type: string, value: mixed, literal: bool}
+     */
+    private function literal(mixed $value, ?string $key = null): array
+    {
+        return ['key' => $key, 'type' => 'scalar', 'value' => $value, 'literal' => true];
+    }
+
+    /**
+     * @return array{key: string|null, type: string, value: mixed, literal: bool}
+     */
+    private function tagged(string $tag, ?string $key = null): array
+    {
+        return ['key' => $key, 'type' => 'scalar', 'value' => \sprintf('all services tagged "%s"', $tag), 'literal' => false];
+    }
+}
+
+/**
+ * A variadic signature cannot be written with promoted properties, so it keeps a body.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class VariadicFixture
+{
+    /**
+     * @var list<string>
+     */
+    public readonly array $arguments;
+
+    public function __construct(string $label = '', string ...$extras)
+    {
+        $this->arguments = [$label, ...$extras];
+    }
+}

--- a/src/mate/src/Bridge/Symfony/Tests/Service/ServiceArgumentResolverTest.php
+++ b/src/mate/src/Bridge/Symfony/Tests/Service/ServiceArgumentResolverTest.php
@@ -125,7 +125,7 @@ final class ServiceArgumentResolverTest extends TestCase
     }
 
     /**
-     * A collection sitting under a sensitive parameter has to go entirely, keys or not —
+     * A collection sitting under a sensitive parameter has to go entirely, keys or not:
      * otherwise `$credentials = ['user' => ..., 'pass' => ...]` leaks through the entry
      * whose own key looks innocent.
      */
@@ -188,7 +188,7 @@ final class ServiceArgumentResolverTest extends TestCase
     }
 
     /**
-     * More arguments than parameters means the extras are unidentified — unless the
+     * More arguments than parameters means the extras are unidentified, unless the
      * signature ends in a variadic, which owns all of them.
      */
     public function testRedactsArgumentsBeyondTheEndOfTheSignature()

--- a/src/mate/src/Bridge/Symfony/config/config.php
+++ b/src/mate/src/Bridge/Symfony/config/config.php
@@ -23,6 +23,7 @@ use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\TimeCollectorForma
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\Formatter\TranslationCollectorFormatter;
 use Symfony\AI\Mate\Bridge\Symfony\Profiler\Service\ProfilerDataProvider;
 use Symfony\AI\Mate\Bridge\Symfony\Service\ContainerProvider;
+use Symfony\AI\Mate\Bridge\Symfony\Service\ServiceArgumentResolver;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
@@ -38,11 +39,13 @@ return static function (ContainerConfigurator $configurator) {
 
     // Container introspection services (always available)
     $services->set(ContainerProvider::class);
+    $services->set(ServiceArgumentResolver::class);
 
     $services->set(ServiceTool::class)
         ->args([
             '%ai_mate_symfony.cache_dir%',
             service(ContainerProvider::class),
+            service(ServiceArgumentResolver::class),
         ]);
 
     // Profiler services (optional - only if profiler classes are available)

--- a/src/mate/src/Bridge/Symfony/skills/symfony-service-inspection/SKILL.md
+++ b/src/mate/src/Bridge/Symfony/skills/symfony-service-inspection/SKILL.md
@@ -8,7 +8,7 @@ description: Diagnose a Symfony dependency-injection or wiring problem, service 
 Reads the compiled DI container through Mate's CLI, from the dumped `*DebugContainer.xml`. Two tools:
 
 - `symfony-services` (opt `query`, `tag`, `limit`): `query` is a case-insensitive partial match on service id OR class; `tag` is an exact tag name. Returns `{services: {id => class}, count, truncated}`. `count` is the number of matches before the cut, `truncated` says whether `limit` (default 100) hid some. Narrow the filter rather than raising `limit`.
-- `symfony-service-detail --id=<exact id>`: full detail for one service, `{id, class, tags, calls, factory?}`. The id must be exact.
+- `symfony-service-detail --id=<exact id>`: full detail for one service, `{id, class, tags, calls, arguments, factory?}`. The id must be exact.
 
 Both commands accept `--format`: `json` to parse the result, `toon` (when `helgesverre/toon` is installed) for the smallest context footprint. The service map can be large, so filter it rather than dumping it wide.
 
@@ -26,9 +26,16 @@ Both commands accept `--format`: `json` to parse the result, `toon` (when `helge
 - **Wrong implementation injected:** query the interface. Every id mapping to a class is a candidate. The one wired in is usually the alias whose id equals the interface FQCN. Aliases are resolved for you: asking for the alias id returns the target's class, tags, and calls, so `detail` on the interface id shows the concrete class that actually gets injected.
 - **Tag not applied (listener/subscriber/extension silent):** `detail` the service and check `tags`. If the expected tag is absent, autoconfiguration did not fire, usually because the class does not implement the expected interface/attribute, or `autoconfigure` is off. Each tag entry carries its attributes (`event`, `priority`, `method`, ...); a listener bound to the wrong `event` or `priority` is a common cause.
 - **Constructor/factory surprise:** `factory` (present only when set) is `Class::method`, telling you the object is built by a factory, not `new`. `calls` lists setter-injection method names invoked after construction. A dependency that is null at runtime is often a missing setter call here.
+- **What is actually wired in:** `arguments` is the constructor argument list in declaration order, each `{name, type, value}`.
+  - `type: service` — `value` is the referenced service id. Feed it straight back into `--id=` to walk one level deeper.
+  - `type: collection` — `value` is a nested list of the same shape. This is where a list of collaborators lives, and it is usually the answer to "which of these is registered": **the middleware on a messenger bus**, the handlers on a chain, the wrapped services of a decorator.
+  - `type: scalar` — a literal, or a description like `all services tagged "app.plugin"` for a tagged iterator.
+  - `name` comes from the constructor (or factory method) signature. A name like `#3` means the position could not be matched to a parameter — the class is not loadable, or it is built by a factory service that records no class.
+  - `value: ***REDACTED***` means the parameter name looked like a secret (`key`, `password`, `token`, `secret`, `auth`, …) **or** the parameter could not be identified. Service ids and collections are never redacted, so wiring stays readable either way. If you need the literal, read the config that sets it, not this tool.
 
 ## Failure paths
 
 - `symfony-service-detail` errors "Service ... not found": the id is not exact. Ids are case-sensitive and a leading dot is stripped (`.inner` is stored as `inner`). Re-run `symfony-services` with a fragment to copy the real id. Note a service can exist yet be private; it still appears here.
 - Either tool errors "No compiled container found": the dump only exists after the container is compiled. Warm it (`bin/console cache:warmup`, or just boot the app once) in the environment you are inspecting, then retry. An empty `services` map with `count: 0` is a different answer and means the filter matched nothing. If a warm cache still yields nothing, the parse itself may be failing because the runtime lacks `simplexml`; confirm the environment with php environment check.
+- `arguments` is empty for a service that takes none, and for a synthetic or synthesized one there is nothing to read. It is also empty for anything injected by a setter instead — check `calls`.
 - Reads the first of dev/test/prod it finds. If you are chasing an env-specific binding, make sure that environment's container has been compiled, otherwise you are reading dev.

--- a/src/mate/src/Bridge/Symfony/skills/symfony-service-inspection/SKILL.md
+++ b/src/mate/src/Bridge/Symfony/skills/symfony-service-inspection/SKILL.md
@@ -27,15 +27,15 @@ Both commands accept `--format`: `json` to parse the result, `toon` (when `helge
 - **Tag not applied (listener/subscriber/extension silent):** `detail` the service and check `tags`. If the expected tag is absent, autoconfiguration did not fire, usually because the class does not implement the expected interface/attribute, or `autoconfigure` is off. Each tag entry carries its attributes (`event`, `priority`, `method`, ...); a listener bound to the wrong `event` or `priority` is a common cause.
 - **Constructor/factory surprise:** `factory` (present only when set) is `Class::method`, telling you the object is built by a factory, not `new`. `calls` lists setter-injection method names invoked after construction. A dependency that is null at runtime is often a missing setter call here.
 - **What is actually wired in:** `arguments` is the constructor argument list in declaration order, each `{name, type, value}`.
-  - `type: service` — `value` is the referenced service id. Feed it straight back into `--id=` to walk one level deeper.
-  - `type: collection` — `value` is a nested list of the same shape. This is where a list of collaborators lives, and it is usually the answer to "which of these is registered": **the middleware on a messenger bus**, the handlers on a chain, the wrapped services of a decorator.
-  - `type: scalar` — a literal, or a description like `all services tagged "app.plugin"` for a tagged iterator.
-  - `name` comes from the constructor (or factory method) signature. A name like `#3` means the position could not be matched to a parameter — the class is not loadable, or it is built by a factory service that records no class.
+  - `type: service`: `value` is the referenced service id. Feed it straight back into `--id=` to walk one level deeper.
+  - `type: collection`: `value` is a nested list of the same shape. This is where a list of collaborators lives, and it is usually the answer to "which of these is registered": **the middleware on a messenger bus**, the handlers on a chain, the wrapped services of a decorator.
+  - `type: scalar`: a literal, or a description like `all services tagged "app.plugin"` for a tagged iterator.
+  - `name` comes from the constructor (or factory method) signature. A name like `#3` means the position could not be matched to a parameter: the class is not loadable, or it is built by a factory service that records no class.
   - `value: ***REDACTED***` means the parameter name looked like a secret (`key`, `password`, `token`, `secret`, `auth`, …) **or** the parameter could not be identified. Service ids and collections are never redacted, so wiring stays readable either way. If you need the literal, read the config that sets it, not this tool.
 
 ## Failure paths
 
 - `symfony-service-detail` errors "Service ... not found": the id is not exact. Ids are case-sensitive and a leading dot is stripped (`.inner` is stored as `inner`). Re-run `symfony-services` with a fragment to copy the real id. Note a service can exist yet be private; it still appears here.
 - Either tool errors "No compiled container found": the dump only exists after the container is compiled. Warm it (`bin/console cache:warmup`, or just boot the app once) in the environment you are inspecting, then retry. An empty `services` map with `count: 0` is a different answer and means the filter matched nothing. If a warm cache still yields nothing, the parse itself may be failing because the runtime lacks `simplexml`; confirm the environment with php environment check.
-- `arguments` is empty for a service that takes none, and for a synthetic or synthesized one there is nothing to read. It is also empty for anything injected by a setter instead — check `calls`.
+- `arguments` is empty for a service that takes none, and for a synthetic or synthesized one there is nothing to read. It is also empty for anything injected by a setter instead: check `calls`.
 - Reads the first of dev/test/prod it finds. If you are chasing an env-specific binding, make sure that environment's container has been compiled, otherwise you are reading dev.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Docs?         | yes
| Issues        | -
| License       | MIT

`symfony-service-detail` couldn't show constructor arguments, so finding which services are wired into a definition, like the middleware list of a messenger bus, meant reading the dumped container XML by hand. Symfony's `XmlDumper` already records them; `ContainerProvider` just never read the argument nodes.

Parameter names come from reflecting the constructor or factory method, since the dump only records positions. A scalar whose name looks like a secret (the same word list `RequestCollectorFormatter` uses) is redacted as `***REDACTED***`; an unidentified position (unloadable class, or a factory service with no recorded class) is redacted too, fail-closed. Service references and collections are never redacted, since they're the wiring the tool exists to reveal.

`symfony-services` (the list view) is untouched; arguments stay on the detail view only.

